### PR TITLE
Lazily initialize `UnionBuilder` when transforming a `Union`

### DIFF
--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -1,5 +1,7 @@
 use itertools::Either;
 
+use std::convert::Infallible;
+
 use crate::place::{
     DefinedPlace, Definedness, Place, PlaceAndQualifiers, PublicTypePolicy, TypeOrigin,
 };
@@ -126,33 +128,39 @@ impl<'db> UnionType<'db> {
     pub(crate) fn map(
         self,
         db: &'db dyn Db,
-        transform_fn: impl FnMut(&Type<'db>) -> Type<'db>,
+        mut transform_fn: impl FnMut(&Type<'db>) -> Type<'db>,
     ) -> Type<'db> {
-        self.elements(db)
-            .iter()
-            .map(transform_fn)
-            .fold(UnionBuilder::new(db), |builder, element| {
-                builder.add(element)
-            })
-            .recursively_defined(self.recursively_defined(db))
-            .build()
+        let Ok(mapped) =
+            self.try_map_impl(db, |element| Ok::<_, Infallible>(transform_fn(element)));
+        mapped
     }
 
     /// A version of [`UnionType::map`] that does not unpack type aliases.
     pub(crate) fn map_leave_aliases(
         self,
         db: &'db dyn Db,
-        transform_fn: impl FnMut(&Type<'db>) -> Type<'db>,
+        mut transform_fn: impl FnMut(&Type<'db>) -> Type<'db>,
     ) -> Type<'db> {
-        self.elements(db)
-            .iter()
-            .map(transform_fn)
-            .fold(
-                UnionBuilder::new(db).unpack_aliases(false),
-                UnionBuilder::add,
-            )
-            .recursively_defined(self.recursively_defined(db))
-            .build()
+        let elements = self.elements(db);
+        let mut iter = elements.iter().enumerate();
+        while let Some((i, ty)) = iter.next() {
+            let new_ty = transform_fn(ty);
+            if &new_ty != ty {
+                let mut builder = UnionBuilder::new(db).unpack_aliases(false);
+                for prev in &elements[..i] {
+                    builder = builder.add(*prev);
+                }
+                builder = builder.add(new_ty);
+                for (_, element) in iter {
+                    builder = builder.add(transform_fn(element));
+                }
+                return builder
+                    .recursively_defined(self.recursively_defined(db))
+                    .build();
+            }
+        }
+
+        Type::Union(self)
     }
 
     /// A fallible version of [`UnionType::map`].
@@ -165,14 +173,37 @@ impl<'db> UnionType<'db> {
     pub(crate) fn try_map(
         self,
         db: &'db dyn Db,
-        transform_fn: impl FnMut(&Type<'db>) -> Option<Type<'db>>,
+        mut transform_fn: impl FnMut(&Type<'db>) -> Option<Type<'db>>,
     ) -> Option<Type<'db>> {
-        let mut builder = UnionBuilder::new(db);
-        for element in self.elements(db).iter().map(transform_fn) {
-            builder = builder.add(element?);
+        self.try_map_impl(db, |element| transform_fn(element).ok_or(()))
+            .ok()
+    }
+
+    fn try_map_impl<E>(
+        self,
+        db: &'db dyn Db,
+        mut transform_fn: impl FnMut(&Type<'db>) -> Result<Type<'db>, E>,
+    ) -> Result<Type<'db>, E> {
+        let elements = self.elements(db);
+        let mut iter = elements.iter().enumerate();
+        while let Some((i, ty)) = iter.next() {
+            let new_ty = transform_fn(ty)?;
+            if &new_ty != ty || matches!(new_ty, Type::TypeAlias(_)) {
+                let mut builder = elements[..i]
+                    .iter()
+                    .copied()
+                    .fold(UnionBuilder::new(db), UnionBuilder::add);
+                builder = builder.add(new_ty);
+                for (_, element) in iter {
+                    builder = builder.add(transform_fn(element)?);
+                }
+                return Ok(builder
+                    .recursively_defined(self.recursively_defined(db))
+                    .build());
+            }
         }
-        builder = builder.recursively_defined(self.recursively_defined(db));
-        Some(builder.build())
+
+        Ok(Type::Union(self))
     }
 
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1615,13 +1615,17 @@ impl<'db> InnerIntersectionBuilder<'db> {
 
 #[cfg(test)]
 mod tests {
-    use super::{IntersectionBuilder, Type, UnionBuilder, UnionType};
+    use super::{
+        IntersectionBuilder, MAX_NON_RECURSIVE_UNION_LITERALS, Type, UnionBuilder, UnionType,
+    };
 
     use crate::db::tests::{TestDb, setup_db};
-    use crate::place::known_module_symbol;
+    use crate::place::{global_symbol, known_module_symbol};
     use crate::types::enums::enum_member_literals;
-    use crate::types::{KnownClass, Truthiness};
+    use crate::types::type_alias::TypeAliasType;
+    use crate::types::{KnownClass, KnownInstanceType, Truthiness};
 
+    use ruff_db::system::DbWithWritableSystem as _;
     use ty_module_resolver::KnownModule;
 
     #[test]
@@ -1650,6 +1654,62 @@ mod tests {
         let union = UnionType::from_elements(&db, [t0, t1]).expect_union();
 
         assert_eq!(union.elements(&db), &[t0, t1]);
+    }
+
+    fn map_marker<'db>(ty: &Type<'db>, marker: Type<'db>, replacement: Type<'db>) -> Type<'db> {
+        if *ty == marker { replacement } else { *ty }
+    }
+
+    #[test]
+    fn map_rebuilds_prefix_for_literal_widening() {
+        let db = setup_db();
+
+        let marker = KnownClass::Str.to_instance(&db);
+        let literal_limit =
+            i64::try_from(MAX_NON_RECURSIVE_UNION_LITERALS).expect("literal limit fits in i64");
+        let widening_literal = Type::int_literal(literal_limit);
+        let expected = KnownClass::Int.to_instance(&db);
+
+        let elements = (0..literal_limit).map(Type::int_literal).chain([marker]);
+        let union = UnionType::from_elements(&db, elements).expect_union();
+
+        assert_eq!(
+            union.map(&db, |ty| map_marker(ty, marker, widening_literal)),
+            expected
+        );
+        assert_eq!(
+            union.map_leave_aliases(&db, |ty| map_marker(ty, marker, widening_literal)),
+            expected
+        );
+        assert_eq!(
+            union.try_map(&db, |ty| Some(map_marker(ty, marker, widening_literal))),
+            Some(expected)
+        );
+    }
+
+    #[test]
+    fn map_preserves_alias_unpacking_behavior() {
+        let mut db = setup_db();
+        db.write_dedented("/src/a.py", "type Alias = int").unwrap();
+
+        let module = ruff_db::files::system_path_to_file(&db, "/src/a.py").unwrap();
+        let alias_ty = global_symbol(&db, module, "Alias").place.expect_type();
+        let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias))) =
+            alias_ty
+        else {
+            panic!("Expected `Alias` to be a type alias");
+        };
+
+        let alias = Type::TypeAlias(TypeAliasType::PEP695(alias));
+        let str_instance = KnownClass::Str.to_instance(&db);
+        let union_ty = UnionType::from_elements_leave_aliases(&db, [alias, str_instance]);
+        let union = union_ty.expect_union();
+        let unpacked =
+            UnionType::from_elements(&db, [KnownClass::Int.to_instance(&db), str_instance]);
+
+        assert_eq!(union.map(&db, |ty| *ty), unpacked);
+        assert_eq!(union.try_map(&db, |ty| Some(*ty)), Some(unpacked));
+        assert_eq!(union.map_leave_aliases(&db, |ty| *ty), union_ty);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Second attempt at https://github.com/astral-sh/ruff/pull/24929

Unlike https://github.com/astral-sh/ruff/pull/24929, this PR now

* Ensures that `map` and `try_map` don't preserve `TypeAliases`
* It doesn't use `push_normalized` to ensure we correctly widen literals


All credit goes to @mtshiba 

## Test Plan

Added tests, although I'm not sure if we should keep them. 

Let's see if the memory report is neutral on this one
