### PR TITLE
[flake8-todos] Recognize Jira-style issue IDs on the TODO line (TD003)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
@@ -41,3 +41,14 @@ def foo(x):
 # TODO: A todo with a random number, 5431
 
 # TODO: here's a TODO on the last line with no link
+
+# Jira-style issue IDs on the same line (should pass)
+# TODO(charlie): PROJ-123 fix the widget
+# TODO(charlie): Fix bug (AIRFLOW-456)
+# TODO(charlie): Update config SUPERSET-789
+# TODO(charlie): ABC-456: fix bug with colon
+
+# Jira-style patterns that should still fail
+# TODO(charlie): Single letter project key A-1
+# TODO(charlie): No hyphen pattern ABC123
+# TODO(charlie): Lowercase project key abc-123

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -102,6 +102,12 @@ impl Violation for MissingTodoAuthor {
 ///
 /// # TODO(charlie): this comment has an issue code (matches the regex `[A-Z]+\-?\d+`)
 /// # SIXCHR-003
+///
+/// # TODO(charlie): PROJ-123 this comment has a Jira-style issue ID on the same line
+///
+/// # TODO(charlie): Fix bug (PROJ-456) with parenthesized issue ID
+///
+/// # TODO(charlie): Fix this bug PROJ-789
 /// ```
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.269")]
@@ -249,8 +255,12 @@ static ISSUE_LINK_OWN_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
 
 static ISSUE_LINK_TODO_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
-        r"\s*(http|https)://.*", // issue link
-        r"\s*#\d+.*",            // issue code - like "#003"
+        r"\s*(http|https)://.*",        // issue link
+        r"\s*#\d+.*",                   // issue code - like "#003"
+        r":\s+[A-Z]{2,}-\d+",           // Jira-style right after colon - like "TODO: PROJ-123 ..."
+        r"[A-Z]{2,}-\d+\s*$",          // Jira-style at end of line - like "fix this PROJ-123"
+        r"\([A-Z]{2,}-\d+\)",          // Jira-style in parentheses - like "(PROJ-123)"
+        r"[A-Z]{2,}-\d+\s*:",          // Jira-style followed by colon - like "PROJ-123: fix bug"
     ])
     .unwrap()
 });

--- a/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_todos/mod.rs
+assertion_line: 27
 ---
 TD003 Missing issue link for this TODO
   --> TD003.py:15:3
@@ -60,5 +61,36 @@ TD003 Missing issue link for this TODO
 41 | # TODO: A todo with a random number, 5431
 42 |
 43 | # TODO: here's a TODO on the last line with no link
+   |   ^^^^
+44 |
+45 | # Jira-style issue IDs on the same line (should pass)
+   |
+
+TD003 Missing issue link for this TODO
+  --> TD003.py:52:3
+   |
+51 | # Jira-style patterns that should still fail
+52 | # TODO(charlie): Single letter project key A-1
+   |   ^^^^
+53 | # TODO(charlie): No hyphen pattern ABC123
+54 | # TODO(charlie): Lowercase project key abc-123
+   |
+
+TD003 Missing issue link for this TODO
+  --> TD003.py:53:3
+   |
+51 | # Jira-style patterns that should still fail
+52 | # TODO(charlie): Single letter project key A-1
+53 | # TODO(charlie): No hyphen pattern ABC123
+   |   ^^^^
+54 | # TODO(charlie): Lowercase project key abc-123
+   |
+
+TD003 Missing issue link for this TODO
+  --> TD003.py:54:3
+   |
+52 | # TODO(charlie): Single letter project key A-1
+53 | # TODO(charlie): No hyphen pattern ABC123
+54 | # TODO(charlie): Lowercase project key abc-123
    |   ^^^^
    |


### PR DESCRIPTION
## Summary

Fixes #16519. TD003 currently only recognizes URLs and `#NNN` codes on the
same line as a TODO comment. Jira-style issue IDs like `PROJ-123` are only
matched on a separate line, causing false positives for projects that write
`# TODO: PROJ-123 fix the widget`.

This adds four regex patterns to `ISSUE_LINK_TODO_LINE_REGEX_SET` that
recognize Jira-style IDs (`[A-Z]{2,}-\d+`) in the positions MichaReiser
requested in #20880:

- Directly after the colon: `TODO: PROJ-123 ...`
- At end of line: `TODO: fix this PROJ-123`
- In parentheses: `TODO: fix bug (PROJ-123)`
- Followed by a colon: `TODO: PROJ-123: fix bug`

The `{2,}` minimum on the uppercase prefix aligns with Jira's project key
requirements and prevents single-letter matches like `A-1`.

Prior work: #20880 by @danparizher addressed the same issue but stalled
after review feedback requesting tighter patterns. This PR incorporates
that feedback directly.

## Test Plan

- Added 7 test cases to `TD003.py` fixture covering valid Jira-style
  patterns (after colon, parentheses, end of line, followed by colon)
  and invalid patterns (single-letter key, no hyphen, lowercase)
- Updated snapshot to reflect corrected diagnostics
- Verified on main: new fixture causes snapshot mismatch (7 extra violations)
- Verified on fix branch: all flake8_todos tests pass

> This PR was developed with AI assistance (Claude). All pattern choices
> trace to MichaReiser's review feedback on #20880.