### PR TITLE
[ty] Make overload public type reachability-aware

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -1043,7 +1043,37 @@ if flag():
 else:
     a = f
 
-reveal_type(a)  # revealed: Overload[(x: int) -> int, (x: str) -> str]
+reveal_type(a)  # revealed: (def a() -> Unknown) | (Overload[(x: int) -> int, (x: str) -> str])
+```
+
+### Conditional overloaded value and fallback implementation
+
+`module.pyi`:
+
+```pyi
+from typing import overload
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+```
+
+`main.py`:
+
+```py
+from module import f
+
+def flag() -> bool:
+    return True
+
+if flag():
+    g = f
+else:
+    def g(x: bytes) -> bytes:
+        return x
+
+reveal_type(g)  # revealed: (Overload[(x: int) -> int, (x: str) -> str]) | (def g(x: bytes) -> bytes)
 ```
 
 ### Later overload set after shadowed overload set

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -308,17 +308,13 @@ class Foo:
     elif coinflip():
         @overload
         @override
-        def method2(self, x: str) -> str: ...
+        def method2(self, x: str) -> str: ...  # error: [invalid-explicit-override]
         @overload
         def method2(self, x: int) -> int: ...
 
     else:
-        # TODO: not sure why this is being emitted on this line rather than on
-        # the first overload in the `elif` block? Ideally it would be emitted
-        # on the first reachable definition, but perhaps this is due to the way
-        # name lookups are deferred in stub files...? -- AW
         @override
-        def method2(self, x): ...  # error: [invalid-explicit-override]
+        def method2(self, x): ...
 ```
 
 ## Definitions in statically known branches

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1468,7 +1468,7 @@ fn place_from_bindings_impl<'db>(
                 // `Never` will be eliminated automatically.
 
                 if unbound_visibility().is_none_or(Truthiness::is_always_false) {
-                    return Some(Type::Never);
+                    return Some((Type::Never, static_reachability));
                 }
                 return None;
             }
@@ -1492,18 +1492,21 @@ fn place_from_bindings_impl<'db>(
 
             first_definition.get_or_insert(binding);
             let binding_ty = binding_type(db, binding);
-            Some(narrowing_constraint.narrow(db, binding_ty, binding.place(db)))
+            Some((
+                narrowing_constraint.narrow(db, binding_ty, binding.place(db)),
+                static_reachability,
+            ))
         },
     );
 
-    let place = if let Some(first) = types.next() {
-        let ty = if let Some(second) = types.next() {
+    let place = if let Some((first, first_reachability)) = types.next() {
+        let ty = if let Some((second, second_reachability)) = types.next() {
             let mut builder = PublicTypeBuilder::new(db);
-            builder.add(first);
-            builder.add(second);
+            builder.add(first, first_reachability);
+            builder.add(second, second_reachability);
 
-            for ty in types {
-                builder.add(ty);
+            for (ty, reachability) in types {
+                builder.add(ty, reachability);
             }
 
             builder.build()
@@ -1557,7 +1560,7 @@ pub(super) struct PlaceWithDefinition<'db> {
 /// Accumulates types from multiple bindings or declarations, and eventually builds a
 /// union type from them.
 ///
-/// `@overload`ed function literal types are discarded if they are immediately followed
+/// `@overload`ed function literal types are discarded if they are definitely followed
 /// by their implementation. This is to ensure that we do not merge all of them into the
 /// union type. The last one will include the other overloads already.
 struct PublicTypeBuilder<'db> {
@@ -1585,18 +1588,42 @@ impl<'db> PublicTypeBuilder<'db> {
         }
     }
 
-    fn add(&mut self, element: Type<'db>) -> bool {
+    fn add(&mut self, element: Type<'db>, reachability: Truthiness) -> bool {
         match element {
             Type::FunctionLiteral(function) => {
-                if function
-                    .literal(self.db)
-                    .last_definition
-                    .is_overload(self.db)
-                {
+                let last_definition = function.literal(self.db).last_definition;
+                if last_definition.is_overload(self.db) {
+                    // Distinct overloaded function values can be assigned to the same public
+                    // symbol in separate branches. Preserve the queued value unless the next
+                    // overload belongs to the same place.
+                    if !self.queue.is_some_and(|queued| {
+                        let Type::FunctionLiteral(queued_function) = queued else {
+                            return false;
+                        };
+                        function.has_same_place_as(self.db, queued_function)
+                    }) {
+                        self.drain_queue();
+                    }
+
                     self.queue = Some(element);
                     false
                 } else {
-                    self.queue = None;
+                    // An unconditional implementation shadows preceding overload definitions. A
+                    // conditional definition, however, can be only one public possibility among
+                    // several, so keep any unrelated queued overloaded function in the union.
+                    if reachability.is_always_true()
+                        || self.queue.is_some_and(|queued| {
+                            let Type::FunctionLiteral(queued_function) = queued else {
+                                return false;
+                            };
+                            let queued_definition = queued_function.last_definition(self.db);
+                            function.contains_definition(self.db, queued_definition)
+                        })
+                    {
+                        self.queue = None;
+                    } else {
+                        self.drain_queue();
+                    }
                     self.add_to_union(element);
                     true
                 }
@@ -1634,10 +1661,10 @@ impl<'db> DeclaredTypeBuilder<'db> {
         }
     }
 
-    fn add(&mut self, element: TypeAndQualifiers<'db>) {
+    fn add(&mut self, element: TypeAndQualifiers<'db>, reachability: Truthiness) {
         let element_ty = element.inner_type();
 
-        if self.inner.add(element_ty) {
+        if self.inner.add(element_ty, reachability) {
             if let Some(first_ty) = self.first_type {
                 if !first_ty.is_equivalent_to(self.inner.db, element_ty) {
                     self.conflicting_types.insert(element_ty);
@@ -1730,17 +1757,17 @@ fn place_from_declarations_impl<'db>(
             all_declarations_definitely_reachable =
                 all_declarations_definitely_reachable && static_reachability.is_always_true();
 
-            Some(declaration_type(db, declaration))
+            Some((declaration_type(db, declaration), static_reachability))
         }
     });
 
-    if let Some(first) = types.next() {
-        let (declared, conflicting) = if let Some(second) = types.next() {
+    if let Some((first, first_reachability)) = types.next() {
+        let (declared, conflicting) = if let Some((second, second_reachability)) = types.next() {
             let mut builder = DeclaredTypeBuilder::new(db);
-            builder.add(first);
-            builder.add(second);
-            for element in types {
-                builder.add(element);
+            builder.add(first, first_reachability);
+            builder.add(second, second_reachability);
+            for (element, reachability) in types {
+                builder.add(element, reachability);
             }
             builder.build()
         } else {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1151,6 +1151,16 @@ impl<'db> FunctionType<'db> {
         self.literal(db).definition(db)
     }
 
+    /// Returns `true` if this function's last definition uses the same place as `other`.
+    pub(crate) fn has_same_place_as(self, db: &'db dyn Db, other: FunctionType<'db>) -> bool {
+        self.last_definition(db).place(db) == other.last_definition(db).place(db)
+    }
+
+    /// Returns the [`Definition`] for the last overload or implementation in this function.
+    pub(crate) fn last_definition(self, db: &'db dyn Db) -> Definition<'db> {
+        self.literal(db).last_definition.definition(db)
+    }
+
     /// Returns `true` if this function includes `definition` as one of its overload signatures or
     /// implementation.
     pub(crate) fn contains_definition(self, db: &'db dyn Db, definition: Definition<'db>) -> bool {


### PR DESCRIPTION
## Summary

This PR makes public type construction for overloaded functions respect reachability.

Before this change, we treated an overloaded functio followed by any non-overload function as an overload set followed by its implementation. That works for ordinary overloads:

```python
@overload
def f(x: int) -> int: ...
@overload
def f(x: str) -> str: ...
def f(x: int | str) -> int | str: ...
```

But, it's wrong if those definitions are behind control-flow:

```python
from module import f

if flag():
    g = f
else:
    def g(x: bytes) -> bytes:
        return x
```

Here, the fallback implementation in the `else` is _not_ guaranteed to replace the imported overload set. It is just the public value of `g` on one branch -- we need to use the _union_ of the two definitions. (Previously, we would silently drop the overloaded branch and expose only the fallback function.)
