### PR TITLE
[`pylint`] Fix false positives in `PLR1733` and `PLR1736`

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pylint/unnecessary-dict-index-lookup.md
+++ b/crates/ruff_linter/resources/mdtest/pylint/unnecessary-dict-index-lookup.md
@@ -1,0 +1,105 @@
+# `unnecessary-dict-index-lookup` (`PLR1733`)
+
+```toml
+[lint]
+select = ["PLR1733"]
+```
+
+## False positives related to [#25150] and [#25182]
+
+The reference to `k` in the `else` clause is possibly unbound and should not emit a diagnostic:
+
+```py
+def foo(d: dict):
+    for k, v in d.items():
+        ...
+    else:
+        print(d[k])
+```
+
+We also shouldn't emit a diagnostic when the key has been shadowed by another loop:
+
+```py
+def foo(d: dict):
+    for k, v in d.items():
+        ...
+        for k in v:
+            print(d[k])
+```
+
+The same applies when the dictionary itself is shadowed:
+
+```py
+def foo(d: dict):
+    for k, v in d.items():
+        ...
+        for d in range(1):
+            print(d[k])
+```
+
+And when the value binding is shadowed:
+
+```py
+def foo(d: dict, values: list):
+    for k, v in d.items():
+        ...
+        for v in values:
+            print(d[k])
+```
+
+Destructuring loop targets can shadow the tracked bindings too:
+
+```py
+def foo(d: dict, values: list):
+    for k, v in d.items():
+        ...
+        for _, v in values:
+            print(d[k])
+```
+
+The same applies to other same-scope binders:
+
+```py
+def foo(d: dict, manager, subject):
+    for k, v in d.items():
+        with manager as v:
+            print(d[k])
+
+        try:
+            ...
+        except Exception as k:
+            print(d[k])
+
+        if (k := 1):
+            print(d[k])
+
+        match subject:
+            case {"k": k}:
+                print(d[k])
+```
+
+Lookups evaluated before a rebinding target takes effect should still emit diagnostics:
+
+```py
+def foo(d: dict, values, manager, exc_factory):
+    for k, v in d.items():
+        if k := d[k]:  # error: [unnecessary-dict-index-lookup]
+            ...
+
+    for k, v in d.items():
+        for k in values(d[k]):  # error: [unnecessary-dict-index-lookup]
+            ...
+
+    for k, v in d.items():
+        with manager(d[k]) as k:  # error: [unnecessary-dict-index-lookup]
+            ...
+
+    for k, v in d.items():
+        try:
+            ...
+        except exc_factory(d[k]) as k:  # error: [unnecessary-dict-index-lookup]
+            ...
+```
+
+[#25150]: https://github.com/astral-sh/ruff/issues/25150
+[#25182]: https://github.com/astral-sh/ruff/issues/25182

--- a/crates/ruff_linter/resources/mdtest/pylint/unnecessary-list-index-lookup.md
+++ b/crates/ruff_linter/resources/mdtest/pylint/unnecessary-list-index-lookup.md
@@ -1,0 +1,105 @@
+# `unnecessary-list-index-lookup` (`PLR1736`)
+
+```toml
+[lint]
+select = ["PLR1736"]
+```
+
+## False positives related to [#25150] and [#25182]
+
+The reference to `i` in the `else` clause is possibly unbound and should not emit a diagnostic:
+
+```py
+def foo(l: list):
+    for i, v in enumerate(l):
+        ...
+    else:
+        print(l[i])
+```
+
+We also shouldn't emit a diagnostic when the index has been shadowed by another loop:
+
+```py
+def foo(l: list):
+    for i, v in enumerate(l):
+        ...
+        for i in v:
+            print(l[i])
+```
+
+The same applies when the sequence itself is shadowed:
+
+```py
+def foo(l: list):
+    for i, v in enumerate(l):
+        ...
+        for l in range(1):
+            print(l[i])
+```
+
+And when the value binding is shadowed:
+
+```py
+def foo(l: list, values: list):
+    for i, v in enumerate(l):
+        ...
+        for v in values:
+            print(l[i])
+```
+
+Destructuring loop targets can shadow the tracked bindings too:
+
+```py
+def foo(l: list, values: list):
+    for i, v in enumerate(l):
+        ...
+        for _, v in values:
+            print(l[i])
+```
+
+The same applies to other same-scope binders:
+
+```py
+def foo(l: list, manager, subject):
+    for i, v in enumerate(l):
+        with manager as v:
+            print(l[i])
+
+        try:
+            ...
+        except Exception as i:
+            print(l[i])
+
+        if (i := 1):
+            print(l[i])
+
+        match subject:
+            case {"i": i}:
+                print(l[i])
+```
+
+Lookups evaluated before a rebinding target takes effect should still emit diagnostics:
+
+```py
+def foo(l: list, values, manager, exc_factory):
+    for i, v in enumerate(l):
+        if i := l[i]:  # error: [unnecessary-list-index-lookup]
+            ...
+
+    for i, v in enumerate(l):
+        for i in values(l[i]):  # error: [unnecessary-list-index-lookup]
+            ...
+
+    for i, v in enumerate(l):
+        with manager(l[i]) as i:  # error: [unnecessary-list-index-lookup]
+            ...
+
+    for i, v in enumerate(l):
+        try:
+            ...
+        except exc_factory(l[i]) as i:  # error: [unnecessary-list-index-lookup]
+            ...
+```
+
+[#25150]: https://github.com/astral-sh/ruff/issues/25150
+[#25182]: https://github.com/astral-sh/ruff/issues/25182

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -1,7 +1,6 @@
 use ruff_python_ast as ast;
-use ruff_python_ast::ExceptHandler;
 use ruff_python_ast::visitor::Visitor;
-use ruff_python_ast::{Arguments, Expr, Stmt, visitor};
+use ruff_python_ast::{Arguments, ExceptHandler, Expr, Pattern, Stmt, visitor};
 use ruff_python_semantic::analyze::function_type;
 use ruff_python_semantic::{ScopeKind, SemanticModel};
 use ruff_text_size::TextRange;
@@ -88,13 +87,15 @@ impl<'a> SequenceIndexVisitor<'a> {
 }
 
 impl SequenceIndexVisitor<'_> {
+    fn is_tracked_name(&self, name: &str) -> bool {
+        name == self.sequence_name || name == self.index_name || name == self.value_name
+    }
+
     fn is_assignment(&self, expr: &Expr) -> bool {
         // If we see the sequence, a subscript, or the index being modified, we'll stop emitting
         // diagnostics.
         match expr {
-            Expr::Name(ast::ExprName { id, .. }) => {
-                id == self.sequence_name || id == self.index_name || id == self.value_name
-            }
+            Expr::Name(ast::ExprName { id, .. }) => self.is_tracked_name(id),
             Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
                 let Expr::Name(ast::ExprName { id, .. }) = value.as_ref() else {
                     return false;
@@ -109,6 +110,10 @@ impl SequenceIndexVisitor<'_> {
                 }
                 false
             }
+            Expr::List(ast::ExprList { elts, .. }) | Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+                elts.iter().any(|elt| self.is_assignment(elt))
+            }
+            Expr::Starred(ast::ExprStarred { value, .. }) => self.is_assignment(value),
             _ => false,
         }
     }
@@ -137,12 +142,63 @@ impl Visitor<'_> for SequenceIndexVisitor<'_> {
             Stmt::Delete(ast::StmtDelete { targets, .. }) => {
                 self.modified = targets.iter().any(|target| self.is_assignment(target));
             }
+            Stmt::For(ast::StmtFor {
+                target,
+                iter,
+                body,
+                orelse,
+                ..
+            }) => {
+                // A nested loop target can rebind the sequence, index, or replacement value.
+                self.visit_expr(iter);
+                if self.modified {
+                    return;
+                }
+                self.modified = self.is_assignment(target);
+                if !self.modified {
+                    self.visit_expr(target);
+                    self.visit_body(body);
+                    self.visit_body(orelse);
+                }
+            }
+            Stmt::With(ast::StmtWith { items, body, .. }) => {
+                for item in items {
+                    self.visit_expr(&item.context_expr);
+                    if self.modified {
+                        return;
+                    }
+                    let Some(target) = item.optional_vars.as_deref() else {
+                        continue;
+                    };
+                    self.modified = self.is_assignment(target);
+                    if self.modified {
+                        return;
+                    }
+                    self.visit_expr(target);
+                    if self.modified {
+                        return;
+                    }
+                }
+                self.visit_body(body);
+            }
             _ => visitor::walk_stmt(self, stmt),
         }
     }
 
     fn visit_expr(&mut self, expr: &Expr) {
         if self.modified {
+            return;
+        }
+        if let Expr::Named(ast::ExprNamed { target, value, .. }) = expr {
+            self.visit_expr(value);
+            if self.modified {
+                return;
+            }
+            self.modified = self.is_assignment(target);
+            if self.modified {
+                return;
+            }
+            self.visit_expr(target);
             return;
         }
         if let Expr::Subscript(ast::ExprSubscript {
@@ -164,6 +220,50 @@ impl Visitor<'_> for SequenceIndexVisitor<'_> {
         }
 
         visitor::walk_expr(self, expr);
+    }
+
+    fn visit_except_handler(&mut self, except_handler: &ExceptHandler) {
+        if self.modified {
+            return;
+        }
+
+        let ExceptHandler::ExceptHandler(ast::ExceptHandlerExceptHandler {
+            type_, name, body, ..
+        }) = except_handler;
+        if let Some(type_) = type_ {
+            self.visit_expr(type_);
+            if self.modified {
+                return;
+            }
+        }
+        self.modified = name
+            .as_ref()
+            .is_some_and(|name| self.is_tracked_name(name.as_str()));
+        if !self.modified {
+            self.visit_body(body);
+        }
+    }
+
+    fn visit_pattern(&mut self, pattern: &Pattern) {
+        if self.modified {
+            return;
+        }
+
+        self.modified = match pattern {
+            Pattern::MatchAs(ast::PatternMatchAs {
+                name: Some(name), ..
+            })
+            | Pattern::MatchStar(ast::PatternMatchStar {
+                name: Some(name), ..
+            })
+            | Pattern::MatchMapping(ast::PatternMatchMapping {
+                rest: Some(name), ..
+            }) => self.is_tracked_name(name.as_str()),
+            _ => false,
+        };
+        if !self.modified {
+            visitor::walk_pattern(self, pattern);
+        }
     }
 }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
@@ -57,7 +57,6 @@ pub(crate) fn unnecessary_list_index_lookup(checker: &Checker, stmt_for: &StmtFo
     let ranges = {
         let mut visitor = SequenceIndexVisitor::new(&sequence.id, &index_name.id, &value_name.id);
         visitor.visit_body(&stmt_for.body);
-        visitor.visit_body(&stmt_for.orelse);
         visitor.into_accesses()
     };
 


### PR DESCRIPTION
Summary
--

This PR fixes #25182, as well as some related issues I didn't notice there. In short, both of these
rules flag issues like:

```py
FRUITS = {"apple": 1, "orange": 10, "berry": 22}

for fruit_name, fruit_count in FRUITS.items():
    print(FRUITS[fruit_name])
```

where the `FRUITS[fruit_name]` can be replaced by `fruit_count` from the loop. However, both rules
were missing some ways of shadowing these variables, so I added more tracking to `SequenceIndexVisitor`.

Initially I tried comparing `Binding`s instead of the `str` names currently stored on the visitor
before realizing that the rules were tracking this information via the `is_modified` field, which
also handles other modifications. I'm still not sure I'm entirely happy with this, but I wanted to
check the ecosystem report and checkpoint the progress so far.

Test Plan
--

New mdtests based on the issue
