### PR TITLE
Fix lambda formatting in interpolated string expressions

### DIFF
--- a/crates/ruff_formatter/src/buffer.rs
+++ b/crates/ruff_formatter/src/buffer.rs
@@ -406,6 +406,11 @@ fn clean_interned(
                         Some((cleaned, &interned[index + 1..]))
                     }
                 }
+                FormatElement::BestFitting { .. } => {
+                    let mut cleaned = Vec::new();
+                    cleaned.extend_from_slice(&interned[..index]);
+                    Some((cleaned, &interned[index..]))
+                }
 
                 element => {
                     if state.should_drop(element) {
@@ -422,20 +427,28 @@ fn clean_interned(
         let result = match result {
             // Copy the whole interned buffer so that becomes possible to change the necessary elements.
             Some((mut cleaned, rest)) => {
-                for element in rest {
+                let mut element_stack = rest.iter().rev().collect::<Vec<_>>();
+                while let Some(element) = element_stack.pop() {
                     if state.should_drop(element) {
                         continue;
                     }
 
-                    let element = match element {
-                        FormatElement::Line(LineMode::SoftOrSpace) => FormatElement::Space,
+                    match element {
+                        FormatElement::Line(LineMode::SoftOrSpace) => {
+                            cleaned.push(FormatElement::Space);
+                        }
                         FormatElement::Interned(interned) => {
-                            FormatElement::Interned(clean_interned(interned, interned_cache))
+                            cleaned.push(FormatElement::Interned(clean_interned(
+                                interned,
+                                interned_cache,
+                            )));
+                        }
+                        FormatElement::BestFitting { variants, mode: _ } => {
+                            element_stack.extend(variants.most_flat().iter().rev());
                         }
 
-                        element => element.clone(),
-                    };
-                    cleaned.push(element);
+                        element => cleaned.push(element.clone()),
+                    }
                 }
 
                 Interned::new(cleaned)

--- a/crates/ruff_formatter/src/buffer.rs
+++ b/crates/ruff_formatter/src/buffer.rs
@@ -383,7 +383,8 @@ fn clean_interned(
     } else {
         let mut state = RemoveSoftLineBreaksState::default();
 
-        // Find the first soft line break element or interned element that must be changed
+        // Find the first soft line break element, interned element, or best-fitting element that
+        // must be changed
         let result = interned
             .iter()
             .enumerate()

--- a/crates/ruff_formatter/src/buffer.rs
+++ b/crates/ruff_formatter/src/buffer.rs
@@ -462,6 +462,12 @@ impl<Context> Buffer for RemoveSoftLinesBuffer<'_, Context> {
             FormatElement::Interned(interned) => {
                 FormatElement::Interned(self.clean_interned(&interned))
             }
+            FormatElement::BestFitting { variants, mode: _ } => {
+                for element in variants.most_flat() {
+                    self.write_element(element.clone());
+                }
+                return;
+            }
 
             element => element,
         };

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
@@ -839,3 +839,7 @@ foo = lambda: call(argument_one,)(extra_argument_one, extra_argument_twooooooooo
 foo = lambda: call(argument_one, argument_two, argument_threeeeeeeeeeeeeeeeeeeeeeeeeeee)(extra_argument_one, extra_argument_twooooooooooooooooooo, extra_argument_threeeeeeeee)
 
 foo = lambda: callllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll(argument_one, argument_two, argument_threeeeeeeeeeeeeeeeeeeeeeeeeeee)(extra_argument_one, extra_argument_twooooooooooooooooooo, extra_argument_threeeeeeeee)
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/24807
+def foo():
+    subprocess.check_call(f"rm -rf {' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))}", shell=True)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
@@ -852,3 +852,7 @@ def bar():
 value = f"prefix {
     ' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))
 } suffix"
+
+# This can also be triggered in nested, interned elements within `BestFitting` elements
+def foo():
+    subprocess.check_call(f"rm -rf {' '.join(map(lambda object_name: max(candidate_paths, key=lambda candidate: os.path.join(dest_path, object_name, candidate)), objects_to_remove))}", shell=True)

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/lambda.py
@@ -843,3 +843,12 @@ foo = lambda: callllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll
 # Regression tests for https://github.com/astral-sh/ruff/issues/24807
 def foo():
     subprocess.check_call(f"rm -rf {' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))}", shell=True)
+
+def bar():
+    lambda x=" ".join(
+        map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove)
+    ): ...
+
+value = f"prefix {
+    ' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))
+} suffix"

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
@@ -849,6 +849,15 @@ foo = lambda: callllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll
 # Regression tests for https://github.com/astral-sh/ruff/issues/24807
 def foo():
     subprocess.check_call(f"rm -rf {' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))}", shell=True)
+
+def bar():
+    lambda x=" ".join(
+        map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove)
+    ): ...
+
+value = f"prefix {
+    ' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))
+} suffix"
 ```
 
 ## Output
@@ -1781,6 +1790,19 @@ def foo():
         f"rm -rf {' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))}",
         shell=True,
     )
+
+
+def bar():
+    lambda x=" ".join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove)): (
+        ...
+    )
+
+
+value = f"prefix {
+    ' '.join(
+        map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove)
+    )
+} suffix"
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
@@ -845,6 +845,10 @@ foo = lambda: call(argument_one,)(extra_argument_one, extra_argument_twooooooooo
 foo = lambda: call(argument_one, argument_two, argument_threeeeeeeeeeeeeeeeeeeeeeeeeeee)(extra_argument_one, extra_argument_twooooooooooooooooooo, extra_argument_threeeeeeeee)
 
 foo = lambda: callllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllll(argument_one, argument_two, argument_threeeeeeeeeeeeeeeeeeeeeeeeeeee)(extra_argument_one, extra_argument_twooooooooooooooooooo, extra_argument_threeeeeeeee)
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/24807
+def foo():
+    subprocess.check_call(f"rm -rf {' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))}", shell=True)
 ```
 
 ## Output
@@ -1769,6 +1773,14 @@ foo = lambda: (
         extra_argument_threeeeeeeee,
     )
 )
+
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/24807
+def foo():
+    subprocess.check_call(
+        f"rm -rf {' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))}",
+        shell=True,
+    )
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__lambda.py.snap
@@ -858,6 +858,10 @@ def bar():
 value = f"prefix {
     ' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))
 } suffix"
+
+# This can also be triggered in nested, interned elements within `BestFitting` elements
+def foo():
+    subprocess.check_call(f"rm -rf {' '.join(map(lambda object_name: max(candidate_paths, key=lambda candidate: os.path.join(dest_path, object_name, candidate)), objects_to_remove))}", shell=True)
 ```
 
 ## Output
@@ -1803,6 +1807,14 @@ value = f"prefix {
         map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove)
     )
 } suffix"
+
+
+# This can also be triggered in nested, interned elements within `BestFitting` elements
+def foo():
+    subprocess.check_call(
+        f"rm -rf {' '.join(map(lambda object_name: max(candidate_paths, key=lambda candidate: os.path.join(dest_path, object_name, candidate)), objects_to_remove))}",
+        shell=True,
+    )
 ```
 
 


### PR DESCRIPTION
Summary
--

This PR fixes #24807 by making `RemoveSoftLinesBuffer` aware of
`BestFitting` and always selecting the most-flat variant, as suggested
in [Micha's comment], assuming I interpreted it correctly.

As I noted on the issue, I was hoping I could get away with making a
local change to the lambda formatting, but this turned out to affect
the two other uses of `RemoveSoftLinesBuffer` too.

The formatting of the new regression tests:

```py
def foo():
    subprocess.check_call(f"rm -rf {' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))}", shell=True)

def bar():
    lambda x=" ".join(
        map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove)
    ): ...

value = f"prefix {
    ' '.join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove))
} suffix"
```

now (nearly) matches the output before #21385:

```console
❯ git diff <(uvx ruff@0.14.10 format - < fmt.py) <(./target/debug/ruff format - < fmt.py)
 def bar():
-    lambda x=" ".join(
-        map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove)
-    ): ...
+    lambda x=" ".join(map(lambda object_name: os.path.join(dest_path, object_name), objects_to_remove)): (
+        ...
+    )

 value = f"prefix {
```

with the only difference being that the body of this second lambda
still wraps in the new formatting.

Test Plan
--

New tests based on the reported issue and possibly the ecosystem check
on this PR

[Micha's comment]: https://github.com/astral-sh/ruff/issues/24807#issuecomment-4314406097
