### PR TITLE
[pylint] Fix PLW0108 false positive for module-scope forward references

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
@@ -61,3 +61,10 @@ _ = lambda *args: f(*args, y=x)
 # https://github.com/astral-sh/ruff/issues/18675
 _ = lambda x: (string := str)(x)
 _ = lambda x: ((x := 1) and str)(x)
+
+# https://github.com/astral-sh/ruff/issues/24704
+# Forward reference: `forward_ref_fn` is defined after the lambda, so inlining would cause a NameError.
+x = {"a": lambda y: forward_ref_fn(y)}
+
+def forward_ref_fn(y):
+    pass

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
@@ -1,6 +1,7 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr, ExprLambda, Parameter, ParameterWithDefault, visitor};
+use ruff_python_semantic::ScopeKind;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -215,6 +216,14 @@ pub(crate) fn unnecessary_lambda(checker: &Checker, lambda: &ExprLambda) {
         if let Some(binding_id) = checker.semantic().resolve_name(name) {
             let binding = checker.semantic().binding(binding_id);
             if checker.semantic().is_current_scope(binding.scope) {
+                return;
+            }
+            // If the callable is defined in the module scope after the lambda, replacing
+            // the lambda with the bare name would cause a `NameError` at evaluation time.
+            let binding_scope = &checker.semantic().scopes[binding.scope];
+            if matches!(binding_scope.kind, ScopeKind::Module)
+                && binding.range.start() > lambda.range().start()
+            {
                 return;
             }
         }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
@@ -171,6 +171,8 @@ help: Inline function call
    - _ = lambda x: (string := str)(x)
 62 + _ = (string := str)
 63 | _ = lambda x: ((x := 1) and str)(x)
+64 |
+65 | # https://github.com/astral-sh/ruff/issues/24704
 note: This is an unsafe fix and may change runtime behavior
 
 PLW0108 Lambda may be unnecessary; consider inlining inner function
@@ -180,5 +182,7 @@ PLW0108 Lambda may be unnecessary; consider inlining inner function
 62 | _ = lambda x: (string := str)(x)
 63 | _ = lambda x: ((x := 1) and str)(x)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+64 |
+65 | # https://github.com/astral-sh/ruff/issues/24704
    |
 help: Inline function call


### PR DESCRIPTION
PLW0108 was incorrectly flagging lambdas that wrap a callable defined later in the same module. For example, `x = {"a": lambda y: f(y)}` followed by `def f(y): pass` would trigger the lint, but inlining to `x = {"a": f}` would raise a `NameError` since `f` isn't defined yet at that point.

The fix checks whether the resolved callable binding lives in the module scope and is defined after the lambda. If so, the lambda is considered necessary and the diagnostic is suppressed.

Fixes #24704