### PR TITLE
docs: F901 - Clarify NotImplemented is a value, not an exception

### DIFF
--- a/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -10,11 +10,10 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// Checks for `raise` statements that raise `NotImplemented`.
 ///
 /// ## Why is this bad?
-/// `NotImplemented` is an exception used by binary special methods to indicate
+/// `NotImplemented` is a special value returned by binary special methods to indicate
 /// that an operation is not implemented with respect to a particular type.
 ///
-/// `NotImplemented` should not be raised directly. Instead, raise
-/// `NotImplementedError`, which is used to indicate that the method is
+/// Raise `NotImplementedError` instead, which is used to indicate that a method is
 /// abstract or not implemented in the derived class.
 ///
 /// ## Example

--- a/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -13,6 +13,7 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// `NotImplemented` is a special value returned by binary special methods to indicate
 /// that an operation is not implemented with respect to a particular type.
 ///
+/// Because `NotImplemented` is not an exception, it cannot be raised.
 /// Raise `NotImplementedError` instead, which is used to indicate that a method is
 /// abstract or not implemented in the derived class.
 ///


### PR DESCRIPTION
- clarified that `NotImplemented` is a value, not an exception

- changed a bit wording in a second paragaph too - "should not be raised directly" seems to imply a bit that `NotImplemented` could be raised in theory somehow.

Resolves https://github.com/astral-sh/ruff/issues/25047