### PR TITLE
[`flynt`] Skip FLY002 fix when joined content can't fit a raw literal

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flynt/FLY002.py
+++ b/crates/ruff_linter/resources/test/fixtures/flynt/FLY002.py
@@ -29,3 +29,9 @@ nok10 = "".join((foo, '"'))
 nok11 = ''.join((foo, "'"))
 nok12 = ''.join([foo, "'", '"'])
 nok13 = "".join([foo, "'", '"'])
+
+# Regression test for: https://github.com/astral-sh/ruff/issues/21082
+nok14 = "".join((r"", '"'))
+nok15 = "".join((r"", "\\"))
+nok16 = "".join((r"", "\0"))
+nok17 = "".join((r"abc", "def"))

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -69,6 +69,23 @@ fn is_static_length(elts: &[Expr]) -> bool {
     elts.iter().all(|e| !e.is_starred_expr())
 }
 
+/// Return whether `content` can appear inside a raw string literal with the
+/// given `flags` without parser errors. Raw literals cannot contain the chosen
+/// closing quote (or three of it for triple-quoted), cannot end with a single
+/// backslash, and cannot contain NUL bytes (Python source rejects those).
+fn raw_string_can_hold(content: &str, flags: ast::StringLiteralFlags) -> bool {
+    if content.contains('\0') {
+        return false;
+    }
+    if content.ends_with('\\') {
+        return false;
+    }
+    if content.contains(flags.quote_str()) {
+        return false;
+    }
+    true
+}
+
 /// Build an f-string consisting of `joinees` joined by `joiner` with `flags`.
 fn build_fstring(joiner: &str, joinees: &[Expr], flags: FStringFlags) -> Option<Expr> {
     // If all elements are string constants, join them into a single string.
@@ -104,6 +121,14 @@ fn build_fstring(joiner: &str, joinees: &[Expr], flags: FStringFlags) -> Option<
                     return None;
                 }
             }
+        }
+
+        // Raw strings can't represent arbitrary content (the chosen quote can't
+        // appear, nor a trailing backslash, nor a NUL byte in the source).
+        // If the merged content can't be expressed with the selected flags,
+        // bail rather than emit a fix that produces a syntax error.
+        if flags.prefix().is_raw() && !raw_string_can_hold(&content, flags) {
+            return None;
         }
 
         let node = ast::StringLiteral {

--- a/crates/ruff_linter/src/rules/flynt/snapshots/ruff_linter__rules__flynt__tests__FLY002_FLY002.py.snap
+++ b/crates/ruff_linter/src/rules/flynt/snapshots/ruff_linter__rules__flynt__tests__FLY002_FLY002.py.snap
@@ -205,4 +205,21 @@ help: Replace with `f"{foo}'"`
 29 + nok11 = f"{foo}'"
 30 | nok12 = ''.join([foo, "'", '"'])
 31 | nok13 = "".join([foo, "'", '"'])
+32 |
+note: This is an unsafe fix and may change runtime behavior
+
+FLY002 [*] Consider `r"abcdef"` instead of string join
+  --> FLY002.py:37:9
+   |
+35 | nok15 = "".join((r"", "\\"))
+36 | nok16 = "".join((r"", "\0"))
+37 | nok17 = "".join((r"abc", "def"))
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: Replace with `r"abcdef"`
+34 | nok14 = "".join((r"", '"'))
+35 | nok15 = "".join((r"", "\\"))
+36 | nok16 = "".join((r"", "\0"))
+   - nok17 = "".join((r"abc", "def"))
+37 + nok17 = r"abcdef"
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Closes #21082.

When the all-string-literal merge path picks the first joinee's flags, the merged content sometimes can't be represented in those flags. The existing fix already handles the raw + newline case by switching to triple quotes, but several other cases still slip through and produce syntax errors:

- raw double-quoted output containing `"` (closing quote in content)
- raw output ending in `\\` (raw literals can't end with a single backslash)
- output containing a NUL byte (Python source rejects them)

This adds an explicit `raw_string_can_hold` check after the existing newline branch and bails the fix when the content can't be expressed safely. Cases where the merged content is plain enough to live in either flavor (e.g. `\"\".join((r\"abc\", \"def\"))` → `r\"abcdef\"`) still get fixed.

New fixture entries cover all three failure modes and the still-fixable mixed-raw case.