### PR TITLE
[ty] Avoid panic from non-name walrus targets

### DIFF
--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -219,9 +219,10 @@ impl MemberExprBuilder {
                 path: name.id.clone(),
                 segments: smallvec::SmallVec::new_const(),
             }),
-            ast::ExprRef::Named(named) => {
+            ast::ExprRef::Named(named) if named.target.is_name_expr() => {
                 MemberExprBuilder::visit_expr(ast::ExprRef::from(named.target.as_ref()))
             }
+            ast::ExprRef::Named(_) => None,
 
             ast::ExprRef::Attribute(attribute) => {
                 let mut builder =

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -43,9 +43,13 @@ impl PlaceExpr {
     pub fn try_from_expr<'e>(expr: impl Into<ast::ExprRef<'e>>) -> Option<Self> {
         let expr = expr.into();
 
-        // For named expressions (walrus operator), extract the target.
+        // For named expressions (walrus operator), extract the target. The grammar only permits
+        // names as targets; parser recovery may still produce other expressions here.
         let expr = match expr {
-            ast::ExprRef::Named(named) => named.target.as_ref().into(),
+            ast::ExprRef::Named(named) if named.target.is_name_expr() => {
+                named.target.as_ref().into()
+            }
+            ast::ExprRef::Named(_) => return None,
             _ => expr,
         };
 

--- a/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
+++ b/crates/ty_python_semantic/resources/mdtest/invalid_syntax.md
@@ -92,6 +92,22 @@ for x in foo.pass:
     pass
 ```
 
+## Invalid assignment expression target
+
+Parser recovery can produce a named expression target that is not a name. If that named expression
+is used as part of a member expression, we should report the syntax error without treating it as a
+valid place.
+
+```py
+obj = 1
+
+# error: [invalid-syntax] "Assignment expression target must be an identifier"
+out = (obj.attr := obj).attr
+
+# error: [invalid-syntax] "Assignment expression target must be an identifier"
+out = (obj[0] := obj).attr
+```
+
 ## Invalid annotation
 
 ### `typing.Callable`


### PR DESCRIPTION
## Summary

This PR fixes a panic when parser recovery produces a walrus expression whose target is not an identifier, and that expression is then used as part of a member expression:

```python
obj = 1
out = (obj.attr := obj).attr
```