### PR TITLE
[ty] Treat custom enum `__new__` values as dynamic

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -558,6 +558,49 @@ class Child(Parent):
 reveal_type(Child.A.value)  # revealed: Any
 ```
 
+### Inherited `__new__`
+
+A custom `__new__` on a parent enum is inherited by subclasses. Without an explicit `_value_`
+annotation, subclass member values remain dynamic:
+
+```py
+from enum import Enum
+
+class Base(Enum):
+    def __new__(cls, value: str, connector_id: int) -> "Base":
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.connector_id = connector_id
+        return obj
+
+class Child(Base):
+    GITHUB = ("github", 1)
+
+reveal_type(Child.GITHUB.value)  # revealed: Any
+reveal_type(Child.GITHUB._value_)  # revealed: Any
+```
+
+An explicit `_value_` annotation on the subclass still takes precedence:
+
+```py
+from enum import Enum
+
+class Base(Enum):
+    def __new__(cls, value: str, connector_id: int = 0) -> "Base":
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.connector_id = connector_id
+        return obj
+
+class Child(Base):
+    _value_: str
+
+    GITHUB = "github"
+
+reveal_type(Child.GITHUB.value)  # revealed: str
+reveal_type(Child.GITHUB._value_)  # revealed: str
+```
+
 ### Non-member attributes with disallowed type
 
 Methods, callables, descriptors (including properties), and nested classes that are defined in the

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -601,6 +601,25 @@ reveal_type(Child.GITHUB.value)  # revealed: str
 reveal_type(Child.GITHUB._value_)  # revealed: str
 ```
 
+Member values are still validated against the inherited `__new__` signature, even when `_value_` is
+explicitly annotated:
+
+```py
+from enum import Enum
+
+class Base(Enum):
+    def __new__(cls, value: int, connector_id: int = 0) -> "Base":
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.connector_id = connector_id
+        return obj
+
+class Child(Base):
+    _value_: str
+
+    GITHUB = "github"  # error: [invalid-assignment]
+```
+
 ### Non-member attributes with disallowed type
 
 Methods, callables, descriptors (including properties), and nested classes that are defined in the

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -441,6 +441,48 @@ reveal_type(Planet2.MERCURY.value)  # revealed: Any
 reveal_type(Planet2.MERCURY._value_)  # revealed: Any
 ```
 
+### `__new__` without `_value_` annotation
+
+When `__new__` is defined but no explicit `_value_` annotation exists, member RHS values are passed
+to `__new__`, but the method can assign `_value_` independently. In this case, `.value` falls back
+to `Any`:
+
+```py
+from enum import Enum
+
+class Connector(Enum):
+    def __new__(cls, value: str, connector_id: int) -> "Connector":
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.connector_id = connector_id
+        return obj
+
+    GITHUB = ("github", 1)
+
+reveal_type(Connector.GITHUB.value)  # revealed: Any
+reveal_type(Connector.GITHUB._value_)  # revealed: Any
+```
+
+An explicit `_value_` annotation still takes precedence:
+
+```py
+from enum import Enum
+
+class AnnotatedConnector(Enum):
+    _value_: str
+
+    def __new__(cls, value: str, connector_id: int = 0) -> "AnnotatedConnector":
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.connector_id = connector_id
+        return obj
+
+    GITHUB = "github"
+
+reveal_type(AnnotatedConnector.GITHUB.value)  # revealed: str
+reveal_type(AnnotatedConnector.GITHUB._value_)  # revealed: str
+```
+
 ### Inherited `_value_` annotation
 
 A `_value_` annotation on a parent enum is inherited by subclasses. Member values are validated

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -31,6 +31,13 @@ pub(crate) struct EnumMetadata<'db> {
     /// When present, member values are validated by synthesizing a call to
     /// `__init__` rather than by simple type assignability.
     pub(crate) init_function: Option<FunctionType<'db>>,
+
+    /// The custom `__new__` function, if defined on this enum.
+    ///
+    /// When present, the RHS of a member declaration is not necessarily the
+    /// value exposed through `.value`; the method can assign `_value_`
+    /// independently.
+    pub(crate) new_function: Option<FunctionType<'db>>,
 }
 
 impl get_size2::GetSize for EnumMetadata<'_> {}
@@ -43,12 +50,13 @@ impl<'db> EnumMetadata<'db> {
             auto_members: FxHashSet::default(),
             value_annotation: None,
             init_function: None,
+            new_function: None,
         }
     }
 
     /// Returns the type of `.value`/`._value_` for a given enum member.
     ///
-    /// Priority: explicit `_value_` annotation, then `__init__` → `Any`,
+    /// Priority: explicit `_value_` annotation, then custom construction hooks → `Any`,
     /// then the inferred member value type.
     pub(crate) fn value_type(&self, member_name: &Name) -> Option<Type<'db>> {
         if !self.members.contains_key(member_name) {
@@ -56,7 +64,7 @@ impl<'db> EnumMetadata<'db> {
         }
         if let Some(annotation) = self.value_annotation {
             Some(annotation)
-        } else if self.init_function.is_some() {
+        } else if self.init_function.is_some() || self.new_function.is_some() {
             Some(Type::Dynamic(DynamicType::Any))
         } else {
             self.members.get(member_name).copied()
@@ -76,7 +84,7 @@ impl<'db> EnumMetadata<'db> {
     /// narrowed to a specific member (e.g. `x: MyEnum` where `MyEnum` has multiple members).
     ///
     /// If there is an explicit `_value_` annotation, returns that.
-    /// If there is a custom `__init__`, returns `Any`.
+    /// If there is a custom `__init__` or `__new__`, returns `Any`.
     /// Otherwise, returns the union of all member value types.
     pub(crate) fn instance_value_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         if self.members.is_empty() {
@@ -84,7 +92,7 @@ impl<'db> EnumMetadata<'db> {
         }
         if let Some(annotation) = self.value_annotation {
             Some(annotation)
-        } else if self.init_function.is_some() {
+        } else if self.init_function.is_some() || self.new_function.is_some() {
             Some(Type::Dynamic(DynamicType::Any))
         } else {
             let union = self
@@ -221,6 +229,7 @@ pub(crate) fn enum_metadata<'db>(
                 auto_members: FxHashSet::default(),
                 value_annotation: None,
                 init_function: None,
+                new_function: None,
             });
         }
     };
@@ -431,8 +440,9 @@ pub(crate) fn enum_metadata<'db>(
     let value_annotation =
         custom_value_annotation(db, scope_id).or_else(|| inherited_value_annotation(db, class));
 
-    // Look up a custom `__init__`, falling back to parent enum classes.
+    // Look up custom construction hooks, falling back to parent enum classes.
     let init_function = custom_init(db, scope_id).or_else(|| inherited_init(db, class));
+    let new_function = custom_new(db, scope_id).or_else(|| inherited_new(db, class));
 
     Some(EnumMetadata {
         members,
@@ -440,6 +450,7 @@ pub(crate) fn enum_metadata<'db>(
         auto_members,
         value_annotation,
         init_function,
+        new_function,
     })
 }
 
@@ -492,6 +503,14 @@ fn inherited_init<'db>(
     iter_parent_enum_classes(db, class).find_map(|base| custom_init(db, base.body_scope(db)))
 }
 
+/// Looks up an inherited `__new__` from parent enum classes in the MRO.
+fn inherited_new<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+) -> Option<FunctionType<'db>> {
+    iter_parent_enum_classes(db, class).find_map(|base| custom_new(db, base.body_scope(db)))
+}
+
 /// Returns the custom `__init__` function type if one is defined on the enum.
 fn custom_init<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Option<FunctionType<'db>> {
     let init_symbol_id = place_table(db, scope).symbol_id("__init__")?;
@@ -503,6 +522,22 @@ fn custom_init<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Option<FunctionType
     .ignore_possibly_undefined()?;
 
     match init_type {
+        Type::FunctionLiteral(f) => Some(f),
+        _ => None,
+    }
+}
+
+/// Returns the custom `__new__` function type if one is defined on the enum.
+fn custom_new<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Option<FunctionType<'db>> {
+    let new_symbol_id = place_table(db, scope).symbol_id("__new__")?;
+    let new_type = place_from_declarations(
+        db,
+        use_def_map(db, scope).end_of_scope_symbol_declarations(new_symbol_id),
+    )
+    .ignore_conflicting_declarations()
+    .ignore_possibly_undefined()?;
+
+    match new_type {
         Type::FunctionLiteral(f) => Some(f),
         _ => None,
     }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -253,16 +253,31 @@ fn check_class_declaration<'db>(
             let skip_type_check = (context.in_stub() && is_ellipsis) || is_auto;
 
             if !skip_type_check {
+                if let Some(new_function) = enum_info.new_function {
+                    check_enum_member_against_constructor_hook(
+                        context,
+                        new_function,
+                        Type::from(class),
+                        member_value_type,
+                        &member.name,
+                        *first_reachable_definition,
+                        EnumConstructorHook::New,
+                    );
+                }
+
                 if let Some(init_function) = enum_info.init_function {
-                    check_enum_member_against_init(
+                    check_enum_member_against_constructor_hook(
                         context,
                         init_function,
                         instance_of_class,
                         member_value_type,
                         &member.name,
                         *first_reachable_definition,
+                        EnumConstructorHook::Init,
                     );
-                } else if let Some(expected_type) = enum_info.value_annotation {
+                } else if enum_info.new_function.is_none()
+                    && let Some(expected_type) = enum_info.value_annotation
+                {
                     if !member_value_type.is_assignable_to(db, expected_type) {
                         if let Some(builder) = context.report_lint(
                             &INVALID_ASSIGNMENT,
@@ -1145,25 +1160,41 @@ fn check_post_init_signature<'db>(
     );
 }
 
-/// Validates an enum member value against the enum's `__init__` signature.
+#[derive(Clone, Copy, Debug)]
+enum EnumConstructorHook {
+    New,
+    Init,
+}
+
+impl EnumConstructorHook {
+    fn name(self) -> &'static str {
+        match self {
+            Self::New => "__new__",
+            Self::Init => "__init__",
+        }
+    }
+}
+
+/// Validates an enum member value against an enum construction hook signature.
 ///
-/// The enum metaclass unpacks tuple values as positional arguments to `__init__`,
+/// The enum metaclass unpacks tuple values as positional arguments to `__new__` and `__init__`,
 /// and passes non-tuple values as a single argument. This function synthesizes
-/// a call to `__init__` with the appropriate arguments and reports a diagnostic
+/// a call with the appropriate arguments and reports a diagnostic
 /// if the call would fail.
-fn check_enum_member_against_init<'db>(
+fn check_enum_member_against_constructor_hook<'db>(
     context: &InferContext<'db, '_>,
-    init_function: FunctionType<'db>,
-    self_type: Type<'db>,
+    function: FunctionType<'db>,
+    bound_self_type: Type<'db>,
     member_value_type: Type<'db>,
     member_name: &Name,
     definition: Definition<'db>,
+    hook: EnumConstructorHook,
 ) {
     let db = context.db();
 
     // The enum metaclass unpacks tuple values as positional args:
-    //   MEMBER = (a, b, c)  →  __init__(self, a, b, c)
-    //   MEMBER = x          →  __init__(self, x)
+    //   MEMBER = (a, b, c)  →  __new__(cls, a, b, c) / __init__(self, a, b, c)
+    //   MEMBER = x          →  __new__(cls, x) / __init__(self, x)
     let args: Vec<Type<'db>> = if let Type::NominalInstance(instance) = member_value_type {
         if let Some(spec) = instance.tuple_spec(db) {
             if let Tuple::Fixed(fixed) = &*spec {
@@ -1180,10 +1211,10 @@ fn check_enum_member_against_init<'db>(
     };
 
     let call_args = CallArguments::positional(args);
-    let call_args = call_args.with_self(Some(self_type));
+    let call_args = call_args.with_self(Some(bound_self_type));
 
     let constraints = ConstraintSetBuilder::new();
-    let result = Type::FunctionLiteral(init_function)
+    let result = Type::FunctionLiteral(function)
         .bindings(db)
         .match_parameters(db, &call_args)
         .check_types(db, &constraints, &call_args, TypeContext::default(), &[]);
@@ -1194,11 +1225,12 @@ fn check_enum_member_against_init<'db>(
             definition.focus_range(db, context.module()),
         ) {
             let mut diagnostic = builder.into_diagnostic(format_args!(
-                "Enum member `{member_name}` is incompatible with `__init__`",
+                "Enum member `{member_name}` is incompatible with `{}`",
+                hook.name(),
             ));
             diagnostic.info(format_args!(
                 "Expected compatible arguments for `{}`",
-                Type::FunctionLiteral(init_function).display(db),
+                Type::FunctionLiteral(function).display(db),
             ));
         }
     }


### PR DESCRIPTION
## Summary

For enums with a custom `__new__`, the member RHS is input to the constructor, but `__new__` can assign `_value_` independently. We now treat such values as dynamically typed, unless `_value_` is explicitly annotated.

To quote @JelleZijlstra: "Looks right and fairly simple, behavior matches pyright and mypy."
