### PR TITLE
[ty] Fix diagnostics in ignored folders after adding new files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,6 +4610,7 @@ dependencies = [
  "crossbeam",
  "get-size2",
  "globset",
+ "ignore",
  "insta",
  "notify",
  "ordermap",

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -760,6 +760,26 @@ fn new_files_with_explicit_included_paths() -> anyhow::Result<()> {
 }
 
 #[test]
+fn explicit_nested_included_file_ignores_parent_root_ignore_file() -> anyhow::Result<()> {
+    let case = setup(|context: &mut SetupContext| {
+        context.write_project_file(".ignore", "build/\n")?;
+        context.write_project_file("build/keep.py", "")?;
+        context.set_included_paths(vec![
+            context.project_path().to_path_buf(),
+            context.join_project_path("build/keep.py"),
+        ]);
+        Ok(())
+    })?;
+
+    let keep_path = case.project_path("build/keep.py");
+    let keep_file = case.system_file(&keep_path).unwrap();
+
+    case.assert_indexed_project_files([keep_file]);
+
+    Ok(())
+}
+
+#[test]
 fn new_file_in_included_out_of_project_directory() -> anyhow::Result<()> {
     let mut case = setup(|context: &mut SetupContext| {
         context.write_project_file("src/main.py", "")?;

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -555,6 +555,27 @@ fn new_file() -> anyhow::Result<()> {
 }
 
 #[test]
+fn new_non_python_file_is_not_indexed() -> anyhow::Result<()> {
+    let mut case = setup([("bar.py", "")])?;
+    let bar_path = case.project_path("bar.py");
+    let bar_file = case.system_file(&bar_path).unwrap();
+    let readme_path = case.project_path("README.md");
+
+    case.assert_indexed_project_files([bar_file]);
+
+    std::fs::write(readme_path.as_std_path(), "not Python\n")?;
+
+    let changes = case.stop_watch(event_for_file("README.md"));
+
+    case.apply_changes(&changes, None);
+
+    assert!(case.system_file(&readme_path).is_ok());
+    case.assert_indexed_project_files([bar_file]);
+
+    Ok(())
+}
+
+#[test]
 fn new_ignored_file() -> anyhow::Result<()> {
     let mut case = setup([("bar.py", ""), (".ignore", "foo.py")])?;
     let bar_path = case.project_path("bar.py");
@@ -580,7 +601,8 @@ fn new_ignored_file() -> anyhow::Result<()> {
 fn new_file_in_ignored_directory() -> anyhow::Result<()> {
     let mut case = setup(|context: &mut SetupContext| {
         context.write_project_file("bar.py", "")?;
-        context.write_project_file(".ignore", "build/\n")?;
+        context.write_project_file(".git/HEAD", "ref: refs/heads/main\n")?;
+        context.write_project_file(".gitignore", "build/\n")?;
         std::fs::create_dir(context.join_project_path("build").as_std_path())?;
         Ok(())
     })?;
@@ -588,7 +610,32 @@ fn new_file_in_ignored_directory() -> anyhow::Result<()> {
     let bar_file = case.system_file(&bar_path).unwrap();
     let bad_path = case.project_path("build/bad.py");
 
-    assert_eq!(case.system_file(&bad_path), Err(FileError::NotFound));
+    case.assert_indexed_project_files([bar_file]);
+
+    std::fs::write(bad_path.as_std_path(), "x: int = 'bad'\n")?;
+
+    let changes = case.stop_watch(event_for_file("bad.py"));
+
+    case.apply_changes(&changes, None);
+
+    assert!(case.system_file(&bad_path).is_ok());
+    case.assert_indexed_project_files([bar_file]);
+
+    Ok(())
+}
+
+#[test]
+fn new_file_in_parent_ignored_directory() -> anyhow::Result<()> {
+    let mut case = setup(|context: &mut SetupContext| {
+        context.write_file(".ignore", "project/build/\n")?;
+        context.write_project_file("bar.py", "")?;
+        std::fs::create_dir(context.join_project_path("build").as_std_path())?;
+        Ok(())
+    })?;
+    let bar_path = case.project_path("bar.py");
+    let bar_file = case.system_file(&bar_path).unwrap();
+    let bad_path = case.project_path("build/bad.py");
+
     case.assert_indexed_project_files([bar_file]);
 
     std::fs::write(bad_path.as_std_path(), "x: int = 'bad'\n")?;
@@ -612,14 +659,8 @@ fn new_ignore_file_in_ignored_directory() -> anyhow::Result<()> {
     ])?;
     let bar_path = case.project_path("bar.py");
     let bar_file = case.system_file(&bar_path).unwrap();
-    let bad_path = case.project_path("build/bad.py");
     let nested_ignore_path = case.project_path("build/.gitignore");
 
-    assert!(case.system_file(&bad_path).is_ok());
-    assert_eq!(
-        case.system_file(&nested_ignore_path),
-        Err(FileError::NotFound)
-    );
     case.assert_indexed_project_files([bar_file]);
 
     std::fs::write(nested_ignore_path.as_std_path(), "# harmless\n")?;
@@ -755,26 +796,6 @@ fn new_files_with_explicit_included_paths() -> anyhow::Result<()> {
     let sub_a_file = case.system_file(&sub_a_path).expect("sub/a.py to exist");
 
     case.assert_indexed_project_files([main_file, sub_init, sub_a_file]);
-
-    Ok(())
-}
-
-#[test]
-fn explicit_nested_included_file_ignores_parent_root_ignore_file() -> anyhow::Result<()> {
-    let case = setup(|context: &mut SetupContext| {
-        context.write_project_file(".ignore", "build/\n")?;
-        context.write_project_file("build/keep.py", "")?;
-        context.set_included_paths(vec![
-            context.project_path().to_path_buf(),
-            context.join_project_path("build/keep.py"),
-        ]);
-        Ok(())
-    })?;
-
-    let keep_path = case.project_path("build/keep.py");
-    let keep_file = case.system_file(&keep_path).unwrap();
-
-    case.assert_indexed_project_files([keep_file]);
 
     Ok(())
 }

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -577,6 +577,64 @@ fn new_ignored_file() -> anyhow::Result<()> {
 }
 
 #[test]
+fn new_file_in_ignored_directory() -> anyhow::Result<()> {
+    let mut case = setup(|context: &mut SetupContext| {
+        context.write_project_file("bar.py", "")?;
+        context.write_project_file(".ignore", "build/\n")?;
+        std::fs::create_dir(context.join_project_path("build").as_std_path())?;
+        Ok(())
+    })?;
+    let bar_path = case.project_path("bar.py");
+    let bar_file = case.system_file(&bar_path).unwrap();
+    let bad_path = case.project_path("build/bad.py");
+
+    assert_eq!(case.system_file(&bad_path), Err(FileError::NotFound));
+    case.assert_indexed_project_files([bar_file]);
+
+    std::fs::write(bad_path.as_std_path(), "x: int = 'bad'\n")?;
+
+    let changes = case.stop_watch(event_for_file("bad.py"));
+
+    case.apply_changes(&changes, None);
+
+    assert!(case.system_file(&bad_path).is_ok());
+    case.assert_indexed_project_files([bar_file]);
+
+    Ok(())
+}
+
+#[test]
+fn new_ignore_file_in_ignored_directory() -> anyhow::Result<()> {
+    let mut case = setup([
+        ("bar.py", ""),
+        (".ignore", "build/\n"),
+        ("build/bad.py", "x: int = 'bad'\n"),
+    ])?;
+    let bar_path = case.project_path("bar.py");
+    let bar_file = case.system_file(&bar_path).unwrap();
+    let bad_path = case.project_path("build/bad.py");
+    let nested_ignore_path = case.project_path("build/.gitignore");
+
+    assert!(case.system_file(&bad_path).is_ok());
+    assert_eq!(
+        case.system_file(&nested_ignore_path),
+        Err(FileError::NotFound)
+    );
+    case.assert_indexed_project_files([bar_file]);
+
+    std::fs::write(nested_ignore_path.as_std_path(), "# harmless\n")?;
+
+    let changes = case.stop_watch(event_for_file(".gitignore"));
+
+    case.apply_changes(&changes, None);
+
+    assert!(case.system_file(&nested_ignore_path).is_ok());
+    case.assert_indexed_project_files([bar_file]);
+
+    Ok(())
+}
+
+#[test]
 fn ignore_file_change_reloads_files_not_project_metadata() -> anyhow::Result<()> {
     let mut case = setup([("bar.py", ""), ("foo.py", ""), (".ignore", "foo.py")])?;
     let bar = case.system_file(case.project_path("bar.py"))?;

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -407,7 +407,7 @@ pub(crate) fn symbols_for_file_global_only(db: &dyn Db, file: File) -> FlatSymbo
     if file
         .path(db)
         .as_system_path()
-        .is_none_or(|path| !db.project().is_file_included(db, path))
+        .is_none_or(|path| !db.project().is_file_included(db, path).is_included())
     {
         // Eagerly clear ASTs of third party files.
         parsed.clear();

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -36,6 +36,7 @@ colored = { workspace = true }
 crossbeam = { workspace = true }
 get-size2 = { workspace = true, features = ["ordermap"] }
 globset = { workspace = true }
+ignore = { workspace = true }
 notify = { workspace = true }
 ordermap = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["version-ranges"] }
@@ -55,7 +56,7 @@ toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-ruff_db = { workspace = true, features = ["testing"] }
+ruff_db = { workspace = true, features = ["os", "testing"] }
 
 insta = { workspace = true, features = ["redactions", "ron"] }
 

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -22,6 +22,7 @@ use ty_python_semantic::lint::{LintRegistry, RuleSelection};
 use ty_python_semantic::{AnalysisSettings, Db as SemanticDb};
 
 mod changes;
+mod ignore;
 
 #[salsa::db]
 pub trait Db: SemanticDb {

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -4,10 +4,11 @@ use crate::watch::{ChangeEvent, CreatedKind, DeletedKind};
 use crate::{ProjectMetadata, ProjectReloadResult};
 use std::collections::BTreeSet;
 
+use super::ignore::IgnoreFiles;
 use crate::walk::ProjectFilesWalker;
 use ruff_db::Db as _;
 use ruff_db::file_revision::FileRevision;
-use ruff_db::files::{File, FileRootKind, Files};
+use ruff_db::files::{File, FileRootKind, Files, system_path_to_file};
 use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
 use rustc_hash::FxHashSet;
 use salsa::Setter;
@@ -63,6 +64,12 @@ impl ProjectDatabase {
         let mut removed_paths = BTreeSet::default();
         let mut reload_project = false;
         let mut reload_project_files = false;
+        let respect_ignore_files = project.settings(self).src().respect_ignore_files;
+        let ignore_walk_roots =
+            respect_ignore_files.then(|| project.included_paths_or_root(self).to_vec());
+        let mut ignore_files = ignore_walk_roots
+            .as_deref()
+            .map(|walk_roots| IgnoreFiles::new(self.system().dyn_clone(), walk_roots));
 
         for change in changes {
             tracing::debug!("Handling file watcher change event: {:?}", change);
@@ -94,7 +101,11 @@ impl ProjectDatabase {
                                 "Reloading project files for changed ignore file at or above included path"
                             );
                             reload_project_files = true;
-                        } else if project.is_directory_included(self, directory) {
+                        } else if project.is_directory_included(self, directory)
+                            && ignore_files.as_mut().is_none_or(|ignore_files| {
+                                ignore_files.is_ignored(directory, true).is_uncertain()
+                            })
+                        {
                             tracing::debug!(
                                 ignore_file = %path,
                                 directory = %directory,
@@ -110,7 +121,7 @@ impl ProjectDatabase {
                             tracing::debug!(
                                 ignore_file = %path,
                                 directory = %directory,
-                                "Ignoring changed ignore file because it doesn't affect project paths"
+                                "Ignoring changed ignore file because it doesn't affect indexed project paths"
                             );
                         }
                     }
@@ -171,21 +182,34 @@ impl ProjectDatabase {
                         }
                     }
 
-                    // Unlike other files, it's not only important to update the status of existing
-                    // and known `File`s (`sync_recursively`), it's also important to discover new files
-                    // that were added in the project's root (or any of the paths included for checking).
-                    //
-                    // This is important because `Project::check` iterates over all included files.
-                    // The code below walks the `added_paths` and adds all files that
-                    // should be included in the project. We can skip this check for
-                    // paths that aren't part of the project or shouldn't be included
-                    // when checking the project.
-                    if self.system().is_file(path) {
-                        if project.is_file_included(self, path) {
-                            added_paths.insert(path.to_path_buf());
+                    // A created file can be indexed directly unless project indexing needs the
+                    // walker to apply ignore-file semantics. The ignore fast path below skips
+                    // that walk when it can prove a root ignore file already prunes the path.
+                    if !project.file_set(self).is_lazy() {
+                        if self.system().is_file(path) {
+                            if !project
+                                .is_file_included(self, path)
+                                .should_index_file(self.system(), path)
+                            {
+                                continue;
+                            }
+
+                            if let Some(ignore_files) = ignore_files.as_mut() {
+                                if ignore_files.is_ignored(path, false).is_uncertain() {
+                                    added_paths.insert(path.to_path_buf());
+                                }
+                            } else if let Ok(file) = system_path_to_file(self, path) {
+                                project.add_file(self, file);
+                            }
+                        } else if project.is_directory_included(self, path)
+                            && ignore_files.as_mut().is_none_or(|ignore_files| {
+                                ignore_files.is_ignored(path, true).is_uncertain()
+                            })
+                        {
+                            // Unlike a new file, a new directory needs walking to discover
+                            // project files that exist below it.
+                            added_paths.insert(path.clone());
                         }
-                    } else if project.is_directory_included(self, path) {
-                        added_paths.insert(path.clone());
                     }
                 }
 

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -182,10 +182,7 @@ impl ProjectDatabase {
                     // when checking the project.
                     if self.system().is_file(path) {
                         if project.is_file_included(self, path) {
-                            // Add the parent directory because `walkdir`
-                            // always visits explicitly passed files even if
-                            // they match an exclude filter.
-                            added_paths.insert(path.parent().unwrap().to_path_buf());
+                            added_paths.insert(path.to_path_buf());
                         }
                     } else if project.is_directory_included(self, path) {
                         added_paths.insert(path.clone());
@@ -381,12 +378,11 @@ impl ProjectDatabase {
             }
         }
 
-        project.remove_files_under(self, deduplicate_nested_paths(removed_paths));
+        project.remove_files_under(self, removed_paths);
 
-        let diagnostics = if !project.file_set(self).is_lazy()
-            && let Some(walker) = ProjectFilesWalker::incremental(self, added_paths)
-        {
+        let diagnostics = if !project.file_set(self).is_lazy() {
             // Use directory walking to discover newly added files.
+            let walker = ProjectFilesWalker::incremental(added_paths);
             let (files, diagnostics) = walker.collect_vec(self);
 
             for file in files {

--- a/crates/ty_project/src/db/ignore.rs
+++ b/crates/ty_project/src/db/ignore.rs
@@ -1,0 +1,372 @@
+//! Checks whether a root ignore file lets incremental indexing skip a project
+//! walk.
+//!
+//! A full project walk decides which files belong to a project. Incremental
+//! file watcher updates must make the same decision for newly created paths,
+//! including the effect of `.ignore` and `.gitignore` files. Ideally, the
+//! `ignore` crate would expose an API that answers whether a given path is
+//! ignored. It does not, and reimplementing that decision is involved because
+//! it would need to reproduce all of the walker's ignore behavior:
+//!
+//! - parent `.ignore` files;
+//! - parent `.gitignore` files;
+//! - `.git/info/exclude`;
+//! - the global gitignore;
+//! - git and jj repository discovery;
+//! - traversal ordering, such as pruning `build/` before reading a nested
+//!   `build/.ignore`; and
+//! - linked git worktree handling.
+//!
+//! This module is a compromise. It avoids unnecessary traversal in the common
+//! case where a file or directory is already ignored by an ignore file at the
+//! project walk root.
+
+use ignore::gitignore;
+use ruff_db::system::{System, SystemPath, SystemPathBuf};
+use rustc_hash::FxHashMap;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(super) enum Ignored {
+    /// A root ignore file proves that the project walker would skip this path.
+    Yes,
+
+    /// The file might be ignored, but we need to use the ignore walker to know for sure.
+    Uncertain,
+}
+
+impl Ignored {
+    pub(super) const fn is_uncertain(self) -> bool {
+        matches!(self, Self::Uncertain)
+    }
+}
+
+pub(super) struct IgnoreFiles<'a> {
+    walk_roots: &'a [SystemPathBuf],
+    system: Box<dyn System>,
+    roots: FxHashMap<SystemPathBuf, RootIgnoreFiles>,
+}
+
+impl<'a> IgnoreFiles<'a> {
+    pub(super) fn new(system: Box<dyn System>, walk_roots: &'a [SystemPathBuf]) -> Self {
+        Self {
+            walk_roots,
+            system,
+            roots: FxHashMap::default(),
+        }
+    }
+
+    /// Returns `Yes` only when the matching walk root can prune `path`
+    /// from its own ignore files. In all other cases, return uncertain.
+    pub(super) fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> Ignored {
+        // A nested explicit walk root gets its own depth-0 walk, so an ancestor
+        // root cannot prove that the nested root's descendants are ignored.
+        let Some(root) = self
+            .walk_roots
+            .iter()
+            .filter(|root| path.starts_with(root))
+            .max_by_key(|root| root.as_str().len())
+        else {
+            return Ignored::Uncertain;
+        };
+
+        if self.root_ignore_prunes_path(root, path, is_directory) {
+            Ignored::Yes
+        } else {
+            Ignored::Uncertain
+        }
+    }
+
+    /// Answers the question whether the ignore file in the `root` directory
+    /// ignores `path`.
+    fn root_ignore_prunes_path(
+        &mut self,
+        root: &SystemPath,
+        path: &SystemPath,
+        is_directory: bool,
+    ) -> bool {
+        let Ok(relative_path) = path.strip_prefix(root) else {
+            return false;
+        };
+        let mut components = relative_path.components();
+        let Some(first_component) = components.next() else {
+            return false;
+        };
+
+        let first_child = root.join(first_component);
+        let first_child_is_target = components.next().is_none();
+
+        let first_child_is_directory = !first_child_is_target || is_directory;
+
+        self.root_ignore_files(root)
+            .is_ignored(&first_child, first_child_is_directory)
+    }
+
+    fn root_ignore_files(&mut self, root: &SystemPath) -> &RootIgnoreFiles {
+        self.roots
+            .entry(root.to_path_buf())
+            .or_insert_with(|| RootIgnoreFiles::read(self.system.as_ref(), root))
+    }
+}
+
+/// The cached ignore files for a specific root-folder.
+struct RootIgnoreFiles {
+    ignore: Option<IgnoreFile>,
+    gitignore: Option<IgnoreFile>,
+}
+
+impl RootIgnoreFiles {
+    fn read(system: &dyn System, root: &SystemPath) -> Self {
+        let canonical_root = system.canonicalize_path(root).ok();
+
+        let gitignore = if let Some(canonical_root) = canonical_root.as_deref()
+            && in_git_repository(system, canonical_root)
+            // A parent `.ignore` allowlist takes precedence over a matching
+            // `.gitignore` at the walk root. Let the walker resolve that case.
+            && !has_parent_ignore_file(system, canonical_root)
+        {
+            IgnoreFile::read(system, root, ".gitignore")
+        } else {
+            None
+        };
+
+        Self {
+            ignore: IgnoreFile::read(system, root, ".ignore"),
+            gitignore,
+        }
+    }
+
+    fn is_ignored(&self, path: &SystemPath, is_directory: bool) -> bool {
+        for ignore_file in [&self.ignore, &self.gitignore].into_iter().flatten() {
+            match ignore_file.match_path(path, is_directory) {
+                Ok(Some(is_ignored)) => return is_ignored,
+                Ok(_) => {}
+                Err(()) => return false,
+            }
+        }
+
+        false
+    }
+}
+
+enum IgnoreFile {
+    Matcher(gitignore::Gitignore),
+    /// Building the matcher failed.
+    Error,
+}
+
+impl IgnoreFile {
+    fn read(system: &dyn System, root: &SystemPath, file_name: &str) -> Option<Self> {
+        let ignore_path = root.join(file_name);
+        let contents = match system.read_to_string(&ignore_path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+            Err(_) => return Some(Self::Error),
+        };
+
+        match build_matcher(root, &ignore_path, &contents) {
+            Some(matcher) => Some(Self::Matcher(matcher)),
+            None => Some(Self::Error),
+        }
+    }
+
+    fn match_path(&self, path: &SystemPath, is_directory: bool) -> Result<Option<bool>, ()> {
+        let matcher = match self {
+            Self::Matcher(matcher) => matcher,
+            Self::Error => return Err(()),
+        };
+
+        Ok(match matcher.matched(path.as_std_path(), is_directory) {
+            ignore::Match::None => None,
+            ignore::Match::Ignore(_) => Some(true),
+            ignore::Match::Whitelist(_) => Some(false),
+        })
+    }
+}
+
+fn build_matcher(
+    root: &SystemPath,
+    ignore_path: &SystemPath,
+    contents: &str,
+) -> Option<gitignore::Gitignore> {
+    const UTF8_BOM: &str = "\u{feff}";
+
+    let mut builder = gitignore::GitignoreBuilder::new(root.as_std_path());
+
+    let contents = contents.trim_start_matches(UTF8_BOM);
+
+    for line in contents.lines() {
+        builder
+            .add_line(Some(ignore_path.as_std_path().to_path_buf()), line)
+            .ok()?;
+    }
+
+    builder.build().ok()
+}
+
+fn in_git_repository(system: &dyn System, canonical_root: &SystemPath) -> bool {
+    canonical_root.ancestors().any(|directory| {
+        system.path_exists(&directory.join(".git")) || system.path_exists(&directory.join(".jj"))
+    })
+}
+
+fn has_parent_ignore_file(system: &dyn System, canonical_root: &SystemPath) -> bool {
+    canonical_root
+        .parent()
+        .into_iter()
+        .flat_map(SystemPath::ancestors)
+        .any(|directory| system.path_exists(&directory.join(".ignore")))
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::system::{InMemorySystem, System, SystemPath, SystemPathBuf};
+
+    use super::{IgnoreFiles, Ignored};
+
+    struct TestProject {
+        system: InMemorySystem,
+        root: SystemPathBuf,
+    }
+
+    impl TestProject {
+        fn new() -> Self {
+            Self::with_root("/project")
+        }
+
+        fn with_root(root: &str) -> Self {
+            let system = InMemorySystem::new(root.into());
+            let root = system.current_directory().to_path_buf();
+
+            Self { system, root }
+        }
+
+        fn path(&self, relative_path: &str) -> SystemPathBuf {
+            self.root.join(relative_path)
+        }
+
+        fn write_files<'a>(&self, files: impl IntoIterator<Item = (SystemPathBuf, &'a str)>) {
+            self.system.fs().write_files_all(files).unwrap();
+        }
+
+        fn create_directory(&self, path: impl AsRef<SystemPath>) {
+            self.system.fs().create_directory_all(path).unwrap();
+        }
+
+        fn is_ignored(&self, path: &SystemPath) -> Ignored {
+            self.is_ignored_from(std::slice::from_ref(&self.root), path)
+        }
+
+        fn is_ignored_from(&self, walk_roots: &[SystemPathBuf], path: &SystemPath) -> Ignored {
+            IgnoreFiles::new(self.system.dyn_clone(), walk_roots).is_ignored(path, false)
+        }
+    }
+
+    #[test]
+    fn root_ignore_file_prunes_top_level_directory() {
+        let project = TestProject::new();
+        let path = project.path("build/keep.py");
+        project.write_files([
+            (project.path(".ignore"), "build/\n"),
+            (project.path("build/.ignore"), "!keep.py\n"),
+        ]);
+
+        assert_eq!(project.is_ignored(&path), Ignored::Yes);
+    }
+
+    #[test]
+    fn root_gitignore_file_requires_repository() {
+        let project = TestProject::new();
+        let path = project.path("build/keep.py");
+        project.write_files([(project.path(".gitignore"), "build/\n")]);
+
+        assert_eq!(project.is_ignored(&path), Ignored::Uncertain);
+    }
+
+    #[test]
+    fn bom() {
+        let project = TestProject::new();
+        let path = project.path("build/keep.py");
+        project.write_files([(project.path(".ignore"), "\u{feff}build/\n")]);
+
+        assert_eq!(project.is_ignored(&path), Ignored::Yes);
+    }
+
+    #[test]
+    fn root_ignore_file_allowlist_overrides_root_gitignore_file() {
+        let project = TestProject::new();
+        let path = project.path("build/keep.py");
+        project.write_files([
+            (project.path(".git/HEAD"), "ref: refs/heads/main\n"),
+            (project.path(".ignore"), "!build/\n"),
+            (project.path(".gitignore"), "build/\n"),
+        ]);
+
+        assert_eq!(project.is_ignored(&path), Ignored::Uncertain);
+    }
+
+    #[test]
+    fn parent_ignore_file_disables_root_gitignore_pruning() {
+        let project = TestProject::with_root("/workspace/project");
+        let path = project.path("build/keep.py");
+        project.write_files([
+            (project.path(".git/HEAD"), "ref: refs/heads/main\n"),
+            (project.path(".gitignore"), "build/\n"),
+            (
+                project.root.parent().unwrap().join(".ignore"),
+                "!project/build/\n",
+            ),
+        ]);
+
+        assert_eq!(project.is_ignored(&path), Ignored::Uncertain);
+    }
+
+    #[test]
+    fn root_ignore_file_cannot_prune_deeper_file_match() {
+        let project = TestProject::new();
+        let path = project.path("pkg/keep.py");
+        project.write_files([(project.path(".ignore"), "pkg/keep.py\n")]);
+
+        assert_eq!(project.is_ignored(&path), Ignored::Uncertain);
+    }
+
+    #[test]
+    fn unreadable_root_ignore_file_cannot_prune_path() {
+        let project = TestProject::new();
+        let path = project.path("build/ignored.py");
+        project.create_directory(project.path(".ignore"));
+        project.write_files([
+            (project.path(".git/HEAD"), "ref: refs/heads/main\n"),
+            (project.path(".gitignore"), "build/\n"),
+        ]);
+
+        assert_eq!(project.is_ignored(&path), Ignored::Uncertain);
+    }
+
+    #[test]
+    fn explicit_file_walk_root_cannot_be_pruned_by_parent_root() {
+        let project = TestProject::new();
+        let path = project.path("build/keep.py");
+        project.write_files([(project.path(".ignore"), "build/\n")]);
+
+        assert_eq!(
+            project.is_ignored_from(&[project.root.clone(), path.clone()], &path),
+            Ignored::Uncertain
+        );
+    }
+
+    #[test]
+    fn nested_directory_walk_root_uses_its_own_ignore_file() {
+        let project = TestProject::new();
+        let path = project.path("pkg/build/ignored.py");
+        let nested_root = project.path("pkg");
+        project.write_files([
+            (project.path(".ignore"), "pkg/\n"),
+            (project.path("pkg/.ignore"), "build/\n"),
+        ]);
+
+        assert_eq!(
+            project.is_ignored_from(&[project.root.clone(), nested_root], &path),
+            Ignored::Yes
+        );
+    }
+}

--- a/crates/ty_project/src/glob.rs
+++ b/crates/ty_project/src/glob.rs
@@ -1,4 +1,5 @@
-use ruff_db::system::SystemPath;
+use ruff_db::system::{System, SystemPath};
+use ruff_python_ast::PySourceType;
 
 use crate::glob::include::MatchFile;
 pub(crate) use exclude::{ExcludeFilter, ExcludeFilterBuilder};
@@ -126,7 +127,7 @@ pub(crate) enum GlobFilterCheckMode {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub(crate) enum IncludeResult {
+pub enum IncludeResult {
     /// The path matches or at least is a prefix of an include pattern.
     ///
     /// For directories: This isn't a guarantee that any file in this directory gets included
@@ -139,4 +140,24 @@ pub(crate) enum IncludeResult {
     /// The path matches neither an include nor an exclude pattern and, therefore,
     /// isn't included.
     NotIncluded,
+}
+
+impl IncludeResult {
+    pub fn is_included(self) -> bool {
+        matches!(self, Self::Included { .. })
+    }
+
+    /// Returns `true` if an included file should be indexed.
+    pub(crate) fn should_index_file(self, system: &dyn System, path: &SystemPath) -> bool {
+        let Self::Included { literal_match } = self else {
+            return false;
+        };
+
+        literal_match == Some(true)
+            || path
+                .extension()
+                .and_then(PySourceType::try_from_extension)
+                .or_else(|| system.source_type(path))
+                .is_some()
+    }
 }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -17,7 +17,7 @@ use ruff_db::diagnostic::{
 };
 use ruff_db::files::{File, FileRootKind};
 use ruff_db::parsed::parsed_module;
-use ruff_db::system::{SystemPath, SystemPathBuf};
+use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
 use rustc_hash::FxHashSet;
 use salsa::{Database, Durability, Setter};
 use std::backtrace::BacktraceStatus;
@@ -602,10 +602,12 @@ impl Project {
         I: IntoIterator<Item = P>,
         P: AsRef<SystemPath>,
     {
-        let paths = paths
-            .into_iter()
-            .map(|path| SystemPath::absolute(path, db.system().current_directory()))
-            .collect::<BTreeSet<_>>();
+        let paths = deduplicate_nested_paths(
+            paths
+                .into_iter()
+                .map(|path| SystemPath::absolute(path, db.system().current_directory())),
+        )
+        .collect::<BTreeSet<_>>();
 
         if paths.is_empty() {
             return;
@@ -622,9 +624,10 @@ impl Project {
                 .copied()
                 .filter(|file| {
                     file.path(db).as_system_path().is_some_and(|file_path| {
-                        file_path
-                            .ancestors()
-                            .any(|ancestor| paths.contains(ancestor))
+                        paths
+                            .range(..=file_path.to_path_buf())
+                            .next_back()
+                            .is_some_and(|path| file_path.starts_with(path))
                     })
                 })
                 .collect::<Vec<_>>()
@@ -679,7 +682,7 @@ impl Project {
                         .entered();
                 let start = ruff_db::Instant::now();
 
-                let walker = ProjectFilesWalker::new(db);
+                let walker = ProjectFilesWalker::full();
                 let (files, diagnostics) = walker.collect_set(db);
 
                 tracing::info!(

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -220,18 +220,15 @@ impl Project {
         self.settings(db).to_rules()
     }
 
-    /// Returns `true` if `path` is both part of the project and included (see `included_paths_list`).
+    /// Returns whether `path` is part of the project and included (see `included_paths_list`).
     ///
     /// Unlike [Self::files], this method does not respect `.gitignore` files. It only checks
     /// the project's include and exclude settings as well as the paths that were passed to `ty check <paths>`.
     /// This means, that this method is an over-approximation of `Self::files` and may return `true` for paths
     /// that won't be included when checking the project because they're ignored in a `.gitignore` file.
-    pub fn is_file_included(self, db: &dyn Db, path: &SystemPath) -> bool {
-        matches!(
-            ProjectFilesFilter::from_project(db, self)
-                .is_file_included(path, GlobFilterCheckMode::Adhoc),
-            IncludeResult::Included { .. }
-        )
+    pub fn is_file_included(self, db: &dyn Db, path: &SystemPath) -> IncludeResult {
+        ProjectFilesFilter::from_project(db, self)
+            .is_file_included(path, GlobFilterCheckMode::Adhoc)
     }
 
     pub fn is_directory_included(self, db: &dyn Db, path: &SystemPath) -> bool {
@@ -868,9 +865,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::ProjectMetadata;
     use crate::check_file_impl;
+    use crate::db::Db as _;
     use crate::db::tests::TestDb;
+    use crate::{IncludeResult, ProjectMetadata};
     use ruff_db::files::system_path_to_file;
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
@@ -921,5 +919,23 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn explicit_nested_included_file_is_a_literal_match() {
+        let root = SystemPathBuf::from("/project");
+        let explicit_file = root.join("build/keep.txt");
+        let project = ProjectMetadata::new(Name::new_static("test"), root.clone());
+        let mut db = TestDb::new(project);
+        let project = db.project();
+
+        project.set_included_paths(&mut db, vec![root, explicit_file.clone()]);
+
+        assert_eq!(
+            project.is_file_included(&db, &explicit_file),
+            IncludeResult::Included {
+                literal_match: Some(true)
+            }
+        );
     }
 }

--- a/crates/ty_project/src/walk.rs
+++ b/crates/ty_project/src/walk.rs
@@ -3,9 +3,10 @@ use crate::{Db, GlobFilterCheckMode, IncludeResult, Project};
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::walk_directory::{ErrorKind, WalkDirectoryBuilder, WalkState};
-use ruff_db::system::{SystemPath, SystemPathBuf};
+use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
 use ruff_python_ast::PySourceType;
 use rustc_hash::FxHashSet;
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -119,69 +120,63 @@ enum CheckPathMatch {
     Full,
 }
 
-pub(crate) struct ProjectFilesWalker<'a> {
-    walker: WalkDirectoryBuilder,
-
-    filter: ProjectFilesFilter<'a>,
+pub(crate) struct ProjectFilesWalker {
+    /// If set, the walker only visits directories that contain
+    /// at least one of these paths. Otherwise, the visitor
+    /// walks all paths recursively, except paths that are excluded or not included by the project.
+    incremental_paths: Option<BTreeSet<SystemPathBuf>>,
 }
 
-impl<'a> ProjectFilesWalker<'a> {
-    pub(crate) fn new(db: &'a dyn Db) -> Self {
-        let project = db.project();
-
-        let filter = ProjectFilesFilter::from_project(db, project);
-
-        Self::from_paths(db, project.included_paths_or_root(db), filter)
-            .expect("included_paths_or_root to never return an empty iterator")
-    }
-
-    /// Creates a walker for indexing the project files incrementally.
-    ///
-    /// The main difference to a full project walk is that `paths` may contain paths
-    /// that aren't part of the included files.
-    pub(crate) fn incremental<P>(db: &'a dyn Db, paths: impl IntoIterator<Item = P>) -> Option<Self>
-    where
-        P: AsRef<SystemPath>,
-    {
-        let project = db.project();
-
-        let filter = ProjectFilesFilter::from_project(db, project);
-
-        Self::from_paths(db, paths, filter)
-    }
-
-    fn from_paths<P>(
-        db: &'a dyn Db,
-        paths: impl IntoIterator<Item = P>,
-        filter: ProjectFilesFilter<'a>,
-    ) -> Option<Self>
-    where
-        P: AsRef<SystemPath>,
-    {
-        let mut paths = paths.into_iter();
-
-        let mut walker = db
-            .system()
-            .walk_directory(paths.next()?.as_ref())
-            .standard_filters(db.project().settings(db).src().respect_ignore_files)
-            .ignore_hidden(false);
-
-        for path in paths {
-            walker = walker.add(path);
+impl ProjectFilesWalker {
+    pub(crate) fn full() -> Self {
+        Self {
+            incremental_paths: None,
         }
+    }
 
-        Some(Self { walker, filter })
+    /// Creates a walker for indexing newly added project files incrementally.
+    pub(crate) fn incremental(paths: impl IntoIterator<Item = SystemPathBuf>) -> Self {
+        let incremental_paths = deduplicate_nested_paths(paths).collect();
+
+        Self {
+            incremental_paths: Some(incremental_paths),
+        }
     }
 
     /// Walks the project paths and collects the paths of all files that
     /// are included in the project.
     pub(crate) fn collect_vec(self, db: &dyn Db) -> (Vec<File>, Vec<Diagnostic>) {
+        let project = db.project();
+        let root_paths = project.included_paths_or_root(db);
+
+        let walker = if let Some(incremental_paths) = &self.incremental_paths {
+            if incremental_paths.is_empty() {
+                return (Vec::new(), Vec::new());
+            }
+
+            create_walker(
+                db,
+                // Trim root paths that have no overlap with any of the incremental paths.
+                root_paths.iter().filter(|root| {
+                    should_visit_incremental_path(root.as_path(), &incremental_paths)
+                }),
+            )
+        } else {
+            create_walker(db, root_paths)
+        };
+
+        let Some(walker) = walker else {
+            return (Vec::new(), Vec::new());
+        };
+
+        let filter = ProjectFilesFilter::from_project(db, project);
         let files = std::sync::Mutex::new(Vec::new());
         let diagnostics = std::sync::Mutex::new(Vec::new());
 
-        self.walker.run(|| {
+        walker.run(|| {
             let db = Db::dyn_clone(db);
-            let filter = &self.filter;
+            let filter = &filter;
+            let incremental_paths = &self.incremental_paths;
             let files = &files;
             let diagnostics = &diagnostics;
             let force_exclude = filter.force_exclude();
@@ -191,6 +186,12 @@ impl<'a> ProjectFilesWalker<'a> {
 
                 match entry {
                     Ok(entry) => {
+                        if incremental_paths.as_ref().is_some_and(|incremental_paths| {
+                            !should_visit_incremental_path(entry.path(), incremental_paths)
+                        }) {
+                            return WalkState::Skip;
+                        }
+
                         // Skip excluded directories unless they were explicitly passed to the walker
                         // (which is the case passed to `ty check <paths>`).
                         if entry.file_type().is_directory() {
@@ -316,6 +317,42 @@ impl<'a> ProjectFilesWalker<'a> {
         let (files, diagnostics) = self.collect_vec(db);
         (files.into_iter().collect(), diagnostics)
     }
+}
+
+fn create_walker<I, T>(db: &dyn Db, paths: I) -> Option<WalkDirectoryBuilder>
+where
+    I: IntoIterator<Item = T>,
+    T: AsRef<SystemPath>,
+{
+    let mut paths = paths.into_iter();
+
+    let mut walker = db
+        .system()
+        .walk_directory(paths.next()?.as_ref())
+        .standard_filters(db.project().settings(db).src().respect_ignore_files)
+        .ignore_hidden(false);
+
+    for path in paths {
+        walker = walker.add(path);
+    }
+
+    Some(walker)
+}
+
+fn should_visit_incremental_path(
+    path: &SystemPath,
+    incremental_paths: &BTreeSet<SystemPathBuf>,
+) -> bool {
+    let incremental_path_is_ancestor = incremental_paths
+        .range(..=path.to_path_buf())
+        .next_back()
+        .is_some_and(|incremental_path| path.starts_with(incremental_path));
+    let incremental_path_is_descendant = incremental_paths
+        .range(path.to_path_buf()..)
+        .next()
+        .is_some_and(|incremental_path| incremental_path.starts_with(path));
+
+    incremental_path_is_ancestor || incremental_path_is_descendant
 }
 
 #[derive(Error, Debug, Clone, get_size2::GetSize)]

--- a/crates/ty_project/src/walk.rs
+++ b/crates/ty_project/src/walk.rs
@@ -158,7 +158,7 @@ impl ProjectFilesWalker {
                 db,
                 // Trim root paths that have no overlap with any of the incremental paths.
                 root_paths.iter().filter(|root| {
-                    should_visit_incremental_path(root.as_path(), &incremental_paths)
+                    should_visit_incremental_path(root.as_path(), incremental_paths)
                 }),
             )
         } else {

--- a/crates/ty_project/src/walk.rs
+++ b/crates/ty_project/src/walk.rs
@@ -4,7 +4,6 @@ use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::walk_directory::{ErrorKind, WalkDirectoryBuilder, WalkState};
 use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
-use ruff_python_ast::PySourceType;
 use rustc_hash::FxHashSet;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
@@ -121,9 +120,10 @@ enum CheckPathMatch {
 }
 
 pub(crate) struct ProjectFilesWalker {
-    /// If set, the walker only visits directories that contain
-    /// at least one of these paths. Otherwise, the visitor
-    /// walks all paths recursively, except paths that are excluded or not included by the project.
+    /// If set, the walker only visits paths that lead to one of these paths.
+    ///
+    /// Otherwise, the visitor walks all paths recursively, except paths that are excluded or
+    /// not included by the project.
     incremental_paths: Option<BTreeSet<SystemPathBuf>>,
 }
 
@@ -136,10 +136,8 @@ impl ProjectFilesWalker {
 
     /// Creates a walker for indexing newly added project files incrementally.
     pub(crate) fn incremental(paths: impl IntoIterator<Item = SystemPathBuf>) -> Self {
-        let incremental_paths = deduplicate_nested_paths(paths).collect();
-
         Self {
-            incremental_paths: Some(incremental_paths),
+            incremental_paths: Some(deduplicate_nested_paths(paths).collect()),
         }
     }
 
@@ -156,7 +154,6 @@ impl ProjectFilesWalker {
 
             create_walker(
                 db,
-                // Trim root paths that have no overlap with any of the incremental paths.
                 root_paths.iter().filter(|root| {
                     should_visit_incremental_path(root.as_path(), incremental_paths)
                 }),
@@ -230,22 +227,13 @@ impl ProjectFilesWalker {
                                     GlobFilterCheckMode::TopDown
                                 };
                                 match filter.is_file_included(entry.path(), match_mode) {
-                                    IncludeResult::Included { literal_match } => {
+                                    include_result @ IncludeResult::Included { .. } => {
                                         // Ignore any non python files to avoid creating too many entries in `Files`.
                                         // Unless the file is explicitly passed on the CLI or a literal match in the `include`, we then always assume it's a file ty can analyze
-                                        let source_type = if literal_match == Some(true)
-                                            || entry.depth() == 0
+                                        if entry.depth() > 0
+                                            && !include_result
+                                                .should_index_file(db.system(), entry.path())
                                         {
-                                            Some(PySourceType::Python)
-                                        } else {
-                                            entry
-                                                .path()
-                                                .extension()
-                                                .and_then(PySourceType::try_from_extension)
-                                                .or_else(|| db.system().source_type(entry.path()))
-                                        };
-
-                                        if source_type.is_none() {
                                             return WalkState::Skip;
                                         }
                                     }

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -1233,7 +1233,7 @@ impl Session {
 
                         // Only mark this file as open if it's part of the project.
                         // This ensures that we don't show diagnostics for files outside the project.
-                        if project.is_file_included(db, system_path) {
+                        if project.is_file_included(db, system_path).is_included() {
                             project.open_file(db, file);
                         }
                     }


### PR DESCRIPTION
## Summary

@dhruvmanila pointed out in https://github.com/astral-sh/ruff/pull/25183#discussion_r3257612254 that there are cases where ty incorrectly adds files to the project during an incremental walk if the created files (or folders) are within an ignored directory. 

The root cause is that the `ignore` crate doesn't check whether an input path is ignored. It follows the order, you've told me to walk this directory so I will. And neither did ty. It simply walks any directory in which it sees new files. 

Unfortunately, there's no ad-hoc way of testing whether a directory or file is ignored. This is why, at least for now, this PR changes our incremental walking to always start from the project root, but incremental walking skips directories in which we didn't observe any newly created files or directories. However, we want to avoid unnecessary traversal when we can. E.g. we don't want to schedule a traversal for compilation results in the `target` directory if that directory is excluded. That's why this PR implements a heuristic for the common case where there is one root-level `ignore` or `gitignore` file. Any path that's excluded by those ignore files don't schedule a re-index. 

