### PR TITLE
Add `@lerebear` to `ty_ide` and `ty_server` reviewer pools.

### DIFF
--- a/.github/pr-assignee-pools.toml
+++ b/.github/pr-assignee-pools.toml
@@ -36,9 +36,9 @@ reviewers = ["MichaReiser"]
 [[pools]]
 name = "ty-ide"
 paths = ["/crates/ty_ide/**"]
-reviewers = ["charliermarsh", "MichaReiser", "dhruvmanila"]
+reviewers = ["charliermarsh", "MichaReiser", "dhruvmanila", "lerebear"]
 
 [[pools]]
 name = "ty-server"
 paths = ["/crates/ty_server/**"]
-reviewers = ["charliermarsh", "MichaReiser", "dhruvmanila"]
+reviewers = ["charliermarsh", "MichaReiser", "dhruvmanila", "lerebear"]


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This adds @lerebear to the reviewer pool for the `ty_ide` and `ty_server`. Given my recent contributions to those crates, I feel comfortable reviewing contributions to them.

## Test Plan

<!-- How was it tested? -->
