### PR TITLE
[ty] Support class decorators

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -1745,6 +1745,36 @@ Model(x=1)
 reveal_type(Model.__init__)  # revealed: (self: Model, x: int) -> None
 ```
 
+### Decorator return types are still metadata-only in decorator position
+
+When a `@dataclass_transform()`-decorated function is used as a class decorator, we currently use
+it to shape the class like a dataclass but do not yet let an explicit non-class return annotation
+replace the public class binding.
+
+```py
+from typing import Protocol, TypeVar
+from typing_extensions import dataclass_transform
+
+class Wrapped(Protocol):
+    def f(self) -> int: ...
+
+T = TypeVar("T", bound=object)
+
+@dataclass_transform()
+def model(cls: type[T]) -> Wrapped:
+    raise NotImplementedError
+
+@model
+class C:
+    x: int
+
+reveal_type(C)  # revealed: <class 'C'>
+reveal_type(C.__init__)  # revealed: (self: C, x: int) -> None
+
+# TODO: Decide whether the explicit `Wrapped` return type should replace the public binding here.
+C.f()  # error: [unresolved-attribute]
+```
+
 ## `__dataclass_transform__` compatibility
 
 For backwards compatibility with pre-3.11 Python, ty recognizes any function named

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -1747,8 +1747,8 @@ reveal_type(Model.__init__)  # revealed: (self: Model, x: int) -> None
 
 ### Decorator return types are still metadata-only in decorator position
 
-When a `@dataclass_transform()`-decorated function is used as a class decorator, we currently use
-it to shape the class like a dataclass but do not yet let an explicit non-class return annotation
+When a `@dataclass_transform()`-decorated function is used as a class decorator, we currently use it
+to shape the class like a dataclass but do not yet let an explicit non-class return annotation
 replace the public class binding.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -574,6 +574,40 @@ class DerivedPreservedClass(PreservedClass):
     value: PreservedClass
 ```
 
+Class decorator factories that preserve the original class object also preserve the class binding:
+
+```py
+from collections.abc import Callable
+from typing import Any, TypeVar, overload
+
+DecoratorT = TypeVar("DecoratorT", bound=object)
+DecoratedClass = type[DecoratorT]
+
+@overload
+def identity_class_decorator_factory(cls: DecoratedClass, **kwargs: Any) -> DecoratedClass: ...
+@overload
+def identity_class_decorator_factory(
+    **kwargs: Any,
+) -> Callable[[DecoratedClass], DecoratedClass]: ...
+def identity_class_decorator_factory(
+    cls: DecoratedClass | None = None, **kwargs: Any
+) -> DecoratedClass | Callable[[DecoratedClass], DecoratedClass]:
+    def decorator(inner_cls: DecoratedClass) -> DecoratedClass:
+        return inner_cls
+
+    if cls is not None:
+        return decorator(cls)
+    return decorator
+
+@identity_class_decorator_factory(frozen=True)
+class FactoryPreservedClass: ...
+
+reveal_type(FactoryPreservedClass)  # revealed: <class 'FactoryPreservedClass'>
+
+class DerivedFactoryPreservedClass(FactoryPreservedClass):
+    value: FactoryPreservedClass
+```
+
 Class decorators can return intersections that expose attributes added to the decorated class
 object:
 

--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -312,7 +312,7 @@ class AcceptsType:
 @AcceptsType
 class MyClass: ...
 
-reveal_type(MyClass)  # revealed: <class 'MyClass'>
+reveal_type(MyClass)  # revealed: AcceptsType
 ```
 
 ### Generic class, used as a decorator
@@ -378,6 +378,224 @@ def decorator(cls: type[int]) -> type[int]:
 @decorator
 class Baz: ...
 
-# TODO: the revealed type should ideally be `type[int]` (the decorator's return type)
-reveal_type(Baz)  # revealed: <class 'Baz'>
+reveal_type(Baz)  # revealed: type[int]
+```
+
+Class decorators can also replace the class object with an instance:
+
+```py
+from dataclasses import dataclass
+from typing import Generic, Protocol, TypeVar, overload
+from typing_extensions import Self
+
+T = TypeVar("T")
+
+class Backend(Protocol):
+    def get(self, key: str) -> bytes | None: ...
+
+class WrapBackend:
+    def __init__(self, cls: type[object]) -> None:
+        self.cls = cls
+
+    def get(self, key: str) -> bytes | None:
+        return None
+
+@WrapBackend
+class CacheClient:
+    def clone(self) -> Self:
+        reveal_type(self)  # revealed: Self@clone
+        return self
+
+    @classmethod
+    def make(cls) -> Self:
+        reveal_type(cls)  # revealed: type[Self@make]
+        return cls()
+
+reveal_type(CacheClient)  # revealed: WrapBackend
+reveal_type(CacheClient.get("x"))  # revealed: bytes | None
+
+@WrapBackend
+@dataclass
+class DataclassThenWrapped:
+    value: int
+
+reveal_type(DataclassThenWrapped)  # revealed: WrapBackend
+
+# error: [no-matching-overload]
+@dataclass
+@WrapBackend
+class WrappedThenDataclass:
+    value: int
+
+reveal_type(WrappedThenDataclass)  # revealed: Unknown
+
+@WrapBackend
+class InvalidWrappedBase(1): ...  # error: [invalid-base]
+
+@WrapBackend
+class GenericCacheClient(Generic[T]):
+    value: T
+
+    def get_value(self) -> T:
+        return self.value
+
+reveal_type(GenericCacheClient)  # revealed: WrapBackend
+
+@WrapBackend
+class OverloadedCacheClient:
+    @overload
+    # error: [invalid-overload] "Overloads for function `get` must be followed by a non-`@overload`-decorated implementation function"
+    def get(self, key: str) -> bytes: ...
+    @overload
+    def get(self, key: bytes) -> bytes: ...
+```
+
+Unannotated class decorators are assumed to preserve the class binding. We do not infer returned
+classes from decorator bodies:
+
+```py
+def personify(cls):
+    class Wrapped(cls):
+        full_name: str
+
+        def set_full_name(self, full_name: str) -> None:
+            self.full_name = full_name
+
+    return Wrapped
+
+@personify
+class Animal: ...
+
+reveal_type(Animal)  # revealed: <class 'Animal'>
+reveal_type(Animal())  # revealed: Animal
+
+Animal().set_full_name("John")  # error: [unresolved-attribute]
+```
+
+This also applies to unannotated callables that are not function definitions:
+
+```py
+lambda_decorator = lambda cls: cls
+
+@lambda_decorator
+class LambdaDecorated: ...
+
+reveal_type(LambdaDecorated)  # revealed: <class 'LambdaDecorated'>
+
+class DecoratorFactory:
+    def decorator(self, cls):
+        return cls
+
+decorator_factory = DecoratorFactory()
+
+@decorator_factory.decorator
+class BoundMethodDecorated: ...
+
+reveal_type(BoundMethodDecorated)  # revealed: <class 'BoundMethodDecorated'>
+
+class CallableDecorator:
+    def __call__(self, cls):
+        return cls
+
+callable_decorator = CallableDecorator()
+
+@callable_decorator
+class CallableInstanceDecorated: ...
+
+reveal_type(CallableInstanceDecorated)  # revealed: <class 'CallableInstanceDecorated'>
+
+class ExplicitReturnDecorator(Generic[T]):
+    def __call__(self, cls) -> T:
+        raise NotImplementedError
+
+explicit_return_decorator = ExplicitReturnDecorator()
+
+@explicit_return_decorator
+class ExplicitReturnCallableInstanceDecorated: ...
+
+reveal_type(ExplicitReturnCallableInstanceDecorated)  # revealed: Unknown
+```
+
+An unknown class decorator still makes the class binding unknown:
+
+```py
+# error: [unresolved-reference] "Name `unknown_class_decorator` used when not defined"
+@unknown_class_decorator
+class UnknownDecorated: ...
+
+reveal_type(UnknownDecorated)  # revealed: Unknown
+```
+
+An unannotated class decorator preserves the result of earlier decorators:
+
+```py
+def unannotated_identity(cls):
+    return cls
+
+@unannotated_identity
+@WrapBackend
+class WrappedThenUnannotated: ...
+
+reveal_type(WrappedThenUnannotated)  # revealed: WrapBackend
+```
+
+Metadata decorators still apply above an unannotated class-preserving decorator:
+
+```py
+from typing_extensions import deprecated
+
+def unannotated_identity(cls):
+    return cls
+
+@deprecated("use OtherClass")
+@unannotated_identity
+class DeprecatedThenUnannotated: ...
+
+DeprecatedThenUnannotated()  # error: [deprecated] "use OtherClass"
+```
+
+If a class decorator returns the original class object, we preserve the class binding so it can
+still be used in annotations and as a base class:
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T", bound=object)
+
+def identity_class_decorator(cls: type[T]) -> type[T]:
+    return cls
+
+@identity_class_decorator
+class PreservedClass: ...
+
+reveal_type(PreservedClass)  # revealed: <class 'PreservedClass'>
+
+class DerivedPreservedClass(PreservedClass):
+    value: PreservedClass
+```
+
+Class decorators can return intersections that expose attributes added to the decorated class
+object:
+
+```py
+from ty_extensions import Intersection
+from typing import Protocol, TypeVar
+
+class Resource:
+    def fetch(self) -> str:
+        return "data"
+
+class ResourceEnabled(Protocol):
+    resource: Resource
+
+SchemaT = TypeVar("SchemaT")
+
+def register(cls: type[SchemaT]) -> Intersection[type[SchemaT], ResourceEnabled]:
+    return cls
+
+@register
+class UserSchema:
+    id: int
+
+reveal_type(UserSchema.resource.fetch())  # revealed: str
 ```

--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -385,7 +385,7 @@ Class decorators can also replace the class object with an instance:
 
 ```py
 from dataclasses import dataclass
-from typing import Generic, Protocol, TypeVar, overload
+from typing import Callable, Generic, Protocol, TypeVar, overload
 from typing_extensions import Self
 
 T = TypeVar("T")
@@ -428,6 +428,19 @@ class WrappedThenDataclass:
     value: int
 
 reveal_type(WrappedThenDataclass)  # revealed: Unknown
+
+def int_decorator_factory() -> Callable[[type[object]], int]:
+    def decorator(cls: type[object]) -> int:
+        return 1
+    return decorator
+
+# error: [no-matching-overload]
+@dataclass
+@int_decorator_factory()
+class IntThenDataclass:
+    value: int
+
+reveal_type(IntThenDataclass)  # revealed: Unknown
 
 @WrapBackend
 class InvalidWrappedBase(1): ...  # error: [invalid-base]
@@ -632,4 +645,63 @@ class UserSchema:
     id: int
 
 reveal_type(UserSchema.resource.fetch())  # revealed: str
+```
+
+Metadata decorators stacked above an intersection-returning class decorator still apply to the
+original class object, while preserving the extra intersection members:
+
+```py
+from dataclasses import dataclass
+from ty_extensions import Intersection
+from typing import Protocol, TypeVar
+
+class Resource:
+    def fetch(self) -> str:
+        return "data"
+
+class ResourceEnabled(Protocol):
+    resource: Resource
+
+SchemaT = TypeVar("SchemaT")
+
+def register(cls: type[SchemaT]) -> Intersection[type[SchemaT], ResourceEnabled]:
+    return cls
+
+@dataclass
+@register
+class RegisteredDataclass:
+    id: int
+
+reveal_type(RegisteredDataclass.resource.fetch())  # revealed: str
+reveal_type(RegisteredDataclass(1))  # revealed: RegisteredDataclass
+```
+
+Class-preserving decorators stacked above an intersection-returning class decorator preserve the
+existing intersection members:
+
+```py
+from ty_extensions import Intersection
+from typing import Protocol, TypeVar
+
+class Resource:
+    def fetch(self) -> str:
+        return "data"
+
+class ResourceEnabled(Protocol):
+    resource: Resource
+
+SchemaT = TypeVar("SchemaT")
+
+def register(cls: type[SchemaT]) -> Intersection[type[SchemaT], ResourceEnabled]:
+    return cls
+
+def identity(cls: type[SchemaT]) -> type[SchemaT]:
+    return cls
+
+@identity
+@register
+class RegisteredIdentity:
+    id: int
+
+reveal_type(RegisteredIdentity.resource.fetch())  # revealed: str
 ```

--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -307,8 +307,6 @@ class AcceptsType:
     def __init__(self, cls: type) -> None:
         self.cls = cls
 
-# Decorator call is validated, but the type transformation isn't applied yet.
-# TODO: Class decorator return types should transform the class binding type.
 @AcceptsType
 class MyClass: ...
 
@@ -445,6 +443,8 @@ reveal_type(IntThenDataclass)  # revealed: Unknown
 @WrapBackend
 class InvalidWrappedBase(1): ...  # error: [invalid-base]
 
+reveal_type(InvalidWrappedBase)  # revealed: WrapBackend
+
 @WrapBackend
 class GenericCacheClient(Generic[T]):
     value: T
@@ -457,10 +457,11 @@ reveal_type(GenericCacheClient)  # revealed: WrapBackend
 @WrapBackend
 class OverloadedCacheClient:
     @overload
-    # error: [invalid-overload] "Overloads for function `get` must be followed by a non-`@overload`-decorated implementation function"
     def get(self, key: str) -> bytes: ...
     @overload
     def get(self, key: bytes) -> bytes: ...
+    def get(self, key: str | bytes) -> bytes:
+        return b""
 ```
 
 Unannotated class decorators are assumed to preserve the class binding. We do not infer returned
@@ -527,6 +528,13 @@ explicit_return_decorator = ExplicitReturnDecorator()
 class ExplicitReturnCallableInstanceDecorated: ...
 
 reveal_type(ExplicitReturnCallableInstanceDecorated)  # revealed: Unknown
+
+specialized_explicit_return_decorator = ExplicitReturnDecorator[int]()
+
+@specialized_explicit_return_decorator
+class SpecializedExplicitReturnCallableInstanceDecorated: ...
+
+reveal_type(SpecializedExplicitReturnCallableInstanceDecorated)  # revealed: int
 ```
 
 An unknown class decorator still makes the class binding unknown:

--- a/crates/ty_python_semantic/resources/mdtest/decorators/total_ordering.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators/total_ordering.md
@@ -38,6 +38,35 @@ reveal_type(s1 > s2)  # revealed: bool
 reveal_type(s1 >= s2)  # revealed: bool
 ```
 
+## Stacked with class-preserving decorator
+
+Metadata from `@total_ordering` still applies above an explicitly typed class-preserving decorator:
+
+```py
+from functools import total_ordering
+from typing import TypeVar
+
+T = TypeVar("T", bound=object)
+
+def identity(cls: type[T]) -> type[T]:
+    return cls
+
+@total_ordering
+@identity
+class OrderedIdentity:
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, OrderedIdentity)
+
+    def __lt__(self, other: "OrderedIdentity") -> bool:
+        return True
+
+left = OrderedIdentity()
+right = OrderedIdentity()
+
+reveal_type(left <= right)  # revealed: bool
+reveal_type(left >= right)  # revealed: bool
+```
+
 ## Signature derived from source ordering method
 
 When the source ordering method accepts a broader type (like `object`) for its `other` parameter,

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -37,6 +37,22 @@ reveal_type(generic_context(SingleTypeVarTuple))
 reveal_type(generic_context(TypeVarAndTypeVarTuple))
 ```
 
+Decorated generic classes still use the original class for their class-body generic context:
+
+```py
+class Wrap:
+    def __init__(self, cls: type[object]) -> None: ...
+
+@Wrap
+class DecoratedGeneric[T]:
+    value: T
+
+    def get_value(self) -> T:
+        return self.value
+
+reveal_type(DecoratedGeneric)  # revealed: Wrap
+```
+
 You cannot use the same typevar more than once.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5328,6 +5328,14 @@ class B(TypedDict, extra_items=ReadOnly[int]):
 class C(TypedDict, extra_items=Required[int]):
     name: str
 
+class ReplacesClass:
+    def __init__(self, cls: type[object]) -> None: ...
+
+@ReplacesClass
+# error: [invalid-type-form] "Type qualifier `typing.Required` is not valid in a TypedDict `extra_items` argument"
+class DecoratedC(TypedDict, extra_items=Required[int]):
+    name: str
+
 # error: [invalid-type-form] "Type qualifier `typing.NotRequired` is not valid in a TypedDict `extra_items` argument"
 class D(TypedDict, extra_items=NotRequired[int]):
     name: str

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4979,6 +4979,21 @@ class Foo(TypedDict("Foo", {"x": int, "y": str})):
     pass
 ```
 
+Other class decorators can replace the public TypedDict binding:
+
+```py
+from typing import TypedDict
+
+class ReplacesClass:
+    def __init__(self, cls: type[object]) -> None: ...
+
+@ReplacesClass
+class Decorated(TypedDict):
+    name: str
+
+reveal_type(Decorated)  # revealed: ReplacesClass
+```
+
 ## Class header validation
 
 <!-- snapshot-diagnostics -->
@@ -5326,14 +5341,6 @@ class B(TypedDict, extra_items=ReadOnly[int]):
 
 # error: [invalid-type-form] "Type qualifier `typing.Required` is not valid in a TypedDict `extra_items` argument"
 class C(TypedDict, extra_items=Required[int]):
-    name: str
-
-class ReplacesClass:
-    def __init__(self, cls: type[object]) -> None: ...
-
-@ReplacesClass
-# error: [invalid-type-form] "Type qualifier `typing.Required` is not valid in a TypedDict `extra_items` argument"
-class DecoratedC(TypedDict, extra_items=Required[int]):
     name: str
 
 # error: [invalid-type-form] "Type qualifier `typing.NotRequired` is not valid in a TypedDict `extra_items` argument"

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1411,6 +1411,7 @@ impl<'db> Type<'db> {
         }
     }
 
+    #[cfg(test)]
     #[track_caller]
     pub(crate) const fn expect_class_literal(self) -> ClassLiteral<'db> {
         self.as_class_literal()

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1216,6 +1216,16 @@ impl<'db> FunctionType<'db> {
     }
 
     /// Returns `true` if any overload or implementation has an explicit return annotation.
+    ///
+    /// This distinguishes untyped decorators that infer an unknown return from decorators that
+    /// explicitly promise a replacement type:
+    /// ```python
+    /// def identity(cls):
+    ///     return cls
+    ///
+    /// def replace(cls) -> object:
+    ///     return object()
+    /// ```
     pub(crate) fn has_explicit_return_annotation(self, db: &'db dyn Db) -> bool {
         self.iter_overloads_and_implementation(db)
             .any(|overload| overload.spans(db).return_type.is_some())

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -76,7 +76,7 @@ use crate::types::diagnostic::{
 };
 use crate::types::display::DisplaySettings;
 use crate::types::generics::{ApplySpecialization, GenericContext, typing_self};
-use crate::types::infer::nearest_enclosing_class;
+use crate::types::infer::{nearest_enclosing_class, original_class_type};
 use crate::types::known_instance::DeprecatedInstance;
 use crate::types::list_members::all_members;
 use crate::types::narrow::ClassInfoConstraintFunction;
@@ -89,7 +89,7 @@ use crate::types::{
     ClassLiteral, ClassType, DynamicType, FindLegacyTypeVarsVisitor, IntersectionBuilder,
     KnownClass, KnownInstanceType, SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness,
     Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints, UnionBuilder, UnionType,
-    binding_type, definition_expression_type, infer_definition_types, walk_signature,
+    definition_expression_type, walk_signature,
 };
 use crate::{Db, FxOrderSet};
 use ty_python_core::ast_ids::HasScopedUseId;
@@ -544,9 +544,8 @@ impl<'db> OverloadLiteral<'db> {
             // or there is but it isn't using the PEP-484 convention,
             // then `self`/`cls` are only implicitly positional-only if
             // it is a protocol class.
-            let class_type = binding_type(db, class_definition);
-            class_type
-                .to_class_type(db)
+            original_class_type(db, class_definition)
+                .map(|class_literal| class_literal.default_specialization(db))
                 .is_some_and(|class| class.is_protocol(db))
         }
 
@@ -593,12 +592,7 @@ impl<'db> OverloadLiteral<'db> {
             let class_scope = index.scope(class_scope_id.file_scope_id(db));
             let class_node = class_scope.node().as_class()?;
             let class_def = index.expect_single_definition(class_node);
-            let Type::ClassLiteral(class_literal) = infer_definition_types(db, class_def)
-                .declaration_type(class_def)
-                .inner_type()
-            else {
-                return None;
-            };
+            let class_literal = original_class_type(db, class_def)?;
             let class_is_generic = class_literal.generic_context(db).is_some();
             let class_is_fallback = class_literal
                 .known(db)
@@ -1219,6 +1213,12 @@ impl<'db> FunctionType<'db> {
     /// Returns `true` if this function has a trivial body.
     pub(crate) fn has_trivial_body(self, db: &'db dyn Db) -> bool {
         self.literal(db).has_trivial_body(db)
+    }
+
+    /// Returns `true` if any overload or implementation has an explicit return annotation.
+    pub(crate) fn has_explicit_return_annotation(self, db: &'db dyn Db) -> bool {
+        self.iter_overloads_and_implementation(db)
+            .any(|overload| overload.spans(db).return_type.is_some())
     }
 
     /// Returns all of the overload signatures and the implementation definition, if any, of this

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -273,6 +273,9 @@ pub struct OverloadLiteral<'db> {
     /// The arguments to `dataclass_transformer`, if this function was annotated
     /// with `@dataclass_transformer(...)`.
     pub(crate) dataclass_transformer_params: Option<DataclassTransformerParams<'db>>,
+
+    /// Whether this overload or implementation has an explicit return annotation.
+    pub(crate) has_explicit_return_annotation: bool,
 }
 
 // The Salsa heap is tracked separately.
@@ -293,6 +296,7 @@ impl<'db> OverloadLiteral<'db> {
             self.decorators(db),
             self.deprecated(db),
             Some(params),
+            self.has_explicit_return_annotation(db),
         )
     }
 
@@ -1228,7 +1232,7 @@ impl<'db> FunctionType<'db> {
     /// ```
     pub(crate) fn has_explicit_return_annotation(self, db: &'db dyn Db) -> bool {
         self.iter_overloads_and_implementation(db)
-            .any(|overload| overload.spans(db).return_type.is_some())
+            .any(|overload| overload.has_explicit_return_annotation(db))
     }
 
     /// Returns all of the overload signatures and the implementation definition, if any, of this

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -14,6 +14,7 @@ use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
     Solutions,
 };
+use crate::types::infer::original_class_type;
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
@@ -346,9 +347,7 @@ impl<'db> GenericContext<'db> {
         match node {
             NodeWithScopeKind::Class(class) => {
                 let definition = index.expect_single_definition(class);
-                binding_type(db, definition)
-                    .as_class_literal()?
-                    .generic_context(db)
+                original_class_type(db, definition)?.generic_context(db)
             }
             NodeWithScopeKind::Function(function) => {
                 let definition = index.expect_single_definition(function);

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -672,6 +672,17 @@ pub(crate) fn nearest_enclosing_class<'db>(
 /// For decorated classes, this is the class object before applying decorators. The public
 /// binding may be replaced by a class decorator's return type, but class-body inference still
 /// needs the original class object for implicit `self`/`cls`, `Self`, and dataclass logic.
+///
+/// For example, the public binding for `C` may be the `int` returned by `replace`, but the class
+/// body and nested definitions still need the original class object:
+/// ```python
+/// def replace(cls: type[object]) -> int:
+///     return 1
+///
+/// @replace
+/// class C:
+///     def method(self) -> None: ...
+/// ```
 pub(crate) fn original_class_type<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -56,7 +56,6 @@ use crate::types::generics::Specialization;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
     ClassLiteral, KnownClass, StaticClassLiteral, Type, TypeAndQualifiers, TypeQualifiers,
-    declaration_type,
 };
 use builder::TypeInferenceBuilder;
 pub(super) use comparisons::UnsupportedComparisonError;
@@ -664,11 +663,24 @@ pub(crate) fn nearest_enclosing_class<'db>(
         .find_map(|(_, ancestor_scope)| {
             let class = ancestor_scope.node().as_class()?;
             let definition = semantic.expect_single_definition(class);
-            declaration_type(db, definition)
-                .inner_type()
-                .as_class_literal()
-                .and_then(ClassLiteral::as_static)
+            original_class_type(db, definition).and_then(ClassLiteral::as_static)
         })
+}
+
+/// Return the original class literal for a class definition.
+///
+/// For decorated classes, this is the class object before applying decorators. The public
+/// binding may be replaced by a class decorator's return type, but class-body inference still
+/// needs the original class object for implicit `self`/`cls`, `Self`, and dataclass logic.
+pub(crate) fn original_class_type<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+) -> Option<ClassLiteral<'db>> {
+    let inference = infer_definition_types(db, definition);
+    inference
+        .undecorated_type()
+        .unwrap_or_else(|| inference.declaration_type(definition).inner_type())
+        .as_class_literal()
 }
 
 /// Returns the type of the nearest enclosing function for the given scope.
@@ -876,7 +888,7 @@ struct DefinitionInferenceExtra<'db> {
     /// The diagnostics for this region.
     diagnostics: TypeCheckDiagnostics,
 
-    /// For function definitions, the undecorated type of the function.
+    /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
 
     /// Type qualifiers (`Required`, `NotRequired`, etc.) for annotation expressions.

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -690,7 +690,7 @@ pub(crate) fn original_class_type<'db>(
     let inference = infer_definition_types(db, definition);
     inference
         .undecorated_type()
-        .unwrap_or_else(|| inference.declaration_type(definition).inner_type())
+        .unwrap_or_else(|| inference.binding_type(definition))
         .as_class_literal()
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -79,6 +79,7 @@ use crate::types::infer::builder::typed_dict::TypedDictConstructorForm;
 use crate::types::infer::{
     StatementInference, StatementInferenceInner, StatementInferenceInnerExtra, TypeExpressionFlags,
     infer_statement_types, nearest_enclosing_class, nearest_enclosing_function,
+    original_class_type,
 };
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::newtype::NewType;
@@ -315,7 +316,7 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// is a stub file but we're still in a non-deferred region.
     deferred_state: DeferredExpressionState,
 
-    /// For function definitions, the undecorated type of the function.
+    /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
 
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
@@ -539,11 +540,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let enclosing_scope = index.scope(scope.file_scope_id(db));
             let class_node = enclosing_scope.node().as_class()?;
             let class_definition = index.expect_single_definition(class_node);
-            let class_literal = infer_definition_types(db, class_definition)
-                .declaration_type(class_definition)
-                .inner_type()
-                .as_class_literal()?
-                .as_static()?;
+            let class_literal = original_class_type(db, class_definition)?.as_static()?;
 
             class_literal
                 .dataclass_params(db)
@@ -821,6 +818,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         );
                     }
                     DefinitionKind::Class(class_node) => {
+                        let original_ty = match self.region {
+                            InferenceRegion::Definition(current) if current == definition => {
+                                self.undecorated_type
+                            }
+                            _ => original_class_type(self.db(), definition).map(Type::ClassLiteral),
+                        };
+                        let ty = original_ty.unwrap_or(ty);
                         post_inference::static_class::check_static_class_definitions(
                             &self.context,
                             ty,
@@ -1504,7 +1508,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn class_context_of_current_method(&self) -> Option<ClassType<'db>> {
         let current_scope_id = self.scope().file_scope_id(self.db());
         let class_definition = self.index.class_definition_of_method(current_scope_id)?;
-        binding_type(self.db(), class_definition).to_class_type(self.db())
+        original_class_type(self.db(), class_definition)
+            .map(|class_literal| class_literal.default_specialization(self.db()))
     }
 
     /// If the current scope is a (non-lambda) function, return that function's AST node.

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -61,19 +61,11 @@ fn can_preserve_unknown_class_decorator_result<'db>(
         return false;
     }
 
-    unannotated_class_decorator_preservation(db, decorator_ty)
+    class_decorator_known_preservation(db, decorator_ty)
         .unwrap_or_else(|| decorator_ty.try_upcast_to_callable(db).is_some())
 }
 
-/// Return true if a decorator can be skipped when looking upward for class metadata decorators.
-fn does_not_block_class_metadata_decorator<'db>(
-    db: &'db dyn crate::Db,
-    decorator_ty: Type<'db>,
-) -> bool {
-    unannotated_class_decorator_preservation(db, decorator_ty).unwrap_or(false)
-}
-
-fn unannotated_class_decorator_preservation<'db>(
+fn class_decorator_known_preservation<'db>(
     db: &'db dyn crate::Db,
     decorator_ty: Type<'db>,
 ) -> Option<bool> {
@@ -92,17 +84,20 @@ fn unannotated_class_decorator_preservation<'db>(
             if let Place::Defined(place) = call_symbol
                 && place.is_definitely_defined()
             {
-                Some(unannotated_class_decorator_preservation(db, place.ty).unwrap_or(false))
+                Some(class_decorator_known_preservation(db, place.ty).unwrap_or(false))
             } else {
                 Some(false)
             }
         }
-        Type::Union(union) => Some(union.elements(db).iter().all(|element| {
-            unannotated_class_decorator_preservation(db, *element).unwrap_or(false)
-        })),
-        Type::TypeAlias(alias) => Some(
-            unannotated_class_decorator_preservation(db, alias.value_type(db)).unwrap_or(false),
+        Type::Union(union) => Some(
+            union
+                .elements(db)
+                .iter()
+                .all(|element| class_decorator_known_preservation(db, *element).unwrap_or(false)),
         ),
+        Type::TypeAlias(alias) => {
+            Some(class_decorator_known_preservation(db, alias.value_type(db)).unwrap_or(false))
+        }
         Type::Callable(_) => Some(true),
         _ => None,
     }
@@ -171,76 +166,63 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .iter()
             .map(|decorator| (self.infer_decorator(decorator), decorator))
             .collect();
-        let mut folded_decorators = vec![false; decorator_types_and_nodes.len()];
-        let mut can_fold_metadata_decorators = true;
+        let mut decorators_to_apply = Vec::with_capacity(decorator_types_and_nodes.len());
+        let mut metadata_applies_to_original_class = true;
         let mut deprecated = None;
         let mut type_check_only = false;
         let mut dataclass_params = None;
         let mut dataclass_transformer_params = None;
         let mut total_ordering = false;
-        for (index, (decorator_ty, decorator)) in decorator_types_and_nodes.iter().enumerate().rev()
-        {
-            if can_fold_metadata_decorators
-                && decorator_ty
+        for &(decorator_ty, decorator) in decorator_types_and_nodes.iter().rev() {
+            if metadata_applies_to_original_class {
+                if decorator_ty
                     .as_function_literal()
                     .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
-            {
-                dataclass_params = Some(DataclassParams::default_params(db));
-                folded_decorators[index] = true;
-                continue;
-            }
+                {
+                    dataclass_params = Some(DataclassParams::default_params(db));
+                    continue;
+                }
 
-            if can_fold_metadata_decorators
-                && decorator_ty
+                if decorator_ty
                     .as_function_literal()
                     .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
-            {
-                total_ordering = true;
-                folded_decorators[index] = true;
-                continue;
-            }
+                {
+                    total_ordering = true;
+                    continue;
+                }
 
-            if can_fold_metadata_decorators && let Type::DataclassDecorator(params) = *decorator_ty
-            {
-                dataclass_params = Some(params);
-                folded_decorators[index] = true;
-                continue;
-            }
+                if let Type::DataclassDecorator(params) = decorator_ty {
+                    dataclass_params = Some(params);
+                    continue;
+                }
 
-            if can_fold_metadata_decorators
-                && decorator_ty.is_unknown()
-                && let ast::Expr::Call(call) = &decorator.expression
-                && self
-                    .expression_type(&call.func)
-                    .as_function_literal()
-                    .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
-            {
-                folded_decorators[index] = true;
-                continue;
-            }
+                if decorator_ty.is_unknown()
+                    && let ast::Expr::Call(call) = &decorator.expression
+                    && self
+                        .expression_type(&call.func)
+                        .as_function_literal()
+                        .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
+                {
+                    continue;
+                }
 
-            if can_fold_metadata_decorators
-                && let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) =
-                    *decorator_ty
-            {
-                deprecated = Some(deprecated_inst);
-                folded_decorators[index] = true;
-                continue;
-            }
+                if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) =
+                    decorator_ty
+                {
+                    deprecated = Some(deprecated_inst);
+                    continue;
+                }
 
-            if can_fold_metadata_decorators
-                && decorator_ty
+                if decorator_ty
                     .as_function_literal()
                     .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
-            {
-                type_check_only = true;
-                folded_decorators[index] = true;
-                continue;
-            }
+                {
+                    type_check_only = true;
+                    continue;
+                }
 
-            // Skip identity decorators to avoid salsa cycles on typeshed.
-            if can_fold_metadata_decorators
-                && decorator_ty.as_function_literal().is_some_and(|function| {
+                // Skip identity decorators to avoid salsa cycles on typeshed.
+                if decorator_ty.as_function_literal().is_some_and(|function| {
                     matches!(
                         function.known(db),
                         Some(
@@ -249,50 +231,45 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 | KnownFunction::RuntimeCheckable
                         )
                     )
-                })
-            {
-                folded_decorators[index] = true;
-                continue;
-            }
-
-            if can_fold_metadata_decorators && let Type::FunctionLiteral(f) = *decorator_ty {
-                // We do not yet detect or flag `@dataclass_transform` applied to more than one
-                // overload, or an overload and the implementation both. Nevertheless, this is not
-                // allowed. We do not try to treat the offenders intelligently -- just use the
-                // params of the last seen usage of `@dataclass_transform`
-                let transformer_params = f
-                    .iter_overloads_and_implementation(db)
-                    .rev()
-                    .find_map(|overload| overload.dataclass_transformer_params(db));
-                if let Some(transformer_params) = transformer_params {
-                    dataclass_params = Some(DataclassParams::from_transformer_params(
-                        db,
-                        transformer_params,
-                    ));
-                    folded_decorators[index] = true;
+                }) {
                     continue;
+                }
+
+                if let Type::FunctionLiteral(f) = decorator_ty {
+                    // We do not yet detect or flag `@dataclass_transform` applied to more than one
+                    // overload, or an overload and the implementation both. Nevertheless, this is not
+                    // allowed. We do not try to treat the offenders intelligently -- just use the
+                    // params of the last seen usage of `@dataclass_transform`
+                    let transformer_params = f
+                        .iter_overloads_and_implementation(db)
+                        .rev()
+                        .find_map(|overload| overload.dataclass_transformer_params(db));
+                    if let Some(transformer_params) = transformer_params {
+                        dataclass_params = Some(DataclassParams::from_transformer_params(
+                            db,
+                            transformer_params,
+                        ));
+                        continue;
+                    }
+                }
+
+                if let Type::DataclassTransformer(params) = decorator_ty {
+                    dataclass_transformer_params = Some(params);
+                    continue;
+                }
+
+                let decorator_preserves_unknown_result =
+                    class_decorator_known_preservation(db, decorator_ty).unwrap_or(false)
+                        || matches!(&decorator.expression, ast::Expr::Call(call) if {
+                            class_decorator_known_preservation(db, self.expression_type(&call.func))
+                                .unwrap_or(false)
+                        });
+                if !decorator_preserves_unknown_result {
+                    metadata_applies_to_original_class = false;
                 }
             }
 
-            if can_fold_metadata_decorators
-                && let Type::DataclassTransformer(params) = *decorator_ty
-            {
-                dataclass_transformer_params = Some(params);
-                folded_decorators[index] = true;
-                continue;
-            }
-
-            let decorator_preserves_unknown_result =
-                does_not_block_class_metadata_decorator(db, *decorator_ty)
-                    || matches!(&decorator.expression, ast::Expr::Call(call) if {
-                        does_not_block_class_metadata_decorator(
-                            db,
-                            self.expression_type(&call.func),
-                        )
-                    });
-            if !decorator_preserves_unknown_result {
-                can_fold_metadata_decorators = false;
-            }
+            decorators_to_apply.push((decorator_ty, decorator));
         }
 
         let body_scope = self
@@ -334,23 +311,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let original_class_ty = inferred_ty;
         let mut class_ty_before_replacement = inferred_ty;
         let mut replaces_class_binding = false;
-        for (index, (decorator_ty, decorator_node)) in
-            decorator_types_and_nodes.iter().enumerate().rev()
-        {
-            if folded_decorators[index] {
-                continue;
-            }
-
-            let decorated_ty =
-                match self.apply_decorator(*decorator_ty, inferred_ty, decorator_node) {
-                    Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
-                    decorated_ty => decorated_ty,
-                };
+        for (decorator_ty, decorator_node) in decorators_to_apply {
+            let decorated_ty = match self.apply_decorator(decorator_ty, inferred_ty, decorator_node)
+            {
+                Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
+                decorated_ty => decorated_ty,
+            };
             // For unannotated class decorators, assume the decorator preserves the class binding
             // instead of replacing it with `Unknown`. We do not infer returned classes from
             // decorator bodies, because each call can create a distinct runtime class.
             let preserves_unannotated_decorator_binding = decorated_ty.is_unknown()
-                && (can_preserve_unknown_class_decorator_result(db, *decorator_ty)
+                && (can_preserve_unknown_class_decorator_result(db, decorator_ty)
                     || matches!(&decorator_node.expression, ast::Expr::Call(call) if {
                         can_preserve_unknown_class_decorator_result(
                             db,

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -1,19 +1,112 @@
-use crate::types::{
-    CallArguments, DataclassParams, KnownClass, KnownInstanceType, SpecialFormType,
-    StaticClassLiteral, Type, TypeContext,
-    call::CallError,
-    function::KnownFunction,
-    infer::{
-        TypeInferenceBuilder,
-        builder::{DeclaredAndInferredType, DeferredExpressionState},
+use crate::{
+    place::Place,
+    types::{
+        CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
+        SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
+        function::KnownFunction,
+        infer::{
+            TypeInferenceBuilder,
+            builder::{DeclaredAndInferredType, DeferredExpressionState},
+        },
+        infer_definition_types,
+        signatures::ParameterForm,
+        special_form::TypeQualifier,
     },
-    infer_definition_types,
-    signatures::ParameterForm,
-    special_form::TypeQualifier,
 };
-use ruff_python_ast::{self as ast, helpers::any_over_expr};
+use ruff_python_ast::{self as ast, helpers::any_over_expr, name::Name};
 use ty_module_resolver::{KnownModule, file_to_module};
 use ty_python_core::{definition::Definition, scope::NodeWithScopeRef};
+
+/// Return true if a decorator result still binds the name to the original class.
+fn class_decorator_preserves_class_binding<'db>(
+    db: &'db dyn crate::Db,
+    original_class: Type<'db>,
+    decorated_class: Type<'db>,
+) -> bool {
+    let Type::ClassLiteral(original_literal) = original_class else {
+        return false;
+    };
+
+    match decorated_class {
+        Type::ClassLiteral(decorated_literal) => {
+            let decorated_definition = decorated_literal.definition(db);
+            decorated_literal == original_literal
+                || decorated_definition.is_some()
+                    && decorated_definition == original_literal.definition(db)
+        }
+        Type::SubclassOf(subclass_of) => subclass_of
+            .subclass_of()
+            .into_class(db)
+            .is_some_and(|class| class == original_literal.default_specialization(db)),
+        Type::Divergent(_) => true,
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| class_decorator_preserves_class_binding(db, original_class, *element)),
+        Type::TypeAlias(alias) => {
+            class_decorator_preserves_class_binding(db, original_class, alias.value_type(db))
+        }
+        _ => SubclassOfType::try_from_type(db, original_class).is_some_and(|original_meta_type| {
+            decorated_class.is_equivalent_to(db, original_meta_type)
+        }),
+    }
+}
+
+/// Return true if an unknown class-decorator result should preserve the decorated class binding.
+fn can_preserve_unknown_class_decorator_result<'db>(
+    db: &'db dyn crate::Db,
+    decorator_ty: Type<'db>,
+) -> bool {
+    if decorator_ty.is_unknown() {
+        return false;
+    }
+
+    unannotated_class_decorator_preservation(db, decorator_ty)
+        .unwrap_or_else(|| decorator_ty.try_upcast_to_callable(db).is_some())
+}
+
+/// Return true if a decorator can be skipped when looking upward for class metadata decorators.
+fn does_not_block_class_metadata_decorator<'db>(
+    db: &'db dyn crate::Db,
+    decorator_ty: Type<'db>,
+) -> bool {
+    unannotated_class_decorator_preservation(db, decorator_ty).unwrap_or(false)
+}
+
+fn unannotated_class_decorator_preservation<'db>(
+    db: &'db dyn crate::Db,
+    decorator_ty: Type<'db>,
+) -> Option<bool> {
+    match decorator_ty {
+        Type::FunctionLiteral(function) => Some(!function.has_explicit_return_annotation(db)),
+        Type::BoundMethod(method) => Some(!method.function(db).has_explicit_return_annotation(db)),
+        Type::NominalInstance(_) | Type::ProtocolInstance(_) => {
+            let call_symbol = decorator_ty
+                .member_lookup_with_policy(
+                    db,
+                    Name::new_static("__call__"),
+                    MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                )
+                .place;
+
+            if let Place::Defined(place) = call_symbol
+                && place.is_definitely_defined()
+            {
+                Some(unannotated_class_decorator_preservation(db, place.ty).unwrap_or(false))
+            } else {
+                Some(false)
+            }
+        }
+        Type::Union(union) => Some(union.elements(db).iter().all(|element| {
+            unannotated_class_decorator_preservation(db, *element).unwrap_or(false)
+        })),
+        Type::TypeAlias(alias) => Some(
+            unannotated_class_decorator_preservation(db, alias.value_type(db)).unwrap_or(false),
+        ),
+        Type::Callable(_) => Some(true),
+        _ => None,
+    }
+}
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     pub(super) fn infer_class_body(&mut self, class: &ast::StmtClassDef) {
@@ -74,66 +167,95 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         } = class_node;
         let db = self.db();
 
-        let mut decorator_types_and_nodes: Vec<(Type<'db>, &ast::Decorator)> =
-            Vec::with_capacity(decorator_list.len());
+        let decorator_types_and_nodes: Vec<(Type<'db>, &ast::Decorator)> = decorator_list
+            .iter()
+            .map(|decorator| (self.infer_decorator(decorator), decorator))
+            .collect();
+        let mut folded_decorators = vec![false; decorator_types_and_nodes.len()];
+        let mut can_fold_metadata_decorators = true;
         let mut deprecated = None;
         let mut type_check_only = false;
         let mut dataclass_params = None;
         let mut dataclass_transformer_params = None;
         let mut total_ordering = false;
-        for decorator in decorator_list {
-            let decorator_ty = self.infer_decorator(decorator);
-            if decorator_ty
-                .as_function_literal()
-                .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
+        for (index, (decorator_ty, decorator)) in decorator_types_and_nodes.iter().enumerate().rev()
+        {
+            if can_fold_metadata_decorators
+                && decorator_ty
+                    .as_function_literal()
+                    .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
             {
                 dataclass_params = Some(DataclassParams::default_params(db));
+                folded_decorators[index] = true;
                 continue;
             }
 
-            if decorator_ty
-                .as_function_literal()
-                .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
+            if can_fold_metadata_decorators
+                && decorator_ty
+                    .as_function_literal()
+                    .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
             {
                 total_ordering = true;
+                folded_decorators[index] = true;
                 continue;
             }
 
-            if let Type::DataclassDecorator(params) = decorator_ty {
+            if can_fold_metadata_decorators && let Type::DataclassDecorator(params) = *decorator_ty
+            {
                 dataclass_params = Some(params);
+                folded_decorators[index] = true;
                 continue;
             }
 
-            if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) =
-                decorator_ty
+            if can_fold_metadata_decorators
+                && decorator_ty.is_unknown()
+                && let ast::Expr::Call(call) = &decorator.expression
+                && self
+                    .expression_type(&call.func)
+                    .as_function_literal()
+                    .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
+            {
+                folded_decorators[index] = true;
+                continue;
+            }
+
+            if can_fold_metadata_decorators
+                && let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) =
+                    *decorator_ty
             {
                 deprecated = Some(deprecated_inst);
+                folded_decorators[index] = true;
                 continue;
             }
 
-            if decorator_ty
-                .as_function_literal()
-                .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
+            if can_fold_metadata_decorators
+                && decorator_ty
+                    .as_function_literal()
+                    .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
             {
                 type_check_only = true;
+                folded_decorators[index] = true;
                 continue;
             }
 
             // Skip identity decorators to avoid salsa cycles on typeshed.
-            if decorator_ty.as_function_literal().is_some_and(|function| {
-                matches!(
-                    function.known(db),
-                    Some(
-                        KnownFunction::Final
-                            | KnownFunction::DisjointBase
-                            | KnownFunction::RuntimeCheckable
+            if can_fold_metadata_decorators
+                && decorator_ty.as_function_literal().is_some_and(|function| {
+                    matches!(
+                        function.known(db),
+                        Some(
+                            KnownFunction::Final
+                                | KnownFunction::DisjointBase
+                                | KnownFunction::RuntimeCheckable
+                        )
                     )
-                )
-            }) {
+                })
+            {
+                folded_decorators[index] = true;
                 continue;
             }
 
-            if let Type::FunctionLiteral(f) = decorator_ty {
+            if can_fold_metadata_decorators && let Type::FunctionLiteral(f) = *decorator_ty {
                 // We do not yet detect or flag `@dataclass_transform` applied to more than one
                 // overload, or an overload and the implementation both. Nevertheless, this is not
                 // allowed. We do not try to treat the offenders intelligently -- just use the
@@ -147,16 +269,30 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         db,
                         transformer_params,
                     ));
+                    folded_decorators[index] = true;
                     continue;
                 }
             }
 
-            if let Type::DataclassTransformer(params) = decorator_ty {
+            if can_fold_metadata_decorators
+                && let Type::DataclassTransformer(params) = *decorator_ty
+            {
                 dataclass_transformer_params = Some(params);
+                folded_decorators[index] = true;
                 continue;
             }
 
-            decorator_types_and_nodes.push((decorator_ty, decorator));
+            let decorator_preserves_unknown_result =
+                does_not_block_class_metadata_decorator(db, *decorator_ty)
+                    || matches!(&decorator.expression, ast::Expr::Call(call) if {
+                        does_not_block_class_metadata_decorator(
+                            db,
+                            self.expression_type(&call.func),
+                        )
+                    });
+            if !decorator_preserves_unknown_result {
+                can_fold_metadata_decorators = false;
+            }
         }
 
         let body_scope = self
@@ -174,7 +310,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             )
         };
 
-        let inferred_ty = match (maybe_known_class, &*name.id) {
+        let mut inferred_ty = match (maybe_known_class, &*name.id) {
             (None, "NamedTuple") if in_typing_module() => {
                 Type::SpecialForm(SpecialFormType::NamedTuple)
             }
@@ -195,13 +331,52 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             )),
         };
 
-        // Validate decorator calls (but don't use return types yet).
-        for (decorator_ty, decorator_node) in decorator_types_and_nodes.iter().rev() {
-            if let Err(CallError(_, bindings)) =
-                decorator_ty.try_call(db, &CallArguments::positional([inferred_ty]))
-            {
-                bindings.report_diagnostics(&self.context, (*decorator_node).into());
+        let original_class_ty = inferred_ty;
+        let mut class_ty_before_replacement = inferred_ty;
+        let mut replaces_class_binding = false;
+        for (index, (decorator_ty, decorator_node)) in
+            decorator_types_and_nodes.iter().enumerate().rev()
+        {
+            if folded_decorators[index] {
+                continue;
             }
+
+            let decorated_ty =
+                match self.apply_decorator(*decorator_ty, inferred_ty, decorator_node) {
+                    Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
+                    decorated_ty => decorated_ty,
+                };
+            // For unannotated class decorators, assume the decorator preserves the class binding
+            // instead of replacing it with `Unknown`. We do not infer returned classes from
+            // decorator bodies, because each call can create a distinct runtime class.
+            let preserves_unannotated_decorator_binding = decorated_ty.is_unknown()
+                && (can_preserve_unknown_class_decorator_result(db, *decorator_ty)
+                    || matches!(&decorator_node.expression, ast::Expr::Call(call) if {
+                        can_preserve_unknown_class_decorator_result(
+                            db,
+                            self.expression_type(&call.func),
+                        )
+                    }));
+            inferred_ty = if preserves_unannotated_decorator_binding {
+                inferred_ty
+            } else if class_decorator_preserves_class_binding(db, original_class_ty, decorated_ty) {
+                decorated_ty
+                    .as_class_literal()
+                    .map(Type::ClassLiteral)
+                    .unwrap_or(original_class_ty)
+            } else {
+                decorated_ty
+            };
+
+            if class_decorator_preserves_class_binding(db, original_class_ty, inferred_ty) {
+                class_ty_before_replacement = inferred_ty;
+            } else {
+                replaces_class_binding = true;
+            }
+        }
+
+        if replaces_class_binding {
+            self.undecorated_type = Some(class_ty_before_replacement);
         }
 
         self.add_declaration_with_binding(

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -65,6 +65,21 @@ fn can_preserve_unknown_class_decorator_result<'db>(
         .unwrap_or_else(|| decorator_ty.try_upcast_to_callable(db).is_some())
 }
 
+fn is_unknown_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bool {
+    if ty.is_unknown() {
+        return true;
+    }
+
+    let Type::SubclassOf(subclass_of) = ty.resolve_type_alias(db) else {
+        return false;
+    };
+
+    subclass_of
+        .subclass_of()
+        .into_dynamic()
+        .is_some_and(|dynamic| Type::Dynamic(dynamic).is_unknown())
+}
+
 fn class_decorator_known_preservation<'db>(
     db: &'db dyn crate::Db,
     decorator_ty: Type<'db>,
@@ -317,10 +332,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
                 decorated_ty => decorated_ty,
             };
-            // For unannotated class decorators, assume the decorator preserves the class binding
-            // instead of replacing it with `Unknown`. We do not infer returned classes from
-            // decorator bodies, because each call can create a distinct runtime class.
-            let preserves_unannotated_decorator_binding = decorated_ty.is_unknown()
+            // If a class decorator application loses all precision, preserve the original class
+            // binding when the decorator is known to preserve unknown results.
+            let preserves_unknown_decorator_binding = is_unknown_decorator_result(db, decorated_ty)
                 && (can_preserve_unknown_class_decorator_result(db, decorator_ty)
                     || matches!(&decorator_node.expression, ast::Expr::Call(call) if {
                         can_preserve_unknown_class_decorator_result(
@@ -328,7 +342,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             self.expression_type(&call.func),
                         )
                     }));
-            inferred_ty = if preserves_unannotated_decorator_binding {
+            inferred_ty = if preserves_unknown_decorator_binding {
                 inferred_ty
             } else if class_decorator_preserves_class_binding(db, original_class_ty, decorated_ty) {
                 decorated_ty

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -7,8 +7,8 @@ use crate::{
         infer::{
             TypeInferenceBuilder,
             builder::{DeclaredAndInferredType, DeferredExpressionState},
+            original_class_type,
         },
-        infer_definition_types,
         signatures::ParameterForm,
         special_form::TypeQualifier,
     },
@@ -18,6 +18,18 @@ use ty_module_resolver::{KnownModule, file_to_module};
 use ty_python_core::{definition::Definition, scope::NodeWithScopeRef};
 
 /// Return true if a decorator result still binds the name to the original class.
+///
+/// For example, an identity decorator keeps the public name bound to the same class:
+/// ```python
+/// def identity[T](cls: type[T]) -> type[T]:
+///     return cls
+///
+/// @identity
+/// class C: ...
+/// ```
+///
+/// This also accepts metaclass-shaped results such as `type[C]`, because those still describe the
+/// original class object even if the decorator call produced a `SubclassOf` type internally.
 fn class_decorator_preserves_class_binding<'db>(
     db: &'db dyn crate::Db,
     original_class: Type<'db>,
@@ -52,7 +64,91 @@ fn class_decorator_preserves_class_binding<'db>(
     }
 }
 
+/// Return true if a type still contains the original class object, even if it also carries extra
+/// intersection members.
+fn class_binding_retains_original_class<'db>(
+    db: &'db dyn crate::Db,
+    original_class: Type<'db>,
+    decorated_class: Type<'db>,
+) -> bool {
+    match decorated_class {
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .any(|element| class_binding_retains_original_class(db, original_class, *element)),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| class_binding_retains_original_class(db, original_class, *element)),
+        Type::TypeAlias(alias) => {
+            class_binding_retains_original_class(db, original_class, alias.value_type(db))
+        }
+        _ => class_decorator_preserves_class_binding(db, original_class, decorated_class),
+    }
+}
+
+/// Return true if metadata decorators stacked above this decorator should still apply to the
+/// original class object.
+///
+/// Metadata decorators such as `@dataclass` should keep shaping the original class when an inner
+/// decorator preserves that class:
+/// ```python
+/// from dataclasses import dataclass
+///
+/// def identity[T](cls: type[T]) -> type[T]:
+///     return cls
+///
+/// @dataclass
+/// @identity
+/// class C:
+///     x: int
+/// ```
+///
+/// If the inner decorator returns an unrelated value, the outer metadata decorator applies to that
+/// replacement instead, so we must not record dataclass metadata on the original class.
+fn class_decorator_preserves_class_metadata<'db>(
+    db: &'db dyn crate::Db,
+    original_class: Type<'db>,
+    decorated_class: Type<'db>,
+) -> bool {
+    class_binding_retains_original_class(db, original_class, decorated_class)
+}
+
+/// Merge a class-preserving decorator result into the public binding.
+///
+/// If earlier decorators already exposed extra members through an intersection, keep those
+/// members instead of collapsing back to the undecorated class when a later decorator simply
+/// returns the original class object again.
+fn merge_class_preserving_decorator_result<'db>(
+    db: &'db dyn crate::Db,
+    original_class: Type<'db>,
+    current_binding: Type<'db>,
+    decorated_binding: Type<'db>,
+) -> Type<'db> {
+    if class_binding_retains_original_class(db, original_class, current_binding) {
+        current_binding
+    } else {
+        decorated_binding
+            .as_class_literal()
+            .map(Type::ClassLiteral)
+            .unwrap_or(original_class)
+    }
+}
+
 /// Return true if an unknown class-decorator result should preserve the decorated class binding.
+///
+/// Untyped decorators often infer an unknown return type even when they are identity decorators:
+/// ```python
+/// def decorator(cls):
+///     return cls
+///
+/// @decorator
+/// class C: ...
+/// ```
+///
+/// In that case, keeping `C` bound to the original class is usually more useful than replacing it
+/// with `Unknown`. This helper decides when that recovery is justified from the decorator type
+/// itself, rather than from the unknown result.
 fn can_preserve_unknown_class_decorator_result<'db>(
     db: &'db dyn crate::Db,
     decorator_ty: Type<'db>,
@@ -65,6 +161,19 @@ fn can_preserve_unknown_class_decorator_result<'db>(
         .unwrap_or_else(|| decorator_ty.try_upcast_to_callable(db).is_some())
 }
 
+/// Return true if applying a class decorator produced no useful replacement type.
+///
+/// Besides plain `Unknown`, class decorators can produce unknown class-object types such as
+/// `type[Any]`. Those are represented as a `SubclassOf` dynamic type, but they should trigger the
+/// same preservation fallback as an unknown result:
+/// ```python
+/// from typing import Any
+///
+/// def decorator(cls) -> type[Any]: ...
+///
+/// @decorator
+/// class C: ...
+/// ```
 fn is_unknown_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bool {
     if ty.is_unknown() {
         return true;
@@ -80,6 +189,53 @@ fn is_unknown_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bo
         .is_some_and(|dynamic| Type::Dynamic(dynamic).is_unknown())
 }
 
+/// Return the value type produced by applying a class decorator.
+///
+/// Synthetic dataclass-transform marker types are metadata for class construction, not real values
+/// that should replace the class binding. For example, the result of calling `model` should not be
+/// recorded as the public type of `C` merely because `model` carries dataclass-transform metadata:
+/// ```python
+/// from typing import dataclass_transform
+///
+/// @dataclass_transform()
+/// def model(cls): ...
+///
+/// @model
+/// class C: ...
+/// ```
+fn class_decorator_return_type<'db>(
+    db: &'db dyn crate::Db,
+    decorator_ty: Type<'db>,
+    decorated_ty: Type<'db>,
+) -> Type<'db> {
+    let call_arguments = CallArguments::positional([decorated_ty]);
+    let return_ty = decorator_ty.try_call(db, &call_arguments).map_or_else(
+        |error| error.return_type(db),
+        |bindings| bindings.return_type(db),
+    );
+
+    match return_ty {
+        Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
+        return_ty => return_ty,
+    }
+}
+
+/// Return the known preservation policy for a class decorator, if one can be read statically.
+///
+/// For unknown decorator results, unannotated functions are treated as likely identity-preserving:
+/// ```python
+/// def decorator(cls):
+///     return cls
+/// ```
+///
+/// Explicit return annotations are trusted instead:
+/// ```python
+/// def decorator(cls) -> object:
+///     return object()
+/// ```
+///
+/// Callable instances and protocols delegate the decision to their `__call__` member, because the
+/// decorator value itself is not the function that receives the class.
 fn class_decorator_known_preservation<'db>(
     db: &'db dyn crate::Db,
     decorator_ty: Type<'db>,
@@ -157,6 +313,42 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         self.typevar_binding_context = previous_typevar_binding_context;
     }
 
+    /// Return true if an unknown class-decorator result should leave the current class type in
+    /// place.
+    ///
+    /// This handles both direct decorators and decorator factories:
+    /// ```python
+    /// def decorator(cls):
+    ///     return cls
+    ///
+    /// def decorator_factory():
+    ///     return decorator
+    ///
+    /// @decorator_factory()
+    /// class C: ...
+    /// ```
+    ///
+    /// The factory case needs the type of the call target, because the type of
+    /// `@decorator_factory()` is the returned decorator, while the expression type of
+    /// `decorator_factory` carries the static information that tells us whether an unknown result
+    /// can be preserved.
+    fn class_decorator_preserves_unknown_result(
+        &self,
+        decorator_ty: Type<'db>,
+        decorator: &ast::Decorator,
+        decorator_result_ty: Type<'db>,
+    ) -> bool {
+        let db = self.db();
+        is_unknown_decorator_result(db, decorator_result_ty)
+            && (can_preserve_unknown_class_decorator_result(db, decorator_ty)
+                || matches!(&decorator.expression, ast::Expr::Call(call) if {
+                    can_preserve_unknown_class_decorator_result(
+                        db,
+                        self.expression_type(&call.func),
+                    )
+                }))
+    }
+
     pub(super) fn infer_class_definition_statement(&mut self, class: &ast::StmtClassDef) {
         self.infer_definition(class);
     }
@@ -181,6 +373,22 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .iter()
             .map(|decorator| (self.infer_decorator(decorator), decorator))
             .collect();
+
+        let body_scope = self
+            .index
+            .node_scope(NodeWithScopeRef::Class(class_node))
+            .to_scope_id(db, self.file());
+
+        let maybe_known_class = KnownClass::try_from_file_and_name(db, self.file(), name);
+
+        let known_module = || file_to_module(db, self.file()).and_then(|module| module.known(db));
+        let in_typing_module = || {
+            matches!(
+                known_module(),
+                Some(KnownModule::Typing | KnownModule::TypingExtensions)
+            )
+        };
+
         let mut decorators_to_apply = Vec::with_capacity(decorator_types_and_nodes.len());
         let mut metadata_applies_to_original_class = true;
         let mut deprecated = None;
@@ -188,6 +396,32 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let mut dataclass_params = None;
         let mut dataclass_transformer_params = None;
         let mut total_ordering = false;
+        let original_class_ty = |deprecated,
+                                 type_check_only,
+                                 dataclass_params,
+                                 dataclass_transformer_params,
+                                 total_ordering| {
+            match (maybe_known_class, &*name.id) {
+                (None, "NamedTuple") if in_typing_module() => {
+                    Type::SpecialForm(SpecialFormType::NamedTuple)
+                }
+                (None, "Any") if in_typing_module() => Type::SpecialForm(SpecialFormType::Any),
+                (None, "InitVar") if known_module() == Some(KnownModule::Dataclasses) => {
+                    Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar))
+                }
+                _ => Type::from(StaticClassLiteral::new(
+                    db,
+                    name.id.clone(),
+                    body_scope,
+                    maybe_known_class,
+                    deprecated,
+                    type_check_only,
+                    dataclass_params,
+                    dataclass_transformer_params,
+                    total_ordering,
+                )),
+            }
+        };
         for &(decorator_ty, decorator) in decorator_types_and_nodes.iter().rev() {
             if metadata_applies_to_original_class {
                 if decorator_ty
@@ -254,7 +488,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     // We do not yet detect or flag `@dataclass_transform` applied to more than one
                     // overload, or an overload and the implementation both. Nevertheless, this is not
                     // allowed. We do not try to treat the offenders intelligently -- just use the
-                    // params of the last seen usage of `@dataclass_transform`
+                    // params of the last seen usage of `@dataclass_transform`.
+                    //
+                    // TODO: Decide whether a class decorator that carries
+                    // `@dataclass_transform` metadata and also declares a non-class return type
+                    // should replace the public binding or remain metadata-only in decorator
+                    // position.
                     let transformer_params = f
                         .iter_overloads_and_implementation(db)
                         .rev()
@@ -273,13 +512,24 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     continue;
                 }
 
-                let decorator_preserves_unknown_result =
-                    class_decorator_known_preservation(db, decorator_ty).unwrap_or(false)
-                        || matches!(&decorator.expression, ast::Expr::Call(call) if {
-                            class_decorator_known_preservation(db, self.expression_type(&call.func))
-                                .unwrap_or(false)
-                        });
-                if !decorator_preserves_unknown_result {
+                let current_original_class_ty = original_class_ty(
+                    deprecated,
+                    type_check_only,
+                    dataclass_params,
+                    dataclass_transformer_params,
+                    total_ordering,
+                );
+                let decorated_ty =
+                    class_decorator_return_type(db, decorator_ty, current_original_class_ty);
+                if !(self.class_decorator_preserves_unknown_result(
+                    decorator_ty,
+                    decorator,
+                    decorated_ty,
+                ) || class_decorator_preserves_class_metadata(
+                    db,
+                    current_original_class_ty,
+                    decorated_ty,
+                )) {
                     metadata_applies_to_original_class = false;
                 }
             }
@@ -287,45 +537,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             decorators_to_apply.push((decorator_ty, decorator));
         }
 
-        let body_scope = self
-            .index
-            .node_scope(NodeWithScopeRef::Class(class_node))
-            .to_scope_id(db, self.file());
-
-        let maybe_known_class = KnownClass::try_from_file_and_name(db, self.file(), name);
-
-        let known_module = || file_to_module(db, self.file()).and_then(|module| module.known(db));
-        let in_typing_module = || {
-            matches!(
-                known_module(),
-                Some(KnownModule::Typing | KnownModule::TypingExtensions)
-            )
-        };
-
-        let mut inferred_ty = match (maybe_known_class, &*name.id) {
-            (None, "NamedTuple") if in_typing_module() => {
-                Type::SpecialForm(SpecialFormType::NamedTuple)
-            }
-            (None, "Any") if in_typing_module() => Type::SpecialForm(SpecialFormType::Any),
-            (None, "InitVar") if known_module() == Some(KnownModule::Dataclasses) => {
-                Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar))
-            }
-            _ => Type::from(StaticClassLiteral::new(
-                db,
-                name.id.clone(),
-                body_scope,
-                maybe_known_class,
-                deprecated,
-                type_check_only,
-                dataclass_params,
-                dataclass_transformer_params,
-                total_ordering,
-            )),
-        };
+        let mut inferred_ty = original_class_ty(
+            deprecated,
+            type_check_only,
+            dataclass_params,
+            dataclass_transformer_params,
+            total_ordering,
+        );
 
         let original_class_ty = inferred_ty;
-        let mut class_ty_before_replacement = inferred_ty;
-        let mut replaces_class_binding = false;
+        let mut undecorated_ty = None;
         for (decorator_ty, decorator_node) in decorators_to_apply {
             let decorated_ty = match self.apply_decorator(decorator_ty, inferred_ty, decorator_node)
             {
@@ -334,35 +555,28 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             };
             // If a class decorator application loses all precision, preserve the original class
             // binding when the decorator is known to preserve unknown results.
-            let preserves_unknown_decorator_binding = is_unknown_decorator_result(db, decorated_ty)
-                && (can_preserve_unknown_class_decorator_result(db, decorator_ty)
-                    || matches!(&decorator_node.expression, ast::Expr::Call(call) if {
-                        can_preserve_unknown_class_decorator_result(
-                            db,
-                            self.expression_type(&call.func),
-                        )
-                    }));
+            let preserves_unknown_decorator_binding = self
+                .class_decorator_preserves_unknown_result(
+                    decorator_ty,
+                    decorator_node,
+                    decorated_ty,
+                );
             inferred_ty = if preserves_unknown_decorator_binding {
                 inferred_ty
             } else if class_decorator_preserves_class_binding(db, original_class_ty, decorated_ty) {
-                decorated_ty
-                    .as_class_literal()
-                    .map(Type::ClassLiteral)
-                    .unwrap_or(original_class_ty)
+                merge_class_preserving_decorator_result(
+                    db,
+                    original_class_ty,
+                    inferred_ty,
+                    decorated_ty,
+                )
             } else {
+                undecorated_ty.get_or_insert(inferred_ty);
                 decorated_ty
             };
-
-            if class_decorator_preserves_class_binding(db, original_class_ty, inferred_ty) {
-                class_ty_before_replacement = inferred_ty;
-            } else {
-                replaces_class_binding = true;
-            }
         }
 
-        if replaces_class_binding {
-            self.undecorated_type = Some(class_ty_before_replacement);
-        }
+        self.undecorated_type = undecorated_ty;
 
         self.add_declaration_with_binding(
             class_node.into(),
@@ -430,9 +644,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         if let Some(arguments) = class.arguments.as_deref()
             && let Some(extra_items_keyword) = arguments.find_keyword("extra_items")
         {
-            let class_type = infer_definition_types(self.db(), definition).binding_type(definition);
-            if let Type::ClassLiteral(class_literal) = class_type
-                && class_literal.is_typed_dict(self.db())
+            if original_class_type(self.db(), definition)
+                .is_some_and(|class_literal| class_literal.is_typed_dict(self.db()))
             {
                 self.infer_extra_items_kwarg(&extra_items_keyword.value);
             } else if self.in_stub() {

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -4,14 +4,12 @@ use crate::{
         CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
         SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
         call::CallError,
-        function::DataclassTransformerParams,
         function::KnownFunction,
         infer::{
             TypeInferenceBuilder,
             builder::{DeclaredAndInferredType, DeferredExpressionState},
             original_class_type,
         },
-        known_instance::DeprecatedInstance,
         signatures::ParameterForm,
         special_form::TypeQualifier,
     },
@@ -79,18 +77,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         } = class_node;
         let db = self.db();
 
-        let decorator_types_and_nodes: Vec<(
-            Type<'db>,
-            &ast::Decorator,
-            ClassDecoratorMetadataAction<'db>,
-        )> = decorator_list
+        let decorator_types_and_nodes: Vec<(Type<'db>, &ast::Decorator, bool)> = decorator_list
             .iter()
             .map(|decorator| {
                 let decorator_ty = self.infer_decorator(decorator);
                 (
                     decorator_ty,
                     decorator,
-                    self.class_decorator_metadata_action(decorator_ty, decorator),
+                    self.class_decorator_is_metadata_only(decorator_ty, decorator),
                 )
             })
             .collect();
@@ -112,7 +106,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let mut pending_metadata_decorators = decorator_types_and_nodes
             .iter()
-            .filter(|(_, _, action)| action.applies_to_original_class())
+            .filter(|(_, _, metadata_only)| *metadata_only)
             .count();
 
         let mut decorators_to_apply = Vec::with_capacity(decorator_types_and_nodes.len());
@@ -148,42 +142,99 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 )),
             }
         };
-        for &(decorator_ty, decorator, metadata_action) in decorator_types_and_nodes.iter().rev() {
-            if metadata_action.applies_to_original_class() {
+        for &(decorator_ty, decorator, metadata_only) in decorator_types_and_nodes.iter().rev() {
+            if metadata_only {
                 pending_metadata_decorators -= 1;
             }
 
             if metadata_applies_to_original_class {
-                match metadata_action {
-                    ClassDecoratorMetadataAction::None => {}
-                    ClassDecoratorMetadataAction::Dataclass(params) => {
-                        dataclass_params = Some(params);
+                if metadata_only {
+                    if decorator_ty
+                        .as_function_literal()
+                        .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
+                    {
+                        dataclass_params = Some(DataclassParams::default_params(db));
                         continue;
                     }
-                    ClassDecoratorMetadataAction::TotalOrdering => {
+
+                    if decorator_ty
+                        .as_function_literal()
+                        .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
+                    {
                         total_ordering = true;
                         continue;
                     }
-                    ClassDecoratorMetadataAction::Deprecated(deprecated_inst) => {
+
+                    if let Type::DataclassDecorator(params) = decorator_ty {
+                        dataclass_params = Some(params);
+                        continue;
+                    }
+
+                    if decorator_ty.is_unknown()
+                        && let ast::Expr::Call(call) = &decorator.expression
+                        && self
+                            .expression_type(&call.func)
+                            .as_function_literal()
+                            .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
+                    {
+                        continue;
+                    }
+
+                    if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) =
+                        decorator_ty
+                    {
                         deprecated = Some(deprecated_inst);
                         continue;
                     }
-                    ClassDecoratorMetadataAction::TypeCheckOnly => {
+
+                    if decorator_ty
+                        .as_function_literal()
+                        .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
+                    {
                         type_check_only = true;
                         continue;
                     }
-                    ClassDecoratorMetadataAction::DataclassTransform(transformer_params) => {
-                        dataclass_params = Some(DataclassParams::from_transformer_params(
-                            db,
-                            transformer_params,
-                        ));
+
+                    // Skip identity decorators to avoid salsa cycles on typeshed.
+                    if decorator_ty.as_function_literal().is_some_and(|function| {
+                        matches!(
+                            function.known(db),
+                            Some(
+                                KnownFunction::Final
+                                    | KnownFunction::DisjointBase
+                                    | KnownFunction::RuntimeCheckable
+                            )
+                        )
+                    }) {
                         continue;
                     }
-                    ClassDecoratorMetadataAction::DataclassTransformer(params) => {
+
+                    if let Type::FunctionLiteral(function) = decorator_ty {
+                        // We do not yet detect or flag `@dataclass_transform` applied to more than one
+                        // overload, or an overload and the implementation both. Nevertheless, this is not
+                        // allowed. We do not try to treat the offenders intelligently -- just use the
+                        // params of the last seen usage of `@dataclass_transform`.
+                        //
+                        // In class-decorator position, dataclass-transform metadata shapes the
+                        // original class object. We keep it metadata-only here because the call path
+                        // uses synthetic dataclass-transform return types to model decorator factories;
+                        // treating this as an ordinary replacement-returning class decorator would
+                        // conflate those two cases.
+                        let transformer_params = function
+                            .iter_overloads_and_implementation(db)
+                            .rev()
+                            .find_map(|overload| overload.dataclass_transformer_params(db));
+                        if let Some(transformer_params) = transformer_params {
+                            dataclass_params = Some(DataclassParams::from_transformer_params(
+                                db,
+                                transformer_params,
+                            ));
+                            continue;
+                        }
+                    }
+
+                    if let Type::DataclassTransformer(params) = decorator_ty {
                         dataclass_transformer_params = Some(params);
-                        continue;
-                    }
-                    ClassDecoratorMetadataAction::Skip => {
                         continue;
                     }
                 }
@@ -201,8 +252,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     total_ordering,
                 );
                 let decorator_result =
-                    ClassDecoratorApplication::apply(db, decorator_ty, current_original_class_ty);
-                let decorated_ty = decorator_result.return_type(db);
+                    apply_class_decorator(db, decorator_ty, current_original_class_ty);
+                let decorated_ty = match &decorator_result {
+                    Ok(return_ty) => *return_ty,
+                    Err(error) => error.return_type(db),
+                };
                 let decorated_ty_is_unknown = is_unknown_decorator_result(db, decorated_ty);
                 let metadata_still_applies_to_original_class = if decorated_ty_is_unknown {
                     let decorator_call_ty = match &decorator.expression {
@@ -239,14 +293,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let original_class_ty = inferred_ty;
         let mut undecorated_ty = None;
         for (decorator_ty, decorator_node, precomputed_result) in decorators_to_apply {
-            let decorated_ty = match precomputed_result {
+            let decorator_result = match precomputed_result {
                 Some((precomputed_input_ty, decorator_result))
                     if precomputed_input_ty == inferred_ty =>
                 {
-                    decorator_result.return_type_and_report_diagnostics(self, db, decorator_node)
+                    decorator_result
                 }
-                _ => ClassDecoratorApplication::apply(db, decorator_ty, inferred_ty)
-                    .return_type_and_report_diagnostics(self, db, decorator_node),
+                _ => apply_class_decorator(db, decorator_ty, inferred_ty),
+            };
+            let decorated_ty = match decorator_result {
+                Ok(return_ty) => return_ty,
+                Err(CallError(_, bindings)) => {
+                    bindings.report_diagnostics(&self.context, decorator_node.into());
+                    bindings.return_type(db)
+                }
             };
             let decorated_ty = match decorated_ty {
                 Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
@@ -365,29 +425,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
     }
 
-    fn class_decorator_metadata_action(
+    fn class_decorator_is_metadata_only(
         &self,
         decorator_ty: Type<'db>,
         decorator: &ast::Decorator,
-    ) -> ClassDecoratorMetadataAction<'db> {
+    ) -> bool {
         let db = self.db();
 
-        if decorator_ty
-            .as_function_literal()
-            .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
-        {
-            return ClassDecoratorMetadataAction::Dataclass(DataclassParams::default_params(db));
-        }
-
-        if decorator_ty
-            .as_function_literal()
-            .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
-        {
-            return ClassDecoratorMetadataAction::TotalOrdering;
-        }
-
-        if let Type::DataclassDecorator(params) = decorator_ty {
-            return ClassDecoratorMetadataAction::Dataclass(params);
+        if matches!(
+            decorator_ty,
+            Type::DataclassDecorator(_)
+                | Type::DataclassTransformer(_)
+                | Type::KnownInstance(KnownInstanceType::Deprecated(_))
+        ) {
+            return true;
         }
 
         if decorator_ty.is_unknown()
@@ -397,114 +448,47 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .as_function_literal()
                 .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
         {
-            return ClassDecoratorMetadataAction::Skip;
+            return true;
         }
 
-        if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) = decorator_ty {
-            return ClassDecoratorMetadataAction::Deprecated(deprecated_inst);
-        }
-
-        if decorator_ty
-            .as_function_literal()
-            .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
-        {
-            return ClassDecoratorMetadataAction::TypeCheckOnly;
-        }
-
-        // Skip identity decorators to avoid salsa cycles on typeshed.
         if decorator_ty.as_function_literal().is_some_and(|function| {
             matches!(
                 function.known(db),
                 Some(
-                    KnownFunction::Final
+                    KnownFunction::Dataclass
+                        | KnownFunction::TotalOrdering
+                        | KnownFunction::TypeCheckOnly
+                        | KnownFunction::Final
                         | KnownFunction::DisjointBase
                         | KnownFunction::RuntimeCheckable
                 )
             )
         }) {
-            return ClassDecoratorMetadataAction::Skip;
+            return true;
         }
 
-        if let Type::FunctionLiteral(function) = decorator_ty {
-            // We do not yet detect or flag `@dataclass_transform` applied to more than one
-            // overload, or an overload and the implementation both. Nevertheless, this is not
-            // allowed. We do not try to treat the offenders intelligently -- just use the
-            // params of the last seen usage of `@dataclass_transform`.
-            //
-            // In class-decorator position, dataclass-transform metadata shapes the original
-            // class object. We keep it metadata-only here because the call path uses synthetic
-            // dataclass-transform return types to model decorator factories; treating this as
-            // an ordinary replacement-returning class decorator would conflate those two cases.
-            if let Some(transformer_params) = function
+        if let Type::FunctionLiteral(function) = decorator_ty
+            && function
                 .iter_overloads_and_implementation(db)
                 .rev()
-                .find_map(|overload| overload.dataclass_transformer_params(db))
-            {
-                return ClassDecoratorMetadataAction::DataclassTransform(transformer_params);
-            }
+                .any(|overload| overload.dataclass_transformer_params(db).is_some())
+        {
+            return true;
         }
 
-        if let Type::DataclassTransformer(params) = decorator_ty {
-            return ClassDecoratorMetadataAction::DataclassTransformer(params);
-        }
-
-        ClassDecoratorMetadataAction::None
+        false
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-enum ClassDecoratorMetadataAction<'db> {
-    None,
-    Dataclass(DataclassParams<'db>),
-    TotalOrdering,
-    Deprecated(DeprecatedInstance<'db>),
-    TypeCheckOnly,
-    DataclassTransform(DataclassTransformerParams<'db>),
-    DataclassTransformer(DataclassTransformerParams<'db>),
-    Skip,
-}
-
-impl ClassDecoratorMetadataAction<'_> {
-    fn applies_to_original_class(self) -> bool {
-        !matches!(self, Self::None)
-    }
-}
-
-enum ClassDecoratorApplication<'db> {
-    Ok(Type<'db>),
-    Err(CallError<'db>),
-}
-
-impl<'db> ClassDecoratorApplication<'db> {
-    fn apply(db: &'db dyn crate::Db, decorator_ty: Type<'db>, decorated_ty: Type<'db>) -> Self {
-        let call_arguments = CallArguments::positional([decorated_ty]);
-        match decorator_ty.try_call(db, &call_arguments) {
-            Ok(bindings) => Self::Ok(bindings.return_type(db)),
-            Err(error) => Self::Err(error),
-        }
-    }
-
-    fn return_type(&self, db: &'db dyn crate::Db) -> Type<'db> {
-        match self {
-            Self::Ok(return_ty) => *return_ty,
-            Self::Err(error) => error.return_type(db),
-        }
-    }
-
-    fn return_type_and_report_diagnostics(
-        self,
-        builder: &mut TypeInferenceBuilder<'db, '_>,
-        db: &'db dyn crate::Db,
-        decorator_node: &ast::Decorator,
-    ) -> Type<'db> {
-        match self {
-            Self::Ok(return_ty) => return_ty,
-            Self::Err(CallError(_, bindings)) => {
-                bindings.report_diagnostics(&builder.context, decorator_node.into());
-                bindings.return_type(db)
-            }
-        }
-    }
+fn apply_class_decorator<'db>(
+    db: &'db dyn crate::Db,
+    decorator_ty: Type<'db>,
+    decorated_ty: Type<'db>,
+) -> Result<Type<'db>, CallError<'db>> {
+    let call_arguments = CallArguments::positional([decorated_ty]);
+    decorator_ty
+        .try_call(db, &call_arguments)
+        .map(|bindings| bindings.return_type(db))
 }
 
 /// Return true if a decorator result still binds the name to the original class.

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -646,6 +646,8 @@ impl ClassDecoratorUnknownResultPolicy {
                 Self::known_from_decorator(db, alias.value_type(db))
                     .unwrap_or(Self::ReplaceBinding),
             ),
+            // TODO: We preserve the class binding for every `Callable` decorator today. Figure out
+            // which of these cases should instead let an unknown decorator result replace it.
             Type::Callable(_) => Some(Self::PreserveBinding),
             _ => None,
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -229,16 +229,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 );
                 let decorated_ty =
                     class_decorator_return_type(db, decorator_ty, current_original_class_ty);
-                let decorator_call_ty = match &decorator.expression {
-                    ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
-                    _ => None,
-                };
-                let metadata_still_applies_to_original_class =
-                    if is_unknown_decorator_result(db, decorated_ty) {
-                        preserve_binding_for_unknown_result(db, decorator_ty, decorator_call_ty)
-                    } else {
-                        type_retains_original_class(db, current_original_class_ty, decorated_ty)
+                let decorated_ty_is_unknown = is_unknown_decorator_result(db, decorated_ty);
+                let metadata_still_applies_to_original_class = if decorated_ty_is_unknown {
+                    let decorator_call_ty = match &decorator.expression {
+                        ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
+                        _ => None,
                     };
+                    preserve_binding_for_unknown_result(db, decorator_ty, decorator_call_ty)
+                } else {
+                    type_retains_original_class(db, current_original_class_ty, decorated_ty)
+                };
                 if !metadata_still_applies_to_original_class {
                     metadata_applies_to_original_class = false;
                 }
@@ -265,12 +265,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             };
             // If a class decorator application loses all precision, preserve the original class
             // binding when the decorator is known to preserve unknown results.
-            let decorator_call_ty = match &decorator_node.expression {
-                ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
-                _ => None,
-            };
-            let should_preserve_binding = is_unknown_decorator_result(db, decorated_ty)
-                && preserve_binding_for_unknown_result(db, decorator_ty, decorator_call_ty);
+            let decorated_ty_is_unknown = is_unknown_decorator_result(db, decorated_ty);
+            let should_preserve_binding = decorated_ty_is_unknown
+                && preserve_binding_for_unknown_result(
+                    db,
+                    decorator_ty,
+                    match &decorator_node.expression {
+                        ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
+                        _ => None,
+                    },
+                );
             inferred_ty = if should_preserve_binding {
                 inferred_ty
             } else if class_decorator_preserves_class_binding(db, original_class_ty, decorated_ty) {
@@ -519,20 +523,13 @@ impl ClassDecoratorUnknownResultPolicy {
     ///
     /// Unannotated function and method decorators are treated as class-preserving when their
     /// application result is unknown. Explicit return annotations are trusted as replacement
-    /// intent. For opaque callable types, we preserve the binding only because the decorator
-    /// application already failed to produce a more precise replacement type.
+    /// intent.
     fn from_decorator<'db>(db: &'db dyn crate::Db, decorator_ty: Type<'db>) -> Self {
         if decorator_ty.is_unknown() {
             return Self::ReplaceBinding;
         }
 
-        Self::known_from_decorator(db, decorator_ty).unwrap_or_else(|| {
-            if decorator_ty.try_upcast_to_callable(db).is_some() {
-                Self::PreserveBinding
-            } else {
-                Self::ReplaceBinding
-            }
-        })
+        Self::known_from_decorator(db, decorator_ty).unwrap_or(Self::ReplaceBinding)
     }
 
     /// Return the known preservation policy for a class decorator, if one can be read statically.
@@ -598,12 +595,7 @@ impl ClassDecoratorUnknownResultPolicy {
                 Self::known_from_decorator(db, alias.value_type(db))
                     .unwrap_or(Self::ReplaceBinding),
             ),
-            Type::Callable(_) => {
-                // A `Callable` type is already a static callable interface. If applying it still
-                // produces an unknown result, we do not have a trustworthy replacement type, so we
-                // preserve the current class binding.
-                Some(Self::PreserveBinding)
-            }
+            Type::Callable(_) => Some(Self::PreserveBinding),
             _ => None,
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -56,172 +56,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         self.typevar_binding_context = previous_typevar_binding_context;
     }
 
-    /// Return true if an unknown class-decorator result should leave the current class type in
-    /// place.
-    ///
-    /// This handles both direct decorators and decorator factories:
-    /// ```python
-    /// def decorator(cls):
-    ///     return cls
-    ///
-    /// def decorator_factory():
-    ///     return decorator
-    ///
-    /// @decorator_factory()
-    /// class C: ...
-    /// ```
-    ///
-    /// The factory case needs the type of the call target, because the type of
-    /// `@decorator_factory()` is the returned decorator, while the expression type of
-    /// `decorator_factory` carries the static information that tells us whether an unknown result
-    /// can be preserved.
-
-    // TODO(charlie): This should just be a free function
-    fn class_decorator_preserves_unknown_result(
-        &self,
-        decorator_ty: Type<'db>,
-        decorator: &ast::Decorator,
-        decorated_ty: Type<'db>,
-    ) -> bool {
-
-        // TODO(charlie): Use an enum rather than a bool, make class_decorator_known_preservation
-        // a method (from_decorator).
-        #[derive(Debug, Copy, Clone)]
-        enum PreservationPolicy {
-            IdentityPreserving,
-
-        }
-
-        impl PreservationPolicy {
-            fn from_decorator<'db>(    db: &'db dyn crate::Db,
-                                       decorator_ty: Type<'db>) -> Option<PreservationPolicy> {
-
-            }
-        }
-
-        /// Return the known preservation policy for a class decorator, if one can be read statically.
-        ///
-        /// For unknown decorator results, unannotated functions are treated as likely identity-preserving:
-        /// ```python
-        /// def decorator(cls):
-        ///     return cls
-        /// ```
-        ///
-        /// Explicit return annotations are trusted instead:
-        /// ```python
-        /// def decorator(cls) -> object:
-        ///     return object()
-        /// ```
-        ///
-        /// Callable instances and protocols delegate the decision to their `__call__` member, because the
-        /// decorator value itself is not the function that receives the class.
-        fn class_decorator_known_preservation<'db>(
-            db: &'db dyn crate::Db,
-            decorator_ty: Type<'db>,
-        ) -> Option<bool> {
-            match decorator_ty {
-                Type::FunctionLiteral(function) => Some(!function.has_explicit_return_annotation(db)),
-                Type::BoundMethod(method) => Some(!method.function(db).has_explicit_return_annotation(db)),
-                Type::NominalInstance(_) | Type::ProtocolInstance(_) => {
-                    let call_symbol = decorator_ty
-                        .member_lookup_with_policy(
-                            db,
-                            Name::new_static("__call__"),
-                            MemberLookupPolicy::NO_INSTANCE_FALLBACK,
-                        )
-                        .place;
-
-                    if let Place::Defined(place) = call_symbol
-                        && place.is_definitely_defined()
-                    {
-                        Some(class_decorator_known_preservation(db, place.ty).unwrap_or(false))
-                    } else {
-                        Some(false)
-                    }
-                }
-                Type::Union(union) => Some(
-                    union
-                        .elements(db)
-                        .iter()
-                        .all(|element| class_decorator_known_preservation(db, *element).unwrap_or(false)),
-                ),
-                Type::TypeAlias(alias) => {
-                    Some(class_decorator_known_preservation(db, alias.value_type(db)).unwrap_or(false))
-                }
-                // TODO(charlie): Why is this true...?
-                Type::Callable(_) => Some(true),
-                _ => None,
-            }
-        }
-
-        /// Return true if an unknown class-decorator result should preserve the decorated class binding.
-        ///
-        /// Untyped decorators often infer an unknown return type even when they are identity decorators:
-        /// ```python
-        /// def decorator(cls):
-        ///     return cls
-        ///
-        /// @decorator
-        /// class C: ...
-        /// ```
-        ///
-        /// In that case, keeping `C` bound to the original class is usually more useful than replacing it
-        /// with `Unknown`. This helper decides when that recovery is justified from the decorator type
-        /// itself, rather than from the unknown result.
-
-        // TODO(charlie): Then, maybe we can get rid of this?
-        fn can_preserve_unknown_class_decorator_result<'db>(
-            db: &'db dyn crate::Db,
-            decorator_ty: Type<'db>,
-        ) -> bool {
-            if decorator_ty.is_unknown() {
-                return false;
-            }
-
-            class_decorator_known_preservation(db, decorator_ty)
-                .unwrap_or_else(|| decorator_ty.try_upcast_to_callable(db).is_some())
-        }
-
-        /// Return true if applying a class decorator produced no useful replacement type.
-        ///
-        /// Besides plain `Unknown`, class decorators can produce unknown class-object types such as
-        /// `type[Any]`. Those are represented as a `SubclassOf` dynamic type, but they should trigger the
-        /// same preservation fallback as an unknown result:
-        /// ```python
-        /// from typing import Any
-        ///
-        /// def decorator(cls) -> type[Any]: ...
-        ///
-        /// @decorator
-        /// class C: ...
-        /// ```
-        fn is_unknown_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bool {
-            if ty.is_unknown() {
-                return true;
-            }
-
-            let Type::SubclassOf(subclass_of) = ty.resolve_type_alias(db) else {
-                return false;
-            };
-
-            subclass_of
-                .subclass_of()
-                .into_dynamic()
-                .is_some_and(|dynamic| Type::Dynamic(dynamic).is_unknown())
-        }
-
-
-        let db = self.db();
-        is_unknown_decorator_result(db, decorated_ty)
-            && (can_preserve_unknown_class_decorator_result(db, decorator_ty)
-                || matches!(&decorator.expression, ast::Expr::Call(call) if {
-                    can_preserve_unknown_class_decorator_result(
-                        db,
-                        self.expression_type(&call.func),
-                    )
-                }))
-    }
-
     pub(super) fn infer_class_definition_statement(&mut self, class: &ast::StmtClassDef) {
         self.infer_definition(class);
     }
@@ -363,10 +197,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     // allowed. We do not try to treat the offenders intelligently -- just use the
                     // params of the last seen usage of `@dataclass_transform`.
                     //
-                    // TODO: Decide whether a class decorator that carries
-                    // `@dataclass_transform` metadata and also declares a non-class return type
-                    // should replace the public binding or remain metadata-only in decorator
-                    // position.
+                    // In class-decorator position, dataclass-transform metadata shapes the
+                    // original class object. We keep it metadata-only here because the call path
+                    // uses synthetic dataclass-transform return types to model decorator factories;
+                    // treating this as an ordinary replacement-returning class decorator would
+                    // conflate those two cases.
                     let transformer_params = f
                         .iter_overloads_and_implementation(db)
                         .rev()
@@ -394,15 +229,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 );
                 let decorated_ty =
                     class_decorator_return_type(db, decorator_ty, current_original_class_ty);
-                if !(self.class_decorator_preserves_unknown_result(
-                    decorator_ty,
-                    decorator,
-                    decorated_ty,
-                ) || class_binding_retains_original_class(
-                    db,
-                    current_original_class_ty,
-                    decorated_ty,
-                )) {
+                let decorator_call_ty = match &decorator.expression {
+                    ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
+                    _ => None,
+                };
+                let metadata_still_applies_to_original_class =
+                    if is_unknown_decorator_result(db, decorated_ty) {
+                        preserve_binding_for_unknown_result(db, decorator_ty, decorator_call_ty)
+                    } else {
+                        type_retains_original_class(db, current_original_class_ty, decorated_ty)
+                    };
+                if !metadata_still_applies_to_original_class {
                     metadata_applies_to_original_class = false;
                 }
             }
@@ -428,13 +265,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             };
             // If a class decorator application loses all precision, preserve the original class
             // binding when the decorator is known to preserve unknown results.
-            let preserves_unknown_decorator_binding = self
-                .class_decorator_preserves_unknown_result(
-                    decorator_ty,
-                    decorator_node,
-                    decorated_ty,
-                );
-            inferred_ty = if preserves_unknown_decorator_binding {
+            let decorator_call_ty = match &decorator_node.expression {
+                ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
+                _ => None,
+            };
+            let should_preserve_binding = is_unknown_decorator_result(db, decorated_ty)
+                && preserve_binding_for_unknown_result(db, decorator_ty, decorator_call_ty);
+            inferred_ty = if should_preserve_binding {
                 inferred_ty
             } else if class_decorator_preserves_class_binding(db, original_class_ty, decorated_ty) {
                 merge_class_preserving_decorator_result(
@@ -583,7 +420,7 @@ fn class_decorator_preserves_class_binding<'db>(
 
 /// Return true if a type still contains the original class object, even if it also carries extra
 /// intersection members.
-fn class_binding_retains_original_class<'db>(
+fn type_retains_original_class<'db>(
     db: &'db dyn crate::Db,
     original_class: Type<'db>,
     decorated_class: Type<'db>,
@@ -592,15 +429,183 @@ fn class_binding_retains_original_class<'db>(
         Type::Intersection(intersection) => intersection
             .positive(db)
             .iter()
-            .any(|element| class_binding_retains_original_class(db, original_class, *element)),
+            .any(|element| type_retains_original_class(db, original_class, *element)),
         Type::Union(union) => union
             .elements(db)
             .iter()
-            .all(|element| class_binding_retains_original_class(db, original_class, *element)),
+            .all(|element| type_retains_original_class(db, original_class, *element)),
         Type::TypeAlias(alias) => {
-            class_binding_retains_original_class(db, original_class, alias.value_type(db))
+            type_retains_original_class(db, original_class, alias.value_type(db))
         }
         _ => class_decorator_preserves_class_binding(db, original_class, decorated_class),
+    }
+}
+
+/// Return true if an unknown class-decorator result should leave the current class type in place.
+///
+/// This handles both direct decorators and decorator factories:
+/// ```python
+/// def decorator(cls):
+///     return cls
+///
+/// def decorator_factory():
+///     return decorator
+///
+/// @decorator_factory()
+/// class C: ...
+/// ```
+///
+/// The factory case needs the type of the call target, because the type of
+/// `@decorator_factory()` is the returned decorator, while the expression type of
+/// `decorator_factory` carries the static information that tells us whether an unknown result can
+/// be preserved.
+fn preserve_binding_for_unknown_result<'db>(
+    db: &'db dyn crate::Db,
+    decorator_ty: Type<'db>,
+    decorator_call_ty: Option<Type<'db>>,
+) -> bool {
+    ClassDecoratorUnknownResultPolicy::from_decorator(db, decorator_ty)
+        == ClassDecoratorUnknownResultPolicy::PreserveBinding
+        || decorator_call_ty.is_some_and(|ty| {
+            ClassDecoratorUnknownResultPolicy::from_decorator(db, ty)
+                == ClassDecoratorUnknownResultPolicy::PreserveBinding
+        })
+}
+
+/// Return true if applying a class decorator produced no useful replacement type.
+///
+/// Besides plain `Unknown`, class decorators can produce unknown class-object types such as
+/// `type[Any]`. Those are represented as a `SubclassOf` dynamic type, but they should trigger the
+/// same preservation fallback as an unknown result:
+/// ```python
+/// from typing import Any
+///
+/// def decorator(cls) -> type[Any]: ...
+///
+/// @decorator
+/// class C: ...
+/// ```
+fn is_unknown_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bool {
+    if ty.is_unknown() {
+        return true;
+    }
+
+    let Type::SubclassOf(subclass_of) = ty.resolve_type_alias(db) else {
+        return false;
+    };
+
+    subclass_of
+        .subclass_of()
+        .into_dynamic()
+        .is_some_and(|dynamic| Type::Dynamic(dynamic).is_unknown())
+}
+
+/// Policy for class decorators whose application result is unknown.
+///
+/// This is only consulted after applying the decorator produced no useful replacement type. If the
+/// decorator itself statically suggests an unannotated identity-preserving shape, we keep the
+/// current class binding; if it explicitly promises a replacement type, or if the decorator is
+/// unknown, we let the unknown result replace the binding.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum ClassDecoratorUnknownResultPolicy {
+    /// Preserve the current class binding when the decorator result is unknown.
+    PreserveBinding,
+    /// Use the unknown decorator result as the public binding.
+    ReplaceBinding,
+}
+
+impl ClassDecoratorUnknownResultPolicy {
+    /// Infer the unknown-result policy from the decorator's own type.
+    ///
+    /// Unannotated function and method decorators are treated as class-preserving when their
+    /// application result is unknown. Explicit return annotations are trusted as replacement
+    /// intent. For opaque callable types, we preserve the binding only because the decorator
+    /// application already failed to produce a more precise replacement type.
+    fn from_decorator<'db>(db: &'db dyn crate::Db, decorator_ty: Type<'db>) -> Self {
+        if decorator_ty.is_unknown() {
+            return Self::ReplaceBinding;
+        }
+
+        Self::known_from_decorator(db, decorator_ty).unwrap_or_else(|| {
+            if decorator_ty.try_upcast_to_callable(db).is_some() {
+                Self::PreserveBinding
+            } else {
+                Self::ReplaceBinding
+            }
+        })
+    }
+
+    /// Return the known preservation policy for a class decorator, if one can be read statically.
+    ///
+    /// For unknown decorator results, unannotated functions are treated as likely
+    /// identity-preserving:
+    /// ```python
+    /// def decorator(cls):
+    ///     return cls
+    /// ```
+    ///
+    /// Explicit return annotations are trusted instead:
+    /// ```python
+    /// def decorator(cls) -> object:
+    ///     return object()
+    /// ```
+    ///
+    /// Callable instances and protocols delegate the decision to their `__call__` member, because
+    /// the decorator value itself is not the function that receives the class.
+    fn known_from_decorator<'db>(db: &'db dyn crate::Db, decorator_ty: Type<'db>) -> Option<Self> {
+        match decorator_ty {
+            Type::FunctionLiteral(function) => {
+                Some(if function.has_explicit_return_annotation(db) {
+                    Self::ReplaceBinding
+                } else {
+                    Self::PreserveBinding
+                })
+            }
+            Type::BoundMethod(method) => {
+                Some(if method.function(db).has_explicit_return_annotation(db) {
+                    Self::ReplaceBinding
+                } else {
+                    Self::PreserveBinding
+                })
+            }
+            Type::NominalInstance(_) | Type::ProtocolInstance(_) => {
+                let call_symbol = decorator_ty
+                    .member_lookup_with_policy(
+                        db,
+                        Name::new_static("__call__"),
+                        MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                    )
+                    .place;
+
+                if let Place::Defined(place) = call_symbol
+                    && place.is_definitely_defined()
+                {
+                    Some(Self::known_from_decorator(db, place.ty).unwrap_or(Self::ReplaceBinding))
+                } else {
+                    Some(Self::ReplaceBinding)
+                }
+            }
+            Type::Union(union) => Some(
+                if union.elements(db).iter().all(|element| {
+                    Self::known_from_decorator(db, *element) == Some(Self::PreserveBinding)
+                }) {
+                    Self::PreserveBinding
+                } else {
+                    Self::ReplaceBinding
+                },
+            ),
+            Type::TypeAlias(alias) => Some(
+                Self::known_from_decorator(db, alias.value_type(db))
+                    .unwrap_or(Self::ReplaceBinding),
+            ),
+            Type::Callable(_) => {
+                // A `Callable` type is already a static callable interface. If applying it still
+                // produces an unknown result, we do not have a trustworthy replacement type, so we
+                // preserve the current class binding.
+                Some(Self::PreserveBinding)
+            }
+            _ => None,
+        }
     }
 }
 
@@ -615,7 +620,7 @@ fn merge_class_preserving_decorator_result<'db>(
     current_binding: Type<'db>,
     decorated_binding: Type<'db>,
 ) -> Type<'db> {
-    if class_binding_retains_original_class(db, original_class, current_binding) {
+    if type_retains_original_class(db, original_class, current_binding) {
         current_binding
     } else {
         decorated_binding

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -17,263 +17,6 @@ use ruff_python_ast::{self as ast, helpers::any_over_expr, name::Name};
 use ty_module_resolver::{KnownModule, file_to_module};
 use ty_python_core::{definition::Definition, scope::NodeWithScopeRef};
 
-/// Return true if a decorator result still binds the name to the original class.
-///
-/// For example, an identity decorator keeps the public name bound to the same class:
-/// ```python
-/// def identity[T](cls: type[T]) -> type[T]:
-///     return cls
-///
-/// @identity
-/// class C: ...
-/// ```
-///
-/// This also accepts metaclass-shaped results such as `type[C]`, because those still describe the
-/// original class object even if the decorator call produced a `SubclassOf` type internally.
-fn class_decorator_preserves_class_binding<'db>(
-    db: &'db dyn crate::Db,
-    original_class: Type<'db>,
-    decorated_class: Type<'db>,
-) -> bool {
-    let Type::ClassLiteral(original_literal) = original_class else {
-        return false;
-    };
-
-    match decorated_class {
-        Type::ClassLiteral(decorated_literal) => {
-            let decorated_definition = decorated_literal.definition(db);
-            decorated_literal == original_literal
-                || decorated_definition.is_some()
-                    && decorated_definition == original_literal.definition(db)
-        }
-        Type::SubclassOf(subclass_of) => subclass_of
-            .subclass_of()
-            .into_class(db)
-            .is_some_and(|class| class == original_literal.default_specialization(db)),
-        Type::Divergent(_) => true,
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .all(|element| class_decorator_preserves_class_binding(db, original_class, *element)),
-        Type::TypeAlias(alias) => {
-            class_decorator_preserves_class_binding(db, original_class, alias.value_type(db))
-        }
-        _ => SubclassOfType::try_from_type(db, original_class).is_some_and(|original_meta_type| {
-            decorated_class.is_equivalent_to(db, original_meta_type)
-        }),
-    }
-}
-
-/// Return true if a type still contains the original class object, even if it also carries extra
-/// intersection members.
-fn class_binding_retains_original_class<'db>(
-    db: &'db dyn crate::Db,
-    original_class: Type<'db>,
-    decorated_class: Type<'db>,
-) -> bool {
-    match decorated_class {
-        Type::Intersection(intersection) => intersection
-            .positive(db)
-            .iter()
-            .any(|element| class_binding_retains_original_class(db, original_class, *element)),
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .all(|element| class_binding_retains_original_class(db, original_class, *element)),
-        Type::TypeAlias(alias) => {
-            class_binding_retains_original_class(db, original_class, alias.value_type(db))
-        }
-        _ => class_decorator_preserves_class_binding(db, original_class, decorated_class),
-    }
-}
-
-/// Return true if metadata decorators stacked above this decorator should still apply to the
-/// original class object.
-///
-/// Metadata decorators such as `@dataclass` should keep shaping the original class when an inner
-/// decorator preserves that class:
-/// ```python
-/// from dataclasses import dataclass
-///
-/// def identity[T](cls: type[T]) -> type[T]:
-///     return cls
-///
-/// @dataclass
-/// @identity
-/// class C:
-///     x: int
-/// ```
-///
-/// If the inner decorator returns an unrelated value, the outer metadata decorator applies to that
-/// replacement instead, so we must not record dataclass metadata on the original class.
-fn class_decorator_preserves_class_metadata<'db>(
-    db: &'db dyn crate::Db,
-    original_class: Type<'db>,
-    decorated_class: Type<'db>,
-) -> bool {
-    class_binding_retains_original_class(db, original_class, decorated_class)
-}
-
-/// Merge a class-preserving decorator result into the public binding.
-///
-/// If earlier decorators already exposed extra members through an intersection, keep those
-/// members instead of collapsing back to the undecorated class when a later decorator simply
-/// returns the original class object again.
-fn merge_class_preserving_decorator_result<'db>(
-    db: &'db dyn crate::Db,
-    original_class: Type<'db>,
-    current_binding: Type<'db>,
-    decorated_binding: Type<'db>,
-) -> Type<'db> {
-    if class_binding_retains_original_class(db, original_class, current_binding) {
-        current_binding
-    } else {
-        decorated_binding
-            .as_class_literal()
-            .map(Type::ClassLiteral)
-            .unwrap_or(original_class)
-    }
-}
-
-/// Return true if an unknown class-decorator result should preserve the decorated class binding.
-///
-/// Untyped decorators often infer an unknown return type even when they are identity decorators:
-/// ```python
-/// def decorator(cls):
-///     return cls
-///
-/// @decorator
-/// class C: ...
-/// ```
-///
-/// In that case, keeping `C` bound to the original class is usually more useful than replacing it
-/// with `Unknown`. This helper decides when that recovery is justified from the decorator type
-/// itself, rather than from the unknown result.
-fn can_preserve_unknown_class_decorator_result<'db>(
-    db: &'db dyn crate::Db,
-    decorator_ty: Type<'db>,
-) -> bool {
-    if decorator_ty.is_unknown() {
-        return false;
-    }
-
-    class_decorator_known_preservation(db, decorator_ty)
-        .unwrap_or_else(|| decorator_ty.try_upcast_to_callable(db).is_some())
-}
-
-/// Return true if applying a class decorator produced no useful replacement type.
-///
-/// Besides plain `Unknown`, class decorators can produce unknown class-object types such as
-/// `type[Any]`. Those are represented as a `SubclassOf` dynamic type, but they should trigger the
-/// same preservation fallback as an unknown result:
-/// ```python
-/// from typing import Any
-///
-/// def decorator(cls) -> type[Any]: ...
-///
-/// @decorator
-/// class C: ...
-/// ```
-fn is_unknown_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bool {
-    if ty.is_unknown() {
-        return true;
-    }
-
-    let Type::SubclassOf(subclass_of) = ty.resolve_type_alias(db) else {
-        return false;
-    };
-
-    subclass_of
-        .subclass_of()
-        .into_dynamic()
-        .is_some_and(|dynamic| Type::Dynamic(dynamic).is_unknown())
-}
-
-/// Return the value type produced by applying a class decorator.
-///
-/// Synthetic dataclass-transform marker types are metadata for class construction, not real values
-/// that should replace the class binding. For example, the result of calling `model` should not be
-/// recorded as the public type of `C` merely because `model` carries dataclass-transform metadata:
-/// ```python
-/// from typing import dataclass_transform
-///
-/// @dataclass_transform()
-/// def model(cls): ...
-///
-/// @model
-/// class C: ...
-/// ```
-fn class_decorator_return_type<'db>(
-    db: &'db dyn crate::Db,
-    decorator_ty: Type<'db>,
-    decorated_ty: Type<'db>,
-) -> Type<'db> {
-    let call_arguments = CallArguments::positional([decorated_ty]);
-    let return_ty = decorator_ty.try_call(db, &call_arguments).map_or_else(
-        |error| error.return_type(db),
-        |bindings| bindings.return_type(db),
-    );
-
-    match return_ty {
-        Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
-        return_ty => return_ty,
-    }
-}
-
-/// Return the known preservation policy for a class decorator, if one can be read statically.
-///
-/// For unknown decorator results, unannotated functions are treated as likely identity-preserving:
-/// ```python
-/// def decorator(cls):
-///     return cls
-/// ```
-///
-/// Explicit return annotations are trusted instead:
-/// ```python
-/// def decorator(cls) -> object:
-///     return object()
-/// ```
-///
-/// Callable instances and protocols delegate the decision to their `__call__` member, because the
-/// decorator value itself is not the function that receives the class.
-fn class_decorator_known_preservation<'db>(
-    db: &'db dyn crate::Db,
-    decorator_ty: Type<'db>,
-) -> Option<bool> {
-    match decorator_ty {
-        Type::FunctionLiteral(function) => Some(!function.has_explicit_return_annotation(db)),
-        Type::BoundMethod(method) => Some(!method.function(db).has_explicit_return_annotation(db)),
-        Type::NominalInstance(_) | Type::ProtocolInstance(_) => {
-            let call_symbol = decorator_ty
-                .member_lookup_with_policy(
-                    db,
-                    Name::new_static("__call__"),
-                    MemberLookupPolicy::NO_INSTANCE_FALLBACK,
-                )
-                .place;
-
-            if let Place::Defined(place) = call_symbol
-                && place.is_definitely_defined()
-            {
-                Some(class_decorator_known_preservation(db, place.ty).unwrap_or(false))
-            } else {
-                Some(false)
-            }
-        }
-        Type::Union(union) => Some(
-            union
-                .elements(db)
-                .iter()
-                .all(|element| class_decorator_known_preservation(db, *element).unwrap_or(false)),
-        ),
-        Type::TypeAlias(alias) => {
-            Some(class_decorator_known_preservation(db, alias.value_type(db)).unwrap_or(false))
-        }
-        Type::Callable(_) => Some(true),
-        _ => None,
-    }
-}
-
 impl<'db> TypeInferenceBuilder<'db, '_> {
     pub(super) fn infer_class_body(&mut self, class: &ast::StmtClassDef) {
         self.infer_body(&class.body);
@@ -332,14 +75,144 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// `@decorator_factory()` is the returned decorator, while the expression type of
     /// `decorator_factory` carries the static information that tells us whether an unknown result
     /// can be preserved.
+
+    // TODO(charlie): This should just be a free function
     fn class_decorator_preserves_unknown_result(
         &self,
         decorator_ty: Type<'db>,
         decorator: &ast::Decorator,
-        decorator_result_ty: Type<'db>,
+        decorated_ty: Type<'db>,
     ) -> bool {
+
+        // TODO(charlie): Use an enum rather than a bool, make class_decorator_known_preservation
+        // a method (from_decorator).
+        #[derive(Debug, Copy, Clone)]
+        enum PreservationPolicy {
+            IdentityPreserving,
+
+        }
+
+        impl PreservationPolicy {
+            fn from_decorator<'db>(    db: &'db dyn crate::Db,
+                                       decorator_ty: Type<'db>) -> Option<PreservationPolicy> {
+
+            }
+        }
+
+        /// Return the known preservation policy for a class decorator, if one can be read statically.
+        ///
+        /// For unknown decorator results, unannotated functions are treated as likely identity-preserving:
+        /// ```python
+        /// def decorator(cls):
+        ///     return cls
+        /// ```
+        ///
+        /// Explicit return annotations are trusted instead:
+        /// ```python
+        /// def decorator(cls) -> object:
+        ///     return object()
+        /// ```
+        ///
+        /// Callable instances and protocols delegate the decision to their `__call__` member, because the
+        /// decorator value itself is not the function that receives the class.
+        fn class_decorator_known_preservation<'db>(
+            db: &'db dyn crate::Db,
+            decorator_ty: Type<'db>,
+        ) -> Option<bool> {
+            match decorator_ty {
+                Type::FunctionLiteral(function) => Some(!function.has_explicit_return_annotation(db)),
+                Type::BoundMethod(method) => Some(!method.function(db).has_explicit_return_annotation(db)),
+                Type::NominalInstance(_) | Type::ProtocolInstance(_) => {
+                    let call_symbol = decorator_ty
+                        .member_lookup_with_policy(
+                            db,
+                            Name::new_static("__call__"),
+                            MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                        )
+                        .place;
+
+                    if let Place::Defined(place) = call_symbol
+                        && place.is_definitely_defined()
+                    {
+                        Some(class_decorator_known_preservation(db, place.ty).unwrap_or(false))
+                    } else {
+                        Some(false)
+                    }
+                }
+                Type::Union(union) => Some(
+                    union
+                        .elements(db)
+                        .iter()
+                        .all(|element| class_decorator_known_preservation(db, *element).unwrap_or(false)),
+                ),
+                Type::TypeAlias(alias) => {
+                    Some(class_decorator_known_preservation(db, alias.value_type(db)).unwrap_or(false))
+                }
+                // TODO(charlie): Why is this true...?
+                Type::Callable(_) => Some(true),
+                _ => None,
+            }
+        }
+
+        /// Return true if an unknown class-decorator result should preserve the decorated class binding.
+        ///
+        /// Untyped decorators often infer an unknown return type even when they are identity decorators:
+        /// ```python
+        /// def decorator(cls):
+        ///     return cls
+        ///
+        /// @decorator
+        /// class C: ...
+        /// ```
+        ///
+        /// In that case, keeping `C` bound to the original class is usually more useful than replacing it
+        /// with `Unknown`. This helper decides when that recovery is justified from the decorator type
+        /// itself, rather than from the unknown result.
+
+        // TODO(charlie): Then, maybe we can get rid of this?
+        fn can_preserve_unknown_class_decorator_result<'db>(
+            db: &'db dyn crate::Db,
+            decorator_ty: Type<'db>,
+        ) -> bool {
+            if decorator_ty.is_unknown() {
+                return false;
+            }
+
+            class_decorator_known_preservation(db, decorator_ty)
+                .unwrap_or_else(|| decorator_ty.try_upcast_to_callable(db).is_some())
+        }
+
+        /// Return true if applying a class decorator produced no useful replacement type.
+        ///
+        /// Besides plain `Unknown`, class decorators can produce unknown class-object types such as
+        /// `type[Any]`. Those are represented as a `SubclassOf` dynamic type, but they should trigger the
+        /// same preservation fallback as an unknown result:
+        /// ```python
+        /// from typing import Any
+        ///
+        /// def decorator(cls) -> type[Any]: ...
+        ///
+        /// @decorator
+        /// class C: ...
+        /// ```
+        fn is_unknown_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bool {
+            if ty.is_unknown() {
+                return true;
+            }
+
+            let Type::SubclassOf(subclass_of) = ty.resolve_type_alias(db) else {
+                return false;
+            };
+
+            subclass_of
+                .subclass_of()
+                .into_dynamic()
+                .is_some_and(|dynamic| Type::Dynamic(dynamic).is_unknown())
+        }
+
+
         let db = self.db();
-        is_unknown_decorator_result(db, decorator_result_ty)
+        is_unknown_decorator_result(db, decorated_ty)
             && (can_preserve_unknown_class_decorator_result(db, decorator_ty)
                 || matches!(&decorator.expression, ast::Expr::Call(call) if {
                     can_preserve_unknown_class_decorator_result(
@@ -525,7 +398,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     decorator_ty,
                     decorator,
                     decorated_ty,
-                ) || class_decorator_preserves_class_metadata(
+                ) || class_binding_retains_original_class(
                     db,
                     current_original_class_ty,
                     decorated_ty,
@@ -658,5 +531,127 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.infer_expression(&extra_items_keyword.value, TypeContext::default());
             }
         }
+    }
+}
+
+/// Return true if a decorator result still binds the name to the original class.
+///
+/// For example, an identity decorator keeps the public name bound to the same class:
+/// ```python
+/// def identity[T](cls: type[T]) -> type[T]:
+///     return cls
+///
+/// @identity
+/// class C: ...
+/// ```
+///
+/// This also accepts metaclass-shaped results such as `type[C]`, because those still describe the
+/// original class object even if the decorator call produced a `SubclassOf` type internally.
+fn class_decorator_preserves_class_binding<'db>(
+    db: &'db dyn crate::Db,
+    original_class: Type<'db>,
+    decorated_class: Type<'db>,
+) -> bool {
+    let Type::ClassLiteral(original_literal) = original_class else {
+        return false;
+    };
+
+    match decorated_class {
+        Type::ClassLiteral(decorated_literal) => {
+            let decorated_definition = decorated_literal.definition(db);
+            decorated_literal == original_literal
+                || decorated_definition.is_some()
+                    && decorated_definition == original_literal.definition(db)
+        }
+        Type::SubclassOf(subclass_of) => subclass_of
+            .subclass_of()
+            .into_class(db)
+            .is_some_and(|class| class == original_literal.default_specialization(db)),
+        Type::Divergent(_) => true,
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| class_decorator_preserves_class_binding(db, original_class, *element)),
+        Type::TypeAlias(alias) => {
+            class_decorator_preserves_class_binding(db, original_class, alias.value_type(db))
+        }
+        _ => SubclassOfType::try_from_type(db, original_class).is_some_and(|original_meta_type| {
+            decorated_class.is_equivalent_to(db, original_meta_type)
+        }),
+    }
+}
+
+/// Return true if a type still contains the original class object, even if it also carries extra
+/// intersection members.
+fn class_binding_retains_original_class<'db>(
+    db: &'db dyn crate::Db,
+    original_class: Type<'db>,
+    decorated_class: Type<'db>,
+) -> bool {
+    match decorated_class {
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .any(|element| class_binding_retains_original_class(db, original_class, *element)),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| class_binding_retains_original_class(db, original_class, *element)),
+        Type::TypeAlias(alias) => {
+            class_binding_retains_original_class(db, original_class, alias.value_type(db))
+        }
+        _ => class_decorator_preserves_class_binding(db, original_class, decorated_class),
+    }
+}
+
+/// Merge a class-preserving decorator result into the public binding.
+///
+/// If earlier decorators already exposed extra members through an intersection, keep those
+/// members instead of collapsing back to the undecorated class when a later decorator simply
+/// returns the original class object again.
+fn merge_class_preserving_decorator_result<'db>(
+    db: &'db dyn crate::Db,
+    original_class: Type<'db>,
+    current_binding: Type<'db>,
+    decorated_binding: Type<'db>,
+) -> Type<'db> {
+    if class_binding_retains_original_class(db, original_class, current_binding) {
+        current_binding
+    } else {
+        decorated_binding
+            .as_class_literal()
+            .map(Type::ClassLiteral)
+            .unwrap_or(original_class)
+    }
+}
+
+/// Return the value type produced by applying a class decorator.
+///
+/// Synthetic dataclass-transform marker types are metadata for class construction, not real values
+/// that should replace the class binding. For example, the result of calling `model` should not be
+/// recorded as the public type of `C` merely because `model` carries dataclass-transform metadata:
+/// ```python
+/// from typing import dataclass_transform
+///
+/// @dataclass_transform()
+/// def model(cls): ...
+///
+/// @model
+/// class C: ...
+/// ```
+fn class_decorator_return_type<'db>(
+    db: &'db dyn crate::Db,
+    decorator_ty: Type<'db>,
+    decorated_ty: Type<'db>,
+) -> Type<'db> {
+    let call_arguments = CallArguments::positional([decorated_ty]);
+    let return_ty = decorator_ty.try_call(db, &call_arguments).map_or_else(
+        |error| error.return_type(db),
+        |bindings| bindings.return_type(db),
+    );
+
+    match return_ty {
+        Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
+        return_ty => return_ty,
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -1,20 +1,19 @@
-use crate::{
-    place::Place,
-    types::{
-        CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
-        SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
-        call::CallError,
-        function::KnownFunction,
-        infer::{
-            TypeInferenceBuilder,
-            builder::{DeclaredAndInferredType, DeferredExpressionState},
-            original_class_type,
-        },
-        signatures::ParameterForm,
-        special_form::TypeQualifier,
+use crate::place::Place;
+use crate::types::{
+    CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
+    SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
+    call::CallError,
+    function::KnownFunction,
+    infer::{
+        TypeInferenceBuilder,
+        builder::{DeclaredAndInferredType, DeferredExpressionState},
+        original_class_type,
     },
+    signatures::ParameterForm,
+    special_form::TypeQualifier,
 };
-use ruff_python_ast::{self as ast, helpers::any_over_expr, name::Name};
+use ruff_python_ast::name::Name;
+use ruff_python_ast::{self as ast, helpers::any_over_expr};
 use ty_module_resolver::{KnownModule, file_to_module};
 use ty_python_core::{definition::Definition, scope::NodeWithScopeRef};
 
@@ -77,10 +76,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         } = class_node;
         let db = self.db();
 
-        let decorator_types_and_nodes: Vec<(Type<'db>, &ast::Decorator)> = decorator_list
-            .iter()
-            .map(|decorator| (self.infer_decorator(decorator), decorator))
-            .collect();
+        let mut decorator_types_and_nodes: Vec<(Type<'db>, &ast::Decorator)> =
+            Vec::with_capacity(decorator_list.len());
+        for decorator in decorator_list {
+            let decorator_ty = self.infer_decorator(decorator);
+            decorator_types_and_nodes.push((decorator_ty, decorator));
+        }
 
         let body_scope = self
             .index
@@ -131,131 +132,130 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         };
         for &(decorator_ty, decorator) in decorator_types_and_nodes.iter().rev() {
-            if metadata_applies_to_original_class {
-                if decorator_ty
-                    .as_function_literal()
-                    .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
-                {
-                    dataclass_params = Some(DataclassParams::default_params(db));
-                    continue;
-                }
-
-                if decorator_ty
-                    .as_function_literal()
-                    .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
-                {
-                    total_ordering = true;
-                    continue;
-                }
-
-                if let Type::DataclassDecorator(params) = decorator_ty {
-                    dataclass_params = Some(params);
-                    continue;
-                }
-
-                if decorator_ty.is_unknown()
-                    && let ast::Expr::Call(call) = &decorator.expression
-                    && self
-                        .expression_type(&call.func)
-                        .as_function_literal()
-                        .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
-                {
-                    continue;
-                }
-
-                if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) =
-                    decorator_ty
-                {
-                    deprecated = Some(deprecated_inst);
-                    continue;
-                }
-
-                if decorator_ty
-                    .as_function_literal()
-                    .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
-                {
-                    type_check_only = true;
-                    continue;
-                }
-
-                // Skip identity decorators to avoid salsa cycles on typeshed.
-                if decorator_ty.as_function_literal().is_some_and(|function| {
-                    matches!(
-                        function.known(db),
-                        Some(
-                            KnownFunction::Final
-                                | KnownFunction::DisjointBase
-                                | KnownFunction::RuntimeCheckable
-                        )
-                    )
-                }) {
-                    continue;
-                }
-
-                if let Type::FunctionLiteral(f) = decorator_ty {
-                    // We do not yet detect or flag `@dataclass_transform` applied to more than one
-                    // overload, or an overload and the implementation both. Nevertheless, this is not
-                    // allowed. We do not try to treat the offenders intelligently -- just use the
-                    // params of the last seen usage of `@dataclass_transform`.
-                    //
-                    // In class-decorator position, dataclass-transform metadata shapes the
-                    // original class object. We keep it metadata-only here because the call path
-                    // uses synthetic dataclass-transform return types to model decorator factories;
-                    // treating this as an ordinary replacement-returning class decorator would
-                    // conflate those two cases.
-                    let transformer_params = f
-                        .iter_overloads_and_implementation(db)
-                        .rev()
-                        .find_map(|overload| overload.dataclass_transformer_params(db));
-                    if let Some(transformer_params) = transformer_params {
-                        dataclass_params = Some(DataclassParams::from_transformer_params(
-                            db,
-                            transformer_params,
-                        ));
-                        continue;
-                    }
-                }
-
-                if let Type::DataclassTransformer(params) = decorator_ty {
-                    dataclass_transformer_params = Some(params);
-                    continue;
-                }
-
-                let current_original_class_ty = original_class_ty(
-                    deprecated,
-                    type_check_only,
-                    dataclass_params,
-                    dataclass_transformer_params,
-                    total_ordering,
-                );
-                let decorator_result =
-                    apply_class_decorator(db, decorator_ty, current_original_class_ty);
-                let decorated_ty = match &decorator_result {
-                    Ok(return_ty) => *return_ty,
-                    Err(error) => error.return_type(db),
-                };
-                if is_unknown_decorator_result(db, decorated_ty) {
-                    let decorator_call_ty = match &decorator.expression {
-                        ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
-                        _ => None,
-                    };
-                    if !preserve_binding_for_unknown_result(db, decorator_ty, decorator_call_ty) {
-                        metadata_applies_to_original_class = false;
-                    }
-                } else if !type_retains_original_class(db, current_original_class_ty, decorated_ty)
-                {
-                    metadata_applies_to_original_class = false;
-                }
-
-                decorators_to_apply.push((
-                    decorator_ty,
-                    decorator,
-                    Some((current_original_class_ty, decorator_result)),
-                ));
+            if !metadata_applies_to_original_class {
+                decorators_to_apply.push((decorator_ty, decorator, None));
                 continue;
             }
 
-            decorators_to_apply.push((decorator_ty, decorator, None));
+            if decorator_ty
+                .as_function_literal()
+                .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
+            {
+                dataclass_params = Some(DataclassParams::default_params(db));
+                continue;
+            }
+
+            if decorator_ty
+                .as_function_literal()
+                .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
+            {
+                total_ordering = true;
+                continue;
+            }
+
+            if let Type::DataclassDecorator(params) = decorator_ty {
+                dataclass_params = Some(params);
+                continue;
+            }
+
+            if decorator_ty.is_unknown()
+                && let ast::Expr::Call(call) = &decorator.expression
+                && self
+                    .expression_type(&call.func)
+                    .as_function_literal()
+                    .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
+            {
+                continue;
+            }
+
+            if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) =
+                decorator_ty
+            {
+                deprecated = Some(deprecated_inst);
+                continue;
+            }
+
+            if decorator_ty
+                .as_function_literal()
+                .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
+            {
+                type_check_only = true;
+                continue;
+            }
+
+            // Skip identity decorators to avoid salsa cycles on typeshed.
+            if decorator_ty.as_function_literal().is_some_and(|function| {
+                matches!(
+                    function.known(db),
+                    Some(
+                        KnownFunction::Final
+                            | KnownFunction::DisjointBase
+                            | KnownFunction::RuntimeCheckable
+                    )
+                )
+            }) {
+                continue;
+            }
+
+            if let Type::FunctionLiteral(f) = decorator_ty {
+                // We do not yet detect or flag `@dataclass_transform` applied to more than one
+                // overload, or an overload and the implementation both. Nevertheless, this is not
+                // allowed. We do not try to treat the offenders intelligently -- just use the
+                // params of the last seen usage of `@dataclass_transform`.
+                //
+                // In class-decorator position, dataclass-transform metadata shapes the
+                // original class object. We keep it metadata-only here because the call path
+                // uses synthetic dataclass-transform return types to model decorator factories;
+                // treating this as an ordinary replacement-returning class decorator would
+                // conflate those two cases.
+                let transformer_params = f
+                    .iter_overloads_and_implementation(db)
+                    .rev()
+                    .find_map(|overload| overload.dataclass_transformer_params(db));
+                if let Some(transformer_params) = transformer_params {
+                    dataclass_params = Some(DataclassParams::from_transformer_params(
+                        db,
+                        transformer_params,
+                    ));
+                    continue;
+                }
+            }
+
+            if let Type::DataclassTransformer(params) = decorator_ty {
+                dataclass_transformer_params = Some(params);
+                continue;
+            }
+
+            let current_original_class_ty = original_class_ty(
+                deprecated,
+                type_check_only,
+                dataclass_params,
+                dataclass_transformer_params,
+                total_ordering,
+            );
+            let decorator_result =
+                apply_class_decorator(db, decorator_ty, current_original_class_ty);
+            let decorated_ty = match &decorator_result {
+                Ok(return_ty) => *return_ty,
+                Err(error) => error.return_type(db),
+            };
+            if is_unknown_decorator_result(db, decorated_ty) {
+                let decorator_call_ty = match &decorator.expression {
+                    ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
+                    _ => None,
+                };
+                if !preserve_binding_for_unknown_result(db, decorator_ty, decorator_call_ty) {
+                    metadata_applies_to_original_class = false;
+                }
+            } else if !type_retains_original_class(db, current_original_class_ty, decorated_ty) {
+                metadata_applies_to_original_class = false;
+            }
+
+            decorators_to_apply.push((
+                decorator_ty,
+                decorator,
+                Some((current_original_class_ty, decorator_result)),
+            ));
         }
 
         let mut inferred_ty = original_class_ty(
@@ -268,6 +268,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let original_class_ty = inferred_ty;
         let mut undecorated_ty = None;
+
+        // Apply class decorators from inner to outer and use their return types to update the
+        // public binding. `original_class_ty` remains the class object whose body and metadata
+        // were inferred above.
         for (decorator_ty, decorator_node, precomputed_result) in decorators_to_apply {
             let decorator_result = match precomputed_result {
                 Some((precomputed_input_ty, decorator_result))

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -77,16 +77,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         } = class_node;
         let db = self.db();
 
-        let decorator_types_and_nodes: Vec<(Type<'db>, &ast::Decorator, bool)> = decorator_list
+        let decorator_types_and_nodes: Vec<(Type<'db>, &ast::Decorator)> = decorator_list
             .iter()
-            .map(|decorator| {
-                let decorator_ty = self.infer_decorator(decorator);
-                (
-                    decorator_ty,
-                    decorator,
-                    self.class_decorator_is_metadata_only(decorator_ty, decorator),
-                )
-            })
+            .map(|decorator| (self.infer_decorator(decorator), decorator))
             .collect();
 
         let body_scope = self
@@ -103,11 +96,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 Some(KnownModule::Typing | KnownModule::TypingExtensions)
             )
         };
-
-        let mut pending_metadata_decorators = decorator_types_and_nodes
-            .iter()
-            .filter(|(_, _, metadata_only)| *metadata_only)
-            .count();
 
         let mut decorators_to_apply = Vec::with_capacity(decorator_types_and_nodes.len());
         let mut metadata_applies_to_original_class = true;
@@ -142,105 +130,94 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 )),
             }
         };
-        for &(decorator_ty, decorator, metadata_only) in decorator_types_and_nodes.iter().rev() {
-            if metadata_only {
-                pending_metadata_decorators -= 1;
-            }
-
+        for &(decorator_ty, decorator) in decorator_types_and_nodes.iter().rev() {
             if metadata_applies_to_original_class {
-                if metadata_only {
-                    if decorator_ty
+                if decorator_ty
+                    .as_function_literal()
+                    .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
+                {
+                    dataclass_params = Some(DataclassParams::default_params(db));
+                    continue;
+                }
+
+                if decorator_ty
+                    .as_function_literal()
+                    .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
+                {
+                    total_ordering = true;
+                    continue;
+                }
+
+                if let Type::DataclassDecorator(params) = decorator_ty {
+                    dataclass_params = Some(params);
+                    continue;
+                }
+
+                if decorator_ty.is_unknown()
+                    && let ast::Expr::Call(call) = &decorator.expression
+                    && self
+                        .expression_type(&call.func)
                         .as_function_literal()
                         .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
-                    {
-                        dataclass_params = Some(DataclassParams::default_params(db));
-                        continue;
-                    }
+                {
+                    continue;
+                }
 
-                    if decorator_ty
-                        .as_function_literal()
-                        .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
-                    {
-                        total_ordering = true;
-                        continue;
-                    }
+                if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) =
+                    decorator_ty
+                {
+                    deprecated = Some(deprecated_inst);
+                    continue;
+                }
 
-                    if let Type::DataclassDecorator(params) = decorator_ty {
-                        dataclass_params = Some(params);
-                        continue;
-                    }
+                if decorator_ty
+                    .as_function_literal()
+                    .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
+                {
+                    type_check_only = true;
+                    continue;
+                }
 
-                    if decorator_ty.is_unknown()
-                        && let ast::Expr::Call(call) = &decorator.expression
-                        && self
-                            .expression_type(&call.func)
-                            .as_function_literal()
-                            .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
-                    {
-                        continue;
-                    }
-
-                    if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) =
-                        decorator_ty
-                    {
-                        deprecated = Some(deprecated_inst);
-                        continue;
-                    }
-
-                    if decorator_ty
-                        .as_function_literal()
-                        .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
-                    {
-                        type_check_only = true;
-                        continue;
-                    }
-
-                    // Skip identity decorators to avoid salsa cycles on typeshed.
-                    if decorator_ty.as_function_literal().is_some_and(|function| {
-                        matches!(
-                            function.known(db),
-                            Some(
-                                KnownFunction::Final
-                                    | KnownFunction::DisjointBase
-                                    | KnownFunction::RuntimeCheckable
-                            )
+                // Skip identity decorators to avoid salsa cycles on typeshed.
+                if decorator_ty.as_function_literal().is_some_and(|function| {
+                    matches!(
+                        function.known(db),
+                        Some(
+                            KnownFunction::Final
+                                | KnownFunction::DisjointBase
+                                | KnownFunction::RuntimeCheckable
                         )
-                    }) {
-                        continue;
-                    }
+                    )
+                }) {
+                    continue;
+                }
 
-                    if let Type::FunctionLiteral(function) = decorator_ty {
-                        // We do not yet detect or flag `@dataclass_transform` applied to more than one
-                        // overload, or an overload and the implementation both. Nevertheless, this is not
-                        // allowed. We do not try to treat the offenders intelligently -- just use the
-                        // params of the last seen usage of `@dataclass_transform`.
-                        //
-                        // In class-decorator position, dataclass-transform metadata shapes the
-                        // original class object. We keep it metadata-only here because the call path
-                        // uses synthetic dataclass-transform return types to model decorator factories;
-                        // treating this as an ordinary replacement-returning class decorator would
-                        // conflate those two cases.
-                        let transformer_params = function
-                            .iter_overloads_and_implementation(db)
-                            .rev()
-                            .find_map(|overload| overload.dataclass_transformer_params(db));
-                        if let Some(transformer_params) = transformer_params {
-                            dataclass_params = Some(DataclassParams::from_transformer_params(
-                                db,
-                                transformer_params,
-                            ));
-                            continue;
-                        }
-                    }
-
-                    if let Type::DataclassTransformer(params) = decorator_ty {
-                        dataclass_transformer_params = Some(params);
+                if let Type::FunctionLiteral(f) = decorator_ty {
+                    // We do not yet detect or flag `@dataclass_transform` applied to more than one
+                    // overload, or an overload and the implementation both. Nevertheless, this is not
+                    // allowed. We do not try to treat the offenders intelligently -- just use the
+                    // params of the last seen usage of `@dataclass_transform`.
+                    //
+                    // In class-decorator position, dataclass-transform metadata shapes the
+                    // original class object. We keep it metadata-only here because the call path
+                    // uses synthetic dataclass-transform return types to model decorator factories;
+                    // treating this as an ordinary replacement-returning class decorator would
+                    // conflate those two cases.
+                    let transformer_params = f
+                        .iter_overloads_and_implementation(db)
+                        .rev()
+                        .find_map(|overload| overload.dataclass_transformer_params(db));
+                    if let Some(transformer_params) = transformer_params {
+                        dataclass_params = Some(DataclassParams::from_transformer_params(
+                            db,
+                            transformer_params,
+                        ));
                         continue;
                     }
                 }
 
-                if pending_metadata_decorators == 0 {
-                    decorators_to_apply.push((decorator_ty, decorator, None));
+                if let Type::DataclassTransformer(params) = decorator_ty {
+                    dataclass_transformer_params = Some(params);
                     continue;
                 }
 
@@ -257,17 +234,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     Ok(return_ty) => *return_ty,
                     Err(error) => error.return_type(db),
                 };
-                let decorated_ty_is_unknown = is_unknown_decorator_result(db, decorated_ty);
-                let metadata_still_applies_to_original_class = if decorated_ty_is_unknown {
+                if is_unknown_decorator_result(db, decorated_ty) {
                     let decorator_call_ty = match &decorator.expression {
                         ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
                         _ => None,
                     };
-                    preserve_binding_for_unknown_result(db, decorator_ty, decorator_call_ty)
-                } else {
-                    type_retains_original_class(db, current_original_class_ty, decorated_ty)
-                };
-                if !metadata_still_applies_to_original_class {
+                    if !preserve_binding_for_unknown_result(db, decorator_ty, decorator_call_ty) {
+                        metadata_applies_to_original_class = false;
+                    }
+                } else if !type_retains_original_class(db, current_original_class_ty, decorated_ty)
+                {
                     metadata_applies_to_original_class = false;
                 }
 
@@ -314,20 +290,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             };
             // If a class decorator application loses all precision, preserve the original class
             // binding when the decorator is known to preserve unknown results.
-            inferred_ty = if is_unknown_decorator_result(db, decorated_ty) {
-                if preserve_binding_for_unknown_result(
+            let decorated_ty_is_unknown = is_unknown_decorator_result(db, decorated_ty);
+            let should_preserve_binding = decorated_ty_is_unknown
+                && preserve_binding_for_unknown_result(
                     db,
                     decorator_ty,
                     match &decorator_node.expression {
                         ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
                         _ => None,
                     },
-                ) {
-                    inferred_ty
-                } else {
-                    undecorated_ty.get_or_insert(inferred_ty);
-                    decorated_ty
-                }
+                );
+            inferred_ty = if should_preserve_binding {
+                inferred_ty
             } else if class_decorator_preserves_class_binding(db, original_class_ty, decorated_ty) {
                 merge_class_preserving_decorator_result(
                     db,
@@ -424,60 +398,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         }
     }
-
-    fn class_decorator_is_metadata_only(
-        &self,
-        decorator_ty: Type<'db>,
-        decorator: &ast::Decorator,
-    ) -> bool {
-        let db = self.db();
-
-        if matches!(
-            decorator_ty,
-            Type::DataclassDecorator(_)
-                | Type::DataclassTransformer(_)
-                | Type::KnownInstance(KnownInstanceType::Deprecated(_))
-        ) {
-            return true;
-        }
-
-        if decorator_ty.is_unknown()
-            && let ast::Expr::Call(call) = &decorator.expression
-            && self
-                .expression_type(&call.func)
-                .as_function_literal()
-                .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
-        {
-            return true;
-        }
-
-        if decorator_ty.as_function_literal().is_some_and(|function| {
-            matches!(
-                function.known(db),
-                Some(
-                    KnownFunction::Dataclass
-                        | KnownFunction::TotalOrdering
-                        | KnownFunction::TypeCheckOnly
-                        | KnownFunction::Final
-                        | KnownFunction::DisjointBase
-                        | KnownFunction::RuntimeCheckable
-                )
-            )
-        }) {
-            return true;
-        }
-
-        if let Type::FunctionLiteral(function) = decorator_ty
-            && function
-                .iter_overloads_and_implementation(db)
-                .rev()
-                .any(|overload| overload.dataclass_transformer_params(db).is_some())
-        {
-            return true;
-        }
-
-        false
-    }
 }
 
 fn apply_class_decorator<'db>(
@@ -515,15 +435,10 @@ fn class_decorator_preserves_class_binding<'db>(
 
     match decorated_class {
         Type::ClassLiteral(decorated_literal) => {
-            if decorated_literal == original_literal {
-                return true;
-            }
-
-            let Some(decorated_definition) = decorated_literal.definition(db) else {
-                return false;
-            };
-
-            Some(decorated_definition) == original_literal.definition(db)
+            let decorated_definition = decorated_literal.definition(db);
+            decorated_literal == original_literal
+                || decorated_definition.is_some()
+                    && decorated_definition == original_literal.definition(db)
         }
         Type::SubclassOf(subclass_of) => subclass_of
             .subclass_of()

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -4,12 +4,14 @@ use crate::{
         CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
         SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
         call::CallError,
+        function::DataclassTransformerParams,
         function::KnownFunction,
         infer::{
             TypeInferenceBuilder,
             builder::{DeclaredAndInferredType, DeferredExpressionState},
             original_class_type,
         },
+        known_instance::DeprecatedInstance,
         signatures::ParameterForm,
         special_form::TypeQualifier,
     },
@@ -77,9 +79,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         } = class_node;
         let db = self.db();
 
-        let decorator_types_and_nodes: Vec<(Type<'db>, &ast::Decorator)> = decorator_list
+        let decorator_types_and_nodes: Vec<(
+            Type<'db>,
+            &ast::Decorator,
+            ClassDecoratorMetadataAction<'db>,
+        )> = decorator_list
             .iter()
-            .map(|decorator| (self.infer_decorator(decorator), decorator))
+            .map(|decorator| {
+                let decorator_ty = self.infer_decorator(decorator);
+                (
+                    decorator_ty,
+                    decorator,
+                    self.class_decorator_metadata_action(decorator_ty, decorator),
+                )
+            })
             .collect();
 
         let body_scope = self
@@ -96,6 +109,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 Some(KnownModule::Typing | KnownModule::TypingExtensions)
             )
         };
+
+        let mut pending_metadata_decorators = decorator_types_and_nodes
+            .iter()
+            .filter(|(_, _, action)| action.applies_to_original_class())
+            .count();
 
         let mut decorators_to_apply = Vec::with_capacity(decorator_types_and_nodes.len());
         let mut metadata_applies_to_original_class = true;
@@ -130,94 +148,48 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 )),
             }
         };
-        for &(decorator_ty, decorator) in decorator_types_and_nodes.iter().rev() {
+        for &(decorator_ty, decorator, metadata_action) in decorator_types_and_nodes.iter().rev() {
+            if metadata_action.applies_to_original_class() {
+                pending_metadata_decorators -= 1;
+            }
+
             if metadata_applies_to_original_class {
-                if decorator_ty
-                    .as_function_literal()
-                    .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
-                {
-                    dataclass_params = Some(DataclassParams::default_params(db));
-                    continue;
-                }
-
-                if decorator_ty
-                    .as_function_literal()
-                    .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
-                {
-                    total_ordering = true;
-                    continue;
-                }
-
-                if let Type::DataclassDecorator(params) = decorator_ty {
-                    dataclass_params = Some(params);
-                    continue;
-                }
-
-                if decorator_ty.is_unknown()
-                    && let ast::Expr::Call(call) = &decorator.expression
-                    && self
-                        .expression_type(&call.func)
-                        .as_function_literal()
-                        .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
-                {
-                    continue;
-                }
-
-                if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) =
-                    decorator_ty
-                {
-                    deprecated = Some(deprecated_inst);
-                    continue;
-                }
-
-                if decorator_ty
-                    .as_function_literal()
-                    .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
-                {
-                    type_check_only = true;
-                    continue;
-                }
-
-                // Skip identity decorators to avoid salsa cycles on typeshed.
-                if decorator_ty.as_function_literal().is_some_and(|function| {
-                    matches!(
-                        function.known(db),
-                        Some(
-                            KnownFunction::Final
-                                | KnownFunction::DisjointBase
-                                | KnownFunction::RuntimeCheckable
-                        )
-                    )
-                }) {
-                    continue;
-                }
-
-                if let Type::FunctionLiteral(f) = decorator_ty {
-                    // We do not yet detect or flag `@dataclass_transform` applied to more than one
-                    // overload, or an overload and the implementation both. Nevertheless, this is not
-                    // allowed. We do not try to treat the offenders intelligently -- just use the
-                    // params of the last seen usage of `@dataclass_transform`.
-                    //
-                    // In class-decorator position, dataclass-transform metadata shapes the
-                    // original class object. We keep it metadata-only here because the call path
-                    // uses synthetic dataclass-transform return types to model decorator factories;
-                    // treating this as an ordinary replacement-returning class decorator would
-                    // conflate those two cases.
-                    let transformer_params = f
-                        .iter_overloads_and_implementation(db)
-                        .rev()
-                        .find_map(|overload| overload.dataclass_transformer_params(db));
-                    if let Some(transformer_params) = transformer_params {
+                match metadata_action {
+                    ClassDecoratorMetadataAction::None => {}
+                    ClassDecoratorMetadataAction::Dataclass(params) => {
+                        dataclass_params = Some(params);
+                        continue;
+                    }
+                    ClassDecoratorMetadataAction::TotalOrdering => {
+                        total_ordering = true;
+                        continue;
+                    }
+                    ClassDecoratorMetadataAction::Deprecated(deprecated_inst) => {
+                        deprecated = Some(deprecated_inst);
+                        continue;
+                    }
+                    ClassDecoratorMetadataAction::TypeCheckOnly => {
+                        type_check_only = true;
+                        continue;
+                    }
+                    ClassDecoratorMetadataAction::DataclassTransform(transformer_params) => {
                         dataclass_params = Some(DataclassParams::from_transformer_params(
                             db,
                             transformer_params,
                         ));
                         continue;
                     }
+                    ClassDecoratorMetadataAction::DataclassTransformer(params) => {
+                        dataclass_transformer_params = Some(params);
+                        continue;
+                    }
+                    ClassDecoratorMetadataAction::Skip => {
+                        continue;
+                    }
                 }
 
-                if let Type::DataclassTransformer(params) = decorator_ty {
-                    dataclass_transformer_params = Some(params);
+                if pending_metadata_decorators == 0 {
+                    decorators_to_apply.push((decorator_ty, decorator, None));
                     continue;
                 }
 
@@ -282,18 +254,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             };
             // If a class decorator application loses all precision, preserve the original class
             // binding when the decorator is known to preserve unknown results.
-            let decorated_ty_is_unknown = is_unknown_decorator_result(db, decorated_ty);
-            let should_preserve_binding = decorated_ty_is_unknown
-                && preserve_binding_for_unknown_result(
+            inferred_ty = if is_unknown_decorator_result(db, decorated_ty) {
+                if preserve_binding_for_unknown_result(
                     db,
                     decorator_ty,
                     match &decorator_node.expression {
                         ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
                         _ => None,
                     },
-                );
-            inferred_ty = if should_preserve_binding {
-                inferred_ty
+                ) {
+                    inferred_ty
+                } else {
+                    undecorated_ty.get_or_insert(inferred_ty);
+                    decorated_ty
+                }
             } else if class_decorator_preserves_class_binding(db, original_class_ty, decorated_ty) {
                 merge_class_preserving_decorator_result(
                     db,
@@ -390,6 +364,110 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         }
     }
+
+    fn class_decorator_metadata_action(
+        &self,
+        decorator_ty: Type<'db>,
+        decorator: &ast::Decorator,
+    ) -> ClassDecoratorMetadataAction<'db> {
+        let db = self.db();
+
+        if decorator_ty
+            .as_function_literal()
+            .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
+        {
+            return ClassDecoratorMetadataAction::Dataclass(DataclassParams::default_params(db));
+        }
+
+        if decorator_ty
+            .as_function_literal()
+            .is_some_and(|function| function.is_known(db, KnownFunction::TotalOrdering))
+        {
+            return ClassDecoratorMetadataAction::TotalOrdering;
+        }
+
+        if let Type::DataclassDecorator(params) = decorator_ty {
+            return ClassDecoratorMetadataAction::Dataclass(params);
+        }
+
+        if decorator_ty.is_unknown()
+            && let ast::Expr::Call(call) = &decorator.expression
+            && self
+                .expression_type(&call.func)
+                .as_function_literal()
+                .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
+        {
+            return ClassDecoratorMetadataAction::Skip;
+        }
+
+        if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) = decorator_ty {
+            return ClassDecoratorMetadataAction::Deprecated(deprecated_inst);
+        }
+
+        if decorator_ty
+            .as_function_literal()
+            .is_some_and(|function| function.is_known(db, KnownFunction::TypeCheckOnly))
+        {
+            return ClassDecoratorMetadataAction::TypeCheckOnly;
+        }
+
+        // Skip identity decorators to avoid salsa cycles on typeshed.
+        if decorator_ty.as_function_literal().is_some_and(|function| {
+            matches!(
+                function.known(db),
+                Some(
+                    KnownFunction::Final
+                        | KnownFunction::DisjointBase
+                        | KnownFunction::RuntimeCheckable
+                )
+            )
+        }) {
+            return ClassDecoratorMetadataAction::Skip;
+        }
+
+        if let Type::FunctionLiteral(function) = decorator_ty {
+            // We do not yet detect or flag `@dataclass_transform` applied to more than one
+            // overload, or an overload and the implementation both. Nevertheless, this is not
+            // allowed. We do not try to treat the offenders intelligently -- just use the
+            // params of the last seen usage of `@dataclass_transform`.
+            //
+            // In class-decorator position, dataclass-transform metadata shapes the original
+            // class object. We keep it metadata-only here because the call path uses synthetic
+            // dataclass-transform return types to model decorator factories; treating this as
+            // an ordinary replacement-returning class decorator would conflate those two cases.
+            if let Some(transformer_params) = function
+                .iter_overloads_and_implementation(db)
+                .rev()
+                .find_map(|overload| overload.dataclass_transformer_params(db))
+            {
+                return ClassDecoratorMetadataAction::DataclassTransform(transformer_params);
+            }
+        }
+
+        if let Type::DataclassTransformer(params) = decorator_ty {
+            return ClassDecoratorMetadataAction::DataclassTransformer(params);
+        }
+
+        ClassDecoratorMetadataAction::None
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+enum ClassDecoratorMetadataAction<'db> {
+    None,
+    Dataclass(DataclassParams<'db>),
+    TotalOrdering,
+    Deprecated(DeprecatedInstance<'db>),
+    TypeCheckOnly,
+    DataclassTransform(DataclassTransformerParams<'db>),
+    DataclassTransformer(DataclassTransformerParams<'db>),
+    Skip,
+}
+
+impl ClassDecoratorMetadataAction<'_> {
+    fn applies_to_original_class(self) -> bool {
+        !matches!(self, Self::None)
+    }
 }
 
 enum ClassDecoratorApplication<'db> {
@@ -453,10 +531,15 @@ fn class_decorator_preserves_class_binding<'db>(
 
     match decorated_class {
         Type::ClassLiteral(decorated_literal) => {
-            let decorated_definition = decorated_literal.definition(db);
-            decorated_literal == original_literal
-                || decorated_definition.is_some()
-                    && decorated_definition == original_literal.definition(db)
+            if decorated_literal == original_literal {
+                return true;
+            }
+
+            let Some(decorated_definition) = decorated_literal.definition(db) else {
+                return false;
+            };
+
+            Some(decorated_definition) == original_literal.definition(db)
         }
         Type::SubclassOf(subclass_of) => subclass_of
             .subclass_of()
@@ -666,7 +749,9 @@ fn merge_class_preserving_decorator_result<'db>(
     current_binding: Type<'db>,
     decorated_binding: Type<'db>,
 ) -> Type<'db> {
-    if type_retains_original_class(db, original_class, current_binding) {
+    if current_binding == original_class
+        || type_retains_original_class(db, original_class, current_binding)
+    {
         current_binding
     } else {
         decorated_binding

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -106,10 +106,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let mut dataclass_transformer_params = None;
         let mut total_ordering = false;
         let infer_original_class_ty = |deprecated,
-                                 type_check_only,
-                                 dataclass_params,
-                                 dataclass_transformer_params,
-                                 total_ordering| {
+                                       type_check_only,
+                                       dataclass_params,
+                                       dataclass_transformer_params,
+                                       total_ordering| {
             match (maybe_known_class, &*name.id) {
                 (None, "NamedTuple") if in_typing_module() => {
                     Type::SpecialForm(SpecialFormType::NamedTuple)
@@ -131,9 +131,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 )),
             }
         };
+        let decorator_call_ty = |decorator: &ast::Decorator| match &decorator.expression {
+            ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
+            _ => None,
+        };
 
-        // TODO(charlie): Fill this out.
-        // In the first pass, ...
+        // In the first pass, collect metadata decorators that shape the original class object.
+        // Once an inner decorator replaces the public binding, outer decorators are ordinary
+        // runtime applications only: they cannot retroactively add metadata to the original class.
+        // For ordinary decorators that still apply to the original class, precompute the call so
+        // the second pass can reuse it if no inner decorator has changed the binding.
         for &(decorator_ty, decorator) in decorator_types_and_nodes.iter().rev() {
             if !metadata_applies_to_original_class {
                 decorators_to_apply.push((decorator_ty, decorator, None));
@@ -236,18 +243,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 dataclass_transformer_params,
                 total_ordering,
             );
-            let decorator_result =
-                apply_class_decorator(db, decorator_ty, original_class_ty);
+            let decorator_result = apply_class_decorator(db, decorator_ty, original_class_ty);
             let decorated_ty = match &decorator_result {
                 Ok(return_ty) => *return_ty,
                 Err(error) => error.return_type(db),
             };
             if is_unknown_decorator_result(db, decorated_ty) {
-                let decorator_call_ty = match &decorator.expression {
-                    ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
-                    _ => None,
-                };
-                if !preserve_binding_for_unknown_result(db, decorator_ty, decorator_call_ty) {
+                if !preserve_binding_for_unknown_result(
+                    db,
+                    decorator_ty,
+                    decorator_call_ty(decorator),
+                ) {
                     metadata_applies_to_original_class = false;
                 }
             } else if !type_retains_original_class(db, original_class_ty, decorated_ty) {
@@ -277,7 +283,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // metadata were inferred above.
         for (decorator_ty, decorator_node, precomputed_result) in decorators_to_apply {
             let decorator_result = match precomputed_result {
-                // TODO(charlie): Why can we reuse this here...? But not in the second branch?
+                // The metadata pass already called this decorator with the same input. If an inner
+                // decorator changed the binding, apply this decorator to the new public binding.
                 Some((precomputed_input_ty, decorator_result))
                     if precomputed_input_ty == inferred_ty =>
                 {
@@ -297,18 +304,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 decorated_ty => decorated_ty,
             };
             // If a class decorator application loses all precision, preserve the original class
-            // binding when the decorator is known to preserve unknown results.
-            // TODO(charlie): Can we avoid re-computing these here...? Didn't we compute these
-            // above?
+            // binding for decorators known to preserve unknown results.
             let decorated_ty_is_unknown = is_unknown_decorator_result(db, decorated_ty);
             let should_preserve_binding = decorated_ty_is_unknown
                 && preserve_binding_for_unknown_result(
                     db,
                     decorator_ty,
-                    match &decorator_node.expression {
-                        ast::Expr::Call(call) => Some(self.expression_type(&call.func)),
-                        _ => None,
-                    },
+                    decorator_call_ty(decorator_node),
                 );
             inferred_ty = if should_preserve_binding {
                 inferred_ty
@@ -320,8 +322,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     decorated_ty,
                 )
             } else {
-                // Trying to understand this... do we not always set this? Or we don't need to if
-                // they all preserve?
+                // Only record an undecorated type once a decorator actually replaces the public
+                // binding. If all decorators preserve the class, there is no alternate class type
+                // to expose.
                 undecorated_ty.get_or_insert(inferred_ty);
                 decorated_ty
             };

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -3,6 +3,7 @@ use crate::{
     types::{
         CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
         SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
+        call::CallError,
         function::KnownFunction,
         infer::{
             TypeInferenceBuilder,
@@ -227,8 +228,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     dataclass_transformer_params,
                     total_ordering,
                 );
-                let decorated_ty =
-                    class_decorator_return_type(db, decorator_ty, current_original_class_ty);
+                let decorator_result =
+                    ClassDecoratorApplication::apply(db, decorator_ty, current_original_class_ty);
+                let decorated_ty = decorator_result.return_type(db);
                 let decorated_ty_is_unknown = is_unknown_decorator_result(db, decorated_ty);
                 let metadata_still_applies_to_original_class = if decorated_ty_is_unknown {
                     let decorator_call_ty = match &decorator.expression {
@@ -242,9 +244,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 if !metadata_still_applies_to_original_class {
                     metadata_applies_to_original_class = false;
                 }
+
+                decorators_to_apply.push((
+                    decorator_ty,
+                    decorator,
+                    Some((current_original_class_ty, decorator_result)),
+                ));
+                continue;
             }
 
-            decorators_to_apply.push((decorator_ty, decorator));
+            decorators_to_apply.push((decorator_ty, decorator, None));
         }
 
         let mut inferred_ty = original_class_ty(
@@ -257,9 +266,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let original_class_ty = inferred_ty;
         let mut undecorated_ty = None;
-        for (decorator_ty, decorator_node) in decorators_to_apply {
-            let decorated_ty = match self.apply_decorator(decorator_ty, inferred_ty, decorator_node)
-            {
+        for (decorator_ty, decorator_node, precomputed_result) in decorators_to_apply {
+            let decorated_ty = match precomputed_result {
+                Some((precomputed_input_ty, decorator_result))
+                    if precomputed_input_ty == inferred_ty =>
+                {
+                    decorator_result.return_type_and_report_diagnostics(self, db, decorator_node)
+                }
+                _ => ClassDecoratorApplication::apply(db, decorator_ty, inferred_ty)
+                    .return_type_and_report_diagnostics(self, db, decorator_node),
+            };
+            let decorated_ty = match decorated_ty {
                 Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
                 decorated_ty => decorated_ty,
             };
@@ -370,6 +387,43 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 );
             } else {
                 self.infer_expression(&extra_items_keyword.value, TypeContext::default());
+            }
+        }
+    }
+}
+
+enum ClassDecoratorApplication<'db> {
+    Ok(Type<'db>),
+    Err(CallError<'db>),
+}
+
+impl<'db> ClassDecoratorApplication<'db> {
+    fn apply(db: &'db dyn crate::Db, decorator_ty: Type<'db>, decorated_ty: Type<'db>) -> Self {
+        let call_arguments = CallArguments::positional([decorated_ty]);
+        match decorator_ty.try_call(db, &call_arguments) {
+            Ok(bindings) => Self::Ok(bindings.return_type(db)),
+            Err(error) => Self::Err(error),
+        }
+    }
+
+    fn return_type(&self, db: &'db dyn crate::Db) -> Type<'db> {
+        match self {
+            Self::Ok(return_ty) => *return_ty,
+            Self::Err(error) => error.return_type(db),
+        }
+    }
+
+    fn return_type_and_report_diagnostics(
+        self,
+        builder: &mut TypeInferenceBuilder<'db, '_>,
+        db: &'db dyn crate::Db,
+        decorator_node: &ast::Decorator,
+    ) -> Type<'db> {
+        match self {
+            Self::Ok(return_ty) => return_ty,
+            Self::Err(CallError(_, bindings)) => {
+                bindings.report_diagnostics(&builder.context, decorator_node.into());
+                bindings.return_type(db)
             }
         }
     }
@@ -619,36 +673,5 @@ fn merge_class_preserving_decorator_result<'db>(
             .as_class_literal()
             .map(Type::ClassLiteral)
             .unwrap_or(original_class)
-    }
-}
-
-/// Return the value type produced by applying a class decorator.
-///
-/// Synthetic dataclass-transform marker types are metadata for class construction, not real values
-/// that should replace the class binding. For example, the result of calling `model` should not be
-/// recorded as the public type of `C` merely because `model` carries dataclass-transform metadata:
-/// ```python
-/// from typing import dataclass_transform
-///
-/// @dataclass_transform()
-/// def model(cls): ...
-///
-/// @model
-/// class C: ...
-/// ```
-fn class_decorator_return_type<'db>(
-    db: &'db dyn crate::Db,
-    decorator_ty: Type<'db>,
-    decorated_ty: Type<'db>,
-) -> Type<'db> {
-    let call_arguments = CallArguments::positional([decorated_ty]);
-    let return_ty = decorator_ty.try_call(db, &call_arguments).map_or_else(
-        |error| error.return_type(db),
-        |bindings| bindings.return_type(db),
-    );
-
-    match return_ty {
-        Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
-        return_ty => return_ty,
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -105,7 +105,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let mut dataclass_params = None;
         let mut dataclass_transformer_params = None;
         let mut total_ordering = false;
-        let original_class_ty = |deprecated,
+        let infer_original_class_ty = |deprecated,
                                  type_check_only,
                                  dataclass_params,
                                  dataclass_transformer_params,
@@ -131,6 +131,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 )),
             }
         };
+
+        // TODO(charlie): Fill this out.
+        // In the first pass, ...
         for &(decorator_ty, decorator) in decorator_types_and_nodes.iter().rev() {
             if !metadata_applies_to_original_class {
                 decorators_to_apply.push((decorator_ty, decorator, None));
@@ -226,7 +229,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 continue;
             }
 
-            let current_original_class_ty = original_class_ty(
+            let original_class_ty = infer_original_class_ty(
                 deprecated,
                 type_check_only,
                 dataclass_params,
@@ -234,7 +237,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 total_ordering,
             );
             let decorator_result =
-                apply_class_decorator(db, decorator_ty, current_original_class_ty);
+                apply_class_decorator(db, decorator_ty, original_class_ty);
             let decorated_ty = match &decorator_result {
                 Ok(return_ty) => *return_ty,
                 Err(error) => error.return_type(db),
@@ -247,18 +250,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 if !preserve_binding_for_unknown_result(db, decorator_ty, decorator_call_ty) {
                     metadata_applies_to_original_class = false;
                 }
-            } else if !type_retains_original_class(db, current_original_class_ty, decorated_ty) {
+            } else if !type_retains_original_class(db, original_class_ty, decorated_ty) {
                 metadata_applies_to_original_class = false;
             }
 
             decorators_to_apply.push((
                 decorator_ty,
                 decorator,
-                Some((current_original_class_ty, decorator_result)),
+                Some((original_class_ty, decorator_result)),
             ));
         }
 
-        let mut inferred_ty = original_class_ty(
+        let mut inferred_ty = infer_original_class_ty(
             deprecated,
             type_check_only,
             dataclass_params,
@@ -269,11 +272,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let original_class_ty = inferred_ty;
         let mut undecorated_ty = None;
 
-        // Apply class decorators from inner to outer and use their return types to update the
-        // public binding. `original_class_ty` remains the class object whose body and metadata
-        // were inferred above.
+        // In the second pass, apply class decorators from inner to outer and use their return types
+        // to update the public binding. `original_class_ty` remains the class object whose body and
+        // metadata were inferred above.
         for (decorator_ty, decorator_node, precomputed_result) in decorators_to_apply {
             let decorator_result = match precomputed_result {
+                // TODO(charlie): Why can we reuse this here...? But not in the second branch?
                 Some((precomputed_input_ty, decorator_result))
                     if precomputed_input_ty == inferred_ty =>
                 {
@@ -294,6 +298,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             };
             // If a class decorator application loses all precision, preserve the original class
             // binding when the decorator is known to preserve unknown results.
+            // TODO(charlie): Can we avoid re-computing these here...? Didn't we compute these
+            // above?
             let decorated_ty_is_unknown = is_unknown_decorator_result(db, decorated_ty);
             let should_preserve_binding = decorated_ty_is_unknown
                 && preserve_binding_for_unknown_result(
@@ -314,6 +320,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     decorated_ty,
                 )
             } else {
+                // Trying to understand this... do we not always set this? Or we don't need to if
+                // they all preserve?
                 undecorated_ty.get_or_insert(inferred_ty);
                 decorated_ty
             };

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -23,6 +23,7 @@ use crate::{
                 validate_paramspec_components,
             },
             function_known_decorators, infer_statement_types, nearest_enclosing_function,
+            original_class_type,
         },
         infer_definition_types, infer_scope_types,
         signatures::ReturnCallableTypeVarScope,
@@ -990,10 +991,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let class_definition = self.index.expect_single_definition(class);
-        let class_literal = infer_definition_types(db, class_definition)
-            .declaration_type(class_definition)
-            .inner_type()
-            .as_class_literal()?;
+        let class_literal = original_class_type(db, class_definition)?;
 
         let typing_self = typing_self(db, self.scope(), Some(method_definition), class_literal);
         if is_classmethod || function_name == "__new__" {

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -415,6 +415,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             function_decorators,
             deprecated,
             dataclass_transformer_params,
+            function.returns.is_some(),
         );
         let function_literal = FunctionLiteral {
             last_definition: overload_literal,

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -9,10 +9,11 @@ use crate::{
     Db,
     place::{DefinedPlace, Definedness, Place, place_from_bindings},
     types::{
-        KnownClass, Type, binding_type,
+        KnownClass, Type,
         context::InferContext,
         diagnostic::INVALID_OVERLOAD,
         function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral},
+        infer::original_class_type,
         signatures::{ParameterConsistency, ReturnTypeConsistency},
     },
 };
@@ -134,13 +135,12 @@ pub(crate) fn check_overloaded_function<'db>(
             )
         }) {
             implementation_required = false;
-        } else if let NodeWithScopeKind::Class(class_node_ref) = scope {
-            let class = binding_type(
+        } else if let NodeWithScopeKind::Class(class_node_ref) = scope
+            && let Some(class) = original_class_type(
                 db,
                 index.expect_single_definition(class_node_ref.node(context.module())),
             )
-            .expect_class_literal();
-
+        {
             if class.is_protocol(db)
                 || (Type::ClassLiteral(class)
                     .is_subtype_of(db, KnownClass::ABCMeta.to_instance(db))


### PR DESCRIPTION
## Summary

This PR adds support for class decorator return types, following Carl's comment in https://github.com/astral-sh/ty/issues/2604#issuecomment-3793310652: assume unannotated decorators preserve the class binding when their result is otherwise `Unknown`, but support explicit spelling of an annotated decorator return type.

In more detail, the rule is roughly:

- If applying the decorator gives a non-`Unknown` result...
  - And that result still retains the original class object, we preserve the class.
  - Otherwise, we replace the public binding with that result.
- If applying the decorator gives an `Unknown` result:
  - We fall back to the decorator’s own shape.
  - Unannotated function/method decorators are treated as "identity-preserving", so we keep the current class binding.
  - Decorators with an explicit return annotation are not, so we do _not_ preserve the binding.

As a concrete example, an unannotated decorator like the personify example from #2604 is still treated as preserving the original class (since we don't have a static replacement type):

```python
def personify(cls):
    class Wrapped(cls):
        full_name: str

        def set_full_name(self, full_name: str) -> None:
            self.full_name = full_name

    return Wrapped

@personify
class Animal: ...

reveal_type(Animal)  # <class 'Animal'>
Animal().set_full_name("John")  # error: unresolved attribute
```

But if the decorator has an explicit return type, we use it for the public class binding:

```python
class WrapBackend:
    def __init__(self, cls: type[object]) -> None: ...

    def get(self, key: str) -> bytes | None: ...

@WrapBackend
class CacheClient: ...

reveal_type(CacheClient)  # WrapBackend
reveal_type(CacheClient.get("x"))  # bytes | None
```

This gives us stable behavior for common untyped identity decorators while leaving the advanced and unsound returned-class inference path out of scope...

Closes https://github.com/astral-sh/ty/issues/143.
