### PR TITLE
[ty] Avoid forcing lazy `NewType` bases during cycle recovery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -183,6 +183,34 @@ class B:
         self.__slots__  # error: [unresolved-attribute]
 ```
 
+## Function annotation and dynamic `NamedTuple` / `NewType`
+
+This is a regression test for <https://github.com/astral-sh/ty/issues/3485>. Recursive type
+normalization should not force the lazy base of a `NewType` while Salsa is recovering the cycle
+created by the forward reference to `T`.
+
+```py
+class C:
+    pass
+
+def f():
+    pass
+
+def g() -> T:  # error: [unresolved-reference]
+    pass
+
+g()
+
+from typing import NamedTuple, NewType
+
+X = NamedTuple("X", [("x", "X")]), None  # error: [invalid-type-form]
+
+list(X)
+T = f()
+
+X = NewType("X", C)
+```
+
 ## Lazy cached property behind `hasattr`
 
 This pattern used to panic with "too many cycle iterations".

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2044,9 +2044,7 @@ impl<'db> Type<'db> {
             }
             Type::TypeAlias(_) => Some(self),
             Type::NewTypeInstance(newtype) => newtype
-                .try_map_base_class_type(db, |class_type| {
-                    class_type.recursive_type_normalized_impl(db, div, nested)
-                })
+                .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::NewTypeInstance),
             Type::AlwaysFalsy
             | Type::AlwaysTruthy

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -234,9 +234,7 @@ impl<'db> KnownInstanceType<'db> {
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Self::Callable),
             Self::NewType(newtype) => newtype
-                .try_map_base_class_type(db, |class_type| {
-                    class_type.recursive_type_normalized_impl(db, div, true)
-                })
+                .recursive_type_normalized_impl(db, div, true)
                 .map(Self::NewType),
             Self::Sentinel(sentinel) => Some(Self::Sentinel(sentinel)),
             Self::GenericContext(generic) => Some(Self::GenericContext(generic)),

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -175,6 +175,25 @@ impl<'db> NewType<'db> {
         self.try_map_base_class_type(db, |class_type| Some(f(class_type)))
             .unwrap()
     }
+
+    pub(super) fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        let eager_base = match self.eager_base(db) {
+            Some(base) => Some(base.recursive_type_normalized_impl(db, div, nested)?),
+            None => None,
+        };
+
+        Some(NewType::new(
+            db,
+            self.name(db).clone(),
+            self.definition(db),
+            eager_base,
+        ))
+    }
 }
 
 impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
@@ -249,6 +268,23 @@ impl<'db> NewTypeBase<'db> {
             NewTypeBase::NewType(newtype) => Type::NewTypeInstance(newtype),
             NewTypeBase::Float => KnownUnion::Float.to_type(db),
             NewTypeBase::Complex => KnownUnion::Complex.to_type(db),
+        }
+    }
+
+    fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        match self {
+            NewTypeBase::ClassType(class_type) => class_type
+                .recursive_type_normalized_impl(db, div, nested)
+                .map(NewTypeBase::ClassType),
+            NewTypeBase::NewType(newtype) => newtype
+                .recursive_type_normalized_impl(db, div, nested)
+                .map(NewTypeBase::NewType),
+            NewTypeBase::Float | NewTypeBase::Complex => Some(self),
         }
     }
 }


### PR DESCRIPTION
## Summary

Prior to this change, normalizing a `NewType` walked through its base via `try_map_base_class_type`, which could force the lazy base of a `NewType` while another cycle was mid-recovery, which in turn could introduce a new dependency back through function signature inference and panic on code like:

```python
def g() -> T: ...

X = NamedTuple("X", [("x", "X")]), None
T = f()
X = NewType("X", C)
```

This PR keeps lazy `NewType` bases lazy during recursive normalization.

Closes https://github.com/astral-sh/ty/issues/3485.
