### PR TITLE
[ty] Emit folding ranges for an entire block from the language server.

### DIFF
--- a/crates/ty_ide/src/folding_range.rs
+++ b/crates/ty_ide/src/folding_range.rs
@@ -940,6 +940,279 @@ else:
     }
 
     #[test]
+    fn test_folding_range_multi_line_block_headers() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+def choose(
+    value,
+    fallback,
+):
+    if any(
+        [
+            value,
+        ]
+    ):
+        return value
+    elif (
+        fallback
+    ):
+        return fallback
+
+class Repository[
+    Model,
+    Key,
+](
+    Mapping[Key, Model],
+    Protocol,
+):
+    pass
+
+try:
+    pass
+except (
+    ValueError,
+    TypeError,
+) as error:
+    raise error
+
+match value:
+    case {
+        "kind": kind,
+        "payload": payload,
+    }:
+        handle_mapping()
+<CURSOR>
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.folding_ranges(), @r#"
+        info[folding-range]: Folding Range
+          --> main.py:2:12
+           |
+         2 |   def choose(
+           |  ____________^
+         3 | |     value,
+         4 | |     fallback,
+         5 | | ):
+         6 | |     if any(
+         7 | |         [
+         8 | |             value,
+         9 | |         ]
+        10 | |     ):
+        11 | |         return value
+        12 | |     elif (
+        13 | |         fallback
+        14 | |     ):
+        15 | |         return fallback
+           | |_______________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:5:3
+           |
+         5 |   ):
+           |  ___^
+         6 | |     if any(
+         7 | |         [
+         8 | |             value,
+         9 | |         ]
+        10 | |     ):
+        11 | |         return value
+        12 | |     elif (
+        13 | |         fallback
+        14 | |     ):
+        15 | |         return fallback
+           | |_______________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:6:12
+           |
+         6 |       if any(
+           |  ____________^
+         7 | |         [
+         8 | |             value,
+         9 | |         ]
+        10 | |     ):
+        11 | |         return value
+           | |____________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:10:7
+           |
+        10 |       ):
+           |  _______^
+        11 | |         return value
+           | |____________________^
+           |
+
+        info[folding-range]: Folding Range
+         --> main.py:7:9
+          |
+        7 | /         [
+        8 | |             value,
+        9 | |         ]
+          | |_________^
+          |
+
+        info[folding-range]: Folding Range
+          --> main.py:12:11
+           |
+        12 |       elif (
+           |  ___________^
+        13 | |         fallback
+        14 | |     ):
+        15 | |         return fallback
+           | |_______________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:14:7
+           |
+        14 |       ):
+           |  _______^
+        15 | |         return fallback
+           | |_______________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:17:18
+           |
+        17 |   class Repository[
+           |  __________________^
+        18 | |     Model,
+        19 | |     Key,
+        20 | | ](
+        21 | |     Mapping[Key, Model],
+        22 | |     Protocol,
+        23 | | ):
+        24 | |     pass
+           | |________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:23:3
+           |
+        23 |   ):
+           |  ___^
+        24 | |     pass
+           | |________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:26:5
+           |
+        26 |   try:
+           |  _____^
+        27 | |     pass
+           | |________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:28:9
+           |
+        28 |   except (
+           |  _________^
+        29 | |     ValueError,
+        30 | |     TypeError,
+        31 | | ) as error:
+        32 | |     raise error
+           | |_______________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:31:12
+           |
+        31 |   ) as error:
+           |  ____________^
+        32 | |     raise error
+           | |_______________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:34:13
+           |
+        34 |   match value:
+           |  _____________^
+        35 | |     case {
+        36 | |         "kind": kind,
+        37 | |         "payload": payload,
+        38 | |     }:
+        39 | |         handle_mapping()
+           | |________________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:35:11
+           |
+        35 |       case {
+           |  ___________^
+        36 | |         "kind": kind,
+        37 | |         "payload": payload,
+        38 | |     }:
+        39 | |         handle_mapping()
+           | |________________________^
+           |
+
+        info[folding-range]: Folding Range
+          --> main.py:38:7
+           |
+        38 |       }:
+           |  _______^
+        39 | |         handle_mapping()
+           | |________________________^
+           |
+        "#);
+    }
+
+    #[test]
+    fn test_folding_range_suppresses_header_expression_on_block_start_line() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+def foo(x=[
+    bar,
+    baz,
+]):
+    qux = x[0] + 1
+    return qux
+<CURSOR>
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.folding_ranges(), @"
+        info[folding-range]: Folding Range
+         --> main.py:2:12
+          |
+        2 |   def foo(x=[
+          |  ____________^
+        3 | |     bar,
+        4 | |     baz,
+        5 | | ]):
+        6 | |     qux = x[0] + 1
+        7 | |     return qux
+          | |______________^
+          |
+
+        info[folding-range]: Folding Range
+         --> main.py:5:4
+          |
+        5 |   ]):
+          |  ____^
+        6 | |     qux = x[0] + 1
+        7 | |     return qux
+          | |______________^
+          |
+        ");
+    }
+
+    #[test]
     fn test_folding_range_preserves_inline_block_header_comment() {
         let test = CursorTest::builder()
             .source(
@@ -1811,14 +2084,23 @@ with open("file.txt") as f:
     }
 
     #[test]
-    fn test_folding_multiline() {
-        // A class definition on a single line shouldn't have
-        // any folding ranges.
+    fn test_folding_range_single_line_class() {
         let test = CursorTest::builder()
             .source("main.py", "class MyClass: pass\n<CURSOR>")
             .build();
         assert_snapshot!(test.folding_ranges(), @"No folding ranges found");
+    }
 
+    #[test]
+    fn test_folding_range_single_line_class_with_trailing_comment() {
+        let test = CursorTest::builder()
+            .source("main.py", "class MyClass: pass  # comment\n<CURSOR>")
+            .build();
+        assert_snapshot!(test.folding_ranges(), @"No folding ranges found");
+    }
+
+    #[test]
+    fn test_folding_multiline() {
         // A single LF new-line results in a folding range.
         let test = CursorTest::builder()
             .source("main.py", "class MyClass:\n    pass\n<CURSOR>")

--- a/crates/ty_ide/src/folding_range.rs
+++ b/crates/ty_ide/src/folding_range.rs
@@ -59,10 +59,15 @@ pub fn folding_ranges(
     let mut visitor = FoldingRangeVisitor {
         source: source.as_str(),
         ranges: vec![],
+        active_block_fold_start_lines: vec![],
         tokens: parsed.tokens(),
         range_filter,
     };
     walk_node(&mut visitor, AnyNodeRef::from(parsed.syntax()));
+    debug_assert!(
+        visitor.active_block_fold_start_lines.is_empty(),
+        "all active block fold start lines should be cleared after traversal"
+    );
 
     // Add remaining ranges not covered by the AST visitor.
     let own_line_comment_ranges: Vec<_> = parsed
@@ -90,11 +95,18 @@ pub fn folding_ranges(
 struct FoldingRangeVisitor<'a> {
     source: &'a str,
     ranges: Vec<FoldingRange>,
+    active_block_fold_start_lines: Vec<ActiveBlockFoldStartLine<'a>>,
     tokens: &'a Tokens,
     range_filter: Option<TextRange>,
 }
 
-impl FoldingRangeVisitor<'_> {
+#[derive(Debug, Clone, Copy)]
+struct ActiveBlockFoldStartLine<'a> {
+    parent: AnyNodeRef<'a>,
+    line_start: TextSize,
+}
+
+impl<'a> FoldingRangeVisitor<'a> {
     fn intersects_range_filter(&self, range: TextRange) -> bool {
         self.range_filter
             .is_none_or(|range_filter| range_filter.intersect(range).is_some())
@@ -106,15 +118,43 @@ impl FoldingRangeVisitor<'_> {
     }
 
     /// Add the given folding range if it spans multiple lines.
-    fn add_range(&mut self, folding_range: impl Into<FoldingRange>) {
+    fn add_range(&mut self, folding_range: impl Into<FoldingRange>) -> bool {
         let folding_range = folding_range.into();
         if !self.contains_range_filter(folding_range.range) {
-            return;
+            return false;
         }
         if !self.is_multiline(folding_range.range) {
-            return;
+            return false;
         }
         self.ranges.push(folding_range);
+        true
+    }
+
+    /// Adds a single folding range for a block.
+    fn add_block_range(&mut self, parent: AnyNodeRef<'a>, range: TextRange) {
+        if self.add_range(range) {
+            self.active_block_fold_start_lines
+                .push(ActiveBlockFoldStartLine {
+                    parent,
+                    line_start: self.source.line_start(range.start()),
+                });
+        }
+    }
+
+    /// Adds a folding range for an expression.
+    fn add_expression_range(&mut self, range: TextRange) {
+        // Block folds preserve statement headers, so they take precedence over expression folds
+        // when both would render a folding trigger on the same line.
+        let line_start = self.source.line_start(range.start());
+        if self
+            .active_block_fold_start_lines
+            .iter()
+            .any(|block_fold| block_fold.line_start == line_start)
+        {
+            return;
+        }
+
+        self.add_range(range);
     }
 
     fn is_multiline(&self, range: TextRange) -> bool {
@@ -295,27 +335,118 @@ impl FoldingRangeVisitor<'_> {
             .map(Ranged::start)
     }
 
-    /// Adds a folding range for the body of the given block, while leaving the block header visible.
-    fn add_block_body_range<T: Ranged>(&mut self, header_start: TextSize, block: &[T]) {
+    /// Finds where a class or function definition actually starts once we skip over decorators.
+    fn definition_header_start<D: Ranged>(
+        &self,
+        keyword: TokenKind,
+        statement_start: TextSize,
+        decorators: &[D],
+        name_start: TextSize,
+    ) -> TextSize {
+        let search_start = decorators.last().map_or(statement_start, Ranged::end);
+        self.find_token_start(keyword, TextRange::new(search_start, name_start))
+            .unwrap_or(search_start)
+    }
+
+    /// Returns the start offsets for a block's full fold and body fold.
+    ///
+    /// The first offset marks the line on which we should start the full fold (the actual character
+    /// offset will be computed as the end of this line).
+    ///
+    /// The second offset marks where we start scanning for the newline that begins the body fold.
+    fn block_range_starts(&self, parent: AnyNodeRef<'a>) -> (TextSize, TextSize) {
+        match parent {
+            AnyNodeRef::StmtFunctionDef(func) => {
+                let keyword = if func.is_async {
+                    TokenKind::Async
+                } else {
+                    TokenKind::Def
+                };
+                (
+                    self.definition_header_start(
+                        keyword,
+                        func.start(),
+                        &func.decorator_list,
+                        func.name.start(),
+                    ),
+                    func.name.end(),
+                )
+            }
+            AnyNodeRef::StmtClassDef(class) => (
+                self.definition_header_start(
+                    TokenKind::Class,
+                    class.start(),
+                    &class.decorator_list,
+                    class.name.start(),
+                ),
+                class.name.end(),
+            ),
+            _ => (parent.start(), parent.start()),
+        }
+    }
+
+    /// Adds folding ranges for a block.
+    fn add_block_ranges<T: Ranged>(&mut self, parent: AnyNodeRef<'a>, block: &[T]) {
+        let (block_start, body_header_start) = self.block_range_starts(parent);
+        let full_range = self.full_block_range(block_start, block);
+        let body_range = self.block_body_range(body_header_start, block);
+        self.add_distinct_block_ranges(parent, full_range, body_range);
+    }
+
+    /// Adds the full range if present, and also adds the body range if both present and distinct
+    /// from the full range.
+    fn add_distinct_block_ranges(
+        &mut self,
+        parent: AnyNodeRef<'a>,
+        full_range: Option<TextRange>,
+        body_range: Option<TextRange>,
+    ) {
+        if let Some(full_range) = full_range {
+            self.add_block_range(parent, full_range);
+        }
+        if body_range != full_range
+            && let Some(body_range) = body_range
+        {
+            self.add_block_range(parent, body_range);
+        }
+    }
+
+    /// Returns a folding range for a full block, preserving the first line of the block header.
+    fn full_block_range<T: Ranged>(&self, block_start: TextSize, block: &[T]) -> Option<TextRange> {
+        let last_block_statement = block.last()?;
+        let start = self.source.line_end(block_start);
+        let end = last_block_statement.end();
+
+        if start >= end {
+            return None;
+        }
+
+        Some(TextRange::new(start, end))
+    }
+
+    /// Returns a folding range for just the body of a block.
+    fn block_body_range<T: Ranged>(
+        &self,
+        header_start: TextSize,
+        block: &[T],
+    ) -> Option<TextRange> {
         let (Some(first_block_statement), Some(last_block_statement)) =
             (block.first(), block.last())
         else {
-            return;
+            return None;
         };
-        let Some(block_fold_start) = self.find_token_start(
+        let block_fold_start = self.find_token_start(
             TokenKind::Newline,
             TextRange::new(header_start, first_block_statement.start()),
-        ) else {
-            return;
-        };
+        )?;
 
-        self.add_range(TextRange::new(block_fold_start, last_block_statement.end()));
+        Some(TextRange::new(block_fold_start, last_block_statement.end()))
     }
 
-    /// Searches for a given keyword and, if present, adds a fold for the body of the block while
-    /// leaving the block header visible.
-    fn add_block_body_range_after_keyword<T: Ranged>(
+    /// Searches for a given keyword and, if present, adds folds for the block it defines.
+    fn add_block_ranges_after_keyword<T: Ranged>(
         &mut self,
+        parent: AnyNodeRef<'a>,
         keyword: TokenKind,
         previous_block_end: TextSize,
         block: &[T],
@@ -330,12 +461,16 @@ impl FoldingRangeVisitor<'_> {
             return;
         };
 
-        self.add_block_body_range(keyword_start, block);
+        self.add_distinct_block_ranges(
+            parent,
+            self.full_block_range(keyword_start, block),
+            self.block_body_range(keyword_start, block),
+        );
     }
 }
 
-impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
-    fn enter_node(&mut self, node: AnyNodeRef<'_>) -> TraversalSignal {
+impl<'a> SourceOrderVisitor<'a> for FoldingRangeVisitor<'a> {
+    fn enter_node(&mut self, node: AnyNodeRef<'a>) -> TraversalSignal {
         if !self.intersects_range_filter(node.range()) {
             return TraversalSignal::Skip;
         }
@@ -346,7 +481,7 @@ impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
             }
             // Compound statements that create folding regions
             AnyNodeRef::StmtFunctionDef(func) => {
-                self.add_block_body_range(func.name.end(), &func.body);
+                self.add_block_ranges(node, &func.body);
                 // Note that this may be duplicative with folding
                 // ranges added for string literals. But I don't think
                 // the LSP protocol specifies that this is a problem.
@@ -357,7 +492,7 @@ impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
                 self.add_docstring_range(&func.body);
             }
             AnyNodeRef::StmtClassDef(class) => {
-                self.add_block_body_range(class.name.end(), &class.body);
+                self.add_block_ranges(node, &class.body);
                 // See comment above for class docstrings about this
                 // being duplicative with adding folding ranges for
                 // string literals.
@@ -365,17 +500,18 @@ impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
             }
             AnyNodeRef::StmtIf(if_stmt) => {
                 // Fold each branch individually rather than the entire if block.
-                self.add_block_body_range(if_stmt.start(), &if_stmt.body);
+                self.add_block_ranges(node, &if_stmt.body);
             }
             AnyNodeRef::ElifElseClause(clause) => {
                 // Each elif/else clause has its own range.
-                self.add_block_body_range(clause.start(), &clause.body);
+                self.add_block_ranges(node, &clause.body);
             }
             AnyNodeRef::StmtFor(for_stmt) => {
                 // Fold the for body separately from the else block.
-                self.add_block_body_range(for_stmt.start(), &for_stmt.body);
+                self.add_block_ranges(node, &for_stmt.body);
                 if let Some(body_last) = for_stmt.body.last() {
-                    self.add_block_body_range_after_keyword(
+                    self.add_block_ranges_after_keyword(
+                        node,
                         TokenKind::Else,
                         body_last.end(),
                         &for_stmt.orelse,
@@ -384,9 +520,10 @@ impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
             }
             AnyNodeRef::StmtWhile(while_stmt) => {
                 // Fold the while body separately from the else block.
-                self.add_block_body_range(while_stmt.start(), &while_stmt.body);
+                self.add_block_ranges(node, &while_stmt.body);
                 if let Some(body_last) = while_stmt.body.last() {
-                    self.add_block_body_range_after_keyword(
+                    self.add_block_ranges_after_keyword(
+                        node,
                         TokenKind::Else,
                         body_last.end(),
                         &while_stmt.orelse,
@@ -394,11 +531,11 @@ impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
                 }
             }
             AnyNodeRef::StmtWith(with_stmt) => {
-                self.add_block_body_range(with_stmt.start(), &with_stmt.body);
+                self.add_block_ranges(node, &with_stmt.body);
             }
             AnyNodeRef::StmtTry(try_stmt) => {
                 // Fold the try body separately from handlers, else, and finally.
-                self.add_block_body_range(try_stmt.start(), &try_stmt.body);
+                self.add_block_ranges(node, &try_stmt.body);
                 // Exception handlers are folded via ExceptHandlerExceptHandler.
                 // Fold the else block if present.
                 if let Some(previous_block_end) = try_stmt
@@ -407,7 +544,8 @@ impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
                     .map(Ranged::end)
                     .or_else(|| try_stmt.body.last().map(Ranged::end))
                 {
-                    self.add_block_body_range_after_keyword(
+                    self.add_block_ranges_after_keyword(
+                        node,
                         TokenKind::Else,
                         previous_block_end,
                         &try_stmt.orelse,
@@ -421,7 +559,8 @@ impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
                     .or_else(|| try_stmt.handlers.last().map(Ranged::end))
                     .or_else(|| try_stmt.body.last().map(Ranged::end))
                 {
-                    self.add_block_body_range_after_keyword(
+                    self.add_block_ranges_after_keyword(
+                        node,
                         TokenKind::Finally,
                         previous_block_end,
                         &try_stmt.finalbody,
@@ -429,69 +568,69 @@ impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
                 }
             }
             AnyNodeRef::StmtMatch(match_stmt) => {
-                self.add_block_body_range(match_stmt.start(), &match_stmt.cases);
+                self.add_block_ranges(node, &match_stmt.cases);
             }
 
             // Match cases within match statements
             AnyNodeRef::MatchCase(case) => {
-                self.add_block_body_range(case.start(), &case.body);
+                self.add_block_ranges(node, &case.body);
             }
 
             // Exception handlers
             AnyNodeRef::ExceptHandlerExceptHandler(handler) => {
-                self.add_block_body_range(handler.start(), &handler.body);
+                self.add_block_ranges(node, &handler.body);
             }
 
             // Multiline expressions
             AnyNodeRef::ExprList(list) => {
-                self.add_range(list.range());
+                self.add_expression_range(list.range());
             }
             AnyNodeRef::ExprTuple(tuple)
                 // Only fold parenthesized tuples.
                 if tuple.parenthesized => {
-                    self.add_range(tuple.range());
+                    self.add_expression_range(tuple.range());
                 }
             AnyNodeRef::ExprDict(dict) => {
-                self.add_range(dict.range());
+                self.add_expression_range(dict.range());
             }
             AnyNodeRef::ExprSet(set) => {
-                self.add_range(set.range());
+                self.add_expression_range(set.range());
             }
             AnyNodeRef::ExprListComp(listcomp) => {
-                self.add_range(listcomp.range());
+                self.add_expression_range(listcomp.range());
             }
             AnyNodeRef::ExprSetComp(setcomp) => {
-                self.add_range(setcomp.range());
+                self.add_expression_range(setcomp.range());
             }
             AnyNodeRef::ExprDictComp(dictcomp) => {
-                self.add_range(dictcomp.range());
+                self.add_expression_range(dictcomp.range());
             }
             AnyNodeRef::ExprGenerator(generator) => {
-                self.add_range(generator.range());
+                self.add_expression_range(generator.range());
             }
 
             // Function calls with arguments spanning multiple lines
             AnyNodeRef::ExprCall(call) => {
-                self.add_range(call.range());
+                self.add_expression_range(call.range());
             }
 
             // String and bytes literals
             AnyNodeRef::ExprStringLiteral(string) => {
-                self.add_range(string.range());
+                self.add_expression_range(string.range());
             }
             AnyNodeRef::ExprBytesLiteral(bytes) => {
-                self.add_range(bytes.range());
+                self.add_expression_range(bytes.range());
             }
             AnyNodeRef::ExprFString(fstring) => {
-                self.add_range(fstring.range());
+                self.add_expression_range(fstring.range());
             }
             AnyNodeRef::ExprTString(tstring) => {
-                self.add_range(tstring.range());
+                self.add_expression_range(tstring.range());
             }
 
             // Type parameter lists
             AnyNodeRef::TypeParams(params) => {
-                self.add_range(params.range());
+                self.add_expression_range(params.range());
             }
 
             _ => {}
@@ -500,7 +639,17 @@ impl SourceOrderVisitor<'_> for FoldingRangeVisitor<'_> {
         TraversalSignal::Traverse
     }
 
-    fn visit_body(&mut self, body: &'_ [Stmt]) {
+    fn leave_node(&mut self, node: AnyNodeRef<'a>) {
+        while self
+            .active_block_fold_start_lines
+            .last()
+            .is_some_and(|block_fold| block_fold.parent.ptr_eq(node))
+        {
+            self.active_block_fold_start_lines.pop();
+        }
+    }
+
+    fn visit_body(&mut self, body: &'a [Stmt]) {
         // Handle import blocks in any body (module, function, class, etc.).
         self.add_import_ranges(body);
         walk_body(self, body);

--- a/crates/ty_server/tests/e2e/folding_range.rs
+++ b/crates/ty_server/tests/e2e/folding_range.rs
@@ -32,6 +32,39 @@ fn folding_range_basic_functionality() -> Result<()> {
 }
 
 #[test]
+fn folding_range_multiline_block_headers() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = r#"def foo(
+    x: int,
+    y: str,
+) -> None:
+    pass
+
+match value:
+    case {
+        "kind": kind,
+        "payload": payload,
+    }:
+        handle_mapping()
+"#;
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(foo, foo_content)?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+
+    let ranges = server.folding_range_request(&server.file_uri(foo));
+
+    insta::assert_json_snapshot!(ranges);
+
+    Ok(())
+}
+
+#[test]
 fn folding_range_notebook_cells_are_filtered_to_the_requested_cell() -> Result<()> {
     let mut server = TestServerBuilder::new()?
         .build()

--- a/crates/ty_server/tests/e2e/snapshots/e2e__folding_range__folding_range_multiline_block_headers.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__folding_range__folding_range_multiline_block_headers.snap
@@ -1,0 +1,36 @@
+---
+source: crates/ty_server/tests/e2e/folding_range.rs
+expression: ranges
+---
+[
+  {
+    "startLine": 0,
+    "startCharacter": 8,
+    "endLine": 4,
+    "endCharacter": 8
+  },
+  {
+    "startLine": 3,
+    "startCharacter": 10,
+    "endLine": 4,
+    "endCharacter": 8
+  },
+  {
+    "startLine": 6,
+    "startCharacter": 12,
+    "endLine": 11,
+    "endCharacter": 24
+  },
+  {
+    "startLine": 7,
+    "startCharacter": 10,
+    "endLine": 11,
+    "endCharacter": 24
+  },
+  {
+    "startLine": 10,
+    "startCharacter": 6,
+    "endLine": 11,
+    "endCharacter": 24
+  }
+]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Building on https://github.com/astral-sh/ruff/pull/25118, this adds a folding range to every block that allows the user to fold the entire block (i.e., it's header and its body). This supplements the now nested inner range for just the block body, thereby allowing a user to fold either the entire block or just the block body.

For example, the diagram below shows where folding triggers appear for a function definition with a multi-line param list and a multi-line body:

```py
def foo(
        ^
    bar,
    baz,
):
  ^
    qux = bar + baz
    return qux
```

When a user clicks the first folding trigger the entire function folds as:

```py
def foo(...
```

and the second folding trigger is hidden. But when a user clicks the second folding trigger first, we show the following (the first folding trigger is still accessible for an additional fold):

```py
def foo(
        ^
    bar,
    baz,
): ...
```

After which you could fold again to get:

```py
def foo(...
```

This second scenario is also accessible via a sequence of the "Fold Level 2" and "Fold Level 1" commands exposed by many editors (e.g., VS Code, Zed).

Closes https://github.com/astral-sh/ty/issues/3320.

## Test Plan

- I have also tested this manually in VS Code and Zed (see [below](https://github.com/astral-sh/ruff/pull/25113#issuecomment-4437228675)).
- I have updated unit tests and e2e tests in this PR.

<!-- How was it tested? -->
