### PR TITLE
[ty] Avoid enforcing `__new__` with custom metaclasses

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -641,7 +641,8 @@ class MyModelChoices(IntegerChoices):
 reveal_type(MyModelChoices.GOOD.value)  # revealed: Any
 ```
 
-An explicit `_value_` annotation on the transformed enum class still takes precedence:
+An explicit `_value_` annotation on the transformed enum class still takes precedence, even when the
+annotation is inherited from a user-defined enum base:
 
 ```py
 from enum import EnumMeta, IntEnum
@@ -650,14 +651,13 @@ class ChoicesType(EnumMeta):
     def __new__(metacls, classname, bases, classdict, **kwds): ...
 
 class IntegerChoices(IntEnum, metaclass=ChoicesType):
-    pass
-
-class AnnotatedChoices(IntegerChoices):
     _value_: int
 
+class AnnotatedChoices(IntegerChoices):
     GOOD = 1, "I like this"
 
 reveal_type(AnnotatedChoices.GOOD.value)  # revealed: int
+reveal_type(AnnotatedChoices.GOOD._value_)  # revealed: int
 ```
 
 ### Non-member attributes with disallowed type

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -620,6 +620,46 @@ class Child(Base):
     GITHUB = "github"  # error: [invalid-assignment]
 ```
 
+### Custom enum metaclass member transformation
+
+A custom `EnumMeta` metaclass can rewrite member values before the stdlib enum constructor validates
+and forwards them to `__new__` / `__init__`. We therefore avoid validating the raw right-hand side
+of member declarations in this case:
+
+```py
+from enum import EnumMeta, IntEnum
+
+class ChoicesType(EnumMeta):
+    def __new__(metacls, classname, bases, classdict, **kwds): ...
+
+class IntegerChoices(IntEnum, metaclass=ChoicesType):
+    pass
+
+class MyModelChoices(IntegerChoices):
+    GOOD = 1, "I like this"
+
+reveal_type(MyModelChoices.GOOD.value)  # revealed: Any
+```
+
+An explicit `_value_` annotation on the transformed enum class still takes precedence:
+
+```py
+from enum import EnumMeta, IntEnum
+
+class ChoicesType(EnumMeta):
+    def __new__(metacls, classname, bases, classdict, **kwds): ...
+
+class IntegerChoices(IntEnum, metaclass=ChoicesType):
+    pass
+
+class AnnotatedChoices(IntegerChoices):
+    _value_: int
+
+    GOOD = 1, "I like this"
+
+reveal_type(AnnotatedChoices.GOOD.value)  # revealed: int
+```
+
 ### Non-member attributes with disallowed type
 
 Methods, callables, descriptors (including properties), and nested classes that are defined in the

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -38,6 +38,10 @@ pub(crate) struct EnumMetadata<'db> {
     /// value exposed through `.value`; the method can assign `_value_`
     /// independently.
     pub(crate) new_function: Option<FunctionType<'db>>,
+
+    /// Whether the enum metaclass may transform member values before they are
+    /// passed to enum construction hooks.
+    pub(crate) custom_enum_metaclass_new: bool,
 }
 
 impl get_size2::GetSize for EnumMetadata<'_> {}
@@ -51,20 +55,25 @@ impl<'db> EnumMetadata<'db> {
             value_annotation: None,
             init_function: None,
             new_function: None,
+            custom_enum_metaclass_new: false,
         }
     }
 
     /// Returns the type of `.value`/`._value_` for a given enum member.
     ///
-    /// Priority: explicit `_value_` annotation, then custom construction hooks → `Any`,
-    /// then the inferred member value type.
+    /// Priority: explicit `_value_` annotation, then custom construction hooks
+    /// or metaclass value transformation → `Any`, then the inferred member
+    /// value type.
     pub(crate) fn value_type(&self, member_name: &Name) -> Option<Type<'db>> {
         if !self.members.contains_key(member_name) {
             return None;
         }
         if let Some(annotation) = self.value_annotation {
             Some(annotation)
-        } else if self.init_function.is_some() || self.new_function.is_some() {
+        } else if self.init_function.is_some()
+            || self.new_function.is_some()
+            || self.custom_enum_metaclass_new
+        {
             Some(Type::Dynamic(DynamicType::Any))
         } else {
             self.members.get(member_name).copied()
@@ -84,7 +93,8 @@ impl<'db> EnumMetadata<'db> {
     /// narrowed to a specific member (e.g. `x: MyEnum` where `MyEnum` has multiple members).
     ///
     /// If there is an explicit `_value_` annotation, returns that.
-    /// If there is a custom `__init__` or `__new__`, returns `Any`.
+    /// If there is a custom `__init__` or `__new__` or a custom enum
+    /// metaclass may transform member values, returns `Any`.
     /// Otherwise, returns the union of all member value types.
     pub(crate) fn instance_value_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         if self.members.is_empty() {
@@ -92,7 +102,10 @@ impl<'db> EnumMetadata<'db> {
         }
         if let Some(annotation) = self.value_annotation {
             Some(annotation)
-        } else if self.init_function.is_some() || self.new_function.is_some() {
+        } else if self.init_function.is_some()
+            || self.new_function.is_some()
+            || self.custom_enum_metaclass_new
+        {
             Some(Type::Dynamic(DynamicType::Any))
         } else {
             let union = self
@@ -230,6 +243,7 @@ pub(crate) fn enum_metadata<'db>(
                 value_annotation: None,
                 init_function: None,
                 new_function: None,
+                custom_enum_metaclass_new: false,
             });
         }
     };
@@ -435,14 +449,18 @@ pub(crate) fn enum_metadata<'db>(
         return None;
     }
 
-    // Look up an explicit `_value_` annotation, if present. Falls back to
-    // checking parent enum classes in the MRO.
-    let value_annotation =
-        custom_value_annotation(db, scope_id).or_else(|| inherited_value_annotation(db, class));
-
     // Look up custom construction hooks, falling back to parent enum classes.
     let init_function = custom_init(db, scope_id).or_else(|| inherited_init(db, class));
     let new_function = custom_new(db, scope_id).or_else(|| inherited_new(db, class));
+    let custom_enum_metaclass_new = custom_enum_metaclass_new(db, class);
+    let custom_value_annotation = custom_value_annotation(db, scope_id);
+    let value_annotation = custom_value_annotation.or_else(|| {
+        if custom_enum_metaclass_new {
+            None
+        } else {
+            inherited_value_annotation(db, class)
+        }
+    });
 
     Some(EnumMetadata {
         members,
@@ -451,7 +469,27 @@ pub(crate) fn enum_metadata<'db>(
         value_annotation,
         init_function,
         new_function,
+        custom_enum_metaclass_new,
     })
+}
+
+/// Returns whether an enum's metaclass has a custom `__new__` before the stdlib
+/// `EnumType`/`EnumMeta` implementation.
+///
+/// Such a metaclass can rewrite the class dictionary's member values before the
+/// stdlib enum constructor validates and forwards them to `__new__`/`__init__`.
+fn custom_enum_metaclass_new<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> bool {
+    let Some(metaclass) = class.metaclass(db).to_class_type(db) else {
+        return false;
+    };
+
+    metaclass
+        .class_literal(db)
+        .iter_mro(db)
+        .filter_map(ClassBase::into_class)
+        .filter_map(|base| base.class_literal(db).as_static())
+        .take_while(|base| base.known(db) != Some(KnownClass::EnumType))
+        .any(|base| custom_new(db, base.body_scope(db)).is_some())
 }
 
 /// Iterates over parent enum classes in the MRO, skipping known enum

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -456,7 +456,7 @@ pub(crate) fn enum_metadata<'db>(
     let custom_value_annotation = custom_value_annotation(db, scope_id);
     let value_annotation = custom_value_annotation.or_else(|| {
         if custom_enum_metaclass_new {
-            None
+            inherited_user_defined_value_annotation(db, class)
         } else {
             inherited_value_annotation(db, class)
         }
@@ -494,7 +494,7 @@ fn custom_enum_metaclass_new<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db
 
 /// Iterates over parent enum classes in the MRO, skipping known enum
 /// infrastructure classes but including `IntEnum`, `Flag`, and `IntFlag`
-/// which declare `_value_` annotations that should be inherited.
+/// which declare `_value_` annotations that normally should be inherited.
 fn iter_parent_enum_classes<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
@@ -530,6 +530,16 @@ fn inherited_value_annotation<'db>(
     class: StaticClassLiteral<'db>,
 ) -> Option<Type<'db>> {
     iter_parent_enum_classes(db, class)
+        .find_map(|base| custom_value_annotation(db, base.body_scope(db)))
+}
+
+/// Looks up an inherited `_value_` annotation from user-defined parent enum classes in the MRO.
+fn inherited_user_defined_value_annotation<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+) -> Option<Type<'db>> {
+    iter_parent_enum_classes(db, class)
+        .filter(|base| base.known(db).is_none())
         .find_map(|base| custom_value_annotation(db, base.body_scope(db)))
 }
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -250,7 +250,9 @@ fn check_class_declaration<'db>(
             // `auto()` values are computed at runtime by the enum metaclass,
             // so we can't validate them against _value_ or __init__ at the type level.
             let is_auto = enum_info.auto_members.contains(&member.name);
-            let skip_type_check = (context.in_stub() && is_ellipsis) || is_auto;
+            let skip_type_check = (context.in_stub() && is_ellipsis)
+                || is_auto
+                || enum_info.custom_enum_metaclass_new;
 
             if !skip_type_check {
                 if let Some(new_function) = enum_info.new_function {


### PR DESCRIPTION
## Summary

This PR makes enum member validation account for custom `EnumMeta.__new__` methods. Prior to this change, we validated the raw right-hand side of an enum member against inherited `_value_,` `__new__,` or `__init__`. But that's too strict for Django’s `IntegerChoices` pattern...

```python
from django.db import models

class Status(models.IntegerChoices):
    GOOD = 1, "I like this"
```

Django’s custom metaclass strips the label out of the member value before `IntEnum` construction, so the raw `(1,
"I like this")` tuple is _not_ the value that should be checked against `int.__new__`.

We now detect a custom enum metaclass `__new__` and treat member values as potentially transformed. In that case, we skip raw-RHS validation against enum construction hooks, and `.value` / `._value_` falls back to `Any` (unless the enum class itself declares an explicit `_value_` annotation).

Pyright has similar behavior here: https://github.com/microsoft/pyright/blob/63998f4d0720a86447f4c4a04716e34f3e703660/packages/pyright-internal/src/analyzer/enums.ts#L653-L660

But we do differ in this case:

```python
class Status(IntegerChoices):
    _value_: int
    GOOD = 1, "label"
```

Pyright exposes `Status.GOOD.value` as `int`, but still reports that the raw tuple is not assignable to `int`. We expose `Status.GOOD.value` as `int`, and don't report anything.

Closes https://github.com/astral-sh/ty/issues/3468.