### PR TITLE
[ty] Use incremental file walk on `.gitignore` change

### DIFF
--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -52,8 +52,8 @@ impl ProjectDatabase {
             project_changed: false,
             custom_stdlib_changed: false,
         };
-        // Paths that were added
-        let mut added_paths = FxHashSet::default();
+        // Paths whose project files should be discovered incrementally.
+        let mut added_paths = BTreeSet::default();
 
         // Deduplicate the `sync` calls. Many file watchers emit multiple events for the same path.
         let mut synced_files = FxHashSet::default();
@@ -80,9 +80,40 @@ impl ProjectDatabase {
                     continue;
                 }
 
-                if is_ignore_file(path) {
+                if is_ignore_file(path) && project.settings(self).src().respect_ignore_files {
                     File::sync_path(self, path);
-                    reload_project_files = true;
+                    if let Some(directory) = path.parent() {
+                        if project
+                            .included_paths_or_root(self)
+                            .iter()
+                            .any(|included_path| included_path.starts_with(directory))
+                        {
+                            tracing::debug!(
+                                ignore_file = %path,
+                                directory = %directory,
+                                "Reloading project files for changed ignore file at or above included path"
+                            );
+                            reload_project_files = true;
+                        } else if project.is_directory_included(self, directory) {
+                            tracing::debug!(
+                                ignore_file = %path,
+                                directory = %directory,
+                                "Queueing project-file reindex for changed ignore file"
+                            );
+
+                            removed_paths.insert(directory.to_path_buf());
+
+                            if self.system().path_exists(directory) {
+                                added_paths.insert(directory.to_path_buf());
+                            }
+                        } else {
+                            tracing::debug!(
+                                ignore_file = %path,
+                                directory = %directory,
+                                "Ignoring changed ignore file because it doesn't affect project paths"
+                            );
+                        }
+                    }
 
                     continue;
                 }
@@ -350,11 +381,11 @@ impl ProjectDatabase {
             }
         }
 
-        for path in deduplicate_nested_paths(removed_paths) {
-            project.remove_files_under(self, &path);
-        }
+        project.remove_files_under(self, deduplicate_nested_paths(removed_paths));
 
-        let diagnostics = if let Some(walker) = ProjectFilesWalker::incremental(self, added_paths) {
+        let diagnostics = if !project.file_set(self).is_lazy()
+            && let Some(walker) = ProjectFilesWalker::incremental(self, added_paths)
+        {
             // Use directory walking to discover newly added files.
             let (files, diagnostics) = walker.collect_vec(self);
 

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -21,7 +21,7 @@ use ruff_db::system::{SystemPath, SystemPathBuf};
 use rustc_hash::FxHashSet;
 use salsa::{Database, Durability, Setter};
 use std::backtrace::BacktraceStatus;
-use std::collections::hash_set;
+use std::collections::{BTreeSet, hash_set};
 use std::iter::FusedIterator;
 use std::panic::{AssertUnwindSafe, UnwindSafe};
 use std::sync::Arc;
@@ -593,12 +593,23 @@ impl Project {
         index.remove(file);
     }
 
-    /// Removes all indexed project files under `path`.
+    /// Removes all indexed project files under `paths`.
     ///
     /// This is a no-op if the project files are still lazily indexed.
-    #[tracing::instrument(level = "debug", skip(self, db))]
-    pub(crate) fn remove_files_under(self, db: &mut dyn Db, path: &SystemPath) {
-        let path = SystemPath::absolute(path, db.system().current_directory());
+    #[tracing::instrument(level = "debug", skip(self, db, paths))]
+    pub(crate) fn remove_files_under<P, I>(self, db: &mut dyn Db, paths: I)
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<SystemPath>,
+    {
+        let paths = paths
+            .into_iter()
+            .map(|path| SystemPath::absolute(path, db.system().current_directory()))
+            .collect::<BTreeSet<_>>();
+
+        if paths.is_empty() {
+            return;
+        }
 
         if self.file_set(db).is_lazy() {
             return;
@@ -610,9 +621,11 @@ impl Project {
                 .iter()
                 .copied()
                 .filter(|file| {
-                    file.path(db)
-                        .as_system_path()
-                        .is_some_and(|file_path| file_path.starts_with(&path))
+                    file.path(db).as_system_path().is_some_and(|file_path| {
+                        file_path
+                            .ancestors()
+                            .any(|ancestor| paths.contains(ancestor))
+                    })
                 })
                 .collect::<Vec<_>>()
         };


### PR DESCRIPTION
## Summary

Today, ty walks the entire project directory when any `.gitignore` or `.ignore` file changed. This can be very expensive in large projects. 

This PR avoids the full-project walk in-favor of incrementally walking the directory containing the changed `.gitignore` (or `.ignore`) file (unless the root changed, in which case we simply have to walk the entire directory).

A more elegant solution would be to match the project files against the now updated gitignore filters, but the `ignore` crate doesn't provide the necessary API. 

This PR makes three more optimizations:

1. Change `remove_files_under` to take a `BTreeSet` of directories to remove to avoid walking the project files more than once
2. Skip the incremental file walk if the files aren't indexed (they're lazy). If the state is `lazy`, calling `project.add_file` is a no-op, so there's no point in doing the file walking
3. Make `added_paths` a `BTreeSet` for better consistency with `removed_paths`


## Test plan

I ran VS Code and switched between two revisions that are 2500 commits apart (and contain a few gitignore changes). On main, ty started two full project file scans. On this PR, it only performs an incremental walk.

