### PR TITLE
[ty] Improve diagnostics for syntax errors in forward annotations

### DIFF
--- a/crates/mdtest/src/diagnostic.rs
+++ b/crates/mdtest/src/diagnostic.rs
@@ -30,7 +30,7 @@ impl<'a> SortedDiagnostics<'a> {
                     .primary_span()
                     .and_then(|span| span.range())
                     .map(line_start)
-                    .unwrap_or_else(|| OneIndexed::from_zero_indexed(0)),
+                    .unwrap_or_default(),
                 diagnostic,
             })
             .collect();

--- a/crates/mdtest/src/diagnostic.rs
+++ b/crates/mdtest/src/diagnostic.rs
@@ -3,7 +3,8 @@
 //! We don't assume that we will get the diagnostics in source order.
 
 use ruff_db::diagnostic::Diagnostic;
-use ruff_source_file::{LineIndex, OneIndexed};
+use ruff_source_file::OneIndexed;
+use ruff_text_size::TextRange;
 use std::ops::{Deref, Range};
 
 /// All diagnostics for one embedded Python file, sorted and grouped by start line number.
@@ -20,7 +21,7 @@ pub(crate) struct SortedDiagnostics<'a> {
 impl<'a> SortedDiagnostics<'a> {
     pub(crate) fn new(
         diagnostics: impl IntoIterator<Item = &'a Diagnostic>,
-        line_index: &LineIndex,
+        line_start: &dyn Fn(TextRange) -> OneIndexed,
     ) -> Self {
         let mut diagnostics: Vec<_> = diagnostics
             .into_iter()
@@ -28,9 +29,8 @@ impl<'a> SortedDiagnostics<'a> {
                 line_number: diagnostic
                     .primary_span()
                     .and_then(|span| span.range())
-                    .map_or(OneIndexed::from_zero_indexed(0), |range| {
-                        line_index.line_index(range.start())
-                    }),
+                    .map(line_start)
+                    .unwrap_or_else(|| OneIndexed::from_zero_indexed(0)),
                 diagnostic,
             })
             .collect();
@@ -176,7 +176,9 @@ mod tests {
             })
             .collect();
 
-        let sorted = super::SortedDiagnostics::new(diagnostics.iter(), &lines);
+        let sorted = super::SortedDiagnostics::new(diagnostics.iter(), &|diagnostic_range| {
+            lines.line_index(diagnostic_range.start())
+        });
         let grouped = sorted.iter_lines().collect::<Vec<_>>();
 
         let [line1, line2] = &grouped[..] else {

--- a/crates/mdtest/src/matcher.rs
+++ b/crates/mdtest/src/matcher.rs
@@ -96,9 +96,24 @@ pub fn match_file(
     // ordered by line number.
     let source = source_text(db, file);
     let parsed = parsed_module(db, file).load(db);
-    let assertions = InlineFileAssertions::from_file(&source, &parsed, &line_index(db, file));
+    let line_index = line_index(db, file);
+    let assertions = InlineFileAssertions::from_file(&source, &parsed, &line_index);
 
-    let diagnostics = SortedDiagnostics::new(diagnostics, &line_index(db, file));
+    // Sort diagnostics according to the line number of the starting offset of the token in which the diagnostic appears.
+    //
+    // This can be different to the line number of the starting offset of the diagnostic range!
+    // For example, if the diagnostic is a syntax error inside a stringized annotation,
+    // the syntax error's range will likely point to a sub-range of the string literal,
+    // which will make the error unmatchable by mdtest unless we look at the token in which
+    // the diagnostic occurs (the string-literal) and use the token start as the basis for
+    // the line number.
+    let diagnostics = SortedDiagnostics::new(diagnostics, &|diagnostic_range| {
+        let token_start = parsed
+            .tokens()
+            .token_range(diagnostic_range.start())
+            .start();
+        line_index.line_index(token_start)
+    });
 
     let mut line_diagnostics = diagnostics.iter_lines();
 

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -60,25 +60,29 @@ pub fn parsed_string_annotation(
     indexed::ensure_indexed(&expr, string.node_index().load()).map_err(|err| {
         let message = match err {
             NodeIndexError::NoParent => {
-                "internal error: string annotation's parent had no NodeIndex".to_owned()
+                "Internal error: string annotation's parent had no NodeIndex"
             }
-            NodeIndexError::TooNested => "too many levels of nested string annotations; remove the redundant nested quotes".to_owned(),
+            NodeIndexError::TooNested => {
+                "Too many levels of nested string annotations; \
+                remove the redundant nested quotes"
+            }
             NodeIndexError::OverflowedIndices => {
-                "file too long for string annotations; either break up the file or don't use string annotations".to_owned()
+                "File too long for string annotations; either break up the file \
+                or don't use string annotations"
             }
             NodeIndexError::OverflowedSubIndices => {
-                "file too long for nested string annotations; remove the redundant nested quotes".to_owned()
+                "File too long for nested string annotations; remove the redundant nested quotes"
             }
             NodeIndexError::ExhaustedSubIndices => {
-                "string annotation is too long; consider introducing type aliases to simplify".to_owned()
+                "String annotation is too long; consider introducing type aliases to simplify"
             }
             NodeIndexError::ExhaustedSubSubIndices => {
-                "nested string annotation is too long; remove the redundant nested quotes".to_owned()
+                "Nested string annotation is too long; remove the redundant nested quotes"
             }
         };
 
         ParseError {
-            error: ParseErrorType::OtherError(message),
+            error: ParseErrorType::StringAnnotationError(message),
             location: string.range,
         }
     })?;

--- a/crates/ruff_python_ast/src/token/tokens.rs
+++ b/crates/ruff_python_ast/src/token/tokens.rs
@@ -212,6 +212,17 @@ impl Tokens {
         }
         (before, after)
     }
+
+    /// Return the range of the token at the given offset.
+    ///
+    /// Returns an empty range at the given offset if there's no token at the offset,
+    /// or if the offset is between two tokens.
+    pub fn token_range(&self, offset: TextSize) -> TextRange {
+        match self.at_offset(offset) {
+            TokenAt::Single(token) => token.range(),
+            TokenAt::None | TokenAt::Between(..) => TextRange::empty(offset),
+        }
+    }
 }
 
 impl<'a> IntoIterator for &'a Tokens {

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -107,6 +107,9 @@ pub enum ParseErrorType {
     /// An unexpected error occurred.
     OtherError(String),
 
+    /// An error specific to stringified annotations occurred.
+    StringAnnotationError(&'static str),
+
     /// An empty slice was found during parsing, e.g `data[]`.
     EmptySlice,
     /// An empty global names list was found during parsing.
@@ -222,7 +225,8 @@ impl std::error::Error for ParseErrorType {}
 impl std::fmt::Display for ParseErrorType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            ParseErrorType::OtherError(msg) => write!(f, "{msg}"),
+            ParseErrorType::OtherError(msg) => f.write_str(msg),
+            ParseErrorType::StringAnnotationError(msg) => f.write_str(msg),
             ParseErrorType::ExpectedToken { found, expected } => {
                 write!(f, "Expected {expected}, found {found}")
             }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1507,7 +1507,7 @@ impl<'src> Parser<'src> {
             if tstring_count < strings.len() {
                 self.add_error(
                     ParseErrorType::OtherError(
-                        "cannot mix t-string literals with string or bytes literals".to_string(),
+                        "Cannot mix t-string literals with string or bytes literals".to_string(),
                     ),
                     range,
                 );
@@ -2124,7 +2124,7 @@ impl<'src> Parser<'src> {
         // Nice error message when having a unclosed open bracket `[`
         if self.at_ts(NEWLINE_EOF_SET) {
             self.add_error(
-                ParseErrorType::OtherError("missing closing bracket `]`".to_string()),
+                ParseErrorType::OtherError("Missing closing bracket `]`".to_string()),
                 self.current_token_range(),
             );
         }
@@ -2216,7 +2216,7 @@ impl<'src> Parser<'src> {
         // Nice error message when having a unclosed open brace `{`
         if self.at_ts(NEWLINE_EOF_SET) {
             self.add_error(
-                ParseErrorType::OtherError("missing closing brace `}`".to_string()),
+                ParseErrorType::OtherError("Missing closing brace `}`".to_string()),
                 self.current_token_range(),
             );
         }
@@ -2377,7 +2377,7 @@ impl<'src> Parser<'src> {
         if self.at_ts(NEWLINE_EOF_SET) {
             let range = self.current_token_range();
             self.add_error(
-                ParseErrorType::OtherError("missing closing parenthesis `)`".to_string()),
+                ParseErrorType::OtherError("Missing closing parenthesis `)`".to_string()),
                 range,
             );
         }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_t_string_concat_1_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_t_string_concat_1_error.snap
@@ -4,7 +4,7 @@ expression: suite
 ---
 ParseError {
     error: OtherError(
-        "cannot mix t-string literals with string or bytes literals",
+        "Cannot mix t-string literals with string or bytes literals",
     ),
     location: 0..18,
 }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_t_string_concat_2_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_f_t_string_concat_2_error.snap
@@ -4,7 +4,7 @@ expression: suite
 ---
 ParseError {
     error: OtherError(
-        "cannot mix t-string literals with string or bytes literals",
+        "Cannot mix t-string literals with string or bytes literals",
     ),
     location: 0..22,
 }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_t_string_concat_1_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_t_string_concat_1_error.snap
@@ -4,7 +4,7 @@ expression: suite
 ---
 ParseError {
     error: OtherError(
-        "cannot mix t-string literals with string or bytes literals",
+        "Cannot mix t-string literals with string or bytes literals",
     ),
     location: 0..17,
 }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_t_string_concat_2_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_t_string_concat_2_error.snap
@@ -4,7 +4,7 @@ expression: suite
 ---
 ParseError {
     error: OtherError(
-        "cannot mix t-string literals with string or bytes literals",
+        "Cannot mix t-string literals with string or bytes literals",
     ),
     location: 0..17,
 }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_t_string_concat_3_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_t_string_concat_3_error.snap
@@ -4,7 +4,7 @@ expression: suite
 ---
 ParseError {
     error: OtherError(
-        "cannot mix t-string literals with string or bytes literals",
+        "Cannot mix t-string literals with string or bytes literals",
     ),
     location: 0..22,
 }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_t_string_concat_4_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_t_string_concat_4_error.snap
@@ -4,7 +4,7 @@ expression: suite
 ---
 ParseError {
     error: OtherError(
-        "cannot mix t-string literals with string or bytes literals",
+        "Cannot mix t-string literals with string or bytes literals",
     ),
     location: 0..31,
 }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_t_string_concat_1_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_t_string_concat_1_error.snap
@@ -4,7 +4,7 @@ expression: suite
 ---
 ParseError {
     error: OtherError(
-        "cannot mix t-string literals with string or bytes literals",
+        "Cannot mix t-string literals with string or bytes literals",
     ),
     location: 0..18,
 }

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_t_string_concat_2_error.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_u_t_string_concat_2_error.snap
@@ -4,7 +4,7 @@ expression: suite
 ---
 ParseError {
     error: OtherError(
-        "cannot mix t-string literals with string or bytes literals",
+        "Cannot mix t-string literals with string or bytes literals",
     ),
     location: 0..22,
 }

--- a/crates/ty_python_semantic/mdtest.py
+++ b/crates/ty_python_semantic/mdtest.py
@@ -31,6 +31,7 @@ DIRS_TO_WATCH: Final = (
     CRATE_ROOT,
     TY_VENDORED,
     CRATE_ROOT.parent / "ty_test/src",
+    CRATE_ROOT.parent / "mdtest/src",
 )
 MDTEST_DIR: Final = CRATE_ROOT / "resources" / "mdtest"
 SNAPSHOTS_DIR: Final = MDTEST_DIR / "snapshots"

--- a/crates/ty_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/string.md
@@ -281,12 +281,12 @@ reveal_type(Aliases.not_forward)  # revealed: str
 ```py
 a: "int" = 1
 b: "'int'" = 1
-# error: [invalid-syntax-in-forward-annotation] "too many levels of nested string annotations; remove the redundant nested quotes"
+# snapshot
 c: """'"int"'""" = 1
 d: "Foo"
 # error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to `Foo`"
 e: "Foo" = 1
-# error: [invalid-syntax-in-forward-annotation] "nested string annotation is too long; remove the redundant nested quotes"
+# snapshot
 f: "'str | int | bool | Foo | Bar'" = 1
 
 class Foo: ...
@@ -299,6 +299,23 @@ reveal_type(c)  # revealed: Literal[1]
 reveal_type(d)  # revealed: Foo
 reveal_type(e)  # revealed: Foo
 reveal_type(f)  # revealed: Literal[1]
+```
+
+```snapshot
+error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation
+ --> src/mdtest_snippet.py:4:8
+  |
+4 | c: """'"int"'""" = 1
+  |        ^^^^^ Too many levels of nested string annotations; remove the redundant nested quotes
+  |
+
+
+error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation
+ --> src/mdtest_snippet.py:9:5
+  |
+9 | f: "'str | int | bool | Foo | Bar'" = 1
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Nested string annotation is too long; remove the redundant nested quotes
+  |
 ```
 
 ## Parameter
@@ -352,9 +369,9 @@ j: "{i: i for i in range(5)}"
 k: "(i for i in range(5))"
 # error: [invalid-type-form]
 l: "await 1"
-# error: [invalid-syntax-in-forward-annotation]
+# snapshot
 m: "yield 1"
-# error: [invalid-syntax-in-forward-annotation]
+# snapshot
 n: "yield from 1"
 # error: [invalid-type-form]
 o: "1 < 2"
@@ -364,6 +381,51 @@ p: "call()"
 r: "[1, 2]"
 # error: [invalid-type-form] "Tuple literals are not allowed"
 s: "(1, 2)"
+# snapshot
+t: "list[yield from 1]"
+# snapshot
+u: "type]"
+```
+
+```snapshot
+error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation
+  --> src/mdtest_snippet.py:43:5
+   |
+43 | m: "yield 1"
+   |     ^^^^^^^ Yield expression cannot be used here
+   |
+help: Did you mean `typing.Literal["yield 1"]`?
+
+
+error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation
+  --> src/mdtest_snippet.py:45:5
+   |
+45 | n: "yield from 1"
+   |     ^^^^^^^^^^^^ Yield expression cannot be used here
+   |
+help: Did you mean `typing.Literal["yield from 1"]`?
+
+
+error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation
+  --> src/mdtest_snippet.py:55:5
+   |
+55 | t: "list[yield from 1]"
+   |     -----^^^^^^^^^^^^-
+   |          |
+   |          Yield expression cannot be used here
+   |
+help: Did you mean `typing.Literal["list[yield from 1]"]`?
+
+
+error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation
+  --> src/mdtest_snippet.py:57:5
+   |
+57 | u: "type]"
+   |     ----^
+   |         |
+   |         Unexpected token at the end of an expression
+   |
+help: Did you mean `typing.Literal["type]"]`?
 ```
 
 ## Multi line annotation
@@ -386,19 +448,57 @@ def valid(
     reveal_type(a2)  # revealed: int | str
 
 def invalid(
-    # error: [invalid-syntax-in-forward-annotation]
+    # snapshot
     a1: """
   int |
 str)
 """,
-    # error: [invalid-syntax-in-forward-annotation]
+    # snapshot
     a2: """
   int) |
 str
 """,
-    # error: [invalid-syntax-in-forward-annotation]
+    # snapshot
     a3: """
       (int)) """,
 ):
     pass
+```
+
+```snapshot
+error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation
+  --> src/mdtest_snippet.py:17:12
+   |
+17 |       a1: """
+   |  ____________-
+18 | |   int |
+19 | | str)
+   | |____^-
+   |      |
+   |      Unexpected token at the end of an expression
+   |
+
+
+error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation
+  --> src/mdtest_snippet.py:22:12
+   |
+22 |       a2: """
+   |  ____________-
+23 | |   int) |
+   | |      ^ Unexpected token at the end of an expression
+24 | | str
+   | |____-
+   |
+
+
+error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation
+  --> src/mdtest_snippet.py:27:12
+   |
+27 |       a3: """
+   |  ____________-
+28 | |       (int)) """,
+   | |____________^-
+   |              |
+   |              Unexpected token at the end of an expression
+   |
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_AST_nodes_that_are_o…_(58a3839a9bc7026d).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_AST_nodes_that_are_o…_(58a3839a9bc7026d).snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ty_test/src/lib.rs
+source: crates/mdtest/src/lib.rs
 expression: snapshot
 ---
 
@@ -64,11 +64,14 @@ info: https://typing.python.org/en/latest/spec/annotations.html#type-and-annotat
 ```
 
 ```
-error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation: Unexpected token at the end of an expression
- --> src/mdtest_snippet.py:9:8
+error[invalid-syntax-in-forward-annotation]: Syntax error in forward annotation
+ --> src/mdtest_snippet.py:9:9
   |
 9 |     d: "invalid syntax",
-  |        ^^^^^^^^^^^^^^^^ Did you mean `typing.Literal["invalid syntax"]`?
+  |         --------^^^^^^
+  |                 |
+  |                 Unexpected token at the end of an expression
   |
+help: Did you mean `typing.Literal["invalid syntax"]`?
 
 ```

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -221,14 +221,8 @@ fn suppression_range(db: &dyn Db, file: File, range: TextRange) -> TextRange {
 }
 
 fn line_start(tokens: &ruff_python_ast::token::Tokens, offset: TextSize) -> TextSize {
-    let token_range = match tokens.at_offset(offset) {
-        ruff_python_ast::token::TokenAt::None => TextRange::empty(offset),
-        ruff_python_ast::token::TokenAt::Single(token) => token.range(),
-        ruff_python_ast::token::TokenAt::Between(..) => TextRange::empty(offset),
-    };
-
     tokens
-        .before(token_range.start())
+        .before(tokens.token_range(offset).start())
         .iter()
         .rfind(|token| {
             matches!(

--- a/crates/ty_python_semantic/src/types/string_annotation.rs
+++ b/crates/ty_python_semantic/src/types/string_annotation.rs
@@ -1,7 +1,7 @@
 use ruff_db::parsed::parsed_string_annotation;
 use ruff_db::source::source_text;
-use ruff_python_ast::{self as ast, ModExpression};
-use ruff_python_parser::Parsed;
+use ruff_python_ast::{self as ast, ModExpression, StringFlags};
+use ruff_python_parser::{ParseError, ParseErrorType, Parsed};
 use ruff_text_size::Ranged;
 
 use crate::declare_lint;
@@ -151,18 +151,34 @@ pub(crate) fn parse_string_annotation(
         } else if &source[string_literal.content_range()] == string_literal.as_str() {
             match parsed_string_annotation(source.as_str(), string_literal) {
                 Ok(parsed) => return Some(parsed),
-                Err(parse_error) => {
+                Err(ParseError { error, location }) => {
                     if let Some(builder) =
-                        context.report_lint(&INVALID_SYNTAX_IN_FORWARD_ANNOTATION, string_literal)
+                        context.report_lint(&INVALID_SYNTAX_IN_FORWARD_ANNOTATION, location)
                     {
-                        let mut diagnostic = builder.into_diagnostic(format_args!(
-                            "Syntax error in forward annotation: {}",
-                            parse_error.error
-                        ));
-                        diagnostic.set_primary_message(format_args!(
-                            "Did you mean `typing.Literal[\"{}\"]`?",
-                            string_literal.as_str()
-                        ));
+                        let mut diagnostic =
+                            builder.into_diagnostic("Syntax error in forward annotation");
+
+                        diagnostic.set_primary_message(&error);
+
+                        let possible_secondary = string_literal
+                            .range()
+                            .add_start(string_literal.flags.opener_len())
+                            .sub_end(string_literal.flags.closer_len());
+                        if possible_secondary.contains_range(location)
+                            && (possible_secondary.start() < location.start()
+                                || possible_secondary.end() > location.end())
+                        {
+                            diagnostic.annotate(context.secondary(possible_secondary));
+                        }
+
+                        if !matches!(error, ParseErrorType::StringAnnotationError(_))
+                            && !string_literal.contains('\n')
+                        {
+                            diagnostic.help(format_args!(
+                                "Did you mean `typing.Literal[\"{}\"]`?",
+                                string_literal.as_str()
+                            ));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/1627.

Here's an example diagnostic with the current release of ty:

<img width="2286" height="286" alt="image" src="https://github.com/user-attachments/assets/46ab9154-aaf0-4451-b301-5ff12fcd8507" />

On this branch, this diagnostic becomes:

<img width="1464" height="408" alt="image" src="https://github.com/user-attachments/assets/449e0b6c-58d2-4501-91df-c267db6f48ca" />

The exact span of the node that creates the syntax error is now retained and highlighted in the diagnostic.

## Implementation

Propagating the range of the node inside the string annotation into the diagnostic is trivial. However, naively implementing that quickly revealed that this would make diagnostics like this unsuppressable:

```py
x: """list[
    yield from range(42)
]"""
```

The primary range of the diagnostic is now specifically the `yield from range(42)` part of the string rather than the string node as a whole. But I cannot add a `ty: ignore` comment that is either on or above the `yield from range(42)` part of the string -- the "comment" there would just become part of the string. ~~In order to ensure that these diagnostics are suppressible (and testable in mdtest), therefore, it was necessary to add a way to attach a custom primary range to a diagnostic _separate_ to that diagnostic's suppression range. This is something we've talked about doing lots of times before, so I hope it isn't _too_ controversial.~~

~~This in itself was also fairly trivial, but I soon realised that in order for mdtest to be able to recognise `# error` assertions correctly, we would need to retain the custom suppression ranges for diagnostics iff the `testing` feature was activated. This ended up feeling slightly icky (lots of `#[cfg(feature = "testing")]` attributes everywhere), but I'm not sure I see another way.~~

This PR also improves the consistency of our parser error messages in general when it comes to capitalization.

## Test Plan

Mdtests extended and updated