### PR TITLE
[ty] Preserve walrus bindings through negated short-circuit conditions

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -927,6 +927,23 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.current_use_def_map().snapshot()
     }
 
+    fn bool_op_snapshots_for_condition(&self, expr: &ast::Expr) -> Option<BoolOpSnapshots> {
+        match expr {
+            ast::Expr::BoolOp(_) => self
+                .bool_op_snapshots_by_node
+                .get(&ExpressionNodeKey::from(expr))
+                .cloned(),
+            ast::Expr::UnaryOp(unary_op) if unary_op.op == ast::UnaryOp::Not => {
+                let snapshots = self.bool_op_snapshots_for_condition(&unary_op.operand)?;
+                Some(BoolOpSnapshots {
+                    truthy: snapshots.falsy,
+                    falsy: snapshots.truthy,
+                })
+            }
+            _ => None,
+        }
+    }
+
     fn flow_restore(&mut self, state: FlowSnapshot) {
         self.current_use_def_map_mut().restore(state);
     }
@@ -2707,12 +2724,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ast::Stmt::If(node) => {
                 let flow_snapshot = |builder: &Self, test: &'ast ast::Expr| {
                     let no_branch_taken = builder.flow_snapshot();
-                    let bool_op_snapshots = builder
-                        .bool_op_snapshots_by_node
-                        .get(&ExpressionNodeKey::from(test));
                     BoolOpSnapshot {
                         before: no_branch_taken,
-                        after: bool_op_snapshots.cloned(),
+                        after: builder.bool_op_snapshots_for_condition(test),
                     }
                 };
 

--- a/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
+++ b/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
@@ -125,3 +125,13 @@ def _(flag1: bool, flag2: bool):
         # error: [possibly-unresolved-reference]
         reveal_type(z)  # revealed: Literal[1]
 ```
+
+## Negated expressions
+
+```py
+def _(x: str):
+    if not (x and (y := x)):
+        raise ValueError
+
+    reveal_type(y)  # revealed: str & ~AlwaysFalsy
+```


### PR DESCRIPTION
## Summary

When an `if` condition used unary `not` around a short-circuiting boolean expression, we failed to reuse the precise truthy and falsy flow snapshots that we already compute for the inner boolean operation, as in;

```python
def f(x: str):
    if not (x and (y := x)):
        raise ValueError

    reveal_type(y)
```

We now look through the `not` when retrieving boolean-op snapshots, swapping the truthy and falsy snapshots for the outer condition.

Closes https://github.com/astral-sh/ty/issues/3456.
