### PR TITLE
Add RUF028 class signature regression test

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF028.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF028.py
@@ -101,3 +101,15 @@ import pytest
 )  # fmt: skip
 def test_eval(test_input, expected):
     assert eval(test_input) == expected
+
+
+class FmtOffInClassSignature(
+    # fmt: off
+    dict[str, str],
+):
+    pass
+
+
+class FmtOffBeforeClassBody:
+    # fmt: off
+    key = "value"

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF028_RUF028.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF028_RUF028.py.snap
@@ -215,3 +215,22 @@ help: Remove this comment
 65 |
 66 | # all of these should be fine
 note: This is an unsafe fix and may change runtime behavior
+
+RUF028 [*] This suppression comment is invalid because it cannot be in an expression, pattern, argument list, or other non-statement
+   --> RUF028.py:107:5
+    |
+106 | class FmtOffInClassSignature(
+107 |     # fmt: off
+    |     ^^^^^^^^^^
+108 |     dict[str, str],
+109 | ):
+    |
+help: Remove this comment
+104 |
+105 |
+106 | class FmtOffInClassSignature(
+    -     # fmt: off
+107 |     dict[str, str],
+108 | ):
+109 |     pass
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

- add a regression fixture for `fmt: off` comments inside class signatures
- keep a valid `fmt: off` class-body comment fixture to cover the statement-boundary case

Closes #20425.

## Test Plan

- `cargo test -p ruff_linter --lib rule_invalidformattersuppressioncomment_path_new_ruf028_py_expects --features test-rules -- --nocapture`
