### PR TITLE
[ty] Use variance-aware constraint solving for a subset of callables

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -1057,6 +1057,7 @@ x2: list[A | bool] = [{"bar": 1}, 1]
 However, the declared type should be ignored if the specialization is not solvable:
 
 ```py
+from collections import defaultdict
 from typing import Any, Callable
 
 def g[T](x: list[T]) -> T:
@@ -1075,6 +1076,10 @@ def make_callable[T](x: T) -> Callable[[T], bool]:
 def _(a: int | None):
     # error: [invalid-assignment] "Object of type `(int | None, /) -> bool` is not assignable to `(str, /) -> bool`"
     x1: Callable[[str], bool] = make_callable(a)
+
+def _():
+    # error: [invalid-assignment] "Object of type `defaultdict[int, int | None]` is not assignable to `defaultdict[int, int]`"
+    x1: defaultdict[int, int] = defaultdict(lambda: None)
 ```
 
 ## Forward annotation with unclosed string literal

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -232,7 +232,7 @@ def return_invalid_dict() -> TD:
 ## Propagating return type annotation
 
 ```py
-from typing import overload, Callable
+from typing import overload, Callable, Iterable
 
 def list1[T](x: T) -> list[T]:
     return [x]
@@ -280,6 +280,23 @@ def h[T](x: T, cond: bool) -> T | list[T]:
 
 def i[T](x: T, cond: bool) -> T | list[T]:
     return x if cond else [x]
+
+def accepts_callback[T](callback: Callable[[T], None]) -> list[T]:
+    raise NotImplementedError
+
+def consume_int(x: int) -> None: ...
+
+reveal_type(accepts_callback(consume_int))  # revealed: list[int]
+xs: list[int] = accepts_callback(consume_int)
+
+def make_with_callback[T](x: Iterable[T], callback: Callable[[T], None]) -> list[T]:
+    raise NotImplementedError
+
+ints = [1]
+
+def consume_object(x: object) -> None: ...
+
+objects: list[object] = make_with_callback(ints, consume_object)
 ```
 
 ## Type context sources

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -299,6 +299,39 @@ result = apply_twice(f, x, y)
 reveal_type(result)
 ```
 
+Generic calls can combine evidence from an iterable with contravariant evidence from a callback for
+the same type variable. Passing `list[Derived]` with a `Callable[[Base], int]` callback preserves
+`list[Derived]` as the return type.
+
+```py
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+class Base: ...
+
+class Derived(Base):
+    foo: int = 1
+
+def sort_key(value: Base) -> int:
+    return 0
+
+def use_sorted(items: list[Derived]) -> int:
+    sorted_items = sorted(items, key=sort_key)
+    # revealed: list[Derived]
+    reveal_type(sorted_items)
+    return sorted_items[0].foo
+
+def collect_with_key(items: list[T], key: Callable[[T], int]) -> list[T]:
+    return items
+
+def use_collected(items: list[Derived]) -> int:
+    collected_items = collect_with_key(items, sort_key)
+    # revealed: list[Derived]
+    reveal_type(collected_items)
+    return collected_items[0].foo
+```
+
 An overloaded callable returned from a generic callable factory should still be assignable to the
 declared generic callable return type.
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
@@ -303,6 +303,95 @@ result = apply_twice(f, x, y)
 reveal_type(result)
 ```
 
+Generic calls can combine evidence from an iterable with contravariant evidence from a callback for
+the same type variable. Passing `list[Derived]` with a `Callable[[Base], int]` callback preserves
+the return type `list[Derived]`.
+
+```py
+class Base: ...
+
+class Derived(Base):
+    foo: int = 1
+
+def sort_key(value: Base) -> int:
+    return 0
+
+def use_sorted(items: list[Derived]) -> int:
+    sorted_items = sorted(items, key=sort_key)
+    # revealed: list[Derived]
+    reveal_type(sorted_items)
+    return sorted_items[0].foo
+```
+
+## Callable constraints through type aliases
+
+When an argument type alias contains a type variable, the aliased iterable element type determines
+the returned item type. Contravariant evidence from the key function is preserved, and the helper
+returns `list[AliasDerived]`.
+
+```py
+from collections.abc import Callable, Iterable
+
+class AliasBase: ...
+
+class AliasDerived(AliasBase):
+    foo: int = 1
+
+type Items[T] = Iterable[T]
+
+def alias_sort_key(value: AliasBase) -> int:
+    return 0
+
+def collect[T](items: Items[T], key: Callable[[T], int]) -> list[T]:
+    return list(items)
+
+def use_collected(items: list[AliasDerived]) -> int:
+    collected_items = collect(items, alias_sort_key)
+    # revealed: list[AliasDerived]
+    reveal_type(collected_items)
+    return collected_items[0].foo
+```
+
+When a callback only accepts a literal type, inference preserves that literal for `T`. Passing `1`
+with a `Callable[[Literal[1]], None]` callback returns a callable that still requires `Literal[1]`.
+
+```py
+from collections.abc import Callable
+from typing import Literal
+
+def preserves_literal[T](x: T, callback: Callable[[T], None]) -> Callable[[T], None]:
+    return callback
+
+def only_one(value: Literal[1]) -> None:
+    pass
+
+reveal_type(preserves_literal(1, only_one))  # revealed: (Literal[1], /) -> None
+```
+
+## Callable constraints with nested unions
+
+A callable parameter whose argument type is a union of type variables constrains each variable
+independently. Passing `X1`, `X2`, and a consumer of `X1 | X2` returns `tuple[X1, X2]`.
+
+```py
+from collections.abc import Callable
+
+class X1: ...
+class X2: ...
+
+def consume(value: X1 | X2) -> None:
+    pass
+
+def pair[T1, T2](left: T1, right: T2, callback: Callable[[T1 | T2], None]) -> tuple[T1, T2]:
+    callback(left)
+    callback(right)
+    return left, right
+
+result = pair(X1(), X2(), consume)
+# revealed: tuple[X1, X2]
+reveal_type(result)
+```
+
 An overloaded callable returned from a generic callable factory should still be assignable to the
 declared generic callable return type.
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4800,16 +4800,22 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
             // If the TypeVar has an upper bound, only use the promoted type if it
             // still satisfies the bound.
-            if let Some(TypeVarBoundOrConstraints::UpperBound(bound)) = bound_or_constraints {
-                if !promoted.is_assignable_to(self.db, bound) {
-                    return None;
-                }
+            if let Some(TypeVarBoundOrConstraints::UpperBound(bound)) = bound_or_constraints
+                && !promoted.is_assignable_to(self.db, bound)
+            {
+                return None;
             }
 
             Some(promoted)
         };
 
-        let specialization = builder.build_with(generic_context, maybe_promote);
+        let specialization = builder
+            .build_from_solver_constraints(
+                generic_context,
+                &preferred_type_mappings,
+                &maybe_promote,
+            )
+            .unwrap_or_else(|| builder.build_with(generic_context, &maybe_promote));
 
         self.return_ty = self.return_ty.apply_specialization(self.db, specialization);
         self.specialization = Some(specialization);
@@ -4837,11 +4843,22 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
                 let declared_type = parameters[parameter_index].annotated_type();
                 let argument_type = argument_types.get_for_declared_type(declared_type);
+                let actual_type = variadic_argument_type.unwrap_or(argument_type);
 
-                let specialization_result = builder.infer_map(
-                    declared_type,
-                    variadic_argument_type.unwrap_or(argument_type),
-                    |(identity, _, inferred_ty)| {
+                let parameter = &parameters[parameter_index];
+                if (parameter.is_variadic()
+                    || parameter.is_keyword_variadic()
+                    || parameter.has_starred_annotation())
+                    && (builder.has_inferable_typevar(declared_type)
+                        || builder.has_inferable_typevar(actual_type))
+                {
+                    builder.mark_solver_constraints_unsupported();
+                } else if !matches!(declared_type, Type::Callable(_)) {
+                    builder.stage_solver_constraint(declared_type, actual_type);
+                }
+
+                let specialization_result =
+                    builder.infer_map(declared_type, actual_type, |(identity, _, inferred_ty)| {
                         // Avoid widening the inferred type if it is already assignable to the
                         // preferred declared type.
                         if let Some(preferred_ty) = preferred_type_mappings.get(&identity) {
@@ -4857,8 +4874,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         }
 
                         Some(inferred_ty)
-                    },
-                );
+                    });
 
                 if let Err(error) = specialization_result {
                     specialization_errors.push(BindingError::SpecializationError {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4629,7 +4629,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // tension between type context preferences and argument constraints. If the combined set
         // is unsatisfiable, we will fall back to argument constraints alone (which the current
         // code does via `assignable_to_declared_type`).
-        let preferred_type_mappings = return_with_tcx
+        let mut preferred_type_mappings = return_with_tcx
             .and_then(|(return_ty, tcx)| {
                 if !tcx
                     .filter_union(self.db, |ty| ty.may_prefer_declared_type(self.db))
@@ -4749,10 +4749,11 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         if !assignable_to_declared_type {
             builder = SpecializationBuilder::new(self.db, constraints, self.inferable_typevars);
             specialization_errors.clear();
+            preferred_type_mappings.clear();
 
             self.infer_argument_constraints(
                 &mut builder,
-                &FxHashMap::default(),
+                &preferred_type_mappings,
                 &FxHashSet::default(),
                 &mut specialization_errors,
             );

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -565,6 +565,15 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         self.node.solutions(db, builder)
     }
 
+    pub(crate) fn path_bounds(
+        self,
+        db: &'db dyn Db,
+        builder: &'c ConstraintSetBuilder<'db>,
+    ) -> PathBounds<'db> {
+        self.verify_builder(builder);
+        PathBounds::compute(db, builder, self.node)
+    }
+
     #[expect(dead_code)] // Keep this around for debugging purposes
     pub(crate) fn display(self, db: &'db dyn Db) -> impl Display {
         self.node

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -12,7 +12,7 @@ use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
-    Solutions,
+    PathBounds, Solutions,
 };
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
@@ -26,7 +26,9 @@ use crate::types::typevar::{
     BoundTypeVarIdentity, TypeVarIdentity, TypeVarInstance, walk_type_var_bounds,
 };
 use crate::types::variance::VarianceInferable;
-use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
+use crate::types::visitor::{
+    TypeCollector, TypeVisitor, any_over_type, walk_type_with_recursion_guard,
+};
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, CallableTypes,
     ClassLiteral, FindLegacyTypeVarsVisitor, IntersectionType, KnownClass, KnownInstanceType,
@@ -1787,6 +1789,28 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
     constraints: &'c ConstraintSetBuilder<'db>,
     inferable: InferableTypeVars<'db>,
     types: FxHashMap<BoundTypeVarIdentity<'db>, UnionAccumulator<'db>>,
+    solver_constraint_state: SolverConstraintState<'db, 'c>,
+}
+
+#[derive(Debug)]
+enum SolverConstraintState<'db, 'c> {
+    Pending(Vec<PendingSolverConstraint<'db>>),
+    Enabled(ConstraintSet<'db, 'c>),
+    Unsupported,
+}
+
+enum SolverConstraintKind<'db> {
+    /// A constraint that cannot affect specialization.
+    Irrelevant,
+    Ordinary,
+    Callable(CallableType<'db>),
+    Unsupported,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PendingSolverConstraint<'db> {
+    formal: Type<'db>,
+    actual: Type<'db>,
 }
 
 /// An assignment from a bound type variable to a given type, along with the variance of the outermost
@@ -1804,7 +1828,162 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             constraints,
             inferable,
             types: FxHashMap::default(),
+            solver_constraint_state: SolverConstraintState::Pending(Vec::new()),
         }
+    }
+
+    /// Stage ordinary argument constraints until a supported callable activates solver-backed solving.
+    pub(crate) fn stage_solver_constraint(&mut self, formal: Type<'db>, actual: Type<'db>) {
+        let has_inferable_typevar =
+            self.has_inferable_typevar(formal) || self.has_inferable_typevar(actual);
+        if matches!(
+            &self.solver_constraint_state,
+            SolverConstraintState::Unsupported
+        ) || !has_inferable_typevar
+        {
+            return;
+        }
+
+        match &mut self.solver_constraint_state {
+            SolverConstraintState::Pending(pending) => {
+                pending.push(PendingSolverConstraint { formal, actual });
+            }
+            SolverConstraintState::Enabled(_) => {
+                self.materialize_solver_constraint(formal, actual);
+            }
+            SolverConstraintState::Unsupported => {}
+        }
+    }
+
+    pub(crate) fn mark_solver_constraints_unsupported(&mut self) {
+        self.solver_constraint_state = SolverConstraintState::Unsupported;
+    }
+
+    /// Activate solver-backed constraint solving from a supported callable comparison.
+    ///
+    /// If flushing pending ordinary constraints finds an unsupported comparison involving an
+    /// inferable type variable, return `None`. In that case, the specialization has to be
+    /// built from eager typevar mappings.
+    fn activate_solver_constraints(
+        &mut self,
+        formal: Type<'db>,
+        actual: Type<'db>,
+    ) -> Option<CallableType<'db>> {
+        if matches!(
+            self.solver_constraint_state,
+            SolverConstraintState::Unsupported
+        ) {
+            return None;
+        }
+
+        let actual_callable = match self.solver_constraint_kind(formal, actual) {
+            SolverConstraintKind::Callable(actual_callable) => actual_callable,
+            SolverConstraintKind::Unsupported => {
+                self.solver_constraint_state = SolverConstraintState::Unsupported;
+                return None;
+            }
+            SolverConstraintKind::Irrelevant | SolverConstraintKind::Ordinary => return None,
+        };
+
+        let first_constraint =
+            actual.when_constraint_set_assignable_to(self.db, formal, self.constraints);
+        let pending = match &mut self.solver_constraint_state {
+            SolverConstraintState::Pending(pending) => std::mem::take(pending),
+            SolverConstraintState::Enabled(existing) => {
+                *existing = existing.and(self.db, self.constraints, || first_constraint);
+                return Some(actual_callable);
+            }
+            SolverConstraintState::Unsupported => return None,
+        };
+
+        self.solver_constraint_state = SolverConstraintState::Enabled(first_constraint);
+        for PendingSolverConstraint { formal, actual } in pending {
+            self.materialize_solver_constraint(formal, actual);
+            if matches!(
+                self.solver_constraint_state,
+                SolverConstraintState::Unsupported
+            ) {
+                return None;
+            }
+        }
+
+        Some(actual_callable)
+    }
+
+    /// Accumulate an assignability constraint only for comparisons the solver can represent.
+    fn materialize_solver_constraint(&mut self, formal: Type<'db>, actual: Type<'db>) {
+        match self.solver_constraint_kind(formal, actual) {
+            SolverConstraintKind::Irrelevant => return,
+            SolverConstraintKind::Unsupported => {
+                self.solver_constraint_state = SolverConstraintState::Unsupported;
+                return;
+            }
+            SolverConstraintKind::Ordinary | SolverConstraintKind::Callable(_) => {}
+        }
+
+        let when = actual.when_constraint_set_assignable_to(self.db, formal, self.constraints);
+        if let SolverConstraintState::Enabled(existing) = &mut self.solver_constraint_state {
+            *existing = existing.and(self.db, self.constraints, || when);
+        }
+    }
+
+    pub(crate) fn has_inferable_typevar(&self, ty: Type<'db>) -> bool {
+        any_over_type(self.db, ty, false, |ty| match ty {
+            Type::TypeVar(typevar) => typevar.is_inferable(self.db, self.inferable),
+
+            Type::TypeAlias(alias) => alias.specialization(self.db).is_some_and(|specialization| {
+                specialization
+                    .types(self.db)
+                    .iter()
+                    .any(|ty| self.has_inferable_typevar(*ty))
+            }),
+
+            _ => false,
+        })
+    }
+
+    fn solver_constraint_kind(
+        &self,
+        formal: Type<'db>,
+        actual: Type<'db>,
+    ) -> SolverConstraintKind<'db> {
+        if !self.has_inferable_typevar(formal) && !self.has_inferable_typevar(actual) {
+            return SolverConstraintKind::Irrelevant;
+        }
+
+        let has_unsupported_type = |ty| {
+            any_over_type(self.db, ty, false, |ty| match ty {
+                Type::TypeVar(typevar) => typevar.is_paramspec(self.db),
+                Type::Callable(callable) => !Self::supports_callable(self.db, callable),
+                _ => false,
+            })
+        };
+
+        if has_unsupported_type(formal) || has_unsupported_type(actual) {
+            return SolverConstraintKind::Unsupported;
+        }
+
+        if !matches!(formal, Type::Callable(_)) {
+            return SolverConstraintKind::Ordinary;
+        }
+
+        let Some(callables) = actual.try_upcast_to_callable(self.db) else {
+            return SolverConstraintKind::Unsupported;
+        };
+
+        match callables.as_slice() {
+            [callable] if Self::supports_callable(self.db, *callable) => {
+                SolverConstraintKind::Callable(*callable)
+            }
+            _ => SolverConstraintKind::Unsupported,
+        }
+    }
+
+    fn supports_callable(db: &'db dyn Db, callable: CallableType<'db>) -> bool {
+        matches!(
+            callable.signatures(db).overloads.as_slice(),
+            [signature] if signature.generic_context.is_none() && signature.parameters().is_standard()
+        )
     }
 
     /// Build a specialization, using a caller-provided hook to select the solution for each
@@ -1842,6 +2021,98 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             });
 
         generic_context.specialize_recursive(db, types)
+    }
+
+    pub(crate) fn build_from_solver_constraints(
+        &mut self,
+        generic_context: GenericContext<'db>,
+        preferred_type_mappings: &FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>>,
+        mut choose: impl FnMut(
+            BoundTypeVarInstance<'db>,
+            Option<(Type<'db>, Type<'db>)>,
+        ) -> Option<Type<'db>>,
+    ) -> Option<Specialization<'db>> {
+        let solver_constraints = match &self.solver_constraint_state {
+            SolverConstraintState::Pending(_) | SolverConstraintState::Unsupported => return None,
+            SolverConstraintState::Enabled(solver_constraints) => *solver_constraints,
+        };
+
+        let db = self.db;
+        let solver_constraints =
+            solver_constraints.remove_noninferable(db, self.constraints, self.inferable);
+        let path_bounds = solver_constraints.path_bounds(db, self.constraints);
+
+        // Each BDD path represents one satisfiable way to combine all argument constraints.
+        // For each typevar, solve the path's lower/upper bounds. Prefer a caller-provided type
+        // only if it satisfies those same bounds. Then let `choose` adjust the candidate, again
+        // only if the adjusted type stays within the path bounds.
+        let solutions = path_bounds.solve_with(|typevar, _variance, lower, upper| {
+            let solution = PathBounds::default_solve(db, self.constraints, typevar, lower, upper)?;
+            let is_within_bounds = |ty| {
+                !lower
+                    .when_constraint_set_assignable_to(db, ty, self.constraints)
+                    .is_never_satisfied(db)
+                    && !ty
+                        .when_constraint_set_assignable_to(db, upper, self.constraints)
+                        .is_never_satisfied(db)
+            };
+            let mut choose_within_bounds = |ty| {
+                choose(typevar, Some((ty, ty)))
+                    .filter(|&chosen| is_within_bounds(chosen))
+                    .unwrap_or(ty)
+            };
+
+            if let Some(preferred) = preferred_type_mappings.get(&typevar.identity(db)).copied()
+                && is_within_bounds(preferred)
+                && PathBounds::default_solve(db, self.constraints, typevar, preferred, preferred)
+                    .is_ok()
+            {
+                return Ok(Some(choose_within_bounds(preferred)));
+            }
+
+            Ok(solution.map(choose_within_bounds))
+        });
+
+        // A single call specialization has to summarize all satisfiable paths. If different paths
+        // solve the same type variable differently, keep all alternatives by unioning them.
+        let mut solved: FxHashMap<BoundTypeVarIdentity<'db>, UnionAccumulator<'db>> =
+            FxHashMap::default();
+        match solutions {
+            Solutions::Unsatisfiable => return None,
+            Solutions::Unconstrained => {}
+            Solutions::Constrained(solutions) => {
+                for solution in solutions {
+                    for binding in solution {
+                        let identity = binding.bound_typevar.identity(db);
+                        solved
+                            .entry(identity)
+                            .and_modify(|existing| existing.add(db, binding.solution))
+                            .or_insert_with(|| UnionAccumulator::new(binding.solution));
+                    }
+                }
+            }
+        }
+
+        let types = generic_context
+            .variables_inner(db)
+            .iter()
+            .map(|(identity, variable)| {
+                if let Some(mapped_ty) = solved.get_mut(identity) {
+                    let mapped_ty = mapped_ty.get_or_build(db);
+
+                    return Some(mapped_ty);
+                }
+
+                if let Some(mapped_ty) = self.types.get_mut(identity) {
+                    let mapped_ty = mapped_ty.get_or_build(db);
+                    let chosen = choose(*variable, Some((mapped_ty, mapped_ty)));
+                    return Some(chosen.unwrap_or(mapped_ty));
+                }
+
+                choose(*variable, None)
+            });
+
+        Some(generic_context.specialize_recursive(db, types))
     }
 
     /// Insert a type mapping for a bound typevar.
@@ -2503,6 +2774,17 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
 
             (Type::Callable(formal_callable), _) => {
+                if let Some(actual_callable) = self.activate_solver_constraints(formal, actual) {
+                    let actual_callables = CallableTypes::one(actual_callable);
+                    let _ = self.infer_from_callable_signature(
+                        formal,
+                        formal_callable.signatures(self.db),
+                        &actual_callables,
+                        f,
+                    );
+                    return Ok(());
+                }
+
                 let Some(actual_callables) = actual.try_upcast_to_callable(self.db) else {
                     return Ok(());
                 };


### PR DESCRIPTION
This is an attempt to tackle a few of the issues that surface from https://github.com/astral-sh/ty/issues/2799.

It enables variance-aware constraint solving for typevars inferred from callables if the callables have a "simple shape". If not, it falls back to the existing union-based heuristic for anything that's more complex than that.

"Simple" here basically means callables that are non-generic, non-overloaded and don't use paramspec or `typing.Concatenate`

It looks like this:
Fixes https://github.com/astral-sh/ty/issues/2572
Fixes https://github.com/astral-sh/ty/issues/3203
Fixes https://github.com/astral-sh/ty/issues/3228
Fixes https://github.com/astral-sh/ty/issues/3428
