### PR TITLE
[`flake8-annotations`] Don't infer `NoReturn` from raise inside potentially-skipped loop

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
@@ -325,3 +325,25 @@ class Class:
 # Test case: function that raises other exceptions should still get NoReturn
 def func():
     raise ValueError
+
+
+# https://github.com/astral-sh/ruff/issues/22315
+# A `for`/`while` loop body that always raises is conditional: the iterable may
+# be empty (or the test falsy), so the function may return None implicitly.
+class Test:
+    items_list = []
+
+    def method(self):
+        for item in self.items_list:
+            raise Exception(item)
+
+
+def while_var(x):
+    while x:
+        raise ValueError
+
+
+# `while True:` (always-truthy literal) does run the body, so NoReturn is fine.
+def while_true():
+    while True:
+        raise ValueError

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type.snap
@@ -842,4 +842,74 @@ help: Add return type annotation: `Never`
     - def func():
 326 + def func() -> Never:
 327 |     raise ValueError
+328 |
+329 |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `method`
+   --> auto_return_type.py:336:9
+    |
+334 |     items_list = []
+335 |
+336 |     def method(self):
+    |         ^^^^^^
+337 |         for item in self.items_list:
+338 |             raise Exception(item)
+    |
+help: Add return type annotation: `None`
+333 | class Test:
+334 |     items_list = []
+335 |
+    -     def method(self):
+336 +     def method(self) -> None:
+337 |         for item in self.items_list:
+338 |             raise Exception(item)
+339 |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `while_var`
+   --> auto_return_type.py:341:5
+    |
+341 | def while_var(x):
+    |     ^^^^^^^^^
+342 |     while x:
+343 |         raise ValueError
+    |
+help: Add return type annotation: `None`
+338 |             raise Exception(item)
+339 |
+340 |
+    - def while_var(x):
+341 + def while_var(x) -> None:
+342 |     while x:
+343 |         raise ValueError
+344 |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `while_true`
+   --> auto_return_type.py:347:5
+    |
+346 | # `while True:` (always-truthy literal) does run the body, so NoReturn is fine.
+347 | def while_true():
+    |     ^^^^^^^^^^
+348 |     while True:
+349 |         raise ValueError
+    |
+help: Add return type annotation: `Never`
+214 |         return 1
+215 |
+216 |
+    - from typing import overload
+217 + from typing import overload, Never
+218 |
+219 |
+220 | @overload
+--------------------------------------------------------------------------------
+344 |
+345 |
+346 | # `while True:` (always-truthy literal) does run the body, so NoReturn is fine.
+    - def while_true():
+347 + def while_true() -> Never:
+348 |     while True:
+349 |         raise ValueError
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type_py38.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type_py38.snap
@@ -946,4 +946,74 @@ help: Add return type annotation: `NoReturn`
     - def func():
 326 + def func() -> NoReturn:
 327 |     raise ValueError
+328 |
+329 |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `method`
+   --> auto_return_type.py:336:9
+    |
+334 |     items_list = []
+335 |
+336 |     def method(self):
+    |         ^^^^^^
+337 |         for item in self.items_list:
+338 |             raise Exception(item)
+    |
+help: Add return type annotation: `None`
+333 | class Test:
+334 |     items_list = []
+335 |
+    -     def method(self):
+336 +     def method(self) -> None:
+337 |         for item in self.items_list:
+338 |             raise Exception(item)
+339 |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `while_var`
+   --> auto_return_type.py:341:5
+    |
+341 | def while_var(x):
+    |     ^^^^^^^^^
+342 |     while x:
+343 |         raise ValueError
+    |
+help: Add return type annotation: `None`
+338 |             raise Exception(item)
+339 |
+340 |
+    - def while_var(x):
+341 + def while_var(x) -> None:
+342 |     while x:
+343 |         raise ValueError
+344 |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `while_true`
+   --> auto_return_type.py:347:5
+    |
+346 | # `while True:` (always-truthy literal) does run the body, so NoReturn is fine.
+347 | def while_true():
+    |     ^^^^^^^^^^
+348 |     while True:
+349 |         raise ValueError
+    |
+help: Add return type annotation: `NoReturn`
+214 |         return 1
+215 |
+216 |
+    - from typing import overload
+217 + from typing import overload, NoReturn
+218 |
+219 |
+220 | @overload
+--------------------------------------------------------------------------------
+344 |
+345 |
+346 | # `while True:` (always-truthy literal) does run the body, so NoReturn is fine.
+    - def while_true():
+347 + def while_true() -> NoReturn:
+348 |     while True:
+349 |         raise ValueError
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_python_semantic/src/analyze/terminal.rs
+++ b/crates/ruff_python_semantic/src/analyze/terminal.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::helpers::map_callable;
+use ruff_python_ast::helpers::{is_const_true, map_callable};
 use ruff_python_ast::{self as ast, ExceptHandler, Stmt};
 
 use crate::model::SemanticModel;
@@ -51,13 +51,39 @@ impl Terminal {
 
         for stmt in stmts {
             match stmt {
-                Stmt::For(ast::StmtFor { body, orelse, .. })
-                | Stmt::While(ast::StmtWhile { body, orelse, .. }) => {
+                Stmt::For(ast::StmtFor { body, orelse, .. }) => {
                     if always_breaks(body) {
                         continue;
                     }
 
-                    terminal = terminal.and_then(Self::from_body(body, semantic));
+                    // The iterable may be empty, so the loop body might not run.
+                    // Branch the body's terminal with `Implicit` to model the
+                    // path where the body doesn't execute at all.
+                    let loop_terminal = Self::from_body(body, semantic).branch(Terminal::Implicit);
+                    terminal = terminal.and_then(loop_terminal);
+
+                    if !sometimes_breaks(body, semantic) {
+                        terminal = terminal.and_then(Self::from_body(orelse, semantic));
+                    }
+                }
+                Stmt::While(ast::StmtWhile {
+                    test, body, orelse, ..
+                }) => {
+                    if always_breaks(body) {
+                        continue;
+                    }
+
+                    let body_terminal = Self::from_body(body, semantic);
+                    // `while True:` (and other always-truthy literal tests)
+                    // executes the body at least once, so the body's terminal
+                    // is also the loop's. Otherwise the test may be falsy on
+                    // entry and the body never runs.
+                    let loop_terminal = if is_const_true(test) {
+                        body_terminal
+                    } else {
+                        body_terminal.branch(Terminal::Implicit)
+                    };
+                    terminal = terminal.and_then(loop_terminal);
 
                     if !sometimes_breaks(body, semantic) {
                         terminal = terminal.and_then(Self::from_body(orelse, semantic));


### PR DESCRIPTION
Closes #22315.

`Terminal::from_body` was treating a `for`/`while` loop body's terminal as if it were the loop's terminal. That's wrong when the iterable might be empty (or the test might be falsy on entry): the body never runs and the function falls through to an implicit return. The bug surfaces in ANN201's auto-fix, where a method that does nothing but `for x in self.items: raise Exception(x)` was being annotated `-> NoReturn` even though `self.items == []` makes it return `None`.

Splits the combined for/while arm in `Terminal::from_body` and branches the body's terminal with `Implicit` to model the zero-iteration path. `while` keeps its existing behavior when the test is a literal truthy constant (`while True:` etc.), since that case really does enter the body at least once. Existing tests cover the always-true case; new fixture entries cover the for-with-raise and conditional-while-with-raise cases.