### PR TITLE
[ty] Improve hover responses from the language server for call arguments.

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1522,7 +1522,7 @@ fn add_class_arg_completions<'db>(
 ///
 /// Suggestions are only provided if the cursor is currently inside a
 /// function call and the function arguments have not 1) already been
-/// set and 2) been defined as positional-only.
+/// set and 2) correspond to parameters that can be passed by keyword.
 fn add_function_arg_completions<'db>(
     db: &'db dyn Db,
     file: File,
@@ -1546,11 +1546,7 @@ fn add_function_arg_completions<'db>(
 
     for sig in &sig_help.signatures {
         for p in &sig.parameters {
-            if p.is_positional_only
-                || p.is_variadic
-                || p.is_keyword_variadic
-                || !set_function_args.insert(p.name.as_str())
-            {
+            if !p.kind.can_be_passed_by_keyword() || !set_function_args.insert(p.name.as_str()) {
                 continue;
             }
             let mut builder = CompletionBuilder::argument(&p.name).ty(p.ty);

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -1912,13 +1912,16 @@ mod tests {
             "#,
         );
 
-        // TODO: This should reveal `int` because the user hovers over the parameter and not the value.
         assert_snapshot!(test.hover(), @"
-        Literal[123]
+        (parameter) ab: int
+        ---------------------------------------------
+        a nice little integer
         ---------------------------------------------
         ```python
-        Literal[123]
+        (parameter) ab: int
         ```
+        ---
+        a nice little integer
         ---------------------------------------------
         info[hover]: Hovered content is
           --> main.py:10:6
@@ -1928,6 +1931,597 @@ mod tests {
            |      ||
            |      |Cursor offset
            |      source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_keyword_argument_value() {
+        let test = hover_test(
+            r#"
+            def test(ab: int):
+                """my cool test
+
+                Args:
+                    ab: a nice little integer
+                """
+                return 0
+
+            test(ab=12<CURSOR>3)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (parameter) ab: int
+        ---------------------------------------------
+        a nice little integer
+        ---------------------------------------------
+        ```python
+        (parameter) ab: int
+        ```
+        ---
+        a nice little integer
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:10:9
+           |
+        10 | test(ab=123)
+           |         ^^-
+           |         | |
+           |         | Cursor offset
+           |         source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_argument_value_without_parameter_documentation() {
+        let test = hover_test(
+            r#"
+            value = 123
+            def test(ab: int):
+                return 0
+
+            test(va<CURSOR>lue)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        Literal[123]
+        ---------------------------------------------
+        ```python
+        Literal[123]
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:6:6
+          |
+        6 | test(value)
+          |      ^^-^^
+          |      | |
+          |      | Cursor offset
+          |      source
+          |
+        ");
+    }
+
+    #[test]
+    fn hover_keyword_argument_without_parameter_documentation() {
+        let test = hover_test(
+            r#"
+            def test(ab: int):
+                return 0
+
+            test(a<CURSOR>b=123)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (parameter) ab: int
+        ---------------------------------------------
+        ```python
+        (parameter) ab: int
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:5:6
+          |
+        5 | test(ab=123)
+          |      ^-
+          |      ||
+          |      |Cursor offset
+          |      source
+          |
+        ");
+    }
+
+    #[test]
+    fn hover_second_positional_argument_value() {
+        let test = hover_test(
+            r#"
+            def test(first: int, second: int):
+                """my cool test
+
+                Args:
+                    first: first integer
+                    second: second integer
+                """
+                return 0
+
+            test(123, 45<CURSOR>6)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (parameter) second: int
+        ---------------------------------------------
+        second integer
+        ---------------------------------------------
+        ```python
+        (parameter) second: int
+        ```
+        ---
+        second integer
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:11:11
+           |
+        11 | test(123, 456)
+           |           ^^-
+           |           | |
+           |           | Cursor offset
+           |           source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_positional_only_argument() {
+        let test = hover_test(
+            r#"
+            def test(item: int, /):
+                """my cool test
+
+                Args:
+                    item: positional-only integer
+                """
+                return 0
+
+            test(12<CURSOR>3)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (positional-only parameter) item: int
+        ---------------------------------------------
+        positional-only integer
+        ---------------------------------------------
+        ```python
+        (positional-only parameter) item: int
+        ```
+        ---
+        positional-only integer
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:10:6
+           |
+        10 | test(123)
+           |      ^^-
+           |      | |
+           |      | Cursor offset
+           |      source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_keyword_only_argument() {
+        let test = hover_test(
+            r#"
+            value = "ab"
+            def test(*, option: str):
+                """my cool test
+
+                Args:
+                    option: keyword-only string
+                """
+                return 0
+
+            test(option=va<CURSOR>lue)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (keyword-only parameter) option: str
+        ---------------------------------------------
+        keyword-only string
+        ---------------------------------------------
+        ```python
+        (keyword-only parameter) option: str
+        ```
+        ---
+        keyword-only string
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:11:13
+           |
+        11 | test(option=value)
+           |             ^^-^^
+           |             | |
+           |             | Cursor offset
+           |             source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_defaulted_argument() {
+        let test = hover_test(
+            r#"
+            def test(count: int = 0):
+                """my cool test
+
+                Args:
+                    count: defaulted count
+                """
+                return 0
+
+            test(12<CURSOR>3)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (parameter) count: int = 0
+        ---------------------------------------------
+        defaulted count
+        ---------------------------------------------
+        ```python
+        (parameter) count: int = 0
+        ```
+        ---
+        defaulted count
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:10:6
+           |
+        10 | test(123)
+           |      ^^-
+           |      | |
+           |      | Cursor offset
+           |      source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_variadic_positional_argument() {
+        let test = hover_test(
+            r#"
+            def test(*items: int):
+                """my cool test
+
+                Args:
+                    items: extra integer items
+                """
+                return 0
+
+            test(12<CURSOR>3)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (variadic positional parameter) *items: int
+        ---------------------------------------------
+        extra integer items
+        ---------------------------------------------
+        ```python
+        (variadic positional parameter) *items: int
+        ```
+        ---
+        extra integer items
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:10:6
+           |
+        10 | test(123)
+           |      ^^-
+           |      | |
+           |      | Cursor offset
+           |      source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_variadic_keyword_argument() {
+        let test = hover_test(
+            r#"
+            value = "yes"
+            def test(**options: str):
+                """my cool test
+
+                Args:
+                    options: extra string options
+                """
+                return 0
+
+            test(debug=va<CURSOR>lue)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (variadic keyword parameter) **options: str
+        ---------------------------------------------
+        extra string options
+        ---------------------------------------------
+        ```python
+        (variadic keyword parameter) **options: str
+        ```
+        ---
+        extra string options
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:11:12
+           |
+        11 | test(debug=value)
+           |            ^^-^^
+           |            | |
+           |            | Cursor offset
+           |            source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_starred_argument_unpack() {
+        let test = hover_test(
+            r#"
+            values: tuple[int, ...] = (1, 2)
+            def test(*items: int):
+                """my cool test
+
+                Args:
+                    items: extra integer items
+                """
+                return 0
+
+            test(*va<CURSOR>lues)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (variadic positional parameter) *items: int
+        ---------------------------------------------
+        extra integer items
+        ---------------------------------------------
+        ```python
+        (variadic positional parameter) *items: int
+        ```
+        ---
+        extra integer items
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:11:7
+           |
+        11 | test(*values)
+           |       ^^-^^^
+           |       | |
+           |       | Cursor offset
+           |       source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_double_starred_argument_unpack() {
+        let test = hover_test(
+            r#"
+            options: dict[str, str] = {"debug": "yes"}
+            def test(**settings: str):
+                """my cool test
+
+                Args:
+                    settings: extra string settings
+                """
+                return 0
+
+            test(**opt<CURSOR>ions)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (variadic keyword parameter) **settings: str
+        ---------------------------------------------
+        extra string settings
+        ---------------------------------------------
+        ```python
+        (variadic keyword parameter) **settings: str
+        ```
+        ---
+        extra string settings
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:11:8
+           |
+        11 | test(**options)
+           |        ^^^-^^^
+           |        |  |
+           |        |  Cursor offset
+           |        source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_starred_argument_unpack_multiple_parameters() {
+        let test = hover_test(
+            r#"
+            values: tuple[int, str] = (1, "two")
+            def test(first: int, second: str):
+                """my cool test
+
+                Args:
+                    first: first argument
+                    second: second argument
+                """
+                return 0
+
+            test(*va<CURSOR>lues)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @r#"
+        tuple[Literal[1], Literal["two"]]
+        ---------------------------------------------
+        ```python
+        tuple[Literal[1], Literal["two"]]
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:12:7
+           |
+        12 | test(*values)
+           |       ^^-^^^
+           |       | |
+           |       | Cursor offset
+           |       source
+           |
+        "#);
+    }
+
+    #[test]
+    fn hover_bound_method_argument() {
+        let test = hover_test(
+            r#"
+            class Processor:
+                def run(self, count: int):
+                    """my cool method
+
+                    Args:
+                        count: method count
+                    """
+                    return 0
+
+            processor = Processor()
+            processor.run(12<CURSOR>3)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (parameter) count: int
+        ---------------------------------------------
+        method count
+        ---------------------------------------------
+        ```python
+        (parameter) count: int
+        ```
+        ---
+        method count
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:12:15
+           |
+        12 | processor.run(123)
+           |               ^^-
+           |               | |
+           |               | Cursor offset
+           |               source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_constructor_argument() {
+        let test = hover_test(
+            r#"
+            value = "crate"
+            class Box:
+                def __init__(self, name: str):
+                    """my cool constructor
+
+                    Args:
+                        name: box name
+                    """
+                    self.name = name
+
+            Box(va<CURSOR>lue)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (parameter) name: str
+        ---------------------------------------------
+        box name
+        ---------------------------------------------
+        ```python
+        (parameter) name: str
+        ```
+        ---
+        box name
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:12:5
+           |
+        12 | Box(value)
+           |     ^^-^^
+           |     | |
+           |     | Cursor offset
+           |     source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_overload_argument_disambiguated_by_type() {
+        let test = hover_test(
+            r#"
+            from typing import overload
+
+            @overload
+            def choose(value: int) -> int:
+                """Choose int.
+
+                Args:
+                    value: integer overload argument
+                """
+
+            @overload
+            def choose(value: str) -> str:
+                """Choose str.
+
+                Args:
+                    value: string overload argument
+                """
+
+            def choose(value):
+                return value
+
+            value = "abc"
+            choose(va<CURSOR>lue)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        def choose(value: str) -> str
+        (parameter) value: str
+        ---------------------------------------------
+        string overload argument
+        ---------------------------------------------
+        ```python
+        def choose(value: str) -> str
+        (parameter) value: str
+        ```
+        ---
+        string overload argument
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:24:8
+           |
+        24 | choose(value)
+           |        ^^-^^
+           |        | |
+           |        | Cursor offset
+           |        source
            |
         ");
     }

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -3,11 +3,14 @@ use crate::goto::{GotoTarget, docstring_for_call_definition, find_goto_target};
 use crate::{Db, MarkupKind, RangedValue};
 use ruff_db::files::{File, FileRange};
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast as ast;
+use ruff_python_ast::find_node::covering_node;
+use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextSize};
 use std::fmt;
 use std::fmt::Formatter;
-use ty_python_semantic::types::ide_support::{resolved_call_signature, typed_dict_key_hover};
+use ty_python_semantic::types::ide_support::{
+    resolved_call_signature, resolved_call_signature_with_candidates, typed_dict_key_hover,
+};
 use ty_python_semantic::types::{KnownInstanceType, Type, TypeVarVariance};
 use ty_python_semantic::{DisplaySettings, SemanticModel, TypeQualifiers};
 
@@ -15,6 +18,13 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
     let parsed = parsed_module(db, file).load(db);
     let model = SemanticModel::new(db, file);
     let goto_target = find_goto_target(&model, &parsed, offset)?;
+
+    if let Some(contents) = call_argument_hover_contents(db, &model, &parsed, &goto_target) {
+        return Some(RangedValue {
+            range: FileRange::new(file, goto_target.range()),
+            value: Hover { contents },
+        });
+    }
 
     if let GotoTarget::Expression(expr) = goto_target {
         if expr.is_literal_expr() {
@@ -104,6 +114,185 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
     })
 }
 
+fn call_argument_hover_contents<'db>(
+    db: &'db dyn Db,
+    model: &SemanticModel<'db>,
+    parsed: &ruff_db::parsed::ParsedModuleRef,
+    goto_target: &GotoTarget,
+) -> Option<Vec<HoverContent<'db>>> {
+    let (call, argument_index) = call_argument_for_target(parsed, goto_target)?;
+    let resolved = resolved_call_signature_with_candidates(model, call)?;
+    let details = &resolved.details;
+    let argument_mapping = details.argument_to_parameter_mapping.get(argument_index)?;
+    let first_parameter_index = argument_mapping.parameters.first()?;
+    if argument_mapping
+        .parameters
+        .iter()
+        .any(|parameter_index| parameter_index != first_parameter_index)
+    {
+        return None;
+    }
+    let displayed_parameter_index = details
+        .argument_to_displayed_parameter_mapping
+        .get(argument_index)
+        .copied()
+        .flatten()?;
+    let parameter = details.parameters.get(displayed_parameter_index)?;
+
+    let name = parameter.name.clone();
+    let is_keyword_argument_name = matches!(goto_target, GotoTarget::KeywordArgument { .. });
+    let documentation = details
+        .definition
+        .and_then(|definition| docstring_for_call_definition(db, definition))
+        .and_then(|docstring| parameter_documentation(&docstring, &name))
+        .or_else(|| {
+            call_argument_definition_docstring(db, model, call)
+                .and_then(|docstring| parameter_documentation(&docstring, &name))
+        });
+
+    if documentation.is_none() && !is_keyword_argument_name {
+        return None;
+    }
+
+    let label = parameter.label.clone();
+    let kind = parameter.hover_label();
+    let signature = resolved
+        .has_multiple_signatures
+        .then(|| call_argument_signature(call, &details.label));
+
+    let mut contents = vec![HoverContent::Parameter {
+        kind,
+        label,
+        signature,
+    }];
+    if let Some(documentation) = documentation {
+        contents.push(HoverContent::ParameterDocumentation(documentation));
+    }
+
+    Some(contents)
+}
+
+fn call_argument_definition_docstring<'db>(
+    db: &'db dyn Db,
+    model: &SemanticModel<'db>,
+    call: &ast::ExprCall,
+) -> Option<Docstring> {
+    GotoTarget::Call {
+        callable: ast::ExprRef::from(&call.func),
+        call,
+        on_parenthesis: false,
+    }
+    .definitions(
+        model,
+        ty_python_semantic::ImportAliasResolution::ResolveAliases,
+    )
+    .and_then(|definitions| definitions.docstring(db))
+}
+
+fn parameter_documentation(docstring: &Docstring, name: &str) -> Option<String> {
+    let mut parameter_documentation = docstring.parameter_documentation();
+    parameter_documentation
+        .remove(name)
+        .or_else(|| parameter_documentation.remove(name.trim_start_matches('*')))
+}
+
+fn call_argument_signature(call: &ast::ExprCall, signature: &str) -> String {
+    if let Some(name) = call_argument_signature_name(&call.func) {
+        format!("def {name}{signature}")
+    } else {
+        signature.to_string()
+    }
+}
+
+fn call_argument_signature_name(function: &ast::Expr) -> Option<&str> {
+    match function {
+        ast::Expr::Name(name) => Some(name.id.as_str()),
+        ast::Expr::Attribute(attribute) => Some(attribute.attr.as_str()),
+        _ => None,
+    }
+}
+
+fn call_argument_for_target<'a>(
+    parsed: &'a ruff_db::parsed::ParsedModuleRef,
+    goto_target: &GotoTarget<'a>,
+) -> Option<(&'a ast::ExprCall, usize)> {
+    match goto_target {
+        GotoTarget::KeywordArgument {
+            keyword,
+            call_expression,
+        } => {
+            let argument_index = call_expression
+                .arguments
+                .iter_source_order()
+                .position(|argument| matches!(argument, ast::ArgOrKeyword::Keyword(candidate) if candidate.range == keyword.range))?;
+            Some((call_expression, argument_index))
+        }
+        GotoTarget::Expression(expression) => {
+            call_argument_for_expression(parsed, expression.range())
+        }
+        _ => None,
+    }
+}
+
+fn call_argument_for_expression(
+    parsed: &ruff_db::parsed::ParsedModuleRef,
+    expression_range: ruff_text_size::TextRange,
+) -> Option<(&ast::ExprCall, usize)> {
+    let root_node: AnyNodeRef = parsed.syntax().into();
+    let call = covering_node(root_node, expression_range)
+        .find_first(|node| {
+            let AnyNodeRef::ExprCall(call) = node else {
+                return false;
+            };
+            direct_argument_index(call, expression_range).is_some()
+        })
+        .ok()?;
+
+    let AnyNodeRef::ExprCall(call) = call.node() else {
+        return None;
+    };
+    let argument_index = direct_argument_index(call, expression_range)?;
+    Some((call, argument_index))
+}
+
+fn direct_argument_index(
+    call: &ast::ExprCall,
+    expression_range: ruff_text_size::TextRange,
+) -> Option<usize> {
+    call.arguments
+        .iter_source_order()
+        .enumerate()
+        .find_map(|(index, argument)| match argument {
+            ast::ArgOrKeyword::Arg(argument) => {
+                if direct_argument_value_range(argument) == expression_range {
+                    Some(index)
+                } else {
+                    None
+                }
+            }
+            ast::ArgOrKeyword::Keyword(keyword) => {
+                if keyword.value.range() == expression_range
+                    || keyword
+                        .arg
+                        .as_ref()
+                        .is_some_and(|arg| arg.range == expression_range)
+                {
+                    Some(index)
+                } else {
+                    None
+                }
+            }
+        })
+}
+
+fn direct_argument_value_range(argument: &ast::Expr) -> ruff_text_size::TextRange {
+    if let ast::Expr::Starred(starred) = argument {
+        starred.value.range()
+    } else {
+        argument.range()
+    }
+}
+
 pub struct Hover<'db> {
     contents: Vec<HoverContent<'db>>,
 }
@@ -166,6 +355,12 @@ impl fmt::Display for DisplayHover<'_, '_> {
 #[derive(Debug, Clone)]
 pub enum HoverContent<'db> {
     Signature(String),
+    Parameter {
+        kind: &'static str,
+        label: String,
+        signature: Option<String>,
+    },
+    ParameterDocumentation(String),
     Type(Type<'db>, Option<TypeVarVariance>, TypeQualifiers),
     TypedDictKey {
         owner: String,
@@ -212,6 +407,24 @@ impl fmt::Display for DisplayHoverContent<'_, '_> {
         match self.content {
             HoverContent::Signature(signature) => {
                 self.kind.fenced_code_block(&signature, "python").fmt(f)
+            }
+            HoverContent::Parameter {
+                kind,
+                label,
+                signature,
+            } => {
+                let label = format!("({kind}) {label}");
+                if let Some(signature) = signature {
+                    self.kind
+                        .fenced_code_block(format!("{signature}\n{label}"), "python")
+                        .fmt(f)
+                } else {
+                    self.kind.fenced_code_block(label, "python").fmt(f)
+                }
+            }
+            HoverContent::ParameterDocumentation(documentation) => {
+                let rendered = Docstring::new(documentation.clone()).render(self.kind);
+                f.write_str(rendered.trim_end())
             }
             HoverContent::Type(ty, variance, qualifiers) => {
                 let variance = match variance {
@@ -2463,6 +2676,48 @@ mod tests {
           --> main.py:12:5
            |
         12 | Box(value)
+           |     ^^-^^
+           |     | |
+           |     | Cursor offset
+           |     source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_constructor_argument_class_docstring() {
+        let test = hover_test(
+            r#"
+            value = "crate"
+            class Box:
+                """my cool class
+
+                Args:
+                    name: box name
+                """
+
+                def __init__(self, name: str):
+                    self.name = name
+
+            Box(va<CURSOR>lue)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (parameter) name: str
+        ---------------------------------------------
+        box name
+        ---------------------------------------------
+        ```python
+        (parameter) name: str
+        ```
+        ---
+        box name
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:13:5
+           |
+        13 | Box(value)
            |     ^^-^^
            |     | |
            |     | Cursor offset

--- a/crates/ty_ide/src/signature_help.rs
+++ b/crates/ty_ide/src/signature_help.rs
@@ -18,8 +18,8 @@ use ruff_text_size::{Ranged, TextSize};
 use ty_python_semantic::SemanticModel;
 use ty_python_semantic::types::Type;
 use ty_python_semantic::types::ide_support::{
-    CallSignatureDetails, CallSignatureParameter, call_signature_details,
-    find_active_signature_from_details,
+    CallSignatureDetails, CallSignatureParameter, CallSignatureParameterKind,
+    call_signature_details, find_active_signature_from_details,
 };
 
 // TODO: We may want to add special-case handling for calls to constructors
@@ -38,12 +38,8 @@ pub struct ParameterDetails<'db> {
     /// Documentation specific to the parameter, typically extracted from the
     /// function's docstring
     pub documentation: Option<String>,
-    /// True if the parameter is positional-only.
-    pub is_positional_only: bool,
-    /// True if the parameter can absorb arbitrarily many positional arguments.
-    pub is_variadic: bool,
-    /// True if the parameter can absorb arbitrarily many keyword arguments.
-    pub is_keyword_variadic: bool,
+    /// The displayed parameter category.
+    pub kind: CallSignatureParameterKind,
 }
 
 /// Information about a function signature
@@ -207,9 +203,11 @@ fn create_signature_details_from_call_signature_details<'db>(
                     // converts the parameter count to the zero-based index of that last entry.
                     if current_arg_index < details.parameters.len() {
                         Some(current_arg_index)
-                    } else if details.parameters.last().is_some_and(|parameter| {
-                        parameter.is_variadic || parameter.is_keyword_variadic
-                    }) {
+                    } else if details
+                        .parameters
+                        .last()
+                        .is_some_and(|parameter| parameter.kind.is_any_variadic())
+                    {
                         Some(details.parameters.len() - 1)
                     } else {
                         None
@@ -246,9 +244,8 @@ fn create_parameters<'db>(
                 label,
                 name,
                 ty,
-                is_positional_only,
-                is_variadic,
-                is_keyword_variadic,
+                kind,
+                ..
             } = parameter;
             // Get the parameter name for documentation lookup.
             let documentation = param_docs.get(name.as_str()).cloned();
@@ -258,9 +255,7 @@ fn create_parameters<'db>(
                 label,
                 ty,
                 documentation,
-                is_positional_only,
-                is_variadic,
-                is_keyword_variadic,
+                kind,
             }
         })
         .collect()

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -594,14 +594,64 @@ pub struct CallSignatureParameter<'db> {
     /// Annotated type of the parameter after applying any inferred specialization.
     pub ty: Type<'db>,
 
-    /// True if the parameter is positional-only.
-    pub is_positional_only: bool,
+    /// The displayed parameter category.
+    pub kind: CallSignatureParameterKind,
 
-    /// True if the parameter can absorb arbitrarily many positional arguments.
-    pub is_variadic: bool,
+    /// Whether this parameter was synthesized for a bare `ParamSpec`.
+    ///
+    /// Bare `ParamSpec` parameter lists contain both `*args: P.args` and
+    /// `**kwargs: P.kwargs` internally, but render as one displayed `**P`
+    /// parameter in signature help.
+    pub is_bare_paramspec: bool,
+}
 
-    /// True if the parameter can absorb arbitrarily many keyword arguments.
-    pub is_keyword_variadic: bool,
+impl CallSignatureParameter<'_> {
+    pub const fn hover_label(&self) -> &'static str {
+        if self.is_bare_paramspec {
+            "variadic parameter"
+        } else {
+            self.kind.hover_label()
+        }
+    }
+}
+
+/// The displayed category for a signature-help parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallSignatureParameterKind {
+    /// A parameter before `/`.
+    PositionalOnly,
+    /// A parameter that can be passed positionally or by keyword.
+    PositionalOrKeyword,
+    /// A `*args` parameter.
+    Variadic,
+    /// A keyword-only parameter after `*` or `*args`.
+    KeywordOnly,
+    /// A `**kwargs` parameter.
+    KeywordVariadic,
+}
+
+impl CallSignatureParameterKind {
+    fn from_parameter(parameter: &crate::types::signatures::Parameter) -> Self {
+        if parameter.is_positional_only() {
+            Self::PositionalOnly
+        } else if parameter.is_keyword_only() {
+            Self::KeywordOnly
+        } else if parameter.is_variadic() {
+            Self::Variadic
+        } else if parameter.is_keyword_variadic() {
+            Self::KeywordVariadic
+        } else {
+            Self::PositionalOrKeyword
+        }
+    }
+
+    pub const fn is_any_variadic(self) -> bool {
+        matches!(self, Self::Variadic | Self::KeywordVariadic)
+    }
+
+    pub const fn can_be_passed_by_keyword(self) -> bool {
+        matches!(self, Self::PositionalOrKeyword | Self::KeywordOnly)
+    }
 }
 
 impl<'db> CallSignatureDetails<'db> {
@@ -689,9 +739,8 @@ fn displayed_parameters_for_signature<'db>(
                     label,
                     name,
                     ty: apply_specialization(parameter.annotated_type()),
-                    is_positional_only: parameter.is_positional_only(),
-                    is_variadic: parameter.is_variadic(),
-                    is_keyword_variadic: parameter.is_keyword_variadic(),
+                    kind: CallSignatureParameterKind::from_parameter(parameter),
+                    is_bare_paramspec: false,
                 });
             }
 
@@ -723,9 +772,8 @@ fn displayed_parameters_for_signature<'db>(
                     label,
                     name,
                     ty: Type::TypeVar(typevar),
-                    is_positional_only: false,
-                    is_variadic: true,
-                    is_keyword_variadic: true,
+                    kind: CallSignatureParameterKind::KeywordVariadic,
+                    is_bare_paramspec: true,
                 }],
                 vec![Some(0); parameters.len()],
             )

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -652,6 +652,16 @@ impl CallSignatureParameterKind {
     pub const fn can_be_passed_by_keyword(self) -> bool {
         matches!(self, Self::PositionalOrKeyword | Self::KeywordOnly)
     }
+
+    pub const fn hover_label(self) -> &'static str {
+        match self {
+            Self::PositionalOnly => "positional-only parameter",
+            Self::PositionalOrKeyword => "parameter",
+            Self::Variadic => "variadic positional parameter",
+            Self::KeywordOnly => "keyword-only parameter",
+            Self::KeywordVariadic => "variadic keyword parameter",
+        }
+    }
 }
 
 impl<'db> CallSignatureDetails<'db> {
@@ -1182,31 +1192,29 @@ pub fn find_active_signature_from_details(
     Some(best_index)
 }
 
+/// The resolved signature for a call expression, plus metadata about the candidate set.
+pub struct ResolvedCallSignature<'db> {
+    /// The signature selected for this call.
+    pub details: CallSignatureDetails<'db>,
+
+    /// Whether the callable had more than one candidate signature before selecting the best match.
+    pub has_multiple_signatures: bool,
+}
+
 /// Resolve a call expression to its matching overload's signature details,
 /// using full type checking (not just arity matching) for overload resolution.
 ///
 /// Falls back to arity-based matching if type-based resolution fails.
-pub fn resolved_call_signature<'db>(
+pub fn resolved_call_signature_with_candidates<'db>(
     model: &SemanticModel<'db>,
     call_expr: &ast::ExprCall,
-) -> Option<CallSignatureDetails<'db>> {
+) -> Option<ResolvedCallSignature<'db>> {
     let db = model.db();
     let func_type = call_expr.func.inferred_type(model)?;
     let callable_type = func_type.try_upcast_to_callable(db)?.into_type(db);
+    let bindings = full_type_bindings_for_call(model, callable_type, call_expr);
 
-    let args = CallArguments::from_arguments_typed(&call_expr.arguments, |splatted_value| {
-        splatted_value
-            .inferred_type(model)
-            .unwrap_or(Type::unknown())
-    });
-
-    // Extract the `Bindings` regardless of whether type checking succeeded or failed.
-    let constraints = ConstraintSetBuilder::new();
-    let bindings = callable_type
-        .bindings(db)
-        .match_parameters(db, &args)
-        .check_types(db, &constraints, &args, TypeContext::default(), &[])
-        .unwrap_or_else(|CallError(_, bindings)| *bindings);
+    let has_multiple_signatures = bindings.iter_flat().flatten().nth(1).is_some();
 
     // First, try to find the matching overload after full type checking.
     let type_checked_details: Vec<_> = bindings
@@ -1217,7 +1225,11 @@ pub fn resolved_call_signature<'db>(
 
     if !type_checked_details.is_empty() {
         let active = find_active_signature_from_details(&type_checked_details)?;
-        return type_checked_details.into_iter().nth(active);
+        let details = type_checked_details.into_iter().nth(active)?;
+        return Some(ResolvedCallSignature {
+            details,
+            has_multiple_signatures,
+        });
     }
 
     // If all overloads have type-checking errors (e.g., `InvalidArgumentType`),
@@ -1234,7 +1246,19 @@ pub fn resolved_call_signature<'db>(
     }
 
     let active = find_active_signature_from_details(&all_details)?;
-    all_details.into_iter().nth(active)
+    let details = all_details.into_iter().nth(active)?;
+    Some(ResolvedCallSignature {
+        details,
+        has_multiple_signatures,
+    })
+}
+
+/// Resolve a call expression to its matching overload's signature details.
+pub fn resolved_call_signature<'db>(
+    model: &SemanticModel<'db>,
+    call_expr: &ast::ExprCall,
+) -> Option<CallSignatureDetails<'db>> {
+    resolved_call_signature_with_candidates(model, call_expr).map(|resolved| resolved.details)
 }
 
 #[derive(Default)]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This makes it so that hovering over a call argument with matching parameter documentation or relevant metadata (e.g., parameter kind, default value, selected overload signature) shows that documentation and/or metadata rather than the inferred type of the argument value itself.

Argument values without matching parameter documentation and ambiguous unpacked arguments remain unchanged: those will continue to show just the inferred type of the argument value itself.

Closes https://github.com/astral-sh/ty/issues/1350

### Catalog of new hover contents

#### Argument for an ordinary parameter

```py
def test(first: int, second: int):
    """my cool test

    Args:
        first: first integer
        second: second integer
    """
    return 0

test(123, 456)
           ^
```

````txt
(parameter) second: int
---------------------------------------------
second integer
````

#### Argument for ordinary parameter passed by keyword

```py
def test(ab: int):
    """my cool test

    Args:
        ab: a nice little integer
    """
    return 0

test(ab=123)
      ^
```

````txt
(parameter) ab: int
---------------------------------------------
a nice little integer
````

#### Argument for positional-only parameter

```py
def test(item: int, /):
    """my cool test

    Args:
        item: my special integer
    """
    return 0

test(123)
     ^
```

````txt
(positional-only parameter) item: int
---------------------------------------------
my special integer
````

#### Argument for variadic keyword parameter

```py
options: dict[str, str] = {"debug": "yes"}

def test(**settings: str):
    """my cool test

    Args:
        settings: extra string settings
    """
    return 0

test(**options)
       ^
```

````txt
(variadic keyword parameter) **settings: str
---------------------------------------------
extra string settings
````

#### Argument for parameter from a specific overload

```py
from typing import overload

@overload
def choose(value: int) -> int:
    """Choose int.

    Args:
        value: integer overload argument
    """
    ...

@overload
def choose(value: str) -> str:
    """Choose str.

    Args:
        value: string overload argument
    """
    ...

def choose(value):
    return value

value = "abc"
choose(value)
       ^
```

````txt
def choose(value: str) -> str
(parameter) value: str
---------------------------------------------
string overload argument
````

## Test Plan

Please see included tests.