### PR TITLE
[ty] Contextualize boolean operands

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -37,6 +37,16 @@ def _(l: list[int] | None = None):
     l2: list[int] = l or list()
     reveal_type(l2)  # revealed: list[int]
 
+class TextContent: ...
+class TagContent: ...
+
+def expects_content(content: list[TextContent | TagContent]) -> None: ...
+def optional_content(content: list[TextContent | TagContent] | None) -> None:
+    expects_content(content or [TextContent()])
+
+def invalid_fallback(content: list[TextContent | TagContent] | None) -> None:
+    expects_content(content or [object()])  # error: [invalid-argument-type]
+
 def f[T](x: T, cond: bool) -> T | list[T]:
     return x if cond else [x]
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5444,7 +5444,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ast::Expr::Attribute(attribute) => self.infer_attribute_expression(attribute),
             ast::Expr::UnaryOp(unary_op) => self.infer_unary_expression(unary_op),
             ast::Expr::BinOp(binary) => self.infer_binary_expression(binary, tcx),
-            ast::Expr::BoolOp(bool_op) => self.infer_boolean_expression(bool_op),
+            ast::Expr::BoolOp(bool_op) => self.infer_boolean_expression(bool_op, tcx),
             ast::Expr::Compare(compare) => self.infer_compare_expression(compare),
             ast::Expr::Subscript(subscript) => self.infer_subscript_expression(subscript),
             ast::Expr::Slice(slice) => self.infer_slice_expression(slice),
@@ -8913,7 +8913,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
-    fn infer_boolean_expression(&mut self, bool_op: &ast::ExprBoolOp) -> Type<'db> {
+    fn infer_boolean_expression(
+        &mut self,
+        bool_op: &ast::ExprBoolOp,
+        tcx: TypeContext<'db>,
+    ) -> Type<'db> {
         let ast::ExprBoolOp {
             range: _,
             node_index: _,
@@ -8925,9 +8929,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             values.iter().enumerate(),
             |builder, (index, value)| {
                 let ty = if index == values.len() - 1 {
-                    builder.infer_expression(value, TypeContext::default())
+                    builder.infer_expression(value, tcx)
                 } else {
-                    builder.infer_maybe_standalone_expression(value, TypeContext::default())
+                    builder.infer_maybe_standalone_expression(value, tcx)
                 };
 
                 (ty, value.range())

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -529,7 +529,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             ast::Expr::BoolOp(bool_op) => {
                 if !self.in_string_annotation() {
-                    self.infer_boolean_expression(bool_op);
+                    self.infer_boolean_expression(bool_op, TypeContext::default());
                 }
                 self.report_invalid_type_expression(
                     expression,


### PR DESCRIPTION
## Summary

This adds bidirectional inference for boolean expression operands. Previously, a call context did not reach either side of an `and` or `or` expression, so we inferred fallback literals too narrowly:

```py
expects_content(content or [TextContent()])
```

Now boolean-expression inference passes the outer type context into each operand, as we do for `if` expressions, binary expressions, etc.