### PR TITLE
[`ruff`] Flag `fmt: off`/`fmt: on` around class signatures (`RUF028`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF028.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF028.py
@@ -101,3 +101,38 @@ import pytest
 )  # fmt: skip
 def test_eval(test_input, expected):
     assert eval(test_input) == expected
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/20425
+# `fmt: off`/`fmt: on` between a class header and its body is invalid because
+# the formatter treats the comment as dangling on the class definition.
+# fmt: off
+class FmtOnAfterClassHeader(SomeBase[
+    int,
+    str,
+]):
+# fmt: on
+    pass
+
+
+# fmt: off
+class FmtOnAfterSimpleClassHeader:
+# fmt: on
+    x = 1
+
+
+# fmt: off
+def fmt_on_after_function_header(
+    x: int,
+    y: str,
+):
+# fmt: on
+    pass
+
+
+# Comments aligned with the body (the leading-comment position) remain valid.
+class FmtOffAtBodyIndentation:
+    # fmt: off
+    untouched   =   1
+    # fmt: on
+    formatted = 2

--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_formatter_suppression_comment.rs
@@ -147,11 +147,13 @@ impl<'src, 'loc> UselessSuppressionComments<'src, 'loc> {
                 AnyNodeRef::StmtClassDef(StmtClassDef {
                     name,
                     decorator_list,
+                    body,
                     ..
                 })
                 | AnyNodeRef::StmtFunctionDef(StmtFunctionDef {
                     name,
                     decorator_list,
+                    body,
                     ..
                 }),
             ) = comment.enclosing
@@ -161,6 +163,29 @@ impl<'src, 'loc> UselessSuppressionComments<'src, 'loc> {
                         if decorator.end() < comment.range.start() {
                             return Err(IgnoredReason::AfterDecorator);
                         }
+                    }
+                }
+
+                // Flag own-line `fmt: off`/`fmt: on` comments that sit between a
+                // class or function header and the first statement of its body.
+                // The formatter treats these as dangling comments of the enclosing
+                // definition, so they cannot toggle suppression at the parent
+                // suite level.
+                if comment.line_position.is_own_line()
+                    && let Some(first_body_stmt) = body.first()
+                    && comment.range.start() >= name.end()
+                    && comment.range.end() <= first_body_stmt.start()
+                {
+                    let body_indentation =
+                        indentation_at_offset(first_body_stmt.start(), self.locator.contents())
+                            .unwrap_or_default()
+                            .text_len();
+                    let comment_indentation =
+                        indentation_at_offset(comment.range.start(), self.locator.contents())
+                            .unwrap_or_default()
+                            .text_len();
+                    if comment_indentation < body_indentation {
+                        return Err(IgnoredReason::BetweenClauseHeaderAndBody);
                     }
                 }
             }
@@ -226,6 +251,7 @@ enum IgnoredReason {
     SkipHasToBeTrailing,
     FmtOnCannotBeTrailing,
     FmtOffAboveBlock,
+    BetweenClauseHeaderAndBody,
 }
 
 impl Display for IgnoredReason {
@@ -246,6 +272,12 @@ impl Display for IgnoredReason {
             }
             Self::FmtOffAboveBlock => {
                 write!(f, "it cannot be directly above an alternate body")
+            }
+            Self::BetweenClauseHeaderAndBody => {
+                write!(
+                    f,
+                    "it cannot be between a class or function header and its body"
+                )
             }
         }
     }

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF028_RUF028.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF028_RUF028.py.snap
@@ -215,3 +215,60 @@ help: Remove this comment
 65 |
 66 | # all of these should be fine
 note: This is an unsafe fix and may change runtime behavior
+
+RUF028 [*] This suppression comment is invalid because it cannot be between a class or function header and its body
+   --> RUF028.py:114:1
+    |
+112 |     str,
+113 | ]):
+114 | # fmt: on
+    | ^^^^^^^^^
+115 |     pass
+    |
+help: Remove this comment
+111 |     int,
+112 |     str,
+113 | ]):
+    - # fmt: on
+114 |     pass
+115 |
+116 |
+note: This is an unsafe fix and may change runtime behavior
+
+RUF028 [*] This suppression comment is invalid because it cannot be between a class or function header and its body
+   --> RUF028.py:120:1
+    |
+118 | # fmt: off
+119 | class FmtOnAfterSimpleClassHeader:
+120 | # fmt: on
+    | ^^^^^^^^^
+121 |     x = 1
+    |
+help: Remove this comment
+117 |
+118 | # fmt: off
+119 | class FmtOnAfterSimpleClassHeader:
+    - # fmt: on
+120 |     x = 1
+121 |
+122 |
+note: This is an unsafe fix and may change runtime behavior
+
+RUF028 [*] This suppression comment is invalid because it cannot be between a class or function header and its body
+   --> RUF028.py:129:1
+    |
+127 |     y: str,
+128 | ):
+129 | # fmt: on
+    | ^^^^^^^^^
+130 |     pass
+    |
+help: Remove this comment
+126 |     x: int,
+127 |     y: str,
+128 | ):
+    - # fmt: on
+129 |     pass
+130 |
+131 |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Closes #20425.

`fmt: off` and `fmt: on` only take effect when placed between statements at the same suite level. When a user wraps a class signature with these pragmas — e.g. `# fmt: off` above `class Foo(Bar[...]):` and `# fmt: on` between the class header and the body — the trailing `# fmt: on` lands in a position the formatter treats as a dangling comment of the class definition. It can't reset the parent-suite suppression, and the entire rest of the module silently stops being formatted.

RUF028 already flags suppression comments inside parens/subscripts and between decorators, but didn't catch the dangling between-header-and-body slot. This adds a check for own-line `fmt: off`/`fmt: on` comments enclosed by a class or function definition that fall between the name and the first body statement with strictly less indentation than the body. Comments at body indentation (i.e. real leading comments of the first body statement, like `# fmt: off` for `# fmt: off`/`# fmt: on` blocks inside the body) remain valid.

Regression fixtures cover the original multi-line-subscript example from the issue, a simple class-with-base case, a multi-line function header, and a body-indent comment that must continue to pass.