### PR TITLE
fix(pylint): PLW0108 false positive when function is defined after lambda

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
@@ -61,3 +61,10 @@ _ = lambda *args: f(*args, y=x)
 # https://github.com/astral-sh/ruff/issues/18675
 _ = lambda x: (string := str)(x)
 _ = lambda x: ((x := 1) and str)(x)
+
+# https://github.com/astral-sh/ruff/issues/24704
+# Don't suggest inlining if the function is defined after the lambda.
+x = {"a": lambda y: f(y)}
+
+def f(y):
+    pass

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
@@ -214,11 +214,24 @@ pub(crate) fn unnecessary_lambda(checker: &Checker, lambda: &ExprLambda) {
     for name in &names {
         if let Some(binding_id) = checker.semantic().resolve_name(name) {
             let binding = checker.semantic().binding(binding_id);
+
+            // The lambda is necessary if it uses one of its own parameters as the function call.
+            // Ex) `lambda x, y: x(y)`
             if checker.semantic().is_current_scope(binding.scope) {
+                return;
+            }
+
+            // Don't suggest inlining if the binding appears after the lambda and is defined
+            // outside of it (not a builtin and not inside the lambda body itself).
+            if binding.range.start() > lambda.range().start()
+                && !binding.kind.is_builtin()
+                && !lambda.range().contains_range(binding.range())
+            {
                 return;
             }
         }
     }
+
 
     let mut diagnostic = checker.report_diagnostic(UnnecessaryLambda, lambda.range());
     // Suppress the fix if the assignment expression target shadows one of the lambda's parameters.

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
@@ -35,128 +35,6 @@ help: Inline function call
 note: This is an unsafe fix and may change runtime behavior
 
 PLW0108 [*] Lambda may be unnecessary; consider inlining inner function
- --> unnecessary_lambda.py:4:5
-  |
-2 | _ = lambda x, y: min(x, y) # [unnecessary-lambda]
-3 |
-4 | _ = lambda *args: f(*args) # [unnecessary-lambda]
-  |     ^^^^^^^^^^^^^^^^^^^^^^
-5 | _ = lambda **kwargs: f(**kwargs) # [unnecessary-lambda]
-6 | _ = lambda *args, **kwargs: f(*args, **kwargs) # [unnecessary-lambda]
-  |
-help: Inline function call
-1 | _ = lambda: print()  # [unnecessary-lambda]
-2 | _ = lambda x, y: min(x, y) # [unnecessary-lambda]
-3 |
-  - _ = lambda *args: f(*args) # [unnecessary-lambda]
-4 + _ = f # [unnecessary-lambda]
-5 | _ = lambda **kwargs: f(**kwargs) # [unnecessary-lambda]
-6 | _ = lambda *args, **kwargs: f(*args, **kwargs) # [unnecessary-lambda]
-7 | _ = lambda x, y, z, *args, **kwargs: f(x, y, z, *args, **kwargs) # [unnecessary-lambda]
-note: This is an unsafe fix and may change runtime behavior
-
-PLW0108 [*] Lambda may be unnecessary; consider inlining inner function
- --> unnecessary_lambda.py:5:5
-  |
-4 | _ = lambda *args: f(*args) # [unnecessary-lambda]
-5 | _ = lambda **kwargs: f(**kwargs) # [unnecessary-lambda]
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-6 | _ = lambda *args, **kwargs: f(*args, **kwargs) # [unnecessary-lambda]
-7 | _ = lambda x, y, z, *args, **kwargs: f(x, y, z, *args, **kwargs) # [unnecessary-lambda]
-  |
-help: Inline function call
-2 | _ = lambda x, y: min(x, y) # [unnecessary-lambda]
-3 |
-4 | _ = lambda *args: f(*args) # [unnecessary-lambda]
-  - _ = lambda **kwargs: f(**kwargs) # [unnecessary-lambda]
-5 + _ = f # [unnecessary-lambda]
-6 | _ = lambda *args, **kwargs: f(*args, **kwargs) # [unnecessary-lambda]
-7 | _ = lambda x, y, z, *args, **kwargs: f(x, y, z, *args, **kwargs) # [unnecessary-lambda]
-8 |
-note: This is an unsafe fix and may change runtime behavior
-
-PLW0108 [*] Lambda may be unnecessary; consider inlining inner function
- --> unnecessary_lambda.py:6:5
-  |
-4 | _ = lambda *args: f(*args) # [unnecessary-lambda]
-5 | _ = lambda **kwargs: f(**kwargs) # [unnecessary-lambda]
-6 | _ = lambda *args, **kwargs: f(*args, **kwargs) # [unnecessary-lambda]
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-7 | _ = lambda x, y, z, *args, **kwargs: f(x, y, z, *args, **kwargs) # [unnecessary-lambda]
-  |
-help: Inline function call
-3 |
-4 | _ = lambda *args: f(*args) # [unnecessary-lambda]
-5 | _ = lambda **kwargs: f(**kwargs) # [unnecessary-lambda]
-  - _ = lambda *args, **kwargs: f(*args, **kwargs) # [unnecessary-lambda]
-6 + _ = f # [unnecessary-lambda]
-7 | _ = lambda x, y, z, *args, **kwargs: f(x, y, z, *args, **kwargs) # [unnecessary-lambda]
-8 |
-9 | _ = lambda x: f(lambda x: x)(x) # [unnecessary-lambda]
-note: This is an unsafe fix and may change runtime behavior
-
-PLW0108 [*] Lambda may be unnecessary; consider inlining inner function
- --> unnecessary_lambda.py:7:5
-  |
-5 | _ = lambda **kwargs: f(**kwargs) # [unnecessary-lambda]
-6 | _ = lambda *args, **kwargs: f(*args, **kwargs) # [unnecessary-lambda]
-7 | _ = lambda x, y, z, *args, **kwargs: f(x, y, z, *args, **kwargs) # [unnecessary-lambda]
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-8 |
-9 | _ = lambda x: f(lambda x: x)(x) # [unnecessary-lambda]
-  |
-help: Inline function call
-4  | _ = lambda *args: f(*args) # [unnecessary-lambda]
-5  | _ = lambda **kwargs: f(**kwargs) # [unnecessary-lambda]
-6  | _ = lambda *args, **kwargs: f(*args, **kwargs) # [unnecessary-lambda]
-   - _ = lambda x, y, z, *args, **kwargs: f(x, y, z, *args, **kwargs) # [unnecessary-lambda]
-7  + _ = f # [unnecessary-lambda]
-8  |
-9  | _ = lambda x: f(lambda x: x)(x) # [unnecessary-lambda]
-10 | _ = lambda x, y: f(lambda x, y: x + y)(x, y) # [unnecessary-lambda]
-note: This is an unsafe fix and may change runtime behavior
-
-PLW0108 [*] Lambda may be unnecessary; consider inlining inner function
-  --> unnecessary_lambda.py:9:5
-   |
- 7 | _ = lambda x, y, z, *args, **kwargs: f(x, y, z, *args, **kwargs) # [unnecessary-lambda]
- 8 |
- 9 | _ = lambda x: f(lambda x: x)(x) # [unnecessary-lambda]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-10 | _ = lambda x, y: f(lambda x, y: x + y)(x, y) # [unnecessary-lambda]
-   |
-help: Inline function call
-6  | _ = lambda *args, **kwargs: f(*args, **kwargs) # [unnecessary-lambda]
-7  | _ = lambda x, y, z, *args, **kwargs: f(x, y, z, *args, **kwargs) # [unnecessary-lambda]
-8  |
-   - _ = lambda x: f(lambda x: x)(x) # [unnecessary-lambda]
-9  + _ = f(lambda x: x) # [unnecessary-lambda]
-10 | _ = lambda x, y: f(lambda x, y: x + y)(x, y) # [unnecessary-lambda]
-11 |
-12 | # default value in lambda parameters
-note: This is an unsafe fix and may change runtime behavior
-
-PLW0108 [*] Lambda may be unnecessary; consider inlining inner function
-  --> unnecessary_lambda.py:10:5
-   |
- 9 | _ = lambda x: f(lambda x: x)(x) # [unnecessary-lambda]
-10 | _ = lambda x, y: f(lambda x, y: x + y)(x, y) # [unnecessary-lambda]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-11 |
-12 | # default value in lambda parameters
-   |
-help: Inline function call
-7  | _ = lambda x, y, z, *args, **kwargs: f(x, y, z, *args, **kwargs) # [unnecessary-lambda]
-8  |
-9  | _ = lambda x: f(lambda x: x)(x) # [unnecessary-lambda]
-   - _ = lambda x, y: f(lambda x, y: x + y)(x, y) # [unnecessary-lambda]
-10 + _ = f(lambda x, y: x + y) # [unnecessary-lambda]
-11 |
-12 | # default value in lambda parameters
-13 | _ = lambda x=42: print(x)
-note: This is an unsafe fix and may change runtime behavior
-
-PLW0108 [*] Lambda may be unnecessary; consider inlining inner function
   --> unnecessary_lambda.py:62:5
    |
 61 | # https://github.com/astral-sh/ruff/issues/18675
@@ -171,6 +49,8 @@ help: Inline function call
    - _ = lambda x: (string := str)(x)
 62 + _ = (string := str)
 63 | _ = lambda x: ((x := 1) and str)(x)
+64 |
+65 | # https://github.com/astral-sh/ruff/issues/24704
 note: This is an unsafe fix and may change runtime behavior
 
 PLW0108 Lambda may be unnecessary; consider inlining inner function
@@ -180,5 +60,7 @@ PLW0108 Lambda may be unnecessary; consider inlining inner function
 62 | _ = lambda x: (string := str)(x)
 63 | _ = lambda x: ((x := 1) and str)(x)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+64 |
+65 | # https://github.com/astral-sh/ruff/issues/24704
    |
 help: Inline function call


### PR DESCRIPTION
## Summary

Fixes [astral-sh/ruff#24704](https://github.com/astral-sh/ruff/issues/24704)

When PLW0108 (unnecessary-lambda) flagged a lambda that wraps a function call,
it suggested inlining even when the function is defined *after* the lambda.

Example:
```python
x = {"a": lambda y: f(y)}

def f(y):
    pass
```

Inlining would produce `x = {"a": f}` which fails at runtime because `f` is
not yet bound when `x` is evaluated.

## Fix

In `unnecessary_lambda`, when iterating over the names referenced by the
lambda body, check whether the resolved binding starts after the lambda's
own range. If so, and the binding is not a builtin and is not defined
inside the lambda body (e.g. walrus expression), suppress the diagnostic.

Also added test fixtures and updated the snapshot.

## Test Plan

- `cargo test --package ruff_linter -- unnecessary_lambda` passes with
  updated snapshot.
- `cargo test --package ruff_linter --lib rules::pylint` (183 tests)
  all pass.