### PR TITLE
[ty] Support TypedDict key completions in incomplete, anonymous contexts

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -7054,7 +7054,7 @@ take({"<CURSOR>"})
     }
 
     #[test]
-    fn string_literal_completions_in_incomplete_typed_dict_literal_key_prefers_set_context() {
+    fn string_literal_completions_in_incomplete_typed_dict_literal_key_combines_set_context() {
         let builder = completion_test_builder(
             r#"
 from typing import Literal, TypedDict
@@ -7072,7 +7072,12 @@ take({"<CURSOR>"})
 
         assert_snapshot!(
             builder.skip_keywords().skip_builtins().skip_auto_import().type_signatures().build().snapshot(),
-            @r#"item :: Literal["item"]"#,
+            @r#"
+        item :: Literal["item"]
+        x :: Literal["x"]
+        y :: Literal["y"]
+        z :: Literal["z"]
+        "#,
         );
     }
 

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -7027,6 +7027,56 @@ take({"<CURSOR>": 1})
     }
 
     #[test]
+    fn string_literal_completions_in_incomplete_typed_dict_literal_key() {
+        let builder = completion_test_builder(
+            r#"
+from typing import TypedDict
+
+class Box(TypedDict):
+    x: float
+    y: float
+    z: float
+
+def take(box: Box): ...
+
+take({"<CURSOR>"})
+"#,
+        );
+
+        assert_snapshot!(
+            builder.skip_keywords().skip_builtins().skip_auto_import().type_signatures().build().snapshot(),
+            @r#"
+        x :: Literal["x"]
+        y :: Literal["y"]
+        z :: Literal["z"]
+        "#,
+        );
+    }
+
+    #[test]
+    fn string_literal_completions_in_incomplete_typed_dict_literal_key_prefers_set_context() {
+        let builder = completion_test_builder(
+            r#"
+from typing import Literal, TypedDict
+
+class Box(TypedDict):
+    x: float
+    y: float
+    z: float
+
+def take(value: Box | set[Literal["item"]]): ...
+
+take({"<CURSOR>"})
+"#,
+        );
+
+        assert_snapshot!(
+            builder.skip_keywords().skip_builtins().skip_auto_import().type_signatures().build().snapshot(),
+            @r#"item :: Literal["item"]"#,
+        );
+    }
+
+    #[test]
     fn string_literal_completions_typed_dict_constructor_mixed_literal_keys() {
         let builder = completion_test_builder(
             r#"

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5923,13 +5923,43 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = set;
 
         let elts = elts.iter().map(|elt| [Some(elt)]).collect_vec();
-        let mut infer_elt_ty =
-            |builder: &mut Self, (_, elt, tcx)| builder.infer_expression(elt, tcx);
+        let fallback_tcx = self.incomplete_typed_dict_key_context(set, tcx);
+        let mut infer_elt_ty = |builder: &mut Self, arg: ArgExpr<'db, '_>| {
+            let (_, elt, elt_tcx) = arg;
+            let elt_tcx = if elt_tcx.annotation.is_some() {
+                elt_tcx
+            } else {
+                fallback_tcx
+            };
+
+            builder.infer_expression(elt, elt_tcx)
+        };
 
         self.infer_collection_literal(KnownClass::Set, &elts, &mut infer_elt_ty, tcx)
             .unwrap_or_else(|| {
                 KnownClass::Set.to_specialized_instance(self.db(), &[Type::unknown()])
             })
+    }
+
+    fn incomplete_typed_dict_key_context(
+        &self,
+        set: &ast::ExprSet,
+        tcx: TypeContext<'db>,
+    ) -> TypeContext<'db> {
+        // While editing `{"key": value}` as a `TypedDict` literal, `{""}` parses as a
+        // set until the colon is typed. Preserve key completions in that transient state.
+        let [elt] = set.elts.as_slice() else {
+            return TypeContext::default();
+        };
+
+        if !elt.is_string_literal_expr() {
+            return TypeContext::default();
+        }
+
+        TypeContext::new(
+            tcx.annotation
+                .and_then(|annotation| self.typed_dict_key_expected_type(annotation)),
+        )
     }
 
     fn infer_dict_expression(&mut self, dict: &ast::ExprDict, tcx: TypeContext<'db>) -> Type<'db> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5926,13 +5926,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let fallback_tcx = self.incomplete_typed_dict_key_context(set, tcx);
         let mut infer_elt_ty = |builder: &mut Self, arg: ArgExpr<'db, '_>| {
             let (_, elt, elt_tcx) = arg;
-            let elt_tcx = if elt_tcx.annotation.is_some() {
-                elt_tcx
-            } else {
-                fallback_tcx
-            };
-
-            builder.infer_expression(elt, elt_tcx)
+            builder.infer_set_element(elt, elt_tcx, fallback_tcx)
         };
 
         self.infer_collection_literal(KnownClass::Set, &elts, &mut infer_elt_ty, tcx)
@@ -5941,13 +5935,46 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             })
     }
 
+    /// Infers a set element, optionally with a fallback context for an incomplete `TypedDict` key.
+    ///
+    /// When normal set element context is available, semantic inference keeps that context. If a
+    /// `TypedDict` key fallback is also available, it is only added to the stored expected type used
+    /// by IDE string-literal completions.
+    fn infer_set_element(
+        &mut self,
+        elt: &ast::Expr,
+        elt_tcx: TypeContext<'db>,
+        fallback_tcx: TypeContext<'db>,
+    ) -> Type<'db> {
+        let inference_tcx = if elt_tcx.annotation.is_some() {
+            elt_tcx
+        } else {
+            fallback_tcx
+        };
+        let inferred_ty = self.infer_expression(elt, inference_tcx);
+
+        // `expected_types` is IDE completion metadata. If normal set inference already has a
+        // string-literal context, preserve that semantic context for inference while also offering
+        // the transient `TypedDict` key fallback as a completion candidate.
+        if let (Some(elt_ty), Some(fallback_ty)) = (elt_tcx.annotation, fallback_tcx.annotation) {
+            self.store_expected_type(
+                elt,
+                UnionType::from_two_elements(self.db(), elt_ty, fallback_ty),
+            );
+        }
+
+        inferred_ty
+    }
+
+    /// Returns a fallback type context for completing a `TypedDict` key while editing.
+    ///
+    /// While editing `{"key": value}` as a `TypedDict` literal, `{"key"}` parses as a set
+    /// until the colon is typed. This preserves key completions in that transient state.
     fn incomplete_typed_dict_key_context(
         &self,
         set: &ast::ExprSet,
         tcx: TypeContext<'db>,
     ) -> TypeContext<'db> {
-        // While editing `{"key": value}` as a `TypedDict` literal, `{""}` parses as a
-        // set until the colon is typed. Preserve key completions in that transient state.
         let [elt] = set.elts.as_slice() else {
             return TypeContext::default();
         };

--- a/crates/ty_server/tests/e2e/completions.rs
+++ b/crates/ty_server/tests/e2e/completions.rs
@@ -386,3 +386,60 @@ x: Literal[\"apple\"] = \"app\"
 
     Ok(())
 }
+
+#[test]
+fn typed_dict_literal_key_completion_before_colon() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = "\
+from typing import TypedDict
+
+class Box(TypedDict):
+    x: float
+    y: float
+    z: float
+
+def take(box: Box): ...
+
+take({\"\"})
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_initialization_options(ClientOptions::default().with_auto_import(false))
+        .with_workspace(workspace_root, None)?
+        .with_file(foo, foo_content)?
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+
+    let completions = server.completion_request(&server.file_uri(foo), Position::new(9, 7));
+
+    insta::assert_json_snapshot!(completions, @r#"
+    [
+      {
+        "label": "x",
+        "kind": 12,
+        "detail": "Literal[\"x\"]",
+        "sortText": "0",
+        "insertText": "x"
+      },
+      {
+        "label": "y",
+        "kind": 12,
+        "detail": "Literal[\"y\"]",
+        "sortText": "1",
+        "insertText": "y"
+      },
+      {
+        "label": "z",
+        "kind": 12,
+        "detail": "Literal[\"z\"]",
+        "sortText": "2",
+        "insertText": "z"
+      }
+    ]
+    "#);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#3425.

This adds string-literal completions for `TypedDict` keys while editing an anonymous dictionary literal whose expected type is a `TypedDict`.

Since `{""}` parses as a set of strings, completions weren't offered before. This adds a small bridge that allows TypedDict key completions to be offered.

For example, ty now offers `x`, `y`, and `z` inside:

```py
from typing import TypedDict

class Box(TypedDict):
    x: float
    y: float
    z: float

def take(box: Box): ...

take({"<CURSOR>"})
```

## Test Plan

- Added test case for incomplete dictionary syntax
- Added test case to ensure that `{""}`, where the expected type as a set of string literals, offers completions from the set type.