### PR TITLE
[ty] Fix diagnostics in ignored folders after adding new files by ad-hoc filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,6 +4610,7 @@ dependencies = [
  "crossbeam",
  "get-size2",
  "globset",
+ "ignore",
  "insta",
  "notify",
  "ordermap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,17 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 [[package]]
 name = "globset"
 version = "0.4.18"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
 dependencies = [
@@ -1564,11 +1575,9 @@ dependencies = [
 [[package]]
 name = "ignore"
 version = "0.4.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
 dependencies = [
  "crossbeam-deque",
- "globset",
+ "globset 0.4.18",
  "log",
  "memchr",
  "regex-automata",
@@ -3025,7 +3034,7 @@ version = "0.0.0"
 dependencies = [
  "filetime",
  "glob",
- "globset",
+ "globset 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.14.0",
  "regex",
  "ruff_macros",
@@ -3190,7 +3199,7 @@ dependencies = [
  "compact_str",
  "fern",
  "glob",
- "globset",
+ "globset 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.17.0",
  "imperative",
  "insta",
@@ -3604,7 +3613,7 @@ dependencies = [
  "colored 3.1.1",
  "etcetera",
  "glob",
- "globset",
+ "globset 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore",
  "indexmap",
  "is-macro",
@@ -4609,7 +4618,7 @@ dependencies = [
  "colored 3.1.1",
  "crossbeam",
  "get-size2",
- "globset",
+ "globset 0.4.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore",
  "insta",
  "notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4634,6 +4634,7 @@ dependencies = [
  "shellexpand",
  "strum",
  "strum_macros",
+ "tempfile",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -351,3 +351,6 @@ opt-level = 1
 # The profile that 'cargo dist' will build with.
 [profile.dist]
 inherits = "release"
+
+[patch.crates-io]
+ignore = { path = "/private/tmp/ignore-walk-state-fork/crates/ignore" }

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -555,6 +555,27 @@ fn new_file() -> anyhow::Result<()> {
 }
 
 #[test]
+fn new_non_python_file_is_not_indexed() -> anyhow::Result<()> {
+    let mut case = setup([("bar.py", "")])?;
+    let bar_path = case.project_path("bar.py");
+    let bar_file = case.system_file(&bar_path).unwrap();
+    let readme_path = case.project_path("README.md");
+
+    case.assert_indexed_project_files([bar_file]);
+
+    std::fs::write(readme_path.as_std_path(), "not Python\n")?;
+
+    let changes = case.stop_watch(event_for_file("README.md"));
+
+    case.apply_changes(&changes, None);
+
+    assert!(case.system_file(&readme_path).is_ok());
+    case.assert_indexed_project_files([bar_file]);
+
+    Ok(())
+}
+
+#[test]
 fn new_ignored_file() -> anyhow::Result<()> {
     let mut case = setup([("bar.py", ""), (".ignore", "foo.py")])?;
     let bar_path = case.project_path("bar.py");
@@ -571,6 +592,57 @@ fn new_ignored_file() -> anyhow::Result<()> {
     case.apply_changes(&changes, None);
 
     assert!(case.system_file(&foo_path).is_ok());
+    case.assert_indexed_project_files([bar_file]);
+
+    Ok(())
+}
+
+#[test]
+fn new_file_in_ignored_directory() -> anyhow::Result<()> {
+    let mut case = setup(|context: &mut SetupContext| {
+        context.write_project_file("bar.py", "")?;
+        context.write_project_file(".ignore", "build/\n")?;
+        std::fs::create_dir(context.join_project_path("build").as_std_path())?;
+        Ok(())
+    })?;
+    let bar_path = case.project_path("bar.py");
+    let bar_file = case.system_file(&bar_path).unwrap();
+    let bad_path = case.project_path("build/bad.py");
+
+    case.assert_indexed_project_files([bar_file]);
+
+    std::fs::write(bad_path.as_std_path(), "x: int = 'bad'\n")?;
+
+    let changes = case.stop_watch(event_for_file("bad.py"));
+
+    case.apply_changes(&changes, None);
+
+    assert!(case.system_file(&bad_path).is_ok());
+    case.assert_indexed_project_files([bar_file]);
+
+    Ok(())
+}
+
+#[test]
+fn new_ignore_file_in_ignored_directory() -> anyhow::Result<()> {
+    let mut case = setup([
+        ("bar.py", ""),
+        (".ignore", "build/\n"),
+        ("build/bad.py", "x: int = 'bad'\n"),
+    ])?;
+    let bar_path = case.project_path("bar.py");
+    let bar_file = case.system_file(&bar_path).unwrap();
+    let nested_ignore_path = case.project_path("build/.gitignore");
+
+    case.assert_indexed_project_files([bar_file]);
+
+    std::fs::write(nested_ignore_path.as_std_path(), "# harmless\n")?;
+
+    let changes = case.stop_watch(event_for_file(".gitignore"));
+
+    case.apply_changes(&changes, None);
+
+    assert!(case.system_file(&nested_ignore_path).is_ok());
     case.assert_indexed_project_files([bar_file]);
 
     Ok(())

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -56,9 +56,10 @@ toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-ruff_db = { workspace = true, features = ["testing"] }
+ruff_db = { workspace = true, features = ["os", "testing"] }
 
 insta = { workspace = true, features = ["redactions", "ron"] }
+tempfile = { workspace = true }
 
 [features]
 default = ["zstd"]

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -36,6 +36,7 @@ colored = { workspace = true }
 crossbeam = { workspace = true }
 get-size2 = { workspace = true, features = ["ordermap"] }
 globset = { workspace = true }
+ignore = { workspace = true }
 notify = { workspace = true }
 ordermap = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["version-ranges"] }

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -69,7 +69,7 @@ impl ProjectDatabase {
             respect_ignore_files.then(|| project.included_paths_or_root(self).to_vec());
         let mut ignore_files = ignore_walk_roots
             .as_deref()
-            .map(|walk_roots| IgnoreFiles::new(self.system().dyn_clone(), walk_roots));
+            .map(|walk_roots| IgnoreFiles::new(self.system(), walk_roots));
 
         for change in changes {
             tracing::debug!("Handling file watcher change event: {:?}", change);

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -64,11 +64,12 @@ impl ProjectDatabase {
         let mut removed_paths = BTreeSet::default();
         let mut reload_project = false;
         let mut reload_project_files = false;
-        let mut ignore_files = project
-            .settings(self)
-            .src()
-            .respect_ignore_files
-            .then(|| IgnoreFiles::new(project.included_paths_or_root(self)));
+        let respect_ignore_files = project.settings(self).src().respect_ignore_files;
+        let ignore_walk_roots =
+            respect_ignore_files.then(|| project.included_paths_or_root(self).to_vec());
+        let mut ignore_files = ignore_walk_roots
+            .as_deref()
+            .map(|walk_roots| IgnoreFiles::new(self.system().dyn_clone(), walk_roots));
 
         for change in changes {
             tracing::debug!("Handling file watcher change event: {:?}", change);
@@ -102,7 +103,7 @@ impl ProjectDatabase {
                             reload_project_files = true;
                         } else if project.is_directory_included(self, directory)
                             && ignore_files.as_mut().is_none_or(|ignore_files| {
-                                !ignore_files.is_ignored(self.system(), directory, true)
+                                !ignore_files.is_ignored(directory, true)
                             })
                         {
                             tracing::debug!(
@@ -185,16 +186,16 @@ impl ProjectDatabase {
                         if self.system().is_file(path) {
                             if project.is_file_included_for_indexing(self, path)
                                 && ignore_files.as_mut().is_none_or(|ignore_files| {
-                                    !ignore_files.is_ignored(self.system(), path, false)
+                                    !ignore_files.is_ignored(path, false)
                                 })
                                 && let Ok(file) = system_path_to_file(self, path)
                             {
                                 project.add_file(self, file);
                             }
                         } else if project.is_directory_included(self, path)
-                            && ignore_files.as_mut().is_none_or(|ignore_files| {
-                                !ignore_files.is_ignored(self.system(), path, true)
-                            })
+                            && ignore_files
+                                .as_mut()
+                                .is_none_or(|ignore_files| !ignore_files.is_ignored(path, true))
                         {
                             // Unlike a new file, a new directory needs walking to discover
                             // project files that exist below it.

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -1,4 +1,5 @@
 use crate::db::{Db, ProjectDatabase};
+use crate::ignore::IgnoreFiles;
 use crate::metadata::options::ProjectOptionsOverrides;
 use crate::watch::{ChangeEvent, CreatedKind, DeletedKind};
 use crate::{ProjectMetadata, ProjectReloadResult};
@@ -7,7 +8,7 @@ use std::collections::BTreeSet;
 use crate::walk::ProjectFilesWalker;
 use ruff_db::Db as _;
 use ruff_db::file_revision::FileRevision;
-use ruff_db::files::{File, FileRootKind, Files};
+use ruff_db::files::{File, FileRootKind, Files, system_path_to_file};
 use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
 use rustc_hash::FxHashSet;
 use salsa::Setter;
@@ -63,6 +64,11 @@ impl ProjectDatabase {
         let mut removed_paths = BTreeSet::default();
         let mut reload_project = false;
         let mut reload_project_files = false;
+        let mut ignore_files = project
+            .settings(self)
+            .src()
+            .respect_ignore_files
+            .then(|| IgnoreFiles::new(project.included_paths_or_root(self)));
 
         for change in changes {
             tracing::debug!("Handling file watcher change event: {:?}", change);
@@ -94,7 +100,11 @@ impl ProjectDatabase {
                                 "Reloading project files for changed ignore file at or above included path"
                             );
                             reload_project_files = true;
-                        } else if project.is_directory_included(self, directory) {
+                        } else if project.is_directory_included(self, directory)
+                            && ignore_files.as_mut().is_none_or(|ignore_files| {
+                                !ignore_files.is_ignored(self.system(), directory, true)
+                            })
+                        {
                             tracing::debug!(
                                 ignore_file = %path,
                                 directory = %directory,
@@ -110,7 +120,7 @@ impl ProjectDatabase {
                             tracing::debug!(
                                 ignore_file = %path,
                                 directory = %directory,
-                                "Ignoring changed ignore file because it doesn't affect project paths"
+                                "Ignoring changed ignore file because it doesn't affect indexed project paths"
                             );
                         }
                     }
@@ -171,24 +181,25 @@ impl ProjectDatabase {
                         }
                     }
 
-                    // Unlike other files, it's not only important to update the status of existing
-                    // and known `File`s (`sync_recursively`), it's also important to discover new files
-                    // that were added in the project's root (or any of the paths included for checking).
-                    //
-                    // This is important because `Project::check` iterates over all included files.
-                    // The code below walks the `added_paths` and adds all files that
-                    // should be included in the project. We can skip this check for
-                    // paths that aren't part of the project or shouldn't be included
-                    // when checking the project.
-                    if self.system().is_file(path) {
-                        if project.is_file_included(self, path) {
-                            // Add the parent directory because `walkdir`
-                            // always visits explicitly passed files even if
-                            // they match an exclude filter.
-                            added_paths.insert(path.parent().unwrap().to_path_buf());
+                    if !project.file_set(self).is_lazy() {
+                        if self.system().is_file(path) {
+                            if project.is_file_included_for_indexing(self, path)
+                                && ignore_files.as_mut().is_none_or(|ignore_files| {
+                                    !ignore_files.is_ignored(self.system(), path, false)
+                                })
+                                && let Ok(file) = system_path_to_file(self, path)
+                            {
+                                project.add_file(self, file);
+                            }
+                        } else if project.is_directory_included(self, path)
+                            && ignore_files.as_mut().is_none_or(|ignore_files| {
+                                !ignore_files.is_ignored(self.system(), path, true)
+                            })
+                        {
+                            // Unlike a new file, a new directory needs walking to discover
+                            // project files that exist below it.
+                            added_paths.insert(path.clone());
                         }
-                    } else if project.is_directory_included(self, path) {
-                        added_paths.insert(path.clone());
                     }
                 }
 
@@ -381,7 +392,7 @@ impl ProjectDatabase {
             }
         }
 
-        project.remove_files_under(self, deduplicate_nested_paths(removed_paths));
+        project.remove_files_under(self, removed_paths);
 
         let diagnostics = if !project.file_set(self).is_lazy()
             && let Some(walker) = ProjectFilesWalker::incremental(self, added_paths)

--- a/crates/ty_project/src/ignore.rs
+++ b/crates/ty_project/src/ignore.rs
@@ -1,61 +1,41 @@
 //! Single-path ignore-file matching with project-walk semantics.
 //!
 //! A normal project file walk delegates ignore handling to `ignore::WalkBuilder`.
-//! Some callers need the same decision for one concrete file or directory
-//! without walking an entire subtree.
+//! Some callers need the same answer for one concrete file or directory without
+//! walking an entire subtree.
 //!
-//! `IgnoreFiles` answers that question by replaying the relevant walk branch
-//! from each project walk root to the changed path. At each branch component it
-//! asks whether the active ignore files would prune that component. If an
-//! intermediate directory is ignored, nested ignore files below it are never
-//! considered, matching the full walker's pruning behavior.
+//! `IgnoreFiles` replays just the branch from each matching walk root to that
+//! candidate path using `ignore::IgnoreState`, which is the same matcher state
+//! carried by the full walker. This preserves directory-pruning semantics such
+//! as "a nested allowlist below an already ignored directory is never seen."
 //!
-//! The active directory list represents ignore files that the walker would
-//! already have discovered at the current branch position. It contains:
-//!
-//! - canonical parent directories above the explicit walk root, matching
-//!   `ignore::Ignore::add_parents`;
-//! - the walk root itself once depth-0 admission has happened; and
-//! - descendant directories accepted while replaying the branch.
-//!
-//! Matching needs both the lexical walked path and, when available, the
-//! canonicalized candidate path. Parent ignore files discovered above a
-//! symlinked root match against the canonical path, while ignore files loaded
-//! at or below the explicit root match against the walked path. `ActiveDirectory`
-//! and `CandidatePaths` keep that distinction local.
-//!
-//! Parsed ignore files are cached per directory within one `IgnoreFiles`
-//! instance so repeated checks do not keep reparsing the same ignore files.
+//! Accepted directory states are cached per walk root. Repeated checks for
+//! nearby paths resume from the deepest cached ancestor instead of rebuilding
+//! the same parent and child ignore state from the root each time.
 
-use ignore::gitignore;
+use ignore::IgnoreState;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use rustc_hash::FxHashMap;
 
 /// Cached ignore-file state for single-path project-walk checks.
-///
-/// `ignore::WalkBuilder` decides whether to descend into a directory before it
-/// reads ignore files inside that directory. This checker mirrors that behavior
-/// along the single branch from an active project walk root to a changed path.
-/// A nested ignore file therefore cannot re-include a path below a directory
-/// that the normal project walk would have pruned already.
-///
-/// Directory entries in `directories` are populated lazily. The presence of an
-/// entry means we already checked that directory for ignore files, and any
-/// parsed matchers are reused by later watcher events in the same batch.
 pub(crate) struct IgnoreFiles<'a> {
     walk_roots: &'a [SystemPathBuf],
-    system: Box<dyn System>,
-    directories: FxHashMap<SystemPathBuf, DirectoryIgnoreFiles>,
-    global_gitignore: Option<gitignore::Gitignore>,
+    base_state: IgnoreState,
+    roots: FxHashMap<SystemPathBuf, RootIgnoreStates>,
 }
 
 impl<'a> IgnoreFiles<'a> {
-    pub(crate) fn new(system: Box<dyn System>, walk_roots: &'a [SystemPathBuf]) -> Self {
+    pub(crate) fn new(system: &dyn System, walk_roots: &'a [SystemPathBuf]) -> Self {
+        let cwd = system.current_directory();
+        let mut builder = ignore::WalkBuilder::new(cwd.as_std_path());
+        builder.current_dir(cwd.as_std_path());
+        builder.standard_filters(true);
+        builder.hidden(false);
+
         Self {
             walk_roots,
-            system,
-            directories: FxHashMap::default(),
-            global_gitignore: None,
+            base_state: builder.build_ignore_state(),
+            roots: FxHashMap::default(),
         }
     }
 
@@ -69,7 +49,7 @@ impl<'a> IgnoreFiles<'a> {
 
         if matching_roots.peek().is_none() {
             return false;
-        };
+        }
 
         matching_roots.all(|root| self.is_ignored_from_root(root, path, is_directory))
     }
@@ -85,588 +65,279 @@ impl<'a> IgnoreFiles<'a> {
             return false;
         }
 
-        let Ok(relative_path) = path.strip_prefix(root) else {
+        let (mut current_path, mut state) = self.deepest_cached_state(root, path);
+        let Ok(relative_path) = path.strip_prefix(&current_path) else {
             return false;
         };
-
-        // `ignore::Ignore::add_parents` skips parent matcher setup when the
-        // walk root cannot be canonicalized. Keep walking from the requested
-        // root in that case, but omit canonical parent ignore files.
-        let canonical_root = self.system.canonicalize_path(root).ok();
-        let mut active_directories = canonical_root
-            .as_deref()
-            .into_iter()
-            .flat_map(SystemPath::ancestors)
-            .skip(1)
-            .map(|directory| ActiveDirectory::canonical_parent(directory.to_path_buf()))
-            .collect::<Vec<_>>();
-        active_directories.reverse();
-
-        // Once the walker has accepted the root directory, it reads the root's
-        // ignore files before deciding whether to visit any child paths.
-        active_directories.push(ActiveDirectory::walked(root.to_path_buf()));
-
-        let mut current_paths = CandidatePaths::new(root.to_path_buf(), canonical_root);
         let mut components = relative_path.components().peekable();
 
-        // Replay the walk one branch component at a time. A directory must be
-        // admitted before ignore files inside it can affect deeper descendants.
+        // Replay the remaining branch one component at a time. A directory's
+        // ignore files become visible only after that directory itself has
+        // been admitted, matching the walker's descend-before-loading order.
         while let Some(component) = components.next() {
-            current_paths.push(component);
+            current_path.push(component);
 
             let is_last_component = components.peek().is_none();
             let current_path_is_directory = !is_last_component || is_directory;
 
-            if self.ignored_by_active_ignore_files(
-                &active_directories,
-                &current_paths,
-                current_path_is_directory,
-            ) == Some(true)
+            if state
+                .matched(current_path.as_std_path(), current_path_is_directory)
+                .is_ignore()
             {
                 return true;
             }
 
             if !is_last_component {
-                active_directories.push(ActiveDirectory::walked(
-                    current_paths.walked().to_path_buf(),
-                ));
+                state = add_child_state(&state, &current_path);
+                self.cache_directory_state(root, current_path.clone(), state.clone());
             }
         }
 
         false
     }
 
-    /// Returns whether ignore files already visible at the current branch
-    /// position would prune `paths`.
-    ///
-    /// The active directories intentionally exclude ignore files below the
-    /// candidate path. This keeps nested allowlists from reviving paths in a
-    /// directory the real walker would already have skipped.
-    fn ignored_by_active_ignore_files(
+    fn deepest_cached_state(
         &mut self,
-        active_directories: &[ActiveDirectory],
-        paths: &CandidatePaths,
-        is_directory: bool,
-    ) -> Option<bool> {
-        if let Some(is_ignored) =
-            self.ignored_by_ignore_files(active_directories, paths, is_directory)
-        {
-            return Some(is_ignored);
-        }
-
-        if !self.has_git_repository(active_directories) {
-            return None;
-        }
-
-        if let Some(is_ignored) =
-            self.ignored_by_gitignore_files(active_directories, paths, is_directory)
-        {
-            return Some(is_ignored);
-        }
-
-        if let Some(is_ignored) =
-            self.ignored_by_git_exclude(active_directories, paths, is_directory)
-        {
-            return Some(is_ignored);
-        }
-
-        self.ignored_by_global_gitignore(paths.walked(), is_directory)
-    }
-
-    fn ignored_by_ignore_files(
-        &mut self,
-        active_directories: &[ActiveDirectory],
-        paths: &CandidatePaths,
-        is_directory: bool,
-    ) -> Option<bool> {
-        active_directories.iter().rev().find_map(|directory| {
-            let matcher = self.ignore_files(directory.path()).ignore.as_ref()?;
-            let path = directory.candidate_path(paths)?;
-            ignored_by_match(&matcher.matched(path.as_std_path(), is_directory))
-        })
-    }
-
-    fn ignored_by_gitignore_files(
-        &mut self,
-        active_directories: &[ActiveDirectory],
-        paths: &CandidatePaths,
-        is_directory: bool,
-    ) -> Option<bool> {
-        let mut saw_git_repository = false;
-
-        for directory in active_directories.iter().rev() {
-            let ignore_files = self.ignore_files(directory.path());
-
-            if !saw_git_repository
-                && let Some(matcher) = ignore_files.gitignore.as_ref()
-                && let Some(path) = directory.candidate_path(paths)
-                && let Some(is_ignored) =
-                    ignored_by_match(&matcher.matched(path.as_std_path(), is_directory))
-            {
-                return Some(is_ignored);
-            }
-
-            saw_git_repository |= ignore_files.has_git_repository;
-        }
-
-        None
-    }
-
-    fn ignored_by_git_exclude(
-        &mut self,
-        active_directories: &[ActiveDirectory],
-        paths: &CandidatePaths,
-        is_directory: bool,
-    ) -> Option<bool> {
-        let mut saw_git_repository = false;
-
-        for directory in active_directories.iter().rev() {
-            let ignore_files = self.ignore_files(directory.path());
-
-            if !saw_git_repository
-                && let Some(matcher) = ignore_files.git_exclude.as_ref()
-                && let Some(path) = directory.candidate_path(paths)
-                && let Some(is_ignored) =
-                    ignored_by_match(&matcher.matched(path.as_std_path(), is_directory))
-            {
-                return Some(is_ignored);
-            }
-
-            saw_git_repository |= ignore_files.has_git_repository;
-        }
-
-        None
-    }
-
-    fn ignored_by_global_gitignore(
-        &mut self,
+        root: &SystemPath,
         path: &SystemPath,
-        is_directory: bool,
-    ) -> Option<bool> {
-        ignored_by_match(
-            &self
-                .global_gitignore()
-                .matched(path.as_std_path(), is_directory),
-        )
-    }
+    ) -> (SystemPathBuf, IgnoreState) {
+        let root_states = self.root_states(root);
 
-    fn global_gitignore(&mut self) -> &gitignore::Gitignore {
-        self.global_gitignore.get_or_insert_with(|| {
-            let cwd = self.system.current_directory();
-            let (matcher, error) =
-                gitignore::GitignoreBuilder::new(cwd.as_std_path()).build_global();
-
-            if let Some(error) = error {
-                tracing::warn!("Failed to read global gitignore: {error}");
+        for ancestor in path.parent().into_iter().flat_map(SystemPath::ancestors) {
+            if !ancestor.starts_with(root) {
+                break;
             }
 
-            matcher
-        })
-    }
+            if let Some(state) = root_states.directories.get(ancestor) {
+                return (ancestor.to_path_buf(), state.clone());
+            }
 
-    fn has_git_repository(&mut self, active_directories: &[ActiveDirectory]) -> bool {
-        active_directories
-            .iter()
-            .rev()
-            .any(|directory| self.ignore_files(directory.path()).has_git_repository)
-    }
-
-    fn ignore_files(&mut self, directory: &SystemPath) -> &DirectoryIgnoreFiles {
-        self.directories
-            .entry(directory.to_path_buf())
-            .or_insert_with(|| DirectoryIgnoreFiles::read(self.system.as_ref(), directory))
-    }
-}
-
-/// Candidate paths for the branch component currently being checked.
-///
-/// `walked` follows the lexical path requested by the project walk. `canonical`
-/// tracks the same branch from the canonicalized walk root when that root could
-/// be resolved. Parent ignore files use the canonical path, while ignore files
-/// loaded at or below the explicit walk root use the walked path.
-struct CandidatePaths {
-    walked: SystemPathBuf,
-    canonical: Option<SystemPathBuf>,
-}
-
-impl CandidatePaths {
-    fn new(walked: SystemPathBuf, canonical: Option<SystemPathBuf>) -> Self {
-        Self { walked, canonical }
-    }
-
-    fn push(&mut self, component: impl AsRef<SystemPath>) {
-        let component = component.as_ref();
-        self.walked.push(component);
-
-        if let Some(canonical) = self.canonical.as_mut() {
-            canonical.push(component);
+            if ancestor == root {
+                break;
+            }
         }
+
+        let state = root_states
+            .directories
+            .get(root)
+            .expect("root state to be inserted before descendant lookup")
+            .clone();
+        (root.to_path_buf(), state)
     }
 
-    fn walked(&self) -> &SystemPath {
-        &self.walked
+    fn cache_directory_state(
+        &mut self,
+        root: &SystemPath,
+        directory: SystemPathBuf,
+        state: IgnoreState,
+    ) {
+        self.root_states(root).directories.insert(directory, state);
     }
 
-    fn canonical(&self) -> Option<&SystemPath> {
-        self.canonical.as_deref()
+    fn root_states(&mut self, root: &SystemPath) -> &mut RootIgnoreStates {
+        if !self.roots.contains_key(root) {
+            let root_states = RootIgnoreStates::new(&self.base_state, root);
+            self.roots.insert(root.to_path_buf(), root_states);
+        }
+
+        self.roots
+            .get_mut(root)
+            .expect("root state to be inserted before lookup")
     }
 }
 
-struct ActiveDirectory {
-    path: SystemPathBuf,
-    match_path: MatchPath,
+struct RootIgnoreStates {
+    directories: FxHashMap<SystemPathBuf, IgnoreState>,
 }
 
-impl ActiveDirectory {
-    fn canonical_parent(path: SystemPathBuf) -> Self {
-        Self {
-            path,
-            match_path: MatchPath::Canonical,
-        }
-    }
+impl RootIgnoreStates {
+    fn new(base_state: &IgnoreState, root: &SystemPath) -> Self {
+        let root_state = add_parent_state(base_state, root);
+        let root_state = add_child_state(&root_state, root);
 
-    fn walked(path: SystemPathBuf) -> Self {
-        Self {
-            path,
-            match_path: MatchPath::Walked,
-        }
-    }
+        let mut directories = FxHashMap::default();
+        directories.insert(root.to_path_buf(), root_state);
 
-    fn path(&self) -> &SystemPath {
-        &self.path
-    }
-
-    fn candidate_path<'a>(&self, paths: &'a CandidatePaths) -> Option<&'a SystemPath> {
-        match self.match_path {
-            MatchPath::Canonical => paths.canonical(),
-            MatchPath::Walked => Some(paths.walked()),
-        }
+        Self { directories }
     }
 }
 
-enum MatchPath {
-    /// Match against the canonicalized candidate path.
-    ///
-    /// To mirror `ignore::Ignore::add_parents`, parent ignore files above the
-    /// configured walk root are discovered by first resolving that root through
-    /// the filesystem. If the walk root is a symlink, those parent files belong
-    /// to the symlink target's ancestors, so they must match against the
-    /// correspondingly resolved candidate path.
-    Canonical,
+fn add_parent_state(state: &IgnoreState, root: &SystemPath) -> IgnoreState {
+    let (state, error) = state.add_parents(root.as_std_path());
 
-    /// Match against the lexical path observed during the walk.
-    ///
-    /// Ignore files at the explicit walk root or below it are loaded while
-    /// descending the requested path branch, so they keep the walked path.
-    Walked,
-}
-
-struct DirectoryIgnoreFiles {
-    ignore: Option<gitignore::Gitignore>,
-    gitignore: Option<gitignore::Gitignore>,
-    git_exclude: Option<gitignore::Gitignore>,
-    has_git_repository: bool,
-}
-
-impl DirectoryIgnoreFiles {
-    fn read(system: &dyn System, directory: &SystemPath) -> Self {
-        let git_directory = directory.join(".git");
-        let has_git_repository =
-            system.path_exists(&git_directory) || system.path_exists(&directory.join(".jj"));
-        let git_exclude = git_exclude_matcher(system, directory, &git_directory);
-
-        Self {
-            ignore: ignore_file_matcher(system, &directory.join(".ignore"), directory),
-            gitignore: ignore_file_matcher(system, &directory.join(".gitignore"), directory),
-            git_exclude,
-            has_git_repository,
-        }
-    }
-}
-
-fn git_exclude_matcher(
-    system: &dyn System,
-    directory: &SystemPath,
-    git_directory: &SystemPath,
-) -> Option<gitignore::Gitignore> {
-    let git_common_directory = resolve_git_common_directory(system, git_directory)?;
-    ignore_file_matcher(
-        system,
-        &git_common_directory.join("info/exclude"),
-        directory,
-    )
-}
-
-/// Mirrors the linked-worktree `commondir` lookup in
-/// [`resolve_git_commondir`](https://github.com/BurntSushi/ripgrep/blob/57c190d56eedac90c061a238b63dbfed434fee50/crates/ignore/src/dir.rs#L884-L936).
-fn resolve_git_common_directory(
-    system: &dyn System,
-    git_directory: &SystemPath,
-) -> Option<SystemPathBuf> {
-    if system.is_directory(git_directory) {
-        return Some(git_directory.to_path_buf());
+    if let Some(error) = error {
+        tracing::warn!("Failed to read parent ignore files for `{root}`: {error}");
     }
 
-    if !system.is_file(git_directory) {
-        return None;
-    }
-
-    let git_file = match system.read_to_string(git_directory) {
-        Ok(git_file) => git_file,
-        Err(error) => {
-            tracing::warn!("Failed to read linked-worktree git dir `{git_directory}`: {error}");
-            return None;
-        }
-    };
-
-    let real_git_directory = git_file
-        .lines()
-        .next()?
-        .strip_prefix("gitdir: ")
-        .map(SystemPathBuf::from)?;
-    let common_directory_file = real_git_directory.join("commondir");
-    let common_directory = match system.read_to_string(&common_directory_file) {
-        Ok(common_directory) => common_directory,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
-        Err(error) => {
-            tracing::warn!(
-                "Failed to read linked-worktree common dir `{common_directory_file}`: {error}"
-            );
-            return None;
-        }
-    };
-    let common_directory = common_directory.lines().next()?;
-
-    if common_directory.starts_with('.') {
-        Some(real_git_directory.join(common_directory))
-    } else {
-        Some(SystemPathBuf::from(common_directory))
-    }
+    state
 }
 
-fn ignore_file_matcher(
-    system: &dyn System,
-    ignore_file: &SystemPath,
-    root: &SystemPath,
-) -> Option<gitignore::Gitignore> {
-    const UTF8_BOM: &str = "\u{feff}";
+fn add_child_state(state: &IgnoreState, directory: &SystemPath) -> IgnoreState {
+    let (state, error) = state.add_child(directory.as_std_path());
 
-    let contents = match system.read_to_string(ignore_file) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
-        Err(error) => {
-            tracing::warn!("Failed to read ignore file `{ignore_file}`: {error}");
-            return None;
-        }
-    };
-
-    let mut builder = gitignore::GitignoreBuilder::new(root.as_std_path());
-
-    let contents = contents.trim_start_matches(UTF8_BOM);
-
-    for (line_number, line) in contents.lines().enumerate() {
-        if let Err(error) = builder.add_line(Some(ignore_file.as_std_path().to_path_buf()), line) {
-            tracing::warn!(
-                "Failed to parse ignore file `{ignore_file}` at line {}: {error}",
-                line_number + 1
-            );
-        }
+    if let Some(error) = error {
+        tracing::warn!("Failed to read ignore files in `{directory}`: {error}");
     }
 
-    Some(match builder.build() {
-        Ok(matcher) => matcher,
-        Err(error) => {
-            tracing::warn!("Failed to build ignore matcher for `{ignore_file}`: {error}");
-            gitignore::Gitignore::empty()
-        }
-    })
-}
-
-fn ignored_by_match<T>(match_result: &ignore::Match<T>) -> Option<bool> {
-    match match_result {
-        ignore::Match::None => None,
-        ignore::Match::Ignore(_) => Some(true),
-        ignore::Match::Whitelist(_) => Some(false),
-    }
+    state
 }
 
 #[cfg(test)]
 mod tests {
-    use ruff_db::system::{InMemorySystem, System, SystemPath};
-    #[cfg(unix)]
-    use ruff_db::system::{OsSystem, SystemPathBuf};
-    #[cfg(unix)]
     use std::fs;
+
+    use ruff_db::system::{OsSystem, System, SystemPath, SystemPathBuf};
+
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
 
     use super::IgnoreFiles;
 
-    fn is_ignored(system: &InMemorySystem, path: &SystemPath, is_directory: bool) -> bool {
-        let root = system.current_directory().to_path_buf();
-        IgnoreFiles::new(system.dyn_clone(), std::slice::from_ref(&root))
-            .is_ignored(path, is_directory)
+    struct Fixture {
+        _temp_dir: tempfile::TempDir,
+        root: SystemPathBuf,
+        system: OsSystem,
+    }
+
+    impl Fixture {
+        fn new() -> std::io::Result<Self> {
+            let temp_dir = tempfile::tempdir()?;
+            let root = SystemPathBuf::from_path_buf(temp_dir.path().to_path_buf())
+                .expect("temporary test path to be UTF-8");
+            let system = OsSystem::new(&root);
+
+            Ok(Self {
+                _temp_dir: temp_dir,
+                root,
+                system,
+            })
+        }
+
+        fn path(&self, relative: &str) -> SystemPathBuf {
+            self.root.join(relative)
+        }
+
+        fn write_file(&self, relative: &str, contents: &str) -> std::io::Result<SystemPathBuf> {
+            let path = self.path(relative);
+
+            let system = self
+                .system
+                .as_writable()
+                .expect("OS test system to support writes");
+
+            if let Some(parent) = path.parent() {
+                system.create_directory_all(parent)?;
+            }
+
+            system.write_file(&path, contents)?;
+            Ok(path)
+        }
+
+        fn is_ignored(&self, path: &SystemPath, is_directory: bool) -> bool {
+            IgnoreFiles::new(&self.system, std::slice::from_ref(&self.root))
+                .is_ignored(path, is_directory)
+        }
     }
 
     #[test]
-    fn nested_ignore_file_allowlist_overrides_parent_file_rule() {
-        let system = InMemorySystem::new("/project".into());
-        let root = system.current_directory().to_path_buf();
-        let path = root.join("pkg/keep.py");
+    fn nested_ignore_file_allowlist_overrides_parent_file_rule() -> std::io::Result<()> {
+        let fixture = Fixture::new()?;
+        fixture.write_file(".ignore", "pkg/keep.py\n")?;
+        fixture.write_file("pkg/.ignore", "!keep.py\n")?;
+        let path = fixture.write_file("pkg/keep.py", "")?;
 
-        system
-            .fs()
-            .write_files_all([
-                (root.join(".ignore"), "pkg/keep.py\n"),
-                (root.join("pkg/.ignore"), "!keep.py\n"),
-                (path.clone(), ""),
-            ])
-            .unwrap();
-
-        assert!(!is_ignored(&system, &path, false));
+        assert!(!fixture.is_ignored(&path, false));
+        Ok(())
     }
 
     #[test]
-    fn nested_ignore_file_cannot_allowlist_below_pruned_directory() {
-        let system = InMemorySystem::new("/project".into());
-        let root = system.current_directory().to_path_buf();
-        let path = root.join("build/keep.py");
+    fn nested_ignore_file_cannot_allowlist_below_pruned_directory() -> std::io::Result<()> {
+        let fixture = Fixture::new()?;
+        fixture.write_file(".ignore", "build/\n")?;
+        fixture.write_file("build/.ignore", "!keep.py\n")?;
+        let path = fixture.write_file("build/keep.py", "")?;
 
-        system
-            .fs()
-            .write_files_all([
-                (root.join(".ignore"), "build/\n"),
-                (root.join("build/.ignore"), "!keep.py\n"),
-                (path.clone(), ""),
-            ])
-            .unwrap();
-
-        assert!(is_ignored(&system, &path, false));
+        assert!(fixture.is_ignored(&path, false));
+        Ok(())
     }
 
     #[test]
-    fn ignore_file_takes_precedence_over_gitignore_allowlist() {
-        let system = InMemorySystem::new("/project".into());
-        let root = system.current_directory().to_path_buf();
-        let path = root.join("ignored.py");
+    fn ignore_file_takes_precedence_over_gitignore_allowlist() -> std::io::Result<()> {
+        let fixture = Fixture::new()?;
+        fixture.write_file(".git/HEAD", "ref: refs/heads/main\n")?;
+        fixture.write_file(".ignore", "ignored.py\n")?;
+        fixture.write_file(".gitignore", "!ignored.py\n")?;
+        let path = fixture.write_file("ignored.py", "")?;
 
-        system
-            .fs()
-            .write_files_all([
-                (root.join(".git/HEAD"), "ref: refs/heads/main\n"),
-                (root.join(".ignore"), "ignored.py\n"),
-                (root.join(".gitignore"), "!ignored.py\n"),
-                (path.clone(), ""),
-            ])
-            .unwrap();
-
-        assert!(is_ignored(&system, &path, false));
+        assert!(fixture.is_ignored(&path, false));
+        Ok(())
     }
 
     #[test]
-    fn ignore_file_allowlist_takes_precedence_over_gitignore_ignore() {
-        let system = InMemorySystem::new("/project".into());
-        let root = system.current_directory().to_path_buf();
-        let path = root.join("included.py");
+    fn ignore_file_allowlist_takes_precedence_over_gitignore_ignore() -> std::io::Result<()> {
+        let fixture = Fixture::new()?;
+        fixture.write_file(".git/HEAD", "ref: refs/heads/main\n")?;
+        fixture.write_file(".ignore", "!included.py\n")?;
+        fixture.write_file(".gitignore", "included.py\n")?;
+        let path = fixture.write_file("included.py", "")?;
 
-        system
-            .fs()
-            .write_files_all([
-                (root.join(".git/HEAD"), "ref: refs/heads/main\n"),
-                (root.join(".ignore"), "!included.py\n"),
-                (root.join(".gitignore"), "included.py\n"),
-                (path.clone(), ""),
-            ])
-            .unwrap();
-
-        assert!(!is_ignored(&system, &path, false));
+        assert!(!fixture.is_ignored(&path, false));
+        Ok(())
     }
 
     #[test]
-    fn ignore_file_strips_utf8_bom() {
-        let system = InMemorySystem::new("/project".into());
-        let root = system.current_directory().to_path_buf();
-        let path = root.join("ignored.py");
+    fn ignore_file_strips_utf8_bom() -> std::io::Result<()> {
+        let fixture = Fixture::new()?;
+        fixture.write_file(".ignore", "\u{feff}ignored.py\n")?;
+        let path = fixture.write_file("ignored.py", "")?;
 
-        system
-            .fs()
-            .write_files_all([
-                (root.join(".ignore"), "\u{feff}ignored.py\n"),
-                (path.clone(), ""),
-            ])
-            .unwrap();
-
-        assert!(is_ignored(&system, &path, false));
+        assert!(fixture.is_ignored(&path, false));
+        Ok(())
     }
 
     #[test]
-    fn gitignore_requires_repository() {
-        let system = InMemorySystem::new("/project".into());
-        let root = system.current_directory().to_path_buf();
-        let path = root.join("ignored.py");
+    fn gitignore_requires_repository() -> std::io::Result<()> {
+        let fixture = Fixture::new()?;
+        fixture.write_file(".gitignore", "ignored.py\n")?;
+        let path = fixture.write_file("ignored.py", "")?;
 
-        system
-            .fs()
-            .write_files_all([
-                (root.join(".gitignore"), "ignored.py\n"),
-                (path.clone(), ""),
-            ])
-            .unwrap();
-
-        assert!(!is_ignored(&system, &path, false));
+        assert!(!fixture.is_ignored(&path, false));
+        Ok(())
     }
 
     #[test]
-    fn git_exclude_ignores_files() {
-        let system = InMemorySystem::new("/project".into());
-        let root = system.current_directory().to_path_buf();
-        let path = root.join("ignored.py");
+    fn git_exclude_ignores_files() -> std::io::Result<()> {
+        let fixture = Fixture::new()?;
+        fixture.write_file(".git/HEAD", "ref: refs/heads/main\n")?;
+        fixture.write_file(".git/info/exclude", "ignored.py\n")?;
+        let path = fixture.write_file("ignored.py", "")?;
 
-        system
-            .fs()
-            .write_files_all([
-                (root.join(".git/HEAD"), "ref: refs/heads/main\n"),
-                (root.join(".git/info/exclude"), "ignored.py\n"),
-                (path.clone(), ""),
-            ])
-            .unwrap();
-
-        assert!(is_ignored(&system, &path, false));
+        assert!(fixture.is_ignored(&path, false));
+        Ok(())
     }
 
     #[test]
-    fn linked_worktree_git_exclude_ignores_files() {
-        let system = InMemorySystem::new("/project".into());
-        let root = system.current_directory().to_path_buf();
-        let common_git_directory = root.join(".git-common");
+    fn linked_worktree_git_exclude_ignores_files() -> std::io::Result<()> {
+        let fixture = Fixture::new()?;
+        let common_git_directory = fixture.path(".git-common");
         let worktree_git_directory = common_git_directory.join("worktrees/current");
         let commondir_path = worktree_git_directory.join("commondir");
-        let path = root.join("ignored.py");
+        let path = fixture.write_file("ignored.py", "")?;
 
-        system
-            .fs()
-            .write_files_all([
-                (
-                    root.join(".git"),
-                    format!("gitdir: {worktree_git_directory}\n"),
-                ),
-                (commondir_path.clone(), "../..\n".to_string()),
-                (
-                    common_git_directory.join("info/exclude"),
-                    "ignored.py\n".to_string(),
-                ),
-                (path.clone(), String::new()),
-            ])
-            .unwrap();
+        fixture.write_file(".git", &format!("gitdir: {worktree_git_directory}\n"))?;
+        fixture.write_file(".git-common/worktrees/current/commondir", "../..\n")?;
+        fixture.write_file(".git-common/info/exclude", "ignored.py\n")?;
 
-        assert!(is_ignored(&system, &path, false));
+        assert!(fixture.is_ignored(&path, false));
 
-        system
-            .fs()
-            .write_file_all(&commondir_path, common_git_directory.as_str())
-            .unwrap();
+        fixture
+            .system
+            .as_writable()
+            .expect("OS test system to support writes")
+            .write_file(&commondir_path, common_git_directory.as_str())?;
 
-        assert!(is_ignored(&system, &path, false));
+        assert!(fixture.is_ignored(&path, false));
+        Ok(())
     }
 
     #[cfg(unix)]
@@ -694,7 +365,7 @@ mod tests {
 
         let system = OsSystem::new(&temp_root);
         assert!(
-            IgnoreFiles::new(system.dyn_clone(), std::slice::from_ref(&symlink_root))
+            IgnoreFiles::new(&system, std::slice::from_ref(&symlink_root))
                 .is_ignored(&ignored_path, false)
         );
 

--- a/crates/ty_project/src/ignore.rs
+++ b/crates/ty_project/src/ignore.rs
@@ -1,0 +1,552 @@
+use ruff_db::system::{System, SystemPath, SystemPathBuf};
+use rustc_hash::FxHashMap;
+
+/// Cached ignore-file state for one watcher change batch.
+///
+/// `ignore::WalkBuilder` decides whether to descend into a directory before it
+/// reads ignore files inside that directory. This checker mirrors that behavior
+/// along the single branch from an active project walk root to a changed path.
+/// A nested ignore file therefore cannot re-include a path below a directory
+/// that the normal project walk would have pruned already.
+///
+/// Directory entries in `directories` are populated lazily. The presence of an
+/// entry means we already checked that directory for ignore files, and any
+/// parsed matchers are reused by later watcher events in the same batch.
+pub(crate) struct IgnoreFiles {
+    walk_roots: Vec<SystemPathBuf>,
+    directories: FxHashMap<SystemPathBuf, DirectoryIgnoreFiles>,
+    global_gitignore: Option<ignore::gitignore::Gitignore>,
+}
+
+impl IgnoreFiles {
+    pub(crate) fn new(walk_roots: &[SystemPathBuf]) -> Self {
+        Self {
+            walk_roots: walk_roots.to_vec(),
+            directories: FxHashMap::default(),
+            global_gitignore: None,
+        }
+    }
+
+    /// Returns `true` if every matching project walk root would skip `path`.
+    pub(crate) fn is_ignored(
+        &mut self,
+        system: &dyn System,
+        path: &SystemPath,
+        is_directory: bool,
+    ) -> bool {
+        let matching_roots = self
+            .walk_roots
+            .iter()
+            .filter(|root| path.starts_with(root))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if matching_roots.is_empty() {
+            return false;
+        }
+
+        matching_roots
+            .iter()
+            .all(|root| self.is_ignored_from_root(system, root, path, is_directory))
+    }
+
+    fn is_ignored_from_root(
+        &mut self,
+        system: &dyn System,
+        root: &SystemPath,
+        path: &SystemPath,
+        is_directory: bool,
+    ) -> bool {
+        if path == root {
+            // Walk roots are yielded at depth 0 before ignore filtering runs.
+            return false;
+        }
+
+        let Ok(relative_path) = path.strip_prefix(root) else {
+            return false;
+        };
+
+        let mut active_directories = root
+            .parent()
+            .into_iter()
+            .flat_map(SystemPath::ancestors)
+            .map(SystemPath::to_path_buf)
+            .collect::<Vec<_>>();
+        active_directories.reverse();
+
+        // Once the walker has accepted the root directory, it reads the root's
+        // ignore files before deciding whether to visit any child paths.
+        active_directories.push(root.to_path_buf());
+
+        let mut current_path = root.to_path_buf();
+        let mut components = relative_path.components().peekable();
+
+        while let Some(component) = components.next() {
+            current_path.push(component.as_str());
+
+            let is_last_component = components.peek().is_none();
+            let current_path_is_directory = !is_last_component || is_directory;
+
+            if self
+                .ignored_by_active_ignore_files(
+                    system,
+                    &active_directories,
+                    &current_path,
+                    current_path_is_directory,
+                )
+                .unwrap_or(false)
+            {
+                return true;
+            }
+
+            if !is_last_component {
+                active_directories.push(current_path.clone());
+            }
+        }
+
+        false
+    }
+
+    fn ignored_by_active_ignore_files(
+        &mut self,
+        system: &dyn System,
+        active_directories: &[SystemPathBuf],
+        path: &SystemPath,
+        is_directory: bool,
+    ) -> Option<bool> {
+        if let Some(is_ignored) =
+            self.ignored_by_ignore_files(system, active_directories, path, is_directory)
+        {
+            return Some(is_ignored);
+        }
+
+        if !self.has_git_repository(system, active_directories) {
+            return None;
+        }
+
+        if let Some(is_ignored) =
+            self.ignored_by_gitignore_files(system, active_directories, path, is_directory)
+        {
+            return Some(is_ignored);
+        }
+
+        if let Some(is_ignored) =
+            self.ignored_by_git_exclude(system, active_directories, path, is_directory)
+        {
+            return Some(is_ignored);
+        }
+
+        self.ignored_by_global_gitignore(system, path, is_directory)
+    }
+
+    fn ignored_by_ignore_files(
+        &mut self,
+        system: &dyn System,
+        active_directories: &[SystemPathBuf],
+        path: &SystemPath,
+        is_directory: bool,
+    ) -> Option<bool> {
+        active_directories.iter().rev().find_map(|directory| {
+            let matcher = self.directory(system, directory).ignore.as_ref()?;
+            ignored_by_match(&matcher.matched(path.as_std_path(), is_directory))
+        })
+    }
+
+    fn ignored_by_gitignore_files(
+        &mut self,
+        system: &dyn System,
+        active_directories: &[SystemPathBuf],
+        path: &SystemPath,
+        is_directory: bool,
+    ) -> Option<bool> {
+        let mut saw_git_repository = false;
+
+        for directory in active_directories.iter().rev() {
+            let directory_ignore_files = self.directory(system, directory);
+
+            if !saw_git_repository
+                && let Some(matcher) = directory_ignore_files.gitignore.as_ref()
+                && let Some(is_ignored) =
+                    ignored_by_match(&matcher.matched(path.as_std_path(), is_directory))
+            {
+                return Some(is_ignored);
+            }
+
+            saw_git_repository |= directory_ignore_files.has_git_repository;
+        }
+
+        None
+    }
+
+    fn ignored_by_git_exclude(
+        &mut self,
+        system: &dyn System,
+        active_directories: &[SystemPathBuf],
+        path: &SystemPath,
+        is_directory: bool,
+    ) -> Option<bool> {
+        let mut saw_git_repository = false;
+
+        for directory in active_directories.iter().rev() {
+            let directory_ignore_files = self.directory(system, directory);
+
+            if !saw_git_repository
+                && let Some(matcher) = directory_ignore_files.git_exclude.as_ref()
+                && let Some(is_ignored) =
+                    ignored_by_match(&matcher.matched(path.as_std_path(), is_directory))
+            {
+                return Some(is_ignored);
+            }
+
+            saw_git_repository |= directory_ignore_files.has_git_repository;
+        }
+
+        None
+    }
+
+    fn ignored_by_global_gitignore(
+        &mut self,
+        system: &dyn System,
+        path: &SystemPath,
+        is_directory: bool,
+    ) -> Option<bool> {
+        let matcher = self.global_gitignore.get_or_insert_with(|| {
+            let cwd = system.current_directory();
+            let (matcher, error) =
+                ignore::gitignore::GitignoreBuilder::new(cwd.as_std_path()).build_global();
+
+            if let Some(error) = error {
+                tracing::warn!("Failed to read global gitignore: {error}");
+            }
+
+            matcher
+        });
+
+        ignored_by_match(&matcher.matched(path.as_std_path(), is_directory))
+    }
+
+    fn has_git_repository(
+        &mut self,
+        system: &dyn System,
+        active_directories: &[SystemPathBuf],
+    ) -> bool {
+        active_directories
+            .iter()
+            .rev()
+            .any(|directory| self.directory(system, directory).has_git_repository)
+    }
+
+    fn directory(&mut self, system: &dyn System, directory: &SystemPath) -> &DirectoryIgnoreFiles {
+        if !self.directories.contains_key(directory) {
+            let ignore_files = DirectoryIgnoreFiles::read(system, directory);
+            self.directories
+                .insert(directory.to_path_buf(), ignore_files);
+        }
+
+        self.directories
+            .get(directory)
+            .expect("directory ignore files to be inserted before lookup")
+    }
+}
+
+struct DirectoryIgnoreFiles {
+    ignore: Option<ignore::gitignore::Gitignore>,
+    gitignore: Option<ignore::gitignore::Gitignore>,
+    git_exclude: Option<ignore::gitignore::Gitignore>,
+    has_git_repository: bool,
+}
+
+impl DirectoryIgnoreFiles {
+    fn read(system: &dyn System, directory: &SystemPath) -> Self {
+        let git_directory = directory.join(".git");
+        let has_git_repository =
+            system.path_exists(&git_directory) || system.path_exists(&directory.join(".jj"));
+        let git_exclude = git_exclude_matcher(system, directory, &git_directory);
+
+        Self {
+            ignore: ignore_file_matcher(system, &directory.join(".ignore"), directory),
+            gitignore: ignore_file_matcher(system, &directory.join(".gitignore"), directory),
+            git_exclude,
+            has_git_repository,
+        }
+    }
+}
+
+fn git_exclude_matcher(
+    system: &dyn System,
+    directory: &SystemPath,
+    git_directory: &SystemPath,
+) -> Option<ignore::gitignore::Gitignore> {
+    let git_common_directory = resolve_git_common_directory(system, git_directory)?;
+    ignore_file_matcher(
+        system,
+        &git_common_directory.join("info/exclude"),
+        directory,
+    )
+}
+
+/// Mirrors the linked-worktree `commondir` lookup in
+/// [`resolve_git_commondir`](https://github.com/BurntSushi/ripgrep/blob/57c190d56eedac90c061a238b63dbfed434fee50/crates/ignore/src/dir.rs#L884-L936).
+fn resolve_git_common_directory(
+    system: &dyn System,
+    git_directory: &SystemPath,
+) -> Option<SystemPathBuf> {
+    if system.is_directory(git_directory) {
+        return Some(git_directory.to_path_buf());
+    }
+
+    if !system.is_file(git_directory) {
+        return None;
+    }
+
+    let git_file = match system.read_to_string(git_directory) {
+        Ok(git_file) => git_file,
+        Err(error) => {
+            tracing::warn!("Failed to read linked-worktree git dir `{git_directory}`: {error}");
+            return None;
+        }
+    };
+
+    let real_git_directory = git_file
+        .lines()
+        .next()?
+        .strip_prefix("gitdir: ")
+        .map(|path| SystemPathBuf::from(path.to_string()))?;
+    let common_directory_file = real_git_directory.join("commondir");
+    let common_directory = match system.read_to_string(&common_directory_file) {
+        Ok(common_directory) => common_directory,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(error) => {
+            tracing::warn!(
+                "Failed to read linked-worktree common dir `{common_directory_file}`: {error}"
+            );
+            return None;
+        }
+    };
+    let common_directory = common_directory.lines().next()?;
+
+    if common_directory.starts_with('.') {
+        Some(real_git_directory.join(common_directory))
+    } else {
+        Some(SystemPathBuf::from(common_directory.to_string()))
+    }
+}
+
+fn ignore_file_matcher(
+    system: &dyn System,
+    ignore_file: &SystemPath,
+    root: &SystemPath,
+) -> Option<ignore::gitignore::Gitignore> {
+    const UTF8_BOM: &str = "\u{feff}";
+
+    let contents = match system.read_to_string(ignore_file) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(error) => {
+            tracing::warn!("Failed to read ignore file `{ignore_file}`: {error}");
+            return None;
+        }
+    };
+
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(root.as_std_path());
+
+    let contents = contents.trim_start_matches(UTF8_BOM);
+
+    for (line_number, line) in contents.lines().enumerate() {
+        if let Err(error) = builder.add_line(Some(ignore_file.as_std_path().to_path_buf()), line) {
+            tracing::warn!(
+                "Failed to parse ignore file `{ignore_file}` at line {}: {error}",
+                line_number + 1
+            );
+        }
+    }
+
+    Some(match builder.build() {
+        Ok(matcher) => matcher,
+        Err(error) => {
+            tracing::warn!("Failed to build ignore matcher for `{ignore_file}`: {error}");
+            ignore::gitignore::Gitignore::empty()
+        }
+    })
+}
+
+fn ignored_by_match<T>(match_result: &ignore::Match<T>) -> Option<bool> {
+    match match_result {
+        ignore::Match::None => None,
+        ignore::Match::Ignore(_) => Some(true),
+        ignore::Match::Whitelist(_) => Some(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::system::{InMemorySystem, System, SystemPath};
+
+    use super::IgnoreFiles;
+
+    fn is_ignored(system: &InMemorySystem, path: &SystemPath, is_directory: bool) -> bool {
+        let root = system.current_directory().to_path_buf();
+        IgnoreFiles::new(std::slice::from_ref(&root)).is_ignored(system, path, is_directory)
+    }
+
+    #[test]
+    fn nested_ignore_file_allowlist_overrides_parent_file_rule() {
+        let system = InMemorySystem::new("/project".into());
+        let root = system.current_directory().to_path_buf();
+        let path = root.join("pkg/keep.py");
+
+        system
+            .fs()
+            .write_files_all([
+                (root.join(".ignore"), "pkg/keep.py\n"),
+                (root.join("pkg/.ignore"), "!keep.py\n"),
+                (path.clone(), ""),
+            ])
+            .unwrap();
+
+        assert!(!is_ignored(&system, &path, false));
+    }
+
+    #[test]
+    fn nested_ignore_file_cannot_allowlist_below_pruned_directory() {
+        let system = InMemorySystem::new("/project".into());
+        let root = system.current_directory().to_path_buf();
+        let path = root.join("build/keep.py");
+
+        system
+            .fs()
+            .write_files_all([
+                (root.join(".ignore"), "build/\n"),
+                (root.join("build/.ignore"), "!keep.py\n"),
+                (path.clone(), ""),
+            ])
+            .unwrap();
+
+        assert!(is_ignored(&system, &path, false));
+    }
+
+    #[test]
+    fn ignore_file_takes_precedence_over_gitignore_allowlist() {
+        let system = InMemorySystem::new("/project".into());
+        let root = system.current_directory().to_path_buf();
+        let path = root.join("ignored.py");
+
+        system
+            .fs()
+            .write_files_all([
+                (root.join(".git/HEAD"), "ref: refs/heads/main\n"),
+                (root.join(".ignore"), "ignored.py\n"),
+                (root.join(".gitignore"), "!ignored.py\n"),
+                (path.clone(), ""),
+            ])
+            .unwrap();
+
+        assert!(is_ignored(&system, &path, false));
+    }
+
+    #[test]
+    fn ignore_file_allowlist_takes_precedence_over_gitignore_ignore() {
+        let system = InMemorySystem::new("/project".into());
+        let root = system.current_directory().to_path_buf();
+        let path = root.join("included.py");
+
+        system
+            .fs()
+            .write_files_all([
+                (root.join(".git/HEAD"), "ref: refs/heads/main\n"),
+                (root.join(".ignore"), "!included.py\n"),
+                (root.join(".gitignore"), "included.py\n"),
+                (path.clone(), ""),
+            ])
+            .unwrap();
+
+        assert!(!is_ignored(&system, &path, false));
+    }
+
+    #[test]
+    fn ignore_file_strips_utf8_bom() {
+        let system = InMemorySystem::new("/project".into());
+        let root = system.current_directory().to_path_buf();
+        let path = root.join("ignored.py");
+
+        system
+            .fs()
+            .write_files_all([
+                (root.join(".ignore"), "\u{feff}ignored.py\n"),
+                (path.clone(), ""),
+            ])
+            .unwrap();
+
+        assert!(is_ignored(&system, &path, false));
+    }
+
+    #[test]
+    fn gitignore_requires_repository() {
+        let system = InMemorySystem::new("/project".into());
+        let root = system.current_directory().to_path_buf();
+        let path = root.join("ignored.py");
+
+        system
+            .fs()
+            .write_files_all([
+                (root.join(".gitignore"), "ignored.py\n"),
+                (path.clone(), ""),
+            ])
+            .unwrap();
+
+        assert!(!is_ignored(&system, &path, false));
+    }
+
+    #[test]
+    fn git_exclude_ignores_files() {
+        let system = InMemorySystem::new("/project".into());
+        let root = system.current_directory().to_path_buf();
+        let path = root.join("ignored.py");
+
+        system
+            .fs()
+            .write_files_all([
+                (root.join(".git/HEAD"), "ref: refs/heads/main\n"),
+                (root.join(".git/info/exclude"), "ignored.py\n"),
+                (path.clone(), ""),
+            ])
+            .unwrap();
+
+        assert!(is_ignored(&system, &path, false));
+    }
+
+    #[test]
+    fn linked_worktree_git_exclude_ignores_files() {
+        let system = InMemorySystem::new("/project".into());
+        let root = system.current_directory().to_path_buf();
+        let common_git_directory = root.join(".git-common");
+        let worktree_git_directory = common_git_directory.join("worktrees/current");
+        let commondir_path = worktree_git_directory.join("commondir");
+        let path = root.join("ignored.py");
+
+        system
+            .fs()
+            .write_files_all([
+                (
+                    root.join(".git"),
+                    format!("gitdir: {worktree_git_directory}\n"),
+                ),
+                (commondir_path.clone(), "../..\n".to_string()),
+                (
+                    common_git_directory.join("info/exclude"),
+                    "ignored.py\n".to_string(),
+                ),
+                (path.clone(), String::new()),
+            ])
+            .unwrap();
+
+        assert!(is_ignored(&system, &path, false));
+
+        system
+            .fs()
+            .write_file_all(&commondir_path, common_git_directory.as_str())
+            .unwrap();
+
+        assert!(is_ignored(&system, &path, false));
+    }
+}

--- a/crates/ty_project/src/ignore.rs
+++ b/crates/ty_project/src/ignore.rs
@@ -1,7 +1,37 @@
+//! Single-path ignore-file matching with project-walk semantics.
+//!
+//! A normal project file walk delegates ignore handling to `ignore::WalkBuilder`.
+//! Some callers need the same decision for one concrete file or directory
+//! without walking an entire subtree.
+//!
+//! `IgnoreFiles` answers that question by replaying the relevant walk branch
+//! from each project walk root to the changed path. At each branch component it
+//! asks whether the active ignore files would prune that component. If an
+//! intermediate directory is ignored, nested ignore files below it are never
+//! considered, matching the full walker's pruning behavior.
+//!
+//! The active directory list represents ignore files that the walker would
+//! already have discovered at the current branch position. It contains:
+//!
+//! - canonical parent directories above the explicit walk root, matching
+//!   `ignore::Ignore::add_parents`;
+//! - the walk root itself once depth-0 admission has happened; and
+//! - descendant directories accepted while replaying the branch.
+//!
+//! Matching needs both the lexical walked path and, when available, the
+//! canonicalized candidate path. Parent ignore files discovered above a
+//! symlinked root match against the canonical path, while ignore files loaded
+//! at or below the explicit root match against the walked path. `ActiveDirectory`
+//! and `CandidatePaths` keep that distinction local.
+//!
+//! Parsed ignore files are cached per directory within one `IgnoreFiles`
+//! instance so repeated checks do not keep reparsing the same ignore files.
+
+use ignore::gitignore;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use rustc_hash::FxHashMap;
 
-/// Cached ignore-file state for one watcher change batch.
+/// Cached ignore-file state for single-path project-walk checks.
 ///
 /// `ignore::WalkBuilder` decides whether to descend into a directory before it
 /// reads ignore files inside that directory. This checker mirrors that behavior
@@ -12,47 +42,40 @@ use rustc_hash::FxHashMap;
 /// Directory entries in `directories` are populated lazily. The presence of an
 /// entry means we already checked that directory for ignore files, and any
 /// parsed matchers are reused by later watcher events in the same batch.
-pub(crate) struct IgnoreFiles {
-    walk_roots: Vec<SystemPathBuf>,
+pub(crate) struct IgnoreFiles<'a> {
+    walk_roots: &'a [SystemPathBuf],
+    system: Box<dyn System>,
     directories: FxHashMap<SystemPathBuf, DirectoryIgnoreFiles>,
-    global_gitignore: Option<ignore::gitignore::Gitignore>,
+    global_gitignore: Option<gitignore::Gitignore>,
 }
 
-impl IgnoreFiles {
-    pub(crate) fn new(walk_roots: &[SystemPathBuf]) -> Self {
+impl<'a> IgnoreFiles<'a> {
+    pub(crate) fn new(system: Box<dyn System>, walk_roots: &'a [SystemPathBuf]) -> Self {
         Self {
-            walk_roots: walk_roots.to_vec(),
+            walk_roots,
+            system,
             directories: FxHashMap::default(),
             global_gitignore: None,
         }
     }
 
     /// Returns `true` if every matching project walk root would skip `path`.
-    pub(crate) fn is_ignored(
-        &mut self,
-        system: &dyn System,
-        path: &SystemPath,
-        is_directory: bool,
-    ) -> bool {
-        let matching_roots = self
-            .walk_roots
+    pub(crate) fn is_ignored(&mut self, path: &SystemPath, is_directory: bool) -> bool {
+        let walk_roots = self.walk_roots;
+        let mut matching_roots = walk_roots
             .iter()
             .filter(|root| path.starts_with(root))
-            .cloned()
-            .collect::<Vec<_>>();
+            .peekable();
 
-        if matching_roots.is_empty() {
+        if matching_roots.peek().is_none() {
             return false;
-        }
+        };
 
-        matching_roots
-            .iter()
-            .all(|root| self.is_ignored_from_root(system, root, path, is_directory))
+        matching_roots.all(|root| self.is_ignored_from_root(root, path, is_directory))
     }
 
     fn is_ignored_from_root(
         &mut self,
-        system: &dyn System,
         root: &SystemPath,
         path: &SystemPath,
         is_directory: bool,
@@ -66,113 +89,124 @@ impl IgnoreFiles {
             return false;
         };
 
-        let mut active_directories = root
-            .parent()
+        // `ignore::Ignore::add_parents` skips parent matcher setup when the
+        // walk root cannot be canonicalized. Keep walking from the requested
+        // root in that case, but omit canonical parent ignore files.
+        let canonical_root = self.system.canonicalize_path(root).ok();
+        let mut active_directories = canonical_root
+            .as_deref()
             .into_iter()
             .flat_map(SystemPath::ancestors)
-            .map(SystemPath::to_path_buf)
+            .skip(1)
+            .map(|directory| ActiveDirectory::canonical_parent(directory.to_path_buf()))
             .collect::<Vec<_>>();
         active_directories.reverse();
 
         // Once the walker has accepted the root directory, it reads the root's
         // ignore files before deciding whether to visit any child paths.
-        active_directories.push(root.to_path_buf());
+        active_directories.push(ActiveDirectory::walked(root.to_path_buf()));
 
-        let mut current_path = root.to_path_buf();
+        let mut current_paths = CandidatePaths::new(root.to_path_buf(), canonical_root);
         let mut components = relative_path.components().peekable();
 
+        // Replay the walk one branch component at a time. A directory must be
+        // admitted before ignore files inside it can affect deeper descendants.
         while let Some(component) = components.next() {
-            current_path.push(component.as_str());
+            current_paths.push(component);
 
             let is_last_component = components.peek().is_none();
             let current_path_is_directory = !is_last_component || is_directory;
 
-            if self
-                .ignored_by_active_ignore_files(
-                    system,
-                    &active_directories,
-                    &current_path,
-                    current_path_is_directory,
-                )
-                .unwrap_or(false)
+            if self.ignored_by_active_ignore_files(
+                &active_directories,
+                &current_paths,
+                current_path_is_directory,
+            ) == Some(true)
             {
                 return true;
             }
 
             if !is_last_component {
-                active_directories.push(current_path.clone());
+                active_directories.push(ActiveDirectory::walked(
+                    current_paths.walked().to_path_buf(),
+                ));
             }
         }
 
         false
     }
 
+    /// Returns whether ignore files already visible at the current branch
+    /// position would prune `paths`.
+    ///
+    /// The active directories intentionally exclude ignore files below the
+    /// candidate path. This keeps nested allowlists from reviving paths in a
+    /// directory the real walker would already have skipped.
     fn ignored_by_active_ignore_files(
         &mut self,
-        system: &dyn System,
-        active_directories: &[SystemPathBuf],
-        path: &SystemPath,
+        active_directories: &[ActiveDirectory],
+        paths: &CandidatePaths,
         is_directory: bool,
     ) -> Option<bool> {
         if let Some(is_ignored) =
-            self.ignored_by_ignore_files(system, active_directories, path, is_directory)
+            self.ignored_by_ignore_files(active_directories, paths, is_directory)
         {
             return Some(is_ignored);
         }
 
-        if !self.has_git_repository(system, active_directories) {
+        if !self.has_git_repository(active_directories) {
             return None;
         }
 
         if let Some(is_ignored) =
-            self.ignored_by_gitignore_files(system, active_directories, path, is_directory)
+            self.ignored_by_gitignore_files(active_directories, paths, is_directory)
         {
             return Some(is_ignored);
         }
 
         if let Some(is_ignored) =
-            self.ignored_by_git_exclude(system, active_directories, path, is_directory)
+            self.ignored_by_git_exclude(active_directories, paths, is_directory)
         {
             return Some(is_ignored);
         }
 
-        self.ignored_by_global_gitignore(system, path, is_directory)
+        self.ignored_by_global_gitignore(paths.walked(), is_directory)
     }
 
     fn ignored_by_ignore_files(
         &mut self,
-        system: &dyn System,
-        active_directories: &[SystemPathBuf],
-        path: &SystemPath,
+        active_directories: &[ActiveDirectory],
+        paths: &CandidatePaths,
         is_directory: bool,
     ) -> Option<bool> {
         active_directories.iter().rev().find_map(|directory| {
-            let matcher = self.directory(system, directory).ignore.as_ref()?;
+            let matcher = self.ignore_files(directory.path()).ignore.as_ref()?;
+            let path = directory.candidate_path(paths)?;
             ignored_by_match(&matcher.matched(path.as_std_path(), is_directory))
         })
     }
 
     fn ignored_by_gitignore_files(
         &mut self,
-        system: &dyn System,
-        active_directories: &[SystemPathBuf],
-        path: &SystemPath,
+        active_directories: &[ActiveDirectory],
+        paths: &CandidatePaths,
         is_directory: bool,
     ) -> Option<bool> {
         let mut saw_git_repository = false;
 
         for directory in active_directories.iter().rev() {
-            let directory_ignore_files = self.directory(system, directory);
+            let ignore_files = self.ignore_files(directory.path());
 
             if !saw_git_repository
-                && let Some(matcher) = directory_ignore_files.gitignore.as_ref()
+                && let Some(matcher) = ignore_files.gitignore.as_ref()
+                && let Some(path) = directory.candidate_path(paths)
                 && let Some(is_ignored) =
                     ignored_by_match(&matcher.matched(path.as_std_path(), is_directory))
             {
                 return Some(is_ignored);
             }
 
-            saw_git_repository |= directory_ignore_files.has_git_repository;
+            saw_git_repository |= ignore_files.has_git_repository;
         }
 
         None
@@ -180,25 +214,25 @@ impl IgnoreFiles {
 
     fn ignored_by_git_exclude(
         &mut self,
-        system: &dyn System,
-        active_directories: &[SystemPathBuf],
-        path: &SystemPath,
+        active_directories: &[ActiveDirectory],
+        paths: &CandidatePaths,
         is_directory: bool,
     ) -> Option<bool> {
         let mut saw_git_repository = false;
 
         for directory in active_directories.iter().rev() {
-            let directory_ignore_files = self.directory(system, directory);
+            let ignore_files = self.ignore_files(directory.path());
 
             if !saw_git_repository
-                && let Some(matcher) = directory_ignore_files.git_exclude.as_ref()
+                && let Some(matcher) = ignore_files.git_exclude.as_ref()
+                && let Some(path) = directory.candidate_path(paths)
                 && let Some(is_ignored) =
                     ignored_by_match(&matcher.matched(path.as_std_path(), is_directory))
             {
                 return Some(is_ignored);
             }
 
-            saw_git_repository |= directory_ignore_files.has_git_repository;
+            saw_git_repository |= ignore_files.has_git_repository;
         }
 
         None
@@ -206,53 +240,131 @@ impl IgnoreFiles {
 
     fn ignored_by_global_gitignore(
         &mut self,
-        system: &dyn System,
         path: &SystemPath,
         is_directory: bool,
     ) -> Option<bool> {
-        let matcher = self.global_gitignore.get_or_insert_with(|| {
-            let cwd = system.current_directory();
+        ignored_by_match(
+            &self
+                .global_gitignore()
+                .matched(path.as_std_path(), is_directory),
+        )
+    }
+
+    fn global_gitignore(&mut self) -> &gitignore::Gitignore {
+        self.global_gitignore.get_or_insert_with(|| {
+            let cwd = self.system.current_directory();
             let (matcher, error) =
-                ignore::gitignore::GitignoreBuilder::new(cwd.as_std_path()).build_global();
+                gitignore::GitignoreBuilder::new(cwd.as_std_path()).build_global();
 
             if let Some(error) = error {
                 tracing::warn!("Failed to read global gitignore: {error}");
             }
 
             matcher
-        });
-
-        ignored_by_match(&matcher.matched(path.as_std_path(), is_directory))
+        })
     }
 
-    fn has_git_repository(
-        &mut self,
-        system: &dyn System,
-        active_directories: &[SystemPathBuf],
-    ) -> bool {
+    fn has_git_repository(&mut self, active_directories: &[ActiveDirectory]) -> bool {
         active_directories
             .iter()
             .rev()
-            .any(|directory| self.directory(system, directory).has_git_repository)
+            .any(|directory| self.ignore_files(directory.path()).has_git_repository)
     }
 
-    fn directory(&mut self, system: &dyn System, directory: &SystemPath) -> &DirectoryIgnoreFiles {
-        if !self.directories.contains_key(directory) {
-            let ignore_files = DirectoryIgnoreFiles::read(system, directory);
-            self.directories
-                .insert(directory.to_path_buf(), ignore_files);
-        }
-
+    fn ignore_files(&mut self, directory: &SystemPath) -> &DirectoryIgnoreFiles {
         self.directories
-            .get(directory)
-            .expect("directory ignore files to be inserted before lookup")
+            .entry(directory.to_path_buf())
+            .or_insert_with(|| DirectoryIgnoreFiles::read(self.system.as_ref(), directory))
     }
 }
 
+/// Candidate paths for the branch component currently being checked.
+///
+/// `walked` follows the lexical path requested by the project walk. `canonical`
+/// tracks the same branch from the canonicalized walk root when that root could
+/// be resolved. Parent ignore files use the canonical path, while ignore files
+/// loaded at or below the explicit walk root use the walked path.
+struct CandidatePaths {
+    walked: SystemPathBuf,
+    canonical: Option<SystemPathBuf>,
+}
+
+impl CandidatePaths {
+    fn new(walked: SystemPathBuf, canonical: Option<SystemPathBuf>) -> Self {
+        Self { walked, canonical }
+    }
+
+    fn push(&mut self, component: impl AsRef<SystemPath>) {
+        let component = component.as_ref();
+        self.walked.push(component);
+
+        if let Some(canonical) = self.canonical.as_mut() {
+            canonical.push(component);
+        }
+    }
+
+    fn walked(&self) -> &SystemPath {
+        &self.walked
+    }
+
+    fn canonical(&self) -> Option<&SystemPath> {
+        self.canonical.as_deref()
+    }
+}
+
+struct ActiveDirectory {
+    path: SystemPathBuf,
+    match_path: MatchPath,
+}
+
+impl ActiveDirectory {
+    fn canonical_parent(path: SystemPathBuf) -> Self {
+        Self {
+            path,
+            match_path: MatchPath::Canonical,
+        }
+    }
+
+    fn walked(path: SystemPathBuf) -> Self {
+        Self {
+            path,
+            match_path: MatchPath::Walked,
+        }
+    }
+
+    fn path(&self) -> &SystemPath {
+        &self.path
+    }
+
+    fn candidate_path<'a>(&self, paths: &'a CandidatePaths) -> Option<&'a SystemPath> {
+        match self.match_path {
+            MatchPath::Canonical => paths.canonical(),
+            MatchPath::Walked => Some(paths.walked()),
+        }
+    }
+}
+
+enum MatchPath {
+    /// Match against the canonicalized candidate path.
+    ///
+    /// To mirror `ignore::Ignore::add_parents`, parent ignore files above the
+    /// configured walk root are discovered by first resolving that root through
+    /// the filesystem. If the walk root is a symlink, those parent files belong
+    /// to the symlink target's ancestors, so they must match against the
+    /// correspondingly resolved candidate path.
+    Canonical,
+
+    /// Match against the lexical path observed during the walk.
+    ///
+    /// Ignore files at the explicit walk root or below it are loaded while
+    /// descending the requested path branch, so they keep the walked path.
+    Walked,
+}
+
 struct DirectoryIgnoreFiles {
-    ignore: Option<ignore::gitignore::Gitignore>,
-    gitignore: Option<ignore::gitignore::Gitignore>,
-    git_exclude: Option<ignore::gitignore::Gitignore>,
+    ignore: Option<gitignore::Gitignore>,
+    gitignore: Option<gitignore::Gitignore>,
+    git_exclude: Option<gitignore::Gitignore>,
     has_git_repository: bool,
 }
 
@@ -276,7 +388,7 @@ fn git_exclude_matcher(
     system: &dyn System,
     directory: &SystemPath,
     git_directory: &SystemPath,
-) -> Option<ignore::gitignore::Gitignore> {
+) -> Option<gitignore::Gitignore> {
     let git_common_directory = resolve_git_common_directory(system, git_directory)?;
     ignore_file_matcher(
         system,
@@ -311,7 +423,7 @@ fn resolve_git_common_directory(
         .lines()
         .next()?
         .strip_prefix("gitdir: ")
-        .map(|path| SystemPathBuf::from(path.to_string()))?;
+        .map(SystemPathBuf::from)?;
     let common_directory_file = real_git_directory.join("commondir");
     let common_directory = match system.read_to_string(&common_directory_file) {
         Ok(common_directory) => common_directory,
@@ -328,7 +440,7 @@ fn resolve_git_common_directory(
     if common_directory.starts_with('.') {
         Some(real_git_directory.join(common_directory))
     } else {
-        Some(SystemPathBuf::from(common_directory.to_string()))
+        Some(SystemPathBuf::from(common_directory))
     }
 }
 
@@ -336,7 +448,7 @@ fn ignore_file_matcher(
     system: &dyn System,
     ignore_file: &SystemPath,
     root: &SystemPath,
-) -> Option<ignore::gitignore::Gitignore> {
+) -> Option<gitignore::Gitignore> {
     const UTF8_BOM: &str = "\u{feff}";
 
     let contents = match system.read_to_string(ignore_file) {
@@ -348,7 +460,7 @@ fn ignore_file_matcher(
         }
     };
 
-    let mut builder = ignore::gitignore::GitignoreBuilder::new(root.as_std_path());
+    let mut builder = gitignore::GitignoreBuilder::new(root.as_std_path());
 
     let contents = contents.trim_start_matches(UTF8_BOM);
 
@@ -365,7 +477,7 @@ fn ignore_file_matcher(
         Ok(matcher) => matcher,
         Err(error) => {
             tracing::warn!("Failed to build ignore matcher for `{ignore_file}`: {error}");
-            ignore::gitignore::Gitignore::empty()
+            gitignore::Gitignore::empty()
         }
     })
 }
@@ -381,12 +493,19 @@ fn ignored_by_match<T>(match_result: &ignore::Match<T>) -> Option<bool> {
 #[cfg(test)]
 mod tests {
     use ruff_db::system::{InMemorySystem, System, SystemPath};
+    #[cfg(unix)]
+    use ruff_db::system::{OsSystem, SystemPathBuf};
+    #[cfg(unix)]
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
 
     use super::IgnoreFiles;
 
     fn is_ignored(system: &InMemorySystem, path: &SystemPath, is_directory: bool) -> bool {
         let root = system.current_directory().to_path_buf();
-        IgnoreFiles::new(std::slice::from_ref(&root)).is_ignored(system, path, is_directory)
+        IgnoreFiles::new(system.dyn_clone(), std::slice::from_ref(&root))
+            .is_ignored(path, is_directory)
     }
 
     #[test]
@@ -548,5 +667,37 @@ mod tests {
             .unwrap();
 
         assert!(is_ignored(&system, &path, false));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "Symlinked-root canonicalization requires real filesystem fixtures."
+    )]
+    fn symlinked_walk_root_uses_canonical_parent_ignore_files() -> std::io::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let temp_root = SystemPathBuf::from_path_buf(temp_dir.path().to_path_buf())
+            .expect("temporary test path to be UTF-8");
+        let real_parent = temp_root.join("real");
+        let real_root = real_parent.join("project");
+        let symlink_root = temp_root.join("project-link");
+        let ignored_path = symlink_root.join("ignored.py");
+
+        fs::create_dir_all(real_root.as_std_path())?;
+        fs::write(
+            real_parent.join(".ignore").as_std_path(),
+            "project/ignored.py\n",
+        )?;
+        fs::write(real_root.join("ignored.py").as_std_path(), "")?;
+        symlink(real_root.as_std_path(), symlink_root.as_std_path())?;
+
+        let system = OsSystem::new(&temp_root);
+        assert!(
+            IgnoreFiles::new(system.dyn_clone(), std::slice::from_ref(&symlink_root))
+                .is_ignored(&ignored_path, false)
+        );
+
+        Ok(())
     }
 }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -17,7 +17,8 @@ use ruff_db::diagnostic::{
 };
 use ruff_db::files::{File, FileRootKind};
 use ruff_db::parsed::parsed_module;
-use ruff_db::system::{SystemPath, SystemPathBuf};
+use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
+use ruff_python_ast::PySourceType;
 use rustc_hash::FxHashSet;
 use salsa::{Database, Durability, Setter};
 use std::backtrace::BacktraceStatus;
@@ -30,6 +31,7 @@ use ty_python_semantic::lint::RuleSelection;
 mod db;
 mod files;
 pub mod glob;
+mod ignore;
 pub mod metadata;
 mod walk;
 pub mod watch;
@@ -240,6 +242,22 @@ impl Project {
                 .is_directory_included(path, GlobFilterCheckMode::Adhoc),
             IncludeResult::Included { .. }
         )
+    }
+
+    /// Returns `true` if `path` passes the file inclusion and source-type checks used by indexing.
+    pub(crate) fn is_file_included_for_indexing(self, db: &dyn Db, path: &SystemPath) -> bool {
+        let IncludeResult::Included { literal_match } = ProjectFilesFilter::from_project(db, self)
+            .is_file_included(path, GlobFilterCheckMode::Adhoc)
+        else {
+            return false;
+        };
+
+        literal_match == Some(true)
+            || path
+                .extension()
+                .and_then(PySourceType::try_from_extension)
+                .or_else(|| db.system().source_type(path))
+                .is_some()
     }
 
     /// Reload the project after its metadata or settings have changed.
@@ -602,10 +620,12 @@ impl Project {
         I: IntoIterator<Item = P>,
         P: AsRef<SystemPath>,
     {
-        let paths = paths
-            .into_iter()
-            .map(|path| SystemPath::absolute(path, db.system().current_directory()))
-            .collect::<BTreeSet<_>>();
+        let paths = deduplicate_nested_paths(
+            paths
+                .into_iter()
+                .map(|path| SystemPath::absolute(path, db.system().current_directory())),
+        )
+        .collect::<BTreeSet<_>>();
 
         if paths.is_empty() {
             return;
@@ -622,9 +642,10 @@ impl Project {
                 .copied()
                 .filter(|file| {
                     file.path(db).as_system_path().is_some_and(|file_path| {
-                        file_path
-                            .ancestors()
-                            .any(|ancestor| paths.contains(ancestor))
+                        paths
+                            .range(..=file_path.to_path_buf())
+                            .next_back()
+                            .is_some_and(|path| file_path.starts_with(path))
                     })
                 })
                 .collect::<Vec<_>>()
@@ -867,6 +888,7 @@ where
 mod tests {
     use crate::ProjectMetadata;
     use crate::check_file_impl;
+    use crate::db::Db as _;
     use crate::db::tests::TestDb;
     use ruff_db::files::system_path_to_file;
     use ruff_db::source::source_text;
@@ -918,5 +940,18 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn indexing_inclusion_skips_non_python_files() {
+        let root = SystemPathBuf::from("/project");
+        let project = ProjectMetadata::new(Name::new_static("test"), root.clone());
+        let db = TestDb::new(project);
+        let project = db.project();
+
+        let non_python_file = root.join("README.md");
+
+        assert!(project.is_file_included(&db, &non_python_file));
+        assert!(!project.is_file_included_for_indexing(&db, &non_python_file));
     }
 }


### PR DESCRIPTION
## Summary

@dhruvmanila pointed out in https://github.com/astral-sh/ruff/pull/25183#discussion_r3257612254 that there are cases where ty incorrectly adds files to the project during an incremental walk if the created files (or folders) are within an ignored directory. 

The root cause is that the `ignore` crate doesn't check whether an input path is ignored. It follows the order, you've told me to walk this directory so I will. And neither did ty. It simply walks any directory in which it sees new files. 

This PR adds a re-implementation of the ignore's crate ignore matching that allows for ad-hoc matches and we now use it in `apply_changes` to skip over files that are know to be ignored. This not only fixes the issue pointed out by Dhruv, it also avoids walking directories only because a file was added.

Closes https://github.com/astral-sh/ty/issues/97

A simpler fix for the issue pointed out by Dhruv is https://github.com/astral-sh/ruff/pull/25236 but it has the downside that it requires walking more directories.

## Test plan

Two added integration tests. 
