### PR TITLE
[`pylint`] Suppress `PLW0108` when the inner callable is forward-defined (`unnecessary-lambda`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
@@ -80,3 +80,19 @@ def already_defined(y):
 
 
 _ = lambda y: already_defined(y) # [unnecessary-lambda]
+
+
+# https://github.com/astral-sh/ruff/pull/25074#pullrequestreview-4272365684
+# Self ref via assignment RHS: `g` isn't bound when the lambda evaluates.
+g = lambda y: g(y)
+
+
+# Self ref via def default arg: same shape, in a parameter default.
+def later(x=lambda y: later(y)):
+    return x
+
+
+# Lazy self ref: lambda only evaluates when `lazy_self` is called, by
+# which point the binding has resolved — still safe to inline.
+def lazy_self():
+    return lambda y: lazy_self(y) # [unnecessary-lambda]

--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
@@ -61,3 +61,22 @@ _ = lambda *args: f(*args, y=x)
 # https://github.com/astral-sh/ruff/issues/18675
 _ = lambda x: (string := str)(x)
 _ = lambda x: ((x := 1) and str)(x)
+
+# https://github.com/astral-sh/ruff/issues/24704
+# Forward references: the callable is defined after the lambda, so the
+# lambda's late binding is the only thing keeping the code working —
+# inlining would raise `NameError`.
+_ = lambda y: forward(y)
+_ = {"a": lambda y: forward(y)}
+
+
+def forward(y):
+    pass
+
+
+# Backward references in the same module are still safe to inline.
+def already_defined(y):
+    pass
+
+
+_ = lambda y: already_defined(y) # [unnecessary-lambda]

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
@@ -217,6 +217,15 @@ pub(crate) fn unnecessary_lambda(checker: &Checker, lambda: &ExprLambda) {
             if checker.semantic().is_current_scope(binding.scope) {
                 return;
             }
+            // Forward reference: the lambda body's late binding succeeds at
+            // call time, but inlining would raise `NameError` when the
+            // enclosing expression is evaluated. The binding must start
+            // after the lambda's entire range — bindings nested inside the
+            // call target (e.g. parameters of a lambda passed as an arg)
+            // are part of the replacement expression, not free variables.
+            if binding.range.start() >= lambda.range.end() {
+                return;
+            }
         }
     }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
@@ -1,6 +1,7 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr, ExprLambda, Parameter, ParameterWithDefault, visitor};
+use ruff_python_semantic::BindingKind;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -217,14 +218,23 @@ pub(crate) fn unnecessary_lambda(checker: &Checker, lambda: &ExprLambda) {
             if checker.semantic().is_current_scope(binding.scope) {
                 return;
             }
-            // Forward reference: the lambda body's late binding succeeds at
-            // call time, but inlining would raise `NameError` when the
-            // enclosing expression is evaluated. The binding must start
-            // after the lambda's entire range — bindings nested inside the
-            // call target (e.g. parameters of a lambda passed as an arg)
-            // are part of the replacement expression, not free variables.
+            // Forward ref: binding's name appears after the lambda.
             if binding.range.start() >= lambda.range.end() {
                 return;
+            }
+            // Self ref: lambda evaluates as part of the binding's own
+            // statement (assignment RHS, def default arg).
+            if matches!(
+                binding.kind,
+                BindingKind::Assignment
+                    | BindingKind::FunctionDefinition(_)
+                    | BindingKind::ClassDefinition(_)
+            ) {
+                if let Some(stmt) = binding.statement(checker.semantic()) {
+                    if stmt.range() == checker.semantic().current_statement().range() {
+                        return;
+                    }
+                }
             }
         }
     }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
@@ -199,4 +199,23 @@ help: Inline function call
 81 |
    - _ = lambda y: already_defined(y) # [unnecessary-lambda]
 82 + _ = already_defined # [unnecessary-lambda]
+83 |
+84 |
+85 | # https://github.com/astral-sh/ruff/pull/25074#pullrequestreview-4272365684
+note: This is an unsafe fix and may change runtime behavior
+
+PLW0108 [*] Lambda may be unnecessary; consider inlining inner function
+  --> unnecessary_lambda.py:98:12
+   |
+96 | # which point the binding has resolved — still safe to inline.
+97 | def lazy_self():
+98 |     return lambda y: lazy_self(y) # [unnecessary-lambda]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: Inline function call
+95 | # Lazy self ref: lambda only evaluates when `lazy_self` is called, by
+96 | # which point the binding has resolved — still safe to inline.
+97 | def lazy_self():
+   -     return lambda y: lazy_self(y) # [unnecessary-lambda]
+98 +     return lazy_self # [unnecessary-lambda]
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
@@ -171,6 +171,8 @@ help: Inline function call
    - _ = lambda x: (string := str)(x)
 62 + _ = (string := str)
 63 | _ = lambda x: ((x := 1) and str)(x)
+64 |
+65 | # https://github.com/astral-sh/ruff/issues/24704
 note: This is an unsafe fix and may change runtime behavior
 
 PLW0108 Lambda may be unnecessary; consider inlining inner function
@@ -180,5 +182,21 @@ PLW0108 Lambda may be unnecessary; consider inlining inner function
 62 | _ = lambda x: (string := str)(x)
 63 | _ = lambda x: ((x := 1) and str)(x)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+64 |
+65 | # https://github.com/astral-sh/ruff/issues/24704
    |
 help: Inline function call
+
+PLW0108 [*] Lambda may be unnecessary; consider inlining inner function
+  --> unnecessary_lambda.py:82:5
+   |
+82 | _ = lambda y: already_defined(y) # [unnecessary-lambda]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: Inline function call
+79 |     pass
+80 |
+81 |
+   - _ = lambda y: already_defined(y) # [unnecessary-lambda]
+82 + _ = already_defined # [unnecessary-lambda]
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Closes #24704.

`PLW0108` flagged `_ = lambda y: f(y)` as unnecessary even when `f` was defined later in the same module. Inlining the lambda would force the lookup to happen when the enclosing expression is evaluated (e.g. `x = {...}` at module load) rather than when the lambda is called, raising `NameError`.

The reporter's exact repro:

```python
x = {"a": lambda y: f(y)}

def f(y):
    pass
```

— now passes `ruff check --select PLW0108` cleanly.

## Root cause

The existing free-variable guard inside `unnecessary_lambda` (`crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs`):

```rust
if checker.semantic().is_current_scope(binding.scope) {
    return;
}
```

handles only the case where the resolved name shadows a parameter of the lambda itself (e.g. `lambda f: f(x)`). It does not handle a binding that resolves to an outer scope but is established *after* the lambda's textual range — which is the shape of the false positive in this issue.

## Fix

Add a second guard that suppresses the rule when the resolved binding starts at or after the end of the lambda's textual range:

```rust
if binding.range.start() >= lambda.range.end() {
    return;
}
```

Two design notes:

1. **Why `lambda.range.end()` and not `lambda.range.start()`.** Parameters of inner lambdas passed as arguments — e.g. `lambda x: f(lambda x: x)(x)` — have binding ranges that sit *inside* the outer lambda's text. Comparing against the lambda's *start* would mis-classify those as forward references and silently suppress the existing positive cases at lines 9 and 10 of the fixture. Comparing against the *end* keeps those cases flagged.

2. **Why this is conservative-correct.** The check fires whether the lambda is at module scope, inside a function body, or anywhere else. In a function body the late-binding semantics of bare references and lambdas are technically equivalent, so this introduces a small false-negative for that nested case. I've taken the safer trade-off — the rule's fix is already marked `unsafe`, and a missed lint is preferable to a suggestion that would break the user's code at module load.

## Test plan

Three cases added to `crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py`:

```python
# https://github.com/astral-sh/ruff/issues/24704
_ = lambda y: forward(y)              # not flagged (forward at module scope)
_ = {"a": lambda y: forward(y)}       # not flagged (forward in dict literal)


def forward(y):
    pass


def already_defined(y):
    pass


_ = lambda y: already_defined(y)      # still flagged (backward ref is safe)
```

Verified:

- `cargo test -p ruff_linter rules::pylint::tests::rules::rule_unnecessarylambda_path_new_unnecessary_lambda_py_expects` — **PASS**, snapshot updated cleanly (only the new `already_defined` violation appears in the diff; existing positive cases at lines 9 and 10 are not regressed).
- `ruff check --select PLW0108` on the issue's exact repro — `All checks passed!` (pre-fix this raised `PLW0108`).
- `cargo clippy -p ruff_linter --tests -- -D warnings` — **clean**.
- `cargo fmt -p ruff_linter -- --check` — **clean**.

Credit to @JelleZijlstra for the report and the minimal repro.