### PR TITLE
[ty] Add type context for `**kwargs`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1797,3 +1797,94 @@ def _(args_tuple: tuple[int, int], args_union: tuple[int] | tuple[int, int], kwa
     f(*args_tuple, **kwargs)  # fine
     f(*args_union, **kwargs)  # fine
 ```
+
+## Dictionary-backed keyword splats
+
+A known dictionary field is inferred using the type of the keyword parameter with the same name.
+This also applies when the function has other optional keyword parameters:
+
+```py
+from collections.abc import Mapping
+from enum import Enum
+from typing import Any
+
+class Header(str, Enum):
+    REQUEST_ID = "x-request-id"
+
+def with_headers(*, extra_headers: Mapping[str, str] | None = None) -> None: ...
+def invalid_headers() -> None:
+    kwargs: dict[str, Any] = {
+        "extra_headers": {Header.REQUEST_ID: 1},
+    }
+    with_headers(**kwargs)  # error: [invalid-argument-type]
+
+def with_optional_headers(*, extra_headers: Mapping[str, str] | None = None, other: str = "") -> None: ...
+def invalid_headers_with_optional() -> None:
+    kwargs: dict[str, Any] = {
+        "extra_headers": {Header.REQUEST_ID: 1},
+    }
+    with_optional_headers(**kwargs)  # error: [invalid-argument-type]
+```
+
+Contextual inference does not suppress errors for mappings whose keys may not be strings:
+
+```py
+from typing import Any
+
+def takes_x(*, x: int) -> None: ...
+def invalid_key_type() -> None:
+    kwargs: dict[int | str, Any] = {"x": 1, 1: 2}
+    takes_x(**kwargs)  # error: [invalid-argument-type]
+```
+
+Each overload keeps its own keyword context. A non-matching overload must not widen the context used
+to infer a dictionary field for the matching overload:
+
+```py
+from typing import Any, overload
+
+@overload
+def overloaded_context(a: int, *, x: list[int]) -> int: ...
+@overload
+def overloaded_context(a: str, *, x: list[Any]) -> str: ...
+def overloaded_context(a: object, **kwargs: object) -> object: ...
+def invalid_overload_context() -> None:
+    kwargs: dict[str, object] = {"x": ["s"]}
+    overloaded_context(1, **kwargs)  # error: [no-matching-overload]
+```
+
+Context from an overload can flow into nested literals and select the matching return type:
+
+```py
+from typing import Any, Literal, TypedDict, overload
+
+class InputMessage(TypedDict):
+    role: Literal["user"]
+    content: str
+
+@overload
+def create(*, input: list[InputMessage]) -> int: ...
+@overload
+def create(*, input: str) -> str: ...
+def create(**kwargs: Any) -> object: ...
+def ok(content: str) -> None:
+    kwargs: dict[str, Any] = {
+        "input": [{"role": "user", "content": content}],
+    }
+    reveal_type(create(**kwargs))  # revealed: int
+```
+
+Known dictionary fields are matched to parameters by name, not by iteration order:
+
+```py
+from typing import Any
+
+def out_of_order(*, second: str, first: int, third: bool) -> None: ...
+def ok_out_of_order() -> None:
+    kwargs: dict[str, Any] = {
+        "first": 1,
+        "second": "s",
+        "third": True,
+    }
+    out_of_order(**kwargs)
+```

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1899,6 +1899,7 @@ def ok(content: str) -> None:
         "input": [{"role": "user", "content": content}],
     }
     reveal_type(create(**kwargs))  # revealed: int
+    reveal_type(create(**{"input": [{"role": "user", "content": content}]}))  # revealed: int
 ```
 
 Known fields matched to a keyword-variadic parameter use its annotation as context:

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1901,6 +1901,23 @@ def ok(content: str) -> None:
     reveal_type(create(**kwargs))  # revealed: int
 ```
 
+Known fields matched to a keyword-variadic parameter use its annotation as context:
+
+```py
+from typing import Any, overload
+
+@overload
+def variadic_context(**kwargs: str) -> str: ...
+@overload
+def variadic_context(**kwargs: int) -> int: ...
+def variadic_context(**kwargs: object) -> object: ...
+def takes_strings(**kwargs: str) -> None: ...
+def check_variadic_context() -> None:
+    kwargs: dict[str, Any] = {"x": 1}
+    reveal_type(variadic_context(**kwargs))  # revealed: int
+    takes_strings(**kwargs)  # error: [invalid-argument-type]
+```
+
 Known dictionary fields are matched to parameters by name, not by iteration order:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1826,6 +1826,20 @@ def invalid_headers_with_optional() -> None:
     with_optional_headers(**kwargs)  # error: [invalid-argument-type]
 ```
 
+Diagnostics emitted while inferring a known field with its parameter context are preserved:
+
+```py
+from collections.abc import Callable
+from typing import Any
+
+def takes_callback(*, callback: Callable[[int], int]) -> None: ...
+def invalid_callback() -> None:
+    kwargs: dict[str, Any] = {
+        "callback": lambda value: value.missing,  # error: [unresolved-attribute]
+    }
+    takes_callback(**kwargs)
+```
+
 Contextual inference does not suppress errors for mappings whose keys may not be strings:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1837,6 +1837,19 @@ def invalid_key_type() -> None:
     takes_x(**kwargs)  # error: [invalid-argument-type]
 ```
 
+The original dictionary value type describes possible extra items. Those items must be compatible
+with both unmatched named parameters and a keyword-variadic parameter:
+
+```py
+def extra_item_keyword_only(*, known: int, extra: str = "") -> None: ...
+def extra_item_keyword_variadic(*, known: int, **kwargs: str) -> None: ...
+def extra_item_checks() -> None:
+    kwargs: dict[str, int] = {"known": 1}
+
+    extra_item_keyword_only(**kwargs)  # error: [invalid-argument-type]
+    extra_item_keyword_variadic(**kwargs)  # error: [invalid-argument-type]
+```
+
 Each overload keeps its own keyword context. A non-matching overload must not widen the context used
 to infer a dictionary field for the matching overload:
 

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -88,6 +88,11 @@ impl<'db> CallArgumentTypes<'db> {
             .unwrap_or(Type::unknown())
     }
 
+    /// Returns the type inferred specifically for the provided declared type, if any.
+    pub(crate) fn get_inferred_for_declared_type(&self, tcx: Type<'db>) -> Option<Type<'db>> {
+        self.types.get(&tcx).copied()
+    }
+
     /// Insert the type of this argument when inferred with the provided type context.
     pub(crate) fn insert(&mut self, tcx: impl Into<TypeContext<'db>>, ty: Type<'db>) {
         match tcx.into().annotation {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -57,7 +57,10 @@ use crate::types::signatures::{
     PartialSignatureApplication,
 };
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
-use crate::types::typed_dict::{TypedDictOpenness, extract_unpacked_typed_dict_from_value_type};
+use crate::types::typed_dict::{
+    TypedDictOpenness, extract_unpacked_typed_dict_from_value_type,
+    synthesized_typed_dict_type_from_fields,
+};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarNonceGenerator};
 use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
 use crate::types::{
@@ -5306,14 +5309,20 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     argument,
                     paramspec_component_start,
                 ),
-                Argument::Keywords => self.check_keyword_variadic_argument_type(
-                    constraints,
-                    argument_index,
-                    adjusted_argument_index,
-                    // Splatted arguments are inferred without type context.
-                    argument_types.get_default().unwrap_or(Type::unknown()),
-                    paramspec_component_start,
-                ),
+                Argument::Keywords => {
+                    let contextualized = self.contextualized_keyword_variadic_argument_type(
+                        argument_index,
+                        argument_types,
+                    );
+                    self.check_keyword_variadic_argument_type(
+                        constraints,
+                        argument_index,
+                        adjusted_argument_index,
+                        argument_types,
+                        contextualized,
+                        paramspec_component_start,
+                    );
+                }
                 _ => {
                     // If the argument isn't splatted, just check its type directly.
                     for matched_parameter in self.argument_matches[argument_index].iter() {
@@ -5338,6 +5347,21 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 }
             }
         }
+    }
+
+    /// Return the `**kwargs` type inferred for this overload's matched keyword fields.
+    fn contextualized_keyword_variadic_argument_type(
+        &self,
+        argument_index: usize,
+        argument_types: &CallArgumentTypes<'db>,
+    ) -> Option<Type<'db>> {
+        synthesized_typed_dict_type_from_fields(
+            self.db,
+            self.argument_matches[argument_index]
+                .keyword_parameter_types(self.signature.parameters()),
+            TypedDictOpenness::Closed,
+        )
+        .and_then(|context_ty| argument_types.get_inferred_for_declared_type(context_ty))
     }
 
     /// Invoke a sub-call for the given `ParamSpec` type variable, using the forwarded arguments.
@@ -5489,17 +5513,89 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         constraints: &ConstraintSetBuilder<'db>,
         argument_index: usize,
         adjusted_argument_index: Option<usize>,
-        argument_type: Type<'db>,
+        argument_types: &CallArgumentTypes<'db>,
+        contextualized: Option<Type<'db>>,
         paramspec_component_start: Option<usize>,
     ) {
-        if extract_unpacked_typed_dict_from_value_type(self.db, argument_type).is_some() {
-            self.check_variadic_argument_type(
-                constraints,
-                argument_index,
-                adjusted_argument_index,
-                Argument::Keywords,
-                paramspec_component_start,
-            );
+        let argument_type = contextualized
+            .or_else(|| argument_types.get_default())
+            .unwrap_or(Type::unknown());
+
+        if let Some(unpacked) = extract_unpacked_typed_dict_from_value_type(self.db, argument_type)
+        {
+            if contextualized.is_none() {
+                self.check_variadic_argument_type(
+                    constraints,
+                    argument_index,
+                    adjusted_argument_index,
+                    Argument::Keywords,
+                    paramspec_component_start,
+                );
+                return;
+            }
+
+            let matched_parameters = &self.argument_matches[argument_index].parameters;
+            let keyword_variadic = matched_parameters
+                .iter()
+                .copied()
+                .find(|matched_parameter| {
+                    self.signature.parameters()[matched_parameter.index].is_keyword_variadic()
+                });
+
+            for (name, unpacked_key) in &unpacked.keys {
+                let matched_parameter = matched_parameters
+                    .iter()
+                    .copied()
+                    .find(|matched_parameter| {
+                        let parameter = &self.signature.parameters()[matched_parameter.index];
+                        !parameter.is_keyword_variadic() && parameter.keyword_name() == Some(name)
+                    })
+                    .or(keyword_variadic);
+
+                let Some(matched_parameter) = matched_parameter else {
+                    continue;
+                };
+                if paramspec_component_start.is_some_and(|start| matched_parameter.index >= start) {
+                    continue;
+                }
+
+                self.check_argument_type(
+                    constraints,
+                    argument_index,
+                    adjusted_argument_index,
+                    Argument::Keywords,
+                    unpacked_key.value_ty,
+                    matched_parameter,
+                );
+            }
+
+            if let Some(extra_items) = unpacked.openness.explicit_extra_items() {
+                for matched_parameter in matched_parameters.iter().copied() {
+                    if paramspec_component_start
+                        .is_some_and(|start| matched_parameter.index >= start)
+                    {
+                        continue;
+                    }
+
+                    let parameter = &self.signature.parameters()[matched_parameter.index];
+                    if parameter
+                        .keyword_name()
+                        .is_some_and(|name| unpacked.keys.contains_key(name))
+                    {
+                        continue;
+                    }
+
+                    self.check_argument_type(
+                        constraints,
+                        argument_index,
+                        adjusted_argument_index,
+                        Argument::Keywords,
+                        extra_items.declared_ty,
+                        matched_parameter,
+                    );
+                }
+            }
+
             return;
         }
 
@@ -5610,6 +5706,23 @@ impl<'db> MatchedArgument<'db> {
     /// Returns an iterator over the matched parameters.
     fn iter(&self) -> impl Iterator<Item = MatchedParameter<'db>> + '_ {
         self.parameters.iter().copied()
+    }
+
+    /// Returns the names and types of matched non-variadic keyword parameters.
+    pub(crate) fn keyword_parameter_types<'a>(
+        &'a self,
+        parameters: &'a Parameters<'db>,
+    ) -> impl Iterator<Item = (Name, Type<'db>)> + 'a {
+        self.parameters.iter().filter_map(move |matched_parameter| {
+            let parameter = &parameters[matched_parameter.index];
+            if parameter.is_keyword_variadic() {
+                None
+            } else {
+                parameter
+                    .keyword_name()
+                    .map(|name| (name.clone(), parameter.annotated_type()))
+            }
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5721,8 +5721,10 @@ impl<'db> MatchedArgument<'db> {
         })
     }
 
-    pub(crate) fn keyword_variadic_parameter_type(
+    /// Returns the concrete per-field context contributed by a keyword-variadic parameter.
+    pub(crate) fn keyword_variadic_context_type(
         &self,
+        db: &'db dyn Db,
         parameters: &Parameters<'db>,
     ) -> Option<Type<'db>> {
         self.parameters.iter().find_map(|matched_parameter| {
@@ -5730,6 +5732,12 @@ impl<'db> MatchedArgument<'db> {
             parameter
                 .is_keyword_variadic()
                 .then(|| parameter.annotated_type())
+                .filter(|ty| {
+                    // A dynamic annotation provides no context, while `P.kwargs` describes an
+                    // entire parameter pack rather than the type of each keyword value.
+                    !ty.is_dynamic()
+                        && !matches!(ty, Type::TypeVar(typevar) if typevar.paramspec_attr(db).is_some())
+                })
         })
     }
 
@@ -5738,7 +5746,7 @@ impl<'db> MatchedArgument<'db> {
         db: &'db dyn Db,
         parameters: &Parameters<'db>,
     ) -> Option<Type<'db>> {
-        let variadic_ty = self.keyword_variadic_parameter_type(parameters);
+        let variadic_ty = self.keyword_variadic_context_type(db, parameters);
         let openness = variadic_ty.map_or(TypedDictOpenness::Closed, |ty| {
             TypedDictOpenness::extra(db, ty, false)
         });

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5355,13 +5355,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         argument_index: usize,
         argument_types: &CallArgumentTypes<'db>,
     ) -> Option<Type<'db>> {
-        synthesized_typed_dict_type_from_fields(
-            self.db,
-            self.argument_matches[argument_index]
-                .keyword_parameter_types(self.signature.parameters()),
-            TypedDictOpenness::Closed,
-        )
-        .and_then(|context_ty| argument_types.get_inferred_for_declared_type(context_ty))
+        let context_ty = self.argument_matches[argument_index]
+            .keyword_context_type(self.db, self.signature.parameters())?;
+        argument_types.get_inferred_for_declared_type(context_ty)
     }
 
     /// Invoke a sub-call for the given `ParamSpec` type variable, using the forwarded arguments.
@@ -5723,6 +5719,36 @@ impl<'db> MatchedArgument<'db> {
                     .map(|name| (name.clone(), parameter.annotated_type()))
             }
         })
+    }
+
+    pub(crate) fn keyword_variadic_parameter_type(
+        &self,
+        parameters: &Parameters<'db>,
+    ) -> Option<Type<'db>> {
+        self.parameters.iter().find_map(|matched_parameter| {
+            let parameter = &parameters[matched_parameter.index];
+            parameter
+                .is_keyword_variadic()
+                .then(|| parameter.annotated_type())
+        })
+    }
+
+    pub(crate) fn keyword_context_type(
+        &self,
+        db: &'db dyn Db,
+        parameters: &Parameters<'db>,
+    ) -> Option<Type<'db>> {
+        let variadic_ty = self.keyword_variadic_parameter_type(parameters);
+        let openness = variadic_ty.map_or(TypedDictOpenness::Closed, |ty| {
+            TypedDictOpenness::extra(db, ty, false)
+        });
+
+        synthesized_typed_dict_type_from_fields(
+            db,
+            self.keyword_parameter_types(parameters),
+            openness,
+        )
+        .or(variadic_ty)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -115,6 +115,10 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         self.diagnostics_suppressed = true;
     }
 
+    pub(super) fn diagnostics_are_suppressed(&self) -> bool {
+        self.diagnostics_suppressed
+    }
+
     pub(super) fn is_lint_enabled(&self, lint: &'static LintMetadata) -> bool {
         LintDiagnosticGuardBuilder::severity_and_source(self, LintId::of(lint)).is_some()
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5132,7 +5132,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let mut seen = FxHashSet::default();
                     let argument_type = self.expression_type(value);
                     let teardown = self.setup_expression_cache();
-                    let has_unique_context = overloads_with_binding.len() == 1;
+                    let has_unique_context = !self.context.diagnostics_are_suppressed()
+                        && matches!(
+                            overloads_with_binding.as_slice(),
+                            [(_, binding)] if matches!(
+                                binding.matching_overload_index(),
+                                MatchingOverloadIndex::Single(_)
+                            )
+                        );
 
                     for (overload, binding) in &overloads_with_binding {
                         let adjusted_argument_index = if binding.bound_type.is_some() {
@@ -5150,7 +5157,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             .keyword_parameter_types(overload.signature.parameters())
                             .collect();
                         let expected_variadic_ty = argument_matches
-                            .keyword_variadic_parameter_type(overload.signature.parameters());
+                            .keyword_variadic_context_type(db, overload.signature.parameters());
                         let Some(context_ty) = argument_matches
                             .keyword_context_type(db, overload.signature.parameters())
                         else {
@@ -5162,30 +5169,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                         let ty = if value.is_dict_expr() {
                             let tcx = TypeContext::new(Some(context_ty));
+                            let mut builder = self.speculate_without_diagnostics();
+                            let ty = infer_argument_ty(&mut builder, (argument_index, value, tcx));
+                            Some(ty)
+                        } else {
                             let mut builder = if has_unique_context {
                                 self.speculate()
                             } else {
                                 self.speculate_without_diagnostics()
                             };
-                            let ty = infer_argument_ty(&mut builder, (argument_index, value, tcx));
+                            let ty = builder.try_narrow_dict_kwargs(
+                                argument_type,
+                                keyword,
+                                Some(&expected_fields),
+                                expected_variadic_ty,
+                            );
                             if has_unique_context {
-                                self.extend(builder);
+                                let diagnostics = builder.context.finish();
+                                self.context.extend(&diagnostics);
                             }
-                            Some(ty)
-                        } else if has_unique_context {
-                            self.try_narrow_dict_kwargs(
-                                argument_type,
-                                keyword,
-                                Some(&expected_fields),
-                                expected_variadic_ty,
-                            )
-                        } else {
-                            self.speculate_without_diagnostics().try_narrow_dict_kwargs(
-                                argument_type,
-                                keyword,
-                                Some(&expected_fields),
-                                expected_variadic_ty,
-                            )
+                            ty
                         };
                         if let Some(ty) = ty {
                             arguments_types.insert_type(argument_index, context_ty, ty);
@@ -8988,7 +8991,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let InferenceRegion::Scope(_, tcx) = self.region else {
             return None;
         };
-        let DefinitionKind::LambdaParameter(parameter) = definition.kind(self.db()) else {
+        let DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
+            index,
+            parameter: ParameterDefinitionNodeKind::Parameter(_),
+            ..
+        }) = definition.kind(self.db())
+        else {
             return None;
         };
         let callable = tcx
@@ -9001,7 +9009,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let parameter_ty = signature
             .parameters()
             .as_slice()
-            .get(parameter.index as usize)?
+            .get(*index as usize)?
             .annotated_type();
 
         (!parameter_ty.is_unknown() && !parameter_ty.has_unspecialized_type_var(self.db()))

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -98,7 +98,10 @@ use crate::types::subclass_of::SubclassOfInner;
 use crate::types::tuple::promotion::TupleSizePromotionConstraints;
 use crate::types::tuple::{Tuple, TupleLength, TupleSpecBuilder, TupleType};
 use crate::types::type_alias::{ManualPEP695TypeAliasType, PEP695TypeAliasType};
-use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
+use crate::types::typed_dict::{
+    TypedDictAssignmentKind, TypedDictKeyAssignment, TypedDictOpenness,
+    synthesized_typed_dict_type_from_fields,
+};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
 use crate::types::unpacker::UnpackResult;
 use crate::types::{
@@ -5112,14 +5115,70 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         for (argument_index, ast_argument) in ast_arguments.enumerate() {
-            // Splatted arguments are inferred before parameter matching to
-            // determine their length.
-            //
-            // TODO: Re-infer splatted arguments with their type context.
-            if ast_argument.is_variadic() {
-                continue;
-            }
-            let ast_argument = ast_argument.value();
+            let ast_argument = match ast_argument {
+                // Splatted arguments are inferred before parameter matching to
+                // determine their length.
+                //
+                // TODO: Re-infer starred positional arguments with their type context.
+                ast::ArgOrKeyword::Arg(ast::Expr::Starred(_)) => continue,
+
+                ast::ArgOrKeyword::Keyword(
+                    keyword @ ast::Keyword {
+                        arg: None, value, ..
+                    },
+                ) => {
+                    // Keep `**kwargs` contexts per overload; losing overloads must not widen the
+                    // fields used by viable overloads.
+                    let mut seen = FxHashSet::default();
+                    let argument_type = self.expression_type(value);
+                    let teardown = self.setup_expression_cache();
+
+                    for (overload, binding) in &overloads_with_binding {
+                        let adjusted_argument_index = if binding.bound_type.is_some() {
+                            argument_index + 1
+                        } else {
+                            argument_index
+                        };
+                        let Some(argument_matches) =
+                            overload.argument_matches().get(adjusted_argument_index)
+                        else {
+                            continue;
+                        };
+
+                        let expected_fields: FxHashMap<_, _> = argument_matches
+                            .keyword_parameter_types(overload.signature.parameters())
+                            .collect();
+
+                        let Some(context_ty) = synthesized_typed_dict_type_from_fields(
+                            db,
+                            expected_fields.iter().map(|(name, ty)| (name.clone(), *ty)),
+                            TypedDictOpenness::Closed,
+                        ) else {
+                            continue;
+                        };
+                        if !seen.insert(context_ty) {
+                            continue;
+                        }
+
+                        if let Some(ty) = self.speculate().try_narrow_dict_kwargs(
+                            argument_type,
+                            keyword,
+                            Some(&expected_fields),
+                        ) {
+                            arguments_types.insert_type(argument_index, context_ty, ty);
+                        }
+                    }
+
+                    if teardown {
+                        self.teardown_expression_cache();
+                    }
+
+                    continue;
+                }
+
+                ast::ArgOrKeyword::Arg(argument) => argument,
+                ast::ArgOrKeyword::Keyword(keyword) => &keyword.value,
+            };
 
             let parameter_tcx = |overload: &'bindings Binding<'db>,
                                  binding: &CallableBinding<'db>| {
@@ -7455,46 +7514,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ))
     }
 
-    /// Attempt to narrow a splatted dictionary argument based on the narrowed types of individual
-    /// keys, if any.
+    /// Attempt to narrow a `**kwargs` dictionary using known string-literal fields.
     ///
-    /// Returns the intersection between the dictionary type and a synthesized typed dict of any narrowed
-    /// keys, or `None` otherwise.
+    /// When `expected_fields` is present, fresh dictionary literal fields can be inferred with
+    /// matched keyword parameter types.
     fn try_narrow_dict_kwargs(
-        &self,
+        &mut self,
         argument_type: Type<'db>,
-        argument: &'ast ast::ArgOrKeyword,
+        keyword: &ast::Keyword,
+        expected_fields: Option<&FxHashMap<Name, Type<'db>>>,
     ) -> Option<Type<'db>> {
         let db = self.db();
         let file_scope_id = self.scope().file_scope_id(db);
         let use_def = self.index.use_def_map(file_scope_id);
 
-        let keyword = argument.as_variadic()?;
-
-        if !argument_type
-            .as_nominal_instance()?
-            .has_known_class(db, KnownClass::Dict)
-        {
+        let dict_instance = argument_type.as_nominal_instance()?;
+        if !dict_instance.has_known_class(db, KnownClass::Dict) {
             return None;
         }
-
-        let definition_key = |definition: Definition<'_>| {
-            let key = match definition.kind(db) {
-                DefinitionKind::DictKeyAssignment(assignment) => assignment.key(self.module()),
-                DefinitionKind::Assignment(assignment) => {
-                    &assignment.target(self.module()).as_subscript_expr()?.slice
-                }
-                DefinitionKind::AnnotatedAssignment(assignment) => {
-                    &assignment.target(self.module()).as_subscript_expr()?.slice
-                }
-                _ => return None,
-            };
-
-            Some(key.as_string_literal_expr()?.value.to_str())
-        };
+        let (key_ty, value_ty) = argument_type.unpack_keys_and_items(db)?;
 
         // Collect the types of each distinct key.
-        let mut elements: Vec<(&str, Type<'db>)> = Vec::new();
+        let mut elements: Vec<(Name, Type<'db>)> = Vec::new();
 
         for bindings in use_def.multi_bindings_at_use(keyword.scoped_use_id(db, self.file())) {
             let place = place_from_bindings_with_reachability_cache(
@@ -7502,16 +7543,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 bindings.clone(),
                 self.reachability_cache(),
             );
-            let Some(key) = place.first_definition.and_then(definition_key) else {
+            let Some(first_definition) = place.first_definition else {
                 continue;
             };
+            let Some(key) = self.kwargs_definition_key(first_definition) else {
+                continue;
+            };
+            let contextual_ty = expected_fields.and_then(|expected_fields| {
+                bindings
+                    .filter_map(|binding| binding.binding.definition())
+                    .exactly_one()
+                    .ok()
+                    .and_then(|definition| {
+                        self.contextualized_kwargs_field_type(definition, &key, expected_fields)
+                    })
+            });
 
             if let Place::Defined(DefinedPlace {
-                ty: field_ty,
+                ty,
                 definedness: Definedness::AlwaysDefined,
                 ..
             }) = place.place
             {
+                let field_ty = contextual_ty.unwrap_or(ty);
                 elements.push((key, field_ty));
             }
         }
@@ -7520,13 +7574,37 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return None;
         }
 
+        let has_valid_keyword_keys = key_ty
+            .when_assignable_to(
+                db,
+                KnownClass::Str.to_instance(db),
+                &ConstraintSetBuilder::new(),
+                InferableTypeVars::None,
+            )
+            .is_always_satisfied(db);
+
+        if has_valid_keyword_keys && expected_fields.is_some() {
+            let openness = if value_ty.is_dynamic() {
+                TypedDictOpenness::Closed
+            } else {
+                TypedDictOpenness::extra(db, value_ty, false)
+            };
+            let typed_dict =
+                synthesized_typed_dict_type_from_fields(db, elements.iter().cloned(), openness)?;
+
+            return Some(IntersectionType::from_elements(
+                db,
+                [argument_type, typed_dict],
+            ));
+        }
+
         // Synthesize overloads for `__getitem__` based on known dictionary elements.
         let getitem_overloads = elements.into_iter().map(|(name, ty)| {
             Signature::new(
                 Parameters::standard([
                     Parameter::positional_only(Some(Name::new_static("self"))),
                     Parameter::positional_or_keyword(Name::new_static("key"))
-                        .with_annotated_type(Type::string_literal(db, name)),
+                        .with_annotated_type(Type::string_literal(db, name.as_str())),
                 ]),
                 ty,
             )
@@ -7553,6 +7631,38 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ))
     }
 
+    /// Extract the statically known string key for a `**kwargs` dictionary field definition.
+    fn kwargs_definition_key(&self, definition: Definition<'db>) -> Option<Name> {
+        let key = match definition.kind(self.db()) {
+            DefinitionKind::DictKeyAssignment(assignment) => assignment.key(self.module()),
+            DefinitionKind::Assignment(assignment) => {
+                &assignment.target(self.module()).as_subscript_expr()?.slice
+            }
+            DefinitionKind::AnnotatedAssignment(assignment) => {
+                &assignment.target(self.module()).as_subscript_expr()?.slice
+            }
+            _ => return None,
+        };
+
+        Some(Name::new(key.as_string_literal_expr()?.value.to_str()))
+    }
+
+    /// Re-infer a fresh dictionary literal field with its matched keyword parameter type.
+    fn contextualized_kwargs_field_type(
+        &mut self,
+        definition: Definition<'db>,
+        key: &Name,
+        expected_fields: &FxHashMap<Name, Type<'db>>,
+    ) -> Option<Type<'db>> {
+        let expected_ty = expected_fields.get(key).copied()?;
+        let DefinitionKind::DictKeyAssignment(assignment) = definition.kind(self.db()) else {
+            return None;
+        };
+        let value = assignment.value(self.module());
+
+        Some(self.infer_maybe_standalone_expression(value, TypeContext::new(Some(expected_ty))))
+    }
+
     /// Infer the variadic argument types needed for call binding and emit the shared diagnostics
     /// for invalid `*args` and `**kwargs` inputs.
     fn prepare_call_arguments<'a>(
@@ -7566,7 +7676,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     && argument.is_starred_expr()
                 {
                     self.store_expression_type(argument, ty);
-                } else if let Some(ty) = self.try_narrow_dict_kwargs(ty, arg_or_keyword) {
+                } else if let ast::ArgOrKeyword::Keyword(keyword) = arg_or_keyword
+                    && keyword.arg.is_none()
+                    && let Some(ty) = self.try_narrow_dict_kwargs(ty, keyword, None)
+                {
                     return ty;
                 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5149,12 +5149,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         let expected_fields: FxHashMap<_, _> = argument_matches
                             .keyword_parameter_types(overload.signature.parameters())
                             .collect();
-
-                        let Some(context_ty) = synthesized_typed_dict_type_from_fields(
-                            db,
-                            expected_fields.iter().map(|(name, ty)| (name.clone(), *ty)),
-                            TypedDictOpenness::Closed,
-                        ) else {
+                        let expected_variadic_ty = argument_matches
+                            .keyword_variadic_parameter_type(overload.signature.parameters());
+                        let Some(context_ty) = argument_matches
+                            .keyword_context_type(db, overload.signature.parameters())
+                        else {
                             continue;
                         };
                         if !seen.insert(context_ty) {
@@ -5166,12 +5165,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 argument_type,
                                 keyword,
                                 Some(&expected_fields),
+                                expected_variadic_ty,
                             )
                         } else {
                             self.speculate_without_diagnostics().try_narrow_dict_kwargs(
                                 argument_type,
                                 keyword,
                                 Some(&expected_fields),
+                                expected_variadic_ty,
                             )
                         };
                         if let Some(ty) = ty {
@@ -7544,6 +7545,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         argument_type: Type<'db>,
         keyword: &ast::Keyword,
         expected_fields: Option<&FxHashMap<Name, Type<'db>>>,
+        expected_variadic_ty: Option<Type<'db>>,
     ) -> Option<Type<'db>> {
         let db = self.db();
         let file_scope_id = self.scope().file_scope_id(db);
@@ -7571,12 +7573,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 continue;
             };
             let contextual_ty = expected_fields.and_then(|expected_fields| {
+                let expected_ty = expected_fields
+                    .get(&key)
+                    .copied()
+                    .or(expected_variadic_ty)?;
                 bindings
                     .filter_map(|binding| binding.binding.definition())
                     .exactly_one()
                     .ok()
                     .and_then(|definition| {
-                        self.contextualized_kwargs_field_type(definition, &key, expected_fields)
+                        self.contextualized_kwargs_field_type(definition, expected_ty)
                     })
             });
 
@@ -7668,14 +7674,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         Some(Name::new(key.as_string_literal_expr()?.value.to_str()))
     }
 
-    /// Re-infer a fresh dictionary literal field with its matched keyword parameter type.
+    /// Re-infer a fresh dictionary literal field with its matched parameter type.
     fn contextualized_kwargs_field_type(
         &mut self,
         definition: Definition<'db>,
-        key: &Name,
-        expected_fields: &FxHashMap<Name, Type<'db>>,
+        expected_ty: Type<'db>,
     ) -> Option<Type<'db>> {
-        let expected_ty = expected_fields.get(key).copied()?;
         let DefinitionKind::DictKeyAssignment(assignment) = definition.kind(self.db()) else {
             return None;
         };
@@ -7699,7 +7703,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     self.store_expression_type(argument, ty);
                 } else if let ast::ArgOrKeyword::Keyword(keyword) = arg_or_keyword
                     && keyword.arg.is_none()
-                    && let Some(ty) = self.try_narrow_dict_kwargs(ty, keyword, None)
+                    && let Some(ty) = self.try_narrow_dict_kwargs(ty, keyword, None, None)
                 {
                     return ty;
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5160,7 +5160,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             continue;
                         }
 
-                        let ty = if has_unique_context {
+                        let ty = if value.is_dict_expr() {
+                            let tcx = TypeContext::new(Some(context_ty));
+                            let mut builder = if has_unique_context {
+                                self.speculate()
+                            } else {
+                                self.speculate_without_diagnostics()
+                            };
+                            let ty = infer_argument_ty(&mut builder, (argument_index, value, tcx));
+                            if has_unique_context {
+                                self.extend(builder);
+                            }
+                            Some(ty)
+                        } else if has_unique_context {
                             self.try_narrow_dict_kwargs(
                                 argument_type,
                                 keyword,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5132,6 +5132,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let mut seen = FxHashSet::default();
                     let argument_type = self.expression_type(value);
                     let teardown = self.setup_expression_cache();
+                    let has_unique_context = overloads_with_binding.len() == 1;
 
                     for (overload, binding) in &overloads_with_binding {
                         let adjusted_argument_index = if binding.bound_type.is_some() {
@@ -5160,11 +5161,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             continue;
                         }
 
-                        if let Some(ty) = self.speculate().try_narrow_dict_kwargs(
-                            argument_type,
-                            keyword,
-                            Some(&expected_fields),
-                        ) {
+                        let ty = if has_unique_context {
+                            self.try_narrow_dict_kwargs(
+                                argument_type,
+                                keyword,
+                                Some(&expected_fields),
+                            )
+                        } else {
+                            self.speculate_without_diagnostics().try_narrow_dict_kwargs(
+                                argument_type,
+                                keyword,
+                                Some(&expected_fields),
+                            )
+                        };
+                        if let Some(ty) = ty {
                             arguments_types.insert_type(argument_index, context_ty, ty);
                         }
                     }
@@ -7365,7 +7375,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn infer_lambda_body(&mut self, lambda_expression: &ast::ExprLambda, tcx: TypeContext<'db>) {
-        self.infer_expression(&lambda_expression.body, tcx);
+        let body_tcx = tcx
+            .annotation
+            .and_then(|ty| {
+                ty.filter_union(self.db(), Type::is_callable_type)
+                    .as_callable()
+            })
+            .and_then(|callable| {
+                let [signature] = callable.signatures(self.db()).overloads.as_slice() else {
+                    return None;
+                };
+                Some(match signature.return_ty {
+                    Type::Dynamic(DynamicType::Unknown) => TypeContext::default(),
+                    return_ty => TypeContext::new(Some(return_ty)),
+                })
+            })
+            .unwrap_or(tcx);
+
+        self.infer_expression(&lambda_expression.body, body_tcx);
     }
 
     fn infer_lambda_expression(
@@ -7488,21 +7515,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let scope = scope_id.to_scope_id(self.db(), self.file());
 
-        // If we have a direct `Callable` type context, we can infer the body with the annotated
-        // return type as type context.
-        let return_tcx = if let Some(signature) = callable_tcx {
-            match signature.return_ty {
-                Type::Dynamic(DynamicType::Unknown) => TypeContext::new(None),
-                _ => TypeContext::new(Some(signature.return_ty)),
-            }
+        // The lambda scope needs the full callable context to infer parameter types. The body
+        // extracts and uses only the callable's return type.
+        let scope_tcx = if callable_tcx.is_some() {
+            tcx
         } else {
-            // TODO: Useful inference of a lambda's return type will require a different approach,
-            // which does the inference of the body expression based on arguments at each call site,
-            // rather than eagerly computing a return type without knowing the argument types.
-            TypeContext::new(None)
+            TypeContext::default()
         };
 
-        let inference = infer_scope_types(self.db(), scope, return_tcx);
+        let inference = infer_scope_types(self.db(), scope, scope_tcx);
         self.extend_scope(inference);
 
         let return_ty = inference.expression_type(lambda_expression.body.as_ref());
@@ -8925,15 +8946,50 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             let use_id = expr_ref.scoped_use_id(db, self.file());
-            let place = place_from_bindings_with_reachability_cache(
-                db,
-                use_def.bindings_at_use(use_id),
-                self.reachability_cache(),
-            )
-            .place;
+            let bindings = use_def.bindings_at_use(use_id);
+            let contextual_place = bindings.clone().exactly_one().ok().and_then(|binding| {
+                let definition = binding.binding.definition()?;
+                let parameter_ty = self.contextual_lambda_parameter_type(definition)?;
+                Some(
+                    Place::bound(binding.narrowing_constraint.narrow(
+                        db,
+                        parameter_ty,
+                        definition.place(db),
+                    ))
+                    .with_definition(definition),
+                )
+            });
+            let place = contextual_place.unwrap_or_else(|| {
+                place_from_bindings_with_reachability_cache(db, bindings, self.reachability_cache())
+                    .place
+            });
 
             (place, Some(use_id))
         }
+    }
+
+    fn contextual_lambda_parameter_type(&self, definition: Definition<'db>) -> Option<Type<'db>> {
+        let InferenceRegion::Scope(_, tcx) = self.region else {
+            return None;
+        };
+        let DefinitionKind::LambdaParameter(parameter) = definition.kind(self.db()) else {
+            return None;
+        };
+        let callable = tcx
+            .annotation?
+            .filter_union(self.db(), Type::is_callable_type)
+            .as_callable()?;
+        let [signature] = callable.signatures(self.db()).overloads.as_slice() else {
+            return None;
+        };
+        let parameter_ty = signature
+            .parameters()
+            .as_slice()
+            .get(parameter.index as usize)?
+            .annotated_type();
+
+        (!parameter_ty.is_unknown() && !parameter_ty.has_unspecialized_type_var(self.db()))
+            .then_some(parameter_ty)
     }
 
     /// Resolve a load that has fallen through to the module's explicit global scope.

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -198,6 +198,31 @@ pub(super) fn functional_typed_dict_field(
         .build()
 }
 
+/// Return a synthesized required `TypedDict` for a finite set of keyword fields.
+pub(crate) fn synthesized_typed_dict_type_from_fields<'db>(
+    db: &'db dyn Db,
+    fields: impl IntoIterator<Item = (Name, Type<'db>)>,
+    openness: TypedDictOpenness<'db>,
+) -> Option<Type<'db>> {
+    let schema = fields
+        .into_iter()
+        .map(|(name, ty)| {
+            (
+                name,
+                functional_typed_dict_field(ty, TypeQualifiers::empty(), true),
+            )
+        })
+        .collect::<TypedDictSchema<'db>>();
+
+    if schema.is_empty() {
+        None
+    } else {
+        Some(Type::TypedDict(
+            TypedDictType::from_schema_items_with_openness(db, schema, openness),
+        ))
+    }
+}
+
 /// Type that represents the set of all inhabitants (`dict` instances) that conform to
 /// a given `TypedDict` schema.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, Hash, get_size2::GetSize)]


### PR DESCRIPTION
## Summary

This PR adds contextual inference for dictionary-backed `**kwargs` calls with statically-known string keys.

Previously, we inferred a splatted keyword dictionary before call binding knew which parameters the keys matched. As a result, values inside a dictionary literal were inferred in isolation instead of against the target keyword parameter type. That showed up in cases like:

```python
class InputMessage(TypedDict):
  role: Literal["user"]
  content: str

@overload
def create(*, input: list[InputMessage]) -> int: ...
@overload
def create(*, input: str) -> str: ...

kwargs: dict[str, Any] = {
  "input": [{"role": "user", "content": content}],
}
reveal_type(create(**kwargs))
```

Here, the `"input"` value should be inferred with `list[InputMessage]` as context, just like it would be for
`create(input=...)`. But because the value was hidden behind `**kwargs`, we could infer it too narrowly and lose the
intended overload.
