### PR TITLE
[ty] View ecosystem results for non-empty iterable wrappers

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -37,9 +37,9 @@ use crate::expression::{Expression, ExpressionKind};
 use crate::member::MemberExprBuilder;
 use crate::place::{PlaceExpr, PlaceTableBuilder, PossiblyNarrowedPlacesBuilder, ScopedPlaceId};
 use crate::predicate::{
-    CallableAndCallExpr, ClassPatternKind, NonEmptyIterablePredicate, PatternPredicate,
-    PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral, ScopedPredicateId,
-    StarImportPlaceholderPredicate,
+    CallableAndCallExpr, ClassPatternKind, NonEmptyIterablePredicate, NonEmptyIterableWrapper,
+    PatternPredicate, PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral,
+    ScopedPredicateId, StarImportPlaceholderPredicate,
 };
 use crate::program::Program;
 use crate::re_exports::exported_names;
@@ -1551,15 +1551,23 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             return None;
         };
 
-        if id != "range" || !range_call_iterates_at_least_once(call) {
+        let predicate = if id == "range" && range_call_iterates_at_least_once(call) {
+            NonEmptyIterablePredicate::BuiltinRange {
+                callable: self.add_standalone_expression(&call.func),
+            }
+        } else if let Some(wrapper) = non_empty_iterable_wrapper(id.as_str())
+            && wrapper_call_preserves_non_empty(call, wrapper)
+        {
+            NonEmptyIterablePredicate::BuiltinWrapper {
+                callable: self.add_standalone_expression(&call.func),
+                wrapper,
+            }
+        } else {
             return None;
-        }
+        };
 
-        let callable = self.add_standalone_expression(&call.func);
         Some(PredicateOrLiteral::Predicate(Predicate {
-            node: PredicateNode::IsNonEmptyIterable(NonEmptyIterablePredicate::BuiltinRange {
-                callable,
-            }),
+            node: PredicateNode::IsNonEmptyIterable(predicate),
             is_positive: true,
         }))
     }
@@ -4342,6 +4350,41 @@ fn literal_iterates_at_least_once(expr: &ast::Expr) -> bool {
         ast::Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => !value.is_empty(),
         ast::Expr::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => !value.is_empty(),
         _ => false,
+    }
+}
+
+fn non_empty_iterable_wrapper(name: &str) -> Option<NonEmptyIterableWrapper> {
+    match name {
+        "enumerate" => Some(NonEmptyIterableWrapper::Enumerate),
+        "map" => Some(NonEmptyIterableWrapper::Map),
+        "reversed" => Some(NonEmptyIterableWrapper::Reversed),
+        "sorted" => Some(NonEmptyIterableWrapper::Sorted),
+        "zip" => Some(NonEmptyIterableWrapper::Zip),
+        _ => None,
+    }
+}
+
+fn wrapper_call_preserves_non_empty(
+    call: &ast::ExprCall,
+    wrapper: NonEmptyIterableWrapper,
+) -> bool {
+    let args = call.arguments.args.as_ref();
+    if args.iter().any(ast::Expr::is_starred_expr) {
+        return false;
+    }
+
+    match wrapper {
+        NonEmptyIterableWrapper::Enumerate
+        | NonEmptyIterableWrapper::Reversed
+        | NonEmptyIterableWrapper::Sorted => {
+            args.first().is_some_and(literal_iterates_at_least_once)
+        }
+        NonEmptyIterableWrapper::Zip => {
+            !args.is_empty() && args.iter().all(literal_iterates_at_least_once)
+        }
+        NonEmptyIterableWrapper::Map => {
+            args.len() >= 2 && args[1..].iter().all(literal_iterates_at_least_once)
+        }
     }
 }
 

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -114,12 +114,39 @@ pub enum NonEmptyIterablePredicate<'db> {
     ///
     /// Semantic reachability later confirms that the callable is builtin `range`.
     BuiltinRange { callable: Expression<'db> },
+    /// A builtin call that preserves the non-emptiness of its iterable argument or arguments.
+    BuiltinWrapper {
+        callable: Expression<'db>,
+        wrapper: NonEmptyIterableWrapper,
+    },
 }
 
 impl<'db> NonEmptyIterablePredicate<'db> {
     pub fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
         match self {
-            NonEmptyIterablePredicate::BuiltinRange { callable } => callable.scope(db),
+            NonEmptyIterablePredicate::BuiltinRange { callable }
+            | NonEmptyIterablePredicate::BuiltinWrapper { callable, .. } => callable.scope(db),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+pub enum NonEmptyIterableWrapper {
+    Enumerate,
+    Map,
+    Reversed,
+    Sorted,
+    Zip,
+}
+
+impl NonEmptyIterableWrapper {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Enumerate => "enumerate",
+            Self::Map => "map",
+            Self::Reversed => "reversed",
+            Self::Sorted => "sorted",
+            Self::Zip => "zip",
         }
     }
 }

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -166,6 +166,50 @@ for x in b"a":
 reveal_type(x)  # revealed: Literal[97]
 ```
 
+## With statically non-empty builtin iterable wrappers
+
+```py
+for x in enumerate(["a"]):
+    pass
+
+reveal_type(x)  # revealed: tuple[int, str]
+
+for x in reversed(["a"]):
+    pass
+
+reveal_type(x)  # revealed: str
+
+for x in sorted(["a"]):
+    pass
+
+reveal_type(x)  # revealed: str
+
+for x in zip(["a"], [1]):
+    pass
+
+reveal_type(x)  # revealed: tuple[str, int]
+
+for x in map(str, [1]):
+    pass
+
+reveal_type(x)  # revealed: str
+```
+
+## With shadowed iterable wrapper
+
+```py
+def shadowed_sorted():
+    def sorted(values: list[str]) -> list[str]:
+        return []
+
+    for x in sorted(["a"]):
+        pass
+
+    # revealed: str
+    # error: [possibly-unresolved-reference]
+    reveal_type(x)
+```
+
 ## With non-callable iterator
 
 ```py

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -871,28 +871,40 @@ fn analyze_non_empty_iterable(db: &dyn Db, predicate: NonEmptyIterablePredicate<
         NonEmptyIterablePredicate::BuiltinRange { callable } => {
             analyze_builtin_range_call(db, callable)
         }
+        NonEmptyIterablePredicate::BuiltinWrapper { callable, wrapper } => {
+            analyze_builtin_callable(db, callable, wrapper.name())
+        }
     }
 }
 
 /// Confirms that a syntactically non-empty `range(...)` call refers to builtin `range`.
 fn analyze_builtin_range_call(db: &dyn Db, callable: Expression) -> Truthiness {
-    let callable_ty = infer_expression_type(db, callable, TypeContext::default());
-    let Some(class) = callable_ty
-        .as_class_literal()
-        .and_then(ClassLiteral::as_static)
-    else {
-        return Truthiness::Ambiguous;
-    };
+    analyze_builtin_callable(db, callable, "range")
+}
 
-    if class.name(db) == "range"
-        && file_to_module(db, class.file(db))
-            .and_then(|module| module.known(db))
-            .is_some_and(KnownModule::is_builtins)
-    {
+fn analyze_builtin_callable(db: &dyn Db, callable: Expression, name: &str) -> Truthiness {
+    let callable_ty = infer_expression_type(db, callable, TypeContext::default());
+    if is_builtin_callable(db, callable_ty, name) {
         Truthiness::AlwaysTrue
     } else {
         Truthiness::Ambiguous
     }
+}
+
+fn is_builtin_callable(db: &dyn Db, ty: Type, name: &str) -> bool {
+    if let Some(class) = ty.as_class_literal().and_then(ClassLiteral::as_static) {
+        class.name(db) == name && is_builtin_file(db, class.file(db))
+    } else if let Type::FunctionLiteral(function) = ty {
+        function.name(db) == name && is_builtin_file(db, function.file(db))
+    } else {
+        false
+    }
+}
+
+fn is_builtin_file(db: &dyn Db, file: ruff_db::files::File) -> bool {
+    file_to_module(db, file)
+        .and_then(|module| module.known(db))
+        .is_some_and(KnownModule::is_builtins)
 }
 
 fn analyze_single(db: &dyn Db, predicate: &Predicate) -> Truthiness {


### PR DESCRIPTION
I expect ~nothing here but curious.