### PR TITLE
[ty] Avoid double-inference for single starred positional TypedDict

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -306,6 +306,18 @@ Empty({}, {})
 Person({}, {})
 ```
 
+Variadic positional arguments should not panic during `TypedDict` constructor preparation:
+
+```py
+class Empty(TypedDict):
+    pass
+
+args = []
+
+Empty(*args)
+Empty(*)  # error: [invalid-syntax] "Expected an expression"
+```
+
 Also, the value types ​​declared in a `TypedDict` affect generic call inference:
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -36,6 +36,8 @@ pub(super) enum TypedDictConstructorForm<'expr> {
     MixedLiteralAndKeywords(&'expr ast::ExprDict),
     /// // Ex) `TD(other, y=2)`
     MixedPositionalAndKeywords,
+    /// // Ex) `TD(*args)` or `TD(*args, y=2)`
+    VariadicPositional,
     /// // Ex) `TD(arg1, arg2)`
     MultiplePositionalArguments,
 }
@@ -52,6 +54,7 @@ impl<'expr> TypedDictConstructorForm<'expr> {
         };
 
         match (argument, arguments.keywords.is_empty()) {
+            (argument, _) if argument.is_starred_expr() => Self::VariadicPositional,
             (ast::Expr::Dict(_), true) => Self::LiteralOnly(argument),
             (ast::Expr::Dict(dict_expr), false) => Self::MixedLiteralAndKeywords(dict_expr),
             (_, true) => Self::SinglePositional(argument),
@@ -393,6 +396,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.store_expression_type(&arguments.args[0], Type::unknown());
             }
             TypedDictConstructorForm::KeywordOnly
+            | TypedDictConstructorForm::VariadicPositional
             | TypedDictConstructorForm::MultiplePositionalArguments => {}
         }
 


### PR DESCRIPTION
## Summary

This was getting double-inferred: once in the pre-pass to infer positional arguments, and then later again in a variadic call-argument path.

Closes https://github.com/astral-sh/ty/issues/3465.
