### PR TITLE
suppress NO_COLOR in the environment for ruff_annotate_snippets tests

### DIFF
--- a/crates/ruff_annotate_snippets/tests/examples.rs
+++ b/crates/ruff_annotate_snippets/tests/examples.rs
@@ -31,6 +31,7 @@ fn assert_example(target: &str, expected: snapbox::Data) {
     let bin_path = snapbox::cmd::compile_example(target, ["--features=testing-colors"]).unwrap();
     snapbox::cmd::Command::new(bin_path)
         .env("CLICOLOR_FORCE", "1")
+        .env_remove("NO_COLOR")
         .assert()
         .success()
         .stdout_eq(expected.raw());


### PR DESCRIPTION
I've noticed that Codex tends to set this env var in its own shell when it runs tests, and it currently causes some test failures.