### PR TITLE
[`pyupgrade`] Document UP047 bound and constraint preservation

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP047_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP047_0.py
@@ -63,3 +63,23 @@ def multi_param(t: list[T], c: Callable[[T], None]) -> T:
 def outer():
     def inner(t: T) -> T:
         return t
+
+
+# https://github.com/astral-sh/ruff/issues/19155
+# constraints on a `TypeVar` should be preserved in the generated type parameter
+class Class1: ...
+class Class2: ...
+SameClassT = TypeVar("SameClassT", Class1, Class2)
+
+
+def issue_19155(arg: SameClassT) -> SameClassT:
+    return arg
+
+
+# https://github.com/astral-sh/ruff/issues/19155
+# `bound` on a `TypeVar` should be preserved in the generated type parameter
+BoundedT = TypeVar("BoundedT", bound=Class1)
+
+
+def issue_19155_bound(arg: BoundedT) -> BoundedT:
+    return arg

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
@@ -59,6 +59,45 @@ use super::{DisplayTypeVars, TypeVarReferenceVisitor, check_type_vars, in_nested
 ///     return var
 /// ```
 ///
+/// `bound` and constraint arguments on the original `TypeVar` are preserved
+/// in the new type parameter syntax. For a `TypeVar` with a `bound`:
+///
+/// ```python
+/// from typing import TypeVar
+///
+/// T = TypeVar("T", bound=int)
+///
+///
+/// def generic_function(var: T) -> T:
+///     return var
+/// ```
+///
+/// becomes:
+///
+/// ```python
+/// def generic_function[T: int](var: T) -> T:
+///     return var
+/// ```
+///
+/// And for a `TypeVar` with constraints:
+///
+/// ```python
+/// from typing import TypeVar
+///
+/// T = TypeVar("T", int, str)
+///
+///
+/// def generic_function(var: T) -> T:
+///     return var
+/// ```
+///
+/// becomes:
+///
+/// ```python
+/// def generic_function[T: (int, str)](var: T) -> T:
+///     return var
+/// ```
+///
 /// ## See also
 ///
 /// This rule replaces standalone type variables in function signatures but doesn't remove

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP047_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP047_0.py.snap
@@ -136,3 +136,37 @@ help: Use type parameters
 58 |     return t[1]
 59 |
 note: This is an unsafe fix and may change runtime behavior
+
+UP047 [*] Generic function `issue_19155` should use type parameters
+  --> UP047_0.py:75:5
+   |
+75 | def issue_19155(arg: SameClassT) -> SameClassT:
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+76 |     return arg
+   |
+help: Use type parameters
+72 | SameClassT = TypeVar("SameClassT", Class1, Class2)
+73 |
+74 |
+   - def issue_19155(arg: SameClassT) -> SameClassT:
+75 + def issue_19155[SameClassT: (Class1, Class2)](arg: SameClassT) -> SameClassT:
+76 |     return arg
+77 |
+78 |
+note: This is an unsafe fix and may change runtime behavior
+
+UP047 [*] Generic function `issue_19155_bound` should use type parameters
+  --> UP047_0.py:84:5
+   |
+84 | def issue_19155_bound(arg: BoundedT) -> BoundedT:
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+85 |     return arg
+   |
+help: Use type parameters
+81 | BoundedT = TypeVar("BoundedT", bound=Class1)
+82 |
+83 |
+   - def issue_19155_bound(arg: BoundedT) -> BoundedT:
+84 + def issue_19155_bound[BoundedT: Class1](arg: BoundedT) -> BoundedT:
+85 |     return arg
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Closes #19155.

The reporter expected the UP047 autofix to drop `bound=` and constraint arguments when rewriting `TypeVar`-style generics to PEP 695, and a follow-up commenter noted they had to read the issue thread to learn that the rule actually preserves both. The rule has been preserving them since [#15565](https://github.com/astral-sh/ruff/pull/15565), but the rule docs only show the plain `T = TypeVar("T")` case, so the behavior wasn't discoverable without applying the unsafe fix.

This adds the two missing examples (one with `bound=int`, one with constraints `int, str`) to the rule docstring so the docs page surfaces the same `[T: int]` / `[T: (int, str)]` output the rule already emits. It also adds two fixture entries tagged with the issue URL — one mirroring the `TypeVar("SameClassT", Class1, Class2)` constraints scenario from the original report, and one for `bound=`. Both lock in the existing autofix output so any future regression in the shared `DisplayTypeVars` machinery would show up here.

No behavior change.