### PR TITLE
[ty] Fix goto-definiton for self-imported sub-modules

### DIFF
--- a/crates/ty_ide/src/doc_highlights.rs
+++ b/crates/ty_ide/src/doc_highlights.rs
@@ -56,6 +56,33 @@ mod tests {
         }
     }
 
+    #[test]
+    fn relative_imported_submodule_highlights() {
+        let test = CursorTest::builder()
+            .source(
+                "mypackage/__init__.py",
+                "from . import module_a\nx = module_a<CURSOR>",
+            )
+            .source("mypackage/module_a.py", "class Test: ...")
+            .build();
+
+        assert_snapshot!(test.document_highlights(), @"
+        info[document_highlights]: Highlight 1 (Read)
+         --> mypackage/__init__.py:1:15
+          |
+        1 | from . import module_a
+          |               ^^^^^^^^
+          |
+
+        info[document_highlights]: Highlight 2 (Read)
+         --> mypackage/__init__.py:2:5
+          |
+        2 | x = module_a
+          |     ^^^^^^^^
+          |
+        ");
+    }
+
     struct HighlightResult {
         index: usize,
         file_range: FileRange,

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -41,6 +41,82 @@ pub(super) mod test {
     };
     use ruff_text_size::Ranged;
 
+    #[test]
+    fn goto_definition_relative_import() {
+        let test = CursorTest::builder()
+            .source("mypackage/__init__.py", "from . import module_a<CURSOR>")
+            .source("mypackage/module_a.py", "class Test: ...")
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> mypackage/__init__.py:1:15
+          |
+        1 | from . import module_a
+          |               ^^^^^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mypackage/module_a.py:1:1
+          |
+        1 | class Test: ...
+          | -
+          |
+        ");
+    }
+
+    #[test]
+    fn goto_definition_relative_import_reference() {
+        let test = CursorTest::builder()
+            .source(
+                "mypackage/__init__.py",
+                "from . import module_a\nx = module_a<CURSOR>",
+            )
+            .source("mypackage/module_a.py", "class Test: ...")
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> mypackage/__init__.py:2:5
+          |
+        2 | x = module_a
+          |     ^^^^^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mypackage/module_a.py:1:1
+          |
+        1 | class Test: ...
+          | -
+          |
+        ");
+    }
+
+    #[test]
+    fn goto_definition_relative_star_imported_submodule_reference() {
+        let test = CursorTest::builder()
+            .source(
+                "mypackage/__init__.py",
+                "from .exporter import *\nx = module_a<CURSOR>",
+            )
+            .source("mypackage/exporter.py", "from . import module_a")
+            .source("mypackage/module_a.py", "class Test: ...")
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> mypackage/__init__.py:2:5
+          |
+        2 | x = module_a
+          |     ^^^^^^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> mypackage/module_a.py:1:1
+          |
+        1 | class Test: ...
+          | -
+          |
+        ");
+    }
+
     /// goto-definition on a module should go to the .py not the .pyi
     ///
     /// TODO: this currently doesn't work right! This is especially surprising

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1543,23 +1543,29 @@ mod resolve_definition {
         let definitions_in_module = find_symbol_in_scope(db, global_scope, symbol_name);
 
         // Recursively resolve any import definitions found in the target module
-        if definitions_in_module.is_empty() {
-            // This might be importing a submodule, try that
-            return Vec::from_iter(resolve_from_import_submodule_definitions(
-                db,
-                file,
-                symbol_name,
-                module_name,
-            ));
-        }
-
         let mut resolved_definitions = Vec::new();
         for def in definitions_in_module {
             let resolved =
                 resolve_definition_recursive(db, def, visited, Some(symbol_name), alias_resolution);
             resolved_definitions.extend(resolved);
         }
-        resolved_definitions
+
+        if resolved_definitions.is_empty() {
+            // In `pkg/__init__.py`, `from . import child` resolves `.` to
+            // `pkg/__init__.py`. Looking up `child` there can find an import definition
+            // that recursively resolves back here (possibly through `from . import *`),
+            // so recursive resolution bottoms out before reaching the `pkg.child`
+            // submodule target. Fall back to the same submodule candidate we use when
+            // `child` has no binding in `pkg/__init__.py`.
+            Vec::from_iter(resolve_from_import_submodule_definitions(
+                db,
+                file,
+                symbol_name,
+                module_name,
+            ))
+        } else {
+            resolved_definitions
+        }
     }
 
     // Helper to resolve `from x.y import z` assuming `x.y.z` is a module.


### PR DESCRIPTION
## Summary

Fixes goto-definition for imports that self-reference the current module:

`__init__.py`

```py
from . import ops # can't click to go to module file
from . import xyz # can't click to go to module file
```

Resolving `ops` requires resolving `.` to `__init__.py`. Go-to definition then looks for a `ops` symbol within `__init__.py`, before trying to resolve `ops` as a submodule. However, go-to def now finds the same definition again as it started from (the `ops` import from `.`), which it then tries to resolve that again. The recursion handler catches this and empty result.

This PR catches this and, instead of returning an empty result, returns any available sub module

Fixes https://github.com/astral-sh/ty/issues/2907

