### PR TITLE
[ty] Support narrowing via `is_dataclass`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1551,6 +1551,63 @@ But calling `asdict` on the class object is not allowed:
 asdict(Foo)
 ```
 
+`is_dataclass` is always true for dataclass instances, including instances of subclasses of
+dataclasses:
+
+```py
+from dataclasses import asdict, dataclass, is_dataclass
+
+@dataclass
+class Event:
+    x: int
+
+class ChildEvent(Event): ...
+
+def serialize_event(event: Event) -> dict[str, object]:
+    if is_dataclass(event):
+        reveal_type(event)  # revealed: Event
+        return asdict(event)
+    else:
+        reveal_type(event)  # revealed: Never
+        return dict(event)
+
+def serialize_child_event(event: ChildEvent) -> dict[str, object]:
+    if not is_dataclass(event):
+        reveal_type(event)  # revealed: Never
+        return dict(event)
+    return asdict(event)
+
+def serialize_event_type(event_type: type[Event]) -> None:
+    if is_dataclass(event_type):
+        reveal_type(event_type)  # revealed: type[Event]
+    else:
+        reveal_type(event_type)  # revealed: Never
+```
+
+For consistency with other type checkers, `is_dataclass` is also treated as always true for
+dataclass-like classes created via `dataclass_transform`:
+
+```py
+from dataclasses import is_dataclass
+from typing_extensions import TypeVar, dataclass_transform
+
+T = TypeVar("T")
+
+@dataclass_transform()
+def model(cls: type[T]) -> type[T]:
+    return cls
+
+@model
+class StaticOnly:
+    x: int
+
+def check_static_only(instance: StaticOnly) -> None:
+    if is_dataclass(instance):
+        reveal_type(instance)  # revealed: StaticOnly
+    else:
+        reveal_type(instance)  # revealed: Never
+```
+
 ## `dataclasses.KW_ONLY`
 
 If an attribute is annotated with `dataclasses.KW_ONLY`, it is not added to the synthesized

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -993,6 +993,19 @@ impl<'db> ClassType<'db> {
         self.class_literal(db).is_typed_dict(db)
     }
 
+    /// Return true if this class, or a class in its MRO, is dataclass-like.
+    pub(crate) fn is_dataclass_like_or_subclass(self, db: &'db dyn Db) -> bool {
+        self.iter_mro(db)
+            .filter_map(ClassBase::into_class)
+            .any(|base| {
+                let (class, specialization) = base.class_literal_and_specialization(db);
+                matches!(
+                    CodeGeneratorKind::from_class(db, class, specialization),
+                    Some(CodeGeneratorKind::DataclassLike(_))
+                )
+            })
+    }
+
     /// Return `true` if this class is a subtype of (any specialization of) `class_literal`.
     pub(crate) fn is_subtype_of_class_literal(
         self,

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1591,6 +1591,97 @@ fn is_instance_truthiness<'db>(
     }
 }
 
+/// Evaluate a `dataclasses.is_dataclass` call. Return `AlwaysTrue` for types that are definitely
+/// dataclass-like classes or instances, including subclasses of dataclass-like classes.
+fn is_dataclass_truthiness<'db>(db: &'db dyn Db, ty: Type<'db>) -> Truthiness {
+    let always_true_if = |test: bool| {
+        if test {
+            Truthiness::AlwaysTrue
+        } else {
+            Truthiness::Ambiguous
+        }
+    };
+
+    match ty {
+        Type::Union(union) => always_true_if(
+            union
+                .elements(db)
+                .iter()
+                .all(|ty| is_dataclass_truthiness(db, *ty).is_always_true()),
+        ),
+
+        Type::Intersection(intersection) => always_true_if(
+            intersection
+                .positive(db)
+                .iter()
+                .any(|ty| is_dataclass_truthiness(db, *ty).is_always_true()),
+        ),
+
+        Type::NominalInstance(instance) => {
+            always_true_if(instance.class(db).is_dataclass_like_or_subclass(db))
+        }
+
+        Type::ClassLiteral(class) => always_true_if(
+            class
+                .default_specialization(db)
+                .is_dataclass_like_or_subclass(db),
+        ),
+
+        Type::GenericAlias(alias) => {
+            always_true_if(ClassType::Generic(alias).is_dataclass_like_or_subclass(db))
+        }
+
+        Type::SubclassOf(subclass_of) => always_true_if(
+            subclass_of
+                .subclass_of()
+                .into_class(db)
+                .is_some_and(|class| class.is_dataclass_like_or_subclass(db)),
+        ),
+
+        Type::TypeAlias(alias) => is_dataclass_truthiness(db, alias.value_type(db)),
+
+        Type::TypeVar(bound_typevar) => match bound_typevar.typevar(db).bound_or_constraints(db) {
+            None => Truthiness::Ambiguous,
+            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                is_dataclass_truthiness(db, bound)
+            }
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => always_true_if(
+                constraints
+                    .elements(db)
+                    .iter()
+                    .all(|c| is_dataclass_truthiness(db, *c).is_always_true()),
+            ),
+        },
+
+        Type::NewTypeInstance(newtype) => {
+            is_dataclass_truthiness(db, newtype.concrete_base_type(db))
+        }
+
+        Type::BoundMethod(..)
+        | Type::KnownBoundMethod(..)
+        | Type::WrapperDescriptor(..)
+        | Type::DataclassDecorator(..)
+        | Type::DataclassTransformer(..)
+        | Type::ProtocolInstance(..)
+        | Type::SpecialForm(..)
+        | Type::KnownInstance(..)
+        | Type::PropertyInstance(..)
+        | Type::AlwaysTruthy
+        | Type::AlwaysFalsy
+        | Type::BoundSuper(..)
+        | Type::TypeIs(..)
+        | Type::TypeGuard(..)
+        | Type::Callable(..)
+        | Type::Dynamic(..)
+        | Type::Divergent(_)
+        | Type::Never
+        | Type::TypedDict(_)
+        | Type::LiteralValue(..)
+        | Type::ModuleLiteral(..)
+        | Type::FunctionLiteral(..) => Truthiness::Ambiguous,
+    }
+}
+
 fn last_definition_signature_cycle_initial<'db>(
     _db: &'db dyn Db,
     _id: salsa::Id,
@@ -1742,6 +1833,8 @@ pub enum KnownFunction {
 
     /// `dataclasses.dataclass`
     Dataclass,
+    /// `dataclasses.is_dataclass`
+    IsDataclass,
     /// `dataclasses.field`
     Field,
 
@@ -1847,7 +1940,7 @@ impl KnownFunction {
             Self::AsyncContextManager => {
                 matches!(module, KnownModule::Contextlib)
             }
-            Self::Dataclass | Self::Field => {
+            Self::Dataclass | Self::IsDataclass | Self::Field => {
                 matches!(module, KnownModule::Dataclasses)
             }
             Self::TotalOrdering => module.is_functools(),
@@ -2229,6 +2322,16 @@ impl KnownFunction {
                 }
             }
 
+            KnownFunction::IsDataclass => {
+                let [Some(obj)] = parameter_types else {
+                    return;
+                };
+
+                if is_dataclass_truthiness(db, *obj).is_always_true() {
+                    overload.set_return_type(Type::bool_literal(true));
+                }
+            }
+
             known @ (KnownFunction::DunderImport | KnownFunction::ImportModule) => {
                 let [Some(first), rest @ ..] = parameter_types else {
                     return;
@@ -2339,7 +2442,9 @@ pub(crate) mod tests {
 
                 KnownFunction::AsyncContextManager => KnownModule::Contextlib,
 
-                KnownFunction::Dataclass | KnownFunction::Field => KnownModule::Dataclasses,
+                KnownFunction::Dataclass | KnownFunction::IsDataclass | KnownFunction::Field => {
+                    KnownModule::Dataclasses
+                }
 
                 KnownFunction::GetattrStatic => KnownModule::Inspect,
 


### PR DESCRIPTION
## Summary

This PR adds a known-function specialization for `dataclasses.is_dataclass` when the argument is statically known to be a dataclass-like class or instance, as in:

```py
from dataclasses import asdict, dataclass, is_dataclass

@dataclass
class Event:
    x: int

def serialize(event: Event) -> dict[str, object]:
    if is_dataclass(event):
        return asdict(event)
    else:
        reveal_type(event)  # now revealed: Never
        return dict(event)
```

Like Pyright, we treat classes annotated with `dataclass_transform` to be truthy under this check, even though they empirically do _not_ satisfy this check at runtime.
