### PR TITLE
[ty]: Support generic manual TypeAliasType aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -253,8 +253,7 @@ MyList = TypeAliasType("MyList", list[T], type_params=(T,))
 MyAlias5 = Callable[[MyList[T]], int]
 
 def _(c: MyAlias5[int]):
-    # TODO: should be (list[int], /) -> int
-    reveal_type(c)  # revealed: (Unknown, /) -> int
+    reveal_type(c)  # revealed: (list[int], /) -> int
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -264,14 +263,12 @@ MyDict = TypeAliasType("MyDict", dict[K, V], type_params=(K, V))
 MyAlias6 = Callable[[MyDict[K, V]], int]
 
 def _(c: MyAlias6[str, bytes]):
-    # TODO: should be (dict[str, bytes], /) -> int
-    reveal_type(c)  # revealed: (Unknown, /) -> int
+    reveal_type(c)  # revealed: (dict[str, bytes], /) -> int
 
 ListOrDict: TypeAlias = MyList[T] | dict[str, T]
 
 def _(x: ListOrDict[int]):
-    # TODO: should be list[int] | dict[str, int]
-    reveal_type(x)  # revealed: Unknown | dict[str, int]
+    reveal_type(x)  # revealed: list[int] | dict[str, int]
 
 MyAlias7: TypeAlias = Callable[Concatenate[T, ...], None]
 

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -373,15 +373,34 @@ def f(x: IntOrStr) -> None:
 ### Generic example
 
 ```py
-from typing_extensions import TypeAliasType, TypeVar
+from typing_extensions import TypeAliasType, TypeVar, Union
 
 T = TypeVar("T")
 
 IntAndT = TypeAliasType("IntAndT", tuple[int, T], type_params=(T,))
 
 def f(x: IntAndT[str]) -> None:
-    # TODO: This should be `tuple[int, str]`
-    reveal_type(x)  # revealed: Unknown
+    reveal_type(x)  # revealed: tuple[int, str]
+
+U = TypeVar("U", default=str)
+
+ListOrSet = TypeAliasType("ListOrSet", Union[list[U], set[U]], type_params=(U,))
+
+def g(
+    list_or_set_of_int: ListOrSet[int],
+    list_or_set_of_str: ListOrSet,
+) -> None:
+    reveal_type(list_or_set_of_int)  # revealed: list[int] | set[int]
+    reveal_type(list_or_set_of_str)  # revealed: list[str] | set[str]
+
+MyDict = TypeAliasType("MyDict", dict[U, T], type_params=(U, T))
+
+def h(
+    dict_int_str: MyDict[int, str],
+    dict_str_unknown: MyDict,
+) -> None:
+    reveal_type(dict_int_str)  # revealed: dict[int, str]
+    reveal_type(dict_str_unknown)  # revealed: dict[str, Unknown]
 ```
 
 ### Generic value binds type variables to alias definition
@@ -413,6 +432,35 @@ def get_name() -> str:
 
 # error: [invalid-type-alias-type] "The first argument to `TypeAliasType` must be a string literal"
 IntOrStr = TypeAliasType(get_name(), int | str)
+```
+
+#### Type parameters argument is not a tuple
+
+```py
+from typing_extensions import TypeAliasType, TypeVar
+
+T = TypeVar("T")
+
+# error: [invalid-type-alias-type] "`type_params` argument to `TypeAliasType` must be a tuple"
+IntAndT = TypeAliasType("IntAndT", tuple[int, T], type_params=T)
+
+def _(x: IntAndT[str]) -> None:
+    reveal_type(x)  # revealed: Unknown
+```
+
+#### Invalid type parameters entries
+
+```py
+from typing_extensions import TypeAliasType, TypeVar
+
+T = TypeVar("T")
+
+# TODO: This should be an error
+IntAndT = TypeAliasType("IntAndT", tuple[int, T], type_params=(str,))
+
+# error: [not-subscriptable] "Cannot specialize non-generic type alias `IntAndT`"
+def _(x: IntAndT[str]) -> None:
+    reveal_type(x)  # revealed: Unknown
 ```
 
 #### Name does not match variable

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5729,7 +5729,9 @@ impl<'db> Type<'db> {
 
                     Ok(instance.inner(db).to_meta_type(db))
                 }
-                KnownInstanceType::Callable(callable) => Ok(Type::Callable(*callable)),
+                KnownInstanceType::Callable(callable) => {
+                    Ok(Type::Callable(*callable).expand_eagerly(db))
+                }
                 KnownInstanceType::LiteralStringAlias(ty) => Ok(ty.inner(db)),
                 KnownInstanceType::Sentinel(sentinel) => {
                     Ok(Type::KnownInstance(KnownInstanceType::Sentinel(*sentinel)))
@@ -6224,11 +6226,15 @@ impl<'db> Type<'db> {
 
             Type::TypeAlias(alias) => {
                 match type_mapping {
-                    // For EagerExpansion, expand the raw value type. This path relies on Salsa's cycle
-                    // detection rather than the visitor's cycle detection, because the visitor tracks
-                    // Type values and `RecursiveList` is different from `RecursiveList[T]`.
                     TypeMapping::EagerExpansion => {
-                        alias.raw_value_type(db).expand_eagerly(db)
+                        if alias.specialization(db).is_some() {
+                            alias.value_type(db).expand_eagerly(db)
+                        } else {
+                            // This path relies on Salsa's cycle detection rather than the
+                            // visitor's cycle detection, because the visitor tracks Type values and
+                            // `RecursiveList` is different from `RecursiveList[T]`.
+                            alias.raw_value_type(db).expand_eagerly(db)
+                        }
                     },
                     // When specializing a generic type alias, instead of specializing the expanded type, the type alias itself is specialized.
                     // Without this special handling, recursive type aliases would result in cycles, returning an unspecialized fallback type.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4251,6 +4251,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
         }
 
+        if let Some(type_params_arg) = arguments.find_argument_value("type_params", 2) {
+            let previous_context = self.typevar_binding_context.replace(definition);
+            let type_params_ty = self.infer_expression(type_params_arg, TypeContext::default());
+            self.typevar_binding_context = previous_context;
+
+            if type_params_ty.tuple_instance_spec(db).is_none() {
+                return error(
+                    &self.context,
+                    "`type_params` argument to `TypeAliasType` must be a tuple",
+                    type_params_arg,
+                );
+            }
+        }
+
         // Inference of the value argument must be deferred, to avoid cycles.
         self.deferred.insert(definition);
 
@@ -4259,6 +4273,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 db,
                 ast::name::Name::new(name),
                 definition,
+                None,
             )),
         ))
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -240,19 +240,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     );
                 }
             }
-            Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::ManualPEP695(
-                _,
-            ))) => {
-                let slice_ty = self.infer_expression(slice, TypeContext::default());
-                let mut variables = FxOrderSet::default();
-                slice_ty.bind_and_find_all_legacy_typevars(
-                    db,
-                    self.typevar_binding_context,
-                    &mut variables,
-                );
-                let generic_context = GenericContext::from_typevar_instances(db, variables);
-                return Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
-            }
             Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => {
                 if let Some(generic_context) = type_alias.generic_context(db) {
                     return self.infer_explicit_type_alias_type_specialization(
@@ -566,6 +553,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let typevars = generic_context.variables(db).collect::<Vec<_>>();
         let typevars_len = typevars.len();
+        let has_todo_typevartuple_parameter = matches!(
+            value_ty,
+            Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias))
+                if type_alias.has_todo_typevartuple_parameter(db)
+        );
 
         let mut expanded_type_arguments = Vec::with_capacity(type_arguments.len());
 
@@ -876,6 +868,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
                 error = Some(ExplicitSpecializationError::NonGeneric);
+            } else if has_todo_typevartuple_parameter {
+                // Manual `TypeAliasType` aliases can include a legacy `TypeVarTuple` in
+                // `type_params`, but ty does not fully model `TypeVarTuple` specialization yet.
+                // Avoid emitting arity false positives for arguments that may be consumed by it.
             } else {
                 let node = expanded_type_arguments[first_excess_type_argument_index].node;
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_ARGUMENTS, node) {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -20,8 +20,8 @@ use ty_python_core::scope::ScopeKind;
 use crate::types::{
     BindingContext, CallableType, DynamicType, GenericContext, IntersectionBuilder, KnownClass,
     KnownInstanceType, LintDiagnosticGuard, LiteralValueTypeKind, Parameter, Parameters,
-    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeContext, TypeFormType, TypeGuardType,
-    TypeIsType, TypeMapping, TypeVarKind, UnionBuilder, UnionType, any_over_type, todo_type,
+    SpecialFormType, SubclassOfType, Type, TypeContext, TypeFormType, TypeGuardType, TypeIsType,
+    TypeMapping, TypeVarKind, UnionBuilder, UnionType, any_over_type, todo_type,
 };
 use crate::{FxOrderSet, Program, add_inferred_python_version_hint_to_diagnostic};
 
@@ -1467,7 +1467,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     Type::unknown()
                 }
-                KnownInstanceType::TypeAliasType(type_alias @ TypeAliasType::PEP695(_)) => {
+                KnownInstanceType::TypeAliasType(type_alias) => {
                     if type_alias.specialization(self.db()).is_some() {
                         if !self.in_string_annotation() {
                             self.infer_expression(slice, TypeContext::default());
@@ -1529,19 +1529,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             Type::unknown()
                         }
                     }
-                }
-                KnownInstanceType::TypeAliasType(TypeAliasType::ManualPEP695(_)) => {
-                    // TODO: support generic "manual" PEP 695 type aliases
-                    let slice_ty = self.infer_expression(slice, TypeContext::default());
-                    let mut variables = FxOrderSet::default();
-                    slice_ty.bind_and_find_all_legacy_typevars(
-                        self.db(),
-                        self.typevar_binding_context,
-                        &mut variables,
-                    );
-                    let generic_context =
-                        GenericContext::from_typevar_instances(self.db(), variables);
-                    Type::Dynamic(DynamicType::UnknownGeneric(generic_context))
                 }
                 KnownInstanceType::LiteralStringAlias(_) => {
                     self.infer_expression(slice, TypeContext::default());

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -269,9 +269,7 @@ impl<'db> KnownInstanceType<'db> {
                 KnownClass::ParamSpec
             }
             Self::TypeVar(_) => KnownClass::TypeVar,
-            Self::TypeAliasType(TypeAliasType::PEP695(alias)) if alias.is_specialized(db) => {
-                KnownClass::GenericAlias
-            }
+            Self::TypeAliasType(alias) if alias.is_specialized(db) => KnownClass::GenericAlias,
             Self::TypeAliasType(_) => KnownClass::TypeAliasType,
             Self::Deprecated(_) => KnownClass::Deprecated,
             Self::Field(_) => KnownClass::Field,
@@ -410,9 +408,41 @@ impl<'db> KnownInstanceType<'db> {
                 )))
             }
 
+            KnownInstanceType::TypeAliasType(type_alias) => {
+                if TypeMapping::EagerExpansion == *type_mapping {
+                    return type_alias.value_type(db).expand_eagerly(db);
+                }
+
+                let (TypeMapping::ApplySpecialization(specialization)
+                | TypeMapping::ApplySpecializationWithMaterialization {
+                    specialization, ..
+                }) = type_mapping
+                else {
+                    return Type::KnownInstance(self);
+                };
+                let Some(mut current_specialization) = specialization.as_specialization(db) else {
+                    return Type::KnownInstance(self);
+                };
+                if let TypeMapping::ApplySpecializationWithMaterialization {
+                    materialization_kind,
+                    ..
+                } = type_mapping
+                {
+                    current_specialization = current_specialization
+                        .with_materialization_kind(db, Some(*materialization_kind));
+                }
+                Type::KnownInstance(KnownInstanceType::TypeAliasType(
+                    type_alias.apply_specialization(db, |generic_context| {
+                        type_alias
+                            .specialization(db)
+                            .unwrap_or_else(|| generic_context.default_specialization(db, None))
+                            .apply_specialization(db, current_specialization)
+                    }),
+                ))
+            }
+
             KnownInstanceType::SubscriptedProtocol(_)
             | KnownInstanceType::SubscriptedGeneric(_)
-            | KnownInstanceType::TypeAliasType(_)
             | KnownInstanceType::Deprecated(_)
             | KnownInstanceType::Field(_)
             | KnownInstanceType::ConstraintSet(_)

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -1,10 +1,10 @@
 use std::fmt::Write;
 
 use crate::{
-    Db,
+    Db, FxOrderSet,
     types::{
-        ApplyTypeMappingVisitor, BoundTypeVarInstance, GenericContext, Type, TypeContext,
-        TypeMapping, TypeVarVariance, definition_expression_type,
+        ApplyTypeMappingVisitor, BoundTypeVarInstance, DynamicType, GenericContext, KnownClass,
+        Type, TypeContext, TypeMapping, TypeVarVariance, definition_expression_type,
         display::qualified_name_components_from_scope,
         generics::{ApplySpecialization, Specialization},
         variance::VarianceInferable,
@@ -156,6 +156,7 @@ pub struct ManualPEP695TypeAliasType<'db> {
     #[returns(ref)]
     pub name: Name,
     pub definition: Definition<'db>,
+    pub(super) specialization: Option<Specialization<'db>>,
 }
 
 // The Salsa heap is tracked separately.
@@ -173,8 +174,15 @@ pub(super) fn walk_manual_pep_695_type_alias<'db, V: visitor::TypeVisitor<'db> +
 impl<'db> ManualPEP695TypeAliasType<'db> {
     /// The value type of this manual type alias.
     ///
-    /// Computed lazily from the definition to avoid including the value in the interned
-    /// struct's identity. Returns `Divergent` if the type alias is defined cyclically.
+    /// Computed lazily from the definition with specialization applied.
+    pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+        self.apply_function_specialization(db, self.raw_value_type(db))
+    }
+
+    /// The value type of this manual type alias with no specialization applied.
+    ///
+    /// Computed lazily from the definition to avoid including the value in the interned struct's
+    /// identity. Returns `Divergent` if the type alias is defined cyclically.
     #[salsa::tracked(
         cycle_initial=|_, id, _| Type::divergent(id),
         cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _| {
@@ -182,7 +190,7 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
         },
         heap_size=ruff_memory_usage::heap_size
     )]
-    pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn raw_value_type(self, db: &'db dyn Db) -> Type<'db> {
         let definition = self.definition(db);
         let file = definition.file(db);
         let module = parsed_module(db, file).load(db);
@@ -198,6 +206,102 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
             return Type::unknown();
         };
         definition_expression_type(db, definition, value_arg)
+    }
+
+    fn apply_function_specialization(self, db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+        if let Some(generic_context) = self.generic_context(db) {
+            let specialization = self
+                .specialization(db)
+                .unwrap_or_else(|| generic_context.default_specialization(db, None));
+            let type_mapping = match specialization.materialization_kind(db) {
+                None => {
+                    TypeMapping::ApplySpecialization(ApplySpecialization::TypeAlias(specialization))
+                }
+                Some(materialization_kind) => TypeMapping::ApplySpecializationWithMaterialization {
+                    specialization: ApplySpecialization::TypeAlias(specialization),
+                    materialization_kind,
+                },
+            };
+
+            ty.apply_type_mapping_impl(
+                db,
+                &type_mapping,
+                TypeContext::default(),
+                &ApplyTypeMappingVisitor::default(),
+            )
+        } else {
+            ty
+        }
+    }
+
+    pub(crate) fn apply_specialization(
+        self,
+        db: &'db dyn Db,
+        f: impl FnOnce(GenericContext<'db>) -> Specialization<'db>,
+    ) -> ManualPEP695TypeAliasType<'db> {
+        match self.generic_context(db) {
+            None => self,
+            Some(generic_context) => ManualPEP695TypeAliasType::new(
+                db,
+                self.name(db),
+                self.definition(db),
+                Some(f(generic_context)),
+            ),
+        }
+    }
+
+    pub(crate) fn is_specialized(self, db: &'db dyn Db) -> bool {
+        self.specialization(db).is_some()
+    }
+
+    #[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
+    pub(crate) fn has_todo_typevartuple_parameter(self, db: &'db dyn Db) -> bool {
+        let definition = self.definition(db);
+        let file = definition.file(db);
+        let module = parsed_module(db, file).load(db);
+        let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
+            return false;
+        };
+        let ast::Expr::Call(call) = assignment.value(&module) else {
+            return false;
+        };
+        let Some(type_params_arg) = call.arguments.find_argument_value("type_params", 2) else {
+            return false;
+        };
+        let type_params_ty = definition_expression_type(db, definition, type_params_arg);
+
+        let is_typevartuple = |ty: Type<'db>| {
+            ty == Type::Dynamic(DynamicType::TodoTypeVarTuple)
+                || ty.is_instance_of(db, KnownClass::TypeVarTuple)
+        };
+
+        type_params_ty
+            .tuple_instance_spec(db)
+            .is_some_and(|tuple_spec| tuple_spec.iter_all_elements().any(is_typevartuple))
+    }
+
+    #[salsa::tracked(cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+    pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
+        let definition = self.definition(db);
+        let file = definition.file(db);
+        let module = parsed_module(db, file).load(db);
+        let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
+            return None;
+        };
+        let ast::Expr::Call(call) = assignment.value(&module) else {
+            return None;
+        };
+        let type_params_arg = call.arguments.find_argument_value("type_params", 2)?;
+        let type_params_ty = definition_expression_type(db, definition, type_params_arg);
+
+        let mut variables = FxOrderSet::default();
+        let tuple_spec = type_params_ty.tuple_instance_spec(db)?;
+
+        for element in tuple_spec.iter_all_elements() {
+            element.bind_and_find_all_legacy_typevars(db, Some(definition), &mut variables);
+        }
+
+        (!variables.is_empty()).then(|| GenericContext::from_typevar_instances(db, variables))
     }
 }
 
@@ -252,7 +356,7 @@ impl<'db> TypeAliasType<'db> {
     pub(crate) fn raw_value_type(self, db: &'db dyn Db) -> Type<'db> {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.raw_value_type(db),
-            TypeAliasType::ManualPEP695(type_alias) => type_alias.value_type(db),
+            TypeAliasType::ManualPEP695(type_alias) => type_alias.raw_value_type(db),
         }
     }
 
@@ -264,24 +368,25 @@ impl<'db> TypeAliasType<'db> {
     }
 
     pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
-        // TODO: Add support for generic non-PEP695 type aliases.
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.generic_context(db),
-            TypeAliasType::ManualPEP695(_) => None,
+            TypeAliasType::ManualPEP695(type_alias) => type_alias.generic_context(db),
         }
     }
 
     pub(crate) fn specialization(self, db: &'db dyn Db) -> Option<Specialization<'db>> {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.specialization(db),
-            TypeAliasType::ManualPEP695(_) => None,
+            TypeAliasType::ManualPEP695(type_alias) => type_alias.specialization(db),
         }
     }
 
     pub(super) fn apply_function_specialization(self, db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.apply_function_specialization(db, ty),
-            TypeAliasType::ManualPEP695(_) => ty,
+            TypeAliasType::ManualPEP695(type_alias) => {
+                type_alias.apply_function_specialization(db, ty)
+            }
         }
     }
 
@@ -294,7 +399,25 @@ impl<'db> TypeAliasType<'db> {
             TypeAliasType::PEP695(type_alias) => {
                 TypeAliasType::PEP695(type_alias.apply_specialization(db, f))
             }
-            TypeAliasType::ManualPEP695(_) => self,
+            TypeAliasType::ManualPEP695(type_alias) => {
+                TypeAliasType::ManualPEP695(type_alias.apply_specialization(db, f))
+            }
+        }
+    }
+
+    pub(crate) fn is_specialized(self, db: &'db dyn Db) -> bool {
+        match self {
+            TypeAliasType::PEP695(type_alias) => type_alias.is_specialized(db),
+            TypeAliasType::ManualPEP695(type_alias) => type_alias.is_specialized(db),
+        }
+    }
+
+    pub(crate) fn has_todo_typevartuple_parameter(self, db: &'db dyn Db) -> bool {
+        match self {
+            TypeAliasType::PEP695(_) => false,
+            TypeAliasType::ManualPEP695(type_alias) => {
+                type_alias.has_todo_typevartuple_parameter(db)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

This adds support for specializing manual generic `TypeAliasType(...)` aliases that define `type_params`. Previously, when one of these aliases was subscripted, such as `Alias[str]`, it often lost the alias value and produced `Unknown`.

It now reads the alias type parameters, builds a generic context for the manual alias, and applies the specialization to the alias value. For example, `TypeAliasType("Alias", tuple[int, T], type_params=(T,))` now resolves `Alias[str]` as `tuple[int, str]`.

## Test Plan

- `cargo fmt -p ty_python_semantic -- --check`
- `cargo check -p ty_python_semantic`
- `cargo test -p ty_python_semantic --test mdtest -- pep695_type_aliases.md`
- `cargo test -p ty_python_semantic --test mdtest -- pep613_type_aliases.md`
- `cargo test -p ty_python_semantic --test mdtest`
- `cargo test -p ty_python_semantic --lib`

Closes astral-sh/ty#1737
