### PR TITLE
[ty] Preserve literal types for loop variables over literal collections

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/comprehensions/basic.md
@@ -128,9 +128,10 @@ The type of the expression being iterated over is immutable, and so should not b
 `Unknown` or through literal promotion:
 
 ```py
-# TODO: This should reveal `Literal["a", "b"]`
-# revealed: str
-x = [reveal_type(string) for string in ["a", "b"]]
+x = [
+    reveal_type(string)  # revealed: Literal["a", "b"]
+    for string in ["a", "b"]
+]
 ```
 
 ## Comprehension expression types

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -133,6 +133,13 @@ for x in (1, "a", b"foo"):
 reveal_type(x)
 ```
 
+## With literal list
+
+```py
+for x in ["a", "b"]:
+    reveal_type(x)  # revealed: Literal["a", "b"]
+```
+
 ## With non-callable iterator
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -138,6 +138,11 @@ reveal_type(x)
 ```py
 for x in ["a", "b"]:
     reveal_type(x)  # revealed: Literal["a", "b"]
+
+async def _():
+    # error: [not-iterable]
+    async for x in ["a", "b"]:
+        reveal_type(x)  # revealed: Unknown
 ```
 
 ## With non-callable iterator

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5129,6 +5129,26 @@ def match_with_dict(u: Foo | Bar | dict[Any, Any]):
             reveal_type(u)  # revealed: Foo | (dict[Any, Any] & ~<TypedDict with items 'tag'>)
 ```
 
+Loop variables over literal collections preserve literal key types for `TypedDict` subscripting:
+
+```py
+class EDict(TypedDict):
+    path: str
+
+def equality_key(example: EDict):
+    for key in ["path"]:
+        if key == "path":
+            reveal_type(key)  # revealed: Literal["path"]
+            reveal_type(example[key])  # revealed: str
+
+def match_key(example: EDict):
+    for key in ["path"]:
+        match key:
+            case "path":
+                reveal_type(key)  # revealed: Literal["path"]
+                reveal_type(example[key])  # revealed: str
+```
+
 ## Narrowing tagged unions of `TypedDict`s from PEP 695 type aliases
 
 PEP 695 type aliases are transparently resolved when narrowing tagged unions:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5147,6 +5147,10 @@ def match_key(example: EDict):
             case "path":
                 reveal_type(key)  # revealed: Literal["path"]
                 reveal_type(example[key])  # revealed: str
+
+def comprehension_key(example: EDict):
+    values = [example[key] for key in ["path"]]
+    reveal_type(values)  # revealed: list[str]
 ```
 
 ## Narrowing tagged unions of `TypedDict`s from PEP 695 type aliases

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5047,11 +5047,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_definition(node);
     }
 
-    fn fixed_length_iterable_element_type(&self, iterable: &ast::Expr) -> Option<Type<'db>> {
+    fn fixed_length_iterable_element_type(
+        &self,
+        iterable: &ast::Expr,
+        expression_type: impl FnMut(&ast::Expr) -> Type<'db>,
+    ) -> Option<Type<'db>> {
         let element_types =
-            extract_fixed_length_iterable_element_types(self.db(), iterable, |expr| {
-                self.expression_type(expr)
-            })?;
+            extract_fixed_length_iterable_element_types(self.db(), iterable, expression_type)?;
 
         if element_types.is_empty() {
             None
@@ -5079,8 +5081,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             //  but only if the target is a name. We should report a diagnostic here if the target isn't a name:
             //  `for a.x in not_iterable: ...
             let iterable_type = builder.infer_standalone_expression(iter, tcx);
-            if let Some(element_type) = builder.fixed_length_iterable_element_type(iter)
-                && !*is_async
+            if !*is_async
+                && let Some(element_type) = builder
+                    .fixed_length_iterable_element_type(iter, |expr| builder.expression_type(expr))
             {
                 element_type
             } else {
@@ -5115,8 +5118,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let iterable_type =
                     self.infer_standalone_expression(iterable, TypeContext::default());
 
-                if let Some(element_type) = self.fixed_length_iterable_element_type(iterable)
-                    && !for_stmt.is_async()
+                if !for_stmt.is_async()
+                    && let Some(element_type) = self
+                        .fixed_length_iterable_element_type(iterable, |expr| {
+                            self.expression_type(expr)
+                        })
                 {
                     element_type
                 } else {
@@ -7815,6 +7821,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut infer_iterable_type = || {
             let expression = self.index.expression(iterable);
             let result = infer_expression_types(self.db(), expression, TypeContext::default());
+            let iterable_type = result.expression_type(iterable);
+            let element_type = if comprehension.is_async() {
+                None
+            } else {
+                self.fixed_length_iterable_element_type(iterable, |expr| {
+                    result.expression_type(expr)
+                })
+            };
 
             // Two things are different if it's the first comprehension:
             // (1) We must lookup the `ScopedExpressionId` of the iterable expression in the outer scope,
@@ -7822,12 +7836,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // (2) We must *not* call `self.extend()` on the result of the type inference,
             //     because `ScopedExpressionId`s are only meaningful within their own scope, so
             //     we'd add types for random wrong expressions in the current scope
-            if comprehension.is_first() && target.is_name_expr() {
-                result.expression_type(iterable)
-            } else {
+            if !(comprehension.is_first() && target.is_name_expr()) {
                 self.extend_expression_unchecked(result);
-                result.expression_type(iterable)
             }
+
+            (iterable_type, element_type)
         };
 
         let target_type = match comprehension.target_kind() {
@@ -7840,18 +7853,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 unpacked.expression_type(target)
             }
             TargetKind::Single => {
-                let iterable_type = infer_iterable_type();
+                let (iterable_type, element_type) = infer_iterable_type();
 
-                iterable_type
-                    .try_iterate_with_mode(
-                        self.db(),
-                        EvaluationMode::from_is_async(comprehension.is_async()),
-                    )
-                    .map(|tuple| tuple.homogeneous_element_type(self.db()))
-                    .unwrap_or_else(|err| {
-                        err.report_diagnostic(&self.context, iterable_type, iterable.into());
-                        err.fallback_element_type(self.db())
-                    })
+                if let Some(element_type) = element_type {
+                    element_type
+                } else {
+                    iterable_type
+                        .try_iterate_with_mode(
+                            self.db(),
+                            EvaluationMode::from_is_async(comprehension.is_async()),
+                        )
+                        .map(|tuple| tuple.homogeneous_element_type(self.db()))
+                        .unwrap_or_else(|err| {
+                            err.report_diagnostic(&self.context, iterable_type, iterable.into());
+                            err.fallback_element_type(self.db())
+                        })
+                }
             }
         };
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5079,11 +5079,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             //  but only if the target is a name. We should report a diagnostic here if the target isn't a name:
             //  `for a.x in not_iterable: ...
             let iterable_type = builder.infer_standalone_expression(iter, tcx);
-            if *is_async {
-                iterable_type
-                    .iterate(builder.db())
-                    .homogeneous_element_type(builder.db())
-            } else if let Some(element_type) = builder.fixed_length_iterable_element_type(iter) {
+            if let Some(element_type) = builder.fixed_length_iterable_element_type(iter)
+                && !*is_async
+            {
                 element_type
             } else {
                 iterable_type
@@ -5117,23 +5115,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let iterable_type =
                     self.infer_standalone_expression(iterable, TypeContext::default());
 
-                if for_stmt.is_async() {
+                if let Some(element_type) = self.fixed_length_iterable_element_type(iterable)
+                    && !for_stmt.is_async()
+                {
+                    element_type
+                } else {
                     iterable_type
                         .try_iterate_with_mode(
                             self.db(),
                             EvaluationMode::from_is_async(for_stmt.is_async()),
                         )
-                        .map(|tuple| tuple.homogeneous_element_type(self.db()))
-                        .unwrap_or_else(|err| {
-                            err.report_diagnostic(&self.context, iterable_type, iterable.into());
-                            err.fallback_element_type(self.db())
-                        })
-                } else if let Some(element_type) = self.fixed_length_iterable_element_type(iterable)
-                {
-                    element_type
-                } else {
-                    iterable_type
-                        .try_iterate_with_mode(self.db(), EvaluationMode::Sync)
                         .map(|tuple| tuple.homogeneous_element_type(self.db()))
                         .unwrap_or_else(|err| {
                             err.report_diagnostic(&self.context, iterable_type, iterable.into());

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -104,7 +104,8 @@ use crate::types::{
     SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
     TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType,
     UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
-    infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
+    extract_fixed_length_iterable_element_types, infer_complete_scope_types, infer_scope_types,
+    is_discarded_dict_key_assignment, todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
@@ -5046,6 +5047,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_definition(node);
     }
 
+    fn fixed_length_iterable_element_type(&self, iterable: &ast::Expr) -> Option<Type<'db>> {
+        let element_types =
+            extract_fixed_length_iterable_element_types(self.db(), iterable, |expr| {
+                self.expression_type(expr)
+            })?;
+
+        if element_types.is_empty() {
+            None
+        } else {
+            Some(UnionType::from_elements(
+                self.db(),
+                element_types.iter().copied(),
+            ))
+        }
+    }
+
     fn infer_for_statement(&mut self, for_statement: &ast::StmtFor) {
         let ast::StmtFor {
             range: _,
@@ -5054,17 +5071,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             iter,
             body,
             orelse,
-            is_async: _,
+            is_async,
         } = for_statement;
 
         self.infer_target(target, iter, &|builder, tcx| {
             // TODO: `infer_for_statement_definition` reports a diagnostic if `iter_ty` isn't iterable
             //  but only if the target is a name. We should report a diagnostic here if the target isn't a name:
             //  `for a.x in not_iterable: ...
-            builder
-                .infer_standalone_expression(iter, tcx)
-                .iterate(builder.db())
-                .homogeneous_element_type(builder.db())
+            let iterable_type = builder.infer_standalone_expression(iter, tcx);
+            if *is_async {
+                iterable_type
+                    .iterate(builder.db())
+                    .homogeneous_element_type(builder.db())
+            } else if let Some(element_type) = builder.fixed_length_iterable_element_type(iter) {
+                element_type
+            } else {
+                iterable_type
+                    .iterate(builder.db())
+                    .homogeneous_element_type(builder.db())
+            }
         });
 
         self.infer_body(body);
@@ -5092,16 +5117,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let iterable_type =
                     self.infer_standalone_expression(iterable, TypeContext::default());
 
-                iterable_type
-                    .try_iterate_with_mode(
-                        self.db(),
-                        EvaluationMode::from_is_async(for_stmt.is_async()),
-                    )
-                    .map(|tuple| tuple.homogeneous_element_type(self.db()))
-                    .unwrap_or_else(|err| {
-                        err.report_diagnostic(&self.context, iterable_type, iterable.into());
-                        err.fallback_element_type(self.db())
-                    })
+                if for_stmt.is_async() {
+                    iterable_type
+                        .try_iterate_with_mode(
+                            self.db(),
+                            EvaluationMode::from_is_async(for_stmt.is_async()),
+                        )
+                        .map(|tuple| tuple.homogeneous_element_type(self.db()))
+                        .unwrap_or_else(|err| {
+                            err.report_diagnostic(&self.context, iterable_type, iterable.into());
+                            err.fallback_element_type(self.db())
+                        })
+                } else if let Some(element_type) = self.fixed_length_iterable_element_type(iterable)
+                {
+                    element_type
+                } else {
+                    iterable_type
+                        .try_iterate_with_mode(self.db(), EvaluationMode::Sync)
+                        .map(|tuple| tuple.homogeneous_element_type(self.db()))
+                        .unwrap_or_else(|err| {
+                            err.report_diagnostic(&self.context, iterable_type, iterable.into());
+                            err.fallback_element_type(self.db())
+                        })
+                }
             }
         };
 


### PR DESCRIPTION
## Summary

This PR preserves precise element types when inferring loop targets over fixed-length literal iterables.

Previously, `for key in ["path"]` inferred `key` as `str` because the list literal widened to `list[str]`, so subsequent `TypedDict` indexing still failed even though the loop source is statically a literal key.

By preserving literals, we can support narrowing like:

```python
for key in ["path"]:
  if key == "path":
    example[key]
```

Closes https://github.com/astral-sh/ty/issues/3433.
