### PR TITLE
[ty] Preserve declaration order when synthesizing class fields

### DIFF
--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -29,7 +29,8 @@ use scope::{NodeWithScopeKey, NodeWithScopeRef, Scope, ScopeId, ScopeKind, Scope
 use symbol::ScopedSymbolId;
 pub use use_def::{
     ApplicableConstraints, BindingWithConstraints, BindingWithConstraintsIterator,
-    DeclarationWithConstraint, DeclarationsIterator, LiveBinding, NarrowingEvaluator, UseDefMap,
+    DeclarationWithConstraint, DeclarationsIterator, LiveBinding, NarrowingEvaluator,
+    ScopedDefinitionId, UseDefMap,
 };
 use use_def::{EnclosingSnapshotKey, ScopedEnclosingSnapshotId};
 

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -863,6 +863,8 @@ impl<'map, 'db> DeclarationsIterator<'map, 'db> {
 #[derive(Debug, Clone)]
 pub struct DeclarationWithConstraint<'db> {
     pub declaration: DefinitionState<'db>,
+    /// Stable declaration order within the containing scope.
+    pub declaration_order: u32,
     pub reachability_constraint: ScopedReachabilityConstraintId,
 }
 
@@ -877,6 +879,7 @@ impl<'db> Iterator for DeclarationsIterator<'_, 'db> {
              }| {
                 DeclarationWithConstraint {
                     declaration: self.all_definitions[*declaration],
+                    declaration_order: declaration.as_u32(),
                     reachability_constraint: *reachability_constraint,
                 }
             },

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -266,7 +266,7 @@ mod place_state;
 
 pub use place_state::LiveBinding;
 pub(super) use place_state::PreviousDefinitions;
-pub(crate) use place_state::ScopedDefinitionId;
+pub use place_state::ScopedDefinitionId;
 
 /// Uniquely identifies an interned [`Bindings`] entry in [`UseDefMap::interned_bindings`].
 #[newtype_index]
@@ -864,7 +864,7 @@ impl<'map, 'db> DeclarationsIterator<'map, 'db> {
 pub struct DeclarationWithConstraint<'db> {
     pub declaration: DefinitionState<'db>,
     /// Stable declaration order within the containing scope.
-    pub declaration_order: u32,
+    pub declaration_order: ScopedDefinitionId,
     pub reachability_constraint: ScopedReachabilityConstraintId,
 }
 
@@ -879,7 +879,7 @@ impl<'db> Iterator for DeclarationsIterator<'_, 'db> {
              }| {
                 DeclarationWithConstraint {
                     declaration: self.all_definitions[*declaration],
-                    declaration_order: declaration.as_u32(),
+                    declaration_order: *declaration,
                     reachability_constraint: *reachability_constraint,
                 }
             },

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1705,6 +1705,19 @@ error[too-many-positional-arguments]: Too many positional arguments: expected 1,
    |
 ```
 
+Declaration order still controls `KW_ONLY` when a later field name was already referenced by an
+earlier annotation:
+
+```py
+@dataclass
+class ShadowedOrder:
+    x: int
+    _: KW_ONLY
+    int: int
+
+reveal_type(ShadowedOrder.__init__)  # revealed: (self: ShadowedOrder, x: int, *, int: int) -> None
+```
+
 Using `KW_ONLY` to annotate more than one field in a dataclass causes a `TypeError` to be raised at
 runtime:
 

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/initvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/initvar.md
@@ -77,6 +77,22 @@ reveal_type(bob.metadata)  # revealed: str
 reveal_type(Person.metadata)  # revealed: str
 ```
 
+Field synthesis still follows declaration order even when an `InitVar` field name shadows a type
+name referenced by an earlier annotation:
+
+```py
+from dataclasses import InitVar, dataclass
+from ty_extensions import Top
+
+@dataclass
+class C:
+    a: Top[int]
+    int: InitVar[int] = 0
+
+reveal_type(C.__init__)  # revealed: (self: C, a: int, int: int = 0) -> None
+C()  # error: [missing-argument] "No argument provided for required parameter `a`"
+```
+
 ## Overwritten `InitVar`
 
 We do not emit an error if an `InitVar` attribute is later overwritten on the instance. In that

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1125,6 +1125,7 @@ impl<'db> DeclarationsBoundnessEvaluator<'_, 'db> {
                     Some(DeclarationWithConstraint {
                         declaration,
                         reachability_constraint,
+                        ..
                     }) if declaration.is_undefined_or(|def| {
                         is_non_exported(db, def, requires_explicit_reexport)
                     }) =>
@@ -1737,6 +1738,7 @@ fn place_from_declarations_impl<'db>(
         let DeclarationWithConstraint {
             declaration,
             reachability_constraint,
+            ..
         } = declaration_with_constraint;
 
         let DefinitionState::Defined(declaration) = declaration else {

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -208,7 +208,7 @@ use ruff_text_size::TextRange;
 use rustc_hash::{FxHashMap, FxHashSet};
 use ty_python_core::{
     BindingWithConstraints, DeclarationWithConstraint, DeclarationsIterator, FileScopeId,
-    SemanticIndex, Truthiness, UseDefMap,
+    ScopedDefinitionId, SemanticIndex, Truthiness, UseDefMap,
     definition::DefinitionState,
     place::ScopedPlaceId,
     place_table,
@@ -1153,11 +1153,12 @@ pub(crate) trait DeclarationsIteratorExtension<'db> {
         predicate: impl FnMut(DefinitionState<'db>) -> bool,
     ) -> bool;
 
+    /// Return the first reachable declaration that matches the passed in predicate function.
     fn first_reachable_declaration_order(
         self,
         db: &'db dyn Db,
         predicate: impl FnMut(DefinitionState<'db>) -> bool,
-    ) -> Option<u32>;
+    ) -> Option<ScopedDefinitionId>;
 }
 
 impl<'db> DeclarationsIteratorExtension<'db> for DeclarationsIterator<'_, 'db> {
@@ -1187,8 +1188,8 @@ impl<'db> DeclarationsIteratorExtension<'db> for DeclarationsIterator<'_, 'db> {
         mut self,
         db: &'db dyn Db,
         mut predicate: impl FnMut(DefinitionState<'db>) -> bool,
-    ) -> Option<u32> {
-        let predicates = self.predicates();
+    ) -> Option<ScopedDefinitionId> {
+        let reachability_predicates = self.predicates();
         let reachability_constraints = self.reachability_constraints();
 
         self.find_map(
@@ -1199,7 +1200,7 @@ impl<'db> DeclarationsIteratorExtension<'db> for DeclarationsIterator<'_, 'db> {
              }| {
                 (predicate(declaration)
                     && !reachability_constraints
-                        .evaluate(db, predicates, reachability_constraint)
+                        .evaluate(db, reachability_predicates, reachability_constraint)
                         .is_always_false())
                 .then_some(declaration_order)
             },

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1152,6 +1152,12 @@ pub(crate) trait DeclarationsIteratorExtension<'db> {
         db: &'db dyn Db,
         predicate: impl FnMut(DefinitionState<'db>) -> bool,
     ) -> bool;
+
+    fn first_reachable_declaration_order(
+        self,
+        db: &'db dyn Db,
+        predicate: impl FnMut(DefinitionState<'db>) -> bool,
+    ) -> Option<u32>;
 }
 
 impl<'db> DeclarationsIteratorExtension<'db> for DeclarationsIterator<'_, 'db> {
@@ -1167,11 +1173,35 @@ impl<'db> DeclarationsIteratorExtension<'db> for DeclarationsIterator<'_, 'db> {
             |DeclarationWithConstraint {
                  declaration,
                  reachability_constraint,
+                 ..
              }| {
                 predicate(declaration)
                     && !reachability_constraints
                         .evaluate(db, predicates, reachability_constraint)
                         .is_always_false()
+            },
+        )
+    }
+
+    fn first_reachable_declaration_order(
+        mut self,
+        db: &'db dyn Db,
+        mut predicate: impl FnMut(DefinitionState<'db>) -> bool,
+    ) -> Option<u32> {
+        let predicates = self.predicates();
+        let reachability_constraints = self.reachability_constraints();
+
+        self.find_map(
+            |DeclarationWithConstraint {
+                 declaration,
+                 declaration_order,
+                 reachability_constraint,
+             }| {
+                (predicate(declaration)
+                    && !reachability_constraints
+                        .evaluate(db, predicates, reachability_constraint)
+                        .is_always_false())
+                .then_some(declaration_order)
             },
         )
     }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1845,8 +1845,9 @@ impl<'db> StaticClassLiteral<'db> {
     ///     y: str = "hello"
     ///     z: float = field(kw_only=False, default=1.0)
     /// ```
-    /// we return a map `{"x": Field, "y": Field, "z": Field}` where each `Field` contains
-    /// the annotated type, default value (if any), and field properties.
+    /// we return a map `{"x": Field, "y": Field, "z": Field}` in class-body declaration order,
+    /// where each `Field` contains the annotated type, default value (if any), and field
+    /// properties.
     ///
     /// **Important**: The returned `Field` objects represent our full understanding of the fields,
     /// including properties inherited from class-level dataclass parameters (like `kw_only=True`)
@@ -1863,8 +1864,6 @@ impl<'db> StaticClassLiteral<'db> {
         specialization: Option<Specialization<'db>>,
         field_policy: CodeGeneratorKind<'db>,
     ) -> FxIndexMap<Name, Field<'db>> {
-        let mut attributes = FxIndexMap::default();
-
         let class_body_scope = self.body_scope(db);
         let table = place_table(db, class_body_scope);
 
@@ -1874,6 +1873,7 @@ impl<'db> StaticClassLiteral<'db> {
         let dataclass_kw_only_default = matches!(field_policy, CodeGeneratorKind::DataclassLike(_))
             .then(|| self.has_dataclass_param(db, field_policy, DataclassFlags::KW_ONLY));
         let mut kw_only_sentinel_field_seen = false;
+        let mut field_declarations = Vec::new();
 
         for (symbol_id, declarations) in use_def.all_end_of_scope_symbol_declarations() {
             // Here, we exclude all declarations that are not annotated assignments. We need this because
@@ -1894,9 +1894,31 @@ impl<'db> StaticClassLiteral<'db> {
                 continue;
             }
 
-            let symbol = table.symbol(symbol_id);
+            // Field contents come from the declarations live at end of scope, but field order is
+            // anchored to the first reachable annotated declaration in the class body.
+            let Some(first_declaration_order) = use_def
+                .reachable_symbol_declarations(symbol_id)
+                .first_reachable_declaration_order(db, |declaration| {
+                    declaration.is_defined_and(|declaration| {
+                        matches!(
+                            declaration.kind(db),
+                            DefinitionKind::AnnotatedAssignment(..)
+                        )
+                    })
+                })
+            else {
+                continue;
+            };
 
             let result = place_from_declarations(db, declarations.clone());
+            field_declarations.push((first_declaration_order, symbol_id, result));
+        }
+
+        field_declarations.sort_by_key(|(first_declaration_order, _, _)| *first_declaration_order);
+
+        let mut attributes = FxIndexMap::default();
+        for (_, symbol_id, result) in field_declarations {
+            let symbol = table.symbol(symbol_id);
             let first_declaration = result.first_declaration;
             let attr = result.ignore_conflicting_declarations();
             if attr.is_class_var() {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1914,7 +1914,8 @@ impl<'db> StaticClassLiteral<'db> {
             field_declarations.push((first_declaration_order, symbol_id, result));
         }
 
-        field_declarations.sort_by_key(|(first_declaration_order, _, _)| *first_declaration_order);
+        field_declarations
+            .sort_unstable_by_key(|(first_declaration_order, _, _)| *first_declaration_order);
 
         let mut attributes = FxIndexMap::default();
         for (_, symbol_id, result) in field_declarations {


### PR DESCRIPTION
## Summary

Prior to this change, field synthesis could accidentally follow symbol-table order instead of class-body declaration order in pathological cases like:

```python
from dataclasses import InitVar, dataclass
from ty_extensions import Top

@dataclass
class C:
    a: Top[int]
    int: InitVar[int] = 0
```

Here, `int` can be interned before its own declaration because it already appears in `Top[int]`.

This PR carries a stable declaration ordinal through declaration lookup and uses it when building `own_fields()`.

Closes https://github.com/astral-sh/ty/issues/3493.
