### PR TITLE
[`pylint`] Avoid false positives in `else` clause (`PLR1733`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
@@ -51,3 +51,22 @@ def rewrite_client_arrays(value_arrays: dict[str, list[int]]) -> dict[str, list[
         else:
             mapped_arrays[mapped_label] = [value_arrays[label][i] for i in range(len(array))]  # PLR1733
     return mapped_arrays
+
+
+# FP: for-else with inner loop variable accessed in else clause
+# The else clause runs when the inner loop completes without break.
+# The inner loop variable may be unbound or stale, so dict[index] lookups
+# in the else clause should NOT be flagged (issue #25150).
+def for_else_no_false_positive(result: dict[str, float]) -> dict[str, float]:
+    for res_glob, res_priority in result.items():
+        if res_priority > 0:
+            break
+    else:
+        # `res_glob` is bound to the LAST iteration's key if loop completed without break.
+        # `res_priority` is similarly the last iteration's value.
+        # Replacing result[res_glob] with res_priority here is INCORRECT
+        # because the outer loop's variables may not be in scope in all cases.
+        for res_glob in result.keys():
+            if result[res_glob] <= 0:
+                result.pop(res_glob)
+    return result

--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
@@ -53,20 +53,12 @@ def rewrite_client_arrays(value_arrays: dict[str, list[int]]) -> dict[str, list[
     return mapped_arrays
 
 
-# FP: for-else with inner loop variable accessed in else clause
-# The else clause runs when the inner loop completes without break.
-# The inner loop variable may be unbound or stale, so dict[index] lookups
-# in the else clause should NOT be flagged (issue #25150).
 def for_else_no_false_positive(result: dict[str, float]) -> dict[str, float]:
     for res_glob, res_priority in result.items():
         if res_priority > 0:
             break
     else:
-        # `res_glob` is bound to the LAST iteration's key if loop completed without break.
-        # `res_priority` is similarly the last iteration's value.
-        # Replacing result[res_glob] with res_priority here is INCORRECT
-        # because the outer loop's variables may not be in scope in all cases.
         for res_glob in result.keys():
-            if result[res_glob] <= 0:
+            if result[res_glob] <= 0:  # okay, res_glob from loop may be unbound
                 result.pop(res_glob)
     return result

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dict_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dict_index_lookup.rs
@@ -55,7 +55,6 @@ pub(crate) fn unnecessary_dict_index_lookup(checker: &Checker, stmt_for: &StmtFo
     let ranges = {
         let mut visitor = SequenceIndexVisitor::new(&dict_name.id, &index_name.id, &value_name.id);
         visitor.visit_body(&stmt_for.body);
-        visitor.visit_body(&stmt_for.orelse);
         visitor.into_accesses()
     };
 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1733_unnecessary_dict_index_lookup.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1733_unnecessary_dict_index_lookup.py.snap
@@ -151,3 +151,5 @@ help: Use existing variable
    -             mapped_arrays[mapped_label] = [value_arrays[label][i] for i in range(len(array))]  # PLR1733
 52 +             mapped_arrays[mapped_label] = [array[i] for i in range(len(array))]  # PLR1733
 53 |     return mapped_arrays
+54 |
+55 |


### PR DESCRIPTION
## Summary
The `PLR1733` (unnecessary-dict-index-lookup) rule was incorrectly firing on dictionary accesses inside the `else` clause of a `for` loop. The `else` clause has different control-flow semantics — it only executes when the loop completes without `break` — and iteration variables from inner loops may not be in scope or may have stale values.

## Root cause
In `unnecessary_dict_index_lookup()`, the `stmt_for.orelse` was being visited along with `stmt_for.body`:

```rust
visitor.visit_body(&stmt_for.body);
visitor.visit_body(&stmt_for.orelse);  // <-- this was the bug
```

The `else` clause of a `for` loop is not part of the iteration context. Variables bound in the outer loop may be unbound if the loop body never ran, or stale from the last iteration if the loop completed.

## Fix
Remove the `visitor.visit_body(&stmt_for.orelse)` call so the `else` clause is not checked for unnecessary dict lookups.

## Validation
```bash
# False positive case (now correctly passes)
cargo run -p ruff -- check test.py --isolated --select PLR1733 --preview
# Before: 1 error (PLR1733 false positive)
# After:  All checks passed

# Existing cases still work
cargo test -p ruff_linter unnecessary_dict_index  # PASS

# Zulip pattern is still detected correctly
cargo run -p ruff -- check test_zulip.py --isolated --select PLR1733 --preview
# Correctly detects: mapped_arrays[mapped_label][i] += value_arrays[label][i]
```

## Before
`ruff check` would report a false positive on `result[res_glob]` inside the `else` clause of the outer `for` loop, and the autofix would suggest `res_priority` which is incorrect (the inner loop variable may be unbound/stale).

## After
`ruff check` correctly skips the `else` clause of the `for` loop — no false positive.

Fixes #25150