### PR TITLE
[`isort`] Avoid constructing `glob::Pattern`s for literal known modules

### DIFF
--- a/crates/ruff_linter/src/rules/isort/categorize.rs
+++ b/crates/ruff_linter/src/rules/isort/categorize.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
 use crate::package::PackageRoot;
+use crate::settings::types::IdentifierPattern;
 use crate::warn_user_once;
 use ruff_macros::CacheKey;
 use ruff_python_ast::PythonVersion;
@@ -283,20 +284,20 @@ pub(crate) fn categorize_imports<'a>(
 #[derive(Debug, Clone, Default, CacheKey)]
 pub struct KnownModules {
     /// A map of known modules to their section.
-    known: Vec<(glob::Pattern, ImportSection)>,
+    known: Vec<(IdentifierPattern, ImportSection)>,
     /// Whether any of the known modules are submodules (e.g., `foo.bar`, as opposed to `foo`).
     has_submodules: bool,
 }
 
 impl KnownModules {
     pub fn new(
-        first_party: Vec<glob::Pattern>,
-        third_party: Vec<glob::Pattern>,
-        local_folder: Vec<glob::Pattern>,
-        standard_library: Vec<glob::Pattern>,
-        user_defined: FxHashMap<String, Vec<glob::Pattern>>,
+        first_party: Vec<IdentifierPattern>,
+        third_party: Vec<IdentifierPattern>,
+        local_folder: Vec<IdentifierPattern>,
+        standard_library: Vec<IdentifierPattern>,
+        user_defined: FxHashMap<String, Vec<IdentifierPattern>>,
     ) -> Self {
-        let known: Vec<(glob::Pattern, ImportSection)> = user_defined
+        let known: Vec<(IdentifierPattern, ImportSection)> = user_defined
             .into_iter()
             .flat_map(|(section, modules)| {
                 modules
@@ -395,8 +396,8 @@ impl KnownModules {
     }
 
     /// Return the list of user-defined modules, indexed by section.
-    pub fn user_defined(&self) -> FxHashMap<&str, Vec<&glob::Pattern>> {
-        let mut user_defined: FxHashMap<&str, Vec<&glob::Pattern>> = FxHashMap::default();
+    pub fn user_defined(&self) -> FxHashMap<&str, Vec<&IdentifierPattern>> {
+        let mut user_defined: FxHashMap<&str, Vec<&IdentifierPattern>> = FxHashMap::default();
         for (module, section) in &self.known {
             if let ImportSection::UserDefined(section_name) = section {
                 user_defined

--- a/crates/ruff_linter/src/rules/isort/categorize.rs
+++ b/crates/ruff_linter/src/rules/isort/categorize.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::iter;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use log::debug;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
@@ -9,7 +10,6 @@ use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
 use crate::package::PackageRoot;
-use crate::settings::types::IdentifierPattern;
 use crate::warn_user_once;
 use ruff_macros::CacheKey;
 use ruff_python_ast::PythonVersion;
@@ -284,20 +284,20 @@ pub(crate) fn categorize_imports<'a>(
 #[derive(Debug, Clone, Default, CacheKey)]
 pub struct KnownModules {
     /// A map of known modules to their section.
-    known: Vec<(IdentifierPattern, ImportSection)>,
+    known: Vec<(KnownModulePattern, ImportSection)>,
     /// Whether any of the known modules are submodules (e.g., `foo.bar`, as opposed to `foo`).
     has_submodules: bool,
 }
 
 impl KnownModules {
     pub fn new(
-        first_party: Vec<IdentifierPattern>,
-        third_party: Vec<IdentifierPattern>,
-        local_folder: Vec<IdentifierPattern>,
-        standard_library: Vec<IdentifierPattern>,
-        user_defined: FxHashMap<String, Vec<IdentifierPattern>>,
+        first_party: Vec<KnownModulePattern>,
+        third_party: Vec<KnownModulePattern>,
+        local_folder: Vec<KnownModulePattern>,
+        standard_library: Vec<KnownModulePattern>,
+        user_defined: FxHashMap<String, Vec<KnownModulePattern>>,
     ) -> Self {
-        let known: Vec<(IdentifierPattern, ImportSection)> = user_defined
+        let known: Vec<(KnownModulePattern, ImportSection)> = user_defined
             .into_iter()
             .flat_map(|(section, modules)| {
                 modules
@@ -396,8 +396,8 @@ impl KnownModules {
     }
 
     /// Return the list of user-defined modules, indexed by section.
-    pub fn user_defined(&self) -> FxHashMap<&str, Vec<&IdentifierPattern>> {
-        let mut user_defined: FxHashMap<&str, Vec<&IdentifierPattern>> = FxHashMap::default();
+    pub fn user_defined(&self) -> FxHashMap<&str, Vec<&KnownModulePattern>> {
+        let mut user_defined: FxHashMap<&str, Vec<&KnownModulePattern>> = FxHashMap::default();
         for (module, section) in &self.known {
             if let ImportSection::UserDefined(section_name) = section {
                 user_defined
@@ -425,9 +425,58 @@ impl fmt::Display for KnownModules {
     }
 }
 
+/// Pattern used to classify configured known modules.
+///
+/// Literal entries are common in large inherited configs. Store them directly so categorization
+/// does not need to compile a [`glob::Pattern`] for every literal module name.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, CacheKey)]
+pub enum KnownModulePattern {
+    Literal(String),
+    Glob(Box<glob::Pattern>),
+}
+
+impl KnownModulePattern {
+    pub fn new(pattern: &str) -> Result<Self, glob::PatternError> {
+        // `]` is only special inside `[...]`, which necessarily includes `[`.
+        if memchr::memchr3(b'?', b'*', b'[', pattern.as_bytes()).is_some() {
+            Ok(Self::Glob(Box::new(glob::Pattern::new(pattern)?)))
+        } else {
+            Ok(Self::Literal(pattern.to_string()))
+        }
+    }
+
+    fn matches(&self, candidate: &str) -> bool {
+        match self {
+            Self::Literal(literal) => literal == candidate,
+            Self::Glob(pattern) => pattern.matches(candidate),
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Literal(literal) => literal,
+            Self::Glob(pattern) => pattern.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for KnownModulePattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for KnownModulePattern {
+    type Err = glob::PatternError;
+
+    fn from_str(pattern: &str) -> Result<Self, Self::Err> {
+        Self::new(pattern)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::rules::isort::categorize::match_sources;
+    use crate::rules::isort::categorize::{KnownModulePattern, match_sources};
 
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -445,6 +494,28 @@ mod tests {
     /// Helper function to create a directory and all parent directories
     fn create_dir<P: AsRef<Path>>(path: P) {
         fs::create_dir_all(path).unwrap();
+    }
+
+    #[test]
+    fn known_module_pattern_matches_literals_exactly() {
+        let pattern = KnownModulePattern::new("package.module").unwrap();
+
+        assert!(pattern.matches("package.module"));
+        assert!(!pattern.matches("package"));
+        assert!(!pattern.matches("package.module.extra"));
+    }
+
+    #[test]
+    fn known_module_pattern_preserves_glob_matching() {
+        let pattern = KnownModulePattern::new("package.*").unwrap();
+
+        assert!(pattern.matches("package.module"));
+        assert!(!pattern.matches("other.module"));
+    }
+
+    #[test]
+    fn known_module_pattern_rejects_invalid_globs() {
+        assert!(KnownModulePattern::new("package[").is_err());
     }
 
     /// Tests a traditional Python package layout:

--- a/crates/ruff_linter/src/rules/isort/categorize.rs
+++ b/crates/ruff_linter/src/rules/isort/categorize.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::iter;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use log::debug;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
@@ -10,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
 use crate::package::PackageRoot;
+use crate::settings::types::IdentifierPattern;
 use crate::warn_user_once;
 use ruff_macros::CacheKey;
 use ruff_python_ast::PythonVersion;
@@ -284,20 +284,20 @@ pub(crate) fn categorize_imports<'a>(
 #[derive(Debug, Clone, Default, CacheKey)]
 pub struct KnownModules {
     /// A map of known modules to their section.
-    known: Vec<(KnownModulePattern, ImportSection)>,
+    known: Vec<(IdentifierPattern, ImportSection)>,
     /// Whether any of the known modules are submodules (e.g., `foo.bar`, as opposed to `foo`).
     has_submodules: bool,
 }
 
 impl KnownModules {
     pub fn new(
-        first_party: Vec<KnownModulePattern>,
-        third_party: Vec<KnownModulePattern>,
-        local_folder: Vec<KnownModulePattern>,
-        standard_library: Vec<KnownModulePattern>,
-        user_defined: FxHashMap<String, Vec<KnownModulePattern>>,
+        first_party: Vec<IdentifierPattern>,
+        third_party: Vec<IdentifierPattern>,
+        local_folder: Vec<IdentifierPattern>,
+        standard_library: Vec<IdentifierPattern>,
+        user_defined: FxHashMap<String, Vec<IdentifierPattern>>,
     ) -> Self {
-        let known: Vec<(KnownModulePattern, ImportSection)> = user_defined
+        let known: Vec<(IdentifierPattern, ImportSection)> = user_defined
             .into_iter()
             .flat_map(|(section, modules)| {
                 modules
@@ -396,8 +396,8 @@ impl KnownModules {
     }
 
     /// Return the list of user-defined modules, indexed by section.
-    pub fn user_defined(&self) -> FxHashMap<&str, Vec<&KnownModulePattern>> {
-        let mut user_defined: FxHashMap<&str, Vec<&KnownModulePattern>> = FxHashMap::default();
+    pub fn user_defined(&self) -> FxHashMap<&str, Vec<&IdentifierPattern>> {
+        let mut user_defined: FxHashMap<&str, Vec<&IdentifierPattern>> = FxHashMap::default();
         for (module, section) in &self.known {
             if let ImportSection::UserDefined(section_name) = section {
                 user_defined
@@ -425,58 +425,9 @@ impl fmt::Display for KnownModules {
     }
 }
 
-/// Pattern used to classify configured known modules.
-///
-/// Literal entries are common in large inherited configs. Store them directly so categorization
-/// does not need to compile a [`glob::Pattern`] for every literal module name.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, CacheKey)]
-pub enum KnownModulePattern {
-    Literal(String),
-    Glob(Box<glob::Pattern>),
-}
-
-impl KnownModulePattern {
-    pub fn new(pattern: &str) -> Result<Self, glob::PatternError> {
-        // `]` is only special inside `[...]`, which necessarily includes `[`.
-        if memchr::memchr3(b'?', b'*', b'[', pattern.as_bytes()).is_some() {
-            Ok(Self::Glob(Box::new(glob::Pattern::new(pattern)?)))
-        } else {
-            Ok(Self::Literal(pattern.to_string()))
-        }
-    }
-
-    fn matches(&self, candidate: &str) -> bool {
-        match self {
-            Self::Literal(literal) => literal == candidate,
-            Self::Glob(pattern) => pattern.matches(candidate),
-        }
-    }
-
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Literal(literal) => literal,
-            Self::Glob(pattern) => pattern.as_str(),
-        }
-    }
-}
-
-impl fmt::Display for KnownModulePattern {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl FromStr for KnownModulePattern {
-    type Err = glob::PatternError;
-
-    fn from_str(pattern: &str) -> Result<Self, Self::Err> {
-        Self::new(pattern)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::rules::isort::categorize::{KnownModulePattern, match_sources};
+    use crate::rules::isort::categorize::match_sources;
 
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -494,28 +445,6 @@ mod tests {
     /// Helper function to create a directory and all parent directories
     fn create_dir<P: AsRef<Path>>(path: P) {
         fs::create_dir_all(path).unwrap();
-    }
-
-    #[test]
-    fn known_module_pattern_matches_literals_exactly() {
-        let pattern = KnownModulePattern::new("package.module").unwrap();
-
-        assert!(pattern.matches("package.module"));
-        assert!(!pattern.matches("package"));
-        assert!(!pattern.matches("package.module.extra"));
-    }
-
-    #[test]
-    fn known_module_pattern_preserves_glob_matching() {
-        let pattern = KnownModulePattern::new("package.*").unwrap();
-
-        assert!(pattern.matches("package.module"));
-        assert!(!pattern.matches("other.module"));
-    }
-
-    #[test]
-    fn known_module_pattern_rejects_invalid_globs() {
-        assert!(KnownModulePattern::new("package[").is_err());
     }
 
     /// Tests a traditional Python package layout:

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -317,6 +317,7 @@ mod tests {
     use crate::registry::Rule;
     use crate::rules::isort::categorize::{ImportSection, KnownModules};
     use crate::settings::LinterSettings;
+    use crate::settings::types::IdentifierPattern;
     use crate::test::{test_path, test_resource_path};
 
     use super::categorize::ImportType;
@@ -389,8 +390,8 @@ mod tests {
         Ok(())
     }
 
-    fn pattern(pattern: &str) -> glob::Pattern {
-        glob::Pattern::new(pattern).unwrap()
+    fn pattern(pattern: &str) -> IdentifierPattern {
+        IdentifierPattern::new(pattern).unwrap()
     }
 
     #[test_case(Path::new("separate_subpackage_first_and_third_party_imports.py"))]

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -315,9 +315,8 @@ mod tests {
 
     use crate::assert_diagnostics;
     use crate::registry::Rule;
-    use crate::rules::isort::categorize::{ImportSection, KnownModules};
+    use crate::rules::isort::categorize::{ImportSection, KnownModulePattern, KnownModules};
     use crate::settings::LinterSettings;
-    use crate::settings::types::IdentifierPattern;
     use crate::test::{test_path, test_resource_path};
 
     use super::categorize::ImportType;
@@ -390,8 +389,8 @@ mod tests {
         Ok(())
     }
 
-    fn pattern(pattern: &str) -> IdentifierPattern {
-        IdentifierPattern::new(pattern).unwrap()
+    fn pattern(pattern: &str) -> KnownModulePattern {
+        KnownModulePattern::new(pattern).unwrap()
     }
 
     #[test_case(Path::new("separate_subpackage_first_and_third_party_imports.py"))]

--- a/crates/ruff_linter/src/rules/isort/mod.rs
+++ b/crates/ruff_linter/src/rules/isort/mod.rs
@@ -315,8 +315,9 @@ mod tests {
 
     use crate::assert_diagnostics;
     use crate::registry::Rule;
-    use crate::rules::isort::categorize::{ImportSection, KnownModulePattern, KnownModules};
+    use crate::rules::isort::categorize::{ImportSection, KnownModules};
     use crate::settings::LinterSettings;
+    use crate::settings::types::IdentifierPattern;
     use crate::test::{test_path, test_resource_path};
 
     use super::categorize::ImportType;
@@ -389,8 +390,8 @@ mod tests {
         Ok(())
     }
 
-    fn pattern(pattern: &str) -> KnownModulePattern {
-        KnownModulePattern::new(pattern).unwrap()
+    fn pattern(pattern: &str) -> IdentifierPattern {
+        IdentifierPattern::new(pattern).unwrap()
     }
 
     #[test_case(Path::new("separate_subpackage_first_and_third_party_imports.py"))]

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -705,7 +705,7 @@ pub enum IdentifierPattern {
 impl IdentifierPattern {
     pub fn new(pattern: &str) -> Result<Self, glob::PatternError> {
         // `]` is only special inside `[...]`, which necessarily includes `[`.
-        if memchr::memchr3(b'?', b'*', b'[', pattern.as_bytes()).is_some() {
+        if pattern.contains(['?', '*', '[']) {
             Ok(Self::Glob(Box::new(glob::Pattern::new(pattern)?)))
         } else {
             Ok(Self::Literal(pattern.to_string()))

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -693,59 +693,7 @@ impl Display for RequiredVersion {
 /// For reference pep8-naming uses
 /// [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) for
 /// pattern matching.
-///
-/// Literal patterns without glob metacharacters fall back on string
-/// comparison to avoid the overhead of constructing a [`glob::Pattern`].
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum IdentifierPattern {
-    Literal(String),
-    Glob(Box<glob::Pattern>),
-}
-
-impl IdentifierPattern {
-    pub fn new(pattern: &str) -> Result<Self, glob::PatternError> {
-        // `]` is only special inside `[...]`, which necessarily includes `[`.
-        if memchr::memchr3(b'?', b'*', b'[', pattern.as_bytes()).is_some() {
-            Ok(Self::Glob(Box::new(glob::Pattern::new(pattern)?)))
-        } else {
-            Ok(Self::Literal(pattern.to_string()))
-        }
-    }
-
-    pub fn matches(&self, candidate: &str) -> bool {
-        match self {
-            Self::Literal(literal) => literal == candidate,
-            Self::Glob(pattern) => pattern.matches(candidate),
-        }
-    }
-
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Literal(literal) => literal,
-            Self::Glob(pattern) => pattern.as_str(),
-        }
-    }
-}
-
-impl Display for IdentifierPattern {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl FromStr for IdentifierPattern {
-    type Err = glob::PatternError;
-
-    fn from_str(pattern: &str) -> Result<Self, Self::Err> {
-        Self::new(pattern)
-    }
-}
-
-impl CacheKey for IdentifierPattern {
-    fn cache_key(&self, state: &mut CacheKeyHasher) {
-        self.as_str().cache_key(state);
-    }
-}
+pub type IdentifierPattern = glob::Pattern;
 
 /// Like [`PerFile`] but with string globs compiled to [`GlobMatcher`]s for more efficient usage.
 #[derive(Debug, Clone)]
@@ -995,32 +943,8 @@ impl Display for CompiledPerFileTargetVersionList {
 
 #[cfg(test)]
 mod tests {
-    use super::IdentifierPattern;
-
     #[test]
     fn default_python_version_works() {
         super::PythonVersion::default();
-    }
-
-    #[test]
-    fn identifier_pattern_matches_literals_exactly() {
-        let pattern = IdentifierPattern::new("package.module").unwrap();
-
-        assert!(pattern.matches("package.module"));
-        assert!(!pattern.matches("package"));
-        assert!(!pattern.matches("package.module.extra"));
-    }
-
-    #[test]
-    fn identifier_pattern_preserves_glob_matching() {
-        let pattern = IdentifierPattern::new("package.*").unwrap();
-
-        assert!(pattern.matches("package.module"));
-        assert!(!pattern.matches("other.module"));
-    }
-
-    #[test]
-    fn identifier_pattern_rejects_invalid_globs() {
-        assert!(IdentifierPattern::new("package[").is_err());
     }
 }

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -696,7 +696,7 @@ impl Display for RequiredVersion {
 ///
 /// Literal patterns without glob metacharacters fall back on string
 /// comparison to avoid the overhead of constructing a [`glob::Pattern`].
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, CacheKey)]
 pub enum IdentifierPattern {
     Literal(String),
     Glob(Box<glob::Pattern>),
@@ -738,12 +738,6 @@ impl FromStr for IdentifierPattern {
 
     fn from_str(pattern: &str) -> Result<Self, Self::Err> {
         Self::new(pattern)
-    }
-}
-
-impl CacheKey for IdentifierPattern {
-    fn cache_key(&self, state: &mut CacheKeyHasher) {
-        self.as_str().cache_key(state);
     }
 }
 

--- a/crates/ruff_linter/src/settings/types.rs
+++ b/crates/ruff_linter/src/settings/types.rs
@@ -693,7 +693,59 @@ impl Display for RequiredVersion {
 /// For reference pep8-naming uses
 /// [`fnmatch`](https://docs.python.org/3/library/fnmatch.html) for
 /// pattern matching.
-pub type IdentifierPattern = glob::Pattern;
+///
+/// Literal patterns without glob metacharacters fall back on string
+/// comparison to avoid the overhead of constructing a [`glob::Pattern`].
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum IdentifierPattern {
+    Literal(String),
+    Glob(Box<glob::Pattern>),
+}
+
+impl IdentifierPattern {
+    pub fn new(pattern: &str) -> Result<Self, glob::PatternError> {
+        // `]` is only special inside `[...]`, which necessarily includes `[`.
+        if memchr::memchr3(b'?', b'*', b'[', pattern.as_bytes()).is_some() {
+            Ok(Self::Glob(Box::new(glob::Pattern::new(pattern)?)))
+        } else {
+            Ok(Self::Literal(pattern.to_string()))
+        }
+    }
+
+    pub fn matches(&self, candidate: &str) -> bool {
+        match self {
+            Self::Literal(literal) => literal == candidate,
+            Self::Glob(pattern) => pattern.matches(candidate),
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Literal(literal) => literal,
+            Self::Glob(pattern) => pattern.as_str(),
+        }
+    }
+}
+
+impl Display for IdentifierPattern {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for IdentifierPattern {
+    type Err = glob::PatternError;
+
+    fn from_str(pattern: &str) -> Result<Self, Self::Err> {
+        Self::new(pattern)
+    }
+}
+
+impl CacheKey for IdentifierPattern {
+    fn cache_key(&self, state: &mut CacheKeyHasher) {
+        self.as_str().cache_key(state);
+    }
+}
 
 /// Like [`PerFile`] but with string globs compiled to [`GlobMatcher`]s for more efficient usage.
 #[derive(Debug, Clone)]
@@ -943,8 +995,32 @@ impl Display for CompiledPerFileTargetVersionList {
 
 #[cfg(test)]
 mod tests {
+    use super::IdentifierPattern;
+
     #[test]
     fn default_python_version_works() {
         super::PythonVersion::default();
+    }
+
+    #[test]
+    fn identifier_pattern_matches_literals_exactly() {
+        let pattern = IdentifierPattern::new("package.module").unwrap();
+
+        assert!(pattern.matches("package.module"));
+        assert!(!pattern.matches("package"));
+        assert!(!pattern.matches("package.module.extra"));
+    }
+
+    #[test]
+    fn identifier_pattern_preserves_glob_matching() {
+        let pattern = IdentifierPattern::new("package.*").unwrap();
+
+        assert!(pattern.matches("package.module"));
+        assert!(!pattern.matches("other.module"));
+    }
+
+    #[test]
+    fn identifier_pattern_rejects_invalid_globs() {
+        assert!(IdentifierPattern::new("package[").is_err());
     }
 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -2963,7 +2963,7 @@ impl IsortOptions {
         let sections = self.sections.unwrap_or_default();
 
         // Verify that `sections` doesn't contain any built-in sections.
-        let sections: FxHashMap<String, Vec<glob::Pattern>> = sections
+        let sections: FxHashMap<String, Vec<IdentifierPattern>> = sections
             .into_iter()
             .filter_map(|(section, modules)| match section {
                 ImportSection::Known(section) => {

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -22,6 +22,7 @@ use ruff_linter::rules::flake8_quotes::settings::Quote;
 use ruff_linter::rules::flake8_tidy_imports::settings::{
     AllImports, ApiBan, ImportSelection, ImportSelector, Strictness,
 };
+use ruff_linter::rules::isort::categorize::KnownModulePattern;
 use ruff_linter::rules::isort::settings::RelativeImportsOrder;
 use ruff_linter::rules::isort::{ImportSection, ImportType};
 use ruff_linter::rules::pep8_naming::settings::IgnoreNames;
@@ -2919,7 +2920,7 @@ impl IsortOptions {
             .map(|names| {
                 names
                     .into_iter()
-                    .map(|name| IdentifierPattern::new(&name))
+                    .map(|name| KnownModulePattern::new(&name))
                     .collect()
             })
             .transpose()
@@ -2930,7 +2931,7 @@ impl IsortOptions {
             .map(|names| {
                 names
                     .into_iter()
-                    .map(|name| IdentifierPattern::new(&name))
+                    .map(|name| KnownModulePattern::new(&name))
                     .collect()
             })
             .transpose()
@@ -2941,7 +2942,7 @@ impl IsortOptions {
             .map(|names| {
                 names
                     .into_iter()
-                    .map(|name| IdentifierPattern::new(&name))
+                    .map(|name| KnownModulePattern::new(&name))
                     .collect()
             })
             .transpose()
@@ -2952,7 +2953,7 @@ impl IsortOptions {
             .map(|names| {
                 names
                     .into_iter()
-                    .map(|name| IdentifierPattern::new(&name))
+                    .map(|name| KnownModulePattern::new(&name))
                     .collect()
             })
             .transpose()
@@ -2963,7 +2964,7 @@ impl IsortOptions {
         let sections = self.sections.unwrap_or_default();
 
         // Verify that `sections` doesn't contain any built-in sections.
-        let sections: FxHashMap<String, Vec<IdentifierPattern>> = sections
+        let sections: FxHashMap<String, Vec<KnownModulePattern>> = sections
             .into_iter()
             .filter_map(|(section, modules)| match section {
                 ImportSection::Known(section) => {
@@ -2976,7 +2977,7 @@ impl IsortOptions {
                 let modules = modules
                     .into_iter()
                     .map(|module| {
-                        IdentifierPattern::new(&module)
+                        KnownModulePattern::new(&module)
                             .map_err(isort::settings::SettingsError::InvalidUserDefinedSection)
                     })
                     .collect::<Result<Vec<_>, isort::settings::SettingsError>>()?;

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -22,7 +22,6 @@ use ruff_linter::rules::flake8_quotes::settings::Quote;
 use ruff_linter::rules::flake8_tidy_imports::settings::{
     AllImports, ApiBan, ImportSelection, ImportSelector, Strictness,
 };
-use ruff_linter::rules::isort::categorize::KnownModulePattern;
 use ruff_linter::rules::isort::settings::RelativeImportsOrder;
 use ruff_linter::rules::isort::{ImportSection, ImportType};
 use ruff_linter::rules::pep8_naming::settings::IgnoreNames;
@@ -2920,7 +2919,7 @@ impl IsortOptions {
             .map(|names| {
                 names
                     .into_iter()
-                    .map(|name| KnownModulePattern::new(&name))
+                    .map(|name| IdentifierPattern::new(&name))
                     .collect()
             })
             .transpose()
@@ -2931,7 +2930,7 @@ impl IsortOptions {
             .map(|names| {
                 names
                     .into_iter()
-                    .map(|name| KnownModulePattern::new(&name))
+                    .map(|name| IdentifierPattern::new(&name))
                     .collect()
             })
             .transpose()
@@ -2942,7 +2941,7 @@ impl IsortOptions {
             .map(|names| {
                 names
                     .into_iter()
-                    .map(|name| KnownModulePattern::new(&name))
+                    .map(|name| IdentifierPattern::new(&name))
                     .collect()
             })
             .transpose()
@@ -2953,7 +2952,7 @@ impl IsortOptions {
             .map(|names| {
                 names
                     .into_iter()
-                    .map(|name| KnownModulePattern::new(&name))
+                    .map(|name| IdentifierPattern::new(&name))
                     .collect()
             })
             .transpose()
@@ -2964,7 +2963,7 @@ impl IsortOptions {
         let sections = self.sections.unwrap_or_default();
 
         // Verify that `sections` doesn't contain any built-in sections.
-        let sections: FxHashMap<String, Vec<KnownModulePattern>> = sections
+        let sections: FxHashMap<String, Vec<IdentifierPattern>> = sections
             .into_iter()
             .filter_map(|(section, modules)| match section {
                 ImportSection::Known(section) => {
@@ -2977,7 +2976,7 @@ impl IsortOptions {
                 let modules = modules
                     .into_iter()
                     .map(|module| {
-                        KnownModulePattern::new(&module)
+                        IdentifierPattern::new(&module)
                             .map_err(isort::settings::SettingsError::InvalidUserDefinedSection)
                     })
                     .collect::<Result<Vec<_>, isort::settings::SettingsError>>()?;


### PR DESCRIPTION
Summary
--

For repositories with many known isort modules and a large number of
extended configuration files, Ruff can consume a lot of memory. This
is especially problematic in an LSP context, where this memory hangs
around for the duration of the session. Codex and I tracked this down
to the overhead of constructing `glob::Pattern`s for each
`KnownModule`.

I initially tried a more complicated approach of interning each
`Pattern` during configuration resolution, but I suspected that the
common case for projects with large numbers of known modules would be
plain string literal patterns that don't need the `glob`
infrastructure.

This assumption was supported in the repository I was testing on,
which saw a ~7x decrease in peak memory usage, which was only very
slightly less than I saw with the interned version.

There's probably something more general we could do here, as this
comment alludes to:

https://github.com/astral-sh/ruff/blob/c09080468ab6ef2d3e674043d310f21ec074d219/crates/ruff_workspace/src/resolver.rs#L311-L314

but this seemed like an easy first step for a known issue.

Test plan
--

A couple of new unit tests for the `IdentifierPattern` enum (as well
as existing `isort` tests) and some manual testing on a large repo
