### PR TITLE
[ty] Ignore generic specialization in layout compatibility checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/instance_layout_conflict.md
+++ b/crates/ty_python_semantic/resources/mdtest/instance_layout_conflict.md
@@ -265,6 +265,17 @@ class DD(AA): ...
 class FF(CC, DD): ...  # fine
 ```
 
+CPython's layout check operates on runtime classes, so type arguments in a generic disjoint base's
+inheritance hierarchy do not affect whether the disjoint bases can coexist:
+
+```py
+import asyncio
+
+class Future(asyncio.Future): ...
+class Task(asyncio.Task): ...
+class SubClass(Task, Future): ...  # fine
+```
+
 ## False negatives
 
 ### Possibly unbound `__slots__`

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -147,6 +147,8 @@ static_assert(is_disjoint_from(list[Any], dict[Any, Any]))
 static_assert(is_disjoint_from(type[list], type[dict]))
 
 static_assert(is_disjoint_from(asyncio.Task, dict))
+static_assert(not is_disjoint_from(asyncio.Task, asyncio.Future))
+static_assert(not is_disjoint_from(type[asyncio.Task], type[asyncio.Future]))
 
 @disjoint_base
 class A: ...

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2567,15 +2567,17 @@ impl<'db> DisjointBase<'db> {
 
     /// Two disjoint bases can only coexist in a class's MRO if one is a subclass of the other
     fn could_coexist_in_mro_with(&self, db: &'db dyn Db, other: &Self) -> bool {
+        // CPython's layout check operates on runtime classes. Type arguments are irrelevant here:
+        // a generic disjoint base and any specialization of that base share the same layout.
         self == other
             || self
                 .class
                 .default_specialization(db)
-                .is_subclass_of(db, other.class.default_specialization(db))
+                .is_subtype_of_class_literal(db, other.class)
             || other
                 .class
                 .default_specialization(db)
-                .is_subclass_of(db, self.class.default_specialization(db))
+                .is_subtype_of_class_literal(db, self.class)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4505,6 +4505,9 @@ impl<'db> IncompatibleBases<'db> {
                     .keys()
                     .filter(|other_base| other_base != disjoint_base)
                     .all(|other_base| {
+                        // CPython's layout check operates on runtime classes. Type arguments are
+                        // irrelevant here: a generic disjoint base and any specialization of that
+                        // base share the same layout.
                         !disjoint_base
                             .class
                             .default_specialization(db)

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4508,7 +4508,7 @@ impl<'db> IncompatibleBases<'db> {
                         !disjoint_base
                             .class
                             .default_specialization(db)
-                            .is_subclass_of(db, other_base.class.default_specialization(db))
+                            .is_subtype_of_class_literal(db, other_base.class)
                     })
             })
             .map(|(base, info)| (*base, *info))


### PR DESCRIPTION
## Summary

Every time someone tries to touch this code, it gets rejected, so I don't have high hopes here. Anyway...

Previously, a generic disjoint base and a subclass of that base could be marked as incompatible if the type arguments didn't line up. But at runtime, CPython's instance layout check isn't affected by type arguments. A concrete example is:

```python
import asyncio

class Future(asyncio.Future): ...
class Task(asyncio.Task): ...
class SubClass(Task, Future): ...
```

`asyncio.Task` is a subclass of `asyncio.Future`, so these bases can coexist in the same MRO. But before, we ended up doing a comparison like `Task[Unknown] <: Future[Unknown]`, which I believe ends up failing because `Unknown <: Unknown` is false under subtyping?

Closes https://github.com/astral-sh/ty/issues/3466.
