### PR TITLE
Excessive whitespace trimming with comment formatting

### DIFF
--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -509,7 +509,7 @@ fn normalize_comment<'a>(
             Ok(Cow::Owned(std::format!("# {}", &content["\u{A0}".len()..])))
         }
     } else {
-        Ok(Cow::Owned(std::format!("# {}", content.trim_start())))
+        Ok(Cow::Owned(std::format!("# {content}")))
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

When formatting comments to ensure a whitespace between the hash and content, tabular indentation(s) are stripped.  This should not be the case - to fall in line with how Black handles it, it treats any leading tab as a non-space and injects a space between the hash and tab.

<!-- What's the purpose of the change? What does it do, and why? -->

Write code with beautiful tabs.  Comment out a few lines of code that include indentation.  Also make general normal comments, lazily without proper spaces.   Inspect formatted output that previous reformats are intact, and no tabs in new format are removed.

If  understand the code correctly, it already right-trims the comment first thing.  Then it checks for special cases where spaces should not be injected (including a space already there), Then a special NBSP replacement.  Finally, a left-trim - which as far as I can tell only serves to trim tabs at this point as all other whitespace occurrences are handled/ignored.

<!-- How was it tested? -->

Compiled locally, binaries replaced.  Code with the above comment scenarios were reformatted as expected (aligning with black).


Closes #25019