### PR TITLE
Colorize ruff check 'All checks passed'

### DIFF
--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -104,7 +104,7 @@ impl Printer {
                     let s = if remaining == 1 { "" } else { "s" };
                     writeln!(writer, "Found {remaining} error{s}.")?;
                 } else if remaining == 0 {
-                    writeln!(writer, "All checks passed!")?;
+                    writeln!(writer, "{}", "All checks passed!".green().bold())?;
                 }
 
                 if let Some(fixables) = fixables {


### PR DESCRIPTION
Apply .green().bold() styling to the 'All checks passed!' message in ruff check output, matching the styling already used by ty. This makes the success message visually consistent across both tools.

Closes #24840

