### PR TITLE
[ty] Fix find references for except handler

### DIFF
--- a/crates/ty_ide/src/find_references.rs
+++ b/crates/ty_ide/src/find_references.rs
@@ -260,7 +260,7 @@ except ValueError as err:
         );
 
         assert_snapshot!(test.references(), @"
-        info[references]: Found 4 references
+        info[references]: Found 5 references
           --> main.py:4:29
            |
          4 | except ZeroDivisionError as err:
@@ -273,6 +273,7 @@ except ValueError as err:
          8 | try:
          9 |     y = 2 / 0
         10 | except ValueError as err:
+           |                      ---
         11 |     print(f'Different error: {err}')
            |                               ---
            |

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -22,8 +22,8 @@ use ty_python_semantic::types::ide_support::{
     typed_dict_key_definition,
 };
 use ty_python_semantic::{
-    HasDefinition, HasOptionalDefinition, HasType, ImportAliasResolution, SemanticModel,
-    TypeQualifiers, definitions_for_imported_symbol, definitions_for_name,
+    HasDefinition, HasType, ImportAliasResolution, SemanticModel, TypeQualifiers,
+    definitions_for_imported_symbol, definitions_for_name,
 };
 
 #[derive(Clone, Debug)]
@@ -623,10 +623,17 @@ impl GotoTarget<'_> {
                 call_expression,
             )),
 
-            // For exception variables, they are their own definitions (like parameters)
-            GotoTarget::ExceptVariable(except_handler) => except_handler
-                .optional_definition(model)
-                .map(|definition| vec![ResolvedDefinition::Definition(definition)]),
+            // Exception handler names are bindings but not expressions, so look them up by ident.
+            GotoTarget::ExceptVariable(except_handler) => {
+                except_handler.name.as_ref().map(|name| {
+                    definitions_for_name(
+                        model,
+                        name.as_str(),
+                        AnyNodeRef::Identifier(name),
+                        alias_resolution,
+                    )
+                })
+            }
 
             // Patterns are glorified assignments but we have to look them up by ident
             // because they're not expressions


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Closes https://github.com/astral-sh/ty/issues/3387

We just needed to treat the definition of an except handler 'as' as a binding, not a definition

## Test Plan

Previously incorrect ty_ide test, noted in the issue, has now been fixed
