### PR TITLE
Handle FAST003 aliases from Annotated type aliases

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -129,6 +129,17 @@ async def read_thing(*, author: str, title: str):
 async def read_thing(*, author: Annotated[str, Path(alias="name")], title: str):
     return {"author": author, "title": title}
 
+ExampleIdPathParameter = Annotated[str, Path(alias="exampleId")]
+MultiMetadataPathParameter = Annotated[str, "metadata", Path(alias="multiMetaId")]
+
+@app.get("/examples/{exampleId}")
+async def read_example_alias(example_id: ExampleIdPathParameter):
+    return {"example_id": example_id}
+
+@app.get("/examples/{multiMetaId}")
+async def read_example_multi_metadata_alias(example_id: MultiMetadataPathParameter):
+    return {"example_id": example_id}
+
 
 # Ignored
 @app.get("/things/{thing-id}")

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -449,48 +449,80 @@ fn is_pydantic_base_model(expr: &Expr, semantic: &SemanticModel) -> bool {
 
 /// Extract the expected in-route name for a given parameter, if it has an alias.
 /// For example, given `document_id: Annotated[str, Path(alias="documentId")]`, returns `"documentId"`.
-fn parameter_alias<'a>(parameter: &'a Parameter, semantic: &SemanticModel) -> Option<&'a str> {
-    let Some(annotation) = &parameter.annotation else {
+fn parameter_alias<'a>(parameter: &'a Parameter, semantic: &SemanticModel<'a>) -> Option<&'a str> {
+    annotation_alias(parameter.annotation.as_deref()?, semantic, 0)
+}
+
+fn annotation_alias<'a>(
+    annotation: &'a Expr,
+    semantic: &SemanticModel<'a>,
+    depth: u8,
+) -> Option<&'a str> {
+    if depth > 5 {
+        return None;
+    }
+
+    if let Expr::Subscript(subscript) = annotation {
+        return annotated_path_alias(subscript, semantic);
+    }
+
+    let Expr::Name(name) = annotation else {
         return None;
     };
 
-    let Expr::Subscript(subscript) = annotation.as_ref() else {
+    let binding = semantic
+        .only_binding(name)
+        .or_else(|| semantic.lookup_symbol(name.id.as_str()))
+        .map(|id| semantic.binding(id))?;
+    if !matches!(
+        binding.kind,
+        BindingKind::Assignment | BindingKind::Annotation
+    ) {
         return None;
-    };
+    }
 
-    let Expr::Tuple(tuple) = subscript.slice.as_ref() else {
-        return None;
-    };
+    let statement = binding.source.map(|node_id| semantic.statement(node_id))?;
+    if let Some(assign) = statement.as_assign_stmt() {
+        annotation_alias(&assign.value, semantic, depth + 1)
+    } else if let Some(ann_assign) = statement.as_ann_assign_stmt() {
+        annotation_alias(ann_assign.value.as_deref()?, semantic, depth + 1)
+    } else {
+        None
+    }
+}
 
-    let Some(Expr::Call(path)) = tuple.elts.get(1) else {
-        return None;
-    };
-
-    // Find the `alias` keyword argument.
-    let alias = path
-        .arguments
-        .find_keyword("alias")
-        .map(|alias| &alias.value)?;
-
-    // Ensure that it's a literal string.
-    let Expr::StringLiteral(alias) = alias else {
-        return None;
-    };
-
+fn annotated_path_alias<'a>(
+    subscript: &'a ExprSubscript,
+    semantic: &SemanticModel,
+) -> Option<&'a str> {
     // Verify that the subscript was a `typing.Annotated`.
     if !semantic.match_typing_expr(&subscript.value, "Annotated") {
         return None;
     }
 
-    // Verify that the call was a `fastapi.Path`.
-    if !semantic
-        .resolve_qualified_name(&path.func)
-        .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["fastapi", "Path"]))
-    {
+    let Expr::Tuple(tuple) = subscript.slice.as_ref() else {
         return None;
-    }
+    };
 
-    Some(alias.value.to_str())
+    tuple.elts.iter().skip(1).find_map(|metadata| {
+        let path = metadata.as_call_expr()?;
+
+        // Verify that the call was a `fastapi.Path`.
+        if !semantic
+            .resolve_qualified_name(&path.func)
+            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["fastapi", "Path"]))
+        {
+            return None;
+        }
+
+        let alias = path
+            .arguments
+            .find_keyword("alias")
+            .map(|alias| &alias.value)?;
+        alias
+            .as_string_literal_expr()
+            .map(|alias| alias.value.to_str())
+    })
 }
 
 /// An iterator to extract parameters from FastAPI route paths.

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__deferred_annotations_diff_fast-api-unused-path-parameter_FAST003.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__deferred_annotations_diff_fast-api-unused-path-parameter_FAST003.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/fastapi/mod.rs
+assertion_line: 41
 ---
 --- Linter settings ---
 -linter.unresolved_target_version = 3.13
@@ -11,142 +12,142 @@ Added: 0
 
 --- Removed ---
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `single` signature
-   --> FAST003.py:158:19
+   --> FAST003.py:169:19
     |
-157 | ### Errors
-158 | @app.get("/things/{thing_id}")
+168 | ### Errors
+169 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-159 | async def single(other: Annotated[str, Depends(something_else)]): ...
-160 | @app.get("/things/{thing_id}")
+170 | async def single(other: Annotated[str, Depends(something_else)]): ...
+171 | @app.get("/things/{thing_id}")
     |
 help: Add `thing_id` to function signature
-156 |
-157 | ### Errors
-158 | @app.get("/things/{thing_id}")
+167 |
+168 | ### Errors
+169 | @app.get("/things/{thing_id}")
     - async def single(other: Annotated[str, Depends(something_else)]): ...
-159 + async def single(other: Annotated[str, Depends(something_else)], thing_id): ...
-160 | @app.get("/things/{thing_id}")
-161 | async def default(other: str = Depends(something_else)): ...
-162 |
+170 + async def single(other: Annotated[str, Depends(something_else)], thing_id): ...
+171 | @app.get("/things/{thing_id}")
+172 | async def default(other: str = Depends(something_else)): ...
+173 |
 note: This is an unsafe fix and may change runtime behavior
 
 
 FAST003 [*] Parameter `id` appears in route path, but not in `get_id_pydantic_full` signature
-   --> FAST003.py:197:12
+   --> FAST003.py:208:12
     |
-196 | # Errors
-197 | @app.get("/{id}")
+207 | # Errors
+208 | @app.get("/{id}")
     |            ^^^^
-198 | async def get_id_pydantic_full(
-199 |     params: Annotated[PydanticParams, Depends(PydanticParams)],
+209 | async def get_id_pydantic_full(
+210 |     params: Annotated[PydanticParams, Depends(PydanticParams)],
     |
 help: Add `id` to function signature
-196 | # Errors
-197 | @app.get("/{id}")
-198 | async def get_id_pydantic_full(
+207 | # Errors
+208 | @app.get("/{id}")
+209 | async def get_id_pydantic_full(
     -     params: Annotated[PydanticParams, Depends(PydanticParams)],
-199 +     params: Annotated[PydanticParams, Depends(PydanticParams)], id,
-200 | ): ...
-201 | @app.get("/{id}")
-202 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
+210 +     params: Annotated[PydanticParams, Depends(PydanticParams)], id,
+211 | ): ...
+212 | @app.get("/{id}")
+213 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
 note: This is an unsafe fix and may change runtime behavior
 
 
 FAST003 [*] Parameter `id` appears in route path, but not in `get_id_pydantic_short` signature
-   --> FAST003.py:201:12
+   --> FAST003.py:212:12
     |
-199 |     params: Annotated[PydanticParams, Depends(PydanticParams)],
-200 | ): ...
-201 | @app.get("/{id}")
+210 |     params: Annotated[PydanticParams, Depends(PydanticParams)],
+211 | ): ...
+212 | @app.get("/{id}")
     |            ^^^^
-202 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
-203 | @app.get("/{id}")
+213 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
+214 | @app.get("/{id}")
     |
 help: Add `id` to function signature
-199 |     params: Annotated[PydanticParams, Depends(PydanticParams)],
-200 | ): ...
-201 | @app.get("/{id}")
+210 |     params: Annotated[PydanticParams, Depends(PydanticParams)],
+211 | ): ...
+212 | @app.get("/{id}")
     - async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
-202 + async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()], id): ...
-203 | @app.get("/{id}")
-204 | async def get_id_init_not_annotated(params = Depends(InitParams)): ...
-205 |
+213 + async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()], id): ...
+214 | @app.get("/{id}")
+215 | async def get_id_init_not_annotated(params = Depends(InitParams)): ...
+216 |
 note: This is an unsafe fix and may change runtime behavior
 
 
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_callable_dep` signature
-   --> FAST003.py:314:19
+   --> FAST003.py:325:19
     |
-314 | @app.get("/things/{thing_id}")
+325 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-315 | async def read_thing_callable_dep(query: Annotated[str, Depends(CallableQuery)]): ...
+326 | async def read_thing_callable_dep(query: Annotated[str, Depends(CallableQuery)]): ...
     |
 help: Add `thing_id` to function signature
-312 |
-313 |
-314 | @app.get("/things/{thing_id}")
+323 |
+324 |
+325 | @app.get("/things/{thing_id}")
     - async def read_thing_callable_dep(query: Annotated[str, Depends(CallableQuery)]): ...
-315 + async def read_thing_callable_dep(query: Annotated[str, Depends(CallableQuery)], thing_id): ...
-316 |
-317 |
-318 | # OK: `Depends(CallableQuery())` passes an instance, so FastAPI uses `__call__`,
+326 + async def read_thing_callable_dep(query: Annotated[str, Depends(CallableQuery)], thing_id): ...
+327 |
+328 |
+329 | # OK: `Depends(CallableQuery())` passes an instance, so FastAPI uses `__call__`,
 note: This is an unsafe fix and may change runtime behavior
 
 
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_callable_dep_missing` signature
-   --> FAST003.py:345:19
+   --> FAST003.py:356:19
     |
-345 | @app.get("/things/{thing_id}")
+356 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-346 | async def read_thing_callable_dep_missing(query: Annotated[str, Depends(CallableQueryOther)]): ...
+357 | async def read_thing_callable_dep_missing(query: Annotated[str, Depends(CallableQueryOther)]): ...
     |
 help: Add `thing_id` to function signature
-343 |
-344 |
-345 | @app.get("/things/{thing_id}")
+354 |
+355 |
+356 | @app.get("/things/{thing_id}")
     - async def read_thing_callable_dep_missing(query: Annotated[str, Depends(CallableQueryOther)]): ...
-346 + async def read_thing_callable_dep_missing(query: Annotated[str, Depends(CallableQueryOther)], thing_id): ...
-347 |
-348 |
-349 | # Error: `Depends(InitAndCallQuery())` passes an instance, so FastAPI uses
+357 + async def read_thing_callable_dep_missing(query: Annotated[str, Depends(CallableQueryOther)], thing_id): ...
+358 |
+359 |
+360 | # Error: `Depends(InitAndCallQuery())` passes an instance, so FastAPI uses
 note: This is an unsafe fix and may change runtime behavior
 
 
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_init_and_call_instance` signature
-   --> FAST003.py:351:19
+   --> FAST003.py:362:19
     |
-349 | # Error: `Depends(InitAndCallQuery())` passes an instance, so FastAPI uses
-350 | # `__call__`, which has `other` — not `thing_id`.
-351 | @app.get("/things/{thing_id}")
+360 | # Error: `Depends(InitAndCallQuery())` passes an instance, so FastAPI uses
+361 | # `__call__`, which has `other` — not `thing_id`.
+362 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-352 | async def read_thing_init_and_call_instance(query: Annotated[str, Depends(InitAndCallQuery())]): ...
+363 | async def read_thing_init_and_call_instance(query: Annotated[str, Depends(InitAndCallQuery())]): ...
     |
 help: Add `thing_id` to function signature
-349 | # Error: `Depends(InitAndCallQuery())` passes an instance, so FastAPI uses
-350 | # `__call__`, which has `other` — not `thing_id`.
-351 | @app.get("/things/{thing_id}")
+360 | # Error: `Depends(InitAndCallQuery())` passes an instance, so FastAPI uses
+361 | # `__call__`, which has `other` — not `thing_id`.
+362 | @app.get("/things/{thing_id}")
     - async def read_thing_init_and_call_instance(query: Annotated[str, Depends(InitAndCallQuery())]): ...
-352 + async def read_thing_init_and_call_instance(query: Annotated[str, Depends(InitAndCallQuery())], thing_id): ...
-353 |
-354 |
-355 | # Error: class with no __init__ and no __call__; FastAPI calls __init__ which
+363 + async def read_thing_init_and_call_instance(query: Annotated[str, Depends(InitAndCallQuery())], thing_id): ...
+364 |
+365 |
+366 | # Error: class with no __init__ and no __call__; FastAPI calls __init__ which
 note: This is an unsafe fix and may change runtime behavior
 
 
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_empty_class_dep` signature
-   --> FAST003.py:361:19
+   --> FAST003.py:372:19
     |
-361 | @app.get("/things/{thing_id}")
+372 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-362 | async def read_thing_empty_class_dep(query: Annotated[str, Depends(EmptyClass)]): ...
+373 | async def read_thing_empty_class_dep(query: Annotated[str, Depends(EmptyClass)]): ...
     |
 help: Add `thing_id` to function signature
-359 |
-360 |
-361 | @app.get("/things/{thing_id}")
+370 |
+371 |
+372 | @app.get("/things/{thing_id}")
     - async def read_thing_empty_class_dep(query: Annotated[str, Depends(EmptyClass)]): ...
-362 + async def read_thing_empty_class_dep(query: Annotated[str, Depends(EmptyClass)], thing_id): ...
-363 |
-364 |
-365 | # Same instance patterns as default values (not Annotated).
+373 + async def read_thing_empty_class_dep(query: Annotated[str, Depends(EmptyClass)], thing_id): ...
+374 |
+375 |
+376 | # Same instance patterns as default values (not Annotated).
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/fastapi/mod.rs
+assertion_line: 29
 ---
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing` signature
   --> FAST003.py:9:19
@@ -325,212 +326,212 @@ help: Add `name` to function signature
 note: This is an unsafe fix and may change runtime behavior
 
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `default` signature
-   --> FAST003.py:160:19
+   --> FAST003.py:171:19
     |
-158 | @app.get("/things/{thing_id}")
-159 | async def single(other: Annotated[str, Depends(something_else)]): ...
-160 | @app.get("/things/{thing_id}")
+169 | @app.get("/things/{thing_id}")
+170 | async def single(other: Annotated[str, Depends(something_else)]): ...
+171 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-161 | async def default(other: str = Depends(something_else)): ...
+172 | async def default(other: str = Depends(something_else)): ...
     |
 help: Add `thing_id` to function signature
-158 | @app.get("/things/{thing_id}")
-159 | async def single(other: Annotated[str, Depends(something_else)]): ...
-160 | @app.get("/things/{thing_id}")
+169 | @app.get("/things/{thing_id}")
+170 | async def single(other: Annotated[str, Depends(something_else)]): ...
+171 | @app.get("/things/{thing_id}")
     - async def default(other: str = Depends(something_else)): ...
-161 + async def default(thing_id, other: str = Depends(something_else)): ...
-162 |
-163 |
-164 | ### No errors
+172 + async def default(thing_id, other: str = Depends(something_else)): ...
+173 |
+174 |
+175 | ### No errors
 note: This is an unsafe fix and may change runtime behavior
 
 FAST003 [*] Parameter `id` appears in route path, but not in `get_id_init_not_annotated` signature
-   --> FAST003.py:203:12
+   --> FAST003.py:214:12
     |
-201 | @app.get("/{id}")
-202 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
-203 | @app.get("/{id}")
+212 | @app.get("/{id}")
+213 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
+214 | @app.get("/{id}")
     |            ^^^^
-204 | async def get_id_init_not_annotated(params = Depends(InitParams)): ...
+215 | async def get_id_init_not_annotated(params = Depends(InitParams)): ...
     |
 help: Add `id` to function signature
-201 | @app.get("/{id}")
-202 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
-203 | @app.get("/{id}")
+212 | @app.get("/{id}")
+213 | async def get_id_pydantic_short(params: Annotated[PydanticParams, Depends()]): ...
+214 | @app.get("/{id}")
     - async def get_id_init_not_annotated(params = Depends(InitParams)): ...
-204 + async def get_id_init_not_annotated(id, params = Depends(InitParams)): ...
-205 |
-206 |
-207 | # No errors
+215 + async def get_id_init_not_annotated(id, params = Depends(InitParams)): ...
+216 |
+217 |
+218 | # No errors
 note: This is an unsafe fix and may change runtime behavior
 
 FAST003 Parameter `import` appears in route path, but not in `get_import` signature
-   --> FAST003.py:266:20
+   --> FAST003.py:277:20
     |
-265 | # https://github.com/astral-sh/ruff/issues/20941
-266 | @app.get("/imports/{import}")
+276 | # https://github.com/astral-sh/ruff/issues/20941
+277 | @app.get("/imports/{import}")
     |                    ^^^^^^^^
-267 | async def get_import():
-268 |     ...
+278 | async def get_import():
+279 |     ...
     |
 help: Add `import` to function signature
 
 FAST003 Parameter `__debug__` appears in route path, but not in `get_debug` signature
-   --> FAST003.py:270:18
+   --> FAST003.py:281:18
     |
-268 |     ...
-269 |
-270 | @app.get("/debug/{__debug__}")
+279 |     ...
+280 |
+281 | @app.get("/debug/{__debug__}")
     |                  ^^^^^^^^^^^
-271 | async def get_debug():
-272 |     ...
+282 | async def get_debug():
+283 |     ...
     |
 help: Add `__debug__` to function signature
 
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_vararg` signature
-   --> FAST003.py:278:19
+   --> FAST003.py:289:19
     |
-277 | # Errors: vararg-only and kwarg-only functions
-278 | @app.get("/things/{thing_id}")
+288 | # Errors: vararg-only and kwarg-only functions
+289 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-279 | async def read_thing_vararg(*query: str): ...
+290 | async def read_thing_vararg(*query: str): ...
     |
 help: Add `thing_id` to function signature
-276 |
-277 | # Errors: vararg-only and kwarg-only functions
-278 | @app.get("/things/{thing_id}")
+287 |
+288 | # Errors: vararg-only and kwarg-only functions
+289 | @app.get("/things/{thing_id}")
     - async def read_thing_vararg(*query: str): ...
-279 + async def read_thing_vararg(thing_id, *query: str): ...
-280 |
-281 | @app.get("/things/{thing_id}")
-282 | async def read_thing_kwarg(**query: str): ...
+290 + async def read_thing_vararg(thing_id, *query: str): ...
+291 |
+292 | @app.get("/things/{thing_id}")
+293 | async def read_thing_kwarg(**query: str): ...
 note: This is an unsafe fix and may change runtime behavior
 
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_kwarg` signature
-   --> FAST003.py:281:19
+   --> FAST003.py:292:19
     |
-279 | async def read_thing_vararg(*query: str): ...
-280 |
-281 | @app.get("/things/{thing_id}")
+290 | async def read_thing_vararg(*query: str): ...
+291 |
+292 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-282 | async def read_thing_kwarg(**query: str): ...
+293 | async def read_thing_kwarg(**query: str): ...
     |
 help: Add `thing_id` to function signature
-279 | async def read_thing_vararg(*query: str): ...
-280 |
-281 | @app.get("/things/{thing_id}")
+290 | async def read_thing_vararg(*query: str): ...
+291 |
+292 | @app.get("/things/{thing_id}")
     - async def read_thing_kwarg(**query: str): ...
-282 + async def read_thing_kwarg(thing_id, **query: str): ...
-283 |
-284 | @app.get("/things/{thing_id}")
-285 | async def read_thing_vararg_kwarg(*args, **kwargs): ...
+293 + async def read_thing_kwarg(thing_id, **query: str): ...
+294 |
+295 | @app.get("/things/{thing_id}")
+296 | async def read_thing_vararg_kwarg(*args, **kwargs): ...
 note: This is an unsafe fix and may change runtime behavior
 
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_vararg_kwarg` signature
-   --> FAST003.py:284:19
+   --> FAST003.py:295:19
     |
-282 | async def read_thing_kwarg(**query: str): ...
-283 |
-284 | @app.get("/things/{thing_id}")
+293 | async def read_thing_kwarg(**query: str): ...
+294 |
+295 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-285 | async def read_thing_vararg_kwarg(*args, **kwargs): ...
+296 | async def read_thing_vararg_kwarg(*args, **kwargs): ...
     |
 help: Add `thing_id` to function signature
-282 | async def read_thing_kwarg(**query: str): ...
-283 |
-284 | @app.get("/things/{thing_id}")
+293 | async def read_thing_kwarg(**query: str): ...
+294 |
+295 | @app.get("/things/{thing_id}")
     - async def read_thing_vararg_kwarg(*args, **kwargs): ...
-285 + async def read_thing_vararg_kwarg(thing_id, *args, **kwargs): ...
-286 |
-287 | # Errors: positional-only parameter edge cases
-288 | @app.get("/things/{thing_id}")
+296 + async def read_thing_vararg_kwarg(thing_id, *args, **kwargs): ...
+297 |
+298 | # Errors: positional-only parameter edge cases
+299 | @app.get("/things/{thing_id}")
 note: This is an unsafe fix and may change runtime behavior
 
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_posonly` signature
-   --> FAST003.py:288:19
+   --> FAST003.py:299:19
     |
-287 | # Errors: positional-only parameter edge cases
-288 | @app.get("/things/{thing_id}")
+298 | # Errors: positional-only parameter edge cases
+299 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-289 | async def read_thing_posonly(query: str, /): ...
+300 | async def read_thing_posonly(query: str, /): ...
     |
 help: Add `thing_id` to function signature
-286 |
-287 | # Errors: positional-only parameter edge cases
-288 | @app.get("/things/{thing_id}")
+297 |
+298 | # Errors: positional-only parameter edge cases
+299 | @app.get("/things/{thing_id}")
     - async def read_thing_posonly(query: str, /): ...
-289 + async def read_thing_posonly(query: str, /, thing_id): ...
-290 |
-291 | @app.get("/things/{thing_id}")
-292 | async def read_thing_posonly_trailing(query: str, /,): ...
+300 + async def read_thing_posonly(query: str, /, thing_id): ...
+301 |
+302 | @app.get("/things/{thing_id}")
+303 | async def read_thing_posonly_trailing(query: str, /,): ...
 note: This is an unsafe fix and may change runtime behavior
 
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_posonly_trailing` signature
-   --> FAST003.py:291:19
+   --> FAST003.py:302:19
     |
-289 | async def read_thing_posonly(query: str, /): ...
-290 |
-291 | @app.get("/things/{thing_id}")
+300 | async def read_thing_posonly(query: str, /): ...
+301 |
+302 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-292 | async def read_thing_posonly_trailing(query: str, /,): ...
+303 | async def read_thing_posonly_trailing(query: str, /,): ...
     |
 help: Add `thing_id` to function signature
-289 | async def read_thing_posonly(query: str, /): ...
-290 |
-291 | @app.get("/things/{thing_id}")
+300 | async def read_thing_posonly(query: str, /): ...
+301 |
+302 | @app.get("/things/{thing_id}")
     - async def read_thing_posonly_trailing(query: str, /,): ...
-292 + async def read_thing_posonly_trailing(query: str, /, thing_id,): ...
-293 |
-294 | @app.get("/things/{thing_id}")
-295 | async def read_thing_posonly_default(query: str = "", /): ...
+303 + async def read_thing_posonly_trailing(query: str, /, thing_id,): ...
+304 |
+305 | @app.get("/things/{thing_id}")
+306 | async def read_thing_posonly_default(query: str = "", /): ...
 note: This is an unsafe fix and may change runtime behavior
 
 FAST003 Parameter `thing_id` appears in route path, but not in `read_thing_posonly_default` signature
-   --> FAST003.py:294:19
+   --> FAST003.py:305:19
     |
-292 | async def read_thing_posonly_trailing(query: str, /,): ...
-293 |
-294 | @app.get("/things/{thing_id}")
+303 | async def read_thing_posonly_trailing(query: str, /,): ...
+304 |
+305 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-295 | async def read_thing_posonly_default(query: str = "", /): ...
+306 | async def read_thing_posonly_default(query: str = "", /): ...
     |
 help: Add `thing_id` to function signature
 
 FAST003 Parameter `thing_id` appears in route path, but not in `read_thing_posonly_default_trailing` signature
-   --> FAST003.py:297:19
+   --> FAST003.py:308:19
     |
-295 | async def read_thing_posonly_default(query: str = "", /): ...
-296 |
-297 | @app.get("/things/{thing_id}")
+306 | async def read_thing_posonly_default(query: str = "", /): ...
+307 |
+308 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-298 | async def read_thing_posonly_default_trailing(query: str = "", /,): ...
+309 | async def read_thing_posonly_default_trailing(query: str = "", /,): ...
     |
 help: Add `thing_id` to function signature
 
 FAST003 Parameter `thing_id` appears in route path, but not in `read_thing_posonly_with_regular` signature
-   --> FAST003.py:300:19
+   --> FAST003.py:311:19
     |
-298 | async def read_thing_posonly_default_trailing(query: str = "", /,): ...
-299 |
-300 | @app.get("/things/{thing_id}")
+309 | async def read_thing_posonly_default_trailing(query: str = "", /,): ...
+310 |
+311 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-301 | async def read_thing_posonly_with_regular(query: str = "", /, x=None): ...
+312 | async def read_thing_posonly_with_regular(query: str = "", /, x=None): ...
     |
 help: Add `thing_id` to function signature
 
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `read_thing_init_and_call_instance_default` signature
-   --> FAST003.py:370:19
+   --> FAST003.py:381:19
     |
-368 | async def read_thing_callable_dep_instance_default(query: str = Depends(CallableQuery())): ...
-369 | # Error: `__call__` has `other`, not `thing_id`.
-370 | @app.get("/things/{thing_id}")
+379 | async def read_thing_callable_dep_instance_default(query: str = Depends(CallableQuery())): ...
+380 | # Error: `__call__` has `other`, not `thing_id`.
+381 | @app.get("/things/{thing_id}")
     |                   ^^^^^^^^^^
-371 | async def read_thing_init_and_call_instance_default(query: str = Depends(InitAndCallQuery())): ...
+382 | async def read_thing_init_and_call_instance_default(query: str = Depends(InitAndCallQuery())): ...
     |
 help: Add `thing_id` to function signature
-368 | async def read_thing_callable_dep_instance_default(query: str = Depends(CallableQuery())): ...
-369 | # Error: `__call__` has `other`, not `thing_id`.
-370 | @app.get("/things/{thing_id}")
+379 | async def read_thing_callable_dep_instance_default(query: str = Depends(CallableQuery())): ...
+380 | # Error: `__call__` has `other`, not `thing_id`.
+381 | @app.get("/things/{thing_id}")
     - async def read_thing_init_and_call_instance_default(query: str = Depends(InitAndCallQuery())): ...
-371 + async def read_thing_init_and_call_instance_default(thing_id, query: str = Depends(InitAndCallQuery())): ...
+382 + async def read_thing_init_and_call_instance_default(thing_id, query: str = Depends(InitAndCallQuery())): ...
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

- Teach FAST003 to resolve `Annotated[..., Path(alias=...)]` aliases through same-file type aliases.
- Scan all `Annotated` metadata entries so aliases are recognized when `Path(...)` is not the first metadata element.
- Add FAST003 regression coverage for direct aliased type aliases and multi-metadata aliases.

Related to #16795.

## Test Plan

- `cargo test -p ruff_linter --lib rules::fastapi::tests::rules::rule_fastapiunusedpathparameter_path_new_fast003_py_expects --features test-rules -- --nocapture`
- `cargo test -p ruff_linter --lib rules::fastapi::tests::deferred_annotations_diff::rule_fastapiunusedpathparameter_path_new_fast003_py_expects --features test-rules -- --nocapture`
- `cargo test -p ruff_linter --lib rules::fastapi::tests --features test-rules -- --nocapture`
- `cargo fmt --check`
- `uvx prek run --from-ref origin/main`
