### PR TITLE
[ty] Avoid TypedDict schema cycle for Self fields

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2690,6 +2690,21 @@ def _(node: Node, person: Person):
 _: Node = Person(name="Alice", parent=Node(name="Bob", parent=Person(name="Charlie", parent=None)))
 ```
 
+The `Self` special form can also appear in recursive `TypedDict` fields:
+
+```py
+from typing_extensions import Self
+
+class A(TypedDict):
+    pass
+
+class B(TypedDict):
+    foo: A | Self
+
+# error: [missing-typed-dict-key] "Missing required key 'foo' in TypedDict `B` constructor"
+_: B = {}
+```
+
 TypedDict constructor calls should also use field type context when inferring nested values:
 
 ```py

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -98,7 +98,13 @@ impl<'db> TypedDictType<'db> {
     }
 
     pub(crate) fn items(self, db: &'db dyn Db) -> &'db TypedDictSchema<'db> {
-        #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+        // Field annotations can recursively inspect this schema while the class fields are still
+        // being collected, e.g. through `typing.Self` in a `TypedDict` field.
+        #[salsa::tracked(
+            returns(ref),
+            cycle_initial=|_, _, _| TypedDictSchema::default(),
+            heap_size=ruff_memory_usage::heap_size
+        )]
         fn class_based_items<'db>(db: &'db dyn Db, class: ClassType<'db>) -> TypedDictSchema<'db> {
             let Some((class_literal, specialization)) = class.static_class_literal(db) else {
                 return TypedDictSchema::default();


### PR DESCRIPTION
## Summary

`Self` in a class-based `TypedDict` field can cause field annotation inference to recursively inspect the same `TypedDict` schema while it is still being collected. This PR makes `TypedDictType::items` cycle-safe for class-based schemas by using an empty schema as the cycle fallback, matching the lower-level field collector's recovery behavior.

For example, this no longer panics:

```py
from typing_extensions import Self, TypedDict

class A(TypedDict):
    pass

class B(TypedDict):
    foo: A | Self

_: B = {}
```

Closes https://github.com/astral-sh/ty/issues/3437.
