### PR TITLE
[ty] Respect `dict`-compatible fallbacks in TypedDict unions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -205,9 +205,11 @@ d6_dict: TD = {"x": 1} | {"x": 2}
 
 type IntFloatDict = dict[int, float]
 type TypedDictOrDictAlias = TD | IntFloatDict
+type TypedDictOrMapping = TD | Mapping[int, float]
 
 # The `dict[int, float]` fallback should still win when it is wrapped in an alias.
 d7_alias_fallback: TypedDictOrDictAlias = {1: 5.2}
+d8_mapping_fallback: TypedDictOrMapping = {1: 5.2}
 
 def return_literal() -> TD:
     return {"x": 1}

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -136,7 +136,7 @@ x: list[int | str] = list1(42) * 3
 `typed_dict.py`:
 
 ```py
-from typing import Any, Callable, Hashable, Mapping, TypedDict
+from typing import Any, Callable, Hashable, Iterable, Mapping, TypedDict
 from typing_extensions import Never
 
 class TD(TypedDict):
@@ -216,6 +216,11 @@ d8_mapping_fallback: TypedDictOrMapping = {1: 5.2}
 # error: [invalid-key]
 d9_invalid_mapping_key: TypedDictOrMapping = {"y": 5.2}
 d10_invalid_mapping_value: TypedDictOrMapping = {1: "bad"}  # error: [missing-typed-dict-key]
+
+def takes_td_or_iterable(value: TD | Iterable[int]) -> None:
+    pass
+
+takes_td_or_iterable({42: 42})
 
 def return_literal() -> TD:
     return {"x": 1}

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -211,6 +211,12 @@ type TypedDictOrMapping = TD | Mapping[int, float]
 d7_alias_fallback: TypedDictOrDictAlias = {1: 5.2}
 d8_mapping_fallback: TypedDictOrMapping = {1: 5.2}
 
+# A `Mapping` fallback should only suppress `TypedDict` diagnostics when it accepts the literal.
+# error: [missing-typed-dict-key]
+# error: [invalid-key]
+d9_invalid_mapping_key: TypedDictOrMapping = {"y": 5.2}
+d10_invalid_mapping_value: TypedDictOrMapping = {1: "bad"}  # error: [missing-typed-dict-key]
+
 def return_literal() -> TD:
     return {"x": 1}
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6169,22 +6169,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let union_elements = union.elements(self.db());
                 let mut typed_dicts = Vec::new();
                 let mut has_dict_compatible_fallback = false;
-                let dict_fallback = KnownClass::Dict
-                    .to_specialized_instance(self.db(), &[Type::unknown(), Type::unknown()]);
-                let mapping_fallback = KnownClass::Mapping
-                    .to_specialized_instance(self.db(), &[Type::unknown(), Type::unknown()]);
 
                 for element in union_elements {
                     let element = element.resolve_type_alias(self.db());
 
                     if let Some(typed_dict) = element.as_typed_dict() {
                         typed_dicts.push(typed_dict);
-                    } else if !has_dict_compatible_fallback
-                        && dict_fallback.is_assignable_to(self.db(), element)
-                        && element.is_assignable_to(self.db(), mapping_fallback)
-                    {
-                        // Suppress `TypedDict` diagnostics only when the fallback can actually
-                        // accept this literal. A merely present `Mapping` arm is not sufficient.
+                    } else if !has_dict_compatible_fallback {
+                        // Suppress `TypedDict` diagnostics only if this literal is assignable to
+                        // the non-`TypedDict` arm of the union.
                         let mut speculative_builder = self.speculate();
                         has_dict_compatible_fallback = speculative_builder
                             .infer_dict_expression(dict, TypeContext::new(Some(element)))

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6179,10 +6179,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     if let Some(typed_dict) = element.as_typed_dict() {
                         typed_dicts.push(typed_dict);
-                    } else if dict_fallback.is_assignable_to(self.db(), element)
+                    } else if !has_dict_compatible_fallback
+                        && dict_fallback.is_assignable_to(self.db(), element)
                         && element.is_assignable_to(self.db(), mapping_fallback)
                     {
-                        has_dict_compatible_fallback = true;
+                        // Suppress `TypedDict` diagnostics only when the fallback can actually
+                        // accept this literal. A merely present `Mapping` arm is not sufficient.
+                        let mut speculative_builder = self.speculate();
+                        has_dict_compatible_fallback = speculative_builder
+                            .infer_dict_expression(dict, TypeContext::new(Some(element)))
+                            .is_assignable_to(self.db(), element);
                     }
                 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6169,13 +6169,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let union_elements = union.elements(self.db());
                 let mut typed_dicts = Vec::new();
                 let mut has_dict_compatible_fallback = false;
+                let dict_fallback = KnownClass::Dict
+                    .to_specialized_instance(self.db(), &[Type::unknown(), Type::unknown()]);
+                let mapping_fallback = KnownClass::Mapping
+                    .to_specialized_instance(self.db(), &[Type::unknown(), Type::unknown()]);
 
                 for element in union_elements {
                     let element = element.resolve_type_alias(self.db());
 
                     if let Some(typed_dict) = element.as_typed_dict() {
                         typed_dicts.push(typed_dict);
-                    } else if element.is_instance_of(self.db(), KnownClass::Dict) {
+                    } else if dict_fallback.is_assignable_to(self.db(), element)
+                        && element.is_assignable_to(self.db(), mapping_fallback)
+                    {
                         has_dict_compatible_fallback = true;
                     }
                 }


### PR DESCRIPTION
## Summary

Prior to this change, this snippet would produce a TypedDict-based `missing-key` diagnostic, because the RHS wasn't viewed as assignable to the `Mapping[int, float]` (since we were only gating on `dict`):

```py
from typing import TypedDict, Mapping

class Foo(TypedDict):
    some: str
    name: str

mapping: Foo | Mapping[int, float] = {1: 5.2}
```

We now use speculative inference to determine whether the non-TypedDict union member `T` is a viable fallback type.

Closes https://github.com/astral-sh/ty/issues/3488.
