### PR TITLE
[ty] Retain dataclass field alias from call site

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -1177,6 +1177,35 @@ class Person:
 reveal_type(Person.__init__)  # revealed: (self: Person, name: str, *, age: int | None) -> None
 ```
 
+### With overloaded field specifiers that also accept `**kwargs`
+
+Literal alias metadata should still be preserved when an overloaded field specifier accepts
+additional keyword arguments.
+
+```py
+from typing import overload
+from typing_extensions import Any, dataclass_transform
+
+@overload
+def fancy_field(*, alias: str | None = None, **kwargs: Any) -> Any: ...
+@overload
+def fancy_field(default: object, *, alias: str | None = None, **kwargs: Any) -> Any: ...
+def fancy_field(default: object = ..., *, alias: str | None = None, **kwargs: Any) -> Any: ...
+
+@dataclass_transform(field_specifiers=(fancy_field,))
+class FancyBase: ...
+
+class Person(FancyBase):
+    internal_name: str | None = fancy_field(default=None, alias="name")
+
+reveal_type(Person.__init__)  # revealed: (self: Person, name: str | None = ...) -> None
+
+Person(name="Alice")
+
+# error: [unknown-argument] "Argument `internal_name` does not match any known parameter"
+Person(internal_name="Alice")
+```
+
 ### Converter field specifier with overloaded callables
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -1177,33 +1177,56 @@ class Person:
 reveal_type(Person.__init__)  # revealed: (self: Person, name: str, *, age: int | None) -> None
 ```
 
-### With overloaded field specifiers that also accept `**kwargs`
+### With overloaded field specifier metadata
 
-Literal alias metadata should still be preserved when an overloaded field specifier accepts
-additional keyword arguments.
+Field metadata should still be preserved when an overloaded field specifier widens its metadata
+parameters during binding.
 
 ```py
 from typing import overload
 from typing_extensions import Any, dataclass_transform
 
 @overload
-def fancy_field(*, alias: str | None = None, **kwargs: Any) -> Any: ...
+def fancy_field(
+    *,
+    init: bool = True,
+    kw_only: bool = False,
+    alias: str | None = None,
+) -> Any: ...
 @overload
-def fancy_field(default: object, *, alias: str | None = None, **kwargs: Any) -> Any: ...
-def fancy_field(default: object = ..., *, alias: str | None = None, **kwargs: Any) -> Any: ...
+def fancy_field(
+    default: object,
+    *,
+    init: bool = True,
+    kw_only: bool = False,
+    alias: str | None = None,
+) -> Any: ...
+def fancy_field(
+    default: object = ...,
+    *,
+    init: bool = True,
+    kw_only: bool = False,
+    alias: str | None = None,
+) -> Any: ...
 
 @dataclass_transform(field_specifiers=(fancy_field,))
 class FancyBase: ...
 
 class Person(FancyBase):
+    id: int = fancy_field(init=False)
     internal_name: str | None = fancy_field(default=None, alias="name")
+    age: int | None = fancy_field(default=None, kw_only=True)
 
-reveal_type(Person.__init__)  # revealed: (self: Person, name: str | None = ...) -> None
+reveal_type(Person.__init__)  # revealed: (self: Person, name: str | None = ..., *, age: int | None = ...) -> None
 
-Person(name="Alice")
+Person("Alice", age=30)
 
 # error: [unknown-argument] "Argument `internal_name` does not match any known parameter"
-Person(internal_name="Alice")
+# error: [unknown-argument] "Argument `id` does not match any known parameter"
+Person(id=1, internal_name="Alice", age=30)
+
+# error: [too-many-positional-arguments]
+Person("Alice", 30)
 ```
 
 ### Converter field specifier with overloaded callables

--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -74,6 +74,24 @@ User()
 User(name="alice", extra=1)
 ```
 
+## `Field` alias with a default value
+
+Alias-based constructor synthesis should also work on defaulted `Field(...)` overloads:
+
+```py
+from pydantic import BaseModel, Field
+
+class Result(BaseModel):
+    meta: dict[str, object] | None = Field(alias="_meta", default=None)
+
+reveal_type(Result.__init__)  # revealed: (self: Result, *, _meta: dict[str, object] | None = None) -> None
+
+Result(_meta=None)
+
+# error: [unknown-argument]
+Result(meta=None)
+```
+
 ## Validator and serializer decorators with explicit `@classmethod`
 
 Pydantic [recommends](https://docs.pydantic.dev/latest/concepts/validators/#class-validators) using

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1623,13 +1623,24 @@ impl<'db> Bindings<'db> {
                             })
                         };
 
+                        let get_call_argument_type = |name| -> Option<Type<'db>> {
+                            call_arguments.iter().find_map(|(arg, types)| {
+                                if matches!(arg, Argument::Keyword(arg_name) if arg_name == name) {
+                                    types.get_default()
+                                } else {
+                                    None
+                                }
+                            })
+                        };
+
                         let has_default_value = get_argument_type("default", false).is_some()
                             || get_argument_type("default_factory", false).is_some()
                             || get_argument_type("factory", false).is_some();
 
                         let init = get_argument_type("init", true);
                         let kw_only = get_argument_type("kw_only", true);
-                        let alias = get_argument_type("alias", true);
+                        let alias = get_call_argument_type("alias")
+                            .or_else(|| get_argument_type("alias", true));
                         let converter = get_argument_type("converter", true);
 
                         // `dataclasses.field` and field-specifier functions of commonly used

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1637,10 +1637,19 @@ impl<'db> Bindings<'db> {
                             || get_argument_type("default_factory", false).is_some()
                             || get_argument_type("factory", false).is_some();
 
-                        let init = get_argument_type("init", true);
-                        let kw_only = get_argument_type("kw_only", true);
-                        let alias = get_call_argument_type("alias")
-                            .or_else(|| get_argument_type("alias", true));
+                        let get_metadata_argument_type =
+                            |name, fallback_to_default| -> Option<Type<'db>> {
+                                // These arguments are dataclass-field metadata, not value types.
+                                // Binding them against an overloaded parameter can erase literal
+                                // values like `init=False`, `kw_only=True`, or `alias="name"`,
+                                // so prefer the call-site type.
+                                get_call_argument_type(name)
+                                    .or_else(|| get_argument_type(name, fallback_to_default))
+                            };
+
+                        let init = get_metadata_argument_type("init", true);
+                        let kw_only = get_metadata_argument_type("kw_only", true);
+                        let alias = get_metadata_argument_type("alias", true);
                         let converter = get_argument_type("converter", true);
 
                         // `dataclasses.field` and field-specifier functions of commonly used


### PR DESCRIPTION
## Summary

This PR preserves dataclass field metadata from the call site when binding field specifiers.

Previously, we consulted the bound parameter type first, which erased literal values like `init=False`, `kw_only=True`, and `alias="_meta"` that were passed-in at the call site, if the overload had an explicit type. For example, Pydantic aliases with defaults now synthesize the aliased constructor parameter:

```py
class Result(BaseModel):
    meta: dict[str, object] | None = Field(alias="_meta", default=None)

Result(_meta=None)
```

On `main`, `alias` is lost here, since the `Field` definition is:

```python
@overload
def Field(
    default: _T,
    *,
    alias: str | None = _Unset,
    ...
    **extra: Unpack[_EmptyKwargs],
) -> _T: ...
```

So we extract `str | None`, which fails to convert via `as_string_literal` and is subsequently lost.
