### PR TITLE
[ty] Contextualize generator expression yields

### DIFF
--- a/crates/ty_python_core/src/scope.rs
+++ b/crates/ty_python_core/src/scope.rs
@@ -37,6 +37,7 @@ impl<'db> ScopeId<'db> {
                 | NodeWithScopeKind::ListComprehension(_)
                 | NodeWithScopeKind::SetComprehension(_)
                 | NodeWithScopeKind::DictComprehension(_)
+                | NodeWithScopeKind::GeneratorExpression(_)
         )
     }
 

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -16,7 +16,7 @@ python-version = "3.12"
 ## Propagating target type annotation
 
 ```py
-from typing import Generator, Iterable, Literal
+from typing import AsyncGenerator, AsyncIterable, Generator, Iterable, Literal
 
 def list1[T](x: T) -> list[T]:
     return [x]
@@ -49,12 +49,28 @@ def invalid_fallback(content: list[TextContent | TagContent] | None) -> None:
 
 def expects_generator_content(content: Generator[list[TextContent | TagContent], None, None]) -> None: ...
 def expects_iterable_content(content: Iterable[list[TextContent | TagContent]]) -> None: ...
+def expects_optional_iterable_content(content: Iterable[list[TextContent | TagContent]] | None) -> None: ...
 def generator_content() -> None:
     expects_generator_content([TextContent()] for _ in range(1))
     expects_iterable_content([TextContent()] for _ in range(1))
+    expects_optional_iterable_content([TextContent()] for _ in range(1))
+    expects_generator_content((reveal_type([TextContent()]) for _ in range(1)))  # revealed: list[TextContent | TagContent]
 
 def invalid_generator_content() -> None:
     expects_generator_content([object()] for _ in range(1))  # error: [invalid-argument-type]
+    expects_optional_iterable_content([object()] for _ in range(1))  # error: [invalid-argument-type]
+
+async def async_texts() -> AsyncGenerator[TextContent, None]:
+    yield TextContent()
+
+def expects_async_generator_content(content: AsyncGenerator[list[TextContent | TagContent], None]) -> None: ...
+def expects_async_iterable_content(content: AsyncIterable[list[TextContent | TagContent]]) -> None: ...
+async def async_generator_content() -> None:
+    expects_async_generator_content([TextContent()] async for _ in async_texts())
+    expects_async_iterable_content([TextContent()] async for _ in async_texts())
+
+async def invalid_async_generator_content() -> None:
+    expects_async_generator_content([object()] async for _ in async_texts())  # error: [invalid-argument-type]
 
 def f[T](x: T, cond: bool) -> T | list[T]:
     return x if cond else [x]

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -56,6 +56,10 @@ def generator_content() -> None:
     expects_optional_iterable_content([TextContent()] for _ in range(1))
     expects_generator_content((reveal_type([TextContent()]) for _ in range(1)))  # revealed: list[TextContent | TagContent]
 
+def expects_int_iterable_or_str_generator(content: Generator[list[str], int, None] | Iterable[list[int]]) -> None: ...
+def generator_content_with_incompatible_generator_arm() -> None:
+    expects_int_iterable_or_str_generator((reveal_type([]) for _ in range(1)))  # revealed: list[int]
+
 def invalid_generator_content() -> None:
     expects_generator_content([object()] for _ in range(1))  # error: [invalid-argument-type]
     expects_optional_iterable_content([object()] for _ in range(1))  # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -16,7 +16,7 @@ python-version = "3.12"
 ## Propagating target type annotation
 
 ```py
-from typing import Literal
+from typing import Generator, Iterable, Literal
 
 def list1[T](x: T) -> list[T]:
     return [x]
@@ -40,12 +40,21 @@ def _(l: list[int] | None = None):
 class TextContent: ...
 class TagContent: ...
 
-def expects_content(content: list[TextContent | TagContent]) -> None: ...
+def expects_list_content(content: list[TextContent | TagContent]) -> None: ...
 def optional_content(content: list[TextContent | TagContent] | None) -> None:
-    expects_content(content or [TextContent()])
+    expects_list_content(content or [TextContent()])
 
 def invalid_fallback(content: list[TextContent | TagContent] | None) -> None:
-    expects_content(content or [object()])  # error: [invalid-argument-type]
+    expects_list_content(content or [object()])  # error: [invalid-argument-type]
+
+def expects_generator_content(content: Generator[list[TextContent | TagContent], None, None]) -> None: ...
+def expects_iterable_content(content: Iterable[list[TextContent | TagContent]]) -> None: ...
+def generator_content() -> None:
+    expects_generator_content([TextContent()] for _ in range(1))
+    expects_iterable_content([TextContent()] for _ in range(1))
+
+def invalid_generator_content() -> None:
+    expects_generator_content([object()] for _ in range(1))  # error: [invalid-argument-type]
 
 def f[T](x: T, cond: bool) -> T | list[T]:
     return x if cond else [x]

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6364,8 +6364,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Derive the type context for a generator expression's yielded element from the expected type
     /// of the generator expression itself.
     ///
-    /// We model the generator expression as a synthetic `GeneratorType[T, Any, Any]` or
-    /// `AsyncGeneratorType[T, Any]`, then ask constraint-set assignability to solve for `T` against
+    /// We model the generator expression as a synthetic `GeneratorType[T, None, None]` or
+    /// `AsyncGeneratorType[T, None]`, then ask constraint-set assignability to solve for `T` against
     /// the expected annotation. The solved `T` becomes the type context for the expression being
     /// yielded, so normal assignability handles protocols and unions like `Iterable[int] | None`
     /// without adding target-specific special cases here.
@@ -6385,11 +6385,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             TypeVarVariance::Covariant,
         );
         let yield_ty = Type::TypeVar(yield_typevar);
+        let none = Type::none(db);
         let generator_ty = if evaluation_mode.is_async() {
-            KnownClass::AsyncGeneratorType.to_specialized_instance(db, &[yield_ty, Type::any()])
+            KnownClass::AsyncGeneratorType.to_specialized_instance(db, &[yield_ty, none])
         } else {
-            KnownClass::GeneratorType
-                .to_specialized_instance(db, &[yield_ty, Type::any(), Type::any()])
+            KnownClass::GeneratorType.to_specialized_instance(db, &[yield_ty, none, none])
         };
 
         let generic_context = GenericContext::from_typevar_instances(db, [yield_typevar]);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -70,7 +70,9 @@ use crate::types::enums::{enum_ignored_names, is_enum_class_by_inheritance};
 use crate::types::function::{
     FunctionDecorators, FunctionType, KnownFunction, report_revealed_type,
 };
-use crate::types::generics::{InferableTypeVars, SpecializationBuilder, bind_typevar};
+use crate::types::generics::{
+    GenericContext, InferableTypeVars, SpecializationBuilder, bind_typevar,
+};
 use crate::types::infer::builder::named_tuple::NamedTupleKind;
 use crate::types::infer::builder::paramspec_validation::validate_paramspec_components;
 use crate::types::infer::builder::typed_dict::TypedDictConstructorForm;
@@ -89,14 +91,14 @@ use crate::types::tuple::{Tuple, TupleLength, TupleSpecBuilder, TupleType};
 use crate::types::type_alias::{ManualPEP695TypeAliasType, PEP695TypeAliasType};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
 use crate::types::{
-    CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType, DynamicType,
-    InferenceFlags, InternedConstraintSet, InternedType, IntersectionBuilder, IntersectionType,
-    KnownClass, KnownInstanceType, KnownUnion, LiteralValueTypeKind, MemberLookupPolicy,
-    ParamSpecAttrKind, Parameter, ParameterForm, Parameters, Signature, SpecialFormType,
-    SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext, TypeQualifiers,
-    TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType, UnionAccumulator,
-    UnionBuilder, UnionType, binding_type, infer_complete_scope_types, infer_scope_types,
-    todo_type,
+    BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType,
+    DynamicType, InferenceFlags, InternedConstraintSet, InternedType, IntersectionBuilder,
+    IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueTypeKind,
+    MemberLookupPolicy, ParamSpecAttrKind, Parameter, ParameterForm, Parameters, Signature,
+    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
+    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType,
+    UnionAccumulator, UnionBuilder, UnionType, binding_type, infer_complete_scope_types,
+    infer_scope_types, todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
@@ -6359,6 +6361,64 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    /// Derive the type context for a generator expression's yielded element from the expected type
+    /// of the generator expression itself.
+    ///
+    /// We model the generator expression as a synthetic `GeneratorType[T, Any, Any]` or
+    /// `AsyncGeneratorType[T, Any]`, then ask constraint-set assignability to solve for `T` against
+    /// the expected annotation. The solved `T` becomes the type context for the expression being
+    /// yielded, so normal assignability handles protocols and unions like `Iterable[int] | None`
+    /// without adding target-specific special cases here.
+    fn generator_yield_type_context(
+        &self,
+        tcx: TypeContext<'db>,
+        evaluation_mode: EvaluationMode,
+    ) -> TypeContext<'db> {
+        let Some(annotation) = tcx.annotation else {
+            return TypeContext::default();
+        };
+
+        let db = self.db();
+        let yield_typevar = BoundTypeVarInstance::synthetic(
+            db,
+            Name::new_static("_GeneratorYieldT"),
+            TypeVarVariance::Covariant,
+        );
+        let yield_ty = Type::TypeVar(yield_typevar);
+        let generator_ty = if evaluation_mode.is_async() {
+            KnownClass::AsyncGeneratorType.to_specialized_instance(db, &[yield_ty, Type::any()])
+        } else {
+            KnownClass::GeneratorType
+                .to_specialized_instance(db, &[yield_ty, Type::any(), Type::any()])
+        };
+
+        let generic_context = GenericContext::from_typevar_instances(db, [yield_typevar]);
+        let path_bounds = generator_ty.assignable_solutions_with_inferable(
+            db,
+            annotation,
+            generic_context.inferable_typevars(db),
+        );
+        let constraints = ConstraintSetBuilder::new();
+        let Solutions::Constrained(solutions) = path_bounds.solve(db, &constraints) else {
+            return TypeContext::default();
+        };
+
+        let mut yield_tcx: Option<UnionAccumulator<'db>> = None;
+        for solution in solutions {
+            for binding in solution {
+                if binding.bound_typevar != yield_typevar {
+                    continue;
+                }
+                match &mut yield_tcx {
+                    Some(accumulator) => accumulator.add(db, binding.solution),
+                    None => yield_tcx = Some(UnionAccumulator::new(binding.solution)),
+                }
+            }
+        }
+
+        TypeContext::new(yield_tcx.map(|accumulator| accumulator.into_type(db)))
+    }
+
     fn infer_generator_expression(
         &mut self,
         generator: &ast::ExprGenerator,
@@ -6373,23 +6433,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = generator;
 
         let evaluation_mode = self.infer_first_comprehension_iter(generators);
-        let yield_tcx = TypeContext::new(tcx.annotation.and_then(|annotation| {
-            annotation
-                .generator_types(self.db())
-                .and_then(|generator_types| generator_types.yield_ty)
-                .or_else(|| {
-                    if evaluation_mode.is_async() {
-                        return None;
-                    }
-
-                    annotation
-                        .known_specialization(self.db(), KnownClass::Iterable)
-                        .and_then(|specialization| match specialization.types(self.db()) {
-                            [yield_ty] => Some(*yield_ty),
-                            _ => None,
-                        })
-                })
-        }));
+        let yield_tcx = self.generator_yield_type_context(tcx, evaluation_mode);
 
         let Some(scope_id) = self
             .index
@@ -6399,6 +6443,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
         let scope = scope_id.to_scope_id(self.db(), self.file());
         let inference = infer_scope_types(self.db(), scope, yield_tcx);
+        self.extend_scope(inference);
         let yield_type = inference.expression_type(elt.as_ref());
 
         if evaluation_mode.is_async() {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -759,7 +759,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 );
             }
             NodeWithScopeKind::GeneratorExpression(generator) => {
-                self.infer_generator_expression_scope(generator.node(self.module()));
+                self.infer_generator_expression_scope(generator.node(self.module()), tcx);
             }
         }
 
@@ -5432,7 +5432,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ast::Expr::List(list) => self.infer_list_expression(list, tcx),
             ast::Expr::Set(set) => self.infer_set_expression(set, tcx),
             ast::Expr::Dict(dict) => self.infer_dict_expression(dict, tcx),
-            ast::Expr::Generator(generator) => self.infer_generator_expression(generator),
+            ast::Expr::Generator(generator) => self.infer_generator_expression(generator, tcx),
             ast::Expr::ListComp(listcomp) => {
                 self.infer_list_comprehension_expression(listcomp, tcx)
             }
@@ -6359,7 +6359,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
-    fn infer_generator_expression(&mut self, generator: &ast::ExprGenerator) -> Type<'db> {
+    fn infer_generator_expression(
+        &mut self,
+        generator: &ast::ExprGenerator,
+        tcx: TypeContext<'db>,
+    ) -> Type<'db> {
         let ast::ExprGenerator {
             range: _,
             node_index: _,
@@ -6369,6 +6373,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = generator;
 
         let evaluation_mode = self.infer_first_comprehension_iter(generators);
+        let yield_tcx = TypeContext::new(tcx.annotation.and_then(|annotation| {
+            annotation
+                .generator_types(self.db())
+                .and_then(|generator_types| generator_types.yield_ty)
+                .or_else(|| {
+                    if evaluation_mode.is_async() {
+                        return None;
+                    }
+
+                    annotation
+                        .known_specialization(self.db(), KnownClass::Iterable)
+                        .and_then(|specialization| match specialization.types(self.db()) {
+                            [yield_ty] => Some(*yield_ty),
+                            _ => None,
+                        })
+                })
+        }));
 
         let Some(scope_id) = self
             .index
@@ -6377,7 +6398,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         };
         let scope = scope_id.to_scope_id(self.db(), self.file());
-        let inference = infer_scope_types(self.db(), scope, TypeContext::default());
+        let inference = infer_scope_types(self.db(), scope, yield_tcx);
         let yield_type = inference.expression_type(elt.as_ref());
 
         if evaluation_mode.is_async() {
@@ -6502,7 +6523,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         })
     }
 
-    fn infer_generator_expression_scope(&mut self, generator: &ast::ExprGenerator) {
+    fn infer_generator_expression_scope(
+        &mut self,
+        generator: &ast::ExprGenerator,
+        tcx: TypeContext<'db>,
+    ) {
         let ast::ExprGenerator {
             range: _,
             node_index: _,
@@ -6511,7 +6536,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             parenthesized: _,
         } = generator;
 
-        self.infer_expression(elt, TypeContext::default());
+        self.infer_expression(elt, tcx);
         self.infer_comprehensions(generators);
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -701,7 +701,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             ast::Expr::Generator(generator) => {
                 if !self.in_string_annotation() {
-                    self.infer_generator_expression(generator);
+                    self.infer_generator_expression(generator, TypeContext::default());
                 }
                 self.report_invalid_type_expression(
                     expression,


### PR DESCRIPTION
## Summary

This adds bidirectional inference for generator-expression yields. Previously, expected generator or iterable contexts did not reach the yielded expression, so we inferred literals inside generator expressions too narrowly:

```py
expects_content([TextContent()] for _ in range(1))
```

Now generator-expression inference derives a yield context from `Generator`, `Iterator`, and `Iterable`-style expected types, then passes it into the generator scope before constructing the resulting `GeneratorType`.
