### PR TITLE
[ty] Include severity in JUnit diagnostics

### DIFF
--- a/crates/ruff/tests/cli/snapshots/cli__format__output_format_junit.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__format__output_format_junit.snap
@@ -18,6 +18,9 @@ exit_code: 1
 <testsuites name="ruff" tests="1" failures="1" errors="0">
     <testsuite name="[TMP]/input.py" tests="1" disabled="0" errors="0" failures="1" package="org.ruff">
         <testcase name="org.ruff.unformatted" classname="[TMP]/input" line="1" column="1">
+            <properties>
+                <property name="severity" value="error"/>
+            </properties>
             <failure message="File would be reformatted">line 1, col 1, File would be reformatted</failure>
         </testcase>
     </testsuite>

--- a/crates/ruff/tests/cli/snapshots/cli__lint__output_format_junit.snap
+++ b/crates/ruff/tests/cli/snapshots/cli__lint__output_format_junit.snap
@@ -20,12 +20,21 @@ exit_code: 1
 <testsuites name="ruff" tests="3" failures="3" errors="0">
     <testsuite name="[TMP]/input.py" tests="3" disabled="0" errors="0" failures="3" package="org.ruff">
         <testcase name="org.ruff.F401" classname="[TMP]/input" line="1" column="8">
+            <properties>
+                <property name="severity" value="error"/>
+            </properties>
             <failure message="`os` imported but unused">line 1, col 8, `os` imported but unused</failure>
         </testcase>
         <testcase name="org.ruff.F821" classname="[TMP]/input" line="2" column="5">
+            <properties>
+                <property name="severity" value="error"/>
+            </properties>
             <failure message="Undefined name `y`">line 2, col 5, Undefined name `y`</failure>
         </testcase>
         <testcase name="org.ruff.invalid-syntax" classname="[TMP]/input" line="3" column="1">
+            <properties>
+                <property name="severity" value="error"/>
+            </properties>
             <failure message="Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)">line 3, col 1, Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)</failure>
         </testcase>
     </testsuite>

--- a/crates/ruff_db/src/diagnostic/render/junit.rs
+++ b/crates/ruff_db/src/diagnostic/render/junit.rs
@@ -5,7 +5,7 @@ use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite, X
 
 use ruff_source_file::LineColumn;
 
-use crate::diagnostic::{Diagnostic, SecondaryCode, render::FileResolver};
+use crate::diagnostic::{Diagnostic, SecondaryCode, Severity, render::FileResolver};
 
 /// Print diagnostics as a JUnit-style XML report.
 ///
@@ -80,6 +80,7 @@ impl<'a> JunitRenderer<'a> {
                         status,
                     );
                     case.set_classname(classname.to_str().unwrap_or(filename));
+                    case.add_property(("severity", severity_name(diagnostic.severity())));
 
                     if let Some(location) = location {
                         case.extra.insert(
@@ -100,6 +101,15 @@ impl<'a> JunitRenderer<'a> {
 
         let adapter = FmtAdapter { fmt: f };
         report.serialize(adapter).map_err(|_| std::fmt::Error)
+    }
+}
+
+const fn severity_name(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Info => "info",
+        Severity::Warning => "warning",
+        Severity::Error => "error",
+        Severity::Fatal => "fatal",
     }
 }
 

--- a/crates/ruff_db/src/diagnostic/render/snapshots/ruff_db__diagnostic__render__junit__tests__output.snap
+++ b/crates/ruff_db/src/diagnostic/render/snapshots/ruff_db__diagnostic__render__junit__tests__output.snap
@@ -1,22 +1,35 @@
 ---
 source: crates/ruff_db/src/diagnostic/render/junit.rs
+assertion_line: 203
 expression: env.render_diagnostics(&diagnostics)
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="ty" tests="4" failures="4" errors="0">
     <testsuite name="/fib.py" tests="3" disabled="0" errors="0" failures="3" package="org.ty">
         <testcase name="org.ty.F401" classname="/fib" line="1" column="8">
+            <properties>
+                <property name="severity" value="error"/>
+            </properties>
             <failure message="`os` imported but unused">line 1, col 8, `os` imported but unused</failure>
         </testcase>
         <testcase name="org.ty.F841" classname="/fib" line="6" column="5">
+            <properties>
+                <property name="severity" value="error"/>
+            </properties>
             <failure message="Local variable `x` is assigned to but never used">line 6, col 5, Local variable `x` is assigned to but never used</failure>
         </testcase>
         <testcase name="org.ty.F821" classname="/fib" line="12" column="16">
+            <properties>
+                <property name="severity" value="error"/>
+            </properties>
             <failure message="Undefined name `fibonaccii`">line 12, col 16, Undefined name `fibonaccii`</failure>
         </testcase>
     </testsuite>
     <testsuite name="/undef.py" tests="1" disabled="0" errors="0" failures="1" package="org.ty">
         <testcase name="org.ty.F821" classname="/undef" line="1" column="4">
+            <properties>
+                <property name="severity" value="error"/>
+            </properties>
             <failure message="Undefined name `a`">line 1, col 4, Undefined name `a`</failure>
         </testcase>
     </testsuite>

--- a/crates/ruff_db/src/diagnostic/render/snapshots/ruff_db__diagnostic__render__junit__tests__syntax_errors.snap
+++ b/crates/ruff_db/src/diagnostic/render/snapshots/ruff_db__diagnostic__render__junit__tests__syntax_errors.snap
@@ -1,14 +1,21 @@
 ---
 source: crates/ruff_db/src/diagnostic/render/junit.rs
+assertion_line: 209
 expression: env.render_diagnostics(&diagnostics)
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="ty" tests="2" failures="2" errors="0">
     <testsuite name="/syntax_errors.py" tests="2" disabled="0" errors="0" failures="2" package="org.ty">
         <testcase name="org.ty.invalid-syntax" classname="/syntax_errors" line="1" column="15">
+            <properties>
+                <property name="severity" value="error"/>
+            </properties>
             <failure message="Expected one or more symbol names after import">line 1, col 15, Expected one or more symbol names after import</failure>
         </testcase>
         <testcase name="org.ty.invalid-syntax" classname="/syntax_errors" line="3" column="12">
+            <properties>
+                <property name="severity" value="error"/>
+            </properties>
             <failure message="Expected &apos;)&apos;, found newline">line 3, col 12, Expected &apos;)&apos;, found newline</failure>
         </testcase>
     </testsuite>


### PR DESCRIPTION
## Summary

This PR adds the diagnostic severity to each JUnit testcase as testcase metadata, which allows downstream tooling to reflect the warning vs. error distinction.

For example, a failing testcase now contains:

```xml
<properties>
    <property name="severity" value="error"/>
</properties>
```

This was requested out-of-band from the issue tracker; I think it's reasonable now that we support severities.

Another option, used by `golangci-lint`, is to annotate the `<failure />` itself, as in `<failure type="warning" ... />`; that's also reasonable, though other tools seem to use `type` as (e.g.) the name of the rule or exception, so this feels a bit cleaner.
