### PR TITLE
[ty] more precise exception types when catching a union

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/basic.md
@@ -47,6 +47,7 @@ def foo(
     z: tuple[type[BaseException], ...],
     zz: tuple[type[TypeError | RuntimeError], ...],
     zzz: type[BaseException] | tuple[type[BaseException], ...],
+    v: type[ValueError] | tuple[type[ValueError], ...],
 ):
     try:
         help()
@@ -60,6 +61,8 @@ def foo(
         reveal_type(h)  # revealed: TypeError | RuntimeError
     except zzz as i:
         reveal_type(i)  # revealed: BaseException
+    except v as j:
+        reveal_type(j)  # revealed: ValueError
 ```
 
 We do not emit an `invalid-exception-caught` if a class is caught that has `Any` or `Unknown` in its
@@ -93,7 +96,9 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import Callable
+from typing import Callable, TypeVar
+
+E = TypeVar("E", bound=Exception)
 
 def silence[T: type[BaseException]](
     func: Callable[[], None],
@@ -109,6 +114,22 @@ def silence2[T: (type[ValueError], type[TypeError])](func: Callable[[], None], e
         func()
     except exception_type as e:
         reveal_type(e)  # revealed: T'instance@silence2
+
+def silence3(func: Callable[[], None], exception_types: type[E] | tuple[type[E], ...]):
+    try:
+        func()
+    except exception_types as e:
+        reveal_type(e)  # revealed: E@silence3
+
+def silence4[T: type[BaseException] | tuple[type[BaseException], ...]](
+    func: Callable[[], None],
+    exception_types: T,
+):
+    try:
+        func()
+    except exception_types as e:
+        # TODO: Should reveal something more like `T'instance@silence4`.
+        reveal_type(e)  # revealed: BaseException
 ```
 
 ## Invalid exception handlers

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1875,32 +1875,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             builder.build()
-        } else if node_ty.is_assignable_to(self.db(), type_base_exception) {
-            node_ty.to_instance(self.db()).expect(
-                "`Type::to_instance()` should always return `Some()` \
-                    if called on a type assignable to `type[BaseException]`",
-            )
-        } else if node_ty.is_assignable_to(
-            self.db(),
-            Type::homogeneous_tuple(self.db(), type_base_exception),
-        ) {
-            node_ty
-                .tuple_instance_spec(self.db())
-                .and_then(|spec| {
-                    let specialization = spec
-                        .homogeneous_element_type(self.db())
-                        .to_instance(self.db());
-
-                    debug_assert!(specialization.is_some_and(|specialization_type| {
-                        specialization_type.is_assignable_to(
-                            self.db(),
-                            KnownClass::BaseException.to_instance(self.db()),
-                        )
-                    }));
-
-                    specialization
-                })
-                .unwrap_or_else(|| KnownClass::BaseException.to_instance(self.db()))
+        } else if let Some(symbol_ty) =
+            self.exception_handler_symbol_ty_from_valid_ty(node_ty, type_base_exception)
+        {
+            symbol_ty
         } else if node_ty.is_assignable_to(
             self.db(),
             UnionType::from_two_elements(
@@ -1909,6 +1887,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 Type::homogeneous_tuple(self.db(), type_base_exception),
             ),
         ) {
+            // TODO: Handle valid handler expressions that are opaque to the structural helper
+            // above, for example a type variable bounded by the full class-or-tuple union.
             KnownClass::BaseException.to_instance(self.db())
         } else {
             if let Some(node) = node {
@@ -1928,6 +1908,61 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             class.to_specialized_instance(self.db(), &[symbol_ty])
         } else {
             symbol_ty
+        }
+    }
+
+    fn exception_handler_symbol_ty_from_valid_ty(
+        &self,
+        ty: Type<'db>,
+        type_base_exception: Type<'db>,
+    ) -> Option<Type<'db>> {
+        if let Some(tuple_spec) = ty.tuple_instance_spec(self.db()) {
+            UnionType::try_from_elements(
+                self.db(),
+                tuple_spec.all_elements().iter().map(|element| {
+                    if element.is_assignable_to(self.db(), type_base_exception) {
+                        Some(element.to_instance(self.db()).expect(
+                            "`Type::to_instance()` should always return `Some()` \
+                                if called on a type assignable to `type[BaseException]`",
+                        ))
+                    } else {
+                        None
+                    }
+                }),
+            )
+        } else if ty.is_assignable_to(self.db(), type_base_exception) {
+            Some(ty.to_instance(self.db()).expect(
+                "`Type::to_instance()` should always return `Some()` \
+                    if called on a type assignable to `type[BaseException]`",
+            ))
+        } else if ty.is_assignable_to(
+            self.db(),
+            Type::homogeneous_tuple(self.db(), type_base_exception),
+        ) {
+            Some(
+                ty.tuple_instance_spec(self.db())
+                    .and_then(|spec| {
+                        let specialization = spec
+                            .homogeneous_element_type(self.db())
+                            .to_instance(self.db());
+
+                        debug_assert!(specialization.is_some_and(|specialization_type| {
+                            specialization_type.is_assignable_to(
+                                self.db(),
+                                KnownClass::BaseException.to_instance(self.db()),
+                            )
+                        }));
+
+                        specialization
+                    })
+                    .unwrap_or_else(|| KnownClass::BaseException.to_instance(self.db())),
+            )
+        } else if let Type::Union(union) = ty {
+            union.try_map(self.db(), |element| {
+                self.exception_handler_symbol_ty_from_valid_ty(*element, type_base_exception)
+            })
+        } else {
+            None
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1917,6 +1917,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         type_base_exception: Type<'db>,
     ) -> Option<Type<'db>> {
         if let Some(tuple_spec) = ty.tuple_instance_spec(self.db()) {
+            // `except (ValueError, TypeError) as e:`
             UnionType::try_from_elements(
                 self.db(),
                 tuple_spec.all_elements().iter().map(|element| {
@@ -1931,6 +1932,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }),
             )
         } else if ty.is_assignable_to(self.db(), type_base_exception) {
+            // `except ValueError as e:`
             Some(ty.to_instance(self.db()).expect(
                 "`Type::to_instance()` should always return `Some()` \
                     if called on a type assignable to `type[BaseException]`",
@@ -1939,6 +1941,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.db(),
             Type::homogeneous_tuple(self.db(), type_base_exception),
         ) {
+            // `except exception_types as e:`, where
+            // `exception_types: tuple[type[ValueError], ...]`
             Some(
                 ty.tuple_instance_spec(self.db())
                     .and_then(|spec| {
@@ -1958,6 +1962,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .unwrap_or_else(|| KnownClass::BaseException.to_instance(self.db())),
             )
         } else if let Type::Union(union) = ty {
+            // `except exception_types as e:`, where
+            // `exception_types: type[ValueError] | tuple[type[ValueError], ...]`
             union.try_map(self.db(), |element| {
                 self.exception_handler_symbol_ty_from_valid_ty(*element, type_base_exception)
             })


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/3432.

Currently if you `except some_var as e:` where `some_var` is a union type, we aren't able to extract a precise type for `e` from it; this PR adds that ability.

## Test Plan

Added mdtest.
