### PR TITLE
[flake8-use-pathlib] Avoid file descriptor diagnostics for os.path checks

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH202.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH202.py
@@ -80,3 +80,19 @@ getsize(Path("filename").resolve())
 import pathlib
 
 os.path.getsize(pathlib.Path("filename"))
+
+fd = 1
+
+
+def get_fd() -> int:
+    return fd
+
+
+os.path.getsize(1)
+os.path.getsize(fd)
+os.path.getsize(get_fd())
+os.path.getsize(filename=1)
+getsize(1)
+getsize(fd)
+getsize(get_fd())
+getsize(filename=1)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH203.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH203.py
@@ -33,3 +33,19 @@ getatime(Path("filename").resolve())
 os.path.getatime(pathlib.Path("filename"))
 
 getatime(Path("dir") / "file.txt")
+
+fd = 1
+
+
+def get_fd() -> int:
+    return fd
+
+
+os.path.getatime(1)
+os.path.getatime(fd)
+os.path.getatime(get_fd())
+os.path.getatime(filename=1)
+getatime(1)
+getatime(fd)
+getatime(get_fd())
+getatime(filename=1)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH204.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH204.py
@@ -11,3 +11,19 @@ os.path.getmtime(Path("filename"))
 getmtime("filename")
 getmtime(b"filename")
 getmtime(Path("filename"))
+
+fd = 1
+
+
+def get_fd() -> int:
+    return fd
+
+
+os.path.getmtime(1)
+os.path.getmtime(fd)
+os.path.getmtime(get_fd())
+os.path.getmtime(filename=1)
+getmtime(1)
+getmtime(fd)
+getmtime(get_fd())
+getmtime(filename=1)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH205.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH205.py
@@ -10,3 +10,19 @@ os.path.getctime(Path("filename"))
 getctime("filename")
 getctime(b"filename")
 getctime(Path("filename"))
+
+fd = 1
+
+
+def get_fd() -> int:
+    return fd
+
+
+os.path.getctime(1)
+os.path.getctime(fd)
+os.path.getctime(get_fd())
+os.path.getctime(filename=1)
+getctime(1)
+getctime(fd)
+getctime(get_fd())
+getctime(filename=1)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
@@ -171,3 +171,27 @@ try:
         break
 except TypeError as e:
     print("readlink: not iterable")
+
+fd = 1
+
+
+def get_fd() -> int:
+    return fd
+
+
+os.path.exists(1)
+os.path.exists(fd)
+os.path.exists(get_fd())
+os.path.exists(path=1)
+os.path.isdir(1)
+os.path.isdir(fd)
+os.path.isdir(get_fd())
+os.path.isdir(s=1)
+os.path.isfile(1)
+os.path.isfile(fd)
+os.path.isfile(get_fd())
+os.path.isfile(path=1)
+os.path.samefile(1, p)
+os.path.samefile(fd, p)
+os.path.samefile(get_fd(), p)
+os.path.samefile(f1=1, f2=p)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/import_as.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/import_as.py
@@ -29,3 +29,27 @@ foo_p.basename(p)
 foo_p.dirname(p)
 foo_p.samefile(p)
 foo_p.splitext(p)
+
+fd = 1
+
+
+def get_fd() -> int:
+    return fd
+
+
+foo_p.exists(1)
+foo_p.exists(fd)
+foo_p.exists(get_fd())
+foo_p.exists(path=1)
+foo_p.isdir(1)
+foo_p.isdir(fd)
+foo_p.isdir(get_fd())
+foo_p.isdir(s=1)
+foo_p.isfile(1)
+foo_p.isfile(fd)
+foo_p.isfile(get_fd())
+foo_p.isfile(path=1)
+foo_p.samefile(1, p)
+foo_p.samefile(fd, p)
+foo_p.samefile(get_fd(), p)
+foo_p.samefile(f1=1, f2=p)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/import_from.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/import_from.py
@@ -63,3 +63,27 @@ rename(
 rename(file, "file_2.py", src_dir_fd=None, dst_dir_fd=None)
 
 rename(file, "file_2.py", src_dir_fd=1)
+
+fd = 1
+
+
+def get_fd() -> int:
+    return fd
+
+
+exists(1)
+exists(fd)
+exists(get_fd())
+exists(path=1)
+isdir(1)
+isdir(fd)
+isdir(get_fd())
+isdir(s=1)
+isfile(1)
+isfile(fd)
+isfile(get_fd())
+isfile(path=1)
+samefile(1, p)
+samefile(fd, p)
+samefile(get_fd(), p)
+samefile(f1=1, f2=p)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/import_from_as.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/import_from_as.py
@@ -36,3 +36,27 @@ xbasename(p)
 xdirname(p)
 xsamefile(p)
 xsplitext(p)
+
+fd = 1
+
+
+def get_fd() -> int:
+    return fd
+
+
+xexists(1)
+xexists(fd)
+xexists(get_fd())
+xexists(path=1)
+xisdir(1)
+xisdir(fd)
+xisdir(get_fd())
+xisdir(s=1)
+xisfile(1)
+xisfile(fd)
+xisfile(get_fd())
+xisfile(path=1)
+xsamefile(1, p)
+xsamefile(fd, p)
+xsamefile(get_fd(), p)
+xsamefile(f1=1, f2=p)

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/helpers.rs
@@ -59,6 +59,50 @@ pub(crate) fn check_os_pathlib_single_arg_calls(
     violation: impl Violation,
     applicability: Applicability,
 ) {
+    check_os_pathlib_single_arg_calls_impl(
+        checker,
+        call,
+        attr,
+        fn_argument,
+        fix_enabled,
+        violation,
+        applicability,
+        false,
+    );
+}
+
+pub(crate) fn check_os_pathlib_single_arg_calls_allowing_fd(
+    checker: &Checker,
+    call: &ExprCall,
+    attr: &str,
+    fn_argument: &str,
+    fix_enabled: bool,
+    violation: impl Violation,
+    applicability: Applicability,
+) {
+    check_os_pathlib_single_arg_calls_impl(
+        checker,
+        call,
+        attr,
+        fn_argument,
+        fix_enabled,
+        violation,
+        applicability,
+        true,
+    );
+}
+
+#[expect(clippy::too_many_arguments)]
+fn check_os_pathlib_single_arg_calls_impl(
+    checker: &Checker,
+    call: &ExprCall,
+    attr: &str,
+    fn_argument: &str,
+    fix_enabled: bool,
+    violation: impl Violation,
+    applicability: Applicability,
+    allow_file_descriptor: bool,
+) {
     if call.arguments.len() != 1 {
         return;
     }
@@ -66,6 +110,10 @@ pub(crate) fn check_os_pathlib_single_arg_calls(
     let Some(arg) = call.arguments.find_argument_value(fn_argument, 0) else {
         return;
     };
+
+    if allow_file_descriptor && is_file_descriptor(arg, checker.semantic()) {
+        return;
+    }
 
     let arg_code = checker.locator().slice(arg.range());
     let range = call.range();

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_exists.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_exists.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_exists_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls_allowing_fd;
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -66,7 +66,7 @@ pub(crate) fn os_path_exists(checker: &Checker, call: &ExprCall, segments: &[&st
         return;
     }
 
-    check_os_pathlib_single_arg_calls(
+    check_os_pathlib_single_arg_calls_allowing_fd(
         checker,
         call,
         "exists()",

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getatime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getatime.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getatime_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls_allowing_fd;
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -69,7 +69,7 @@ pub(crate) fn os_path_getatime(checker: &Checker, call: &ExprCall, segments: &[&
         return;
     }
 
-    check_os_pathlib_single_arg_calls(
+    check_os_pathlib_single_arg_calls_allowing_fd(
         checker,
         call,
         "stat().st_atime",

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getctime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getctime.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getctime_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls_allowing_fd;
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -70,7 +70,7 @@ pub(crate) fn os_path_getctime(checker: &Checker, call: &ExprCall, segments: &[&
         return;
     }
 
-    check_os_pathlib_single_arg_calls(
+    check_os_pathlib_single_arg_calls_allowing_fd(
         checker,
         call,
         "stat().st_ctime",

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getmtime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getmtime.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getmtime_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls_allowing_fd;
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -70,7 +70,7 @@ pub(crate) fn os_path_getmtime(checker: &Checker, call: &ExprCall, segments: &[&
         return;
     }
 
-    check_os_pathlib_single_arg_calls(
+    check_os_pathlib_single_arg_calls_allowing_fd(
         checker,
         call,
         "stat().st_mtime",

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getsize.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getsize.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getsize_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls_allowing_fd;
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -70,7 +70,7 @@ pub(crate) fn os_path_getsize(checker: &Checker, call: &ExprCall, segments: &[&s
         return;
     }
 
-    check_os_pathlib_single_arg_calls(
+    check_os_pathlib_single_arg_calls_allowing_fd(
         checker,
         call,
         "stat().st_size",

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isdir.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isdir.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_isdir_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls_allowing_fd;
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -67,7 +67,7 @@ pub(crate) fn os_path_isdir(checker: &Checker, call: &ExprCall, segments: &[&str
         return;
     }
 
-    check_os_pathlib_single_arg_calls(
+    check_os_pathlib_single_arg_calls_allowing_fd(
         checker,
         call,
         "is_dir()",

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isfile.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isfile.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_isfile_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls_allowing_fd;
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -67,7 +67,7 @@ pub(crate) fn os_path_isfile(checker: &Checker, call: &ExprCall, segments: &[&st
         return;
     }
 
-    check_os_pathlib_single_arg_calls(
+    check_os_pathlib_single_arg_calls_allowing_fd(
         checker,
         call,
         "is_file()",

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_samefile.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_samefile.rs
@@ -5,7 +5,7 @@ use ruff_python_ast::ExprCall;
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_samefile_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    check_os_pathlib_two_arg_calls, has_unknown_keywords_or_starred_expr,
+    check_os_pathlib_two_arg_calls, has_unknown_keywords_or_starred_expr, is_file_descriptor,
 };
 use crate::{FixAvailability, Violation};
 
@@ -67,6 +67,14 @@ impl Violation for OsPathSamefile {
 /// PTH121
 pub(crate) fn os_path_samefile(checker: &Checker, call: &ExprCall, segments: &[&str]) {
     if segments != ["os", "path", "samefile"] {
+        return;
+    }
+
+    if call
+        .arguments
+        .find_argument_value("f1", 0)
+        .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+    {
         return;
     }
 


### PR DESCRIPTION
## Summary
- Suppress `flake8-use-pathlib` diagnostics for `os.path` helpers when the path argument is a file descriptor.
- Reuse Ruff's existing file-descriptor inference for affected single-argument path checks.
- Skip `PTH121` only when the first `samefile` argument would become an invalid `Path(fd)` receiver.
- Add negative fixtures for literal, inferred, annotated-return, keyword, direct-import, and alias-import file-descriptor cases.

## Test Plan
- `git diff --check`
- `python3 -m py_compile crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH202.py crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH203.py crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH204.py crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH205.py crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/import_from.py crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/import_as.py crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/import_from_as.py`

Note: I could not run the focused Rust test locally because this environment does not have `cargo` installed. The intended focused check is `cargo test -p ruff_linter flake8_use_pathlib`.

Refs #17699.
