### PR TITLE
[ty] Convert inference hash maps to boxed slices on finish

### DIFF
--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -123,7 +123,9 @@ pub(crate) mod node_key {
 
     use crate::{ast_node_ref::AstNodeRef, node_key::NodeKey};
 
-    #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, salsa::Update, get_size2::GetSize)]
+    #[derive(
+        Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, salsa::Update, get_size2::GetSize,
+    )]
     pub struct ExpressionNodeKey(NodeKey);
 
     impl From<ast::ExprRef<'_>> for ExpressionNodeKey {

--- a/crates/ty_python_core/src/node_key.rs
+++ b/crates/ty_python_core/src/node_key.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::{HasNodeIndex, NodeIndex};
 use crate::ast_node_ref::AstNodeRef;
 
 /// Compact key for a node for use in a hash map.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, get_size2::GetSize)]
 pub struct NodeKey(NodeIndex);
 
 impl NodeKey {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -83,17 +83,58 @@ bitflags::bitflags! {
 
 impl get_size2::GetSize for TypeExpressionFlags {}
 
-pub(super) fn boxed_entries<K: Ord, V>(map: FxHashMap<K, V>) -> Box<[(K, V)]> {
-    let mut entries = map.into_iter().collect::<Vec<_>>();
-    entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
-    entries.into_boxed_slice()
+/// Compact immutable key-value entries stored in key order.
+///
+/// This keeps the mutable construction path on [`FxHashMap`], then switches to a denser retained
+/// representation for cached inference results that only need iteration and keyed lookup.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(super) struct FrozenMap<K, V>(Box<[(K, V)]>);
+
+impl<K, V> FrozenMap<K, V> {
+    pub(super) fn iter(&self) -> std::slice::Iter<'_, (K, V)> {
+        self.0.iter()
+    }
 }
 
-pub(super) fn entry_get<K: Ord, V: Copy>(entries: &[(K, V)], key: &K) -> Option<V> {
-    entries
-        .binary_search_by(|(candidate, _)| candidate.cmp(key))
-        .ok()
-        .map(|index| entries[index].1)
+impl<K: Ord, V> From<FxHashMap<K, V>> for FrozenMap<K, V> {
+    fn from(map: FxHashMap<K, V>) -> Self {
+        let mut entries = map.into_iter().collect::<Vec<_>>();
+        entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        Self(entries.into_boxed_slice())
+    }
+}
+
+impl<K: Ord, V> FrozenMap<K, V> {
+    pub(super) fn get(&self, key: &K) -> Option<&V> {
+        self.0
+            .binary_search_by(|(candidate, _)| candidate.cmp(key))
+            .ok()
+            .map(|index| &self.0[index].1)
+    }
+}
+
+impl<K, V> Default for FrozenMap<K, V> {
+    fn default() -> Self {
+        Self(Box::default())
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a FrozenMap<K, V> {
+    type Item = &'a (K, V);
+    type IntoIter = std::slice::Iter<'a, (K, V)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a mut FrozenMap<K, V> {
+    type Item = &'a mut (K, V);
+    type IntoIter = std::slice::IterMut<'a, (K, V)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
 }
 
 /// Infer all types for a [`Definition`] (including sub-expressions).
@@ -171,7 +212,7 @@ pub(crate) fn function_known_decorator_flags<'db>(
 /// function-definition inference.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct FunctionDecoratorInference<'db> {
-    expression_types: Box<[(ExpressionNodeKey, Type<'db>)]>,
+    expression_types: FrozenMap<ExpressionNodeKey, Type<'db>>,
     bindings: Box<[(Definition<'db>, Type<'db>)]>,
     called_functions: Box<[FunctionType<'db>]>,
     known_decorators: FunctionDecorators,
@@ -183,7 +224,7 @@ impl<'db> FunctionDecoratorInference<'db> {
         &self,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        entry_get(&self.expression_types, &expression.into())
+        self.expression_types.get(&expression.into()).copied()
     }
 
     pub(crate) fn expression_types(
@@ -703,7 +744,7 @@ impl<'db> InferenceRegion<'db> {
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct ScopeInference<'db> {
     /// The types of every expression in this region.
-    expressions: Box<[(ExpressionNodeKey, Type<'db>)]>,
+    expressions: FrozenMap<ExpressionNodeKey, Type<'db>>,
 
     /// The extra data that is only present for few inference regions.
     extra: Option<Box<ScopeInferenceExtra<'db>>>,
@@ -733,7 +774,7 @@ impl<'db> ScopeInference<'db> {
                 cycle_recovery: Some(cycle_recovery),
                 ..ScopeInferenceExtra::default()
             })),
-            expressions: Box::default(),
+            expressions: FrozenMap::default(),
         }
     }
 
@@ -764,7 +805,10 @@ impl<'db> ScopeInference<'db> {
         &self,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        entry_get(&self.expressions, &expression.into()).or_else(|| self.fallback_type())
+        self.expressions
+            .get(&expression.into())
+            .copied()
+            .or_else(|| self.fallback_type())
     }
 
     pub(crate) fn try_expected_type(
@@ -806,7 +850,7 @@ impl<'db> ScopeInference<'db> {
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct DefinitionInference<'db> {
     /// The types of every expression in this region.
-    expressions: Box<[(ExpressionNodeKey, Type<'db>)]>,
+    expressions: FrozenMap<ExpressionNodeKey, Type<'db>>,
 
     /// The scope this region is part of.
     #[cfg(debug_assertions)]
@@ -864,7 +908,7 @@ impl<'db> DefinitionInference<'db> {
         let _ = scope;
 
         Self {
-            expressions: Box::default(),
+            expressions: FrozenMap::default(),
             bindings: Box::default(),
             declarations: Box::default(),
             #[cfg(debug_assertions)]
@@ -924,7 +968,10 @@ impl<'db> DefinitionInference<'db> {
         &self,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        entry_get(&self.expressions, &expression.into()).or_else(|| self.fallback_type())
+        self.expressions
+            .get(&expression.into())
+            .copied()
+            .or_else(|| self.fallback_type())
     }
 
     /// Get qualifiers for an annotation expression
@@ -1013,7 +1060,7 @@ impl<'db> DefinitionInference<'db> {
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct ExpressionInference<'db> {
     /// The types of every expression in this region.
-    expressions: Box<[(ExpressionNodeKey, Type<'db>)]>,
+    expressions: FrozenMap<ExpressionNodeKey, Type<'db>>,
 
     extra: Option<Box<ExpressionInferenceExtra<'db>>>,
 
@@ -1053,7 +1100,7 @@ impl<'db> ExpressionInference<'db> {
                 cycle_recovery: Some(cycle_recovery),
                 ..ExpressionInferenceExtra::default()
             })),
-            expressions: Box::default(),
+            expressions: FrozenMap::default(),
             #[cfg(debug_assertions)]
             scope,
         }
@@ -1092,7 +1139,10 @@ impl<'db> ExpressionInference<'db> {
         &self,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        entry_get(&self.expressions, &expression.into()).or_else(|| self.fallback_type())
+        self.expressions
+            .get(&expression.into())
+            .copied()
+            .or_else(|| self.fallback_type())
     }
 
     pub(crate) fn expression_type(&self, expression: impl Into<ExpressionNodeKey>) -> Type<'db> {
@@ -1130,7 +1180,7 @@ impl<'db> StatementInference<'db> {
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct StatementInferenceInner<'db> {
     /// The types of every expression in this region.
-    expressions: Box<[(ExpressionNodeKey, Type<'db>)]>,
+    expressions: FrozenMap<ExpressionNodeKey, Type<'db>>,
 
     /// The scope this region is part of.
     #[cfg(debug_assertions)]
@@ -1179,7 +1229,7 @@ impl<'db> StatementInferenceInner<'db> {
         let _ = scope;
 
         Self {
-            expressions: Box::default(),
+            expressions: FrozenMap::default(),
             bindings: Box::default(),
             declarations: Box::default(),
             #[cfg(debug_assertions)]
@@ -1239,7 +1289,10 @@ impl<'db> StatementInferenceInner<'db> {
         &self,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        entry_get(&self.expressions, &expression.into()).or_else(|| self.fallback_type())
+        self.expressions
+            .get(&expression.into())
+            .copied()
+            .or_else(|| self.fallback_type())
     }
 
     fn bindings(&self) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -83,6 +83,19 @@ bitflags::bitflags! {
 
 impl get_size2::GetSize for TypeExpressionFlags {}
 
+fn boxed_entries<K: Ord, V>(map: FxHashMap<K, V>) -> Box<[(K, V)]> {
+    let mut entries = map.into_iter().collect::<Vec<_>>();
+    entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    entries.into_boxed_slice()
+}
+
+fn entry_get<K: Ord, V: Copy>(entries: &[(K, V)], key: &K) -> Option<V> {
+    entries
+        .binary_search_by(|(candidate, _)| candidate.cmp(key))
+        .ok()
+        .map(|index| entries[index].1)
+}
+
 /// Infer all types for a [`Definition`] (including sub-expressions).
 /// Use when resolving a place use or public type of a place.
 #[salsa::tracked(
@@ -158,7 +171,7 @@ pub(crate) fn function_known_decorator_flags<'db>(
 /// function-definition inference.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct FunctionDecoratorInference<'db> {
-    expression_types: FxHashMap<ExpressionNodeKey, Type<'db>>,
+    expression_types: Box<[(ExpressionNodeKey, Type<'db>)]>,
     bindings: Box<[(Definition<'db>, Type<'db>)]>,
     called_functions: Box<[FunctionType<'db>]>,
     known_decorators: FunctionDecorators,
@@ -170,11 +183,13 @@ impl<'db> FunctionDecoratorInference<'db> {
         &self,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        self.expression_types.get(&expression.into()).copied()
+        entry_get(&self.expression_types, &expression.into())
     }
 
-    pub(crate) fn expression_types(&self) -> &FxHashMap<ExpressionNodeKey, Type<'db>> {
-        &self.expression_types
+    pub(crate) fn expression_types(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (ExpressionNodeKey, Type<'db>)> + '_ {
+        self.expression_types.iter().copied()
     }
 
     pub(crate) fn bindings(
@@ -688,7 +703,7 @@ impl<'db> InferenceRegion<'db> {
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct ScopeInference<'db> {
     /// The types of every expression in this region.
-    expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
+    expressions: Box<[(ExpressionNodeKey, Type<'db>)]>,
 
     /// The extra data that is only present for few inference regions.
     extra: Option<Box<ScopeInferenceExtra<'db>>>,
@@ -718,7 +733,7 @@ impl<'db> ScopeInference<'db> {
                 cycle_recovery: Some(cycle_recovery),
                 ..ScopeInferenceExtra::default()
             })),
-            expressions: FxHashMap::default(),
+            expressions: Box::default(),
         }
     }
 
@@ -749,10 +764,7 @@ impl<'db> ScopeInference<'db> {
         &self,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        self.expressions
-            .get(&expression.into())
-            .copied()
-            .or_else(|| self.fallback_type())
+        entry_get(&self.expressions, &expression.into()).or_else(|| self.fallback_type())
     }
 
     pub(crate) fn try_expected_type(
@@ -794,7 +806,7 @@ impl<'db> ScopeInference<'db> {
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct DefinitionInference<'db> {
     /// The types of every expression in this region.
-    expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
+    expressions: Box<[(ExpressionNodeKey, Type<'db>)]>,
 
     /// The scope this region is part of.
     #[cfg(debug_assertions)]
@@ -852,7 +864,7 @@ impl<'db> DefinitionInference<'db> {
         let _ = scope;
 
         Self {
-            expressions: FxHashMap::default(),
+            expressions: Box::default(),
             bindings: Box::default(),
             declarations: Box::default(),
             #[cfg(debug_assertions)]
@@ -912,10 +924,7 @@ impl<'db> DefinitionInference<'db> {
         &self,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        self.expressions
-            .get(&expression.into())
-            .copied()
-            .or_else(|| self.fallback_type())
+        entry_get(&self.expressions, &expression.into()).or_else(|| self.fallback_type())
     }
 
     /// Get qualifiers for an annotation expression
@@ -1004,7 +1013,7 @@ impl<'db> DefinitionInference<'db> {
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct ExpressionInference<'db> {
     /// The types of every expression in this region.
-    expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
+    expressions: Box<[(ExpressionNodeKey, Type<'db>)]>,
 
     extra: Option<Box<ExpressionInferenceExtra<'db>>>,
 
@@ -1044,7 +1053,7 @@ impl<'db> ExpressionInference<'db> {
                 cycle_recovery: Some(cycle_recovery),
                 ..ExpressionInferenceExtra::default()
             })),
-            expressions: FxHashMap::default(),
+            expressions: Box::default(),
             #[cfg(debug_assertions)]
             scope,
         }
@@ -1083,10 +1092,7 @@ impl<'db> ExpressionInference<'db> {
         &self,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        self.expressions
-            .get(&expression.into())
-            .copied()
-            .or_else(|| self.fallback_type())
+        entry_get(&self.expressions, &expression.into()).or_else(|| self.fallback_type())
     }
 
     pub(crate) fn expression_type(&self, expression: impl Into<ExpressionNodeKey>) -> Type<'db> {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -83,13 +83,13 @@ bitflags::bitflags! {
 
 impl get_size2::GetSize for TypeExpressionFlags {}
 
-fn boxed_entries<K: Ord, V>(map: FxHashMap<K, V>) -> Box<[(K, V)]> {
+pub(super) fn boxed_entries<K: Ord, V>(map: FxHashMap<K, V>) -> Box<[(K, V)]> {
     let mut entries = map.into_iter().collect::<Vec<_>>();
     entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
     entries.into_boxed_slice()
 }
 
-fn entry_get<K: Ord, V: Copy>(entries: &[(K, V)], key: &K) -> Option<V> {
+pub(super) fn entry_get<K: Ord, V: Copy>(entries: &[(K, V)], key: &K) -> Option<V> {
     entries
         .binary_search_by(|(candidate, _)| candidate.cmp(key))
         .ok()
@@ -1130,7 +1130,7 @@ impl<'db> StatementInference<'db> {
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct StatementInferenceInner<'db> {
     /// The types of every expression in this region.
-    expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
+    expressions: Box<[(ExpressionNodeKey, Type<'db>)]>,
 
     /// The scope this region is part of.
     #[cfg(debug_assertions)]
@@ -1179,7 +1179,7 @@ impl<'db> StatementInferenceInner<'db> {
         let _ = scope;
 
         Self {
-            expressions: FxHashMap::default(),
+            expressions: Box::default(),
             bindings: Box::default(),
             declarations: Box::default(),
             #[cfg(debug_assertions)]
@@ -1239,10 +1239,7 @@ impl<'db> StatementInferenceInner<'db> {
         &self,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        self.expressions
-            .get(&expression.into())
-            .copied()
-            .or_else(|| self.fallback_type())
+        entry_get(&self.expressions, &expression.into()).or_else(|| self.fallback_type())
     }
 
     fn bindings(&self) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -424,7 +424,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         #[cfg(debug_assertions)]
         assert_eq!(self.scope, inference.scope);
 
-        self.expressions.extend(inference.expressions.iter());
+        self.expressions
+            .extend(inference.expressions.iter().copied());
         self.declarations.extend(inference.declarations());
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
@@ -9284,7 +9285,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let Self {
             context,
-            mut expressions,
+            expressions,
             mut qualifiers,
             mut type_expression_flags,
             mut string_annotations,
@@ -9356,10 +9357,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
         }
 
-        expressions.shrink_to_fit();
-
         StatementInferenceInner {
-            expressions,
+            expressions: boxed_entries(expressions),
             #[cfg(debug_assertions)]
             scope,
             bindings: bindings.into_boxed_slice(),

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -25,7 +25,7 @@ use ty_python_core::statement::StatementInner;
 use super::{
     DefinitionInference, DefinitionInferenceExtra, ExpressionInference, ExpressionInferenceExtra,
     FunctionDecoratorInference, InferenceRegion, ScopeInference, ScopeInferenceExtra,
-    infer_deferred_types, infer_definition_types, infer_expression_types,
+    boxed_entries, infer_deferred_types, infer_definition_types, infer_expression_types,
     infer_same_file_expression_type, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
@@ -391,7 +391,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         #[cfg(debug_assertions)]
         assert_eq!(self.scope, inference.scope);
 
-        self.expressions.extend(inference.expressions.iter());
+        self.expressions
+            .extend(inference.expressions.iter().copied());
         self.declarations.extend(inference.declarations());
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
@@ -453,7 +454,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn extend_expression_unchecked(&mut self, inference: &ExpressionInference<'db>) {
-        self.expressions.extend(inference.expressions.iter());
+        self.expressions
+            .extend(inference.expressions.iter().copied());
 
         if let Some(extra) = &inference.extra {
             self.context.extend(&extra.diagnostics);
@@ -471,7 +473,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn extend_scope(&mut self, inference: &ScopeInference<'db>) {
-        self.expressions.extend(inference.expressions.iter());
+        self.expressions
+            .extend(inference.expressions.iter().copied());
 
         if let Some(extra) = &inference.extra {
             self.context.extend(&extra.diagnostics);
@@ -9203,7 +9206,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let Self {
             context,
-            mut expressions,
+            expressions,
             qualifiers: _,
             mut type_expression_flags,
             mut string_annotations,
@@ -9268,10 +9271,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
             });
 
-        expressions.shrink_to_fit();
-
         ExpressionInference {
-            expressions,
+            expressions: boxed_entries(expressions),
             extra,
             #[cfg(debug_assertions)]
             scope,
@@ -9414,7 +9415,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let diagnostics = context.finish();
 
         FunctionDecoratorInference {
-            expression_types: expressions,
+            expression_types: boxed_entries(expressions),
             bindings: bindings.into_boxed_slice(),
             called_functions: called_functions
                 .into_iter()
@@ -9430,7 +9431,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let Self {
             context,
-            mut expressions,
+            expressions,
             mut qualifiers,
             mut type_expression_flags,
             mut string_annotations,
@@ -9502,10 +9503,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             );
         }
 
-        expressions.shrink_to_fit();
-
         DefinitionInference {
-            expressions,
+            expressions: boxed_entries(expressions),
             #[cfg(debug_assertions)]
             scope,
             bindings: bindings.into_boxed_slice(),
@@ -9522,7 +9521,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             mut string_annotations,
             mut expected_types,
             mut type_expression_flags,
-            mut expressions,
+            expressions,
             scope,
             cycle_recovery,
 
@@ -9567,9 +9566,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             })
         });
 
-        expressions.shrink_to_fit();
-
-        ScopeInference { expressions, extra }
+        ScopeInference {
+            expressions: boxed_entries(expressions),
+            extra,
+        }
     }
 
     const fn inference_flags(&self) -> InferenceFlags {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -24,8 +24,8 @@ use ty_python_core::statement::StatementInner;
 
 use super::{
     DefinitionInference, DefinitionInferenceExtra, ExpressionInference, ExpressionInferenceExtra,
-    FunctionDecoratorInference, InferenceRegion, ScopeInference, ScopeInferenceExtra,
-    boxed_entries, infer_deferred_types, infer_definition_types, infer_expression_types,
+    FrozenMap, FunctionDecoratorInference, InferenceRegion, ScopeInference, ScopeInferenceExtra,
+    infer_deferred_types, infer_definition_types, infer_expression_types,
     infer_same_file_expression_type, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
@@ -9273,7 +9273,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             });
 
         ExpressionInference {
-            expressions: boxed_entries(expressions),
+            expressions: FrozenMap::from(expressions),
             extra,
             #[cfg(debug_assertions)]
             scope,
@@ -9358,7 +9358,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         StatementInferenceInner {
-            expressions: boxed_entries(expressions),
+            expressions: FrozenMap::from(expressions),
             #[cfg(debug_assertions)]
             scope,
             bindings: bindings.into_boxed_slice(),
@@ -9414,7 +9414,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let diagnostics = context.finish();
 
         FunctionDecoratorInference {
-            expression_types: boxed_entries(expressions),
+            expression_types: FrozenMap::from(expressions),
             bindings: bindings.into_boxed_slice(),
             called_functions: called_functions
                 .into_iter()
@@ -9503,7 +9503,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         DefinitionInference {
-            expressions: boxed_entries(expressions),
+            expressions: FrozenMap::from(expressions),
             #[cfg(debug_assertions)]
             scope,
             bindings: bindings.into_boxed_slice(),
@@ -9566,7 +9566,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         ScopeInference {
-            expressions: boxed_entries(expressions),
+            expressions: FrozenMap::from(expressions),
             extra,
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -307,12 +307,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (!decorator_list.is_empty()).then(|| function_known_decorators(db, definition));
         if let Some(decorator_inference) = decorator_inference.as_ref() {
             self.context.extend(decorator_inference.diagnostics());
-            self.expressions.extend(
-                decorator_inference
-                    .expression_types()
-                    .iter()
-                    .map(|(expression, ty)| (*expression, *ty)),
-            );
+            self.expressions
+                .extend(decorator_inference.expression_types());
             self.bindings.extend(decorator_inference.bindings());
             self.called_functions
                 .extend(decorator_inference.called_functions().iter().copied());

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -7,7 +7,7 @@ use ruff_python_ast::visitor::{self, Visitor};
 use ruff_python_ast::{self as ast, AnyNodeRef};
 
 use crate::Db;
-use crate::types::infer::{ExpressionInference, boxed_entries, entry_get};
+use crate::types::infer::{ExpressionInference, FrozenMap};
 use crate::types::tuple::{ResizeTupleError, Tuple, TupleLength, TupleSpec, TupleUnpacker};
 use crate::types::{Type, TypeCheckDiagnostics, TypeContext, infer_expression_types};
 use ty_python_core::ExpressionNodeKey;
@@ -272,7 +272,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
     pub(crate) fn finish(self) -> UnpackResult<'db> {
         UnpackResult {
             diagnostics: self.context.finish(),
-            targets: boxed_entries(self.targets),
+            targets: FrozenMap::from(self.targets),
             cycle_recovery: None,
         }
     }
@@ -280,7 +280,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
 
 #[derive(Debug, Default, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct UnpackResult<'db> {
-    targets: Box<[(ExpressionNodeKey, Type<'db>)]>,
+    targets: FrozenMap<ExpressionNodeKey, Type<'db>>,
     diagnostics: TypeCheckDiagnostics,
 
     /// The fallback type for missing expressions.
@@ -309,7 +309,10 @@ impl<'db> UnpackResult<'db> {
         &self,
         expr: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        entry_get(&self.targets, &expr.into()).or(self.cycle_recovery)
+        self.targets
+            .get(&expr.into())
+            .copied()
+            .or(self.cycle_recovery)
     }
 
     /// Returns the diagnostics in this unpacking assignment.
@@ -319,7 +322,7 @@ impl<'db> UnpackResult<'db> {
 
     pub(crate) fn cycle_initial(cycle_recovery: Type<'db>) -> Self {
         Self {
-            targets: Box::default(),
+            targets: FrozenMap::default(),
             diagnostics: TypeCheckDiagnostics::default(),
             cycle_recovery: Some(cycle_recovery),
         }

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -7,7 +7,7 @@ use ruff_python_ast::visitor::{self, Visitor};
 use ruff_python_ast::{self as ast, AnyNodeRef};
 
 use crate::Db;
-use crate::types::infer::ExpressionInference;
+use crate::types::infer::{ExpressionInference, boxed_entries, entry_get};
 use crate::types::tuple::{ResizeTupleError, Tuple, TupleLength, TupleSpec, TupleUnpacker};
 use crate::types::{Type, TypeCheckDiagnostics, TypeContext, infer_expression_types};
 use ty_python_core::ExpressionNodeKey;
@@ -269,12 +269,10 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
         }
     }
 
-    pub(crate) fn finish(mut self) -> UnpackResult<'db> {
-        self.targets.shrink_to_fit();
-
+    pub(crate) fn finish(self) -> UnpackResult<'db> {
         UnpackResult {
             diagnostics: self.context.finish(),
-            targets: self.targets,
+            targets: boxed_entries(self.targets),
             cycle_recovery: None,
         }
     }
@@ -282,7 +280,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
 
 #[derive(Debug, Default, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct UnpackResult<'db> {
-    targets: FxHashMap<ExpressionNodeKey, Type<'db>>,
+    targets: Box<[(ExpressionNodeKey, Type<'db>)]>,
     diagnostics: TypeCheckDiagnostics,
 
     /// The fallback type for missing expressions.
@@ -311,10 +309,7 @@ impl<'db> UnpackResult<'db> {
         &self,
         expr: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
-        self.targets
-            .get(&expr.into())
-            .copied()
-            .or(self.cycle_recovery)
+        entry_get(&self.targets, &expr.into()).or(self.cycle_recovery)
     }
 
     /// Returns the diagnostics in this unpacking assignment.
@@ -324,7 +319,7 @@ impl<'db> UnpackResult<'db> {
 
     pub(crate) fn cycle_initial(cycle_recovery: Type<'db>) -> Self {
         Self {
-            targets: FxHashMap::default(),
+            targets: Box::default(),
             diagnostics: TypeCheckDiagnostics::default(),
             cycle_recovery: Some(cycle_recovery),
         }


### PR DESCRIPTION
## Summary

In inference, after we `finish_*`, these various maps become immutable. By converting them to sorted, boxed slices, we get some very significant memory wins (3.79% on Prefect) and (empirically, at least) don't lose out on performance (at time of writing, the CodSpeed results show a 1% improvement on many projects and a 1% decrease on a few). The hash map is great for inference, since we're constructing, overwriting, etc.; but afterwards, we can just binary search on the boxed slice. This seems like a good tradeoff!
