### PR TITLE
[ty] Preserve NewType and TypeAliasType in implicit aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -126,6 +126,17 @@ def g(_: Callable[[str], Foo]): ...
 g(Foo)  # error: [invalid-argument-type]
 ```
 
+## `NewType` pseudo-classes participate in PEP 604 unions
+
+```py
+from typing import NewType
+
+Foo = NewType("Foo", int)
+
+reveal_type(Foo | str)  # revealed: <types.UnionType special-form 'Foo | str'>
+reveal_type(str | Foo)  # revealed: <types.UnionType special-form 'str | Foo'>
+```
+
 ## `NewType` instances are `Callable` if the base type is
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -217,6 +217,57 @@ def _(int_or_int: IntOrInt, list_of_int_or_list_of_int: ListOfIntOrListOfInt):
 None | None  # error: [unsupported-operator] "Operator `|` is not supported between two objects of type `None`"
 ```
 
+Implicit aliases should also work when one union member is a `NewType` pseudo-class:
+
+```py
+from typing import NewType
+
+Foo = NewType("Foo", int)
+FooOrStr = Foo | str
+
+reveal_type(FooOrStr)  # revealed: <types.UnionType special-form 'Foo | str'>
+
+def _(x: FooOrStr):
+    reveal_type(x)  # revealed: Foo | str
+```
+
+Implicit aliases should also work when one union member is a `TypeAliasType`:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import TypeAliasType, Union
+
+type Pep695IntOrStr = int | str
+
+Pep695OrBytes = Pep695IntOrStr | bytes
+BytesOrPep695 = bytes | Pep695IntOrStr
+
+ManualIntOrStr = TypeAliasType("ManualIntOrStr", Union[int, str])
+
+ManualOrBytes = ManualIntOrStr | bytes
+BytesOrManual = bytes | ManualIntOrStr
+
+reveal_type(Pep695OrBytes)  # revealed: <types.UnionType special-form 'int | str | bytes'>
+reveal_type(BytesOrPep695)  # revealed: <types.UnionType special-form 'bytes | int | str'>
+reveal_type(ManualOrBytes)  # revealed: <types.UnionType special-form 'int | str | bytes'>
+reveal_type(BytesOrManual)  # revealed: <types.UnionType special-form 'bytes | int | str'>
+
+def _(
+    pep695_or_bytes: Pep695OrBytes,
+    bytes_or_pep695: BytesOrPep695,
+    manual_or_bytes: ManualOrBytes,
+    bytes_or_manual: BytesOrManual,
+):
+    reveal_type(pep695_or_bytes)  # revealed: int | str | bytes
+    reveal_type(bytes_or_pep695)  # revealed: bytes | int | str
+    reveal_type(manual_or_bytes)  # revealed: int | str | bytes
+    reveal_type(bytes_or_manual)  # revealed: bytes | int | str
+```
+
 When constructing something nonsensical like `int | 1`, we emit a diagnostic for the expression
 itself, as it leads to a `TypeError` at runtime. The result of the expression is then inferred as
 `Unknown`, so we permit it to be used in a type expression.

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -890,7 +890,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     | KnownInstanceType::Annotated(_)
                     | KnownInstanceType::TypeGenericAlias(_)
                     | KnownInstanceType::Callable(_)
-                    | KnownInstanceType::TypeVar(_),
+                    | KnownInstanceType::TypeVar(_)
+                    | KnownInstanceType::TypeAliasType(_)
+                    | KnownInstanceType::NewType(_),
                 ),
                 Type::ClassLiteral(..)
                 | Type::SubclassOf(..)
@@ -902,7 +904,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     | KnownInstanceType::Annotated(_)
                     | KnownInstanceType::TypeGenericAlias(_)
                     | KnownInstanceType::Callable(_)
-                    | KnownInstanceType::TypeVar(_),
+                    | KnownInstanceType::TypeVar(_)
+                    | KnownInstanceType::TypeAliasType(_)
+                    | KnownInstanceType::NewType(_),
                 ),
                 ast::Operator::BitOr,
             ) if pep_604_unions_allowed() => {


### PR DESCRIPTION
## Summary

This preserves `NewType` pseudo-classes and `TypeAliasType` aliases when building implicit aliases from PEP 604 unions. Previously, these runtime type-form operands were excluded from the set of values accepted by `|`, so aliases like:

```py
Foo = NewType("Foo", int)
FooOrStr = Foo | str

type IntOrStr = int | str
IntOrStrOrBytes = IntOrStr | bytes
```

...did not retain the intended union over those operands.

Now `KnownInstanceType::NewType` and `KnownInstanceType::TypeAliasType` follow the same PEP 604 path as `Literal`, `Annotated`, `Callable`, and `TypeVar`, so both operand orders produce a union type.

Closes #25071.
