### PR TITLE
[ty] Handle aliased dict fallbacks in TypedDict unions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -203,6 +203,12 @@ d5_dict: dict[Hashable, Callable[..., object]] = dict(x=lambda: 1)
 
 d6_dict: TD = {"x": 1} | {"x": 2}
 
+type IntFloatDict = dict[int, float]
+type TypedDictOrDictAlias = TD | IntFloatDict
+
+# The `dict[int, float]` fallback should still win when it is wrapped in an alias.
+d7_alias_fallback: TypedDictOrDictAlias = {1: 5.2}
+
 def return_literal() -> TD:
     return {"x": 1}
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6162,14 +6162,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             } else if let Type::Union(union) = annotation {
                 let union_elements = union.elements(self.db());
-                let typed_dicts = union_elements
-                    .iter()
-                    .filter_map(|element| element.resolve_type_alias(self.db()).as_typed_dict())
-                    .collect_vec();
-                let has_dict_compatible_fallback = union_elements.iter().any(|element| {
+                let mut typed_dicts = Vec::new();
+                let mut has_dict_compatible_fallback = false;
+
+                for element in union_elements {
                     let element = element.resolve_type_alias(self.db());
-                    !element.is_typed_dict() && element.is_instance_of(self.db(), KnownClass::Dict)
-                });
+
+                    if let Some(typed_dict) = element.as_typed_dict() {
+                        typed_dicts.push(typed_dict);
+                    } else if element.is_instance_of(self.db(), KnownClass::Dict) {
+                        has_dict_compatible_fallback = true;
+                    }
+                }
 
                 if let [typed_dict] = typed_dicts.as_slice()
                     && !has_dict_compatible_fallback

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6164,9 +6164,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let union_elements = union.elements(self.db());
                 let typed_dicts = union_elements
                     .iter()
-                    .filter_map(|element| element.as_typed_dict())
+                    .filter_map(|element| element.resolve_type_alias(self.db()).as_typed_dict())
                     .collect_vec();
                 let has_dict_compatible_fallback = union_elements.iter().any(|element| {
+                    let element = element.resolve_type_alias(self.db());
                     !element.is_typed_dict() && element.is_instance_of(self.db(), KnownClass::Dict)
                 });
 


### PR DESCRIPTION
## Summary

When a `TypedDict` union includes a `dict`-compatible fallback behind a type alias, we need to resolve it, as in:

```python
type IntFloatDict = dict[int, float]
type TypedDictOrDictAlias = TD | IntFloatDict

value: TypedDictOrDictAlias = {1: 5.2}
```

There are some other similar bugs that I noticed while working on this, which I'll fix in separate PRs.

Closes https://github.com/astral-sh/ty/issues/3488.