### PR TITLE
Fix false positives in PLR1733 and PLR1736 (else clause and shadowed loop variables)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
@@ -62,3 +62,11 @@ def for_else_no_false_positive(result: dict[str, float]) -> dict[str, float]:
             if result[res_glob] <= 0:  # okay, res_glob from loop may be unbound
                 result.pop(res_glob)
     return result
+
+
+def shadowed_loop_variable(d: dict):
+    for k, v in d.items():
+        for k in d:  # shadows outer `k`
+            print(d[k])  # OK, not the same `k`
+        for v in d:  # shadows outer `v`
+            print(d[k])  # OK, not the same `v`

--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_list_index_lookup.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_list_index_lookup.py
@@ -83,3 +83,18 @@ def nested_index_lookup():
     column_names = ["a", "b"]
     for index, column_name in enumerate(column_names):
         _ = data[column_names[index]]  # PLR1736
+
+
+def for_else_no_false_positive(some_list):
+    for index, letter in enumerate(some_list):
+        ...
+    else:
+        print(some_list[index])  # OK, index may be unbound if loop never entered
+
+
+def shadowed_loop_variable():
+    for index, letter in enumerate(letters):
+        for index in letters:  # shadows outer `index`
+            print(letters[index])  # OK, not the same `index`
+        for letter in letters:  # shadows outer `letter`
+            print(letters[index])  # OK, not the same `letter`

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -137,6 +137,13 @@ impl Visitor<'_> for SequenceIndexVisitor<'_> {
             Stmt::Delete(ast::StmtDelete { targets, .. }) => {
                 self.modified = targets.iter().any(|target| self.is_assignment(target));
             }
+            Stmt::For(ast::StmtFor { target, .. }) => {
+                if self.is_assignment(target) {
+                    self.modified = true;
+                } else {
+                    visitor::walk_stmt(self, stmt);
+                }
+            }
             _ => visitor::walk_stmt(self, stmt),
         }
     }

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
@@ -57,7 +57,6 @@ pub(crate) fn unnecessary_list_index_lookup(checker: &Checker, stmt_for: &StmtFo
     let ranges = {
         let mut visitor = SequenceIndexVisitor::new(&sequence.id, &index_name.id, &value_name.id);
         visitor.visit_body(&stmt_for.body);
-        visitor.visit_body(&stmt_for.orelse);
         visitor.into_accesses()
     };
 


### PR DESCRIPTION
`PLR1736` incorrectly visited the `else` clause of a `for` loop, flagging `sequence[index]` accesses there even though `index` may be unbound if the iterable is empty. This PR removes that `visit_body` call so the `else` clause is no longer checked. It also extends `SequenceIndexVisitor` to treat a nested `for` loop whose target shadows the tracked index or value variable as a modification, stopping false-positive diagnostics in both `PLR1733` and `PLR1736`. To verify, run `cargo nextest run -p ruff_linter -- pylint::tests::PLR1733 pylint::tests::PLR1736` and confirm the new `for_else_no_false_positive` and `shadowed_loop_variable` test cases emit no diagnostics.

Fixes #25182