### PR TITLE
[ty] Allow known non-field writes on frozen dataclass subclasses

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -594,9 +594,112 @@ class MyFrozenClass:
     x: int = 1
 
 class MyFrozenChildClass(MyFrozenClass): ...
+class MyFrozenGrandchildClass(MyFrozenChildClass): ...
 
 frozen = MyFrozenChildClass()
 frozen.x = 2  # error: [invalid-assignment]
+
+grandchild = MyFrozenGrandchildClass()
+grandchild.x = 2  # error: [invalid-assignment]
+```
+
+Non-field attributes on a non-dataclass subclass of a frozen dataclass are still assignable:
+
+```py
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class MyFrozenClass:
+    x: int = 1
+
+class MyFrozenChildClass(MyFrozenClass):
+    y: int
+
+class MyFrozenGrandchildClass(MyFrozenChildClass):
+    z: int
+
+frozen = MyFrozenChildClass()
+frozen.y = 2
+frozen.z = 2
+
+grandchild = MyFrozenGrandchildClass()
+grandchild.y = 2
+grandchild.z = 2
+grandchild.unknown = 2
+```
+
+The synthesized `__setattr__` is exposed as a member on non-dataclass subclasses of frozen
+dataclasses:
+
+```py
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class MyFrozenClass:
+    x: int = 1
+
+class MyFrozenChildClass(MyFrozenClass): ...
+
+child = MyFrozenChildClass()
+reveal_type(child.__setattr__)  # revealed: Overload[(name: Literal["x"], value) -> Never, (name: str, value) -> None]
+```
+
+An explicit `__setattr__` on an intermediate subclass overrides the inherited frozen dataclass
+setter:
+
+```py
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class MyFrozenClass:
+    x: int = 1
+
+class MyFrozenIntermediateClass(MyFrozenClass):
+    def __setattr__(self, name: str, value: object) -> None: ...  # error: [invalid-method-override]
+
+class MyFrozenChildClass(MyFrozenIntermediateClass):
+    y: int
+
+class MyFrozenGrandchildClass(MyFrozenChildClass):
+    z: int
+
+child = MyFrozenChildClass()
+child.x = 2
+child.y = 2
+child.unknown = 2
+
+grandchild = MyFrozenGrandchildClass()
+grandchild.x = 2
+grandchild.y = 2
+grandchild.z = 2
+grandchild.unknown = 2
+```
+
+Non-field attributes on subclasses of slotted frozen dataclasses are still rejected:
+
+```py
+from dataclasses import dataclass
+
+@dataclass(frozen=True, slots=True)
+class MySlottedFrozenClass:
+    x: int = 1
+
+class MySlottedFrozenChildClass(MySlottedFrozenClass):
+    y: int
+
+class MySlottedFrozenGrandchildClass(MySlottedFrozenChildClass):
+    z: int
+
+frozen = MySlottedFrozenChildClass()
+frozen.x = 2  # error: [invalid-assignment]
+frozen.y = 2  # error: [invalid-assignment]
+frozen.z = 2  # error: [invalid-assignment]
+
+grandchild = MySlottedFrozenGrandchildClass()
+grandchild.x = 2  # error: [invalid-assignment]
+grandchild.y = 2  # error: [invalid-assignment]
+grandchild.z = 2  # error: [invalid-assignment]
+grandchild.unknown = 2  # error: [invalid-assignment]
 ```
 
 The same diagnostic is emitted if a frozen dataclass is inherited, and an attempt is made to delete

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -675,7 +675,11 @@ grandchild.z = 2
 grandchild.unknown = 2
 ```
 
-Non-field attributes on subclasses of slotted frozen dataclasses are still rejected:
+Non-field attributes on subclasses of slotted frozen dataclasses are still rejected. This correctly
+models the runtime behavior, but is somewhat surprising and may be a CPython bug, as subclasses of
+slotted classes usually allow arbitrary attributes to be set on them unless the subclass also
+explicitly declares `__slots__`. We should change our behavior here to follow CPython, if they "fix"
+it.
 
 ```py
 from dataclasses import dataclass

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1197,6 +1197,17 @@ impl<'db> StaticClassLiteral<'db> {
             return Some(synthesized_callables.into_type(db));
         }
 
+        // An ordinary subclass of a frozen dataclass is not itself dataclass-like, so the
+        // `CodeGeneratorKind::from_class` check below would return `None` before dataclass-like
+        // synthesis runs. Still, an instance of such a subclass inherits the frozen dataclass's
+        // generated `__setattr__`, which rejects writes to frozen base fields.
+        if name == "__setattr__"
+            && let Some(synthesized_setattr) =
+                self.own_frozen_dataclass_subclass_setattr(db, specialization)
+        {
+            return Some(synthesized_setattr);
+        }
+
         let field_policy = CodeGeneratorKind::from_class(db, self.into(), specialization)?;
 
         let instance_ty =
@@ -1541,6 +1552,103 @@ impl<'db> StaticClassLiteral<'db> {
             }
             _ => None,
         }
+    }
+
+    /// Synthesize a `__setattr__` view for an ordinary subclass of a frozen dataclass.
+    ///
+    /// CPython's generated frozen-dataclass `__setattr__` rejects all writes on exact instances of
+    /// the frozen dataclass, but on subclass instances it only rejects writes to that dataclass's
+    /// fields before delegating to the next `__setattr__` in the MRO.
+    fn own_frozen_dataclass_subclass_setattr(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+    ) -> Option<Type<'db>> {
+        if CodeGeneratorKind::from_static_class(db, self, specialization).is_some() {
+            return None;
+        }
+
+        let frozen_base_fields =
+            self.inherited_non_slotted_frozen_dataclass_fields(db, specialization)?;
+
+        let instance_ty =
+            Type::instance(db, self.apply_optional_specialization(db, specialization));
+        let setattr_signature = |name_ty, return_ty| {
+            Signature::new(
+                Parameters::new(
+                    db,
+                    [
+                        Parameter::positional_or_keyword(Name::new_static("self"))
+                            .with_annotated_type(instance_ty),
+                        Parameter::positional_or_keyword(Name::new_static("name"))
+                            .with_annotated_type(name_ty),
+                        Parameter::positional_or_keyword(Name::new_static("value")),
+                    ],
+                ),
+                return_ty,
+            )
+        };
+
+        let overloads = frozen_base_fields
+            .keys()
+            .map(|field| setattr_signature(Type::string_literal(db, field), Type::Never))
+            .chain([setattr_signature(
+                KnownClass::Str.to_instance(db),
+                Type::none(db),
+            )]);
+
+        Some(Type::Callable(CallableType::new(
+            db,
+            CallableSignature::from_overloads(overloads),
+            CallableTypeKind::FunctionLike,
+        )))
+    }
+
+    /// Return the inherited frozen dataclass fields whose generated `__setattr__` still controls
+    /// assignments on this class.
+    fn inherited_non_slotted_frozen_dataclass_fields(
+        self,
+        db: &'db dyn Db,
+        specialization: Option<Specialization<'db>>,
+    ) -> Option<&'db FxIndexMap<Name, Field<'db>>> {
+        for base in self.iter_mro(db, specialization).skip(1) {
+            let (base_class, base_specialization) = base.into_class()?.static_class_literal(db)?;
+
+            // Stop if another class in the MRO replaces the generated frozen setter:
+            //
+            //   @dataclass(frozen=True)
+            //   class Frozen: x: int
+            //
+            //   class Mutable(Frozen):
+            //       def __setattr__(self, name: str, value: object) -> None: ...
+            //
+            //   class Child(Mutable): ...
+            //
+            // Writes to `Child().x` dispatch to `Mutable.__setattr__`, not to the synthesized
+            // `Frozen.__setattr__`.
+            if class_member(db, base_class.body_scope(db), "__setattr__")
+                .ignore_possibly_undefined()
+                .is_some()
+            {
+                return None;
+            }
+
+            if base_class.is_frozen_dataclass(db) == Some(true) {
+                let field_policy @ CodeGeneratorKind::DataclassLike(_) =
+                    CodeGeneratorKind::from_static_class(db, base_class, base_specialization)?
+                else {
+                    return None;
+                };
+
+                if base_class.has_dataclass_param(db, field_policy, DataclassFlags::SLOTS) {
+                    return None;
+                }
+
+                return Some(base_class.fields(db, base_specialization, field_policy));
+            }
+        }
+
+        None
     }
 
     /// Member lookup for classes that inherit from `typing.TypedDict`.


### PR DESCRIPTION
## Summary

A `frozen=True` dataclass rejects writes to all declared and undeclared attributes; however, a non-frozen subclass of a `frozen=True` dataclass only rejects writes to the attributes declared on the dataclass.

This PR synthesizes a set of `__setattr__` overloads for such subclasses to narrow the scope of the "frozen" behavior to only those attributes defined by the dataclass, matching the behavior used in Mypy and Pyright (and at runtime).

For example, `child.y = 2` is now accepted:

```python
from dataclasses import dataclass

@dataclass(frozen=True)
class Frozen:
    x: int = 1

class Child(Frozen):
    y: int

child = Child()
child.x = 2  # runtime: FrozenInstanceError
child.y = 2  # runtime: OK
```

Closes https://github.com/astral-sh/ty/issues/3434.
