### PR TITLE
Bump docstring-adder pin

### DIFF
--- a/scripts/codemod_docstrings.sh
+++ b/scripts/codemod_docstrings.sh
@@ -18,10 +18,10 @@
 
 set -eu
 
-docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@e98a04941d5a6b8b9240e40392de15990b8cb8be"
+docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@1628984426d65ae0549fc43ed182d7a6157648cc"
 stdlib_path="./crates/ty_vendored/vendor/typeshed/stdlib"
 
-for python_version in 3.14 3.13 3.12 3.11 3.10 3.9
+for python_version in 3.14 3.13 3.12 3.11 3.10
 do
   PYTHONUTF8=1 uvx --python="$python_version" --force-reinstall --from="${docstring_adder}" add-docstrings --stdlib-path="${stdlib_path}"
 done


### PR DESCRIPTION
## Summary

and stop attempting to sync Python 3.9 docstrings, since typeshed no longer has any 3.9 branches.

I wanted to start syncing the Python 3.15 docstrings, but docstring-adder cannot add support for Python 3.15 until libcst adds support for 3.15 upstream.
