### PR TITLE
Add `D203` to rules that conflict with the formatter

### DIFF
--- a/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -38,10 +38,16 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 ///     """Metadata about a photo."""
 /// ```
 ///
+/// ## Formatter compatibility
+/// We recommend against using this rule alongside the [formatter]. The
+/// formatter removes blank lines before class docstrings, which conflicts
+/// with this rule's requirement to include them.
+///
 /// ## Options
 /// - `lint.pydocstyle.convention`
 ///
 /// [D211]: https://docs.astral.sh/ruff/rules/blank-line-before-class
+/// [formatter]: https://docs.astral.sh/ruff/formatter
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.70")]
 pub(crate) struct IncorrectBlankLineBeforeClass;

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -430,6 +430,7 @@ When using Ruff as a formatter, we recommend avoiding the following lint rules:
 - [`indentation-with-invalid-multiple`](rules/indentation-with-invalid-multiple.md) (`E111`)
 - [`indentation-with-invalid-multiple-comment`](rules/indentation-with-invalid-multiple-comment.md) (`E114`)
 - [`over-indented`](rules/over-indented.md) (`E117`)
+- [`incorrect-blank-line-before-class`](rules/incorrect-blank-line-before-class.md) (`D203`)
 - [`docstring-tab-indentation`](rules/docstring-tab-indentation.md) (`D206`)
 - [`triple-single-quotes`](rules/triple-single-quotes.md) (`D300`)
 - [`bad-quotes-inline-string`](rules/bad-quotes-inline-string.md) (`Q000`)


### PR DESCRIPTION
Noticed the warning below when running `ruff format`, which wasn't documented in https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules.

```
ruff format --check
# warning: The following rule may cause conflicts when used with the formatter: `D203`. 
# To avoid unexpected behavior, we recommend disabling this rule, either by removing it from the `lint.select` or `lint.extend-select` configuration, or adding it to the `lint.ignore` configuration.
```
