### PR TITLE
[`flake8-type-checking`] Minimize quote escapes in TC006 fix

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC006.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC006.py
@@ -76,6 +76,14 @@ def f():
 
 
 def f():
+    # Regression test for #22131: avoid nested escapes when content
+    # contains the preferred outer quote character.
+    from typing import cast, Literal
+
+    cast(Literal["'"], "'")
+
+
+def f():
     # Really complex case with nested forward references
     from typing import cast, Annotated, Literal
 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::helpers::{map_callable, map_subscript};
 use ruff_python_ast::name::QualifiedName;
 use ruff_python_ast::str::Quote;
 use ruff_python_ast::visitor::transformer::{Transformer, walk_expr};
-use ruff_python_ast::{self as ast, Decorator, Expr, StringLiteralFlags};
+use ruff_python_ast::{self as ast, Decorator, Expr, StringFlags, StringLiteralFlags};
 use ruff_python_codegen::{Generator, Stylist};
 use ruff_python_parser::typing::parse_type_annotation;
 use ruff_python_semantic::{
@@ -426,11 +426,22 @@ impl<'a> QuoteAnnotator<'a> {
         // generate the string literal with the preferred quote
         let subgenerator = Generator::new(self.stylist.indentation(), self.stylist.line_ending());
         let annotation = subgenerator.expr(&expr_without_forward_references);
+        // Forward-reference type expressions cannot contain backslash escapes
+        // (PEP 484). Pick the outer quote that minimizes escapes in the wrapped
+        // annotation, falling back to the preferred quote when there's a tie.
+        let preferred = self.flags.quote_style();
+        let preferred_count = annotation.matches(preferred.as_char()).count();
+        let opposite_count = annotation.matches(preferred.opposite().as_char()).count();
+        let flags = if preferred_count > opposite_count {
+            self.flags.with_quote_style(preferred.opposite())
+        } else {
+            self.flags
+        };
         generator.expr(&Expr::from(ast::StringLiteral {
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             value: annotation.into_boxed_str(),
-            flags: self.flags,
+            flags,
         }))
     }
 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-cast-value_TC006.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-cast-value_TC006.py.snap
@@ -168,69 +168,87 @@ help: Add quotes
 78 | def f():
 
 TC006 [*] Add quotes to type expression in `typing.cast()`
-  --> TC006.py:82:10
+  --> TC006.py:83:10
    |
-80 |     from typing import cast, Annotated, Literal
-81 |
-82 |     cast(list[Annotated["list['Literal[\"A\"]']", "Foo"]], ['A'])
+81 |     from typing import cast, Literal
+82 |
+83 |     cast(Literal["'"], "'")
+   |          ^^^^^^^^^^^^
+   |
+help: Add quotes
+80 |     # contains the preferred outer quote character.
+81 |     from typing import cast, Literal
+82 |
+   -     cast(Literal["'"], "'")
+83 +     cast('Literal["\'"]', "'")
+84 |
+85 |
+86 | def f():
+
+TC006 [*] Add quotes to type expression in `typing.cast()`
+  --> TC006.py:90:10
+   |
+88 |     from typing import cast, Annotated, Literal
+89 |
+90 |     cast(list[Annotated["list['Literal[\"A\"]']", "Foo"]], ['A'])
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: Add quotes
-79 |     # Really complex case with nested forward references
-80 |     from typing import cast, Annotated, Literal
-81 |
+87 |     # Really complex case with nested forward references
+88 |     from typing import cast, Annotated, Literal
+89 |
    -     cast(list[Annotated["list['Literal[\"A\"]']", "Foo"]], ['A'])
-82 +     cast("list[Annotated[list[Literal['A']], 'Foo']]", ['A'])
-83 |
-84 |
-85 | def f():
-
-TC006 [*] Add quotes to type expression in `typing.cast()`
-  --> TC006.py:89:9
-   |
-88 |     cast(
-89 |         int  # TC006
-   |         ^^^
-90 |         , 6.0
-91 |     )
-   |
-help: Add quotes
-86 |     from typing import cast
-87 |
-88 |     cast(
-   -         int  # TC006
-89 +         "int"  # TC006
-90 |         , 6.0
-91 |     )
+90 +     cast("list[Annotated[list[Literal['A']], 'Foo']]", ['A'])
+91 |
 92 |
+93 | def f():
 
 TC006 [*] Add quotes to type expression in `typing.cast()`
-  --> TC006.py:98:14
+  --> TC006.py:97:9
    |
-96 |     from typing import cast
-97 |
-98 |     cast(typ=int, val=3.0)  # TC006
-   |              ^^^
-99 |     cast(val=3.0, typ=int)  # TC006
+96 |     cast(
+97 |         int  # TC006
+   |         ^^^
+98 |         , 6.0
+99 |     )
    |
 help: Add quotes
-95 |     # Keyword arguments
-96 |     from typing import cast
-97 |
-   -     cast(typ=int, val=3.0)  # TC006
-98 +     cast(typ="int", val=3.0)  # TC006
-99 |     cast(val=3.0, typ=int)  # TC006
+94  |     from typing import cast
+95  |
+96  |     cast(
+    -         int  # TC006
+97  +         "int"  # TC006
+98  |         , 6.0
+99  |     )
+100 |
 
 TC006 [*] Add quotes to type expression in `typing.cast()`
-  --> TC006.py:99:23
-   |
-98 |     cast(typ=int, val=3.0)  # TC006
-99 |     cast(val=3.0, typ=int)  # TC006
-   |                       ^^^
-   |
+   --> TC006.py:106:14
+    |
+104 |     from typing import cast
+105 |
+106 |     cast(typ=int, val=3.0)  # TC006
+    |              ^^^
+107 |     cast(val=3.0, typ=int)  # TC006
+    |
 help: Add quotes
-96 |     from typing import cast
-97 |
-98 |     cast(typ=int, val=3.0)  # TC006
-   -     cast(val=3.0, typ=int)  # TC006
-99 +     cast(val=3.0, typ="int")  # TC006
+103 |     # Keyword arguments
+104 |     from typing import cast
+105 |
+    -     cast(typ=int, val=3.0)  # TC006
+106 +     cast(typ="int", val=3.0)  # TC006
+107 |     cast(val=3.0, typ=int)  # TC006
+
+TC006 [*] Add quotes to type expression in `typing.cast()`
+   --> TC006.py:107:23
+    |
+106 |     cast(typ=int, val=3.0)  # TC006
+107 |     cast(val=3.0, typ=int)  # TC006
+    |                       ^^^
+    |
+help: Add quotes
+104 |     from typing import cast
+105 |
+106 |     cast(typ=int, val=3.0)  # TC006
+    -     cast(val=3.0, typ=int)  # TC006
+107 +     cast(val=3.0, typ="int")  # TC006


### PR DESCRIPTION
Refs #22131.

When the inner annotation rendered by `QuoteAnnotator` contains the preferred outer quote character more often than the opposite, wrap with the opposite quote instead so we emit fewer escape sequences.

Concretely, before this change `cast(Literal["'"], "'")` was rewritten to `cast("Literal[\"'\"]", "'")` (two backslash escapes inside a forward reference, which ty rejects). After the change the same input becomes `cast('Literal["\\'"]', "'")` (one escape).

This is a partial fix: when the inner content contains both quote characters there's no escape-free wrapping, and we still emit one escape rather than skipping the fix. Eliminating that case would require making the rule `Sometimes`-fixable, which is a larger change.