### PR TITLE
[`fastapi`] Resolve type aliases when looking for `Depends` (`FAST003`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -369,3 +369,33 @@ async def read_thing_callable_dep_instance_default(query: str = Depends(Callable
 # Error: `__call__` has `other`, not `thing_id`.
 @app.get("/things/{thing_id}")
 async def read_thing_init_and_call_instance_default(query: str = Depends(InitAndCallQuery())): ...
+
+
+# https://github.com/astral-sh/ruff/issues/21075
+# `Annotated[..., Depends(...)]` hidden behind a type alias.
+ThingDep = Annotated[dict, Depends(takes_thing_id)]
+OtherDep = Annotated[dict, Depends(something_else)]
+NonDependsAlias = Annotated[dict, "metadata"]
+
+
+# OK: alias resolves to `Annotated[..., Depends(takes_thing_id)]`, which covers `thing_id`.
+@app.get("/aliased/{thing_id}")
+async def read_thing_aliased(thing: ThingDep): ...
+
+
+# Error: alias resolves to `Annotated[..., Depends(something_else)]`, which doesn't cover `thing_id`.
+@app.get("/aliased/{thing_id}")
+async def read_thing_aliased_wrong(thing: OtherDep): ...
+
+
+# Error: alias is `Annotated[..., "metadata"]` — no `Depends`, so `thing_id` is unused.
+@app.get("/aliased/{thing_id}")
+async def read_thing_aliased_no_depends(thing: NonDependsAlias): ...
+
+
+# OK: `type` statement (PEP 695) alias to `Annotated[..., Depends(...)]`.
+type ThingDepPep695 = Annotated[dict, Depends(takes_thing_id)]
+
+
+@app.get("/aliased/{thing_id}")
+async def read_thing_aliased_pep695(thing: ThingDepPep695): ...

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -268,7 +268,8 @@ impl<'a> Dependency<'a> {
             return Some(dependency);
         }
 
-        let ExprSubscript { value, slice, .. } = parameter.annotation()?.as_subscript_expr()?;
+        let ExprSubscript { value, slice, .. } =
+            annotated_subscript(parameter.annotation()?, semantic)?;
 
         if !semantic.match_typing_expr(value, "Annotated") {
             return None;
@@ -416,6 +417,44 @@ impl<'a> Dependency<'a> {
 
         Some(Self::Class(parameter_names))
     }
+}
+
+/// Resolve an annotation expression to its underlying subscript, peeking through a single
+/// level of type-alias indirection.
+///
+/// For `Annotated[X, ...]`, returns the subscript directly. For a [`ast::ExprName`] whose
+/// binding is a module-level assignment of the form `Alias = Annotated[X, ...]`, returns the
+/// right-hand side subscript. Anything more involved (re-aliasing, conditional aliases, type
+/// inference) is left to type checkers.
+///
+/// Uses [`SemanticModel::lookup_symbol`] rather than [`SemanticModel::resolve_name`] so the
+/// lookup also works during deferred annotation evaluation (PEP 649 / `from __future__ import
+/// annotations`), where the annotation's [`ast::ExprName`] has not yet been resolved.
+fn annotated_subscript<'a>(
+    annotation: &'a Expr,
+    semantic: &SemanticModel<'a>,
+) -> Option<&'a ExprSubscript> {
+    if let Expr::Subscript(subscript) = annotation {
+        return Some(subscript);
+    }
+
+    let name = annotation.as_name_expr()?;
+    let binding = semantic
+        .lookup_symbol(name.id.as_str())
+        .map(|id| semantic.binding(id))?;
+
+    if !matches!(binding.kind, BindingKind::Assignment) {
+        return None;
+    }
+
+    let value = match binding.statement(semantic)? {
+        ast::Stmt::Assign(ast::StmtAssign { value, .. }) => value.as_ref(),
+        ast::Stmt::AnnAssign(ast::StmtAnnAssign { value, .. }) => value.as_deref()?,
+        ast::Stmt::TypeAlias(ast::StmtTypeAlias { value, .. }) => value.as_ref(),
+        _ => return None,
+    };
+
+    value.as_subscript_expr()
 }
 
 fn depends_arguments<'a>(expr: &'a Expr, semantic: &SemanticModel) -> Option<&'a Arguments> {

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
@@ -533,4 +533,45 @@ help: Add `thing_id` to function signature
 370 | @app.get("/things/{thing_id}")
     - async def read_thing_init_and_call_instance_default(query: str = Depends(InitAndCallQuery())): ...
 371 + async def read_thing_init_and_call_instance_default(thing_id, query: str = Depends(InitAndCallQuery())): ...
+372 |
+373 |
+374 | # https://github.com/astral-sh/ruff/issues/21075
+note: This is an unsafe fix and may change runtime behavior
+
+FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_aliased_wrong` signature
+   --> FAST003.py:387:20
+    |
+386 | # Error: alias resolves to `Annotated[..., Depends(something_else)]`, which doesn't cover `thing_id`.
+387 | @app.get("/aliased/{thing_id}")
+    |                    ^^^^^^^^^^
+388 | async def read_thing_aliased_wrong(thing: OtherDep): ...
+    |
+help: Add `thing_id` to function signature
+385 |
+386 | # Error: alias resolves to `Annotated[..., Depends(something_else)]`, which doesn't cover `thing_id`.
+387 | @app.get("/aliased/{thing_id}")
+    - async def read_thing_aliased_wrong(thing: OtherDep): ...
+388 + async def read_thing_aliased_wrong(thing: OtherDep, thing_id): ...
+389 |
+390 |
+391 | # Error: alias is `Annotated[..., "metadata"]` — no `Depends`, so `thing_id` is unused.
+note: This is an unsafe fix and may change runtime behavior
+
+FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_aliased_no_depends` signature
+   --> FAST003.py:392:20
+    |
+391 | # Error: alias is `Annotated[..., "metadata"]` — no `Depends`, so `thing_id` is unused.
+392 | @app.get("/aliased/{thing_id}")
+    |                    ^^^^^^^^^^
+393 | async def read_thing_aliased_no_depends(thing: NonDependsAlias): ...
+    |
+help: Add `thing_id` to function signature
+390 |
+391 | # Error: alias is `Annotated[..., "metadata"]` — no `Depends`, so `thing_id` is unused.
+392 | @app.get("/aliased/{thing_id}")
+    - async def read_thing_aliased_no_depends(thing: NonDependsAlias): ...
+393 + async def read_thing_aliased_no_depends(thing: NonDependsAlias, thing_id): ...
+394 |
+395 |
+396 | # OK: `type` statement (PEP 695) alias to `Annotated[..., Depends(...)]`.
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Closes #21075.

When a route parameter is annotated with a type alias such as `ThingDep = Annotated[dict, Depends(get_thing)]`, FAST003 only inspected the parameter's syntactic annotation, never followed the alias, and so missed the `Depends(...)` injection. Any path parameter that the dependency was supplying ended up reported as missing from the route signature.

The fix peeks one level through the alias when the annotation is an `ExprName`. If the binding is a module-level assignment (`Alias = ...`, `Alias: TypeAlias = ...`, or `type Alias = ...`) whose right-hand side is a subscript, we treat that subscript as the synthesized annotation and reuse the existing `Annotated[..., Depends(...)]` extraction. Lookup goes through `SemanticModel::lookup_symbol` so the alias is resolvable even when annotations are deferred (PEP 649 / `from __future__ import annotations`).

The resolution stays deliberately narrow: it doesn't chase aliases-of-aliases, conditional bindings, or anything that would require type inference. Aliases imported from other modules are not followed either.