### PR TITLE
[ty] Fix cross-file find-references for keyword arguments

### DIFF
--- a/crates/ty_ide/src/find_references.rs
+++ b/crates/ty_ide/src/find_references.rs
@@ -1353,6 +1353,48 @@ result = func(value=42)
     }
 
     #[test]
+    fn multi_file_parameter_references_from_keyword_argument_include_keyword_argument_labels() {
+        let test = CursorTest::builder()
+            .source(
+                "utils.py",
+                "
+def func(value: int):
+    return value * 2
+
+result = func(value<CURSOR>=42)
+",
+            )
+            .source(
+                "caller.py",
+                "
+from utils import func
+
+result = func(value=1)
+",
+            )
+            .build();
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 4 references
+         --> caller.py:4:15
+          |
+        4 | result = func(value=1)
+          |               -----
+          |
+         ::: utils.py:2:10
+          |
+        2 | def func(value: int):
+          |          -----
+        3 |     return value * 2
+          |            -----
+        4 |
+        5 | result = func(value=42)
+          |               -----
+          |
+        ");
+    }
+
+    #[test]
     fn multi_file_async_function_parameter_references_include_keyword_argument_labels() {
         let test = CursorTest::builder()
             .source(

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -135,13 +135,10 @@ pub(crate) fn references(
                 );
             }
         }
-
         // Parameters are local by scope, but they can have cross-file references via keyword
         // argument labels (e.g. `f(param=...)`). Handle this case with a narrow scan that only
         // considers keyword arguments.
-        if matches!(goto_target, GotoTarget::Parameter(_))
-            && parameter_owner_is_externally_visible(db, &target_definitions)
-        {
+        else if parameter_owner_is_externally_visible(db, &target_definitions) {
             references_for_parameter_keyword_arguments_across_files(
                 db,
                 file,


### PR DESCRIPTION
## Summary

Find references on a parameter already performs a cross-file search today because
the function could be called from any module. However, ty didn't perform a cross-file
search when finding the references of a keyword argument, that is, when calling a function with a keyword argument. 

This PR now uses the same cross-file searh when searching for keyword-arguments as when searching for keyword parameter
referneces.

## Test Plan

Added test
