### PR TITLE
docs: clarify C901 examples have same McCabe complexity

### DIFF
--- a/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
+++ b/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
@@ -45,6 +45,12 @@ use crate::checkers::ast::Checker;
 ///     return 1
 /// ```
 ///
+/// Note that the refactored version may have the same McCabe complexity
+/// (due to the same number of decision points), but it improves
+/// readability through early returns and a flatter structure.
+/// To meaningfully reduce McCabe complexity, consider extracting
+/// complex logic into smaller helper functions.
+///
 /// ## Options
 /// - `lint.mccabe.max-complexity`
 #[derive(ViolationMetadata)]


### PR DESCRIPTION
## Summary

Clarify that the C901 (complex-structure) 'bad' and 'good' documentation examples have the same McCabe complexity.

## Root Cause

The current documentation shows two examples — a 'bad' nested-if version and a 'Use instead' early-return version — but both have 4 decision points, giving them the same McCabe complexity of 4. This is confusing because the 'Use instead' section implies complexity reduction when the real improvement is readability.

## Fix

Add a note explaining that:
- The refactored version may have the same McCabe complexity due to identical decision points
- The improvement is in readability through early returns and a flatter structure
- To meaningfully reduce McCabe complexity, extract complex logic into smaller helper functions

## Changes

- `crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs`: Added clarifying note to the C901 rule documentation

## Testing

- The change is documentation-only; existing tests continue to pass
- No behavioral changes to the lint rule

Closes #25028