### PR TITLE
Remove shellcheck from prek

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,6 +255,30 @@ jobs:
         run: rustup component add rustfmt
       - run: cargo fmt --all --check
 
+  shellcheck:
+    name: "shellcheck"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version: "1.26.2"
+      - name: "Run ShellCheck"
+        env:
+          GOSUMDB: sum.golang.org
+        run: |
+          files=()
+          while IFS= read -r -d '' file; do
+            files+=("${file}")
+          done < <(git ls-files -z '*.sh')
+          if ((${#files[@]} == 0)); then
+            exit 0
+          fi
+          go run github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1 "${files[@]}"
+
   cargo-clippy:
     name: "cargo clippy"
     runs-on: ubuntu-latest
@@ -1255,6 +1279,7 @@ jobs:
       - cargo-test-linux
       - cargo-test-wasm
       - cargo-build-msrv
+      - shellcheck
       - scripts
       - prek
       - docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,12 +74,6 @@ repos:
       - id: check-github-workflows
         priority: 0
 
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
-    hooks:
-      - id: shellcheck
-        priority: 0
-
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0
     hooks:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,7 +4,7 @@
 # All additional options are passed to `rooster release`
 set -eu
 
-export UV_PREVIEW=1
+export UV_PREVIEW=0
 
 script_root="$(realpath "$(dirname "$0")")"
 project_root="$(dirname "$script_root")"


### PR DESCRIPTION
## Summary

`shellcheck-py` requires a build-time binary download from GitHub, which is rejected by some firewalls. There's also [`shellcheck-precommit`](https://github.com/koalaman/shellcheck-precommit), but that uses a Docker-based hook, and would introduce a Docker requirement to our `prek` setup that doesn't currently exist.

So this PR just removes it from our pre-commit setup, and uses `actions/setup-go` instead with a dedicated CI job.
