### PR TITLE
[ty] Track literal iterable emptiness for reachability

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3483,7 +3483,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let iter_expr = self.add_standalone_expression(iter);
                 self.visit_expr(iter);
 
-                let non_empty_range_constraint = if is_direct_range_call(iter) {
+                let non_empty_iterable_constraint = if literal_iterates_at_least_once(iter) {
+                    let after_iter = self.flow_snapshot();
+                    let constraint =
+                        self.record_reachability_constraint(PredicateOrLiteral::Literal(true));
+
+                    Some((after_iter, constraint))
+                } else if is_direct_range_call(iter) {
                     let after_iter = self.flow_snapshot();
                     let constraint = self.record_reachability_constraint(
                         PredicateOrLiteral::Predicate(Predicate {
@@ -3537,10 +3543,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 // We may execute the `else` clause without ever executing the body, so merge in a
                 // zero-iteration state before visiting `else`.
-                if let Some((after_iter, non_empty_range_constraint)) = non_empty_range_constraint {
+                if let Some((after_iter, non_empty_iterable_constraint)) =
+                    non_empty_iterable_constraint
+                {
                     let post_loop_body = self.flow_snapshot();
                     self.flow_restore(after_iter);
-                    self.record_negated_reachability_constraint(non_empty_range_constraint);
+                    self.record_negated_reachability_constraint(non_empty_iterable_constraint);
                     let no_iteration = self.flow_snapshot();
                     self.flow_restore(post_loop_body);
                     self.flow_merge(no_iteration);
@@ -5055,6 +5063,23 @@ impl ExpressionsScopeMapBuilder {
     }
 }
 
+/// Returns `true` if the literal iterable must contain at least one element.
+///
+/// The check is intentionally syntactic and conservative: starred elements and dictionary
+/// unpacking only prove non-emptiness when there is also a non-starred/non-unpacked element.
+fn literal_iterates_at_least_once(expr: &ast::Expr) -> bool {
+    match expr {
+        ast::Expr::Tuple(ast::ExprTuple { elts, .. })
+        | ast::Expr::List(ast::ExprList { elts, .. })
+        | ast::Expr::Set(ast::ExprSet { elts, .. }) => {
+            elts.iter().any(|elt| !elt.is_starred_expr())
+        }
+        ast::Expr::Dict(ast::ExprDict { items, .. }) => items.iter().any(|item| item.key.is_some()),
+        ast::Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => !value.is_empty(),
+        ast::Expr::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => !value.is_empty(),
+        _ => false,
+    }
+}
 /// Returns if the expression is a `TYPE_CHECKING` expression.
 fn is_if_type_checking(expr: &ast::Expr) -> bool {
     match expr {

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3483,28 +3483,36 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let iter_expr = self.add_standalone_expression(iter);
                 self.visit_expr(iter);
 
-                let non_empty_iterable_constraint = if !*is_async
-                    && let Some(is_non_empty) = literal_iterable_truthiness(iter).into_bool()
-                {
-                    let after_iter = self.flow_snapshot();
-                    let constraint = self
-                        .record_reachability_constraint(PredicateOrLiteral::Literal(is_non_empty));
-
-                    Some((after_iter, constraint))
-                } else if is_direct_range_call(iter) {
-                    let after_iter = self.flow_snapshot();
-                    let constraint = self.record_reachability_constraint(
-                        PredicateOrLiteral::Predicate(Predicate {
-                            node: PredicateNode::IsNonEmptyIterable(iter_expr),
-                            is_positive: true,
-                        }),
-                    );
-
-                    Some((after_iter, constraint))
-                } else {
-                    self.record_ambiguous_reachability();
+                let literal_iterable_is_non_empty = if *is_async {
                     None
+                } else {
+                    literal_iterable_truthiness(iter).into_bool()
                 };
+
+                let (after_empty_iter, non_empty_range_constraint) =
+                    match literal_iterable_is_non_empty {
+                        Some(false) => {
+                            let after_iter = self.flow_snapshot();
+                            self.mark_unreachable();
+                            (Some(after_iter), None)
+                        }
+                        Some(true) => (None, None),
+                        None if is_direct_range_call(iter) => {
+                            let after_iter = self.flow_snapshot();
+                            let constraint = self.record_reachability_constraint(
+                                PredicateOrLiteral::Predicate(Predicate {
+                                    node: PredicateNode::IsNonEmptyIterable(iter_expr),
+                                    is_positive: true,
+                                }),
+                            );
+
+                            (None, Some((after_iter, constraint)))
+                        }
+                        None => {
+                            self.record_ambiguous_reachability();
+                            (None, None)
+                        }
+                    };
 
                 let pre_loop = self.flow_snapshot();
 
@@ -3543,19 +3551,23 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.populate_loop_header(&bound_place_ids, header_id, loop_min_definition_id);
                 }
 
-                // We may execute the `else` clause without ever executing the body, so merge in a
-                // zero-iteration state before visiting `else`.
-                if let Some((after_iter, non_empty_iterable_constraint)) =
-                    non_empty_iterable_constraint
-                {
-                    let post_loop_body = self.flow_snapshot();
+                if let Some(after_iter) = after_empty_iter {
                     self.flow_restore(after_iter);
-                    self.record_negated_reachability_constraint(non_empty_iterable_constraint);
-                    let no_iteration = self.flow_snapshot();
-                    self.flow_restore(post_loop_body);
-                    self.flow_merge(no_iteration);
-                } else {
-                    self.flow_merge(pre_loop);
+                } else if literal_iterable_is_non_empty.is_none() {
+                    // We may execute the `else` clause without ever executing the body, so merge
+                    // in a zero-iteration state before visiting `else`.
+                    if let Some((after_iter, non_empty_range_constraint)) =
+                        non_empty_range_constraint
+                    {
+                        let post_loop_body = self.flow_snapshot();
+                        self.flow_restore(after_iter);
+                        self.record_negated_reachability_constraint(non_empty_range_constraint);
+                        let no_iteration = self.flow_snapshot();
+                        self.flow_restore(post_loop_body);
+                        self.flow_merge(no_iteration);
+                    } else {
+                        self.flow_merge(pre_loop);
+                    }
                 }
                 self.visit_body(orelse);
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3483,11 +3483,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let iter_expr = self.add_standalone_expression(iter);
                 self.visit_expr(iter);
 
-                let literal_iterable_is_non_empty = if *is_async {
-                    None
-                } else {
-                    literal_iterable_truthiness(iter).into_bool()
-                };
+                let literal_iterable_is_non_empty = (!*is_async)
+                    .then(|| literal_iterable_truthiness(iter))
+                    .and_then(Truthiness::into_bool);
 
                 let (after_empty_iter, non_empty_range_constraint) =
                     match literal_iterable_is_non_empty {

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use except_handlers::TryNodeContextStackManager;
 use itertools::Itertools;
-use ruff_python_ast::helpers::{any_over_expr, is_dotted_name};
+use ruff_python_ast::helpers::{Truthiness, any_over_expr, is_dotted_name};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use ruff_db::files::File;
@@ -3483,10 +3483,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let iter_expr = self.add_standalone_expression(iter);
                 self.visit_expr(iter);
 
-                let non_empty_iterable_constraint = if literal_iterates_at_least_once(iter) {
+                let non_empty_iterable_constraint = if let Some(is_non_empty) =
+                    literal_iterable_truthiness(iter).into_bool()
+                {
                     let after_iter = self.flow_snapshot();
-                    let constraint =
-                        self.record_reachability_constraint(PredicateOrLiteral::Literal(true));
+                    let constraint = self
+                        .record_reachability_constraint(PredicateOrLiteral::Literal(is_non_empty));
 
                     Some((after_iter, constraint))
                 } else if is_direct_range_call(iter) {
@@ -5063,23 +5065,22 @@ impl ExpressionsScopeMapBuilder {
     }
 }
 
-/// Returns `true` if the literal iterable must contain at least one element.
+/// Returns the static truthiness of a literal iterable.
 ///
-/// The check is intentionally syntactic and conservative: starred elements and dictionary
-/// unpacking only prove non-emptiness when there is also a non-starred/non-unpacked element.
-fn literal_iterates_at_least_once(expr: &ast::Expr) -> bool {
+/// Returns [`Truthiness::Unknown`] for other expressions and when starred elements or dictionary
+/// unpacking make the literal's emptiness ambiguous.
+fn literal_iterable_truthiness(expr: &ast::Expr) -> Truthiness {
     match expr {
-        ast::Expr::Tuple(ast::ExprTuple { elts, .. })
-        | ast::Expr::List(ast::ExprList { elts, .. })
-        | ast::Expr::Set(ast::ExprSet { elts, .. }) => {
-            elts.iter().any(|elt| !elt.is_starred_expr())
-        }
-        ast::Expr::Dict(ast::ExprDict { items, .. }) => items.iter().any(|item| item.key.is_some()),
-        ast::Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => !value.is_empty(),
-        ast::Expr::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => !value.is_empty(),
-        _ => false,
+        ast::Expr::Tuple(_)
+        | ast::Expr::List(_)
+        | ast::Expr::Set(_)
+        | ast::Expr::Dict(_)
+        | ast::Expr::StringLiteral(_)
+        | ast::Expr::BytesLiteral(_) => Truthiness::from_expr(expr, |_| false),
+        _ => Truthiness::Unknown,
     }
 }
+
 /// Returns if the expression is a `TYPE_CHECKING` expression.
 fn is_if_type_checking(expr: &ast::Expr) -> bool {
     match expr {

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3471,7 +3471,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 for_stmt @ ast::StmtFor {
                     range: _,
                     node_index: _,
-                    is_async: _,
+                    is_async,
                     target,
                     iter,
                     body,
@@ -3483,8 +3483,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let iter_expr = self.add_standalone_expression(iter);
                 self.visit_expr(iter);
 
-                let non_empty_iterable_constraint = if let Some(is_non_empty) =
-                    literal_iterable_truthiness(iter).into_bool()
+                let non_empty_iterable_constraint = if !*is_async
+                    && let Some(is_non_empty) = literal_iterable_truthiness(iter).into_bool()
                 {
                     let after_iter = self.flow_snapshot();
                     let constraint = self

--- a/crates/ty_python_semantic/resources/mdtest/import/star.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/star.md
@@ -235,8 +235,8 @@ print((
     D,
     E,
     F,
-    G,  # error: [possibly-unresolved-reference]
-    H,  # error: [possibly-unresolved-reference]
+    G,
+    H,
     I,
     J,
     K,

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -267,6 +267,37 @@ for _ in b"":
 reveal_type(value)  # revealed: Literal[1]
 ```
 
+## With `else` clauses and statically known literal emptiness
+
+```py
+def empty() -> None:
+    value = "before"
+
+    for _ in []:
+        value = "body"
+    else:
+        reveal_type(value)  # revealed: Literal["before"]
+
+def non_empty() -> None:
+    value = "before"
+
+    for _ in [1]:
+        value = "body"
+    else:
+        reveal_type(value)  # revealed: Literal["body"]
+
+def non_empty_break() -> None:
+    value = "before"
+
+    for _ in [1]:
+        value = "body"
+        break
+    else:
+        value = "else"
+
+    reveal_type(value)  # revealed: Literal["body"]
+```
+
 Starred elements and dictionary unpacking make emptiness ambiguous:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -296,6 +296,10 @@ async def _():
     # error: [not-iterable]
     async for x in ["a", "b"]:
         reveal_type(x)  # revealed: Unknown
+
+    # revealed: Unknown
+    # error: [possibly-unresolved-reference]
+    reveal_type(x)
 ```
 
 ## With non-callable iterator

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -298,7 +298,8 @@ def non_empty_break() -> None:
     reveal_type(value)  # revealed: Literal["body"]
 ```
 
-Starred elements and dictionary unpacking make emptiness ambiguous:
+Starred elements and dictionary unpacking make emptiness ambiguous unless the literal also contains
+a required element:
 
 ```py
 def _(items: list[int], mapping: dict[str, int]):
@@ -315,6 +316,16 @@ def _(items: list[int], mapping: dict[str, int]):
     # revealed: str
     # error: [possibly-unresolved-reference]
     reveal_type(key)
+
+    for item in [*items, 1]:
+        pass
+
+    reveal_type(item)  # revealed: int
+
+    for key in {**mapping, "c": 2}:
+        pass
+
+    reveal_type(key)  # revealed: str
 ```
 
 ## With literal list

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -244,6 +244,48 @@ for x in b"a":
 reveal_type(x)  # revealed: Literal[97]
 ```
 
+## With statically empty literals
+
+```py
+value = 1
+
+for _ in ():
+    value = "tuple"
+
+for _ in []:
+    value = "list"
+
+for _ in {}:
+    value = "dict"
+
+for _ in "":
+    value = "str"
+
+for _ in b"":
+    value = "bytes"
+
+reveal_type(value)  # revealed: Literal[1]
+```
+
+Starred elements and dictionary unpacking make emptiness ambiguous:
+
+```py
+def _(items: list[int], mapping: dict[str, int]):
+    for item in [*items]:
+        pass
+
+    # revealed: int
+    # error: [possibly-unresolved-reference]
+    reveal_type(item)
+
+    for key in {**mapping}:
+        pass
+
+    # revealed: str
+    # error: [possibly-unresolved-reference]
+    reveal_type(key)
+```
+
 ## With literal list
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -212,9 +212,36 @@ def _(color: Color):
 for x in (1, "a", b"foo"):
     pass
 
-# revealed: Literal[1, "a", b"foo"]
-# error: [possibly-unresolved-reference]
-reveal_type(x)
+reveal_type(x)  # revealed: Literal[1, "a", b"foo"]
+```
+
+## With statically non-empty literals
+
+```py
+for x in [1]:
+    pass
+
+reveal_type(x)  # revealed: Literal[1]
+
+for x in {1}:
+    pass
+
+reveal_type(x)  # revealed: int
+
+for x in {"foo": 1}:
+    pass
+
+reveal_type(x)  # revealed: str
+
+for x in "a":
+    pass
+
+reveal_type(x)  # revealed: Literal["a"]
+
+for x in b"a":
+    pass
+
+reveal_type(x)  # revealed: Literal[97]
 ```
 
 ## With literal list

--- a/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
@@ -398,10 +398,13 @@ mod tests {
     }
 
     #[test]
-    fn reports_while_false_body_statement() -> anyhow::Result<()> {
+    fn reports_statically_empty_loop_bodies() -> anyhow::Result<()> {
         let source = r#"
             while False:
                 print("dead")
+
+            for _ in ():
+                print("also dead")
             "#;
 
         assert_snapshot!(UnreachableTest::new().render(source)?, @r#"
@@ -410,6 +413,13 @@ mod tests {
           |
         3 |     print("dead")
           |     ^^^^^^^^^^^^^
+          |
+
+        info[unreachable-code]: Code is always unreachable
+         --> src/main.py:6:5
+          |
+        6 |     print("also dead")
+          |     ^^^^^^^^^^^^^^^^^^
           |
         "#);
         Ok(())


### PR DESCRIPTION
## Summary

This extends the static reachability analysis for synchronous `for` loops from #25220 to tuple, list, set, dictionary, string, and bytes literals whose emptiness is known syntactically. We record their static truthiness: a non-empty literal proves that the body executes at least once, while an empty literal marks the body unreachable and prevents its definitions from flowing past the loop.

```python
for item in [1]:
    pass

reveal_type(item)  # Literal[1]

value = 1
for _ in []:
    value = "unreachable"

reveal_type(value)  # Literal[1]
```

Starred elements and dictionary unpacking remain ambiguous when they are the only elements, while an explicit element still proves non-emptiness. Other iterables continue on the existing ambiguous path. Synchronous literals used in `async for` do not use this shortcut because they do not satisfy async iteration.