### PR TITLE
fix(format): Correct line/column for syntax errors in --check --preview

### DIFF
--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -882,17 +882,25 @@ impl FormatCommandError {
 impl From<&FormatCommandError> for Diagnostic {
     fn from(error: &FormatCommandError) -> Self {
         let annotation = error.path().map(|path| {
-            let file = SourceFileBuilder::new(path.to_string_lossy(), "").finish();
-            let span = Span::from(file);
+            let source_text = if let FormatCommandError::Parse(display_parse_error) = error {
+                display_parse_error.source_text()
+            } else {
+                ""
+            };
+            let file = SourceFileBuilder::new(path.to_string_lossy(), source_text).finish();
+            let span = if let FormatCommandError::Parse(display_parse_error) = error {
+                Span::from(file).with_range(display_parse_error.error().location)
+            } else {
+                Span::from(file)
+            };
             let mut annotation = Annotation::primary(span);
             annotation.hide_snippet(true);
             annotation
         });
 
         let mut diagnostic = match error {
-            FormatCommandError::Ignore(error) => {
-                Diagnostic::new(DiagnosticId::Io, Severity::Error, error)
-            }
+            FormatCommandError::Ignore(error) =>
+                Diagnostic::new(DiagnosticId::Io, Severity::Error, error),
             FormatCommandError::Parse(display_parse_error) => Diagnostic::new(
                 DiagnosticId::InvalidSyntax,
                 Severity::Error,
@@ -902,20 +910,21 @@ impl From<&FormatCommandError> for Diagnostic {
                 return create_panic_diagnostic(panic_error, path.as_deref());
             }
             FormatCommandError::Read(_, source_error)
-            | FormatCommandError::Write(_, source_error) => {
-                Diagnostic::new(DiagnosticId::Io, Severity::Error, source_error)
-            }
+            | FormatCommandError::Write(_, source_error) =>
+                Diagnostic::new(DiagnosticId::Io, Severity::Error, source_error),
             FormatCommandError::Format(_, format_module_error) => format_module_error.into(),
-            FormatCommandError::RangeFormatNotSupported(_) => Diagnostic::new(
-                DiagnosticId::InvalidCliOption,
-                Severity::Error,
-                "Range formatting is only supported for Python files.",
-            ),
-            FormatCommandError::MarkdownExperimental(_) => Diagnostic::new(
-                DiagnosticId::PreviewFeature,
-                Severity::Warning,
-                "Markdown formatting is experimental, enable preview mode.",
-            ),
+            FormatCommandError::RangeFormatNotSupported(_) =>
+                Diagnostic::new(
+                    DiagnosticId::InvalidCliOption,
+                    Severity::Error,
+                    "Range formatting is only supported for Python files.",
+                ),
+            FormatCommandError::MarkdownExperimental(_) =>
+                Diagnostic::new(
+                    DiagnosticId::PreviewFeature,
+                    Severity::Warning,
+                    "Markdown formatting is experimental, enable preview mode.",
+                ),
         };
 
         if let Some(annotation) = annotation {
@@ -1360,9 +1369,6 @@ mod tests {
         io: test.py: Permission denied
         --> test.py:1:1
 
-        invalid-syntax: Unexpected indentation
-        --> test.py:1:1
-
         io: File not found
         --> test.py:1:1
 
@@ -1373,6 +1379,9 @@ mod tests {
         --> test.py:1:1
 
         invalid-cli-option: Range formatting is only supported for Python files.
+        --> test.py:1:1
+
+        invalid-syntax: Unexpected indentation
         --> test.py:1:1
 
         panic: Panicked at <location> when checking `test.py`: `Test panic for FormatCommandError`

--- a/crates/ruff_annotate_snippets/src/renderer/display_list.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/display_list.rs
@@ -1224,17 +1224,19 @@ fn format_snippet<'m>(
 
     let is_file_level = snippet.annotations.iter().any(|ann| ann.is_file_level);
     if is_file_level {
-        // TODO(brent) enable this assertion again once we set `is_file_level` for individual rules.
-        // It's causing too many false positives currently when the default is to make any
-        // annotation with a default range file-level. See
-        // https://github.com/astral-sh/ruff/issues/19688.
-        //
-        // assert!(
-        //     snippet.source.is_empty(),
-        //     "Non-empty file-level snippet that won't be rendered: {:?}",
-        //     snippet.source
-        // );
-        let header = format_header(origin, main_range, &[], is_first, snippet.cell_index);
+        // Even though we don't render the snippet body for file-level annotations, we still need
+        // to compute it so that `format_header` can derive the correct line and column numbers for
+        // the `-->` arrow from the source text.
+        let cell_index = snippet.cell_index;
+        let body = format_body(
+            snippet,
+            need_empty_header,
+            has_footer,
+            term_width,
+            anonymized_line_numbers,
+            cut_indicator,
+        );
+        let header = format_header(origin, main_range, &body.display_lines, is_first, cell_index);
         return DisplaySet {
             display_lines: header.map_or_else(Vec::new, |header| vec![header]),
             margin: Margin::new(0, 0, 0, 0, term_width, 0),

--- a/crates/ruff_linter/src/logging.rs
+++ b/crates/ruff_linter/src/logging.rs
@@ -165,6 +165,7 @@ pub struct DisplayParseError {
     error: ParseError,
     path: Option<PathBuf>,
     location: ErrorLocation,
+    source_text: String,
 }
 
 impl DisplayParseError {
@@ -216,6 +217,7 @@ impl DisplayParseError {
             error,
             path,
             location,
+            source_text: source_code.text().to_owned(),
         }
     }
 
@@ -227,6 +229,11 @@ impl DisplayParseError {
     /// Return the underlying [`ParseError`].
     pub fn error(&self) -> &ParseError {
         &self.error
+    }
+
+    /// Return the source text of the file in which the error occurred.
+    pub fn source_text(&self) -> &str {
+        &self.source_text
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes [astral-sh/ruff#24528](https://github.com/astral-sh/ruff/issues/24528)

When 'ruff format --check --preview' encounters a syntax error, the preview diagnostic renderer showed 1:1 for all parse errors regardless of where the error actually occurred.

## Root cause

Two issues combined:

1. DisplayParseError precomputed line/column on creation but lost the source text by the time it was converted to a Diagnostic. The SourceFile in the resulting Span had empty text, so any byte offset mapped to 1:1.

2. ruff_annotate_snippets short-circuited format_body for file-level (hide_snippet=true) annotations, passing an empty body to format_header. With no source lines to scan, it defaulted to 1:1.

## Changes

- ruff_linter/src/logging.rs: added source_text: String to DisplayParseError with a source_text() getter.

- ruff/src/commands/format.rs: use display_parse_error.source_text() when building the SourceFile for the Diagnostic annotation so the renderer has real source lines to map. Also reordered the test snapshot to match the new deterministic ordering.

- ruff_annotate_snippets/src/renderer/display_list.rs: still compute format_body for is_file_level snippets (discarding the body from output) so format_header can derive correct line/column numbers.

## Test Plan

- cargo test --package ruff error_diagnostics — passes
- cargo test --package ruff_annotate_snippets — passes
- cargo test --package ruff_linter — passes
- Manual verification with malformed Python files shows the correct line:column in --preview mode.