### PR TITLE
[ty] Reduce CPU usage of the LSP when switching between large changesets

### DIFF
--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -231,8 +231,6 @@ impl Files {
     /// Refreshing the state of files recursively is expensive. It requires iterating over all known files
     /// and making system calls to get the latest status of matching files.
     /// That's why [`File::sync_path`] is preferred if it is known that the path is a file.
-    ///
-    /// Callers are responsible for removing nested paths that would be redundant to sync.
     pub fn sync_all_recursive<P, I>(db: &mut dyn Db, paths: I)
     where
         P: AsRef<SystemPath>,

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fmt;
 use std::sync::Arc;
 
@@ -222,29 +223,52 @@ impl Files {
         }
     }
 
-    /// Refreshes the state of all known files under `path` recursively.
+    /// Refreshes the state of all known files under `paths` recursively.
     ///
-    /// The most common use case is to update the [`Files`] state after removing or moving a directory.
+    /// The most common use case is to update the [`Files`] state after removing or moving directories.
     ///
     /// # Performance
-    /// Refreshing the state of every file under `path` is expensive. It requires iterating over all known files
-    /// and making system calls to get the latest status of each file in `path`.
-    /// That's why [`File::sync_path`] and [`File::sync_path`] is preferred if it is known that the path is a file.
-    pub fn sync_recursively(db: &mut dyn Db, path: &SystemPath) {
-        let path = SystemPath::absolute(path, db.system().current_directory());
-        tracing::debug!("Syncing all files in '{path}'");
+    /// Refreshing the state of files recursively is expensive. It requires iterating over all known files
+    /// and making system calls to get the latest status of matching files.
+    /// That's why [`File::sync_path`] is preferred if it is known that the path is a file.
+    ///
+    /// Callers are responsible for removing nested paths that would be redundant to sync.
+    pub fn sync_all_recursive<P, I>(db: &mut dyn Db, paths: I)
+    where
+        P: AsRef<SystemPath>,
+        I: IntoIterator<Item = P>,
+    {
+        let current_directory = db.system().current_directory();
+        let paths = paths
+            .into_iter()
+            .map(|path| SystemPath::absolute(path.as_ref(), current_directory))
+            .collect::<BTreeSet<_>>();
+
+        if paths.is_empty() {
+            return;
+        }
 
         let inner = Arc::clone(&db.files().inner);
         for entry in inner.system_by_path.iter_mut() {
-            if entry.key().starts_with(&path) {
-                File::sync_system_path(db, entry.key(), Some(*entry.value()));
+            let path = entry.key();
+            if paths
+                .range(..=path.to_path_buf())
+                .next_back()
+                .is_some_and(|candidate| path.starts_with(candidate.as_path()))
+            {
+                File::sync_system_path(db, path, Some(*entry.value()));
             }
         }
 
         let roots = inner.roots.read().unwrap();
 
         for root in roots.all() {
-            if path.starts_with(root.path(db)) {
+            let root_path = root.path(db);
+            if paths
+                .range(root_path.to_path_buf()..)
+                .next()
+                .is_some_and(|path| path.starts_with(root_path))
+            {
                 root.set_revision(db).to(FileRevision::now());
             }
         }

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -12,12 +12,14 @@ use ruff_db::system::{
 };
 use ruff_python_ast::PythonVersion;
 use ty_module_resolver::{Module, ModuleName, resolve_module_confident};
-use ty_project::metadata::options::{EnvironmentOptions, Options, ProjectOptionsOverrides};
+use ty_project::metadata::options::{
+    EnvironmentOptions, Options, ProjectOptionsOverrides, SrcOptions,
+};
 use ty_project::metadata::pyproject::{PyProject, Tool};
 use ty_project::metadata::python_version::SupportedPythonVersion;
-use ty_project::metadata::value::{RangedValue, RelativePathBuf};
+use ty_project::metadata::value::{RangedValue, RelativeGlobPattern, RelativePathBuf};
 use ty_project::watch::{ChangeEvent, ProjectWatcher, directory_watcher};
-use ty_project::{Db, ProjectDatabase, ProjectMetadata};
+use ty_project::{ChangeResult, Db, ProjectDatabase, ProjectMetadata};
 use ty_python_core::platform::PythonPlatform;
 use ty_static::EnvVars;
 
@@ -181,8 +183,8 @@ impl TestCase {
         &mut self,
         changes: &[ChangeEvent],
         project_options_overrides: Option<&ProjectOptionsOverrides>,
-    ) {
-        self.db.apply_changes(changes, project_options_overrides);
+    ) -> ChangeResult {
+        self.db.apply_changes(changes, project_options_overrides)
     }
 
     fn update_options(&mut self, options: Options) -> anyhow::Result<()> {
@@ -570,6 +572,53 @@ fn new_ignored_file() -> anyhow::Result<()> {
 
     assert!(case.system_file(&foo_path).is_ok());
     case.assert_indexed_project_files([bar_file]);
+
+    Ok(())
+}
+
+#[test]
+fn ignore_file_change_reloads_files_not_project_metadata() -> anyhow::Result<()> {
+    let mut case = setup([("bar.py", ""), ("foo.py", ""), (".ignore", "foo.py")])?;
+    let bar = case.system_file(case.project_path("bar.py"))?;
+    let foo = case.system_file(case.project_path("foo.py"))?;
+
+    case.assert_indexed_project_files([bar]);
+
+    update_file(case.project_path(".ignore"), "")?;
+
+    let changes = case.stop_watch(event_for_file(".ignore"));
+    let result = case.apply_changes(&changes, None);
+
+    assert!(!result.project_changed());
+    case.assert_indexed_project_files([bar, foo]);
+
+    Ok(())
+}
+
+#[test]
+fn src_file_filter_change_reloads_project_files() -> anyhow::Result<()> {
+    let mut case = setup(|context: &mut SetupContext| {
+        context.write_project_file("bar.py", "")?;
+        context.write_project_file("foo.py", "")?;
+        context.set_options(Options {
+            src: Some(SrcOptions {
+                exclude: Some(RangedValue::cli(vec![RelativeGlobPattern::cli("foo.py")])),
+                ..SrcOptions::default()
+            }),
+            ..Options::default()
+        });
+
+        Ok(())
+    })?;
+
+    let bar = case.system_file(case.project_path("bar.py"))?;
+    let foo = case.system_file(case.project_path("foo.py"))?;
+
+    case.assert_indexed_project_files([bar]);
+
+    case.update_options(Options::default())?;
+
+    case.assert_indexed_project_files([bar, foo]);
 
     Ok(())
 }
@@ -1022,7 +1071,8 @@ fn directory_deleted() -> anyhow::Result<()> {
 
     let changes = case.stop_watch(event_for_file("sub"));
 
-    case.apply_changes(&changes, None);
+    let result = case.apply_changes(&changes, None);
+    assert!(!result.project_changed());
 
     // `import sub.a` should no longer resolve
     assert!(
@@ -1761,6 +1811,47 @@ mod unix {
 
         Ok(())
     }
+}
+
+#[test]
+fn active_project_config_change_reloads_project() -> anyhow::Result<()> {
+    let mut case = setup([("foo.py", "")])?;
+
+    std::fs::write(
+        case.project_path("pyproject.toml").as_std_path(),
+        r#"
+        [tool.ty.rules]
+        division-by-zero = "warn"
+        "#,
+    )?;
+
+    let changes = case.stop_watch(event_for_file("pyproject.toml"));
+    let result = case.apply_changes(&changes, None);
+
+    assert!(result.project_changed());
+
+    Ok(())
+}
+
+#[test]
+fn nested_project_config_change_is_cheap_if_active_project_unchanged() -> anyhow::Result<()> {
+    let mut case = setup(|context: &mut SetupContext| {
+        context.write_project_file("foo.py", "")?;
+        std::fs::create_dir(context.join_project_path("pkg").as_std_path())?;
+        Ok(())
+    })?;
+    let project_root = case.db().project().root(case.db()).to_path_buf();
+    let nested_pyproject = case.project_path("pkg/pyproject.toml");
+
+    std::fs::write(nested_pyproject.as_std_path(), "[tool.ty]\n")?;
+
+    let changes = case.stop_watch(event_for_file("pyproject.toml"));
+    let result = case.apply_changes(&changes, None);
+
+    assert!(!result.project_changed());
+    assert_eq!(case.db().project().root(case.db()), &*project_root);
+
+    Ok(())
 }
 
 #[test]

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -1,14 +1,14 @@
-use crate::ProjectMetadata;
 use crate::db::{Db, ProjectDatabase};
 use crate::metadata::options::ProjectOptionsOverrides;
 use crate::watch::{ChangeEvent, CreatedKind, DeletedKind};
+use crate::{ProjectMetadata, ProjectReloadResult};
 use std::collections::BTreeSet;
 
 use crate::walk::ProjectFilesWalker;
 use ruff_db::Db as _;
 use ruff_db::file_revision::FileRevision;
 use ruff_db::files::{File, FileRootKind, Files};
-use ruff_db::system::SystemPath;
+use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
 use rustc_hash::FxHashSet;
 use salsa::Setter;
 use ty_python_core::program::{FallibleStrategy, Program};
@@ -42,6 +42,7 @@ impl ProjectDatabase {
         let project_root = project.root(self).to_path_buf();
         let config_file_override =
             project_options_overrides.and_then(|options| options.config_file_override.clone());
+        let extra_configuration_paths = project.metadata(self).extra_configuration_paths().to_vec();
         let program = Program::get(self);
         let custom_stdlib_versions_path = program
             .custom_stdlib_search_path(self)
@@ -57,27 +58,31 @@ impl ProjectDatabase {
         // Deduplicate the `sync` calls. Many file watchers emit multiple events for the same path.
         let mut synced_files = FxHashSet::default();
         let mut sync_recursively = BTreeSet::default();
+        // A non-file delete may be a deleted directory or an ambiguous LSP delete for a path
+        // that no longer exists. Handle it recursively to keep Salsa's file state in sync.
+        let mut removed_paths = BTreeSet::default();
+        let mut reload_project = false;
+        let mut reload_project_files = false;
 
         for change in changes {
             tracing::debug!("Handling file watcher change event: {:?}", change);
 
             if let Some(path) = change.system_path() {
-                if let Some(config_file) = &config_file_override {
-                    if config_file.as_path() == path {
-                        File::sync_path(self, path);
-                        result.project_changed = true;
-
-                        continue;
-                    }
-                }
-
-                if matches!(
-                    path.file_name(),
-                    Some(".gitignore" | ".ignore" | "ty.toml" | "pyproject.toml")
+                if is_project_configuration_path(
+                    path,
+                    &project_root,
+                    config_file_override.as_ref(),
+                    &extra_configuration_paths,
                 ) {
                     File::sync_path(self, path);
-                    // Changes to ignore files or settings can change the project structure or add/remove files.
-                    result.project_changed = true;
+                    reload_project = true;
+
+                    continue;
+                }
+
+                if is_ignore_file(path) {
+                    File::sync_path(self, path);
+                    reload_project_files = true;
 
                     continue;
                 }
@@ -90,10 +95,8 @@ impl ProjectDatabase {
             match change {
                 ChangeEvent::Changed { path, kind: _ } | ChangeEvent::Opened(path) => {
                     if synced_files.insert(path.to_path_buf()) {
-                        let absolute =
-                            SystemPath::absolute(path, self.system().current_directory());
-                        File::sync_path_only(self, &absolute);
-                        if let Some(root) = self.files().root(self, &absolute) {
+                        File::sync_path_only(self, path);
+                        if let Some(root) = self.files().root(self, path) {
                             match root.kind_at_time_of_creation(self) {
                                 // When a file inside the root of
                                 // the project is changed, we don't
@@ -146,7 +149,6 @@ impl ProjectDatabase {
                     // should be included in the project. We can skip this check for
                     // paths that aren't part of the project or shouldn't be included
                     // when checking the project.
-
                     if self.system().is_file(path) {
                         if project.is_file_included(self, path) {
                             // Add the parent directory because `walkdir`
@@ -162,10 +164,7 @@ impl ProjectDatabase {
                 ChangeEvent::Deleted { kind, path } => {
                     let is_file = match kind {
                         DeletedKind::File => true,
-                        DeletedKind::Directory => {
-                            // file watchers emit an event for every deleted file. No need to scan the entire dir.
-                            continue;
-                        }
+                        DeletedKind::Directory => false,
                         DeletedKind::Any => self
                             .files
                             .try_system(self, path)
@@ -182,6 +181,7 @@ impl ProjectDatabase {
                         }
                     } else {
                         sync_recursively.insert(path.clone());
+                        removed_paths.insert(path.clone());
 
                         if custom_stdlib_versions_path
                             .as_ref()
@@ -190,24 +190,16 @@ impl ProjectDatabase {
                             result.custom_stdlib_changed = true;
                         }
 
-                        let directory_included = project.is_directory_included(self, path);
-
-                        if directory_included || path == &project_root {
-                            // TODO: Shouldn't it be enough to simply traverse the project files and remove all
-                            // that start with the given path?
+                        if directory_may_contain_project_configuration(
+                            path,
+                            &project_root,
+                            config_file_override.as_ref(),
+                            &extra_configuration_paths,
+                        ) {
                             tracing::debug!(
-                                "Reload project because of a path that could have been a directory."
+                                "Reload project because a configuration file may have been deleted."
                             );
-
-                            // Perform a full-reload in case the deleted directory contained the pyproject.toml.
-                            // We may want to make this more clever in the future, to e.g. iterate over the
-                            // indexed files and remove the once that start with the same path, unless
-                            // the deleted path is the project configuration.
-                            result.project_changed = true;
-                        } else if !directory_included {
-                            tracing::debug!(
-                                "Skipping reload because directory '{path}' isn't included in the project"
-                            );
+                            reload_project = true;
                         }
                     }
                 }
@@ -223,35 +215,31 @@ impl ProjectDatabase {
                 }
 
                 ChangeEvent::Rescan => {
-                    result.project_changed = true;
+                    reload_project = true;
                     Files::sync_all(self);
                     sync_recursively.clear();
+                    removed_paths.clear();
                     break;
                 }
             }
         }
 
-        let sync_recursively = sync_recursively.into_iter();
-        let mut last = None;
-
-        for path in sync_recursively {
-            // Avoid re-syncing paths that are sub-paths of each other.
-            if let Some(last) = &last {
-                if path.starts_with(last) {
-                    continue;
-                }
-            }
-
+        for path in deduplicate_nested_paths(sync_recursively) {
             Files::sync_recursively(self, &path);
-            last = Some(path);
         }
 
-        if result.project_changed {
+        if reload_project {
+            // The active project root may have been deleted. Start rediscovery from
+            // the closest existing ancestor so ty can fall back to an enclosing project.
+            let rediscovery_path = project_root
+                .ancestors()
+                .find(|path| self.system().is_directory(path))
+                .unwrap_or(&project_root);
             let new_project_metadata = match config_file_override {
                 Some(config_file) => {
                     ProjectMetadata::from_config_file(config_file, &project_root, self.system())
                 }
-                None => ProjectMetadata::discover(&project_root, self.system()),
+                None => ProjectMetadata::discover(rediscovery_path, self.system()),
             };
             match new_project_metadata {
                 Ok(mut metadata) => {
@@ -298,23 +286,44 @@ impl ProjectDatabase {
                     };
 
                     tracing::debug!("Reloading project after structural change");
-                    project.reload(
+                    match project.reload(
                         self,
                         metadata,
                         settings,
                         settings_diagnostics,
                         program_settings_diagnostics,
-                    );
+                    ) {
+                        ProjectReloadResult::Unchanged => {}
+                        ProjectReloadResult::Changed { files_changed } => {
+                            result.project_changed = true;
+                            if files_changed {
+                                // The project file set has already been rebuilt; continuing would
+                                // run incremental discovery from paths collected before the reload.
+                                return result;
+                            }
+                        }
+                    }
                 }
                 Err(error) => {
                     tracing::error!(
                         "Failed to load project, keeping old project configuration: {error}"
                     );
+                    if reload_project_files {
+                        project.reload_files(self);
+                        return result;
+                    }
                 }
             }
+        }
 
-            return result;
-        } else if result.custom_stdlib_changed {
+        if reload_project_files {
+            project.reload_files(self);
+            // A full project-file reload supersedes incremental project-file updates.
+            added_paths.clear();
+            removed_paths.clear();
+        }
+
+        if result.custom_stdlib_changed {
             match project.metadata(self).to_program_settings(
                 self.system(),
                 self.vendored(),
@@ -342,6 +351,10 @@ impl ProjectDatabase {
             }
         }
 
+        for path in deduplicate_nested_paths(removed_paths) {
+            project.remove_files_under(self, &path);
+        }
+
         let diagnostics = if let Some(walker) = ProjectFilesWalker::incremental(self, added_paths) {
             // Use directory walking to discover newly added files.
             let (files, diagnostics) = walker.collect_vec(self);
@@ -364,4 +377,56 @@ impl ProjectDatabase {
 
         result
     }
+}
+
+fn is_project_configuration_path(
+    path: &SystemPath,
+    project_root: &SystemPath,
+    config_file_override: Option<&SystemPathBuf>,
+    extra_configuration_paths: &[SystemPathBuf],
+) -> bool {
+    if extra_configuration_paths
+        .iter()
+        .any(|config_path| config_path.as_path() == path)
+    {
+        return true;
+    }
+
+    if let Some(config_path) = config_file_override {
+        config_path.as_path() == path
+    } else {
+        path.parent()
+            .is_some_and(|parent| project_root.starts_with(parent))
+            && is_project_config_file(path)
+    }
+}
+
+fn directory_may_contain_project_configuration(
+    directory: &SystemPath,
+    project_root: &SystemPath,
+    config_file_override: Option<&SystemPathBuf>,
+    extra_configuration_paths: &[SystemPathBuf],
+) -> bool {
+    if extra_configuration_paths
+        .iter()
+        .any(|config_path| config_path.starts_with(directory))
+    {
+        return true;
+    }
+
+    if let Some(config_path) = config_file_override {
+        config_path.starts_with(directory)
+    } else {
+        // Deleting the project root or one of its ancestors can change rediscovery:
+        // ty may need to fall back to an enclosing configuration.
+        project_root.starts_with(directory)
+    }
+}
+
+fn is_ignore_file(path: &SystemPath) -> bool {
+    matches!(path.file_name(), Some(".gitignore" | ".ignore"))
+}
+
+fn is_project_config_file(path: &SystemPath) -> bool {
+    matches!(path.file_name(), Some("ty.toml" | "pyproject.toml"))
 }

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -224,9 +224,8 @@ impl ProjectDatabase {
             }
         }
 
-        for path in deduplicate_nested_paths(sync_recursively) {
-            Files::sync_recursively(self, &path);
-        }
+        let sync_recursively = deduplicate_nested_paths(sync_recursively).collect::<Vec<_>>();
+        Files::sync_all_recursive(self, &sync_recursively);
 
         if reload_project {
             // The active project root may have been deleted. Start rediscovery from

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -216,6 +216,7 @@ impl ProjectDatabase {
 
                 ChangeEvent::Rescan => {
                     reload_project = true;
+                    reload_project_files = true;
                     Files::sync_all(self);
                     sync_recursively.clear();
                     removed_paths.clear();
@@ -224,8 +225,7 @@ impl ProjectDatabase {
             }
         }
 
-        let sync_recursively = deduplicate_nested_paths(sync_recursively).collect::<Vec<_>>();
-        Files::sync_all_recursive(self, &sync_recursively);
+        Files::sync_all_recursive(self, deduplicate_nested_paths(sync_recursively));
 
         if reload_project {
             // The active project root may have been deleted. Start rediscovery from

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -253,7 +253,7 @@ impl Project {
         settings: Option<Settings>,
         settings_diagnostics: Vec<OptionDiagnostic>,
         program_settings_diagnostics: Vec<ProgramSettingsDiagnostic>,
-    ) {
+    ) -> ProjectReloadResult {
         tracing::debug!("Reloading project");
         let metadata_changed = &metadata != self.metadata(db);
         let settings_diagnostics = Self::settings_diagnostics_with_program_diagnostics(
@@ -262,24 +262,39 @@ impl Project {
             program_settings_diagnostics,
         );
 
-        self.reload_files(db);
-
-        if let Some(settings) = settings
+        let root_changed = metadata.root() != self.root(db);
+        let (settings_changed, files_changed) = if let Some(settings) = settings
             && self.settings(db) != &settings
         {
+            let files_changed = root_changed || settings.src() != self.settings(db).src();
             self.set_settings(db).to(Box::new(settings));
-        }
+            (true, files_changed)
+        } else {
+            (false, root_changed)
+        };
 
         if self.settings_diagnostics(db) != settings_diagnostics {
             self.set_settings_diagnostics(db).to(settings_diagnostics);
         }
 
-        if !metadata_changed {
-            return;
+        if files_changed {
+            // The project file set only depends on the project root, explicit check paths,
+            // force-exclude, and `src` settings. Check paths and force-exclude are updated
+            // through their own setters, so a config reload only needs to reindex when the
+            // root or resolved `src` settings changed.
+            self.reload_files(db);
         }
 
-        self.set_metadata(db).to(Box::new(metadata));
-        self.try_add_file_root(db);
+        if metadata_changed {
+            self.set_metadata(db).to(Box::new(metadata));
+            self.try_add_file_root(db);
+        }
+
+        if metadata_changed || settings_changed {
+            ProjectReloadResult::Changed { files_changed }
+        } else {
+            ProjectReloadResult::Unchanged
+        }
     }
 
     /// Replace stored settings diagnostics after recomputing program settings.
@@ -578,6 +593,43 @@ impl Project {
         index.remove(file);
     }
 
+    /// Removes all indexed project files under `path`.
+    ///
+    /// This is a no-op if the project files are still lazily indexed.
+    #[tracing::instrument(level = "debug", skip(self, db))]
+    pub(crate) fn remove_files_under(self, db: &mut dyn Db, path: &SystemPath) {
+        let path = SystemPath::absolute(path, db.system().current_directory());
+
+        if self.file_set(db).is_lazy() {
+            return;
+        }
+
+        let files_to_remove = {
+            let files = self.files(db);
+            files
+                .iter()
+                .copied()
+                .filter(|file| {
+                    file.path(db)
+                        .as_system_path()
+                        .is_some_and(|file_path| file_path.starts_with(&path))
+                })
+                .collect::<Vec<_>>()
+        };
+
+        if files_to_remove.is_empty() {
+            return;
+        }
+
+        let Some(mut index) = IndexedFiles::indexed_mut(db, self) else {
+            return;
+        };
+
+        for file in files_to_remove {
+            index.remove(file);
+        }
+    }
+
     pub fn add_file(self, db: &mut dyn Db, file: File) {
         tracing::debug!(
             "Adding file `{}` to project `{}`",
@@ -644,6 +696,17 @@ impl Project {
             .map(OptionDiagnostic::to_diagnostic)
             .collect()
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectReloadResult {
+    /// Neither project metadata nor settings changed.
+    Unchanged,
+    /// Project metadata or settings changed.
+    Changed {
+        /// Whether the indexed project files changed.
+        files_changed: bool,
+    },
 }
 
 #[salsa::tracked(returns(as_deref), heap_size=ruff_memory_usage::heap_size)]

--- a/crates/ty_project/src/walk.rs
+++ b/crates/ty_project/src/walk.rs
@@ -187,6 +187,8 @@ impl<'a> ProjectFilesWalker<'a> {
             let force_exclude = filter.force_exclude();
 
             Box::new(move |entry| {
+                db.unwind_if_revision_cancelled();
+
                 match entry {
                     Ok(entry) => {
                         // Skip excluded directories unless they were explicitly passed to the walker

--- a/crates/ty_project/src/watch.rs
+++ b/crates/ty_project/src/watch.rs
@@ -1,5 +1,7 @@
+use std::fs;
+
 pub use project_watcher::ProjectWatcher;
-use ruff_db::system::{SystemPath, SystemPathBuf, SystemVirtualPathBuf};
+use ruff_db::system::{System, SystemPath, SystemPathBuf, SystemVirtualPathBuf};
 pub use watcher::{EventHandler, Watcher, directory_watcher};
 
 mod project_watcher;
@@ -130,4 +132,44 @@ pub enum DeletedKind {
     File,
     Directory,
     Any,
+}
+
+/// Best-effort classification of a path at the time a file-watcher event is handled.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ExistingPathKind {
+    File,
+    Directory,
+    Any,
+}
+
+impl ExistingPathKind {
+    pub fn from_system(system: &dyn System, path: &SystemPath) -> Self {
+        match system.path_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_file() => Self::File,
+            Ok(metadata) if metadata.file_type().is_directory() => Self::Directory,
+            Ok(_) | Err(_) => Self::Any,
+        }
+    }
+
+    pub fn from_io_metadata(metadata: &std::io::Result<fs::Metadata>) -> Self {
+        match metadata {
+            Ok(metadata) if metadata.is_file() => Self::File,
+            Ok(metadata) if metadata.is_dir() => Self::Directory,
+            Ok(_) | Err(_) => Self::Any,
+        }
+    }
+
+    pub const fn is_file(self) -> bool {
+        matches!(self, Self::File)
+    }
+}
+
+impl From<ExistingPathKind> for CreatedKind {
+    fn from(value: ExistingPathKind) -> Self {
+        match value {
+            ExistingPathKind::File => Self::File,
+            ExistingPathKind::Directory => Self::Directory,
+            ExistingPathKind::Any => Self::Any,
+        }
+    }
 }

--- a/crates/ty_project/src/watch/watcher.rs
+++ b/crates/ty_project/src/watch/watcher.rs
@@ -8,7 +8,7 @@ use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher as _, recomme
 
 use ruff_db::system::{SystemPath, SystemPathBuf};
 
-use crate::watch::{ChangeEvent, ChangedKind, CreatedKind, DeletedKind};
+use crate::watch::{ChangeEvent, ChangedKind, CreatedKind, DeletedKind, ExistingPathKind};
 
 /// Creates a new watcher observing file system changes.
 ///
@@ -268,9 +268,9 @@ impl Debouncer {
                 let kind = match create {
                     CreateKind::File => CreatedKind::File,
                     CreateKind::Folder => CreatedKind::Directory,
-                    CreateKind::Any | CreateKind::Other => {
-                        CreatedKind::from(FileType::from_path(&path))
-                    }
+                    CreateKind::Any | CreateKind::Other => CreatedKind::from(
+                        ExistingPathKind::from_io_metadata(&path.as_std_path().metadata()),
+                    ),
                 };
 
                 ChangeEvent::Created { path, kind }
@@ -278,7 +278,9 @@ impl Debouncer {
 
             EventKind::Modify(modify) => match modify {
                 ModifyKind::Metadata(metadata) => {
-                    if FileType::from_path(&path) != FileType::File {
+                    if ExistingPathKind::from_io_metadata(&path.as_std_path().metadata())
+                        != ExistingPathKind::File
+                    {
                         // Only interested in file metadata events.
                         return;
                     }
@@ -320,7 +322,9 @@ impl Debouncer {
                     }
 
                     RenameMode::To => ChangeEvent::Created {
-                        kind: CreatedKind::from(FileType::from_path(&path)),
+                        kind: CreatedKind::from(ExistingPathKind::from_io_metadata(
+                            &path.as_std_path().metadata(),
+                        )),
                         path,
                     },
 
@@ -340,7 +344,8 @@ impl Debouncer {
                     RenameMode::Any => {
                         // Guess the action based on the current file system state
                         if path.as_std_path().exists() {
-                            let file_type = FileType::from_path(&path);
+                            let file_type =
+                                ExistingPathKind::from_io_metadata(&path.as_std_path().metadata());
 
                             ChangeEvent::Created {
                                 kind: file_type.into(),
@@ -359,7 +364,8 @@ impl Debouncer {
                     return;
                 }
                 ModifyKind::Any => {
-                    if !path.as_std_path().is_file() {
+                    if !ExistingPathKind::from_io_metadata(&path.as_std_path().metadata()).is_file()
+                    {
                         return;
                     }
 
@@ -419,37 +425,5 @@ where
     fn handle(&self, changes: Vec<ChangeEvent>) {
         let f = self;
         f(changes);
-    }
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-enum FileType {
-    /// The event is related to a directory.
-    File,
-
-    /// The event is related to a directory.
-    Directory,
-
-    /// It's unknown whether the event is related to a file or a directory or if it is any other file type.
-    Any,
-}
-
-impl FileType {
-    fn from_path(path: &SystemPath) -> FileType {
-        match path.as_std_path().metadata() {
-            Ok(metadata) if metadata.is_file() => FileType::File,
-            Ok(metadata) if metadata.is_dir() => FileType::Directory,
-            Ok(_) | Err(_) => FileType::Any,
-        }
-    }
-}
-
-impl From<FileType> for CreatedKind {
-    fn from(value: FileType) -> Self {
-        match value {
-            FileType::File => Self::File,
-            FileType::Directory => Self::Directory,
-            FileType::Any => Self::Any,
-        }
     }
 }

--- a/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
@@ -9,9 +9,8 @@ use crate::session::client::Client;
 use crate::system::AnySystemPath;
 use lsp_types as types;
 use lsp_types::{FileChangeType, notification as notif};
-use ruff_db::system::SystemPathBuf;
 use ty_project::Db as _;
-use ty_project::watch::{ChangeEvent, ChangedKind, CreatedKind, DeletedKind};
+use ty_project::watch::{ChangeEvent, ChangedKind, CreatedKind, DeletedKind, ExistingPathKind};
 
 pub(crate) struct DidChangeWatchedFiles;
 
@@ -26,6 +25,7 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         params: types::DidChangeWatchedFilesParams,
     ) -> Result<()> {
         let mut changes = Vec::new();
+        let system = session.system();
 
         for change in params.changes {
             let path = DocumentKey::from_url(&change.uri).into_file_path();
@@ -40,13 +40,21 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
 
             let change_event = match change.typ {
                 FileChangeType::CREATED => ChangeEvent::Created {
+                    kind: CreatedKind::from(ExistingPathKind::from_system(system, &system_path)),
                     path: system_path,
-                    kind: CreatedKind::Any,
                 },
-                FileChangeType::CHANGED => ChangeEvent::Changed {
-                    path: system_path,
-                    kind: ChangedKind::Any,
-                },
+                FileChangeType::CHANGED => {
+                    // We're only interested in file content or metadata changes.
+                    // Renames are modelled as create/delete events.
+                    if ExistingPathKind::from_system(system, &system_path).is_file() {
+                        ChangeEvent::Changed {
+                            path: system_path,
+                            kind: ChangedKind::Any,
+                        }
+                    } else {
+                        continue;
+                    }
+                }
                 FileChangeType::DELETED => ChangeEvent::Deleted {
                     path: system_path,
                     kind: DeletedKind::Any,
@@ -67,7 +75,7 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
             return Ok(());
         }
 
-        let roots: Vec<SystemPathBuf> = session
+        let roots: Vec<_> = session
             .project_dbs()
             .map(|db| db.project().root(db).to_owned())
             .collect();

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -175,6 +175,10 @@ impl Session {
         })
     }
 
+    pub(crate) fn system(&self) -> &dyn System {
+        &*self.native_system
+    }
+
     pub(crate) fn request_queue(&self) -> &RequestQueue {
         &self.request_queue
     }


### PR DESCRIPTION
## Summary

We've seen high CPU usage when switching between large changesets (like 2500 commits). 

This PR implements a set of smaller fixes. It's best if you review this PR commit by commit. 

1. Commit: The LSP sends very coarse grained events. The only classification they have is whether a file or directory was created, changed, or deleted. This commit reuses the infrastructure that we already have in the CLI's `--watch` to classify those events based on the current file system state. Correctly classifying whether an event created a file or directory allows `apply_changes` to skip the somewhat expensive `File::sync_recursive` for file events (which should be much more common than directory events).
2. Today, ty reloads the entire project and all files whenever any `ty.toml` or `pyproject.toml` changed, even if that change is a no-op for ty. This commit more narrowly handles which `pyproject.toml` and `ty.toml`s are relevant and only performs a project and file reload when something meaningful changed.
3. Today, ty scans the entire project directory even if it has a queued `didChangeWatchedFiles` notification, because the project file indexing does not check whether the current request has been cancelled. This PR adds a cancellation check, so that ty stops early when new changes are incoming instead of scanning the entire directory only to throw the results away when processing the next batch of changes.
4. `File::sync_recursive` walks the entire files map and syncs all files that are a descendent of the passed path. This is fine if `sync_recursive` is only called for a single directory (or a few), but quickly becomes expensive when many directories were added or removed, which is not unlikely when switching between large changesets. This PR removes `sync_recursive` and introduce a new `sync_all_recursive`, so that ty only iterates once over all files, making the operation `O(files)` instead of `O(new_or_deleted_directories * files)`. 


## Test Plan

Measuring the impact is a bit tricky because it also depends on how the client chunks the events. The way I tested this is by changing between two revisions that are 2500 commits apart. You can see how this PR reduces the number of times we call `reload` and `reload_files`, as well as the time spent in syncing file state, and `apply_changes` overall 

metric | main | c1 classify | c2 narrow reloads | c3 cancellation | c4 batch sync
-- | -- | -- | -- | -- | --
LSP events | 35,509 | 36,082 | 33,959 | 33,645 | 29,791
apply batches | 15 | 19 | 12 | 19 | 13
Project::reload | 7 | 9 | 0 | 0 | 0
reload_files | 7 | 9 | 2 | 2 | 2
recursive candidates | 29,105 | 18,190 | 17,809 | 18,707 | 18,187
recursive sync calls | 24,580 | 17,217 | 16,836 | 17,734 | 12
apply_changes elapsed | 1.348s | 1.109s | 1.008s | 1.098s | 0.272s

