### PR TITLE
[ty] Support callable assert_type and generic TypeAliasType inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
@@ -210,6 +210,24 @@ def _(a: str | int):
     assert_type(a, int | str)
 ```
 
+## Callable assertions for function literals
+
+Concrete function literals are accepted when asserted against a compatible `Callable` signature.
+
+```py
+from collections.abc import Awaitable, Callable
+from typing_extensions import assert_type
+
+def sync_func() -> str:
+    return "x"
+
+async def async_func(x: int) -> str:
+    return str(x)
+
+assert_type(sync_func, Callable[[], str])
+assert_type(async_func, Callable[[int], Awaitable[str]])
+```
+
 ## Intersections
 
 Intersections are the same when their positive and negative parts are respectively the same,

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -246,8 +246,7 @@ MyList = TypeAliasType("MyList", list[T], type_params=(T,))
 MyAlias5 = Callable[[MyList[T]], int]
 
 def _(c: MyAlias5[int]):
-    # TODO: should be (list[int], /) -> int
-    reveal_type(c)  # revealed: (Unknown, /) -> int
+    reveal_type(c)  # revealed: (list[int], /) -> int
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -257,8 +256,7 @@ MyDict = TypeAliasType("MyDict", dict[K, V], type_params=(K, V))
 MyAlias6 = Callable[[MyDict[K, V]], int]
 
 def _(c: MyAlias6[str, bytes]):
-    # TODO: should be (dict[str, bytes], /) -> int
-    reveal_type(c)  # revealed: (Unknown, /) -> int
+    reveal_type(c)  # revealed: (dict[str, bytes], /) -> int
 
 ListOrDict: TypeAlias = MyList[T] | dict[str, T]
 

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -289,8 +289,7 @@ T = TypeVar("T")
 IntAndT = TypeAliasType("IntAndT", tuple[int, T], type_params=(T,))
 
 def f(x: IntAndT[str]) -> None:
-    # TODO: This should be `tuple[int, str]`
-    reveal_type(x)  # revealed: Unknown
+    reveal_type(x)  # revealed: tuple[int, str]
 ```
 
 ### Generic value binds type variables to alias definition

--- a/crates/ty_python_semantic/resources/mdtest/regression/recursive_generic_alias_heterogeneous_inference.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/recursive_generic_alias_heterogeneous_inference.md
@@ -1,0 +1,43 @@
+# Recursive Generic Alias Heterogeneous Inference
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+```py
+from collections.abc import Callable, Sequence
+from typing import Generic
+from typing_extensions import TypeAliasType, TypeVar, assert_type
+
+T = TypeVar("T", covariant=True, default=str)
+
+class Box(Generic[T]):
+    def __init__(self, value: type[T] | Callable[..., T]):
+        self.value = value
+
+Item = TypeAliasType(
+    "Item",
+    type[T] | Callable[..., T] | Box[T],
+    type_params=(T,),
+)
+
+Spec = TypeAliasType(
+    "Spec",
+    Item[T] | Sequence["Spec[T]"],
+    type_params=(T,),
+)
+
+class C(Generic[T]):
+    def __init__(self, x: Spec[T] = str) -> None:
+        ...
+
+class A: ...
+class B: ...
+
+def f() -> int:
+    return 1
+
+c = C([str, A, B, Box(f)])
+assert_type(c, C[str | A | B | int])
+```

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1271,6 +1271,24 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     }
 }
 
+fn function_literal_is_assignable_to_asserted_callable<'db>(
+    db: &'db dyn Db,
+    actual_ty: Type<'db>,
+    asserted_ty: Type<'db>,
+) -> bool {
+    let Type::Callable(asserted_callable) = asserted_ty else {
+        return false;
+    };
+
+    let actual_callable = match actual_ty {
+        Type::FunctionLiteral(function) => function.into_callable_type(db),
+        Type::BoundMethod(bound_method) => bound_method.into_callable_type(db),
+        _ => return false,
+    };
+
+    Type::Callable(actual_callable).is_assignable_to(db, Type::Callable(asserted_callable))
+}
+
 /// Check the second argument to `isinstance()` or `issubclass()` for types that cannot be used
 /// at runtime (protocol classes, typed dicts, `typing.Any` in `isinstance`, and invalid
 /// `UnionType` elements). Handles class literals, tuples (including nested tuples), and
@@ -1920,7 +1938,13 @@ impl KnownFunction {
                 let [Some(actual_ty), Some(asserted_ty)] = parameter_types else {
                     return;
                 };
-                if actual_ty.is_equivalent_to(db, *asserted_ty) {
+                if actual_ty.is_equivalent_to(db, *asserted_ty)
+                    || function_literal_is_assignable_to_asserted_callable(
+                        db,
+                        *actual_ty,
+                        *asserted_ty,
+                    )
+                {
                     return;
                 }
                 let diagnostic =

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2009,9 +2009,40 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     .elements(self.db)
                     .iter()
                     .filter(|ty| ty.has_typevar(self.db));
-                let Ok(Type::TypeVar(formal_bound_typevar)) = types_have_typevars.exactly_one()
-                else {
-                    return Ok(());
+                let formal_bound_typevar = match types_have_typevars.exactly_one() {
+                    Ok(Type::TypeVar(formal_bound_typevar)) => formal_bound_typevar,
+                    Ok(_) => return Ok(()),
+                    Err(_) => {
+                        let mut first_error = None;
+                        let mut found_matching_element = false;
+                        for actual_element in actual_union.elements(self.db) {
+                            let result = self.infer_map_impl(
+                                formal,
+                                *actual_element,
+                                polarity,
+                                &mut f,
+                                seen,
+                            );
+                            if let Err(err) = result {
+                                first_error.get_or_insert(err);
+                            } else if !actual_element
+                                .when_assignable_to(
+                                    self.db,
+                                    formal,
+                                    self.constraints,
+                                    self.inferable,
+                                )
+                                .is_never_satisfied(self.db)
+                            {
+                                found_matching_element = true;
+                            }
+                        }
+
+                        if !found_matching_element && let Some(error) = first_error {
+                            return Err(error);
+                        }
+                        return Ok(());
+                    }
                 };
                 if actual_union
                     .elements(self.db)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3771,6 +3771,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 db,
                 ast::name::Name::new(name),
                 definition,
+                None,
             )),
         ))
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Db,
+    Db, FxOrderSet,
     reachability::ReachabilityConstraintsExtension,
     types::{
         KnownClass, KnownInstanceType, ParamSpecAttrKind, SubclassOfInner, SubclassOfType, Type,
@@ -15,7 +15,7 @@ use crate::{
             FunctionBodyKind, FunctionDecorators, FunctionLiteral, FunctionType, KnownFunction,
             OverloadLiteral, function_body_kind, is_implicit_classmethod,
         },
-        generics::{enclosing_generic_contexts, typing_self},
+        generics::{GenericContext, enclosing_generic_contexts, typing_self},
         infer::{
             InferenceFlags, TypeExpressionFlags, TypeInferenceBuilder,
             builder::{
@@ -764,7 +764,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // Avoid duplicate diagnostics: invalid TypedDict literals already emit specific errors.
                 let suppress_invalid_default =
                     is_invalid_typed_dict_literal(db, declared_ty, default_expr.into());
+                let default_specialized_declared_ty =
+                    type_with_available_typevar_defaults(db, declared_ty);
+
                 if !default_ty.is_assignable_to(db, declared_ty)
+                    && !default_ty.is_assignable_to(db, default_specialized_declared_ty)
                     && !suppress_invalid_default
                     && !((self.in_stub()
                         || self.in_function_overload_or_abstractmethod()
@@ -1117,4 +1121,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             Some(parameter_type)
         }
     }
+}
+
+fn type_with_available_typevar_defaults<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+    let mut typevars = FxOrderSet::default();
+    ty.find_legacy_typevars(db, None, &mut typevars);
+    if typevars
+        .iter()
+        .all(|typevar| typevar.default_type(db).is_none())
+    {
+        return ty;
+    }
+
+    let generic_context = GenericContext::from_typevar_instances(db, typevars.iter().copied());
+    let types = typevars.iter().map(|typevar| {
+        if typevar.default_type(db).is_some() {
+            None
+        } else {
+            Some(Type::TypeVar(*typevar))
+        }
+    });
+    ty.apply_specialization(db, generic_context.specialize_partial(db, types))
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -20,8 +20,8 @@ use ty_python_core::scope::ScopeKind;
 use crate::types::{
     BindingContext, CallableType, DynamicType, GenericContext, IntersectionBuilder, KnownClass,
     KnownInstanceType, LintDiagnosticGuard, LiteralValueTypeKind, Parameter, Parameters,
-    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeContext, TypeGuardType, TypeIsType,
-    TypeMapping, TypeVarKind, UnionBuilder, UnionType, any_over_type, todo_type,
+    SpecialFormType, SubclassOfType, Type, TypeContext, TypeGuardType, TypeIsType, TypeMapping,
+    TypeVarKind, UnionBuilder, UnionType, any_over_type, todo_type,
 };
 use crate::{FxOrderSet, Program, add_inferred_python_version_hint_to_diagnostic};
 
@@ -1472,7 +1472,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     Type::unknown()
                 }
-                KnownInstanceType::TypeAliasType(type_alias @ TypeAliasType::PEP695(_)) => {
+                KnownInstanceType::TypeAliasType(type_alias) => {
                     if type_alias.specialization(self.db()).is_some() {
                         if !self.in_string_annotation() {
                             self.infer_expression(slice, TypeContext::default());
@@ -1534,19 +1534,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             Type::unknown()
                         }
                     }
-                }
-                KnownInstanceType::TypeAliasType(TypeAliasType::ManualPEP695(_)) => {
-                    // TODO: support generic "manual" PEP 695 type aliases
-                    let slice_ty = self.infer_expression(slice, TypeContext::default());
-                    let mut variables = FxOrderSet::default();
-                    slice_ty.bind_and_find_all_legacy_typevars(
-                        self.db(),
-                        self.typevar_binding_context,
-                        &mut variables,
-                    );
-                    let generic_context =
-                        GenericContext::from_typevar_instances(self.db(), variables);
-                    Type::Dynamic(DynamicType::UnknownGeneric(generic_context))
                 }
                 KnownInstanceType::LiteralStringAlias(_) => {
                     self.infer_expression(slice, TypeContext::default());

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -251,9 +251,7 @@ impl<'db> KnownInstanceType<'db> {
                 KnownClass::ParamSpec
             }
             Self::TypeVar(_) => KnownClass::TypeVar,
-            Self::TypeAliasType(TypeAliasType::PEP695(alias)) if alias.is_specialized(db) => {
-                KnownClass::GenericAlias
-            }
+            Self::TypeAliasType(alias) if alias.is_specialized(db) => KnownClass::GenericAlias,
             Self::TypeAliasType(_) => KnownClass::TypeAliasType,
             Self::Deprecated(_) => KnownClass::Deprecated,
             Self::Field(_) => KnownClass::Field,

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use crate::{
-    Db,
+    Db, FxOrderSet,
     types::{
         GenericContext, Type, definition_expression_type,
         display::qualified_name_components_from_scope, generics::Specialization, visitor,
@@ -137,6 +137,7 @@ pub struct ManualPEP695TypeAliasType<'db> {
     #[returns(ref)]
     pub name: Name,
     pub definition: Definition<'db>,
+    pub(super) specialization: Option<Specialization<'db>>,
 }
 
 // The Salsa heap is tracked separately.
@@ -154,8 +155,15 @@ pub(super) fn walk_manual_pep_695_type_alias<'db, V: visitor::TypeVisitor<'db> +
 impl<'db> ManualPEP695TypeAliasType<'db> {
     /// The value type of this manual type alias.
     ///
-    /// Computed lazily from the definition to avoid including the value in the interned
-    /// struct's identity. Returns `Divergent` if the type alias is defined cyclically.
+    /// Computed lazily from the definition with specialization applied.
+    pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+        self.apply_function_specialization(db, self.raw_value_type(db))
+    }
+
+    /// The value type of this manual type alias with no specialization applied.
+    ///
+    /// Computed lazily from the definition to avoid including the value in the interned struct's
+    /// identity. Returns `Divergent` if the type alias is defined cyclically.
     #[salsa::tracked(
         cycle_initial=|_, id, _| Type::divergent(id),
         cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _| {
@@ -163,7 +171,7 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
         },
         heap_size=ruff_memory_usage::heap_size
     )]
-    pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn raw_value_type(self, db: &'db dyn Db) -> Type<'db> {
         let definition = self.definition(db);
         let file = definition.file(db);
         let module = parsed_module(db, file).load(db);
@@ -179,6 +187,63 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
             return Type::unknown();
         };
         definition_expression_type(db, definition, value_arg)
+    }
+
+    fn apply_function_specialization(self, db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+        if let Some(generic_context) = self.generic_context(db) {
+            let specialization = self
+                .specialization(db)
+                .unwrap_or_else(|| generic_context.default_specialization(db, None));
+            ty.apply_specialization(db, specialization)
+        } else {
+            ty
+        }
+    }
+
+    pub(crate) fn apply_specialization(
+        self,
+        db: &'db dyn Db,
+        f: impl FnOnce(GenericContext<'db>) -> Specialization<'db>,
+    ) -> ManualPEP695TypeAliasType<'db> {
+        match self.generic_context(db) {
+            None => self,
+            Some(generic_context) => ManualPEP695TypeAliasType::new(
+                db,
+                self.name(db),
+                self.definition(db),
+                Some(f(generic_context)),
+            ),
+        }
+    }
+
+    pub(crate) fn is_specialized(self, db: &'db dyn Db) -> bool {
+        self.specialization(db).is_some()
+    }
+
+    #[salsa::tracked(cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+    pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
+        let definition = self.definition(db);
+        let file = definition.file(db);
+        let module = parsed_module(db, file).load(db);
+        let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
+            return None;
+        };
+        let ast::Expr::Call(call) = assignment.value(&module) else {
+            return None;
+        };
+        let type_params_arg = call.arguments.find_argument_value("type_params", 2)?;
+        let type_params_ty = definition_expression_type(db, definition, type_params_arg);
+
+        let mut variables = FxOrderSet::default();
+        if let Some(tuple_spec) = type_params_ty.tuple_instance_spec(db) {
+            for element in tuple_spec.iter_all_elements() {
+                element.bind_and_find_all_legacy_typevars(db, Some(definition), &mut variables);
+            }
+        } else {
+            type_params_ty.bind_and_find_all_legacy_typevars(db, Some(definition), &mut variables);
+        }
+
+        (!variables.is_empty()).then(|| GenericContext::from_typevar_instances(db, variables))
     }
 }
 
@@ -233,7 +298,7 @@ impl<'db> TypeAliasType<'db> {
     pub(crate) fn raw_value_type(self, db: &'db dyn Db) -> Type<'db> {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.raw_value_type(db),
-            TypeAliasType::ManualPEP695(type_alias) => type_alias.value_type(db),
+            TypeAliasType::ManualPEP695(type_alias) => type_alias.raw_value_type(db),
         }
     }
 
@@ -245,24 +310,25 @@ impl<'db> TypeAliasType<'db> {
     }
 
     pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
-        // TODO: Add support for generic non-PEP695 type aliases.
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.generic_context(db),
-            TypeAliasType::ManualPEP695(_) => None,
+            TypeAliasType::ManualPEP695(type_alias) => type_alias.generic_context(db),
         }
     }
 
     pub(crate) fn specialization(self, db: &'db dyn Db) -> Option<Specialization<'db>> {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.specialization(db),
-            TypeAliasType::ManualPEP695(_) => None,
+            TypeAliasType::ManualPEP695(type_alias) => type_alias.specialization(db),
         }
     }
 
     pub(super) fn apply_function_specialization(self, db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.apply_function_specialization(db, ty),
-            TypeAliasType::ManualPEP695(_) => ty,
+            TypeAliasType::ManualPEP695(type_alias) => {
+                type_alias.apply_function_specialization(db, ty)
+            }
         }
     }
 
@@ -275,7 +341,16 @@ impl<'db> TypeAliasType<'db> {
             TypeAliasType::PEP695(type_alias) => {
                 TypeAliasType::PEP695(type_alias.apply_specialization(db, f))
             }
-            TypeAliasType::ManualPEP695(_) => self,
+            TypeAliasType::ManualPEP695(type_alias) => {
+                TypeAliasType::ManualPEP695(type_alias.apply_specialization(db, f))
+            }
+        }
+    }
+
+    pub(crate) fn is_specialized(self, db: &'db dyn Db) -> bool {
+        match self {
+            TypeAliasType::PEP695(type_alias) => type_alias.is_specialized(db),
+            TypeAliasType::ManualPEP695(type_alias) => type_alias.is_specialized(db),
         }
     }
 


### PR DESCRIPTION
## Summary

This fixes two related ty inference gaps.

- Allow `assert_type` to accept concrete function and bound method values when they are assignable to the asserted `Callable[...]` signature.
- Add generic specialization support for manually constructed `TypeAliasType(...)` aliases so recursive and nested alias forms can preserve type variables through specialization.
- Improve generic union inference for heterogeneous actual unions when the formal union has multiple type-variable-bearing branches, allowing constraints from each successful element to contribute to the final solution.

## Root Cause

`assert_type` compared concrete function types directly against `Callable[...]`, so a function literal with an equivalent callable signature was rejected as not equivalent. Manual PEP 695 `TypeAliasType(...)` aliases also did not carry a generic context/specialization, which caused aliases using `type_params` to collapse to `Unknown` or defaulted TypeVars before all constraints were collected.

## User Impact

The following now type-checks as expected:

```py
from collections.abc import Awaitable, Callable
from typing_extensions import assert_type

def sync_func() -> str:
    return "x"

async def async_func(x: int) -> str:
    return str(x)

assert_type(sync_func, Callable[[], str])
assert_type(async_func, Callable[[int], Awaitable[str]])
```

The recursive heterogeneous `TypeAliasType` regression now infers `C[str | A | B | int]` for mixed list elements instead of defaulting early to `str` or falling back to `Unknown`.

## Validation

- `cargo fmt -p ty_python_semantic`
- `cargo check -p ty_python_semantic`
- `cargo test -p ty_python_semantic --lib`
- `cargo test -p ty_python_semantic --test mdtest`
- `uv build`
- `uv sync`

Fixes astral-sh/ty#3435