### PR TITLE
[`flake8-pytest-style`] Drop irrelevant row type from PT007 message for single-name parametrize

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -204,6 +204,7 @@ impl Violation for PytestParametrizeNamesWrongType {
 pub(crate) struct PytestParametrizeValuesWrongType {
     values: types::ParametrizeValuesType,
     row: types::ParametrizeValuesRowType,
+    is_multi_named: bool,
 }
 
 impl Violation for PytestParametrizeValuesWrongType {
@@ -211,13 +212,29 @@ impl Violation for PytestParametrizeValuesWrongType {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let PytestParametrizeValuesWrongType { values, row } = self;
-        format!("Wrong values type in `pytest.mark.parametrize` expected `{values}` of `{row}`")
+        let PytestParametrizeValuesWrongType {
+            values,
+            row,
+            is_multi_named,
+        } = self;
+        if *is_multi_named {
+            format!("Wrong values type in `pytest.mark.parametrize` expected `{values}` of `{row}`")
+        } else {
+            format!("Wrong values type in `pytest.mark.parametrize` expected `{values}`")
+        }
     }
 
     fn fix_title(&self) -> Option<String> {
-        let PytestParametrizeValuesWrongType { values, row } = self;
-        Some(format!("Use `{values}` of `{row}` for parameter values"))
+        let PytestParametrizeValuesWrongType {
+            values,
+            row,
+            is_multi_named,
+        } = self;
+        if *is_multi_named {
+            Some(format!("Use `{values}` of `{row}` for parameter values"))
+        } else {
+            Some(format!("Use `{values}` for parameter values"))
+        }
     }
 }
 
@@ -524,6 +541,7 @@ fn check_values(checker: &Checker, names: &Expr, values: &Expr) {
                     PytestParametrizeValuesWrongType {
                         values: values_type,
                         row: values_row_type,
+                        is_multi_named,
                     },
                     values.range(),
                 );
@@ -571,6 +589,7 @@ fn check_values(checker: &Checker, names: &Expr, values: &Expr) {
                     PytestParametrizeValuesWrongType {
                         values: values_type,
                         row: values_row_type,
+                        is_multi_named,
                     },
                     values.range(),
                 );
@@ -776,6 +795,7 @@ fn handle_value_rows(
                     PytestParametrizeValuesWrongType {
                         values: values_type,
                         row: values_row_type,
+                        is_multi_named: true,
                     },
                     elt.range(),
                 );
@@ -815,6 +835,7 @@ fn handle_value_rows(
                     PytestParametrizeValuesWrongType {
                         values: values_type,
                         row: values_row_type,
+                        is_multi_named: true,
                     },
                     elt.range(),
                 );

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_lists.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_lists.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 ---
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
  --> PT007.py:4:35
   |
 4 | @pytest.mark.parametrize("param", (1, 2))
@@ -9,7 +9,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 5 | def test_tuple(param):
 6 |     ...
   |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 1 | import pytest
 2 |
 3 |

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_tuples.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_tuples.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 ---
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
  --> PT007.py:4:35
   |
 4 | @pytest.mark.parametrize("param", (1, 2))
@@ -9,7 +9,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tup
 5 | def test_tuple(param):
 6 |     ...
   |
-help: Use `list` of `tuple` for parameter values
+help: Use `list` for parameter values
 1 | import pytest
 2 |
 3 |

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_lists.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_lists.snap
@@ -43,7 +43,7 @@ help: Use `tuple` of `list` for parameter values
 16 | def test_tuple_of_tuples(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:31:35
    |
 31 | @pytest.mark.parametrize("param", [1, 2])
@@ -51,7 +51,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 32 | def test_list(param):
 33 |     ...
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 28 |     ...
 29 |
 30 |
@@ -188,7 +188,7 @@ help: Use `tuple` of `list` for parameter values
 66 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:71:5
    |
 69 |   @pytest.mark.parametrize(
@@ -201,7 +201,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 75 |   )
 76 |   def test_single_list_of_lists(param):
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 68 |
 69 | @pytest.mark.parametrize(
 70 |     "param",
@@ -216,7 +216,7 @@ help: Use `tuple` of `list` for parameter values
 77 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:80:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -224,7 +224,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
 82 | @pytest.mark.parametrize("d", [3,])
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 77 |     ...
 78 |
 79 |
@@ -275,7 +275,7 @@ help: Use `tuple` of `list` for parameter values
 84 |     "d",
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:82:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -285,7 +285,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 83 | @pytest.mark.parametrize(
 84 |     "d",
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 79 |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
@@ -296,7 +296,7 @@ help: Use `tuple` of `list` for parameter values
 85 |     [("3", "4")],
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:85:5
    |
 83 | @pytest.mark.parametrize(
@@ -306,7 +306,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 86 | )
 87 | @pytest.mark.parametrize(
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 82 | @pytest.mark.parametrize("d", [3,])
 83 | @pytest.mark.parametrize(
 84 |     "d",
@@ -317,7 +317,7 @@ help: Use `tuple` of `list` for parameter values
 88 |     "e",
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:89:5
    |
 87 | @pytest.mark.parametrize(
@@ -327,7 +327,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 90 | )
 91 | def test_multiple_decorators(a, b, c, d, e):
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 86 | )
 87 | @pytest.mark.parametrize(
 88 |     "e",

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
@@ -43,7 +43,7 @@ help: Use `tuple` of `tuple` for parameter values
 27 | def test_tuple_of_lists(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:31:35
    |
 31 | @pytest.mark.parametrize("param", [1, 2])
@@ -51,7 +51,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 32 | def test_list(param):
 33 |     ...
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 28 |     ...
 29 |
 30 |
@@ -230,7 +230,7 @@ help: Use `tuple` of `tuple` for parameter values
 65 | def test_csv_name_list_of_lists(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:71:5
    |
 69 |   @pytest.mark.parametrize(
@@ -243,7 +243,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 75 |   )
 76 |   def test_single_list_of_lists(param):
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 68 |
 69 | @pytest.mark.parametrize(
 70 |     "param",
@@ -258,7 +258,7 @@ help: Use `tuple` of `tuple` for parameter values
 77 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:80:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -266,7 +266,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
 82 | @pytest.mark.parametrize("d", [3,])
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 77 |     ...
 78 |
 79 |
@@ -277,7 +277,7 @@ help: Use `tuple` of `tuple` for parameter values
 83 | @pytest.mark.parametrize(
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:82:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -287,7 +287,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 83 | @pytest.mark.parametrize(
 84 |     "d",
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 79 |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
@@ -298,7 +298,7 @@ help: Use `tuple` of `tuple` for parameter values
 85 |     [("3", "4")],
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:85:5
    |
 83 | @pytest.mark.parametrize(
@@ -308,7 +308,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 86 | )
 87 | @pytest.mark.parametrize(
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 82 | @pytest.mark.parametrize("d", [3,])
 83 | @pytest.mark.parametrize(
 84 |     "d",
@@ -319,7 +319,7 @@ help: Use `tuple` of `tuple` for parameter values
 88 |     "e",
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:89:5
    |
 87 | @pytest.mark.parametrize(
@@ -329,7 +329,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 90 | )
 91 | def test_multiple_decorators(a, b, c, d, e):
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 86 | )
 87 | @pytest.mark.parametrize(
 88 |     "e",


### PR DESCRIPTION
Closes #14743.

When `pytest.mark.parametrize` has a single name, the row type is irrelevant: each row is a single value, not a sequence. The current message says `expected `tuple` of `tuple`` for `@pytest.mark.parametrize("x", [1, 2])`, which is misleading because the fix produces a flat `(1, 2)`, not a tuple of tuples.

This adds an `is_multi_named` flag to the diagnostic and drops the `of `row`` suffix in the single-name case. Multi-name violations and inner-row violations (which are only emitted for multi-name) keep the full message.

Snapshot diffs only touch single-name occurrences.