### PR TITLE
Skip cache key when file metadata is unreadable

### DIFF
--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use std::ops::{Add, AddAssign};
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use colored::Colorize;
 use log::{debug, warn};
 use ruff_db::diagnostic::Diagnostic;
@@ -191,17 +191,24 @@ pub(crate) fn lint_path(
                 .relative_path(path)
                 .expect("wrong package cache for file");
 
-            let cache_key = FileCacheKey::from_path(path).context("Failed to create cache key")?;
-            let cached_diagnostics = cache
-                .get(relative_path, &cache_key)
-                .is_some_and(FileCache::linted);
-            if cached_diagnostics {
-                return Ok(Diagnostics::default());
-            }
+            // If the file metadata is unreadable (e.g. broken symlink), skip
+            // caching and fall through; the source-load step below will surface
+            // the underlying IO error as a normal diagnostic.
+            match FileCacheKey::from_path(path) {
+                Ok(cache_key) => {
+                    let cached_diagnostics = cache
+                        .get(relative_path, &cache_key)
+                        .is_some_and(FileCache::linted);
+                    if cached_diagnostics {
+                        return Ok(Diagnostics::default());
+                    }
 
-            // Stash the file metadata for later so when we update the cache it reflects the prerun
-            // information
-            Some((cache, relative_path, cache_key))
+                    // Stash the file metadata for later so when we update the cache it reflects
+                    // the prerun information
+                    Some((cache, relative_path, cache_key))
+                }
+                Err(_) => None,
+            }
         }
         _ => None,
     };

--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -1741,6 +1741,38 @@ fn unreadable_pyproject_toml() -> Result<()> {
     Ok(())
 }
 
+/// Regression test for #19421: a broken symlink should be reported as a
+/// regular IO error (or warned about), not crash with "Failed to create cache key".
+#[cfg(unix)]
+#[test]
+fn broken_symlink() -> Result<()> {
+    let tempdir = TempDir::new()?;
+    let target = tempdir.path().join("does_not_exist.py");
+    let link = tempdir.path().join("blah.py");
+    std::os::unix::fs::symlink(&target, &link)?;
+
+    let mut cmd = RuffCheck::default()
+        .filename(link.to_str().unwrap())
+        .args([])
+        .build();
+    insta::with_settings!({filters => vec![
+        (link.display().to_string().as_str(), "[BLAH_PY]"),
+    ]}, {
+        assert_cmd_snapshot!(cmd, @r"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+        E902 No such file or directory (os error 2)
+         --> [BLAH_PY]:1:1
+
+        Found 1 error.
+
+        ----- stderr -----
+        ");
+    });
+    Ok(())
+}
+
 /// Check the output with an unreadable directory
 #[cfg(unix)]
 #[test]


### PR DESCRIPTION
Closes #19421.

When ruff hits a path whose metadata can't be read (e.g. a symlink whose target was deleted), `FileCacheKey::from_path` returns the underlying `io::Error` and the lint pipeline aborts with `Failed to create cache key` (E902 with exit code 1).

The formatter side already swallows this error and skips caching for that file. Mirror the same behavior on the lint side: if the cache key can't be built, don't cache, and let `SourceKind::from_path` surface the IO error through the normal `from_source_error` path. The user gets the same E902 they would get for any missing file (or a warning when E902 is disabled), and the run no longer dies on the first broken symlink it encounters.