### PR TITLE
Fix PLR6301 false positive when `override` is imported under `TYPE_CHECKING`

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/no_self_use.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/no_self_use.py
@@ -152,3 +152,24 @@ class TPerson:
         msg = t"{x}"
         raise NotImplementedError(msg)
 
+
+# See: https://github.com/astral-sh/ruff/issues/24713
+# `override` imported under TYPE_CHECKING with a runtime no-op fallback.
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import override as override
+else:
+    override = lambda f: f  # noqa: E731
+
+
+class BaseClass:
+    def method(self):
+        ...
+
+
+class DerivedClass(BaseClass):
+    @override
+    def method(self):  # OK - decorated with override (TYPE_CHECKING import)
+        ...
+

--- a/crates/ruff_python_semantic/src/analyze/visibility.rs
+++ b/crates/ruff_python_semantic/src/analyze/visibility.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::{self as ast, Decorator, Expr};
 use ruff_python_ast::helpers::map_callable;
 use ruff_python_ast::name::{QualifiedName, UnqualifiedName};
 
+use crate::binding::{BindingKind, FromImport};
 use crate::model::SemanticModel;
 use crate::{Module, ModuleSource};
 
@@ -35,9 +36,40 @@ pub fn is_overload(decorator_list: &[Decorator], semantic: &SemanticModel) -> bo
 
 /// Returns `true` if a function definition is an `@override` (PEP 698).
 pub fn is_override(decorator_list: &[Decorator], semantic: &SemanticModel) -> bool {
-    decorator_list
-        .iter()
-        .any(|decorator| semantic.match_typing_expr(&decorator.expression, "override"))
+    decorator_list.iter().any(|decorator| {
+        if semantic.match_typing_expr(&decorator.expression, "override") {
+            return true;
+        }
+        // Handle the pattern where `override` is imported under `TYPE_CHECKING` with
+        // a runtime no-op fallback, e.g.:
+        //
+        // ```python
+        // if TYPE_CHECKING:
+        //     from typing_extensions import override
+        // else:
+        //     override = lambda f: f
+        // ```
+        //
+        // In this case, `match_typing_expr` resolves the decorator to the runtime
+        // binding (the lambda), so we must also check whether any binding for the
+        // same name in the global scope is a typing-only import of `override`.
+        if let Expr::Name(name) = &decorator.expression {
+            return semantic
+                .global_scope()
+                .get_all(&name.id)
+                .any(|binding_id| {
+                    let binding = semantic.binding(binding_id);
+                    binding.context.is_typing()
+                        && matches!(
+                            &binding.kind,
+                            BindingKind::FromImport(FromImport { qualified_name })
+                                if semantic
+                                    .match_typing_qualified_name(qualified_name, "override")
+                        )
+                });
+        }
+        false
+    })
 }
 
 /// Returns `true` if a function definition is an abstract method based on its decorators.


### PR DESCRIPTION
Fixes #24713.

When `override` is imported inside an `if TYPE_CHECKING:` block with a runtime no-op fallback, PLR6301 (`no-self-use`) incorrectly fires on methods decorated with `@override`.

**Repro pattern:**

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from typing_extensions import override
else:
    override = lambda f: f

class Base:
    def method(self): ...

class Derived(Base):
    @override
    def method(self):  # PLR6301 falsely reported here
        ...
```

**Root cause:** `match_typing_expr` resolves the `override` name to the runtime binding (the lambda), so `is_override` returns `False`. The fix adds a secondary check: if any binding for the decorator name in the global scope is a typing-only import of `override`, we treat it as `@override`.


- `crates/ruff_python_semantic/src/analyze/visibility.rs`: Extended `is_override` to also detect `override` imported under `TYPE_CHECKING`.
- `crates/ruff_linter/resources/test/fixtures/pylint/no_self_use.py`: Added regression test for the `TYPE_CHECKING` import pattern.


- [x] `cargo nextest run -p ruff_linter -- no_self` passes (1 test, 0 failures)
- [x] Snapshot unchanged — the new `@override`-decorated method is correctly not flagged

---