### PR TITLE
Pin cargo-shear to v1.12.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -798,7 +798,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: cargo-bins/cargo-binstall@4852a15cf01e4f33958ce547326406fe78f27c38 # v1.19.0
-      - run: cargo binstall --no-confirm cargo-shear@1.11.2
+      - run: cargo binstall --no-confirm cargo-shear
       - run: cargo shear --deny-warnings
 
   ty-completion-evaluation:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -798,7 +798,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: cargo-bins/cargo-binstall@4852a15cf01e4f33958ce547326406fe78f27c38 # v1.19.0
-      - run: cargo binstall --no-confirm cargo-shear
+      - run: cargo binstall --no-confirm cargo-shear@1.12.4
       - run: cargo shear --deny-warnings
 
   ty-completion-evaluation:


### PR DESCRIPTION
Summary
--

This is a follow-up to 88289f00d45fa78c60d355a51c609d290df01743 now that v1.12.1 should be out with the fix to https://github.com/Boshen/cargo-shear/issues/497 included. There have been 3 additional releases since that bug fix, so this PR pins to the latest release.

Test Plan
--

CI on this PR
