### PR TITLE
fix(eradicate): ERA001 false positive for tab-indented comments

### DIFF
--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -76,7 +76,7 @@ static POSITIVE_CASES: LazyLock<RegexSet> = LazyLock::new(|| {
 
 /// Returns `true` if a comment contains Python code.
 pub(crate) fn comment_contains_code(line: &str, task_tags: &[String]) -> bool {
-    let line = line.trim_start_matches([' ', '#']).trim_end();
+    let line = line.trim_start_matches([' ', '\t', '#']).trim_end();
 
     // Fast path: if none of the indicators are present, the line is not code.
     if !CODE_INDICATORS.is_match(line) {
@@ -165,6 +165,16 @@ mod tests {
             "# SPDX-License-Identifier: MIT",
             &[]
         ));
+
+        // Regression test for tab-indented comments (issue #25116)
+        assert!(!comment_contains_code("\t# testing: Foo Bar Baz", &[]));
+        assert!(!comment_contains_code("\t\t# testing: Foo Bar Baz", &[]));
+        assert!(!comment_contains_code("\t# testing:", &[]));
+
+        assert!(comment_contains_code("\t# x = 1", &[]));
+        assert!(comment_contains_code("\t\t# x = 1", &[]));
+        assert!(comment_contains_code("\t# import os", &[]));
+        assert!(comment_contains_code("\t#return x", &[]));
 
         // TODO(charlie): This should be `true` under aggressive mode.
         assert!(!comment_contains_code("#},", &[]));


### PR DESCRIPTION
## Summary

Fixes [astral-sh/ruff#25116](https://github.com/astral-sh/ruff/issues/25116)

Tab-indented comments like `\t# testing: Foo Bar Baz` were incorrectly flagged as commented-out code (ERA001).

## Root cause

`comment_contains_code` used `trim_start_matches([' ', '#'])` which only stripped spaces and `#`. A leading tab before `#` prevented the `#` from being stripped, leaving `\ttesting: ...` which triggered code detection because it contains `:`.

## Fix

- Include `'\t'` in the set of characters trimmed at the start of a comment line.
- Added regression tests for tab-indented comments.

## Test Plan

- `cargo test --package ruff_linter eradicate` — all 13 tests pass (including the new tab regression cases).
- Manual verification: `\t# testing: Foo Bar Baz` no longer triggers ERA001, while `\t# x = 1` still correctly does.