### PR TITLE
[flake8-commas] Clarify scope of trailing-comma-on-bare-tuple (COM818) documentation

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -169,7 +169,15 @@ impl AlwaysFixableViolation for MissingTrailingComma {
 
 /// ## What it does
 /// Checks for the presence of trailing commas on bare (i.e., unparenthesized)
-/// tuples.
+/// tuples in statement position.
+///
+/// Specifically, this rule flags a trailing comma when it is followed by a
+/// statement-ending newline. Trailing commas in other contexts are out of
+/// scope:
+///
+/// - Bare tuples in subscripts (e.g., `x[1,]`) are covered by [RUF031].
+/// - Bare tuples appearing in `yield` expressions or before a semicolon
+///   are not currently detected.
 ///
 /// ## Why is this bad?
 /// The presence of a misplaced comma will cause Python to interpret the value
@@ -198,6 +206,8 @@ impl AlwaysFixableViolation for MissingTrailingComma {
 ///
 /// foo = (json.dumps({"bar": 1}),)
 /// ```
+///
+/// [RUF031]: https://docs.astral.sh/ruff/rules/incorrectly-parenthesized-tuple-in-subscript/
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.223")]
 pub(crate) struct TrailingCommaOnBareTuple;


### PR DESCRIPTION
Summary
-------

Resolves #18851.

The COM818 docstring currently says it checks for trailing commas on bare (i.e., unparenthesized) tuples, but the implementation in `bare_comma_prohibited` only flags a comma that is followed by a statement-ending newline. The issue thread (ntBre, MichaReiser, 2025-06-23) confirms that subscripts are out of scope (RUF031 covers `x[1,]`) and that bare tuples in `yield` expressions or before a semicolon are not detected either.

This updates the `TrailingCommaOnBareTuple` violation docstring to:

1. Reword the opening sentence to say "in statement position" and document the statement-final-newline limitation explicitly.
2. Cross-reference RUF031 for subscript-position bare tuples.
3. Note yield-expression and semicolon-terminated bare tuples as known exceptions.

The rule behavior is unchanged. The rule-extension question raised by MichaReiser ("double-check what the upstream lint rule does before changing the rule") is intentionally out of scope here.

AI assistance (Claude) was used while drafting parts of this change. The diff was reviewed manually before submission.

Test Plan
---------

`cargo nextest run -p ruff_linter --tests flake8_commas` passes (2 tests, no snapshot drift). `cargo dev generate-all` reports all schemas up-to-date. `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean. `uvx prek run --files crates/ruff_linter/src/rules/flake8_commas/rules/trailing_commas.rs` clean (rustfmt + typos + merge-conflicts checks pass; other hooks not applicable to the changed file).
