### PR TITLE
[ty] Fix async iteration over narrowed typevars

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/async_for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/async_for.md
@@ -35,6 +35,32 @@ async def foo():
         reveal_type(y)  # revealed: str
 ```
 
+## Async for loop over narrowed TypeVar
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Self
+
+class AsyncStrings:
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> str:
+        return "x"
+
+async def foo[T: int | AsyncStrings](value: T) -> None:
+    if isinstance(value, int):
+        return
+
+    reveal_type(value)  # revealed: T@foo & ~int
+    async for item in value:
+        reveal_type(item)  # revealed: str
+```
+
 ## Error cases
 
 ### No `__aiter__` method

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -247,6 +247,13 @@ impl<'db> Type<'db> {
         }
 
         if mode.is_async() {
+            if let Type::Intersection(_) = self {
+                let flattened = self.flatten_typevars(db);
+                if flattened != self {
+                    return flattened.try_iterate_with_mode(db, mode);
+                }
+            }
+
             let try_call_dunder_anext_on_iterator = |iterator: Type<'db>| -> Result<
                 Result<Type<'db>, AwaitError<'db>>,
                 CallDunderError<'db>,


### PR DESCRIPTION
Flatten intersection typevars before resolving async iterator methods.

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary
Fixes the async case (https://github.com/astral-sh/ruff/pull/25143#issuecomment-4449423320) that was left out in https://github.com/astral-sh/ruff/pull/25143

## Test Plan

<!-- How was it tested? -->
New mdtests
