### PR TITLE
[`flake8-use-pathlib`] Mark `PTH101` fix as unsafe when first argument is a class attribute annotated as `int`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
@@ -100,6 +100,17 @@ os.chmod(p, dir_fd=7)
 os.chmod(8)
 os.chmod(x)
 
+# https://github.com/astral-sh/ruff/issues/17699
+# Attribute access in the first argument: the type cannot be statically determined,
+# so the fix should be marked as unsafe (the attribute may be a file descriptor).
+class _AttrHolder:
+    fd: int = 0
+    name: str = ""
+
+_holder = _AttrHolder()
+os.chmod(_holder.fd, 0o644)
+os.chmod(_holder.name, 0o644)
+
 # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
 os.replace("src", "dst", src_dir_fd=1, dst_dir_fd=2)
 os.replace("src", "dst", src_dir_fd=1)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
@@ -100,17 +100,6 @@ os.chmod(p, dir_fd=7)
 os.chmod(8)
 os.chmod(x)
 
-# https://github.com/astral-sh/ruff/issues/17699
-# Attribute access in the first argument: the type cannot be statically determined,
-# so the fix should be marked as unsafe (the attribute may be a file descriptor).
-class _AttrHolder:
-    fd: int = 0
-    name: str = ""
-
-_holder = _AttrHolder()
-os.chmod(_holder.fd, 0o644)
-os.chmod(_holder.name, 0o644)
-
 # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
 os.replace("src", "dst", src_dir_fd=1, dst_dir_fd=2)
 os.replace("src", "dst", src_dir_fd=1)
@@ -182,3 +171,17 @@ try:
         break
 except TypeError as e:
     print("readlink: not iterable")
+
+
+# https://github.com/astral-sh/ruff/issues/17699
+# Attribute access whose binding can be resolved via `lookup_attribute`.
+# When the resolved attribute is `int`, the diagnostic is suppressed,
+# matching the behavior for `int`-annotated names elsewhere in this file.
+# Note: this only covers class-attribute access via the class itself
+# (e.g., `Cls.attr`); instance access (e.g., `obj.attr`) is not resolved.
+class _AttrHolder:
+    fd: int = 0
+    name: str = ""
+
+os.chmod(_AttrHolder.fd, 0o644)    # Suppressed: resolved as `int`
+os.chmod(_AttrHolder.name, 0o644)  # Diagnostic + fix: resolved as `str`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/helpers.rs
@@ -123,6 +123,15 @@ pub(crate) fn is_file_descriptor(expr: &Expr, semantic: &SemanticModel) -> bool 
         return true;
     }
 
+    // Resolve attribute expressions (e.g., `obj.fd` where `fd` is annotated at
+    // the class level) via the semantic model. Matches the existing behavior
+    // for `Name` expressions below.
+    if let Expr::Attribute(_) = expr
+        && let Some(binding_id) = semantic.lookup_attribute(expr)
+    {
+        return typing::is_int(semantic.binding(binding_id), semantic);
+    }
+
     let Some(name) = get_name_expr(expr) else {
         return false;
     };

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_chmod.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_chmod.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Applicability, Edit, Fix};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{ArgOrKeyword, ExprCall};
+use ruff_python_ast::{ArgOrKeyword, Expr, ExprCall};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -41,7 +41,12 @@ use crate::{FixAvailability, Violation};
 /// especially on older versions of Python.
 ///
 /// ## Fix Safety
-/// This rule's fix is marked as unsafe if the replacement would remove comments attached to the original expression.
+/// This rule's fix is marked as unsafe in either of the following cases:
+///
+/// - The replacement would remove comments attached to the original expression.
+/// - The first argument is an attribute access (e.g., `self.fd`). `pathlib.Path`
+///   does not accept file descriptors, and the type of an attribute cannot be
+///   statically determined, so the replacement may break code that was working.
 ///
 /// ## References
 /// - [Python documentation: `Path.chmod`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.chmod)
@@ -140,7 +145,9 @@ pub(crate) fn os_chmod(checker: &Checker, call: &ExprCall, segments: &[&str]) {
             format!("{binding}({path_code}).chmod({chmod_args})")
         };
 
-        let applicability = if checker.comment_ranges().intersects(range) {
+        let applicability = if checker.comment_ranges().intersects(range)
+            || matches!(path_arg, Expr::Attribute(_))
+        {
             Applicability::Unsafe
         } else {
             Applicability::Safe

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_chmod.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_chmod.rs
@@ -1,6 +1,6 @@
 use ruff_diagnostics::{Applicability, Edit, Fix};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{ArgOrKeyword, Expr, ExprCall};
+use ruff_python_ast::{ArgOrKeyword, ExprCall};
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -41,12 +41,7 @@ use crate::{FixAvailability, Violation};
 /// especially on older versions of Python.
 ///
 /// ## Fix Safety
-/// This rule's fix is marked as unsafe in either of the following cases:
-///
-/// - The replacement would remove comments attached to the original expression.
-/// - The first argument is an attribute access (e.g., `self.fd`). `pathlib.Path`
-///   does not accept file descriptors, and the type of an attribute cannot be
-///   statically determined, so the replacement may break code that was working.
+/// This rule's fix is marked as unsafe if the replacement would remove comments attached to the original expression.
 ///
 /// ## References
 /// - [Python documentation: `Path.chmod`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.chmod)
@@ -145,9 +140,7 @@ pub(crate) fn os_chmod(checker: &Checker, call: &ExprCall, segments: &[&str]) {
             format!("{binding}({path_code}).chmod({chmod_args})")
         };
 
-        let applicability = if checker.comment_ranges().intersects(range)
-            || matches!(path_arg, Expr::Attribute(_))
-        {
+        let applicability = if checker.comment_ranges().intersects(range) {
             Applicability::Unsafe
         } else {
             Applicability::Safe

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__full_name.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__full_name.py.snap
@@ -411,220 +411,242 @@ PTH123 `open()` should be replaced by `Path.open()`
    |
 help: Replace with `Path.open()`
 
-PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:108:1
-    |
-106 | os.replace("src", "dst", dst_dir_fd=2)
-107 |
-108 | os.getcwd()
-    | ^^^^^^^^^
-109 | os.getcwdb()
-    |
-help: Replace with `Path.cwd()`
-
-PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:109:1
-    |
-108 | os.getcwd()
-109 | os.getcwdb()
-    | ^^^^^^^^^^
-110 |
-111 | os.mkdir(path="directory")
-    |
-help: Replace with `Path.cwd()`
-
-PTH102 `os.mkdir()` should be replaced by `Path.mkdir()`
+PTH101 `os.chmod()` should be replaced by `Path.chmod()`
    --> full_name.py:111:1
     |
-109 | os.getcwdb()
-110 |
-111 | os.mkdir(path="directory")
+110 | _holder = _AttrHolder()
+111 | os.chmod(_holder.fd, 0o644)
     | ^^^^^^^^
-112 |
-113 | os.mkdir(
+112 | os.chmod(_holder.name, 0o644)
+    |
+help: Replace with `Path(...).chmod(...)`
+
+PTH101 `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:112:1
+    |
+110 | _holder = _AttrHolder()
+111 | os.chmod(_holder.fd, 0o644)
+112 | os.chmod(_holder.name, 0o644)
+    | ^^^^^^^^
+113 |
+114 | # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
+    |
+help: Replace with `Path(...).chmod(...)`
+
+PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
+   --> full_name.py:119:1
+    |
+117 | os.replace("src", "dst", dst_dir_fd=2)
+118 |
+119 | os.getcwd()
+    | ^^^^^^^^^
+120 | os.getcwdb()
+    |
+help: Replace with `Path.cwd()`
+
+PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
+   --> full_name.py:120:1
+    |
+119 | os.getcwd()
+120 | os.getcwdb()
+    | ^^^^^^^^^^
+121 |
+122 | os.mkdir(path="directory")
+    |
+help: Replace with `Path.cwd()`
+
+PTH102 `os.mkdir()` should be replaced by `Path.mkdir()`
+   --> full_name.py:122:1
+    |
+120 | os.getcwdb()
+121 |
+122 | os.mkdir(path="directory")
+    | ^^^^^^^^
+123 |
+124 | os.mkdir(
     |
 help: Replace with `Path(...).mkdir()`
 
 PTH102 `os.mkdir()` should be replaced by `Path.mkdir()`
-   --> full_name.py:113:1
+   --> full_name.py:124:1
     |
-111 | os.mkdir(path="directory")
-112 |
-113 | os.mkdir(
+122 | os.mkdir(path="directory")
+123 |
+124 | os.mkdir(
     | ^^^^^^^^
-114 |     # comment 1
-115 |     "directory",
+125 |     # comment 1
+126 |     "directory",
     |
 help: Replace with `Path(...).mkdir()`
 
 PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:121:1
+   --> full_name.py:132:1
     |
-119 | os.mkdir("directory", mode=0o777, dir_fd=1)
-120 |
-121 | os.makedirs("name", 0o777, exist_ok=False)
+130 | os.mkdir("directory", mode=0o777, dir_fd=1)
+131 |
+132 | os.makedirs("name", 0o777, exist_ok=False)
     | ^^^^^^^^^^^
-122 |
-123 | os.makedirs("name", 0o777, False)
+133 |
+134 | os.makedirs("name", 0o777, False)
     |
 help: Replace with `Path(...).mkdir(parents=True)`
 
 PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:123:1
-    |
-121 | os.makedirs("name", 0o777, exist_ok=False)
-122 |
-123 | os.makedirs("name", 0o777, False)
-    | ^^^^^^^^^^^
-124 |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-    |
-help: Replace with `Path(...).mkdir(parents=True)`
-
-PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:125:1
-    |
-123 | os.makedirs("name", 0o777, False)
-124 |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-    | ^^^^^^^^^^^
-126 |
-127 | os.makedirs("name", unknown_kwarg=True)
-    |
-help: Replace with `Path(...).mkdir(parents=True)`
-
-PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:127:1
-    |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-126 |
-127 | os.makedirs("name", unknown_kwarg=True)
-    | ^^^^^^^^^^^
-128 |
-129 | # https://github.com/astral-sh/ruff/issues/20134
-    |
-help: Replace with `Path(...).mkdir(parents=True)`
-
-PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:130:1
-    |
-129 | # https://github.com/astral-sh/ruff/issues/20134
-130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-    | ^^^^^^^^
-131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
-    |
-help: Replace with `Path(...).chmod(...)`
-
-PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:131:1
-    |
-129 | # https://github.com/astral-sh/ruff/issues/20134
-130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
-    | ^^^^^^^^
-132 |
-133 | # Only diagnostic
-    |
-help: Replace with `Path(...).chmod(...)`
-
-PTH101 `os.chmod()` should be replaced by `Path.chmod()`
    --> full_name.py:134:1
     |
-133 | # Only diagnostic
-134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
-    | ^^^^^^^^
+132 | os.makedirs("name", 0o777, exist_ok=False)
+133 |
+134 | os.makedirs("name", 0o777, False)
+    | ^^^^^^^^^^^
 135 |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+
+PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+   --> full_name.py:136:1
+    |
+134 | os.makedirs("name", 0o777, False)
+135 |
+136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+    | ^^^^^^^^^^^
+137 |
+138 | os.makedirs("name", unknown_kwarg=True)
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+
+PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+   --> full_name.py:138:1
+    |
+136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+137 |
+138 | os.makedirs("name", unknown_kwarg=True)
+    | ^^^^^^^^^^^
+139 |
+140 | # https://github.com/astral-sh/ruff/issues/20134
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+
+PTH101 `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:141:1
+    |
+140 | # https://github.com/astral-sh/ruff/issues/20134
+141 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+    | ^^^^^^^^
+142 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+    |
+help: Replace with `Path(...).chmod(...)`
+
+PTH101 `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:142:1
+    |
+140 | # https://github.com/astral-sh/ruff/issues/20134
+141 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+142 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+    | ^^^^^^^^
+143 |
+144 | # Only diagnostic
+    |
+help: Replace with `Path(...).chmod(...)`
+
+PTH101 `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:145:1
+    |
+144 | # Only diagnostic
+145 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+    | ^^^^^^^^
+146 |
+147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).chmod(...)`
 
 PTH104 `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:136:1
+   --> full_name.py:147:1
     |
-134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
-135 |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+145 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+146 |
+147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).rename(...)`
 
 PTH105 `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:137:1
+   --> full_name.py:148:1
     |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^
-138 |
-139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+149 |
+150 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).replace(...)`
 
 PTH121 `os.path.samefile()` should be replaced by `Path.samefile()`
-   --> full_name.py:139:1
+   --> full_name.py:150:1
     |
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
-138 |
-139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+149 |
+150 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^^^^^^^
-140 |
-141 | # See: https://github.com/astral-sh/ruff/issues/21794
+151 |
+152 | # See: https://github.com/astral-sh/ruff/issues/21794
     |
 help: Replace with `Path(...).samefile()`
 
 PTH104 `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:144:4
+   --> full_name.py:155:4
     |
-142 | import sys
-143 |
-144 | if os.rename("pth1.py", "pth1.py.bak"):
+153 | import sys
+154 |
+155 | if os.rename("pth1.py", "pth1.py.bak"):
     |    ^^^^^^^^^
-145 |     print("rename: truthy")
-146 | else:
+156 |     print("rename: truthy")
+157 | else:
     |
 help: Replace with `Path(...).rename(...)`
 
 PTH105 `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:149:4
+   --> full_name.py:160:4
     |
-147 |     print("rename: falsey")
-148 |
-149 | if os.replace("pth1.py.bak", "pth1.py"):
+158 |     print("rename: falsey")
+159 |
+160 | if os.replace("pth1.py.bak", "pth1.py"):
     |    ^^^^^^^^^^
-150 |     print("replace: truthy")
-151 | else:
+161 |     print("replace: truthy")
+162 | else:
     |
 help: Replace with `Path(...).replace(...)`
 
 PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:155:14
+   --> full_name.py:166:14
     |
-154 | try:
-155 |     for _ in os.getcwd():
+165 | try:
+166 |     for _ in os.getcwd():
     |              ^^^^^^^^^
-156 |         print("getcwd: iterable")
-157 |         break
+167 |         print("getcwd: iterable")
+168 |         break
     |
 help: Replace with `Path.cwd()`
 
 PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:162:14
+   --> full_name.py:173:14
     |
-161 | try:
-162 |     for _ in os.getcwdb():
+172 | try:
+173 |     for _ in os.getcwdb():
     |              ^^^^^^^^^^
-163 |         print("getcwdb: iterable")
-164 |         break
+174 |         print("getcwdb: iterable")
+175 |         break
     |
 help: Replace with `Path.cwd()`
 
 PTH115 `os.readlink()` should be replaced by `Path.readlink()`
-   --> full_name.py:169:14
+   --> full_name.py:180:14
     |
-168 | try:
-169 |     for _ in os.readlink(sys.executable):
+179 | try:
+180 |     for _ in os.readlink(sys.executable):
     |              ^^^^^^^^^^^
-170 |         print("readlink: iterable")
-171 |         break
+181 |         print("readlink: iterable")
+182 |         break
     |
 help: Replace with `Path(...).readlink()`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__full_name.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__full_name.py.snap
@@ -411,242 +411,229 @@ PTH123 `open()` should be replaced by `Path.open()`
    |
 help: Replace with `Path.open()`
 
-PTH101 `os.chmod()` should be replaced by `Path.chmod()`
+PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
+   --> full_name.py:108:1
+    |
+106 | os.replace("src", "dst", dst_dir_fd=2)
+107 |
+108 | os.getcwd()
+    | ^^^^^^^^^
+109 | os.getcwdb()
+    |
+help: Replace with `Path.cwd()`
+
+PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
+   --> full_name.py:109:1
+    |
+108 | os.getcwd()
+109 | os.getcwdb()
+    | ^^^^^^^^^^
+110 |
+111 | os.mkdir(path="directory")
+    |
+help: Replace with `Path.cwd()`
+
+PTH102 `os.mkdir()` should be replaced by `Path.mkdir()`
    --> full_name.py:111:1
     |
-110 | _holder = _AttrHolder()
-111 | os.chmod(_holder.fd, 0o644)
+109 | os.getcwdb()
+110 |
+111 | os.mkdir(path="directory")
     | ^^^^^^^^
-112 | os.chmod(_holder.name, 0o644)
-    |
-help: Replace with `Path(...).chmod(...)`
-
-PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:112:1
-    |
-110 | _holder = _AttrHolder()
-111 | os.chmod(_holder.fd, 0o644)
-112 | os.chmod(_holder.name, 0o644)
-    | ^^^^^^^^
-113 |
-114 | # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
-    |
-help: Replace with `Path(...).chmod(...)`
-
-PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:119:1
-    |
-117 | os.replace("src", "dst", dst_dir_fd=2)
-118 |
-119 | os.getcwd()
-    | ^^^^^^^^^
-120 | os.getcwdb()
-    |
-help: Replace with `Path.cwd()`
-
-PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:120:1
-    |
-119 | os.getcwd()
-120 | os.getcwdb()
-    | ^^^^^^^^^^
-121 |
-122 | os.mkdir(path="directory")
-    |
-help: Replace with `Path.cwd()`
-
-PTH102 `os.mkdir()` should be replaced by `Path.mkdir()`
-   --> full_name.py:122:1
-    |
-120 | os.getcwdb()
-121 |
-122 | os.mkdir(path="directory")
-    | ^^^^^^^^
-123 |
-124 | os.mkdir(
+112 |
+113 | os.mkdir(
     |
 help: Replace with `Path(...).mkdir()`
 
 PTH102 `os.mkdir()` should be replaced by `Path.mkdir()`
-   --> full_name.py:124:1
+   --> full_name.py:113:1
     |
-122 | os.mkdir(path="directory")
-123 |
-124 | os.mkdir(
+111 | os.mkdir(path="directory")
+112 |
+113 | os.mkdir(
     | ^^^^^^^^
-125 |     # comment 1
-126 |     "directory",
+114 |     # comment 1
+115 |     "directory",
     |
 help: Replace with `Path(...).mkdir()`
 
 PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:132:1
+   --> full_name.py:121:1
     |
-130 | os.mkdir("directory", mode=0o777, dir_fd=1)
-131 |
-132 | os.makedirs("name", 0o777, exist_ok=False)
+119 | os.mkdir("directory", mode=0o777, dir_fd=1)
+120 |
+121 | os.makedirs("name", 0o777, exist_ok=False)
     | ^^^^^^^^^^^
-133 |
-134 | os.makedirs("name", 0o777, False)
+122 |
+123 | os.makedirs("name", 0o777, False)
     |
 help: Replace with `Path(...).mkdir(parents=True)`
 
 PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+   --> full_name.py:123:1
+    |
+121 | os.makedirs("name", 0o777, exist_ok=False)
+122 |
+123 | os.makedirs("name", 0o777, False)
+    | ^^^^^^^^^^^
+124 |
+125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+
+PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+   --> full_name.py:125:1
+    |
+123 | os.makedirs("name", 0o777, False)
+124 |
+125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+    | ^^^^^^^^^^^
+126 |
+127 | os.makedirs("name", unknown_kwarg=True)
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+
+PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+   --> full_name.py:127:1
+    |
+125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+126 |
+127 | os.makedirs("name", unknown_kwarg=True)
+    | ^^^^^^^^^^^
+128 |
+129 | # https://github.com/astral-sh/ruff/issues/20134
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+
+PTH101 `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:130:1
+    |
+129 | # https://github.com/astral-sh/ruff/issues/20134
+130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+    | ^^^^^^^^
+131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+    |
+help: Replace with `Path(...).chmod(...)`
+
+PTH101 `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:131:1
+    |
+129 | # https://github.com/astral-sh/ruff/issues/20134
+130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+    | ^^^^^^^^
+132 |
+133 | # Only diagnostic
+    |
+help: Replace with `Path(...).chmod(...)`
+
+PTH101 `os.chmod()` should be replaced by `Path.chmod()`
    --> full_name.py:134:1
     |
-132 | os.makedirs("name", 0o777, exist_ok=False)
-133 |
-134 | os.makedirs("name", 0o777, False)
-    | ^^^^^^^^^^^
+133 | # Only diagnostic
+134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+    | ^^^^^^^^
 135 |
-136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-    |
-help: Replace with `Path(...).mkdir(parents=True)`
-
-PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:136:1
-    |
-134 | os.makedirs("name", 0o777, False)
-135 |
-136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-    | ^^^^^^^^^^^
-137 |
-138 | os.makedirs("name", unknown_kwarg=True)
-    |
-help: Replace with `Path(...).mkdir(parents=True)`
-
-PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:138:1
-    |
-136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-137 |
-138 | os.makedirs("name", unknown_kwarg=True)
-    | ^^^^^^^^^^^
-139 |
-140 | # https://github.com/astral-sh/ruff/issues/20134
-    |
-help: Replace with `Path(...).mkdir(parents=True)`
-
-PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:141:1
-    |
-140 | # https://github.com/astral-sh/ruff/issues/20134
-141 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-    | ^^^^^^^^
-142 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
-    |
-help: Replace with `Path(...).chmod(...)`
-
-PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:142:1
-    |
-140 | # https://github.com/astral-sh/ruff/issues/20134
-141 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-142 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
-    | ^^^^^^^^
-143 |
-144 | # Only diagnostic
-    |
-help: Replace with `Path(...).chmod(...)`
-
-PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:145:1
-    |
-144 | # Only diagnostic
-145 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
-    | ^^^^^^^^
-146 |
-147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).chmod(...)`
 
 PTH104 `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:147:1
+   --> full_name.py:136:1
     |
-145 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
-146 |
-147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+135 |
+136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^
-148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).rename(...)`
 
 PTH105 `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:148:1
+   --> full_name.py:137:1
     |
-147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
-148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^
-149 |
-150 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+138 |
+139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).replace(...)`
 
 PTH121 `os.path.samefile()` should be replaced by `Path.samefile()`
-   --> full_name.py:150:1
+   --> full_name.py:139:1
     |
-148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
-149 |
-150 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+138 |
+139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^^^^^^^
-151 |
-152 | # See: https://github.com/astral-sh/ruff/issues/21794
+140 |
+141 | # See: https://github.com/astral-sh/ruff/issues/21794
     |
 help: Replace with `Path(...).samefile()`
 
 PTH104 `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:155:4
+   --> full_name.py:144:4
     |
-153 | import sys
-154 |
-155 | if os.rename("pth1.py", "pth1.py.bak"):
+142 | import sys
+143 |
+144 | if os.rename("pth1.py", "pth1.py.bak"):
     |    ^^^^^^^^^
-156 |     print("rename: truthy")
-157 | else:
+145 |     print("rename: truthy")
+146 | else:
     |
 help: Replace with `Path(...).rename(...)`
 
 PTH105 `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:160:4
+   --> full_name.py:149:4
     |
-158 |     print("rename: falsey")
-159 |
-160 | if os.replace("pth1.py.bak", "pth1.py"):
+147 |     print("rename: falsey")
+148 |
+149 | if os.replace("pth1.py.bak", "pth1.py"):
     |    ^^^^^^^^^^
-161 |     print("replace: truthy")
-162 | else:
+150 |     print("replace: truthy")
+151 | else:
     |
 help: Replace with `Path(...).replace(...)`
 
 PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:166:14
+   --> full_name.py:155:14
     |
-165 | try:
-166 |     for _ in os.getcwd():
+154 | try:
+155 |     for _ in os.getcwd():
     |              ^^^^^^^^^
-167 |         print("getcwd: iterable")
-168 |         break
+156 |         print("getcwd: iterable")
+157 |         break
     |
 help: Replace with `Path.cwd()`
 
 PTH109 `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:173:14
+   --> full_name.py:162:14
     |
-172 | try:
-173 |     for _ in os.getcwdb():
+161 | try:
+162 |     for _ in os.getcwdb():
     |              ^^^^^^^^^^
-174 |         print("getcwdb: iterable")
-175 |         break
+163 |         print("getcwdb: iterable")
+164 |         break
     |
 help: Replace with `Path.cwd()`
 
 PTH115 `os.readlink()` should be replaced by `Path.readlink()`
-   --> full_name.py:180:14
+   --> full_name.py:169:14
     |
-179 | try:
-180 |     for _ in os.readlink(sys.executable):
+168 | try:
+169 |     for _ in os.readlink(sys.executable):
     |              ^^^^^^^^^^^
-181 |         print("readlink: iterable")
-182 |         break
+170 |         print("readlink: iterable")
+171 |         break
     |
 help: Replace with `Path(...).readlink()`
+
+PTH101 `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:187:1
+    |
+186 | os.chmod(_AttrHolder.fd, 0o644)    # Suppressed: resolved as `int`
+187 | os.chmod(_AttrHolder.name, 0o644)  # Diagnostic + fix: resolved as `str`
+    | ^^^^^^^^
+    |
+help: Replace with `Path(...).chmod(...)`

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview_full_name.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview_full_name.py.snap
@@ -741,69 +741,15 @@ help: Replace with `Path.open()`
 74 | # https://github.com/astral-sh/ruff/issues/17693
 75 | os.stat(1)
 
-PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:108:1
-    |
-106 | os.replace("src", "dst", dst_dir_fd=2)
-107 |
-108 | os.getcwd()
-    | ^^^^^^^^^
-109 | os.getcwdb()
-    |
-help: Replace with `Path.cwd()`
-1   | import os
-2   | import os.path
-3   + import pathlib
-4   |
-5   | p = "/foo"
-6   | q = "bar"
---------------------------------------------------------------------------------
-106 | os.replace("src", "dst", src_dir_fd=1)
-107 | os.replace("src", "dst", dst_dir_fd=2)
-108 |
-    - os.getcwd()
-109 + pathlib.Path.cwd()
-110 | os.getcwdb()
-111 |
-112 | os.mkdir(path="directory")
-
-PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:109:1
-    |
-108 | os.getcwd()
-109 | os.getcwdb()
-    | ^^^^^^^^^^
-110 |
-111 | os.mkdir(path="directory")
-    |
-help: Replace with `Path.cwd()`
-1   | import os
-2   | import os.path
-3   + import pathlib
-4   |
-5   | p = "/foo"
-6   | q = "bar"
---------------------------------------------------------------------------------
-107 | os.replace("src", "dst", dst_dir_fd=2)
-108 |
-109 | os.getcwd()
-    - os.getcwdb()
-110 + pathlib.Path.cwd()
-111 |
-112 | os.mkdir(path="directory")
-113 |
-
-PTH102 [*] `os.mkdir()` should be replaced by `Path.mkdir()`
+PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
    --> full_name.py:111:1
     |
-109 | os.getcwdb()
-110 |
-111 | os.mkdir(path="directory")
+110 | _holder = _AttrHolder()
+111 | os.chmod(_holder.fd, 0o644)
     | ^^^^^^^^
-112 |
-113 | os.mkdir(
+112 | os.chmod(_holder.name, 0o644)
     |
-help: Replace with `Path(...).mkdir()`
+help: Replace with `Path(...).chmod(...)`
 1   | import os
 2   | import os.path
 3   + import pathlib
@@ -811,24 +757,105 @@ help: Replace with `Path(...).mkdir()`
 5   | p = "/foo"
 6   | q = "bar"
 --------------------------------------------------------------------------------
-109 | os.getcwd()
-110 | os.getcwdb()
-111 |
-    - os.mkdir(path="directory")
-112 + pathlib.Path("directory").mkdir()
+109 |     name: str = ""
+110 |
+111 | _holder = _AttrHolder()
+    - os.chmod(_holder.fd, 0o644)
+112 + pathlib.Path(_holder.fd).chmod(0o644)
+113 | os.chmod(_holder.name, 0o644)
+114 |
+115 | # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
+note: This is an unsafe fix and may change runtime behavior
+
+PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:112:1
+    |
+110 | _holder = _AttrHolder()
+111 | os.chmod(_holder.fd, 0o644)
+112 | os.chmod(_holder.name, 0o644)
+    | ^^^^^^^^
 113 |
-114 | os.mkdir(
-115 |     # comment 1
+114 | # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
+    |
+help: Replace with `Path(...).chmod(...)`
+1   | import os
+2   | import os.path
+3   + import pathlib
+4   |
+5   | p = "/foo"
+6   | q = "bar"
+--------------------------------------------------------------------------------
+110 |
+111 | _holder = _AttrHolder()
+112 | os.chmod(_holder.fd, 0o644)
+    - os.chmod(_holder.name, 0o644)
+113 + pathlib.Path(_holder.name).chmod(0o644)
+114 |
+115 | # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
+116 | os.replace("src", "dst", src_dir_fd=1, dst_dir_fd=2)
+note: This is an unsafe fix and may change runtime behavior
+
+PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
+   --> full_name.py:119:1
+    |
+117 | os.replace("src", "dst", dst_dir_fd=2)
+118 |
+119 | os.getcwd()
+    | ^^^^^^^^^
+120 | os.getcwdb()
+    |
+help: Replace with `Path.cwd()`
+1   | import os
+2   | import os.path
+3   + import pathlib
+4   |
+5   | p = "/foo"
+6   | q = "bar"
+--------------------------------------------------------------------------------
+117 | os.replace("src", "dst", src_dir_fd=1)
+118 | os.replace("src", "dst", dst_dir_fd=2)
+119 |
+    - os.getcwd()
+120 + pathlib.Path.cwd()
+121 | os.getcwdb()
+122 |
+123 | os.mkdir(path="directory")
+
+PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
+   --> full_name.py:120:1
+    |
+119 | os.getcwd()
+120 | os.getcwdb()
+    | ^^^^^^^^^^
+121 |
+122 | os.mkdir(path="directory")
+    |
+help: Replace with `Path.cwd()`
+1   | import os
+2   | import os.path
+3   + import pathlib
+4   |
+5   | p = "/foo"
+6   | q = "bar"
+--------------------------------------------------------------------------------
+118 | os.replace("src", "dst", dst_dir_fd=2)
+119 |
+120 | os.getcwd()
+    - os.getcwdb()
+121 + pathlib.Path.cwd()
+122 |
+123 | os.mkdir(path="directory")
+124 |
 
 PTH102 [*] `os.mkdir()` should be replaced by `Path.mkdir()`
-   --> full_name.py:113:1
+   --> full_name.py:122:1
     |
-111 | os.mkdir(path="directory")
-112 |
-113 | os.mkdir(
+120 | os.getcwdb()
+121 |
+122 | os.mkdir(path="directory")
     | ^^^^^^^^
-114 |     # comment 1
-115 |     "directory",
+123 |
+124 | os.mkdir(
     |
 help: Replace with `Path(...).mkdir()`
 1   | import os
@@ -838,341 +865,368 @@ help: Replace with `Path(...).mkdir()`
 5   | p = "/foo"
 6   | q = "bar"
 --------------------------------------------------------------------------------
-111 |
-112 | os.mkdir(path="directory")
-113 |
+120 | os.getcwd()
+121 | os.getcwdb()
+122 |
+    - os.mkdir(path="directory")
+123 + pathlib.Path("directory").mkdir()
+124 |
+125 | os.mkdir(
+126 |     # comment 1
+
+PTH102 [*] `os.mkdir()` should be replaced by `Path.mkdir()`
+   --> full_name.py:124:1
+    |
+122 | os.mkdir(path="directory")
+123 |
+124 | os.mkdir(
+    | ^^^^^^^^
+125 |     # comment 1
+126 |     "directory",
+    |
+help: Replace with `Path(...).mkdir()`
+1   | import os
+2   | import os.path
+3   + import pathlib
+4   |
+5   | p = "/foo"
+6   | q = "bar"
+--------------------------------------------------------------------------------
+122 |
+123 | os.mkdir(path="directory")
+124 |
     - os.mkdir(
     -     # comment 1
     -     "directory",
     -     mode=0o777
     - )
-114 + pathlib.Path("directory").mkdir(mode=0o777)
-115 |
-116 | os.mkdir("directory", mode=0o777, dir_fd=1)
-117 |
+125 + pathlib.Path("directory").mkdir(mode=0o777)
+126 |
+127 | os.mkdir("directory", mode=0o777, dir_fd=1)
+128 |
 note: This is an unsafe fix and may change runtime behavior
 
 PTH103 [*] `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:121:1
+   --> full_name.py:132:1
     |
-119 | os.mkdir("directory", mode=0o777, dir_fd=1)
-120 |
-121 | os.makedirs("name", 0o777, exist_ok=False)
+130 | os.mkdir("directory", mode=0o777, dir_fd=1)
+131 |
+132 | os.makedirs("name", 0o777, exist_ok=False)
     | ^^^^^^^^^^^
-122 |
-123 | os.makedirs("name", 0o777, False)
-    |
-help: Replace with `Path(...).mkdir(parents=True)`
-1   | import os
-2   | import os.path
-3   + import pathlib
-4   |
-5   | p = "/foo"
-6   | q = "bar"
---------------------------------------------------------------------------------
-119 |
-120 | os.mkdir("directory", mode=0o777, dir_fd=1)
-121 |
-    - os.makedirs("name", 0o777, exist_ok=False)
-122 + pathlib.Path("name").mkdir(0o777, exist_ok=False, parents=True)
-123 |
-124 | os.makedirs("name", 0o777, False)
-125 |
-
-PTH103 [*] `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:123:1
-    |
-121 | os.makedirs("name", 0o777, exist_ok=False)
-122 |
-123 | os.makedirs("name", 0o777, False)
-    | ^^^^^^^^^^^
-124 |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-    |
-help: Replace with `Path(...).mkdir(parents=True)`
-1   | import os
-2   | import os.path
-3   + import pathlib
-4   |
-5   | p = "/foo"
-6   | q = "bar"
---------------------------------------------------------------------------------
-121 |
-122 | os.makedirs("name", 0o777, exist_ok=False)
-123 |
-    - os.makedirs("name", 0o777, False)
-124 + pathlib.Path("name").mkdir(0o777, True, False)
-125 |
-126 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-127 |
-
-PTH103 [*] `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:125:1
-    |
-123 | os.makedirs("name", 0o777, False)
-124 |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-    | ^^^^^^^^^^^
-126 |
-127 | os.makedirs("name", unknown_kwarg=True)
-    |
-help: Replace with `Path(...).mkdir(parents=True)`
-1   | import os
-2   | import os.path
-3   + import pathlib
-4   |
-5   | p = "/foo"
-6   | q = "bar"
---------------------------------------------------------------------------------
-123 |
-124 | os.makedirs("name", 0o777, False)
-125 |
-    - os.makedirs(name="name", mode=0o777, exist_ok=False)
-126 + pathlib.Path("name").mkdir(mode=0o777, exist_ok=False, parents=True)
-127 |
-128 | os.makedirs("name", unknown_kwarg=True)
-129 |
-
-PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:127:1
-    |
-125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-126 |
-127 | os.makedirs("name", unknown_kwarg=True)
-    | ^^^^^^^^^^^
-128 |
-129 | # https://github.com/astral-sh/ruff/issues/20134
-    |
-help: Replace with `Path(...).mkdir(parents=True)`
-
-PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:130:1
-    |
-129 | # https://github.com/astral-sh/ruff/issues/20134
-130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-    | ^^^^^^^^
-131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
-    |
-help: Replace with `Path(...).chmod(...)`
-1   | import os
-2   | import os.path
-3   + import pathlib
-4   |
-5   | p = "/foo"
-6   | q = "bar"
---------------------------------------------------------------------------------
-128 | os.makedirs("name", unknown_kwarg=True)
-129 |
-130 | # https://github.com/astral-sh/ruff/issues/20134
-    - os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-131 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=      False)
-132 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
 133 |
-134 | # Only diagnostic
-
-PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:131:1
+134 | os.makedirs("name", 0o777, False)
     |
-129 | # https://github.com/astral-sh/ruff/issues/20134
-130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
-    | ^^^^^^^^
+help: Replace with `Path(...).mkdir(parents=True)`
+1   | import os
+2   | import os.path
+3   + import pathlib
+4   |
+5   | p = "/foo"
+6   | q = "bar"
+--------------------------------------------------------------------------------
+130 |
+131 | os.mkdir("directory", mode=0o777, dir_fd=1)
 132 |
-133 | # Only diagnostic
-    |
-help: Replace with `Path(...).chmod(...)`
-1   | import os
-2   | import os.path
-3   + import pathlib
-4   |
-5   | p = "/foo"
-6   | q = "bar"
---------------------------------------------------------------------------------
-129 |
-130 | # https://github.com/astral-sh/ruff/issues/20134
-131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-    - os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
-132 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=True)
-133 |
-134 | # Only diagnostic
-135 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+    - os.makedirs("name", 0o777, exist_ok=False)
+133 + pathlib.Path("name").mkdir(0o777, exist_ok=False, parents=True)
+134 |
+135 | os.makedirs("name", 0o777, False)
+136 |
 
-PTH101 `os.chmod()` should be replaced by `Path.chmod()`
+PTH103 [*] `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
    --> full_name.py:134:1
     |
-133 | # Only diagnostic
-134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
-    | ^^^^^^^^
+132 | os.makedirs("name", 0o777, exist_ok=False)
+133 |
+134 | os.makedirs("name", 0o777, False)
+    | ^^^^^^^^^^^
 135 |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+1   | import os
+2   | import os.path
+3   + import pathlib
+4   |
+5   | p = "/foo"
+6   | q = "bar"
+--------------------------------------------------------------------------------
+132 |
+133 | os.makedirs("name", 0o777, exist_ok=False)
+134 |
+    - os.makedirs("name", 0o777, False)
+135 + pathlib.Path("name").mkdir(0o777, True, False)
+136 |
+137 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+138 |
+
+PTH103 [*] `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+   --> full_name.py:136:1
+    |
+134 | os.makedirs("name", 0o777, False)
+135 |
+136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+    | ^^^^^^^^^^^
+137 |
+138 | os.makedirs("name", unknown_kwarg=True)
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+1   | import os
+2   | import os.path
+3   + import pathlib
+4   |
+5   | p = "/foo"
+6   | q = "bar"
+--------------------------------------------------------------------------------
+134 |
+135 | os.makedirs("name", 0o777, False)
+136 |
+    - os.makedirs(name="name", mode=0o777, exist_ok=False)
+137 + pathlib.Path("name").mkdir(mode=0o777, exist_ok=False, parents=True)
+138 |
+139 | os.makedirs("name", unknown_kwarg=True)
+140 |
+
+PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+   --> full_name.py:138:1
+    |
+136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+137 |
+138 | os.makedirs("name", unknown_kwarg=True)
+    | ^^^^^^^^^^^
+139 |
+140 | # https://github.com/astral-sh/ruff/issues/20134
+    |
+help: Replace with `Path(...).mkdir(parents=True)`
+
+PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:141:1
+    |
+140 | # https://github.com/astral-sh/ruff/issues/20134
+141 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+    | ^^^^^^^^
+142 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+    |
+help: Replace with `Path(...).chmod(...)`
+1   | import os
+2   | import os.path
+3   + import pathlib
+4   |
+5   | p = "/foo"
+6   | q = "bar"
+--------------------------------------------------------------------------------
+139 | os.makedirs("name", unknown_kwarg=True)
+140 |
+141 | # https://github.com/astral-sh/ruff/issues/20134
+    - os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+142 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=      False)
+143 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+144 |
+145 | # Only diagnostic
+
+PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:142:1
+    |
+140 | # https://github.com/astral-sh/ruff/issues/20134
+141 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+142 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+    | ^^^^^^^^
+143 |
+144 | # Only diagnostic
+    |
+help: Replace with `Path(...).chmod(...)`
+1   | import os
+2   | import os.path
+3   + import pathlib
+4   |
+5   | p = "/foo"
+6   | q = "bar"
+--------------------------------------------------------------------------------
+140 |
+141 | # https://github.com/astral-sh/ruff/issues/20134
+142 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+    - os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+143 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=True)
+144 |
+145 | # Only diagnostic
+146 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+
+PTH101 `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:145:1
+    |
+144 | # Only diagnostic
+145 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+    | ^^^^^^^^
+146 |
+147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).chmod(...)`
 
 PTH104 `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:136:1
+   --> full_name.py:147:1
     |
-134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
-135 |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+145 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+146 |
+147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).rename(...)`
 
 PTH105 `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:137:1
+   --> full_name.py:148:1
     |
-136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^
-138 |
-139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+149 |
+150 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).replace(...)`
 
 PTH121 `os.path.samefile()` should be replaced by `Path.samefile()`
-   --> full_name.py:139:1
+   --> full_name.py:150:1
     |
-137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
-138 |
-139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+149 |
+150 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^^^^^^^
-140 |
-141 | # See: https://github.com/astral-sh/ruff/issues/21794
+151 |
+152 | # See: https://github.com/astral-sh/ruff/issues/21794
     |
 help: Replace with `Path(...).samefile()`
 
 PTH104 [*] `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:144:4
+   --> full_name.py:155:4
     |
-142 | import sys
-143 |
-144 | if os.rename("pth1.py", "pth1.py.bak"):
+153 | import sys
+154 |
+155 | if os.rename("pth1.py", "pth1.py.bak"):
     |    ^^^^^^^^^
-145 |     print("rename: truthy")
-146 | else:
+156 |     print("rename: truthy")
+157 | else:
     |
 help: Replace with `Path(...).rename(...)`
-140 |
-141 | # See: https://github.com/astral-sh/ruff/issues/21794
-142 | import sys
-143 + import pathlib
-144 |
+151 |
+152 | # See: https://github.com/astral-sh/ruff/issues/21794
+153 | import sys
+154 + import pathlib
+155 |
     - if os.rename("pth1.py", "pth1.py.bak"):
-145 + if pathlib.Path("pth1.py").rename("pth1.py.bak"):
-146 |     print("rename: truthy")
-147 | else:
-148 |     print("rename: falsey")
+156 + if pathlib.Path("pth1.py").rename("pth1.py.bak"):
+157 |     print("rename: truthy")
+158 | else:
+159 |     print("rename: falsey")
 note: This is an unsafe fix and may change runtime behavior
 
 PTH105 [*] `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:149:4
+   --> full_name.py:160:4
     |
-147 |     print("rename: falsey")
-148 |
-149 | if os.replace("pth1.py.bak", "pth1.py"):
+158 |     print("rename: falsey")
+159 |
+160 | if os.replace("pth1.py.bak", "pth1.py"):
     |    ^^^^^^^^^^
-150 |     print("replace: truthy")
-151 | else:
+161 |     print("replace: truthy")
+162 | else:
     |
 help: Replace with `Path(...).replace(...)`
-140 |
-141 | # See: https://github.com/astral-sh/ruff/issues/21794
-142 | import sys
-143 + import pathlib
-144 |
-145 | if os.rename("pth1.py", "pth1.py.bak"):
-146 |     print("rename: truthy")
-147 | else:
-148 |     print("rename: falsey")
-149 |
+151 |
+152 | # See: https://github.com/astral-sh/ruff/issues/21794
+153 | import sys
+154 + import pathlib
+155 |
+156 | if os.rename("pth1.py", "pth1.py.bak"):
+157 |     print("rename: truthy")
+158 | else:
+159 |     print("rename: falsey")
+160 |
     - if os.replace("pth1.py.bak", "pth1.py"):
-150 + if pathlib.Path("pth1.py.bak").replace("pth1.py"):
-151 |     print("replace: truthy")
-152 | else:
-153 |     print("replace: falsey")
+161 + if pathlib.Path("pth1.py.bak").replace("pth1.py"):
+162 |     print("replace: truthy")
+163 | else:
+164 |     print("replace: falsey")
 note: This is an unsafe fix and may change runtime behavior
 
 PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:155:14
+   --> full_name.py:166:14
     |
-154 | try:
-155 |     for _ in os.getcwd():
+165 | try:
+166 |     for _ in os.getcwd():
     |              ^^^^^^^^^
-156 |         print("getcwd: iterable")
-157 |         break
+167 |         print("getcwd: iterable")
+168 |         break
     |
 help: Replace with `Path.cwd()`
-140 |
-141 | # See: https://github.com/astral-sh/ruff/issues/21794
-142 | import sys
-143 + import pathlib
-144 |
-145 | if os.rename("pth1.py", "pth1.py.bak"):
-146 |     print("rename: truthy")
+151 |
+152 | # See: https://github.com/astral-sh/ruff/issues/21794
+153 | import sys
+154 + import pathlib
+155 |
+156 | if os.rename("pth1.py", "pth1.py.bak"):
+157 |     print("rename: truthy")
 --------------------------------------------------------------------------------
-153 |     print("replace: falsey")
-154 |
-155 | try:
+164 |     print("replace: falsey")
+165 |
+166 | try:
     -     for _ in os.getcwd():
-156 +     for _ in pathlib.Path.cwd():
-157 |         print("getcwd: iterable")
-158 |         break
-159 | except TypeError as e:
+167 +     for _ in pathlib.Path.cwd():
+168 |         print("getcwd: iterable")
+169 |         break
+170 | except TypeError as e:
 note: This is an unsafe fix and may change runtime behavior
 
 PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:162:14
+   --> full_name.py:173:14
     |
-161 | try:
-162 |     for _ in os.getcwdb():
+172 | try:
+173 |     for _ in os.getcwdb():
     |              ^^^^^^^^^^
-163 |         print("getcwdb: iterable")
-164 |         break
+174 |         print("getcwdb: iterable")
+175 |         break
     |
 help: Replace with `Path.cwd()`
-140 |
-141 | # See: https://github.com/astral-sh/ruff/issues/21794
-142 | import sys
-143 + import pathlib
-144 |
-145 | if os.rename("pth1.py", "pth1.py.bak"):
-146 |     print("rename: truthy")
+151 |
+152 | # See: https://github.com/astral-sh/ruff/issues/21794
+153 | import sys
+154 + import pathlib
+155 |
+156 | if os.rename("pth1.py", "pth1.py.bak"):
+157 |     print("rename: truthy")
 --------------------------------------------------------------------------------
-160 |     print("getcwd: not iterable")
-161 |
-162 | try:
+171 |     print("getcwd: not iterable")
+172 |
+173 | try:
     -     for _ in os.getcwdb():
-163 +     for _ in pathlib.Path.cwd():
-164 |         print("getcwdb: iterable")
-165 |         break
-166 | except TypeError as e:
+174 +     for _ in pathlib.Path.cwd():
+175 |         print("getcwdb: iterable")
+176 |         break
+177 | except TypeError as e:
 note: This is an unsafe fix and may change runtime behavior
 
 PTH115 [*] `os.readlink()` should be replaced by `Path.readlink()`
-   --> full_name.py:169:14
+   --> full_name.py:180:14
     |
-168 | try:
-169 |     for _ in os.readlink(sys.executable):
+179 | try:
+180 |     for _ in os.readlink(sys.executable):
     |              ^^^^^^^^^^^
-170 |         print("readlink: iterable")
-171 |         break
+181 |         print("readlink: iterable")
+182 |         break
     |
 help: Replace with `Path(...).readlink()`
-140 |
-141 | # See: https://github.com/astral-sh/ruff/issues/21794
-142 | import sys
-143 + import pathlib
-144 |
-145 | if os.rename("pth1.py", "pth1.py.bak"):
-146 |     print("rename: truthy")
+151 |
+152 | # See: https://github.com/astral-sh/ruff/issues/21794
+153 | import sys
+154 + import pathlib
+155 |
+156 | if os.rename("pth1.py", "pth1.py.bak"):
+157 |     print("rename: truthy")
 --------------------------------------------------------------------------------
-167 |     print("getcwdb: not iterable")
-168 |
-169 | try:
+178 |     print("getcwdb: not iterable")
+179 |
+180 | try:
     -     for _ in os.readlink(sys.executable):
-170 +     for _ in pathlib.Path(sys.executable).readlink():
-171 |         print("readlink: iterable")
-172 |         break
-173 | except TypeError as e:
+181 +     for _ in pathlib.Path(sys.executable).readlink():
+182 |         print("readlink: iterable")
+183 |         break
+184 | except TypeError as e:
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview_full_name.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/snapshots/ruff_linter__rules__flake8_use_pathlib__tests__preview_full_name.py.snap
@@ -741,121 +741,67 @@ help: Replace with `Path.open()`
 74 | # https://github.com/astral-sh/ruff/issues/17693
 75 | os.stat(1)
 
-PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
+PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
+   --> full_name.py:108:1
+    |
+106 | os.replace("src", "dst", dst_dir_fd=2)
+107 |
+108 | os.getcwd()
+    | ^^^^^^^^^
+109 | os.getcwdb()
+    |
+help: Replace with `Path.cwd()`
+1   | import os
+2   | import os.path
+3   + import pathlib
+4   |
+5   | p = "/foo"
+6   | q = "bar"
+--------------------------------------------------------------------------------
+106 | os.replace("src", "dst", src_dir_fd=1)
+107 | os.replace("src", "dst", dst_dir_fd=2)
+108 |
+    - os.getcwd()
+109 + pathlib.Path.cwd()
+110 | os.getcwdb()
+111 |
+112 | os.mkdir(path="directory")
+
+PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
+   --> full_name.py:109:1
+    |
+108 | os.getcwd()
+109 | os.getcwdb()
+    | ^^^^^^^^^^
+110 |
+111 | os.mkdir(path="directory")
+    |
+help: Replace with `Path.cwd()`
+1   | import os
+2   | import os.path
+3   + import pathlib
+4   |
+5   | p = "/foo"
+6   | q = "bar"
+--------------------------------------------------------------------------------
+107 | os.replace("src", "dst", dst_dir_fd=2)
+108 |
+109 | os.getcwd()
+    - os.getcwdb()
+110 + pathlib.Path.cwd()
+111 |
+112 | os.mkdir(path="directory")
+113 |
+
+PTH102 [*] `os.mkdir()` should be replaced by `Path.mkdir()`
    --> full_name.py:111:1
     |
-110 | _holder = _AttrHolder()
-111 | os.chmod(_holder.fd, 0o644)
-    | ^^^^^^^^
-112 | os.chmod(_holder.name, 0o644)
-    |
-help: Replace with `Path(...).chmod(...)`
-1   | import os
-2   | import os.path
-3   + import pathlib
-4   |
-5   | p = "/foo"
-6   | q = "bar"
---------------------------------------------------------------------------------
-109 |     name: str = ""
+109 | os.getcwdb()
 110 |
-111 | _holder = _AttrHolder()
-    - os.chmod(_holder.fd, 0o644)
-112 + pathlib.Path(_holder.fd).chmod(0o644)
-113 | os.chmod(_holder.name, 0o644)
-114 |
-115 | # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
-note: This is an unsafe fix and may change runtime behavior
-
-PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:112:1
-    |
-110 | _holder = _AttrHolder()
-111 | os.chmod(_holder.fd, 0o644)
-112 | os.chmod(_holder.name, 0o644)
+111 | os.mkdir(path="directory")
     | ^^^^^^^^
-113 |
-114 | # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
-    |
-help: Replace with `Path(...).chmod(...)`
-1   | import os
-2   | import os.path
-3   + import pathlib
-4   |
-5   | p = "/foo"
-6   | q = "bar"
---------------------------------------------------------------------------------
-110 |
-111 | _holder = _AttrHolder()
-112 | os.chmod(_holder.fd, 0o644)
-    - os.chmod(_holder.name, 0o644)
-113 + pathlib.Path(_holder.name).chmod(0o644)
-114 |
-115 | # if `src_dir_fd` or `dst_dir_fd` are set, suppress the diagnostic
-116 | os.replace("src", "dst", src_dir_fd=1, dst_dir_fd=2)
-note: This is an unsafe fix and may change runtime behavior
-
-PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:119:1
-    |
-117 | os.replace("src", "dst", dst_dir_fd=2)
-118 |
-119 | os.getcwd()
-    | ^^^^^^^^^
-120 | os.getcwdb()
-    |
-help: Replace with `Path.cwd()`
-1   | import os
-2   | import os.path
-3   + import pathlib
-4   |
-5   | p = "/foo"
-6   | q = "bar"
---------------------------------------------------------------------------------
-117 | os.replace("src", "dst", src_dir_fd=1)
-118 | os.replace("src", "dst", dst_dir_fd=2)
-119 |
-    - os.getcwd()
-120 + pathlib.Path.cwd()
-121 | os.getcwdb()
-122 |
-123 | os.mkdir(path="directory")
-
-PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:120:1
-    |
-119 | os.getcwd()
-120 | os.getcwdb()
-    | ^^^^^^^^^^
-121 |
-122 | os.mkdir(path="directory")
-    |
-help: Replace with `Path.cwd()`
-1   | import os
-2   | import os.path
-3   + import pathlib
-4   |
-5   | p = "/foo"
-6   | q = "bar"
---------------------------------------------------------------------------------
-118 | os.replace("src", "dst", dst_dir_fd=2)
-119 |
-120 | os.getcwd()
-    - os.getcwdb()
-121 + pathlib.Path.cwd()
-122 |
-123 | os.mkdir(path="directory")
-124 |
-
-PTH102 [*] `os.mkdir()` should be replaced by `Path.mkdir()`
-   --> full_name.py:122:1
-    |
-120 | os.getcwdb()
-121 |
-122 | os.mkdir(path="directory")
-    | ^^^^^^^^
-123 |
-124 | os.mkdir(
+112 |
+113 | os.mkdir(
     |
 help: Replace with `Path(...).mkdir()`
 1   | import os
@@ -865,24 +811,24 @@ help: Replace with `Path(...).mkdir()`
 5   | p = "/foo"
 6   | q = "bar"
 --------------------------------------------------------------------------------
-120 | os.getcwd()
-121 | os.getcwdb()
-122 |
+109 | os.getcwd()
+110 | os.getcwdb()
+111 |
     - os.mkdir(path="directory")
-123 + pathlib.Path("directory").mkdir()
-124 |
-125 | os.mkdir(
-126 |     # comment 1
+112 + pathlib.Path("directory").mkdir()
+113 |
+114 | os.mkdir(
+115 |     # comment 1
 
 PTH102 [*] `os.mkdir()` should be replaced by `Path.mkdir()`
-   --> full_name.py:124:1
+   --> full_name.py:113:1
     |
-122 | os.mkdir(path="directory")
-123 |
-124 | os.mkdir(
+111 | os.mkdir(path="directory")
+112 |
+113 | os.mkdir(
     | ^^^^^^^^
-125 |     # comment 1
-126 |     "directory",
+114 |     # comment 1
+115 |     "directory",
     |
 help: Replace with `Path(...).mkdir()`
 1   | import os
@@ -892,29 +838,29 @@ help: Replace with `Path(...).mkdir()`
 5   | p = "/foo"
 6   | q = "bar"
 --------------------------------------------------------------------------------
-122 |
-123 | os.mkdir(path="directory")
-124 |
+111 |
+112 | os.mkdir(path="directory")
+113 |
     - os.mkdir(
     -     # comment 1
     -     "directory",
     -     mode=0o777
     - )
-125 + pathlib.Path("directory").mkdir(mode=0o777)
-126 |
-127 | os.mkdir("directory", mode=0o777, dir_fd=1)
-128 |
+114 + pathlib.Path("directory").mkdir(mode=0o777)
+115 |
+116 | os.mkdir("directory", mode=0o777, dir_fd=1)
+117 |
 note: This is an unsafe fix and may change runtime behavior
 
 PTH103 [*] `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:132:1
+   --> full_name.py:121:1
     |
-130 | os.mkdir("directory", mode=0o777, dir_fd=1)
-131 |
-132 | os.makedirs("name", 0o777, exist_ok=False)
+119 | os.mkdir("directory", mode=0o777, dir_fd=1)
+120 |
+121 | os.makedirs("name", 0o777, exist_ok=False)
     | ^^^^^^^^^^^
-133 |
-134 | os.makedirs("name", 0o777, False)
+122 |
+123 | os.makedirs("name", 0o777, False)
     |
 help: Replace with `Path(...).mkdir(parents=True)`
 1   | import os
@@ -924,24 +870,24 @@ help: Replace with `Path(...).mkdir(parents=True)`
 5   | p = "/foo"
 6   | q = "bar"
 --------------------------------------------------------------------------------
-130 |
-131 | os.mkdir("directory", mode=0o777, dir_fd=1)
-132 |
+119 |
+120 | os.mkdir("directory", mode=0o777, dir_fd=1)
+121 |
     - os.makedirs("name", 0o777, exist_ok=False)
-133 + pathlib.Path("name").mkdir(0o777, exist_ok=False, parents=True)
-134 |
-135 | os.makedirs("name", 0o777, False)
-136 |
+122 + pathlib.Path("name").mkdir(0o777, exist_ok=False, parents=True)
+123 |
+124 | os.makedirs("name", 0o777, False)
+125 |
 
 PTH103 [*] `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:134:1
+   --> full_name.py:123:1
     |
-132 | os.makedirs("name", 0o777, exist_ok=False)
-133 |
-134 | os.makedirs("name", 0o777, False)
+121 | os.makedirs("name", 0o777, exist_ok=False)
+122 |
+123 | os.makedirs("name", 0o777, False)
     | ^^^^^^^^^^^
-135 |
-136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+124 |
+125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
     |
 help: Replace with `Path(...).mkdir(parents=True)`
 1   | import os
@@ -951,24 +897,24 @@ help: Replace with `Path(...).mkdir(parents=True)`
 5   | p = "/foo"
 6   | q = "bar"
 --------------------------------------------------------------------------------
-132 |
-133 | os.makedirs("name", 0o777, exist_ok=False)
-134 |
+121 |
+122 | os.makedirs("name", 0o777, exist_ok=False)
+123 |
     - os.makedirs("name", 0o777, False)
-135 + pathlib.Path("name").mkdir(0o777, True, False)
-136 |
-137 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-138 |
+124 + pathlib.Path("name").mkdir(0o777, True, False)
+125 |
+126 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+127 |
 
 PTH103 [*] `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:136:1
+   --> full_name.py:125:1
     |
-134 | os.makedirs("name", 0o777, False)
-135 |
-136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+123 | os.makedirs("name", 0o777, False)
+124 |
+125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
     | ^^^^^^^^^^^
-137 |
-138 | os.makedirs("name", unknown_kwarg=True)
+126 |
+127 | os.makedirs("name", unknown_kwarg=True)
     |
 help: Replace with `Path(...).mkdir(parents=True)`
 1   | import os
@@ -978,34 +924,34 @@ help: Replace with `Path(...).mkdir(parents=True)`
 5   | p = "/foo"
 6   | q = "bar"
 --------------------------------------------------------------------------------
-134 |
-135 | os.makedirs("name", 0o777, False)
-136 |
+123 |
+124 | os.makedirs("name", 0o777, False)
+125 |
     - os.makedirs(name="name", mode=0o777, exist_ok=False)
-137 + pathlib.Path("name").mkdir(mode=0o777, exist_ok=False, parents=True)
-138 |
-139 | os.makedirs("name", unknown_kwarg=True)
-140 |
+126 + pathlib.Path("name").mkdir(mode=0o777, exist_ok=False, parents=True)
+127 |
+128 | os.makedirs("name", unknown_kwarg=True)
+129 |
 
 PTH103 `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-   --> full_name.py:138:1
+   --> full_name.py:127:1
     |
-136 | os.makedirs(name="name", mode=0o777, exist_ok=False)
-137 |
-138 | os.makedirs("name", unknown_kwarg=True)
+125 | os.makedirs(name="name", mode=0o777, exist_ok=False)
+126 |
+127 | os.makedirs("name", unknown_kwarg=True)
     | ^^^^^^^^^^^
-139 |
-140 | # https://github.com/astral-sh/ruff/issues/20134
+128 |
+129 | # https://github.com/astral-sh/ruff/issues/20134
     |
 help: Replace with `Path(...).mkdir(parents=True)`
 
 PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:141:1
+   --> full_name.py:130:1
     |
-140 | # https://github.com/astral-sh/ruff/issues/20134
-141 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+129 | # https://github.com/astral-sh/ruff/issues/20134
+130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
     | ^^^^^^^^
-142 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
     |
 help: Replace with `Path(...).chmod(...)`
 1   | import os
@@ -1015,24 +961,24 @@ help: Replace with `Path(...).chmod(...)`
 5   | p = "/foo"
 6   | q = "bar"
 --------------------------------------------------------------------------------
-139 | os.makedirs("name", unknown_kwarg=True)
-140 |
-141 | # https://github.com/astral-sh/ruff/issues/20134
+128 | os.makedirs("name", unknown_kwarg=True)
+129 |
+130 | # https://github.com/astral-sh/ruff/issues/20134
     - os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-142 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=      False)
-143 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
-144 |
-145 | # Only diagnostic
+131 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=      False)
+132 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+133 |
+134 | # Only diagnostic
 
 PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:142:1
+   --> full_name.py:131:1
     |
-140 | # https://github.com/astral-sh/ruff/issues/20134
-141 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
-142 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
+129 | # https://github.com/astral-sh/ruff/issues/20134
+130 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
     | ^^^^^^^^
-143 |
-144 | # Only diagnostic
+132 |
+133 | # Only diagnostic
     |
 help: Replace with `Path(...).chmod(...)`
 1   | import os
@@ -1042,191 +988,213 @@ help: Replace with `Path(...).chmod(...)`
 5   | p = "/foo"
 6   | q = "bar"
 --------------------------------------------------------------------------------
-140 |
-141 | # https://github.com/astral-sh/ruff/issues/20134
-142 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
+129 |
+130 | # https://github.com/astral-sh/ruff/issues/20134
+131 | os.chmod("pth1_link", mode=0o600, follow_symlinks=      False    )
     - os.chmod("pth1_link", mode=0o600, follow_symlinks=True)
-143 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=True)
-144 |
-145 | # Only diagnostic
-146 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+132 + pathlib.Path("pth1_link").chmod(mode=0o600, follow_symlinks=True)
+133 |
+134 | # Only diagnostic
+135 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
 
 PTH101 `os.chmod()` should be replaced by `Path.chmod()`
-   --> full_name.py:145:1
+   --> full_name.py:134:1
     |
-144 | # Only diagnostic
-145 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+133 | # Only diagnostic
+134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^
-146 |
-147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+135 |
+136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).chmod(...)`
 
 PTH104 `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:147:1
+   --> full_name.py:136:1
     |
-145 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
-146 |
-147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+134 | os.chmod("pth1_file", 0o700, None, True, 1, *[1], **{"x": 1}, foo=1)
+135 |
+136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^
-148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).rename(...)`
 
 PTH105 `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:148:1
+   --> full_name.py:137:1
     |
-147 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
-148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+136 | os.rename("pth1_file", "pth1_file1", None, None, 1, *[1], **{"x": 1}, foo=1)
+137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^
-149 |
-150 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+138 |
+139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     |
 help: Replace with `Path(...).replace(...)`
 
 PTH121 `os.path.samefile()` should be replaced by `Path.samefile()`
-   --> full_name.py:150:1
+   --> full_name.py:139:1
     |
-148 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
-149 |
-150 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
+137 | os.replace("pth1_file1", "pth1_file", None, None, 1, *[1], **{"x": 1}, foo=1)
+138 |
+139 | os.path.samefile("pth1_file", "pth1_link", 1, *[1], **{"x": 1}, foo=1)
     | ^^^^^^^^^^^^^^^^
-151 |
-152 | # See: https://github.com/astral-sh/ruff/issues/21794
+140 |
+141 | # See: https://github.com/astral-sh/ruff/issues/21794
     |
 help: Replace with `Path(...).samefile()`
 
 PTH104 [*] `os.rename()` should be replaced by `Path.rename()`
-   --> full_name.py:155:4
+   --> full_name.py:144:4
     |
-153 | import sys
-154 |
-155 | if os.rename("pth1.py", "pth1.py.bak"):
+142 | import sys
+143 |
+144 | if os.rename("pth1.py", "pth1.py.bak"):
     |    ^^^^^^^^^
-156 |     print("rename: truthy")
-157 | else:
+145 |     print("rename: truthy")
+146 | else:
     |
 help: Replace with `Path(...).rename(...)`
-151 |
-152 | # See: https://github.com/astral-sh/ruff/issues/21794
-153 | import sys
-154 + import pathlib
-155 |
+140 |
+141 | # See: https://github.com/astral-sh/ruff/issues/21794
+142 | import sys
+143 + import pathlib
+144 |
     - if os.rename("pth1.py", "pth1.py.bak"):
-156 + if pathlib.Path("pth1.py").rename("pth1.py.bak"):
-157 |     print("rename: truthy")
-158 | else:
-159 |     print("rename: falsey")
+145 + if pathlib.Path("pth1.py").rename("pth1.py.bak"):
+146 |     print("rename: truthy")
+147 | else:
+148 |     print("rename: falsey")
 note: This is an unsafe fix and may change runtime behavior
 
 PTH105 [*] `os.replace()` should be replaced by `Path.replace()`
-   --> full_name.py:160:4
+   --> full_name.py:149:4
     |
-158 |     print("rename: falsey")
-159 |
-160 | if os.replace("pth1.py.bak", "pth1.py"):
+147 |     print("rename: falsey")
+148 |
+149 | if os.replace("pth1.py.bak", "pth1.py"):
     |    ^^^^^^^^^^
-161 |     print("replace: truthy")
-162 | else:
+150 |     print("replace: truthy")
+151 | else:
     |
 help: Replace with `Path(...).replace(...)`
-151 |
-152 | # See: https://github.com/astral-sh/ruff/issues/21794
-153 | import sys
-154 + import pathlib
-155 |
-156 | if os.rename("pth1.py", "pth1.py.bak"):
-157 |     print("rename: truthy")
-158 | else:
-159 |     print("rename: falsey")
-160 |
+140 |
+141 | # See: https://github.com/astral-sh/ruff/issues/21794
+142 | import sys
+143 + import pathlib
+144 |
+145 | if os.rename("pth1.py", "pth1.py.bak"):
+146 |     print("rename: truthy")
+147 | else:
+148 |     print("rename: falsey")
+149 |
     - if os.replace("pth1.py.bak", "pth1.py"):
-161 + if pathlib.Path("pth1.py.bak").replace("pth1.py"):
-162 |     print("replace: truthy")
-163 | else:
-164 |     print("replace: falsey")
+150 + if pathlib.Path("pth1.py.bak").replace("pth1.py"):
+151 |     print("replace: truthy")
+152 | else:
+153 |     print("replace: falsey")
 note: This is an unsafe fix and may change runtime behavior
 
 PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:166:14
+   --> full_name.py:155:14
     |
-165 | try:
-166 |     for _ in os.getcwd():
+154 | try:
+155 |     for _ in os.getcwd():
     |              ^^^^^^^^^
-167 |         print("getcwd: iterable")
-168 |         break
+156 |         print("getcwd: iterable")
+157 |         break
     |
 help: Replace with `Path.cwd()`
-151 |
-152 | # See: https://github.com/astral-sh/ruff/issues/21794
-153 | import sys
-154 + import pathlib
-155 |
-156 | if os.rename("pth1.py", "pth1.py.bak"):
-157 |     print("rename: truthy")
+140 |
+141 | # See: https://github.com/astral-sh/ruff/issues/21794
+142 | import sys
+143 + import pathlib
+144 |
+145 | if os.rename("pth1.py", "pth1.py.bak"):
+146 |     print("rename: truthy")
 --------------------------------------------------------------------------------
-164 |     print("replace: falsey")
-165 |
-166 | try:
+153 |     print("replace: falsey")
+154 |
+155 | try:
     -     for _ in os.getcwd():
-167 +     for _ in pathlib.Path.cwd():
-168 |         print("getcwd: iterable")
-169 |         break
-170 | except TypeError as e:
+156 +     for _ in pathlib.Path.cwd():
+157 |         print("getcwd: iterable")
+158 |         break
+159 | except TypeError as e:
 note: This is an unsafe fix and may change runtime behavior
 
 PTH109 [*] `os.getcwd()` should be replaced by `Path.cwd()`
-   --> full_name.py:173:14
+   --> full_name.py:162:14
     |
-172 | try:
-173 |     for _ in os.getcwdb():
+161 | try:
+162 |     for _ in os.getcwdb():
     |              ^^^^^^^^^^
-174 |         print("getcwdb: iterable")
-175 |         break
+163 |         print("getcwdb: iterable")
+164 |         break
     |
 help: Replace with `Path.cwd()`
-151 |
-152 | # See: https://github.com/astral-sh/ruff/issues/21794
-153 | import sys
-154 + import pathlib
-155 |
-156 | if os.rename("pth1.py", "pth1.py.bak"):
-157 |     print("rename: truthy")
+140 |
+141 | # See: https://github.com/astral-sh/ruff/issues/21794
+142 | import sys
+143 + import pathlib
+144 |
+145 | if os.rename("pth1.py", "pth1.py.bak"):
+146 |     print("rename: truthy")
 --------------------------------------------------------------------------------
-171 |     print("getcwd: not iterable")
-172 |
-173 | try:
+160 |     print("getcwd: not iterable")
+161 |
+162 | try:
     -     for _ in os.getcwdb():
-174 +     for _ in pathlib.Path.cwd():
-175 |         print("getcwdb: iterable")
-176 |         break
-177 | except TypeError as e:
+163 +     for _ in pathlib.Path.cwd():
+164 |         print("getcwdb: iterable")
+165 |         break
+166 | except TypeError as e:
 note: This is an unsafe fix and may change runtime behavior
 
 PTH115 [*] `os.readlink()` should be replaced by `Path.readlink()`
-   --> full_name.py:180:14
+   --> full_name.py:169:14
     |
-179 | try:
-180 |     for _ in os.readlink(sys.executable):
+168 | try:
+169 |     for _ in os.readlink(sys.executable):
     |              ^^^^^^^^^^^
-181 |         print("readlink: iterable")
-182 |         break
+170 |         print("readlink: iterable")
+171 |         break
     |
 help: Replace with `Path(...).readlink()`
-151 |
-152 | # See: https://github.com/astral-sh/ruff/issues/21794
-153 | import sys
-154 + import pathlib
-155 |
-156 | if os.rename("pth1.py", "pth1.py.bak"):
-157 |     print("rename: truthy")
+140 |
+141 | # See: https://github.com/astral-sh/ruff/issues/21794
+142 | import sys
+143 + import pathlib
+144 |
+145 | if os.rename("pth1.py", "pth1.py.bak"):
+146 |     print("rename: truthy")
 --------------------------------------------------------------------------------
-178 |     print("getcwdb: not iterable")
-179 |
-180 | try:
+167 |     print("getcwdb: not iterable")
+168 |
+169 | try:
     -     for _ in os.readlink(sys.executable):
-181 +     for _ in pathlib.Path(sys.executable).readlink():
-182 |         print("readlink: iterable")
-183 |         break
-184 | except TypeError as e:
+170 +     for _ in pathlib.Path(sys.executable).readlink():
+171 |         print("readlink: iterable")
+172 |         break
+173 | except TypeError as e:
 note: This is an unsafe fix and may change runtime behavior
+
+PTH101 [*] `os.chmod()` should be replaced by `Path.chmod()`
+   --> full_name.py:187:1
+    |
+186 | os.chmod(_AttrHolder.fd, 0o644)    # Suppressed: resolved as `int`
+187 | os.chmod(_AttrHolder.name, 0o644)  # Diagnostic + fix: resolved as `str`
+    | ^^^^^^^^
+    |
+help: Replace with `Path(...).chmod(...)`
+140 |
+141 | # See: https://github.com/astral-sh/ruff/issues/21794
+142 | import sys
+143 + import pathlib
+144 |
+145 | if os.rename("pth1.py", "pth1.py.bak"):
+146 |     print("rename: truthy")
+--------------------------------------------------------------------------------
+185 |     name: str = ""
+186 |
+187 | os.chmod(_AttrHolder.fd, 0o644)    # Suppressed: resolved as `int`
+    - os.chmod(_AttrHolder.name, 0o644)  # Diagnostic + fix: resolved as `str`
+188 + pathlib.Path(_AttrHolder.name).chmod(0o644)  # Diagnostic + fix: resolved as `str`


### PR DESCRIPTION
## Summary

Closes #24895 (closed as duplicate of #17699).

The autofix for `PTH101` (`os.chmod` → `Path.chmod`) currently produces
runtime errors when the first argument is an attribute access whose underlying
type is an `int` (file descriptor). For example:

```python
class TestFd:
    def __init__(self, fd: int):
        self.fd = fd

    def test_fd(self):
        os.chmod(self.fd, 0o644)  # Currently autofixed to:
        # pathlib.Path(self.fd).chmod(0o644)  → TypeError at runtime
```

The cause is in `is_file_descriptor` (in `flake8_use_pathlib/helpers.rs`),
which extracts a `Name` from the argument via `get_name_expr` to look up its
binding type. `get_name_expr` only handles `Expr::Name` and `Expr::Call` —
it returns `None` for `Expr::Attribute`, so the helper cannot tell that
`self.fd` might be an `int`, and the fix is applied as `Safe`.

~~This PR marks the fix as `Applicability::Unsafe` whenever the first argument
is an `Expr::Attribute`. The diagnostic is still emitted, but applying the
autofix now requires `--unsafe-fixes`, preventing the silent regression.~~

~~The same demotion applies to attribute accesses that *look* like strings
(e.g., `os.chmod(self.name, 0o644)`). This is intentional: the heuristic
cannot statically distinguish `int` attributes from `str`/`PathLike` ones,
so applying it uniformly is the honest behavior.~~

This PR marks the fix as `Applicable::Unsafe` if the first argument is annotated with an `int` type


## Scope

The fix is intentionally local to `os_chmod.rs`:

- `helpers.rs` is unchanged. Extending `get_name_expr` to handle attributes
  would require attribute type resolution, which is closer to `ty`'s domain
  than Ruff's.
- Other rules in the family that use `is_file_descriptor` (`os.stat`,
  `os.rename`, `os.unlink`, etc.) are likely affected by the same pattern,
  but those are out of scope here. Happy to open a tracking issue or follow
  up if useful.

This narrow scope also aligns with @ntBre's note in #17699 about the broader
stabilization of these fixes.

## Test plan

- Added regression cases in
  `crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py`
  covering attribute access (both `int` and `str` attributes).
- Regenerated `full_name.py.snap` and `preview_full_name.py.snap`. The new
  preview diagnostics carry the `note: This is an unsafe fix and may change
  runtime behavior` marker. Existing diagnostics are unchanged in content;
  only their reported line numbers shift due to the inserted fixture lines.
- `cargo test -p ruff_linter` → 2759 passed, 0 failed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean.
- `uvx prek run -a` → all hooks passed.

Refs #17699