### PR TITLE
[ty] Include TypedDict type context when inferring mixed constructors

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -7027,6 +7027,31 @@ take({"<CURSOR>": 1})
     }
 
     #[test]
+    fn string_literal_completions_typed_dict_constructor_mixed_literal_keys() {
+        let builder = completion_test_builder(
+            r#"
+from typing import TypedDict
+
+class Box(TypedDict):
+    x: float
+    y: float
+    z: float
+
+Box({"<CURSOR>": 1}, y=2)
+"#,
+        );
+
+        assert_snapshot!(
+            builder.skip_keywords().skip_builtins().skip_auto_import().type_signatures().build().snapshot(),
+            @r#"
+        x :: Literal["x"]
+        y :: Literal["y"]
+        z :: Literal["z"]
+        "#,
+        );
+    }
+
+    #[test]
     fn string_literal_completions_typed_dict_keys_assignment() {
         let builder = completion_test_builder(
             r#"

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -433,12 +433,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         dict_expr: &ast::ExprDict,
     ) {
         let items = typed_dict.items(self.db());
+        let key_tcx =
+            TypeContext::new(self.typed_dict_key_expected_type(Type::TypedDict(typed_dict)));
 
         for item in &dict_expr.items {
             let value_tcx = item
                 .key
                 .as_ref()
-                .map(|key| self.get_or_infer_expression(key, TypeContext::default()))
+                .map(|key| self.get_or_infer_expression(key, key_tcx))
                 .and_then(Type::as_string_literal)
                 .and_then(|key| items.get(key.value(self.db())))
                 .map(|field| TypeContext::new(Some(field.declared_ty)))


### PR DESCRIPTION
## Summary

Like #25037, but one other site identified by Codex: mixed constructors (e.g., `Box({"<CURSOR>": 1}, y=2)`).
