### PR TITLE
docs: make RUF026 example self-contained

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs
@@ -41,12 +41,16 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 ///
 /// ## Example
 /// ```python
+/// from collections import defaultdict
+///
 /// defaultdict(default_factory=int)
 /// defaultdict(default_factory=list)
 /// ```
 ///
 /// Use instead:
 /// ```python
+/// from collections import defaultdict
+///
 /// defaultdict(int)
 /// defaultdict(list)
 /// ```


### PR DESCRIPTION
## Summary

Makes the RUF026 documentation example self-contained by importing `defaultdict` in both the bad and good examples.

Without the import, copying the example as-is does not trigger RUF026 because `defaultdict` is unresolved. With the import, the example triggers out of the box.

Closes part of #18972.

## Test plan

- [x] `git diff --check`
- [x] `uvx ruff check --select RUF026 /tmp/ruf026_no_import.py` confirms the old snippet shape reports no diagnostics
- [x] `uvx ruff check --select RUF026 /tmp/ruf026_example.py` confirms the self-contained snippet reports `RUF026`
- [ ] `uvx prek run --files crates/ruff_linter/src/rules/ruff/rules/default_factory_kwarg.rs` could not complete locally because the `rustfmt` hook is unavailable in this environment (`No such file or directory`)
