### PR TITLE
[pylint] Fix PLW0108 false positive for forward-referenced callables

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
@@ -61,3 +61,10 @@ _ = lambda *args: f(*args, y=x)
 # https://github.com/astral-sh/ruff/issues/18675
 _ = lambda x: (string := str)(x)
 _ = lambda x: ((x := 1) and str)(x)
+
+# https://github.com/astral-sh/ruff/issues/24704
+# Forward reference: `forward_ref_fn` is defined after the lambda, so inlining would cause a NameError.
+x = {"a": lambda y: forward_ref_fn(y)}
+
+def forward_ref_fn(y):
+    pass

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
@@ -1,6 +1,7 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr, ExprLambda, Parameter, ParameterWithDefault, visitor};
+use ruff_python_semantic::ScopeKind;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -215,6 +216,14 @@ pub(crate) fn unnecessary_lambda(checker: &Checker, lambda: &ExprLambda) {
         if let Some(binding_id) = checker.semantic().resolve_name(name) {
             let binding = checker.semantic().binding(binding_id);
             if checker.semantic().is_current_scope(binding.scope) {
+                return;
+            }
+            // If the callable is defined in the module scope after the lambda, replacing
+            // the lambda with the bare name would cause a `NameError` at evaluation time.
+            let binding_scope = &checker.semantic().scopes[binding.scope];
+            if matches!(binding_scope.kind, ScopeKind::Module)
+                && binding.range.start() > lambda.range().start()
+            {
                 return;
             }
         }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
@@ -171,6 +171,8 @@ help: Inline function call
    - _ = lambda x: (string := str)(x)
 62 + _ = (string := str)
 63 | _ = lambda x: ((x := 1) and str)(x)
+64 |
+65 | # https://github.com/astral-sh/ruff/issues/24704
 note: This is an unsafe fix and may change runtime behavior
 
 PLW0108 Lambda may be unnecessary; consider inlining inner function
@@ -180,5 +182,7 @@ PLW0108 Lambda may be unnecessary; consider inlining inner function
 62 | _ = lambda x: (string := str)(x)
 63 | _ = lambda x: ((x := 1) and str)(x)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+64 |
+65 | # https://github.com/astral-sh/ruff/issues/24704
    |
 help: Inline function call


### PR DESCRIPTION
Fixes a false positive in the PLW0108 (`unnecessary-lambda`) rule where `lambda y: f(y)` was flagged as unnecessary even when `f` is defined later in the module scope. Replacing the lambda with `f` in that case would raise a `NameError` at runtime.

**Root cause:** The check in `unnecessary_lambda.rs` only skipped lambdas where the callable name matched a lambda parameter. It never verified whether the binding for the callable was a forward reference — i.e., defined *after* the lambda in module scope.

**Fix:** After resolving the callable's binding, added a guard: if the binding lives in module scope and its text range starts *after* the lambda's range, skip the diagnostic. A matching test case and snapshot update are included.

Closes #24704


- Added a new test case in `crates/ruff_linter/src/resources/test/fixtures/pylint/unnecessary_lambda.py` covering the forward-reference scenario.
- Ran the test suite for the `ruff_linter` crate and verified the snapshot is updated correctly.