### PR TITLE
docs: clarify C901 complexity example

### DIFF
--- a/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
+++ b/crates/ruff_linter/src/rules/mccabe/rules/function_is_too_complex.rs
@@ -19,30 +19,38 @@ use crate::checkers::ast::Checker;
 /// Functions with a high complexity are hard to understand and maintain.
 ///
 /// ## Example
+/// Given a maximum complexity of 5, this function is too complex:
+///
 /// ```python
-/// def foo(a, b, c):
-///     if a:
-///         if b:
-///             if c:
-///                 return 1
-///             else:
-///                 return 2
-///         else:
-///             return 3
-///     else:
-///         return 4
+/// def normalize_status(status):
+///     if status == "new":
+///         return "queued"
+///     if status == "queued":
+///         return "running"
+///     if status == "running":
+///         return "done"
+///     if status == "failed":
+///         return "retry"
+///     if status == "cancelled":
+///         return "closed"
+///     return "unknown"
 /// ```
 ///
-/// Use instead:
+/// Use a lookup table to keep the decision table as data instead of branching
+/// control flow:
+///
 /// ```python
-/// def foo(a, b, c):
-///     if not a:
-///         return 4
-///     if not b:
-///         return 3
-///     if not c:
-///         return 2
-///     return 1
+/// STATUS_TRANSITIONS = {
+///     "new": "queued",
+///     "queued": "running",
+///     "running": "done",
+///     "failed": "retry",
+///     "cancelled": "closed",
+/// }
+///
+///
+/// def normalize_status(status):
+///     return STATUS_TRANSITIONS.get(status, "unknown")
 /// ```
 ///
 /// ## Options


### PR DESCRIPTION
## Summary

- clarifies the C901 documentation example so the before/after guidance does not imply that guard clauses necessarily reduce McCabe complexity
- replaces the previous nested-vs-guard-clause example with an example that moves decision-making into a focused helper

Fixes astral-sh/ruff#25028.

## Validation

- `git diff --check`
- sanity-checked the edited docs block with a short Python script

Note: I attempted the repository preflight command `uvx prek run -a`, but this environment does not have the Rust toolchain installed, so the `rustfmt` hook failed before running:

```text
error: Failed to run hook `rustfmt`
  caused by: Run command `run system command` failed
  caused by: No such file or directory (os error 2)
```

This change only updates Rust doc comments for the generated rule documentation.
