### PR TITLE
Fix PLR1733 and PLR1736 loop false positives

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
@@ -62,3 +62,17 @@ def for_else_no_false_positive(result: dict[str, float]) -> dict[str, float]:
             if result[res_glob] <= 0:  # okay, res_glob from loop may be unbound
                 result.pop(res_glob)
     return result
+
+
+def no_false_positive_after_key_shadowing(result: dict[str, float]) -> None:
+    for res_glob, res_priority in result.items():
+        for res_glob in result.keys():
+            print(result[res_glob])  # OK, res_glob from items loop is shadowed
+        print(result[res_glob])  # OK, res_glob from items loop remains shadowed
+
+
+def no_false_positive_after_value_shadowing(result: dict[str, float]) -> None:
+    for res_glob, res_priority in result.items():
+        for res_priority in result.values():
+            print(result[res_glob])  # OK, res_priority from items loop is shadowed
+        print(result[res_glob])  # OK, res_priority from items loop remains shadowed

--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_list_index_lookup.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_list_index_lookup.py
@@ -83,3 +83,24 @@ def nested_index_lookup():
     column_names = ["a", "b"]
     for index, column_name in enumerate(column_names):
         _ = data[column_names[index]]  # PLR1736
+
+
+def no_false_positive_in_loop_else():
+    for index, letter in enumerate(letters):
+        pass
+    else:
+        print(letters[index])  # OK, index may be unbound
+
+
+def no_false_positive_after_index_shadowing():
+    for index, letter in enumerate(letters):
+        for index in range(3):
+            print(letters[index])  # OK, index from enumerate loop is shadowed
+        print(letters[index])  # OK, index from enumerate loop remains shadowed
+
+
+def no_false_positive_after_value_shadowing():
+    for index, letter in enumerate(letters):
+        for letter in range(3):
+            print(letters[index])  # OK, letter from enumerate loop is shadowed
+        print(letters[index])  # OK, letter from enumerate loop remains shadowed

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -109,6 +109,9 @@ impl SequenceIndexVisitor<'_> {
                 }
                 false
             }
+            Expr::List(ast::ExprList { elts, .. }) | Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+                elts.iter().any(|expr| self.is_assignment(expr))
+            }
             _ => false,
         }
     }
@@ -136,6 +139,9 @@ impl Visitor<'_> for SequenceIndexVisitor<'_> {
             }
             Stmt::Delete(ast::StmtDelete { targets, .. }) => {
                 self.modified = targets.iter().any(|target| self.is_assignment(target));
+            }
+            Stmt::For(ast::StmtFor { target, .. }) if self.is_assignment(target) => {
+                self.modified = true;
             }
             _ => visitor::walk_stmt(self, stmt),
         }

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
@@ -57,7 +57,6 @@ pub(crate) fn unnecessary_list_index_lookup(checker: &Checker, stmt_for: &StmtFo
     let ranges = {
         let mut visitor = SequenceIndexVisitor::new(&sequence.id, &index_name.id, &value_name.id);
         visitor.visit_body(&stmt_for.body);
-        visitor.visit_body(&stmt_for.orelse);
         visitor.into_accesses()
     };
 

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1736_unnecessary_list_index_lookup.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1736_unnecessary_list_index_lookup.py.snap
@@ -225,3 +225,6 @@ help: Use the loop variable directly
 84 |     for index, column_name in enumerate(column_names):
    -         _ = data[column_names[index]]  # PLR1736
 85 +         _ = data[column_name]  # PLR1736
+86 |
+87 |
+88 | def no_false_positive_in_loop_else():


### PR DESCRIPTION
## Summary
- skip PLR1736 diagnostics in `for`/`else` blocks, matching the existing PLR1733 behavior
- treat nested `for` targets that rebind the index or value variable as modifications, avoiding unsafe PLR1733/PLR1736 replacements after shadowing
- add regression coverage for loop-else and shadowed loop variables

Closes #25182.

## Test Plan
- `CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_DEBUG=line-tables-only INSTA_UPDATE=always INSTA_FORCE_PASS=1 cargo test -p ruff_linter rules::pylint::tests::rules -- PLR1733_unnecessary_dict_index_lookup.py PLR1736_unnecessary_list_index_lookup.py`
- `cargo fmt --check`
- `uvx prek run --files crates/ruff_linter/src/rules/pylint/helpers.rs crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_list_index_lookup.py crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLR1736_unnecessary_list_index_lookup.py.snap`
