### PR TITLE
[ty] Fix panic from imported overload definition

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -1010,6 +1010,63 @@ def bar(): ...
 reveal_type(bar)
 ```
 
+### Regression: local overload shadowed by an imported overloaded function in another branch
+
+We used to panic on snippets like this, because the post-inference overload checks for the local `a`
+definition would resolve the end-of-scope public binding to the imported `f` overload set, then try
+to render the `f` definitions using the current file's AST.
+
+`module.pyi`:
+
+```pyi
+from typing import overload
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+```
+
+`main.py`:
+
+```py
+from typing import overload
+from module import f
+
+def flag() -> bool:
+    return True
+
+if flag():
+    @overload
+    def a(): ...
+
+else:
+    a = f
+
+reveal_type(a)  # revealed: Overload[(x: int) -> int, (x: str) -> str]
+```
+
+### Later overload set after shadowed overload set
+
+```py
+from typing import overload
+
+def flag() -> bool:
+    return True
+
+if flag():
+    @overload
+    def a(x: int) -> int: ...
+    @overload
+    def a(x: str) -> str: ...
+
+@overload
+# error: [invalid-overload] "Overloads for function `a` must be followed by a non-`@overload`-decorated implementation function"
+def a(x: bytes) -> bytes: ...
+@overload
+def a(x: bool) -> bool: ...
+```
+
 ### Regression: `def` statement shadows a non-`def` symbol with the same name, defined in the same scope
 
 This is an even more pathological version of the above test. This version used to fail in the same

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -58,11 +58,6 @@ pub(crate) fn check_overloaded_function<'db>(
 
     let place = definition.place(db);
 
-    if !seen_overloaded_places.insert(place) {
-        // We have already checked this overloaded function in this scope, so we can skip it.
-        return;
-    }
-
     let use_def = index.use_def_map(context.scope().file_scope_id(db));
 
     let Place::Defined(DefinedPlace {
@@ -77,6 +72,18 @@ pub(crate) fn check_overloaded_function<'db>(
     else {
         return;
     };
+
+    if !function.contains_definition(db, definition) {
+        // The public end-of-scope binding for this place can be a different overloaded function
+        // value assigned to the same name. In that case, the current local overload definition is
+        // shadowed, and checking the public function here would report against the wrong function.
+        return;
+    }
+
+    if !seen_overloaded_places.insert(place) {
+        // We have already checked this overloaded function in this scope, so we can skip it.
+        return;
+    }
 
     if !seen_public_functions.insert(function) {
         // We have already checked this overloaded function as a public function, so we can skip it.


### PR DESCRIPTION
## Summary

Prior to this change, the post-inference overload checks could panic when a local overload definition was shadowed by an imported overloaded function in another branch, as in:

```python
from typing import overload
from module import f

if flag():
    @overload
    def a(): ...
else:
    a = f
```

When checking the local `a` overload, we resolved the end-of-scope public binding for `a` to the imported overload set for `f`. We then tried to render those imported definitions using the current file's AST, which tripped the panic...

We now skip the overload check when the public end-of-scope function does not actually contain the local definition
being checked.

Closes https://github.com/astral-sh/ty/issues/3462.
