### PR TITLE
[ty] more precise tuple addition

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
@@ -13,7 +13,18 @@ reveal_type(x)  # revealed: int | float
 
 x = (1, 2)
 x += (3, 4)
-reveal_type(x)  # revealed: tuple[Literal[1, 2, 3, 4], ...]
+reveal_type(x)  # revealed: tuple[Literal[1], Literal[2], Literal[3], Literal[4]]
+```
+
+## Fixed-length tuple of `Any`
+
+```py
+from typing import Any
+
+def f2():
+    x: tuple[Any, Any, Any] = (0, 1, 2)
+    x += (1, 2, 3)  # error: [invalid-assignment]
+    reveal_type(x)  # revealed: tuple[Any, Any, Any]
 ```
 
 ## Walrus target

--- a/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/augmented.md
@@ -27,6 +27,24 @@ def f2():
     reveal_type(x)  # revealed: tuple[Any, Any, Any]
 ```
 
+## Recursive variable-length tuple
+
+```py
+from typing import Any, Mapping
+
+_marker: tuple[object] = (object(),)
+
+def make_key(args: tuple[Any, ...], kwds: Mapping[Any, object]) -> tuple[Any, ...]:
+    key: tuple[Any, ...] = args
+    if kwds:
+        key += _marker
+        for item in kwds.items():
+            key += item
+
+    reveal_type(key)  # revealed: tuple[object, ...]
+    return key
+```
+
 ## Walrus target
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
@@ -3,14 +3,19 @@
 ## Concatenation for heterogeneous tuples
 
 ```py
-reveal_type((1, 2) + (3, 4))  # revealed: tuple[Literal[1, 2, 3, 4], ...]
-reveal_type(() + (1, 2))  # revealed: tuple[Literal[1, 2], ...]
-reveal_type((1, 2) + ())  # revealed: tuple[Literal[1, 2], ...]
+reveal_type((1, 2) + (3, 4))  # revealed: tuple[Literal[1], Literal[2], Literal[3], Literal[4]]
+reveal_type(() + (1, 2))  # revealed: tuple[Literal[1], Literal[2]]
+reveal_type((1, 2) + ())  # revealed: tuple[Literal[1], Literal[2]]
 reveal_type(() + ())  # revealed: tuple[()]
 
 def _(x: tuple[int, str], y: tuple[None, tuple[int]]):
-    reveal_type(x + y)  # revealed: tuple[int | str | None | tuple[int], ...]
-    reveal_type(y + x)  # revealed: tuple[None | tuple[int] | int | str, ...]
+    reveal_type(x + y)  # revealed: tuple[int, str, None, tuple[int]]
+    reveal_type(y + x)  # revealed: tuple[None, tuple[int], int, str]
+
+def prefix(x: tuple[int, int]) -> tuple[str, int, int]:
+    result = ("asdf",) + x
+    reveal_type(result)  # revealed: tuple[Literal["asdf"], int, int]
+    return result
 ```
 
 ## Concatenation for homogeneous tuples
@@ -19,10 +24,10 @@ def _(x: tuple[int, str], y: tuple[None, tuple[int]]):
 def _(x: tuple[int, ...], y: tuple[str, ...]):
     reveal_type(x + x)  # revealed: tuple[int, ...]
     reveal_type(x + y)  # revealed: tuple[int | str, ...]
-    reveal_type((1, 2) + x)  # revealed: tuple[int, ...]
-    reveal_type(x + (3, 4))  # revealed: tuple[int, ...]
-    reveal_type((1, 2) + x + (3, 4))  # revealed: tuple[int, ...]
-    reveal_type((1, 2) + y + (3, 4) + x)  # revealed: tuple[int | str, ...]
+    reveal_type((1, 2) + x)  # revealed: tuple[Literal[1], Literal[2], *tuple[int, ...]]
+    reveal_type(x + (3, 4))  # revealed: tuple[*tuple[int, ...], Literal[3], Literal[4]]
+    reveal_type((1, 2) + x + (3, 4))  # revealed: tuple[Literal[1], Literal[2], *tuple[int, ...], Literal[3], Literal[4]]
+    reveal_type((1, 2) + y + (3, 4) + x)  # revealed: tuple[Literal[1], Literal[2], *tuple[int | str, ...]]
 ```
 
 We get the same results even when we use a legacy type alias, even though this involves first
@@ -41,8 +46,8 @@ StrTuple = tuple[str, ...]
 def _(one_two: OneTwo, x: IntTuple, y: StrTuple, three_four: ThreeFour):
     reveal_type(x + x)  # revealed: tuple[int, ...]
     reveal_type(x + y)  # revealed: tuple[int | str, ...]
-    reveal_type(one_two + x)  # revealed: tuple[int, ...]
-    reveal_type(x + three_four)  # revealed: tuple[int, ...]
-    reveal_type(one_two + x + three_four)  # revealed: tuple[int, ...]
-    reveal_type(one_two + y + three_four + x)  # revealed: tuple[int | str, ...]
+    reveal_type(one_two + x)  # revealed: tuple[Literal[1], Literal[2], *tuple[int, ...]]
+    reveal_type(x + three_four)  # revealed: tuple[*tuple[int, ...], Literal[3], Literal[4]]
+    reveal_type(one_two + x + three_four)  # revealed: tuple[Literal[1], Literal[2], *tuple[int, ...], Literal[3], Literal[4]]
+    reveal_type(one_two + y + three_four + x)  # revealed: tuple[Literal[1], Literal[2], *tuple[int | str, ...]]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/tuples.md
@@ -51,3 +51,28 @@ def _(one_two: OneTwo, x: IntTuple, y: StrTuple, three_four: ThreeFour):
     reveal_type(one_two + x + three_four)  # revealed: tuple[Literal[1], Literal[2], *tuple[int, ...], Literal[3], Literal[4]]
     reveal_type(one_two + y + three_four + x)  # revealed: tuple[Literal[1], Literal[2], *tuple[int | str, ...]]
 ```
+
+## Conditional tuple concatenation
+
+```py
+def flag() -> bool:
+    return True
+
+t = ()
+if flag():
+    t += (1,)
+if flag():
+    t += (2,)
+if flag():
+    t += (3,)
+if flag():
+    t += (4,)
+if flag():
+    t += (5,)
+if flag():
+    t += (6,)
+if flag():
+    t += (7,)
+
+reveal_type(t)  # revealed: tuple[Literal[1, 2, 3, 4, 5, 6, 7], ...]
+```

--- a/crates/ty_python_semantic/resources/mdtest/instance_layout_conflict.md
+++ b/crates/ty_python_semantic/resources/mdtest/instance_layout_conflict.md
@@ -146,14 +146,12 @@ class A:
     __slots__ = ()
     __slots__ += ("a", "b")
 
-reveal_type(A.__slots__)  # revealed: tuple[Literal["a", "b"], ...]
+reveal_type(A.__slots__)  # revealed: tuple[Literal["a"], Literal["b"]]
 
 class B:
     __slots__ = ("c", "d")
 
-# TODO: ideally this would trigger `[instance-layout-conflict]`
-# (but it's also not high-priority)
-class C(A, B): ...
+class C(A, B): ...  # error: [instance-layout-conflict]
 ```
 
 ## Explicitly annotated `__slots__`

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -8,6 +8,7 @@ use crate::types::cyclic::CycleDetector;
 use crate::types::diagnostic::{
     DIVISION_BY_ZERO, report_unsupported_augmented_assignment, report_unsupported_binary_operation,
 };
+use crate::types::tuple::{TupleSpecBuilder, TupleType};
 use crate::types::typevar::TypeVarConstraints;
 use crate::types::{
     DynamicType, InternedConstraintSet, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -339,6 +340,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 || self.file().is_stub(db)
                 || self.is_in_type_checking_block(self.scope(), node)
         };
+
+        // This is not strictly sound, because a tuple subclass could define `__add__` in a weird
+        // way; but in practice the benefit of understanding this behavior for normal tuples (and
+        // all normally-behaved tuple subclasses) far outweighs the cost of being wrong for a rare
+        // weird subclass.
+        if op == ast::Operator::Add
+            && let Some(left_tuple) = left_ty.exact_tuple_instance_spec(db)
+            && let Some(right_tuple) = right_ty.exact_tuple_instance_spec(db)
+        {
+            let tuple = TupleSpecBuilder::from(left_tuple.as_ref())
+                .concat(db, right_tuple.as_ref())
+                .build();
+            return Some(Type::tuple(TupleType::new(db, &tuple)));
+        }
 
         match (left_ty, right_ty, op) {
             (Type::Union(lhs_union), rhs, _) => lhs_union.try_map(db, |lhs_element| {

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -338,6 +338,9 @@ const MAX_NON_RECURSIVE_UNION_LITERALS: usize = 256;
 /// Huge enums are not uncommon (especially in generated code), and it's annoying
 /// if reachability analysis etc. fails when analysing these enums.
 const MAX_NON_RECURSIVE_UNION_ENUM_LITERALS: usize = 8192;
+/// The maximum number of precise tuple shapes to keep in a union before collapsing them to a
+/// single homogeneous tuple.
+const MAX_UNION_TUPLE_TYPES: usize = 64;
 
 pub(crate) struct UnionBuilder<'db> {
     elements: Vec<UnionElement<'db>>,
@@ -888,21 +891,20 @@ impl<'db> UnionBuilder<'db> {
         self.try_build().unwrap_or(Type::Never)
     }
 
-    /// In a recursively-defined union, collapses precise tuple shapes of differing lengths to a
-    /// single homogeneous variable-length tuple.
+    /// Collapse precise tuple shapes to a single homogeneous variable-length tuple when doing so
+    /// is necessary for convergence or to keep a union from growing without bound.
     ///
-    /// This preserves precise tuple concatenation for acyclic inference while ensuring fixed-point
-    /// iteration can converge when each iteration appends another fixed suffix to the tuple.
-    fn collapse_tuple_shapes_for_cycle_recovery(
+    /// This preserves precise tuple concatenation for small acyclic inference while ensuring
+    /// fixed-point iteration can converge when each iteration appends another fixed suffix to the
+    /// tuple, and prevents conditional tuple concatenation from producing exponentially many tuple
+    /// shapes.
+    fn collapse_tuple_shapes(
         db: &'db dyn Db,
         cycle_recovery: bool,
         recursively_defined: RecursivelyDefined,
         types: Vec<Type<'db>>,
     ) -> Vec<Type<'db>> {
-        if !(cycle_recovery && recursively_defined.is_yes()) {
-            return types;
-        }
-
+        let mut tuple_count = 0;
         let mut first_tuple_length = None;
         let mut has_multiple_tuple_lengths = false;
 
@@ -911,19 +913,23 @@ impl<'db> UnionBuilder<'db> {
                 continue;
             };
 
+            tuple_count += 1;
             has_multiple_tuple_lengths |= first_tuple_length
                 .replace(tuple.len())
                 .is_some_and(|first_tuple_length| first_tuple_length != tuple.len());
         }
 
-        if !has_multiple_tuple_lengths {
+        let collapse_for_cycle_recovery =
+            cycle_recovery && recursively_defined.is_yes() && has_multiple_tuple_lengths;
+        let collapse_for_size_limit = tuple_count > MAX_UNION_TUPLE_TYPES;
+        if !(collapse_for_cycle_recovery || collapse_for_size_limit) {
             return types;
         }
 
         let mut collapsed = Vec::with_capacity(types.len());
         let mut tuple_element_type = UnionBuilder::new(db)
             .unpack_aliases(false)
-            .cycle_recovery(true)
+            .cycle_recovery(cycle_recovery)
             .recursively_defined(recursively_defined);
 
         for ty in types {
@@ -985,12 +991,7 @@ impl<'db> UnionBuilder<'db> {
                 UnionElement::Type(ty) => types.push(ty),
             }
         }
-        let types = Self::collapse_tuple_shapes_for_cycle_recovery(
-            db,
-            cycle_recovery,
-            recursively_defined,
-            types,
-        );
+        let types = Self::collapse_tuple_shapes(db, cycle_recovery, recursively_defined, types);
         match types.len() {
             0 => None,
             1 => Some(types[0]),
@@ -1679,7 +1680,8 @@ impl<'db> InnerIntersectionBuilder<'db> {
 #[cfg(test)]
 mod tests {
     use super::{
-        IntersectionBuilder, MAX_NON_RECURSIVE_UNION_LITERALS, Type, UnionBuilder, UnionType,
+        IntersectionBuilder, MAX_NON_RECURSIVE_UNION_LITERALS, MAX_UNION_TUPLE_TYPES, Type,
+        UnionBuilder, UnionType,
     };
 
     use crate::db::tests::{TestDb, setup_db};
@@ -1773,6 +1775,18 @@ mod tests {
         assert_eq!(union.map(&db, |ty| *ty), unpacked);
         assert_eq!(union.try_map(&db, |ty| Some(*ty)), Some(unpacked));
         assert_eq!(union.map_leave_aliases(&db, |ty| *ty), union_ty);
+    }
+
+    #[test]
+    fn build_union_collapses_many_tuple_shapes() {
+        let db = setup_db();
+
+        let int_instance = KnownClass::Int.to_instance(&db);
+        let tuples = (1..=MAX_UNION_TUPLE_TYPES + 1)
+            .map(|len| Type::heterogeneous_tuple(&db, std::iter::repeat_n(int_instance, len)));
+        let union = UnionType::from_elements(&db, tuples);
+
+        assert_eq!(union, Type::homogeneous_tuple(&db, int_instance));
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -340,7 +340,7 @@ const MAX_NON_RECURSIVE_UNION_LITERALS: usize = 256;
 const MAX_NON_RECURSIVE_UNION_ENUM_LITERALS: usize = 8192;
 /// The maximum number of precise tuple shapes to keep in a union before collapsing them to a
 /// single homogeneous tuple.
-const MAX_UNION_TUPLE_TYPES: usize = 64;
+const MAX_UNION_TUPLE_TYPES: usize = 32;
 
 pub(crate) struct UnionBuilder<'db> {
     elements: Vec<UnionElement<'db>>,

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -888,16 +888,73 @@ impl<'db> UnionBuilder<'db> {
         self.try_build().unwrap_or(Type::Never)
     }
 
+    /// In a recursively-defined union, collapses precise tuple shapes of differing lengths to a
+    /// single homogeneous variable-length tuple.
+    ///
+    /// This preserves precise tuple concatenation for acyclic inference while ensuring fixed-point
+    /// iteration can converge when each iteration appends another fixed suffix to the tuple.
+    fn collapse_tuple_shapes_for_cycle_recovery(
+        db: &'db dyn Db,
+        cycle_recovery: bool,
+        recursively_defined: RecursivelyDefined,
+        types: Vec<Type<'db>>,
+    ) -> Vec<Type<'db>> {
+        if !(cycle_recovery && recursively_defined.is_yes()) {
+            return types;
+        }
+
+        let mut first_tuple_length = None;
+        let mut has_multiple_tuple_lengths = false;
+
+        for ty in &types {
+            let Some(tuple) = ty.exact_tuple_instance_spec(db) else {
+                continue;
+            };
+
+            has_multiple_tuple_lengths |= first_tuple_length
+                .replace(tuple.len())
+                .is_some_and(|first_tuple_length| first_tuple_length != tuple.len());
+        }
+
+        if !has_multiple_tuple_lengths {
+            return types;
+        }
+
+        let mut collapsed = Vec::with_capacity(types.len());
+        let mut tuple_element_type = UnionBuilder::new(db)
+            .unpack_aliases(false)
+            .cycle_recovery(true)
+            .recursively_defined(recursively_defined);
+
+        for ty in types {
+            if let Some(tuple) = ty.exact_tuple_instance_spec(db) {
+                tuple_element_type = tuple_element_type.add(tuple.homogeneous_element_type(db));
+            } else {
+                collapsed.push(ty);
+            }
+        }
+
+        collapsed.push(Type::homogeneous_tuple(db, tuple_element_type.build()));
+        collapsed
+    }
+
     pub(crate) fn try_build(self) -> Option<Type<'db>> {
-        let type_count = self.elements.iter().map(UnionElement::type_count).sum();
+        let Self {
+            elements,
+            db,
+            unpack_aliases: _,
+            cycle_recovery,
+            recursively_defined,
+        } = self;
+        let type_count = elements.iter().map(UnionElement::type_count).sum();
         let mut types = Vec::with_capacity(type_count);
-        for element in self.elements {
+        for element in elements {
             match element {
                 UnionElement::IntLiterals(literals) => {
                     types.extend(literals.into_iter().map(|(literal, promotable)| {
                         Type::from(
                             LiteralValueType::new(literal, promotable)
-                                .with_recursively_defined(self.recursively_defined),
+                                .with_recursively_defined(recursively_defined),
                         )
                     }));
                 }
@@ -905,7 +962,7 @@ impl<'db> UnionBuilder<'db> {
                     types.extend(literals.into_iter().map(|(literal, promotable)| {
                         Type::from(
                             LiteralValueType::new(literal, promotable)
-                                .with_recursively_defined(self.recursively_defined),
+                                .with_recursively_defined(recursively_defined),
                         )
                     }));
                 }
@@ -913,7 +970,7 @@ impl<'db> UnionBuilder<'db> {
                     types.extend(literals.into_iter().map(|(literal, promotable)| {
                         Type::from(
                             LiteralValueType::new(literal, promotable)
-                                .with_recursively_defined(self.recursively_defined),
+                                .with_recursively_defined(recursively_defined),
                         )
                     }));
                 }
@@ -921,20 +978,26 @@ impl<'db> UnionBuilder<'db> {
                     types.extend(literals.into_iter().map(|(literal, promotable)| {
                         Type::from(
                             LiteralValueType::new(literal, promotable)
-                                .with_recursively_defined(self.recursively_defined),
+                                .with_recursively_defined(recursively_defined),
                         )
                     }));
                 }
                 UnionElement::Type(ty) => types.push(ty),
             }
         }
+        let types = Self::collapse_tuple_shapes_for_cycle_recovery(
+            db,
+            cycle_recovery,
+            recursively_defined,
+            types,
+        );
         match types.len() {
             0 => None,
             1 => Some(types[0]),
             _ => Some(Type::Union(UnionType::new(
-                self.db,
+                db,
                 types.into_boxed_slice(),
-                self.recursively_defined,
+                recursively_defined,
             ))),
         }
     }

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -39,6 +39,7 @@
 use super::RecursivelyDefined;
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::set_theoretic::expand_intersection_typevars_and_newtypes;
+use crate::types::tuple::TupleLength;
 use crate::types::{
     BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType, KnownClass,
     LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements, StringLiteralType, Type,
@@ -338,9 +339,9 @@ const MAX_NON_RECURSIVE_UNION_LITERALS: usize = 256;
 /// Huge enums are not uncommon (especially in generated code), and it's annoying
 /// if reachability analysis etc. fails when analysing these enums.
 const MAX_NON_RECURSIVE_UNION_ENUM_LITERALS: usize = 8192;
-/// The maximum number of precise tuple shapes to keep in a union before collapsing them to a
+/// The maximum number of distinct tuple lengths to keep in a union before collapsing them to a
 /// single homogeneous tuple.
-const MAX_UNION_TUPLE_TYPES: usize = 32;
+const MAX_UNION_TUPLE_LENGTHS: usize = 32;
 
 pub(crate) struct UnionBuilder<'db> {
     elements: Vec<UnionElement<'db>>,
@@ -904,8 +905,7 @@ impl<'db> UnionBuilder<'db> {
         recursively_defined: RecursivelyDefined,
         types: Vec<Type<'db>>,
     ) -> Vec<Type<'db>> {
-        let mut tuple_count = 0;
-        let mut first_tuple_length = None;
+        let mut tuple_lengths = SmallVec::<[TupleLength; 8]>::new();
         let mut has_multiple_tuple_lengths = false;
 
         for ty in &types {
@@ -913,15 +913,20 @@ impl<'db> UnionBuilder<'db> {
                 continue;
             };
 
-            tuple_count += 1;
-            has_multiple_tuple_lengths |= first_tuple_length
-                .replace(tuple.len())
-                .is_some_and(|first_tuple_length| first_tuple_length != tuple.len());
+            let tuple_length = tuple.len();
+            has_multiple_tuple_lengths |= tuple_lengths
+                .first()
+                .is_some_and(|first_tuple_length| *first_tuple_length != tuple_length);
+            if tuple_lengths.len() <= MAX_UNION_TUPLE_LENGTHS
+                && !tuple_lengths.contains(&tuple_length)
+            {
+                tuple_lengths.push(tuple_length);
+            }
         }
 
         let collapse_for_cycle_recovery =
             cycle_recovery && recursively_defined.is_yes() && has_multiple_tuple_lengths;
-        let collapse_for_size_limit = tuple_count > MAX_UNION_TUPLE_TYPES;
+        let collapse_for_size_limit = tuple_lengths.len() > MAX_UNION_TUPLE_LENGTHS;
         if !(collapse_for_cycle_recovery || collapse_for_size_limit) {
             return types;
         }
@@ -1680,7 +1685,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
 #[cfg(test)]
 mod tests {
     use super::{
-        IntersectionBuilder, MAX_NON_RECURSIVE_UNION_LITERALS, MAX_UNION_TUPLE_TYPES, Type,
+        IntersectionBuilder, MAX_NON_RECURSIVE_UNION_LITERALS, MAX_UNION_TUPLE_LENGTHS, Type,
         UnionBuilder, UnionType,
     };
 
@@ -1778,11 +1783,31 @@ mod tests {
     }
 
     #[test]
-    fn build_union_collapses_many_tuple_shapes() {
+    fn build_union_preserves_many_tuple_shapes_of_same_length() {
+        let db = setup_db();
+
+        let tuples: Vec<_> = (0..=MAX_UNION_TUPLE_LENGTHS)
+            .map(|literal| {
+                let literal = i64::try_from(literal).expect("test literal fits in i64");
+                let literal = Type::int_literal(literal);
+                Type::heterogeneous_tuple(&db, [literal, literal])
+            })
+            .collect();
+        let union_ty = UnionType::from_elements(&db, tuples.iter().copied());
+        let union = union_ty.expect_union();
+
+        assert_eq!(union.elements(&db).len(), tuples.len());
+        for tuple in tuples {
+            assert!(union.elements(&db).contains(&tuple));
+        }
+    }
+
+    #[test]
+    fn build_union_collapses_many_tuple_lengths() {
         let db = setup_db();
 
         let int_instance = KnownClass::Int.to_instance(&db);
-        let tuples = (1..=MAX_UNION_TUPLE_TYPES + 1)
+        let tuples = (1..=MAX_UNION_TUPLE_LENGTHS + 1)
             .map(|len| Type::heterogeneous_tuple(&db, std::iter::repeat_n(int_instance, len)));
         let union = UnionType::from_elements(&db, tuples);
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/3413

This is not strictly sound, since a tuple subclass could define `__add__` in a weird way. But the benefits of more precise understanding of tuple addition for normal tuples and all reasonably-behaved subclasses outweigh the cost of unsoundness in the case of a rare weirdly-behaved tuple subclass.

In effect we are choosing a more stringent definition of what it means for a tuple subclass to break Liskov compatibility, where redefining dunder methods to have behavior that is unexpectedly different from how a tuple behaves counts as a Liskov break. This is a perfectly reasonable definition (Liskov just means substitutability, it's not required to mean only "compatibility with method type annotations") -- the only problem is it isn't a definition we can automatically enforce (other than conservatively, by erroring on all definitions of dunder methods on tuple subclasses).

This also requires that we flatten tuples to a homogenous shape in cyclically-defined unions, or in any union of tuples that grows too large, to avoid ever-growing unions of precise tuple types causing cycle divergence or pathological performance. Effectively this just gives us the current behavior for cyclic/pathological cases.

## Test Plan

Added mdtests.

### CodSpeed

CodSpeed shows an expected regression on the `many_tuple_assignments` micro-benchmark, since we now create more complex and precise tuple types in this micro-benchmark. But all real-world benchmarks show either no change or a small improvement; not a single one regresses. The original real-world pathological case from https://github.com/astral-sh/ty/issues/362 (which motivated adding the `many_tuple_assignments` micro-benchmark) goes from ~0.045s to ~0.058s on this branch, which is a regression, but well within the acceptable range for a pathological case.

### Ecosystem

Still looking into it...