### PR TITLE
[ty] Escape HTML syntax in docstring rendering

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -417,7 +417,7 @@ fn render_markdown(docstring: &str) -> String {
             // except we need to find and parse it anyway to do this escaping properly! :(
             // For now we assume `inline code` does not span a line (I'm not even sure if can).
             //
-            // Things that need to be escaped: underscores and raw HTML tags.
+            // Things that need to be escaped: underscores and HTML-sensitive characters.
             //
             // e.g. we want __init__ => \_\_init\_\_ but `__init__` => `__init__`
             let escape = |input: &str| {

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -925,14 +925,14 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @r#"
-        Parse a URL into 6 components:  <HB>
+        Parse a URL into 6 components:<HB>
         &lt;scheme&gt;://&lt;netloc&gt;/&lt;path&gt;;&lt;params&gt;?&lt;query&gt;#&lt;fragment&gt;<HB>
         <HB>
-        Markdown code fences keep literal HTML:  <HB>
+        Markdown code fences keep literal HTML:<HB>
         <HB>
         ```text
         <tag attr="value">content</tag>
-        ```
+        ```<HB>
         <HB>
         So does `inline <code>`.
         "#);

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -417,10 +417,16 @@ fn render_markdown(docstring: &str) -> String {
             // except we need to find and parse it anyway to do this escaping properly! :(
             // For now we assume `inline code` does not span a line (I'm not even sure if can).
             //
-            // Things that need to be escaped: underscores
+            // Things that need to be escaped: underscores and raw HTML tags.
             //
             // e.g. we want __init__ => \_\_init\_\_ but `__init__` => `__init__`
-            let escape = |input: &str| input.replace('_', "\\_");
+            let escape = |input: &str| {
+                input
+                    .replace('&', "&amp;")
+                    .replace('<', "&lt;")
+                    .replace('>', "&gt;")
+                    .replace('_', "\\_")
+            };
 
             let mut in_inline_code = false;
             let mut first_chunk = true;
@@ -898,6 +904,38 @@ mod tests {
         Here ```_is_`````__a__``\_random\_````_mess__````<HB>
         ```_is_`````__a__``\_random\_````_mess__````
         ");
+    }
+
+    #[test]
+    fn html_escape() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = r#"
+        Parse a URL into 6 components:
+        <scheme>://<netloc>/<path>;<params>?<query>#<fragment>
+
+        Markdown code fences keep literal HTML:
+
+        ```text
+        <tag attr="value">content</tag>
+        ```
+
+        So does `inline <code>`.
+        "#;
+
+        let docstring = Docstring::new(docstring.to_owned());
+
+        assert_snapshot!(docstring.render_markdown(), @r#"
+        Parse a URL into 6 components:  <HB>
+        &lt;scheme&gt;://&lt;netloc&gt;/&lt;path&gt;;&lt;params&gt;?&lt;query&gt;#&lt;fragment&gt;<HB>
+        <HB>
+        Markdown code fences keep literal HTML:  <HB>
+        <HB>
+        ```text
+        <tag attr="value">content</tag>
+        ```
+        <HB>
+        So does `inline <code>`.
+        "#);
     }
 
     // A literal block where the `::` is flush with the paragraph

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -4619,6 +4619,44 @@ def function():
     }
 
     #[test]
+    fn hover_func_docstring_escapes_html_in_markdown() {
+        let test = hover_test(
+            r#"
+        def url<CURSOR>parse():
+            """Parse a URL into components:
+            <scheme>://<netloc>/<path>;<params>?<query>#<fragment>
+            """
+            return
+        "#,
+        );
+
+        assert_snapshot!(test.hover(), @r#"
+        def urlparse() -> Unknown
+        ---------------------------------------------
+        Parse a URL into components:
+        <scheme>://<netloc>/<path>;<params>?<query>#<fragment>
+
+        ---------------------------------------------
+        ```python
+        def urlparse() -> Unknown
+        ```
+        ---
+        Parse a URL into components:  <HB>
+        &lt;scheme&gt;://&lt;netloc&gt;/&lt;path&gt;;&lt;params&gt;?&lt;query&gt;#&lt;fragment&gt;
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:2:5
+          |
+        2 | def urlparse():
+          |     ^^^-
+          |     ||||
+          |     |||Cursor offset
+          |     ||source
+          |
+        "#);
+    }
+
+    #[test]
     fn hover_func_with_plus_docstring() {
         let test = hover_test(
             r#"

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -4641,17 +4641,17 @@ def function():
         def urlparse() -> Unknown
         ```
         ---
-        Parse a URL into components:  <HB>
+        Parse a URL into components:<HB>
         &lt;scheme&gt;://&lt;netloc&gt;/&lt;path&gt;;&lt;params&gt;?&lt;query&gt;#&lt;fragment&gt;
         ---------------------------------------------
         info[hover]: Hovered content is
          --> main.py:2:5
           |
         2 | def urlparse():
-          |     ^^^-
-          |     ||||
-          |     |||Cursor offset
-          |     ||source
+          |     ^^^-^^^^
+          |     |  |
+          |     |  Cursor offset
+          |     source
           |
         "#);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Closes https://github.com/astral-sh/ty/issues/3482

Fixes the HTML rendering bug by escaping HTML sensitive characters

<img width="731" height="538" alt="image" src="https://github.com/user-attachments/assets/ab1f9e40-5735-45ec-8242-3659ccdcb1e6" />


## Test Plan

Added hover integration tests and docstring unit test
