### PR TITLE
[`flake8-bugbear`] Extend B019 to async caching decorators (`async_lru`, `aiocache`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B019.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B019.py
@@ -1,9 +1,15 @@
 """
-Should emit:
-B019 - on lines 73, 77, 81, 85, 89, 93, 97, 101
+B019 should emit on every method below that is decorated with a method-caching
+decorator (functools.lru_cache, functools.cache, async_lru.alru_cache, or one
+of the aiocache decorators) AND is an instance method on a non-enum class.
 """
 import functools
 from functools import cache, cached_property, lru_cache
+
+import async_lru
+import aiocache
+from async_lru import alru_cache
+from aiocache import cached, cached_stampede, multi_cached
 
 
 def some_other_cache():
@@ -124,3 +130,84 @@ class Metaclass(type):
     @functools.lru_cache
     def lru_cached_instance_method_on_metaclass(cls, x: int):
         ...
+
+
+# `async_lru.alru_cache` and `aiocache.{cached, cached_stampede, multi_cached}`
+# have the same memory-leak failure mode as `functools.lru_cache` when applied
+# to an instance method (they retain a strong reference to `self`).
+class AsyncFoo:
+    def __init__(self, x):
+        self.x = x
+
+    # Classmethods and staticmethods should be ignored, mirroring the synchronous case.
+    @classmethod
+    @async_lru.alru_cache
+    async def alru_cached_classmethod(cls, y):
+        ...
+
+    @classmethod
+    @alru_cache
+    async def alru_cached_classmethod_imported(cls, y):
+        ...
+
+    @staticmethod
+    @aiocache.cached()
+    async def aiocache_cached_staticmethod(y):
+        ...
+
+    @staticmethod
+    @cached()
+    async def aiocache_cached_staticmethod_imported(y):
+        ...
+
+    # Remaining methods should emit B019.
+    @async_lru.alru_cache
+    async def alru_cached_instance_method(self, y):
+        ...
+
+    @alru_cache
+    async def alru_cached_instance_method_imported(self, y):
+        ...
+
+    @async_lru.alru_cache(maxsize=128)
+    async def called_alru_cached_instance_method(self, y):
+        ...
+
+    @aiocache.cached()
+    async def aiocache_cached_instance_method(self, y):
+        ...
+
+    @cached()
+    async def aiocache_cached_instance_method_imported(self, y):
+        ...
+
+    @aiocache.cached_stampede()
+    async def aiocache_cached_stampede_instance_method(self, y):
+        ...
+
+    @cached_stampede()
+    async def aiocache_cached_stampede_instance_method_imported(self, y):
+        ...
+
+    @aiocache.multi_cached()
+    async def aiocache_multi_cached_instance_method(self, keys):
+        ...
+
+    @multi_cached()
+    async def aiocache_multi_cached_instance_method_imported(self, keys):
+        ...
+
+
+class AsyncEnumFoo(enum.Enum):
+    ONE = enum.auto()
+    TWO = enum.auto()
+
+    # Enum members are singletons, so caching their methods does not retain
+    # any references that would not have been retained anyway.
+    @async_lru.alru_cache
+    async def alru_on_enum(self, arg: str) -> str:
+        return f"{self} - {arg}"
+
+    @aiocache.cached()
+    async def aiocache_on_enum(self, arg: str) -> str:
+        return f"{self} - {arg}"

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -9,17 +9,20 @@ use crate::Violation;
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for uses of the `functools.lru_cache` and `functools.cache`
-/// decorators on methods.
+/// Checks for uses of method-caching decorators that retain a strong reference
+/// to `self`. This includes `functools.lru_cache` and `functools.cache`, as
+/// well as the async equivalents `async_lru.alru_cache` and the `aiocache`
+/// decorators (`aiocache.cached`, `aiocache.cached_stampede`, and
+/// `aiocache.multi_cached`).
 ///
 /// ## Why is this bad?
-/// Using the `functools.lru_cache` and `functools.cache` decorators on methods
-/// can lead to memory leaks, as the global cache will retain a reference to
-/// the instance, preventing it from being garbage collected.
+/// Applying these decorators to methods can lead to memory leaks, as the
+/// (global) cache will retain a reference to the instance, preventing it from
+/// being garbage collected.
 ///
 /// Instead, refactor the method to depend only on its arguments and not on the
-/// instance of the class, or use the `@lru_cache` decorator on a function
-/// outside of the class.
+/// instance of the class, or apply the decorator to a function defined outside
+/// of the class.
 ///
 /// This rule ignores instance methods on enumeration classes, as enum members
 /// are singletons.
@@ -69,6 +72,8 @@ use crate::checkers::ast::Checker;
 /// ## References
 /// - [Python documentation: `functools.lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache)
 /// - [Python documentation: `functools.cache`](https://docs.python.org/3/library/functools.html#functools.cache)
+/// - [`async_lru` documentation](https://github.com/aio-libs/async-lru)
+/// - [`aiocache` documentation](https://aiocache.aio-libs.org/)
 /// - [don't lru_cache methods!](https://www.youtube.com/watch?v=sVjtp6tGo0g)
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.114")]
@@ -77,7 +82,8 @@ pub(crate) struct CachedInstanceMethod;
 impl Violation for CachedInstanceMethod {
     #[derive_message_formats]
     fn message(&self) -> String {
-        "Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks"
+        "Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, \
+         `aiocache.cached`) on methods can lead to memory leaks"
             .to_string()
     }
 }
@@ -116,7 +122,16 @@ pub(crate) fn cached_instance_method(checker: &Checker, function_def: &ast::Stmt
     }
 }
 
-/// Returns `true` if the given expression is a call to `functools.lru_cache` or `functools.cache`.
+/// Returns `true` if the given expression is a call to one of the
+/// method-caching decorators handled by `B019`. This currently covers:
+///
+/// - `functools.lru_cache` / `functools.cache`
+/// - `async_lru.alru_cache`
+/// - `aiocache.cached` / `aiocache.cached_stampede` / `aiocache.multi_cached`
+///
+/// All of these store a strong reference to `self` in a (typically global)
+/// cache, so applying any of them to an instance method has the same
+/// memory-leak failure mode that `B019` was originally written to catch.
 fn is_cache_func(expr: &Expr, semantic: &SemanticModel) -> bool {
     semantic
         .resolve_qualified_name(expr)
@@ -124,6 +139,8 @@ fn is_cache_func(expr: &Expr, semantic: &SemanticModel) -> bool {
             matches!(
                 qualified_name.segments(),
                 ["functools", "lru_cache" | "cache"]
+                    | ["async_lru", "alru_cache"]
+                    | ["aiocache", "cached" | "cached_stampede" | "multi_cached"]
             )
         })
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B019_B019.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B019_B019.py.snap
@@ -1,99 +1,197 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
 ---
-B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
-  --> B019.py:78:5
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+  --> B019.py:84:5
    |
-77 |     # Remaining methods should emit B019
-78 |     @functools.cache
+83 |     # Remaining methods should emit B019
+84 |     @functools.cache
    |     ^^^^^^^^^^^^^^^^
-79 |     def cached_instance_method(self, y):
-80 |         ...
+85 |     def cached_instance_method(self, y):
+86 |         ...
    |
 
-B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
-  --> B019.py:82:5
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+  --> B019.py:88:5
    |
-80 |         ...
-81 |
-82 |     @cache
+86 |         ...
+87 |
+88 |     @cache
    |     ^^^^^^
-83 |     def another_cached_instance_method(self, y):
-84 |         ...
+89 |     def another_cached_instance_method(self, y):
+90 |         ...
    |
 
-B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
-  --> B019.py:86:5
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+  --> B019.py:92:5
    |
-84 |         ...
-85 |
-86 |     @functools.cache()
+90 |         ...
+91 |
+92 |     @functools.cache()
    |     ^^^^^^^^^^^^^^^^^^
-87 |     def called_cached_instance_method(self, y):
-88 |         ...
+93 |     def called_cached_instance_method(self, y):
+94 |         ...
    |
 
-B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
-  --> B019.py:90:5
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+  --> B019.py:96:5
    |
-88 |         ...
-89 |
-90 |     @cache()
+94 |         ...
+95 |
+96 |     @cache()
    |     ^^^^^^^^
-91 |     def another_called_cached_instance_method(self, y):
-92 |         ...
+97 |     def another_called_cached_instance_method(self, y):
+98 |         ...
    |
 
-B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
-  --> B019.py:94:5
-   |
-92 |         ...
-93 |
-94 |     @functools.lru_cache
-   |     ^^^^^^^^^^^^^^^^^^^^
-95 |     def lru_cached_instance_method(self, y):
-96 |         ...
-   |
-
-B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
-   --> B019.py:98:5
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:100:5
     |
- 96 |         ...
- 97 |
- 98 |     @lru_cache
-    |     ^^^^^^^^^^
- 99 |     def another_lru_cached_instance_method(self, y):
-100 |         ...
-    |
-
-B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
-   --> B019.py:102:5
-    |
-100 |         ...
-101 |
-102 |     @functools.lru_cache()
-    |     ^^^^^^^^^^^^^^^^^^^^^^
-103 |     def called_lru_cached_instance_method(self, y):
-104 |         ...
-    |
-
-B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
-   --> B019.py:106:5
-    |
-104 |         ...
-105 |
-106 |     @lru_cache()
-    |     ^^^^^^^^^^^^
-107 |     def another_called_lru_cached_instance_method(self, y):
-108 |         ...
-    |
-
-B019 Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
-   --> B019.py:124:5
-    |
-123 | class Metaclass(type):
-124 |     @functools.lru_cache
+ 98 |         ...
+ 99 |
+100 |     @functools.lru_cache
     |     ^^^^^^^^^^^^^^^^^^^^
-125 |     def lru_cached_instance_method_on_metaclass(cls, x: int):
-126 |         ...
+101 |     def lru_cached_instance_method(self, y):
+102 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:104:5
+    |
+102 |         ...
+103 |
+104 |     @lru_cache
+    |     ^^^^^^^^^^
+105 |     def another_lru_cached_instance_method(self, y):
+106 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:108:5
+    |
+106 |         ...
+107 |
+108 |     @functools.lru_cache()
+    |     ^^^^^^^^^^^^^^^^^^^^^^
+109 |     def called_lru_cached_instance_method(self, y):
+110 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:112:5
+    |
+110 |         ...
+111 |
+112 |     @lru_cache()
+    |     ^^^^^^^^^^^^
+113 |     def another_called_lru_cached_instance_method(self, y):
+114 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:130:5
+    |
+129 | class Metaclass(type):
+130 |     @functools.lru_cache
+    |     ^^^^^^^^^^^^^^^^^^^^
+131 |     def lru_cached_instance_method_on_metaclass(cls, x: int):
+132 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:164:5
+    |
+163 |     # Remaining methods should emit B019.
+164 |     @async_lru.alru_cache
+    |     ^^^^^^^^^^^^^^^^^^^^^
+165 |     async def alru_cached_instance_method(self, y):
+166 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:168:5
+    |
+166 |         ...
+167 |
+168 |     @alru_cache
+    |     ^^^^^^^^^^^
+169 |     async def alru_cached_instance_method_imported(self, y):
+170 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:172:5
+    |
+170 |         ...
+171 |
+172 |     @async_lru.alru_cache(maxsize=128)
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+173 |     async def called_alru_cached_instance_method(self, y):
+174 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:176:5
+    |
+174 |         ...
+175 |
+176 |     @aiocache.cached()
+    |     ^^^^^^^^^^^^^^^^^^
+177 |     async def aiocache_cached_instance_method(self, y):
+178 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:180:5
+    |
+178 |         ...
+179 |
+180 |     @cached()
+    |     ^^^^^^^^^
+181 |     async def aiocache_cached_instance_method_imported(self, y):
+182 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:184:5
+    |
+182 |         ...
+183 |
+184 |     @aiocache.cached_stampede()
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+185 |     async def aiocache_cached_stampede_instance_method(self, y):
+186 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:188:5
+    |
+186 |         ...
+187 |
+188 |     @cached_stampede()
+    |     ^^^^^^^^^^^^^^^^^^
+189 |     async def aiocache_cached_stampede_instance_method_imported(self, y):
+190 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:192:5
+    |
+190 |         ...
+191 |
+192 |     @aiocache.multi_cached()
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^
+193 |     async def aiocache_multi_cached_instance_method(self, keys):
+194 |         ...
+    |
+
+B019 Use of caching decorators (e.g. `functools.lru_cache`, `async_lru.alru_cache`, `aiocache.cached`) on methods can lead to memory leaks
+   --> B019.py:196:5
+    |
+194 |         ...
+195 |
+196 |     @multi_cached()
+    |     ^^^^^^^^^^^^^^^
+197 |     async def aiocache_multi_cached_instance_method_imported(self, keys):
+198 |         ...
     |


### PR DESCRIPTION
Closes #16436.

`B019` only matches `functools.lru_cache` / `functools.cache` right now. The same memory-leak shape applies to the async ecosystem's cache decorators (`async_lru.alru_cache`, `aiocache.cached` / `cached_stampede` / `multi_cached`), since they also pin a strong reference to `self` in a long-lived cache.

Per @ntBre on the issue, this is "a reasonable rule extension" that just needs the matcher extended plus tests and docs.

What I changed:

* `cached_instance_method.rs`: extended the `matches!` arm in `is_cache_func` to also accept `["async_lru", "alru_cache"]` and `["aiocache", "cached" | "cached_stampede" | "multi_cached"]`. Updated the rule docstring (What it does / Why is this bad? / References) and shortened the diagnostic message to "Use of cache decorators on methods can lead to memory leaks" so it stays readable for `--output-format=concise`.
* `B019.py` fixture: added an `AsyncFoo` class with positive cases for the new decorators (qualified and imported, plus the call form like `@async_lru.alru_cache(maxsize=128)`), negative cases for `@classmethod` and `@staticmethod` paired with the new decorators, and an `AsyncEnumFoo(enum.Enum)` class to confirm the existing enum carve-out still applies.
* Snapshot regenerated. The rule now emits 18 diagnostics: the original 9 (`functools.{cache, lru_cache}` x classmethod/imported/call variants + the metaclass case) and 9 new ones from `AsyncFoo`. The negative cases (classmethod/staticmethod/enum) stay silent.

No new dependencies. The check is purely on resolved qualified names, so `async_lru` and `aiocache` don't need to be installed for it to fire.

Verification:

* `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" cargo nextest run -p ruff_linter rule_cachedinstancemethod` passes.
* `cargo clippy -p ruff_linter --all-targets --all-features -- -D warnings` clean.
* `cargo dev generate-all` reports up-to-date.
* Spot check via `cargo run --bin ruff -- check --select B019 crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B019.py` shows 18 errors matching the snapshot.
