### PR TITLE
Pin to cargo-shear 1.11.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -796,7 +796,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: cargo-bins/cargo-binstall@4852a15cf01e4f33958ce547326406fe78f27c38 # v1.19.0
-      - run: cargo binstall --no-confirm cargo-shear
+      - run: cargo binstall --no-confirm cargo-shear@1.11.2
       - run: cargo shear --deny-warnings
 
   ty-completion-evaluation:


### PR DESCRIPTION
Summary
--

cargo-shear released v1.12.0 today with an apparent bug around the
handling of optional dependencies used in attributes. I filed an
[issue] upstream, so I think for  now we should just pin to the
previous version to unblock CI.

[issue]: https://github.com/Boshen/cargo-shear/issues/497

Test Plan
--

Local testing with the previous version and CI on this PR
