### PR TITLE
[ty] Fix panic from `reveal_protocol`, `reveal_mro`, etc. with keyword arguments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/classes.md
@@ -24,6 +24,7 @@ A = str
 B = bytes
 
 reveal_mro(C)  # revealed: (<class 'C'>, <class 'int'>, <class 'G[bytes]'>, typing.Generic, <class 'object'>)
+reveal_mro(cls=C)  # revealed: (<class 'C'>, <class 'int'>, <class 'G[bytes]'>, typing.Generic, <class 'object'>)
 ```
 
 ## Starred bases

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -474,6 +474,8 @@ from typing import SupportsIndex, SupportsAbs, ClassVar, Iterator
 
 # revealed: {"method_member": MethodMember(`(self, /) -> bytes`), "x": AttributeMember(`int`), "y": PropertyMember { getter: `def y(self, /) -> str` }, "z": PropertyMember { getter: `def z(self, /) -> int`, setter: `def z(self, /, z: int) -> None` }}
 reveal_protocol_interface(Foo)
+# revealed: {"method_member": MethodMember(`(self, /) -> bytes`), "x": AttributeMember(`int`), "y": PropertyMember { getter: `def y(self, /) -> str` }, "z": PropertyMember { getter: `def z(self, /) -> int`, setter: `def z(self, /, z: int) -> None` }}
+reveal_protocol_interface(protocol=Foo)
 # revealed: {"__index__": MethodMember(`(self, /) -> int`)}
 reveal_protocol_interface(SupportsIndex)
 # revealed: {"__abs__": MethodMember(`(self, /) -> Unknown`)}

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2049,7 +2049,12 @@ impl KnownFunction {
                     .arguments_for_parameter(call_arguments, 0)
                     .fold(UnionBuilder::new(db), |builder, (_, ty)| builder.add(ty))
                     .build();
-                report_revealed_type(context, revealed_type, &call_expression.arguments.args[0]);
+                report_revealed_type(
+                    context,
+                    revealed_type,
+                    call_argument_node(call_expression, "obj", 0)
+                        .unwrap_or_else(|| ast::AnyNodeRef::from(call_expression)),
+                );
             }
 
             KnownFunction::HasMember => {
@@ -2085,8 +2090,13 @@ impl KnownFunction {
                     ));
 
                     diagnostic.annotate(
-                        Annotation::secondary(context.span(&call_expression.arguments.args[0]))
-                            .message(format_args!("Inferred type is `{}`", actual_ty.display(db))),
+                        Annotation::secondary(
+                            context.span(
+                                call_argument_node(call_expression, "val", 0)
+                                    .unwrap_or_else(|| ast::AnyNodeRef::from(call_expression)),
+                            ),
+                        )
+                        .message(format_args!("Inferred type is `{}`", actual_ty.display(db))),
                     );
 
                     if actual_ty.is_subtype_of(db, *asserted_ty) {
@@ -2123,11 +2133,16 @@ impl KnownFunction {
                     let mut diagnostic =
                         builder.into_diagnostic("Argument does not have asserted type `Never`");
                     diagnostic.annotate(
-                        Annotation::secondary(context.span(&call_expression.arguments.args[0]))
-                            .message(format_args!(
-                                "Inferred type of argument is `{}`",
-                                actual_ty.display(db)
-                            )),
+                        Annotation::secondary(
+                            context.span(
+                                call_argument_node(call_expression, "arg", 0)
+                                    .unwrap_or_else(|| ast::AnyNodeRef::from(call_expression)),
+                            ),
+                        )
+                        .message(format_args!(
+                            "Inferred type of argument is `{}`",
+                            actual_ty.display(db)
+                        )),
                     );
                     diagnostic.info(format_args!(
                         "`Never` and `{inferred_type}` are not equivalent types",
@@ -2148,10 +2163,11 @@ impl KnownFunction {
                 let truthiness = match parameter_ty.try_bool(db) {
                     Ok(truthiness) => truthiness,
                     Err(err) => {
-                        let condition = call_argument_node(call_expression, "condition", 0)
-                            .unwrap_or(ast::AnyNodeRef::from(call_expression));
-
-                        err.report_diagnostic(context, condition);
+                        err.report_diagnostic(
+                            context,
+                            call_argument_node(call_expression, "condition", 0)
+                                .unwrap_or_else(|| ast::AnyNodeRef::from(call_expression)),
+                        );
 
                         return;
                     }
@@ -2249,7 +2265,10 @@ impl KnownFunction {
                     context.report_diagnostic(DiagnosticId::RevealedType, Severity::Info)
                 {
                     let mut diag = builder.into_diagnostic("Revealed protocol interface");
-                    let span = context.span(&call_expression.arguments.args[0]);
+                    let span = context.span(
+                        call_argument_node(call_expression, "protocol", 0)
+                            .unwrap_or_else(|| ast::AnyNodeRef::from(call_expression)),
+                    );
                     diag.annotate(Annotation::primary(span).message(format_args!(
                         "`{}`",
                         protocol_class.interface(db).display(db)
@@ -2306,7 +2325,10 @@ impl KnownFunction {
                     context.report_diagnostic(DiagnosticId::RevealedType, Severity::Info)
                 {
                     let mut diag = builder.into_diagnostic("Revealed MRO");
-                    let span = context.span(&call_expression.arguments.args[0]);
+                    let span = context.span(
+                        call_argument_node(call_expression, "cls", 0)
+                            .unwrap_or_else(|| ast::AnyNodeRef::from(call_expression)),
+                    );
                     let mut message = String::new();
                     let display_settings = DisplaySettings::from_possibly_ambiguous_types(
                         db,
@@ -2436,7 +2458,7 @@ impl KnownFunction {
 pub(super) fn report_revealed_type<'db>(
     context: &InferContext<'db, '_>,
     revealed_type: Type<'db>,
-    argument_node: &ast::Expr,
+    argument_node: impl Ranged,
 ) {
     if let Some(builder) = context.report_diagnostic(DiagnosticId::RevealedType, Severity::Info) {
         let mut diag = builder.into_diagnostic("Revealed type");


### PR DESCRIPTION
## Summary

Like 86f3064d6f, but for these other helpers.