### PR TITLE
[`eradicate`] Fix false positive for lines with leading whitespace (`ERA001`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
+++ b/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
@@ -103,3 +103,10 @@ print(1)
 # pyrefly: ignore[unused-import]
 
 print(1)
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/25116,
+# note the leading tab character
+def foo():
+	# testing: Foo Bar Baz
+	...

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -3,7 +3,7 @@ use aho_corasick::AhoCorasick;
 use itertools::Itertools;
 use regex::{Regex, RegexSet};
 use ruff_python_parser::parse_module;
-use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
+use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer, is_python_whitespace};
 use ruff_text_size::TextSize;
 use std::sync::LazyLock;
 
@@ -76,7 +76,9 @@ static POSITIVE_CASES: LazyLock<RegexSet> = LazyLock::new(|| {
 
 /// Returns `true` if a comment contains Python code.
 pub(crate) fn comment_contains_code(line: &str, task_tags: &[String]) -> bool {
-    let line = line.trim_start_matches([' ', '#']).trim_end();
+    let line = line
+        .trim_start_matches(|char| char == '#' || is_python_whitespace(char))
+        .trim_end();
 
     // Fast path: if none of the indicators are present, the line is not code.
     if !CODE_INDICATORS.is_match(line) {
@@ -150,6 +152,7 @@ mod tests {
         assert!(!comment_contains_code("# 123", &[]));
         assert!(!comment_contains_code("# 123.1", &[]));
         assert!(!comment_contains_code("# 1, 2, 3", &[]));
+        assert!(!comment_contains_code("\t# testing: Foo Bar Baz", &[]));
         assert!(!comment_contains_code("# ruff: disable[E501]", &[]));
         assert!(!comment_contains_code("#ruff:enable[E501, F84]", &[]));
         assert!(!comment_contains_code(
@@ -165,6 +168,7 @@ mod tests {
             "# SPDX-License-Identifier: MIT",
             &[]
         ));
+        assert!(comment_contains_code("\t# x = 1", &[]));
 
         // TODO(charlie): This should be `true` under aggressive mode.
         assert!(!comment_contains_code("#},", &[]));

--- a/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
+++ b/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
@@ -361,20 +361,3 @@ help: Remove commented-out code
 79 | # Script tag block followed by normal block (Ok)
 80 |
 note: This is a display-only fix and is likely to be incorrect
-
-ERA001 [*] Found commented-out code
-   --> ERA001.py:111:2
-    |
-109 | # note the leading tab character
-110 | def foo():
-111 |     # testing: Foo Bar Baz
-    |     ^^^^^^^^^^^^^^^^^^^^^^
-112 |     ...
-    |
-help: Remove commented-out code
-108 | # Regression test for https://github.com/astral-sh/ruff/issues/25116,
-109 | # note the leading tab character
-110 | def foo():
-    - 	# testing: Foo Bar Baz
-111 | 	...
-note: This is a display-only fix and is likely to be incorrect

--- a/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
+++ b/crates/ruff_linter/src/rules/eradicate/snapshots/ruff_linter__rules__eradicate__tests__ERA001_ERA001.py.snap
@@ -361,3 +361,20 @@ help: Remove commented-out code
 79 | # Script tag block followed by normal block (Ok)
 80 |
 note: This is a display-only fix and is likely to be incorrect
+
+ERA001 [*] Found commented-out code
+   --> ERA001.py:111:2
+    |
+109 | # note the leading tab character
+110 | def foo():
+111 |     # testing: Foo Bar Baz
+    |     ^^^^^^^^^^^^^^^^^^^^^^
+112 |     ...
+    |
+help: Remove commented-out code
+108 | # Regression test for https://github.com/astral-sh/ruff/issues/25116,
+109 | # note the leading tab character
+110 | def foo():
+    - 	# testing: Foo Bar Baz
+111 | 	...
+note: This is a display-only fix and is likely to be incorrect


### PR DESCRIPTION
Summary
--

This PR fixes #25116 by reusing our `is_python_whitespace` helper for
trimming lines that may contain code. This avoids false positives in
cases where comments are preceded by tabs (or form-feeds). These would
previously fail to trim the whitespace and end up parsing a module
like:

```py
\t# comment here
```

which is valid Python.

Test plan
--

New tests based on the report
