### PR TITLE
[ty] Run full iteration analysis on narrowed typevars

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -896,6 +896,19 @@ def source[T: type | tuple[type, ...]](x: T) -> Intersection[T, Not[tuple[object
     raise NotImplementedError
 
 reveal_type(higher(source))  # revealed: type
+
+def iterable_after_negative_narrow[T: str | list[str]](foo: T) -> None:
+    if isinstance(foo, str):
+        return
+    reveal_type(foo)  # revealed: T@iterable_after_negative_narrow & ~str
+    for x in foo:
+        reveal_type(x)  # revealed: str
+
+def non_iterable_after_negative_narrow[T: int | list[str]](foo: T) -> None:
+    if isinstance(foo, list):
+        return
+    reveal_type(foo)  # revealed: T@non_iterable_after_negative_narrow & ~Top[list[Unknown]]
+    for x in foo: ...  # error: [not-iterable]
 ```
 
 ## Constrained typevars remain assignable to the union of their constraints after narrowing

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -212,7 +212,7 @@ impl<'db> Type<'db> {
                     }
 
                     // Flattening changed the type; recursively iterate the flattened result.
-                    non_async_special_case(db, flattened)
+                    flattened.try_iterate(db).ok()
                 }
                 // N.B. This special case isn't strictly necessary, it's just an obvious optimization
                 Type::Dynamic(_) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),


### PR DESCRIPTION
Previously, if flattening a narrowed typevar changed the type, only the special-case path was used, skipping normal iteration analysis for dunders like `__iter__` and `__getitem__`.

## Summary
Previously ty incorrectly emitted an error on code like this:
```python
def f[T: str | list[str]](foo: T):
    if isinstance(foo, str): return
    for x in foo: ... # Object of type `T@f & ~str` may not be iterable 
```

## Test Plan

<!-- How was it tested? -->
New mdtests
