### PR TITLE
Disable binary caching for macOS to fix macos runner error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -425,6 +425,8 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Fix for https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: "false"
       - name: "Install Rust toolchain"
         run: rustup show
       - name: "Install cargo nextest"


### PR DESCRIPTION
## Summary

Our macOS jobs are currently failing because of https://github.com/actions/runner-images/issues/14097. 

The proposed workaround is to stop caching binary artifacts, see https://github.com/Swatinem/rust-cache/issues/341

## Test Plan

CI
