### PR TITLE
docs: make RUF032 example self-contained

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/decimal_from_float_literal.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/decimal_from_float_literal.rs
@@ -20,11 +20,15 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// ## Example
 ///
 /// ```python
+/// from decimal import Decimal
+///
 /// num = Decimal(1.2345)
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// from decimal import Decimal
+///
 /// num = Decimal("1.2345")
 /// ```
 ///


### PR DESCRIPTION
## Summary

Makes the RUF032 documentation example self-contained by importing `Decimal` in both the bad and good examples.

Without the import, copying the example as-is does not trigger RUF032 because `Decimal` is unresolved. With the import, the example triggers out of the box.

Closes part of #18972.

## Test plan

- [x] `git diff --check`
- [x] `uvx ruff check --select RUF032 /tmp/ruf032_no_import.py` confirms the old snippet shape reports no diagnostics
- [x] `uvx ruff check --select RUF032 /tmp/ruf032_example.py` confirms the self-contained snippet reports `RUF032`
- [ ] `uvx prek run --files crates/ruff_linter/src/rules/ruff/rules/decimal_from_float_literal.rs` could not complete locally because the `rustfmt` hook is unavailable in this environment (`No such file or directory`)
