### PR TITLE
[ty] Allow enum member accesses on `self`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -1510,6 +1510,10 @@ class Answer(Enum):
     YES = 1
     NO = 2
 
+    def through_self(self) -> None:
+        reveal_type(self.YES)  # revealed: Literal[Answer.YES]
+        reveal_type(self.NO)  # revealed: Literal[Answer.NO]
+
 reveal_type(Answer.YES.NO)  # revealed: Literal[Answer.NO]
 
 def _(answer: Answer) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -371,15 +371,26 @@ class Answer(Enum):
     YES = 1
     MAYBE = 2
 
-    def is_yes(self) -> bool:
-        reveal_type(self)  # revealed: Self@is_yes
+    def is_yes_through_class_member(self) -> bool:
+        reveal_type(self)  # revealed: Self@is_yes_through_class_member
 
         match self:
             case Answer.YES:
-                reveal_type(self)  # revealed: Self@is_yes
+                reveal_type(self)  # revealed: Self@is_yes_through_class_member
                 return True
             case Answer.NO | Answer.MAYBE:
-                reveal_type(self)  # revealed: Self@is_yes & ~Literal[Answer.YES]
+                reveal_type(self)  # revealed: Self@is_yes_through_class_member & ~Literal[Answer.YES]
+                return False
+            case _:
+                assert_never(self)  # no error
+
+    def is_yes_through_self_member(self) -> bool:
+        match self:
+            case self.YES:
+                reveal_type(self)  # revealed: Self@is_yes_through_self_member
+                return True
+            case self.NO | self.MAYBE:
+                reveal_type(self)  # revealed: Self@is_yes_through_self_member & ~Literal[Answer.YES]
                 return False
             case _:
                 assert_never(self)  # no error
@@ -395,7 +406,7 @@ class Answer(Enum):
                 reveal_type(self)  # revealed: Self@assert_yes & ~Literal[Answer.YES]
                 raise ValueError("Answer is not YES")
 
-Answer.YES.is_yes()
+Answer.YES.is_yes_through_class_member()
 
 try:
     reveal_type(Answer.MAYBE.assert_yes())  # revealed: Literal[Answer.MAYBE]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -395,6 +395,20 @@ class Answer(Enum):
             case _:
                 assert_never(self)  # no error
 
+    @classmethod
+    def is_yes_through_cls_member(cls, answer: "Answer") -> bool:
+        reveal_type(cls.YES)  # revealed: Literal[Answer.YES]
+
+        match answer:
+            case cls.YES:
+                reveal_type(answer)  # revealed: Literal[Answer.YES]
+                return True
+            case cls.NO | cls.MAYBE:
+                reveal_type(answer)  # revealed: Literal[Answer.NO, Answer.MAYBE]
+                return False
+            case _:
+                assert_never(answer)  # no error
+
     def assert_yes(self) -> Self:
         reveal_type(self)  # revealed: Self@assert_yes
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3535,7 +3535,11 @@ impl<'db> Type<'db> {
                     Type::LiteralValue(literal) => literal
                         .as_enum()
                         .map(|enum_literal| enum_literal.enum_class(db)),
-                    Type::NominalInstance(instance) => Some(instance.class_literal(db)),
+                    // This includes `Self` typevars with an enum-class upper bound, which allows
+                    // enum methods to access members through `self`, e.g. `case self.YES:`.
+                    Type::NominalInstance(_) | Type::TypeVar(_) => {
+                        self.nominal_class(db).map(|class| class.class_literal(db))
+                    }
                     _ => None,
                 };
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1229,6 +1229,7 @@ impl<'db> Type<'db> {
                 };
                 bound.nominal_class(db)
             }
+            Type::LiteralValue(literal) => literal.fallback_instance(db).nominal_class(db),
             _ => None,
         }
     }
@@ -3531,19 +3532,8 @@ impl<'db> Type<'db> {
             | Type::TypedDict(_) => {
                 // Enum members can be accessed through enum instances and other enum members,
                 // e.g. `answer.YES` or `Answer.YES.NO`.
-                let enum_class = match self {
-                    Type::LiteralValue(literal) => literal
-                        .as_enum()
-                        .map(|enum_literal| enum_literal.enum_class(db)),
-                    // This includes `Self` typevars with an enum-class upper bound, which allows
-                    // enum methods to access members through `self`, e.g. `case self.YES:`.
-                    Type::NominalInstance(_) | Type::TypeVar(_) => {
-                        self.nominal_class(db).map(|class| class.class_literal(db))
-                    }
-                    _ => None,
-                };
-
-                if let Some(enum_class) = enum_class
+                if let Some(enum_class) =
+                    self.nominal_class(db).map(|class| class.class_literal(db))
                     && let Some(metadata) = enum_metadata(db, enum_class)
                     && let Some(resolved_name) = metadata.resolve_member(&name)
                 {


### PR DESCRIPTION
## Summary

This allows enum members to be resolved when accessed through a `Self`-typed enum instance. Previously, enum member lookup handled class-member patterns like `case Answer.YES:`, but not equivalent self-member patterns like:

```py
class Answer(Enum):
    NO = 0
    YES = 1

    def is_yes(self) -> bool:
        match self:
            case self.YES:
                return True
```

The lookup reuses the receiver’s nominal class for nominal instances and bounded `Self` typevars before resolving enum metadata, so `case self.YES:` narrows the same way as `case Answer.YES:`.
