### PR TITLE
flake8_bugbear/B005: fix double iteration over implicitly concatenated string arguments

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
@@ -73,7 +73,8 @@ pub(crate) fn strip_with_multi_characters(
         return;
     };
 
-    if value.chars().count() > 1 && !value.chars().all_unique() {
+    let chars: Vec<char> = value.chars().collect();
+    if chars.len() > 1 && !chars.iter().copied().all_unique() {
         checker.report_diagnostic(StripWithMultiCharacters, expr.range());
     }
 }


### PR DESCRIPTION
## PR Title

```
flake8_bugbear/B005: fix double iteration over implicitly concatenated string arguments
```

---

## PR Description

```markdown
## Summary

Rule B005 (`strip-with-multi-characters`) called `value.chars()` twice in its
duplicate-character check:

```rust
if value.chars().count() > 1 && !value.chars().all_unique() {
```

`value` is a `StringLiteralValue`, which for implicitly concatenated strings
(e.g. `"fo" "o"`) constructs a fresh `flat_map` iterator over all string parts
on every call. This means every character in the argument is visited twice —
once for `.count()` and once for `.all_unique()` — with no correctness
justification for the double traversal.

The fix collects the chars into a `Vec<char>` once, then uses `Vec::len()`
(O(1)) and `Iterator::copied().all_unique()` over the in-memory slice:

```rust
let chars: Vec<char> = value.chars().collect();
if chars.len() > 1 && !chars.iter().copied().all_unique() {
```

This is a single-traversal, allocation-bounded fix with identical semantics
for all inputs including implicitly concatenated string arguments.

## Test Plan

Verified by reading the affected code path and the `StringLiteralValue::chars`
implementation in `crates/ruff_python_ast/src/nodes.rs`. Existing B005 tests
continue to cover the rule's detection logic; no behavior change is introduced.
```