### PR TITLE
[ty] Narrow exact finite membership checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -165,7 +165,7 @@ def test(x: Literal["a", "b", "c"] | None | int = None):
 ## Direct `not in` conditional
 
 ```py
-from typing import Literal
+from typing import Any, Literal
 
 def test(x: Literal["a", "b", "c"] | None | int = None):
     if x not in ("a", "c"):
@@ -174,6 +174,48 @@ def test(x: Literal["a", "b", "c"] | None | int = None):
         reveal_type(x)  # revealed: Literal["b"] | None | int
     else:
         reveal_type(x)  # revealed: Literal["a", "c"] | int
+
+def broad_set_element(x: Literal[1, 2], values: set[int]) -> None:
+    if x not in values:
+        reveal_type(x)  # revealed: Literal[1, 2]
+    else:
+        reveal_type(x)  # revealed: Literal[1, 2]
+
+def union_tuple_slot(x: Literal[1, 2], values: tuple[Literal[1, 2]]) -> None:
+    if x not in values:
+        reveal_type(x)  # revealed: Literal[1, 2]
+    else:
+        reveal_type(x)  # revealed: Literal[1, 2]
+
+def union_tuple_slot_with_exact_value(
+    x: Literal[1, 2, 3],
+    values: tuple[Literal[1, 2], Literal[3]],
+) -> None:
+    if x not in values:
+        reveal_type(x)  # revealed: Literal[1, 2]
+    else:
+        reveal_type(x)  # revealed: Literal[1, 2, 3]
+
+def tuple_with_any_slot(x: str | None, missing: Any) -> None:
+    if x not in (missing, None):
+        reveal_type(x)  # revealed: str
+    else:
+        reveal_type(x)  # revealed: str | None
+
+def local_literal_rhs(x: str | None) -> None:
+    unavailable = [None, ""]
+    if x not in unavailable:
+        # TODO: This should narrow to `str` if we can prove that the local
+        # literal collection has not been mutated or aliased before the test.
+        reveal_type(x)  # revealed: str | None
+    else:
+        reveal_type(x)  # revealed: None | str
+
+def mutable_global_rhs(x: str | None, unavailable: set[str | None]) -> None:
+    if x not in unavailable:
+        reveal_type(x)  # revealed: str | None
+    else:
+        reveal_type(x)  # revealed: str | None
 ```
 
 ## No narrowing for the right-hand side (currently)

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -572,6 +572,11 @@ fn could_compare_equal<'db>(db: &'db dyn Db, left_ty: Type<'db>, right_ty: Type<
     }
 }
 
+fn is_exact_membership_value_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    let ty = ty.resolve_type_alias(db);
+    ty == Type::Never || ty.is_single_valued(db)
+}
+
 struct NarrowingConstraintsBuilder<'db, 'ast> {
     db: &'db dyn Db,
     module: &'ast ParsedModuleRef,
@@ -1038,6 +1043,20 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
+    fn exact_fixed_length_membership_values(&self, rhs_ty: Type<'db>) -> Option<Type<'db>> {
+        let iterable = rhs_ty.try_iterate(self.db).ok()?;
+        let fixed_length = iterable.as_fixed_length()?;
+        let mut builder = UnionBuilder::new(self.db);
+
+        for element_ty in fixed_length.all_elements().iter().copied() {
+            if is_exact_membership_value_domain(self.db, element_ty) {
+                builder = builder.add(element_ty);
+            }
+        }
+
+        builder.try_build()
+    }
+
     // TODO `expr_in` and `expr_not_in` should perhaps be unified with `expr_eq` and `expr_ne`,
     // since `eq` and `ne` are equivalent to `in` and `not in` with only one element in the RHS.
     fn evaluate_expr_in(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
@@ -1085,13 +1104,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
-    fn evaluate_expr_not_in(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
+    fn evaluate_expr_not_in(
+        &mut self,
+        lhs_ty: Type<'db>,
+        rhs_values: Type<'db>,
+    ) -> Option<Type<'db>> {
         let lhs_ty = lhs_ty.resolve_type_alias(self.db);
-
-        let rhs_values = rhs_ty
-            .try_iterate(self.db)
-            .ok()?
-            .homogeneous_element_type(self.db);
 
         if lhs_ty.is_single_valued(self.db) || lhs_ty.is_union_of_single_valued(self.db) {
             // Exclude the RHS values from the entire (single-valued) LHS domain.
@@ -1136,6 +1154,15 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
+    fn evaluate_expr_not_in_from_type(
+        &mut self,
+        lhs_ty: Type<'db>,
+        rhs_ty: Type<'db>,
+    ) -> Option<Type<'db>> {
+        let rhs_values = self.exact_fixed_length_membership_values(rhs_ty)?;
+        self.evaluate_expr_not_in(lhs_ty, rhs_values)
+    }
+
     fn evaluate_expr_compare_op(
         &mut self,
         lhs_ty: Type<'db>,
@@ -1158,7 +1185,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             ast::CmpOp::Eq => self.evaluate_expr_eq(lhs_ty, rhs_ty),
             ast::CmpOp::NotEq => self.evaluate_expr_ne(lhs_ty, rhs_ty),
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
-            ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty),
+            ast::CmpOp::NotIn => self.evaluate_expr_not_in_from_type(lhs_ty, rhs_ty),
             _ => None,
         }
     }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1104,12 +1104,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
-    fn evaluate_expr_not_in(
-        &mut self,
-        lhs_ty: Type<'db>,
-        rhs_values: Type<'db>,
-    ) -> Option<Type<'db>> {
+    fn evaluate_expr_not_in(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         let lhs_ty = lhs_ty.resolve_type_alias(self.db);
+        let rhs_values = self.exact_fixed_length_membership_values(rhs_ty)?;
 
         if lhs_ty.is_single_valued(self.db) || lhs_ty.is_union_of_single_valued(self.db) {
             // Exclude the RHS values from the entire (single-valued) LHS domain.
@@ -1154,15 +1151,6 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
-    fn evaluate_expr_not_in_from_type(
-        &mut self,
-        lhs_ty: Type<'db>,
-        rhs_ty: Type<'db>,
-    ) -> Option<Type<'db>> {
-        let rhs_values = self.exact_fixed_length_membership_values(rhs_ty)?;
-        self.evaluate_expr_not_in(lhs_ty, rhs_values)
-    }
-
     fn evaluate_expr_compare_op(
         &mut self,
         lhs_ty: Type<'db>,
@@ -1185,7 +1173,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             ast::CmpOp::Eq => self.evaluate_expr_eq(lhs_ty, rhs_ty),
             ast::CmpOp::NotEq => self.evaluate_expr_ne(lhs_ty, rhs_ty),
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
-            ast::CmpOp::NotIn => self.evaluate_expr_not_in_from_type(lhs_ty, rhs_ty),
+            ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

This first commit in this PR makes not in narrowing use only RHS values that are guaranteed to be present.

Previously, we used the iterable's homogeneous element type as the set of values to exclude. That was too broad for
cases like:

```python
def f(x: Literal[1, 2], values: set[int]):
  if x not in values:
      # Before: `Never`
      reveal_type(x)
```

A `set[int]` _could_ contain 1 or 2, but it does not guarantee that either is present, so we shouldn't remove them from `x`. Instead, we now only use exact values from fixed-length RHS types.

Unfortunately, this does lead to some false positives like: https://github.com/scikit-learn/scikit-learn/blob/8b60698ca92c87a6d836d3a87c18bdfe9a3b6c67/sklearn/linear_model/_ridge.py#L252. But I think those should be improved separately. 

Closes https://github.com/astral-sh/ty/issues/3458.
