### PR TITLE
[ty] Refine Callable class-decorator fallback for unknown results

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -535,6 +535,14 @@ specialized_explicit_return_decorator = ExplicitReturnDecorator[int]()
 class SpecializedExplicitReturnCallableInstanceDecorated: ...
 
 reveal_type(SpecializedExplicitReturnCallableInstanceDecorated)  # revealed: int
+
+def regular_callable_replacement_factory() -> Callable[[type[object]], T]:
+    raise NotImplementedError
+
+@regular_callable_replacement_factory()
+class RegularCallableReplacementDecorated: ...
+
+reveal_type(RegularCallableReplacementDecorated)  # revealed: Unknown
 ```
 
 An unknown class decorator still makes the class binding unknown:

--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -536,6 +536,18 @@ class SpecializedExplicitReturnCallableInstanceDecorated: ...
 
 reveal_type(SpecializedExplicitReturnCallableInstanceDecorated)  # revealed: int
 
+def function_decorator(func: Callable[..., T]) -> Callable[..., T]:
+    return func
+
+@function_decorator
+def explicit_return_callable_decorator(cls) -> T:
+    raise NotImplementedError
+
+@explicit_return_callable_decorator
+class ExplicitReturnCallableDecorated: ...
+
+reveal_type(ExplicitReturnCallableDecorated)  # revealed: Unknown
+
 def regular_callable_replacement_factory() -> Callable[[type[object]], T]:
     raise NotImplementedError
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -7483,7 +7483,7 @@ fn asynccontextmanager_return_type<'db>(db: &'db dyn Db, func_ty: Type<'db>) -> 
         db,
         CallableSignature::single(new_signature),
         CallableTypeKind::FunctionLike,
-        false,
+        None,
     )))
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -28,7 +28,7 @@ use crate::dunder_all::dunder_all_names;
 use crate::place::{DefinedPlace, Definedness, Place, known_module_symbol};
 use crate::subscript::PyIndex;
 use crate::types::call::arguments::{CallArgumentTypes, Expansion, is_expandable_type};
-use crate::types::callable::CallableTypeKind;
+use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::{ConstraintSet, ConstraintSetBuilder, PathBounds, Solutions};
 use crate::types::diagnostic::{
     CALL_NON_CALLABLE, CALL_TOP_CALLABLE, CONFLICTING_ARGUMENT_FORMS, INVALID_ARGUMENT_TYPE,
@@ -7483,7 +7483,7 @@ fn asynccontextmanager_return_type<'db>(db: &'db dyn Db, func_ty: Type<'db>) -> 
         db,
         CallableSignature::single(new_signature),
         CallableTypeKind::FunctionLike,
-        None,
+        CallableFunctionProvenance::None,
     )))
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -7483,6 +7483,7 @@ fn asynccontextmanager_return_type<'db>(db: &'db dyn Db, func_ty: Type<'db>) -> 
         db,
         CallableSignature::single(new_signature),
         CallableTypeKind::FunctionLike,
+        false,
     )))
 }
 

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -163,6 +163,7 @@ impl<'db> Type<'db> {
                                 db,
                                 CallableSignature::from_overloads(signatures),
                                 callable.kind(db),
+                                callable.has_explicit_function_return_annotation(db),
                             )
                         }))
                     }
@@ -183,6 +184,7 @@ impl<'db> Type<'db> {
                                     db,
                                     CallableSignature::from_overloads(signatures),
                                     callable.kind(db),
+                                    callable.has_explicit_function_return_annotation(db),
                                 ));
                             }
                         }
@@ -230,6 +232,7 @@ impl<'db> Type<'db> {
                 db,
                 CallableSignature::from_overloads(method.signatures(db)),
                 CallableTypeKind::Regular,
+                false,
             ))),
 
             Type::WrapperDescriptor(wrapper_descriptor) => {
@@ -237,6 +240,7 @@ impl<'db> Type<'db> {
                     db,
                     CallableSignature::from_overloads(wrapper_descriptor.signatures(db)),
                     CallableTypeKind::Regular,
+                    false,
                 )))
             }
 
@@ -380,6 +384,9 @@ pub struct CallableType<'db> {
     pub(crate) signatures: CallableSignature<'db>,
 
     pub(super) kind: CallableTypeKind,
+
+    /// Whether this callable came from a function with an explicit return annotation.
+    pub(crate) has_explicit_function_return_annotation: bool,
 }
 
 pub(super) fn walk_callable_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
@@ -401,6 +408,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::single(signature),
             CallableTypeKind::Regular,
+            false,
         )
     }
 
@@ -409,6 +417,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::single(signature),
             CallableTypeKind::FunctionLike,
+            false,
         )
     }
 
@@ -420,6 +429,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::single(Signature::new(parameters, Type::unknown())),
             CallableTypeKind::ParamSpecValue,
+            false,
         )
     }
 
@@ -441,7 +451,12 @@ impl<'db> CallableType<'db> {
     }
 
     pub(crate) fn into_regular(self, db: &'db dyn Db) -> CallableType<'db> {
-        CallableType::new(db, self.signatures(db), CallableTypeKind::Regular)
+        CallableType::new(
+            db,
+            self.signatures(db),
+            CallableTypeKind::Regular,
+            self.has_explicit_function_return_annotation(db),
+        )
     }
 
     /// Returns the reduced callable produced by partially applying selected overloads.
@@ -453,6 +468,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::partially_apply(db, overloads)?,
             CallableTypeKind::Regular,
+            false,
         ))
     }
 
@@ -482,6 +498,7 @@ impl<'db> CallableType<'db> {
             db,
             self.signatures(db).bind_self(db, self_type),
             self.kind(db),
+            self.has_explicit_function_return_annotation(db),
         )
     }
 
@@ -490,6 +507,7 @@ impl<'db> CallableType<'db> {
             db,
             self.signatures(db).apply_self(db, self_type),
             self.kind(db),
+            self.has_explicit_function_return_annotation(db),
         )
     }
 
@@ -498,7 +516,12 @@ impl<'db> CallableType<'db> {
     /// Specifically, this represents a callable type with a single signature:
     /// `(*args: object, **kwargs: object) -> Never`.
     pub(crate) fn bottom(db: &'db dyn Db) -> CallableType<'db> {
-        Self::new(db, CallableSignature::bottom(), CallableTypeKind::Regular)
+        Self::new(
+            db,
+            CallableSignature::bottom(),
+            CallableTypeKind::Regular,
+            false,
+        )
     }
 
     pub(super) fn recursive_type_normalized_impl(
@@ -512,6 +535,7 @@ impl<'db> CallableType<'db> {
             self.signatures(db)
                 .recursive_type_normalized_impl(db, div, nested)?,
             self.kind(db),
+            self.has_explicit_function_return_annotation(db),
         ))
     }
 
@@ -531,6 +555,7 @@ impl<'db> CallableType<'db> {
             self.signatures(db)
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
             self.kind(db),
+            self.has_explicit_function_return_annotation(db),
         )
     }
 
@@ -625,6 +650,7 @@ impl<'db> CallableTypes<'db> {
             db,
             CallableSignature::from_overloads(overloads),
             CallableTypeKind::Regular,
+            false,
         )
         .into_precise_functools_partial_instance(db, wrapped)
     }

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -163,7 +163,7 @@ impl<'db> Type<'db> {
                                 db,
                                 CallableSignature::from_overloads(signatures),
                                 callable.kind(db),
-                                callable.has_explicit_function_return_annotation(db),
+                                callable.provenance(db),
                             )
                         }))
                     }
@@ -184,7 +184,7 @@ impl<'db> Type<'db> {
                                     db,
                                     CallableSignature::from_overloads(signatures),
                                     callable.kind(db),
-                                    callable.has_explicit_function_return_annotation(db),
+                                    callable.provenance(db),
                                 ));
                             }
                         }
@@ -232,7 +232,7 @@ impl<'db> Type<'db> {
                 db,
                 CallableSignature::from_overloads(method.signatures(db)),
                 CallableTypeKind::Regular,
-                false,
+                None,
             ))),
 
             Type::WrapperDescriptor(wrapper_descriptor) => {
@@ -240,7 +240,7 @@ impl<'db> Type<'db> {
                     db,
                     CallableSignature::from_overloads(wrapper_descriptor.signatures(db)),
                     CallableTypeKind::Regular,
-                    false,
+                    None,
                 )))
             }
 
@@ -328,6 +328,27 @@ pub enum CallableTypeKind {
     ParamSpecValue,
 }
 
+/// Whether this callable is known to come from a function and how that function's return type was
+/// declared.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
+pub enum CallableFunctionProvenance {
+    /// The callable came from a function without an explicit return annotation.
+    ImplicitReturn,
+
+    /// The callable came from a function with an explicit return annotation.
+    ExplicitReturn,
+}
+
+impl CallableFunctionProvenance {
+    pub(crate) fn from_function_return_annotation(has_explicit_return_annotation: bool) -> Self {
+        if has_explicit_return_annotation {
+            Self::ExplicitReturn
+        } else {
+            Self::ImplicitReturn
+        }
+    }
+}
+
 /// A "policy" enum that describes how `type[]` types should be upcast
 /// to `Callable` types.
 ///
@@ -385,8 +406,7 @@ pub struct CallableType<'db> {
 
     pub(super) kind: CallableTypeKind,
 
-    /// Whether this callable came from a function with an explicit return annotation.
-    pub(crate) has_explicit_function_return_annotation: bool,
+    pub(crate) provenance: Option<CallableFunctionProvenance>,
 }
 
 pub(super) fn walk_callable_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
@@ -408,7 +428,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::single(signature),
             CallableTypeKind::Regular,
-            false,
+            None,
         )
     }
 
@@ -417,7 +437,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::single(signature),
             CallableTypeKind::FunctionLike,
-            false,
+            None,
         )
     }
 
@@ -429,7 +449,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::single(Signature::new(parameters, Type::unknown())),
             CallableTypeKind::ParamSpecValue,
-            false,
+            None,
         )
     }
 
@@ -455,7 +475,7 @@ impl<'db> CallableType<'db> {
             db,
             self.signatures(db),
             CallableTypeKind::Regular,
-            self.has_explicit_function_return_annotation(db),
+            self.provenance(db),
         )
     }
 
@@ -468,7 +488,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::partially_apply(db, overloads)?,
             CallableTypeKind::Regular,
-            false,
+            None,
         ))
     }
 
@@ -498,7 +518,7 @@ impl<'db> CallableType<'db> {
             db,
             self.signatures(db).bind_self(db, self_type),
             self.kind(db),
-            self.has_explicit_function_return_annotation(db),
+            self.provenance(db),
         )
     }
 
@@ -507,7 +527,7 @@ impl<'db> CallableType<'db> {
             db,
             self.signatures(db).apply_self(db, self_type),
             self.kind(db),
-            self.has_explicit_function_return_annotation(db),
+            self.provenance(db),
         )
     }
 
@@ -520,7 +540,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::bottom(),
             CallableTypeKind::Regular,
-            false,
+            None,
         )
     }
 
@@ -535,7 +555,7 @@ impl<'db> CallableType<'db> {
             self.signatures(db)
                 .recursive_type_normalized_impl(db, div, nested)?,
             self.kind(db),
-            self.has_explicit_function_return_annotation(db),
+            self.provenance(db),
         ))
     }
 
@@ -555,7 +575,7 @@ impl<'db> CallableType<'db> {
             self.signatures(db)
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
             self.kind(db),
-            self.has_explicit_function_return_annotation(db),
+            self.provenance(db),
         )
     }
 
@@ -650,7 +670,7 @@ impl<'db> CallableTypes<'db> {
             db,
             CallableSignature::from_overloads(overloads),
             CallableTypeKind::Regular,
-            false,
+            None,
         )
         .into_precise_functools_partial_instance(db, wrapped)
     }

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -232,7 +232,7 @@ impl<'db> Type<'db> {
                 db,
                 CallableSignature::from_overloads(method.signatures(db)),
                 CallableTypeKind::Regular,
-                None,
+                CallableFunctionProvenance::None,
             ))),
 
             Type::WrapperDescriptor(wrapper_descriptor) => {
@@ -240,7 +240,7 @@ impl<'db> Type<'db> {
                     db,
                     CallableSignature::from_overloads(wrapper_descriptor.signatures(db)),
                     CallableTypeKind::Regular,
-                    None,
+                    CallableFunctionProvenance::None,
                 )))
             }
 
@@ -328,10 +328,16 @@ pub enum CallableTypeKind {
     ParamSpecValue,
 }
 
-/// Whether this callable is known to come from a function and how that function's return type was
-/// declared.
+/// Source-function provenance retained by a callable signature.
+///
+/// A [`CallableType`] can describe a bare callable shape, such as one from `Callable[...]`. For
+/// function-like sources, such as a [`FunctionType`] upcast to a [`CallableType`] or a lambda, this
+/// records whether the source function has an explicit return annotation.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub enum CallableFunctionProvenance {
+    /// The callable does not retain source-function provenance.
+    None,
+
     /// The callable came from a function without an explicit return annotation.
     ImplicitReturn,
 
@@ -406,7 +412,19 @@ pub struct CallableType<'db> {
 
     pub(super) kind: CallableTypeKind,
 
-    pub(crate) provenance: Option<CallableFunctionProvenance>,
+    /// Source-function return-annotation provenance retained by this callable.
+    ///
+    /// Function-like values can retain their source-function provenance when converted to a
+    /// callable signature:
+    /// ```python
+    /// def decorator(cls) -> object: ...
+    /// ```
+    ///
+    /// Callables that are only known from a callable shape do not retain that provenance:
+    /// ```python
+    /// def decorator_factory() -> Callable[[type[object]], object]: ...
+    /// ```
+    pub(crate) provenance: CallableFunctionProvenance,
 }
 
 pub(super) fn walk_callable_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
@@ -428,7 +446,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::single(signature),
             CallableTypeKind::Regular,
-            None,
+            CallableFunctionProvenance::None,
         )
     }
 
@@ -437,7 +455,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::single(signature),
             CallableTypeKind::FunctionLike,
-            None,
+            CallableFunctionProvenance::None,
         )
     }
 
@@ -449,7 +467,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::single(Signature::new(parameters, Type::unknown())),
             CallableTypeKind::ParamSpecValue,
-            None,
+            CallableFunctionProvenance::None,
         )
     }
 
@@ -488,7 +506,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::partially_apply(db, overloads)?,
             CallableTypeKind::Regular,
-            None,
+            CallableFunctionProvenance::None,
         ))
     }
 
@@ -540,7 +558,7 @@ impl<'db> CallableType<'db> {
             db,
             CallableSignature::bottom(),
             CallableTypeKind::Regular,
-            None,
+            CallableFunctionProvenance::None,
         )
     }
 
@@ -670,7 +688,7 @@ impl<'db> CallableTypes<'db> {
             db,
             CallableSignature::from_overloads(overloads),
             CallableTypeKind::Regular,
-            None,
+            CallableFunctionProvenance::None,
         )
         .into_precise_functools_partial_instance(db, wrapped)
     }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1587,6 +1587,7 @@ impl<'db> ClassType<'db> {
                             db,
                             getitem_signature,
                             CallableTypeKind::FunctionLike,
+                            false,
                         ));
                         Member::definitely_declared(getitem_type)
                     })
@@ -1828,6 +1829,7 @@ impl<'db> ClassType<'db> {
                 db,
                 dunder_new_signature.bind_self(db, Some(instance_ty)),
                 CallableTypeKind::Regular,
+                false,
             );
 
             if returns_non_subclass {
@@ -1898,6 +1900,7 @@ impl<'db> ClassType<'db> {
                     db,
                     synthesized_dunder_init_signature,
                     CallableTypeKind::Regular,
+                    false,
                 ))
             } else {
                 None

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1587,7 +1587,7 @@ impl<'db> ClassType<'db> {
                             db,
                             getitem_signature,
                             CallableTypeKind::FunctionLike,
-                            false,
+                            None,
                         ));
                         Member::definitely_declared(getitem_type)
                     })
@@ -1829,7 +1829,7 @@ impl<'db> ClassType<'db> {
                 db,
                 dunder_new_signature.bind_self(db, Some(instance_ty)),
                 CallableTypeKind::Regular,
-                false,
+                None,
             );
 
             if returns_non_subclass {
@@ -1900,7 +1900,7 @@ impl<'db> ClassType<'db> {
                     db,
                     synthesized_dunder_init_signature,
                     CallableTypeKind::Regular,
-                    false,
+                    None,
                 ))
             } else {
                 None

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -19,7 +19,7 @@ use super::{
 };
 use super::{TypeVarVariance, display};
 use crate::place::{DefinedPlace, TypeOrigin};
-use crate::types::callable::CallableTypeKind;
+use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
 };
@@ -1587,7 +1587,7 @@ impl<'db> ClassType<'db> {
                             db,
                             getitem_signature,
                             CallableTypeKind::FunctionLike,
-                            None,
+                            CallableFunctionProvenance::None,
                         ));
                         Member::definitely_declared(getitem_type)
                     })
@@ -1829,7 +1829,7 @@ impl<'db> ClassType<'db> {
                 db,
                 dunder_new_signature.bind_self(db, Some(instance_ty)),
                 CallableTypeKind::Regular,
-                None,
+                CallableFunctionProvenance::None,
             );
 
             if returns_non_subclass {
@@ -1900,7 +1900,7 @@ impl<'db> ClassType<'db> {
                     db,
                     synthesized_dunder_init_signature,
                     CallableTypeKind::Regular,
-                    None,
+                    CallableFunctionProvenance::None,
                 ))
             } else {
                 None

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -966,6 +966,7 @@ impl<'db> StaticClassLiteral<'db> {
                     db,
                     callable_ty.signatures(db),
                     CallableTypeKind::FunctionLike,
+                    callable_ty.has_explicit_function_return_annotation(db),
                 )),
                 Type::Union(union) => {
                     union.map(db, |element| into_function_like_callable(db, *element))
@@ -1191,7 +1192,7 @@ impl<'db> StaticClassLiteral<'db> {
                         )
                     }),
                 );
-                CallableType::new(db, signatures, CallableTypeKind::FunctionLike)
+                CallableType::new(db, signatures, CallableTypeKind::FunctionLike, false)
             });
 
             return Some(synthesized_callables.into_type(db));
@@ -1601,6 +1602,7 @@ impl<'db> StaticClassLiteral<'db> {
             db,
             CallableSignature::from_overloads(overloads),
             CallableTypeKind::FunctionLike,
+            false,
         )))
     }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -24,7 +24,7 @@ use crate::{
         Signature, SpecialFormType, StaticMroError, SubclassOfType, Truthiness, Type, TypeContext,
         TypeMapping, TypeVarVariance, UnionBuilder, UnionType,
         call::{CallError, CallErrorKind},
-        callable::CallableTypeKind,
+        callable::{CallableFunctionProvenance, CallableTypeKind},
         class::{
             ClassMemberResult, CodeGeneratorKind, DisjointBase, DynamicTypedDictLiteral, Field,
             FieldKind, InstanceMemberResult, MetaclassError, MetaclassErrorKind, MethodDecorator,
@@ -1192,7 +1192,12 @@ impl<'db> StaticClassLiteral<'db> {
                         )
                     }),
                 );
-                CallableType::new(db, signatures, CallableTypeKind::FunctionLike, None)
+                CallableType::new(
+                    db,
+                    signatures,
+                    CallableTypeKind::FunctionLike,
+                    CallableFunctionProvenance::None,
+                )
             });
 
             return Some(synthesized_callables.into_type(db));
@@ -1602,7 +1607,7 @@ impl<'db> StaticClassLiteral<'db> {
             db,
             CallableSignature::from_overloads(overloads),
             CallableTypeKind::FunctionLike,
-            None,
+            CallableFunctionProvenance::None,
         )))
     }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -966,7 +966,7 @@ impl<'db> StaticClassLiteral<'db> {
                     db,
                     callable_ty.signatures(db),
                     CallableTypeKind::FunctionLike,
-                    callable_ty.has_explicit_function_return_annotation(db),
+                    callable_ty.provenance(db),
                 )),
                 Type::Union(union) => {
                     union.map(db, |element| into_function_like_callable(db, *element))
@@ -1192,7 +1192,7 @@ impl<'db> StaticClassLiteral<'db> {
                         )
                     }),
                 );
-                CallableType::new(db, signatures, CallableTypeKind::FunctionLike, false)
+                CallableType::new(db, signatures, CallableTypeKind::FunctionLike, None)
             });
 
             return Some(synthesized_callables.into_type(db));
@@ -1602,7 +1602,7 @@ impl<'db> StaticClassLiteral<'db> {
             db,
             CallableSignature::from_overloads(overloads),
             CallableTypeKind::FunctionLike,
-            false,
+            None,
         )))
     }
 

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -10,7 +10,7 @@ use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::place::PlaceAndQualifiers;
-use crate::types::callable::CallableTypeKind;
+use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::generics::GenericContext;
 use crate::types::member::Member;
 use crate::types::mro::Mro;
@@ -153,7 +153,7 @@ fn synthesize_typed_dict_init<'db>(
         db,
         CallableSignature::from_overloads([map_overload, keyword_overload]),
         CallableTypeKind::FunctionLike,
-        None,
+        CallableFunctionProvenance::None,
     ))
 }
 
@@ -177,7 +177,7 @@ fn synthesize_typed_dict_getitem<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        None,
+        CallableFunctionProvenance::None,
     ))
 }
 
@@ -221,7 +221,7 @@ fn synthesize_typed_dict_setitem<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        None,
+        CallableFunctionProvenance::None,
     ))
 }
 
@@ -261,7 +261,7 @@ fn synthesize_typed_dict_delitem<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        None,
+        CallableFunctionProvenance::None,
     ))
 }
 
@@ -381,7 +381,7 @@ fn synthesize_typed_dict_get<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        None,
+        CallableFunctionProvenance::None,
     ))
 }
 
@@ -495,7 +495,7 @@ fn synthesize_typed_dict_pop<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        None,
+        CallableFunctionProvenance::None,
     ))
 }
 
@@ -522,7 +522,7 @@ fn synthesize_typed_dict_setdefault<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        None,
+        CallableFunctionProvenance::None,
     ))
 }
 
@@ -590,7 +590,7 @@ fn synthesize_typed_dict_merge<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        None,
+        CallableFunctionProvenance::None,
     ))
 }
 

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -153,6 +153,7 @@ fn synthesize_typed_dict_init<'db>(
         db,
         CallableSignature::from_overloads([map_overload, keyword_overload]),
         CallableTypeKind::FunctionLike,
+        false,
     ))
 }
 
@@ -176,6 +177,7 @@ fn synthesize_typed_dict_getitem<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
+        false,
     ))
 }
 
@@ -219,6 +221,7 @@ fn synthesize_typed_dict_setitem<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
+        false,
     ))
 }
 
@@ -258,6 +261,7 @@ fn synthesize_typed_dict_delitem<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
+        false,
     ))
 }
 
@@ -377,6 +381,7 @@ fn synthesize_typed_dict_get<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
+        false,
     ))
 }
 
@@ -490,6 +495,7 @@ fn synthesize_typed_dict_pop<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
+        false,
     ))
 }
 
@@ -516,6 +522,7 @@ fn synthesize_typed_dict_setdefault<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
+        false,
     ))
 }
 
@@ -583,6 +590,7 @@ fn synthesize_typed_dict_merge<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
+        false,
     ))
 }
 

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -153,7 +153,7 @@ fn synthesize_typed_dict_init<'db>(
         db,
         CallableSignature::from_overloads([map_overload, keyword_overload]),
         CallableTypeKind::FunctionLike,
-        false,
+        None,
     ))
 }
 
@@ -177,7 +177,7 @@ fn synthesize_typed_dict_getitem<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        false,
+        None,
     ))
 }
 
@@ -221,7 +221,7 @@ fn synthesize_typed_dict_setitem<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        false,
+        None,
     ))
 }
 
@@ -261,7 +261,7 @@ fn synthesize_typed_dict_delitem<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        false,
+        None,
     ))
 }
 
@@ -381,7 +381,7 @@ fn synthesize_typed_dict_get<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        false,
+        None,
     ))
 }
 
@@ -495,7 +495,7 @@ fn synthesize_typed_dict_pop<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        false,
+        None,
     ))
 }
 
@@ -522,7 +522,7 @@ fn synthesize_typed_dict_setdefault<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        false,
+        None,
     ))
 }
 
@@ -590,7 +590,7 @@ fn synthesize_typed_dict_merge<'db>(
         db,
         CallableSignature::from_overloads(overloads),
         CallableTypeKind::FunctionLike,
-        false,
+        None,
     ))
 }
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -65,7 +65,7 @@ use ty_module_resolver::{KnownModule, ModuleName, file_to_module, resolve_module
 
 use crate::place::{DefinedPlace, Definedness, Place, place_from_bindings};
 use crate::types::call::{Binding, CallArguments};
-use crate::types::callable::CallableTypeKind;
+use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::ConstraintSet;
 use crate::types::context::InferContext;
 use crate::types::cyclic::ActiveRecursionDetector;
@@ -1356,7 +1356,9 @@ impl<'db> FunctionType<'db> {
             db,
             self.signature(db),
             self.callable_type_kind(db),
-            self.has_explicit_return_annotation(db),
+            Some(CallableFunctionProvenance::from_function_return_annotation(
+                self.has_explicit_return_annotation(db),
+            )),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1339,16 +1339,25 @@ impl<'db> FunctionType<'db> {
             .last_definition_raw_signature(db, return_callable_typevar_scope)
     }
 
-    /// Convert the `FunctionType` into a [`CallableType`].
-    pub(crate) fn into_callable_type(self, db: &'db dyn Db) -> CallableType<'db> {
-        let kind = if self.is_classmethod(db) {
+    /// Return the kind for this function when it is converted into a [`CallableType`].
+    pub(crate) fn callable_type_kind(self, db: &'db dyn Db) -> CallableTypeKind {
+        if self.is_classmethod(db) {
             CallableTypeKind::ClassMethodLike
         } else if self.is_staticmethod(db) {
             CallableTypeKind::StaticMethodLike
         } else {
             CallableTypeKind::FunctionLike
-        };
-        CallableType::new(db, self.signature(db), kind)
+        }
+    }
+
+    /// Convert the `FunctionType` into a [`CallableType`].
+    pub(crate) fn into_callable_type(self, db: &'db dyn Db) -> CallableType<'db> {
+        CallableType::new(
+            db,
+            self.signature(db),
+            self.callable_type_kind(db),
+            self.has_explicit_return_annotation(db),
+        )
     }
 
     /// Convert the `FunctionType` into a [`BoundMethodType`].

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1356,9 +1356,9 @@ impl<'db> FunctionType<'db> {
             db,
             self.signature(db),
             self.callable_type_kind(db),
-            Some(CallableFunctionProvenance::from_function_return_annotation(
+            CallableFunctionProvenance::from_function_return_annotation(
                 self.has_explicit_return_annotation(db),
-            )),
+            ),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -677,7 +677,12 @@ impl<'db> GenericContext<'db> {
                         );
                         let signatures =
                             signatures.with_inherited_generic_context(db, generic_context);
-                        let replacement = CallableType::new(db, signatures, callable.kind(db));
+                        let replacement = CallableType::new(
+                            db,
+                            signatures,
+                            callable.kind(db),
+                            callable.has_explicit_function_return_annotation(db),
+                        );
 
                         Some((callable, replacement))
                     })

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -681,7 +681,7 @@ impl<'db> GenericContext<'db> {
                             db,
                             signatures,
                             callable.kind(db),
-                            callable.has_explicit_function_return_annotation(db),
+                            callable.provenance(db),
                         );
 
                         Some((callable, replacement))

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4995,17 +4995,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db: &'d dyn Db,
             ty: Type<'d>,
             kind: CallableTypeKind,
+            has_explicit_function_return_annotation: bool,
         ) -> Option<Type<'d>> {
             match ty {
                 Type::Callable(callable) => Some(Type::Callable(CallableType::new(
                     db,
                     callable.signatures(db),
                     kind,
+                    has_explicit_function_return_annotation,
                 ))),
-                Type::Union(union) => {
-                    union.try_map(db, |element| propagate_callable_kind(db, *element, kind))
-                }
-                Type::TypeAlias(alias) => propagate_callable_kind(db, alias.value_type(db), kind),
+                Type::Union(union) => union.try_map(db, |element| {
+                    propagate_callable_kind(
+                        db,
+                        *element,
+                        kind,
+                        has_explicit_function_return_annotation,
+                    )
+                }),
+                Type::TypeAlias(alias) => propagate_callable_kind(
+                    db,
+                    alias.value_type(db),
+                    kind,
+                    has_explicit_function_return_annotation,
+                ),
                 // Intersections are currently not handled here because that would require
                 // the decorator to be explicitly annotated as returning an intersection.
                 Type::Intersection(_) | Type::EnumComplement(_) => None,
@@ -5045,23 +5057,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // computing the signature requires evaluating those defaults which may trigger
         // deferred inference.
         let propagatable_kind = match decorated_ty {
-            Type::FunctionLiteral(func) => {
-                let db = self.db();
-                if func.is_classmethod(db) {
-                    Some(CallableTypeKind::ClassMethodLike)
-                } else if func.is_staticmethod(db) {
-                    Some(CallableTypeKind::StaticMethodLike)
-                } else {
-                    Some(CallableTypeKind::FunctionLike)
-                }
-            }
+            Type::FunctionLiteral(func) => Some((
+                func.callable_type_kind(self.db()),
+                func.has_explicit_return_annotation(self.db()),
+            )),
             _ => decorated_ty
                 .try_upcast_to_callable(self.db())
                 .and_then(CallableTypes::exactly_one)
                 .and_then(|callable| match callable.kind(self.db()) {
                     kind @ (CallableTypeKind::FunctionLike
                     | CallableTypeKind::StaticMethodLike
-                    | CallableTypeKind::ClassMethodLike) => Some(kind),
+                    | CallableTypeKind::ClassMethodLike) => Some((
+                        kind,
+                        callable.has_explicit_function_return_annotation(self.db()),
+                    )),
                     _ => None,
                 }),
         };
@@ -5081,7 +5090,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // a `Callable`-typed decorator" in `callables_as_descriptors.md` for the
         // extended explanation.
         propagatable_kind
-            .and_then(|kind| propagate_callable_kind(self.db(), return_ty, kind))
+            .and_then(|(kind, has_explicit_function_return_annotation)| {
+                propagate_callable_kind(
+                    self.db(),
+                    return_ty,
+                    kind,
+                    has_explicit_function_return_annotation,
+                )
+            })
             .unwrap_or(return_ty)
     }
 
@@ -7336,6 +7352,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     db,
                     CallableSignature::from_overloads(getitem_overloads),
                     CallableTypeKind::FunctionLike,
+                    false,
                 ),
             )],
         );

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4995,7 +4995,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db: &'d dyn Db,
             ty: Type<'d>,
             kind: CallableTypeKind,
-            provenance: Option<CallableFunctionProvenance>,
+            provenance: CallableFunctionProvenance,
         ) -> Option<Type<'d>> {
             match ty {
                 Type::Callable(callable) => Some(Type::Callable(CallableType::new(
@@ -5051,9 +5051,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let propagatable_kind = match decorated_ty {
             Type::FunctionLiteral(func) => Some((
                 func.callable_type_kind(self.db()),
-                Some(CallableFunctionProvenance::from_function_return_annotation(
+                CallableFunctionProvenance::from_function_return_annotation(
                     func.has_explicit_return_annotation(self.db()),
-                )),
+                ),
             )),
             _ => decorated_ty
                 .try_upcast_to_callable(self.db())
@@ -7257,7 +7257,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.db(),
             CallableSignature::single(Signature::new(parameters, return_ty)),
             CallableTypeKind::FunctionLike,
-            Some(CallableFunctionProvenance::ImplicitReturn),
+            CallableFunctionProvenance::ImplicitReturn,
         ))
     }
 
@@ -7345,7 +7345,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     db,
                     CallableSignature::from_overloads(getitem_overloads),
                     CallableTypeKind::FunctionLike,
-                    None,
+                    CallableFunctionProvenance::None,
                 ),
             )],
         );

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -40,7 +40,7 @@ use crate::reachability::ReachabilityConstraintsExtension;
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
 use crate::types::call::bind::MatchingOverloadIndex;
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
-use crate::types::callable::CallableTypeKind;
+use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
 use crate::types::constraints::{ConstraintSetBuilder, PathBounds, Solutions};
 use crate::types::context::InferContext;
@@ -4995,29 +4995,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db: &'d dyn Db,
             ty: Type<'d>,
             kind: CallableTypeKind,
-            has_explicit_function_return_annotation: bool,
+            provenance: Option<CallableFunctionProvenance>,
         ) -> Option<Type<'d>> {
             match ty {
                 Type::Callable(callable) => Some(Type::Callable(CallableType::new(
                     db,
                     callable.signatures(db),
                     kind,
-                    has_explicit_function_return_annotation,
+                    provenance,
                 ))),
                 Type::Union(union) => union.try_map(db, |element| {
-                    propagate_callable_kind(
-                        db,
-                        *element,
-                        kind,
-                        has_explicit_function_return_annotation,
-                    )
+                    propagate_callable_kind(db, *element, kind, provenance)
                 }),
-                Type::TypeAlias(alias) => propagate_callable_kind(
-                    db,
-                    alias.value_type(db),
-                    kind,
-                    has_explicit_function_return_annotation,
-                ),
+                Type::TypeAlias(alias) => {
+                    propagate_callable_kind(db, alias.value_type(db), kind, provenance)
+                }
                 // Intersections are currently not handled here because that would require
                 // the decorator to be explicitly annotated as returning an intersection.
                 Type::Intersection(_) | Type::EnumComplement(_) => None,
@@ -5059,7 +5051,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let propagatable_kind = match decorated_ty {
             Type::FunctionLiteral(func) => Some((
                 func.callable_type_kind(self.db()),
-                func.has_explicit_return_annotation(self.db()),
+                Some(CallableFunctionProvenance::from_function_return_annotation(
+                    func.has_explicit_return_annotation(self.db()),
+                )),
             )),
             _ => decorated_ty
                 .try_upcast_to_callable(self.db())
@@ -5067,10 +5061,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .and_then(|callable| match callable.kind(self.db()) {
                     kind @ (CallableTypeKind::FunctionLike
                     | CallableTypeKind::StaticMethodLike
-                    | CallableTypeKind::ClassMethodLike) => Some((
-                        kind,
-                        callable.has_explicit_function_return_annotation(self.db()),
-                    )),
+                    | CallableTypeKind::ClassMethodLike) => {
+                        Some((kind, callable.provenance(self.db())))
+                    }
                     _ => None,
                 }),
         };
@@ -5090,13 +5083,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // a `Callable`-typed decorator" in `callables_as_descriptors.md` for the
         // extended explanation.
         propagatable_kind
-            .and_then(|(kind, has_explicit_function_return_annotation)| {
-                propagate_callable_kind(
-                    self.db(),
-                    return_ty,
-                    kind,
-                    has_explicit_function_return_annotation,
-                )
+            .and_then(|(kind, provenance)| {
+                propagate_callable_kind(self.db(), return_ty, kind, provenance)
             })
             .unwrap_or(return_ty)
     }
@@ -7265,7 +7253,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.extend_scope(inference);
 
         let return_ty = inference.expression_type(lambda_expression.body.as_ref());
-        Type::function_like_callable(self.db(), Signature::new(parameters, return_ty))
+        Type::Callable(CallableType::new(
+            self.db(),
+            CallableSignature::single(Signature::new(parameters, return_ty)),
+            CallableTypeKind::FunctionLike,
+            Some(CallableFunctionProvenance::ImplicitReturn),
+        ))
     }
 
     /// Attempt to narrow a splatted dictionary argument based on the narrowed types of individual
@@ -7352,7 +7345,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     db,
                     CallableSignature::from_overloads(getitem_overloads),
                     CallableTypeKind::FunctionLike,
-                    false,
+                    None,
                 ),
             )],
         );

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -3,6 +3,7 @@ use crate::types::{
     CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
     SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
     call::CallError,
+    callable::CallableTypeKind,
     function::KnownFunction,
     infer::{
         TypeInferenceBuilder,
@@ -253,6 +254,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     db,
                     decorator_ty,
                     decorator_call_ty(decorator),
+                    decorated_ty,
                 ) {
                     metadata_applies_to_original_class = false;
                 }
@@ -305,12 +307,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             };
             // If a class decorator application loses all precision, preserve the original class
             // binding for decorators known to preserve unknown results.
-            let decorated_ty_is_unknown = is_unknown_decorator_result(db, decorated_ty);
-            let should_preserve_binding = decorated_ty_is_unknown
+            let should_preserve_binding = is_unknown_decorator_result(db, decorated_ty)
                 && preserve_binding_for_unknown_result(
                     db,
                     decorator_ty,
                     decorator_call_ty(decorator_node),
+                    decorated_ty,
                 );
             inferred_ty = if should_preserve_binding {
                 inferred_ty
@@ -518,33 +520,23 @@ fn preserve_binding_for_unknown_result<'db>(
     db: &'db dyn crate::Db,
     decorator_ty: Type<'db>,
     decorator_call_ty: Option<Type<'db>>,
+    decorator_result_ty: Type<'db>,
 ) -> bool {
-    ClassDecoratorUnknownResultPolicy::from_decorator(db, decorator_ty)
+    ClassDecoratorUnknownResultPolicy::from_decorator(db, decorator_ty, decorator_result_ty)
         == ClassDecoratorUnknownResultPolicy::PreserveBinding
         || decorator_call_ty.is_some_and(|ty| {
-            ClassDecoratorUnknownResultPolicy::from_decorator(db, ty)
+            ClassDecoratorUnknownResultPolicy::from_decorator(db, ty, decorator_result_ty)
                 == ClassDecoratorUnknownResultPolicy::PreserveBinding
         })
 }
 
 /// Return true if applying a class decorator produced no useful replacement type.
-///
-/// Besides plain `Unknown`, class decorators can produce unknown class-object types such as
-/// `type[Any]`. Those are represented as a `SubclassOf` dynamic type, but they should trigger the
-/// same preservation fallback as an unknown result:
-/// ```python
-/// from typing import Any
-///
-/// def decorator(cls) -> type[Any]: ...
-///
-/// @decorator
-/// class C: ...
-/// ```
 fn is_unknown_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bool {
-    if ty.is_unknown() {
-        return true;
-    }
+    ty.is_unknown() || is_unknown_class_object_decorator_result(db, ty)
+}
 
+/// Return true if applying a class decorator produced an unknown class-object type.
+fn is_unknown_class_object_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bool {
     let Type::SubclassOf(subclass_of) = ty.resolve_type_alias(db) else {
         return false;
     };
@@ -575,12 +567,17 @@ impl ClassDecoratorUnknownResultPolicy {
     /// Unannotated function and method decorators are treated as class-preserving when their
     /// application result is unknown. Explicit return annotations are trusted as replacement
     /// intent.
-    fn from_decorator<'db>(db: &'db dyn crate::Db, decorator_ty: Type<'db>) -> Self {
+    fn from_decorator<'db>(
+        db: &'db dyn crate::Db,
+        decorator_ty: Type<'db>,
+        decorator_result_ty: Type<'db>,
+    ) -> Self {
         if decorator_ty.is_unknown() {
             return Self::ReplaceBinding;
         }
 
-        Self::known_from_decorator(db, decorator_ty).unwrap_or(Self::ReplaceBinding)
+        Self::known_from_decorator(db, decorator_ty, decorator_result_ty)
+            .unwrap_or(Self::ReplaceBinding)
     }
 
     /// Return the known preservation policy for a class decorator, if one can be read statically.
@@ -600,7 +597,11 @@ impl ClassDecoratorUnknownResultPolicy {
     ///
     /// Callable instances and protocols delegate the decision to their `__call__` member, because
     /// the decorator value itself is not the function that receives the class.
-    fn known_from_decorator<'db>(db: &'db dyn crate::Db, decorator_ty: Type<'db>) -> Option<Self> {
+    fn known_from_decorator<'db>(
+        db: &'db dyn crate::Db,
+        decorator_ty: Type<'db>,
+        decorator_result_ty: Type<'db>,
+    ) -> Option<Self> {
         match decorator_ty {
             Type::FunctionLiteral(function) => {
                 Some(if function.has_explicit_return_annotation(db) {
@@ -628,14 +629,18 @@ impl ClassDecoratorUnknownResultPolicy {
                 if let Place::Defined(place) = call_symbol
                     && place.is_definitely_defined()
                 {
-                    Some(Self::known_from_decorator(db, place.ty).unwrap_or(Self::ReplaceBinding))
+                    Some(
+                        Self::known_from_decorator(db, place.ty, decorator_result_ty)
+                            .unwrap_or(Self::ReplaceBinding),
+                    )
                 } else {
                     Some(Self::ReplaceBinding)
                 }
             }
             Type::Union(union) => Some(
                 if union.elements(db).iter().all(|element| {
-                    Self::known_from_decorator(db, *element) == Some(Self::PreserveBinding)
+                    Self::known_from_decorator(db, *element, decorator_result_ty)
+                        == Some(Self::PreserveBinding)
                 }) {
                     Self::PreserveBinding
                 } else {
@@ -643,12 +648,25 @@ impl ClassDecoratorUnknownResultPolicy {
                 },
             ),
             Type::TypeAlias(alias) => Some(
-                Self::known_from_decorator(db, alias.value_type(db))
+                Self::known_from_decorator(db, alias.value_type(db), decorator_result_ty)
                     .unwrap_or(Self::ReplaceBinding),
             ),
-            // TODO: We preserve the class binding for every `Callable` decorator today. Figure out
-            // which of these cases should instead let an unknown decorator result replace it.
-            Type::Callable(_) => Some(Self::PreserveBinding),
+            Type::Callable(callable) => Some(match callable.kind(db) {
+                // Inferred function-like callables, such as lambdas, do not retain the source-level
+                // "explicit return annotation" signal that function literals do. Keep the existing
+                // class-preserving fallback for those cases.
+                CallableTypeKind::FunctionLike
+                | CallableTypeKind::StaticMethodLike
+                | CallableTypeKind::ClassMethodLike => Self::PreserveBinding,
+                CallableTypeKind::Regular | CallableTypeKind::ParamSpecValue
+                    if is_unknown_class_object_decorator_result(db, decorator_result_ty) =>
+                {
+                    Self::PreserveBinding
+                }
+                CallableTypeKind::Regular | CallableTypeKind::ParamSpecValue => {
+                    Self::ReplaceBinding
+                }
+            }),
             _ => None,
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -672,7 +672,7 @@ impl ClassDecoratorUnknownResultPolicy {
                 // @decorator
                 // class C: ...
                 // ```
-                Some(CallableFunctionProvenance::ImplicitReturn) => Self::PreserveBinding,
+                CallableFunctionProvenance::ImplicitReturn => Self::PreserveBinding,
                 // An explicit return annotation can intentionally replace the class binding:
                 // ```python
                 // def decorator[T](cls) -> T: ...
@@ -680,7 +680,7 @@ impl ClassDecoratorUnknownResultPolicy {
                 // @decorator
                 // class C: ...
                 // ```
-                Some(CallableFunctionProvenance::ExplicitReturn) => Self::ReplaceBinding,
+                CallableFunctionProvenance::ExplicitReturn => Self::ReplaceBinding,
                 // Generic class-preserving decorator factories can lose the concrete class in
                 // their returned `Callable`, while still producing an unknown class-object result:
                 // ```python
@@ -689,7 +689,9 @@ impl ClassDecoratorUnknownResultPolicy {
                 // @identity_factory()
                 // class C: ...
                 // ```
-                None if is_unknown_class_object_decorator_result(db, decorator_result_ty) => {
+                CallableFunctionProvenance::None
+                    if is_unknown_class_object_decorator_result(db, decorator_result_ty) =>
+                {
                     Self::PreserveBinding
                 }
                 // An ordinary `Callable` replacement result has no function provenance to justify
@@ -700,7 +702,7 @@ impl ClassDecoratorUnknownResultPolicy {
                 // @replacement_factory()
                 // class C: ...
                 // ```
-                None => Self::ReplaceBinding,
+                CallableFunctionProvenance::None => Self::ReplaceBinding,
             }),
             _ => None,
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -3,7 +3,7 @@ use crate::types::{
     CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
     SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
     call::CallError,
-    callable::CallableTypeKind,
+    callable::CallableFunctionProvenance,
     function::KnownFunction,
     infer::{
         TypeInferenceBuilder,
@@ -663,21 +663,44 @@ impl ClassDecoratorUnknownResultPolicy {
                 Self::known_from_decorator(db, alias.value_type(db), decorator_result_ty)
                     .unwrap_or(Self::ReplaceBinding),
             ),
-            Type::Callable(callable) if callable.has_explicit_function_return_annotation(db) => {
-                Some(Self::ReplaceBinding)
-            }
-            Type::Callable(callable) => Some(match callable.kind(db) {
-                CallableTypeKind::FunctionLike
-                | CallableTypeKind::StaticMethodLike
-                | CallableTypeKind::ClassMethodLike => Self::PreserveBinding,
-                CallableTypeKind::Regular | CallableTypeKind::ParamSpecValue
-                    if is_unknown_class_object_decorator_result(db, decorator_result_ty) =>
-                {
+            Type::Callable(callable) => Some(match callable.provenance(db) {
+                // An unannotated function preserves the class binding when applying it loses the
+                // concrete return type:
+                // ```python
+                // decorator = lambda cls: cls
+                //
+                // @decorator
+                // class C: ...
+                // ```
+                Some(CallableFunctionProvenance::ImplicitReturn) => Self::PreserveBinding,
+                // An explicit return annotation can intentionally replace the class binding:
+                // ```python
+                // def decorator[T](cls) -> T: ...
+                //
+                // @decorator
+                // class C: ...
+                // ```
+                Some(CallableFunctionProvenance::ExplicitReturn) => Self::ReplaceBinding,
+                // Generic class-preserving decorator factories can lose the concrete class in
+                // their returned `Callable`, while still producing an unknown class-object result:
+                // ```python
+                // def identity_factory[T]() -> Callable[[type[T]], type[T]]: ...
+                //
+                // @identity_factory()
+                // class C: ...
+                // ```
+                None if is_unknown_class_object_decorator_result(db, decorator_result_ty) => {
                     Self::PreserveBinding
                 }
-                CallableTypeKind::Regular | CallableTypeKind::ParamSpecValue => {
-                    Self::ReplaceBinding
-                }
+                // An ordinary `Callable` replacement result has no function provenance to justify
+                // the unannotated-function preservation fallback:
+                // ```python
+                // def replacement_factory[T]() -> Callable[[type[object]], T]: ...
+                //
+                // @replacement_factory()
+                // class C: ...
+                // ```
+                None => Self::ReplaceBinding,
             }),
             _ => None,
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -536,6 +536,18 @@ fn is_unknown_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bo
 }
 
 /// Return true if applying a class decorator produced an unknown class-object type.
+///
+/// Besides plain `Unknown`, class decorators can produce unknown class-object types such as
+/// `type[Any]`. Those are represented as a `SubclassOf` dynamic type, but they should trigger the
+/// same preservation fallback as an unknown result:
+/// ```python
+/// from typing import Any
+///
+/// def decorator(cls) -> type[Any]: ...
+///
+/// @decorator
+/// class C: ...
+/// ```
 fn is_unknown_class_object_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bool {
     let Type::SubclassOf(subclass_of) = ty.resolve_type_alias(db) else {
         return false;
@@ -651,10 +663,10 @@ impl ClassDecoratorUnknownResultPolicy {
                 Self::known_from_decorator(db, alias.value_type(db), decorator_result_ty)
                     .unwrap_or(Self::ReplaceBinding),
             ),
+            Type::Callable(callable) if callable.has_explicit_function_return_annotation(db) => {
+                Some(Self::ReplaceBinding)
+            }
             Type::Callable(callable) => Some(match callable.kind(db) {
-                // Inferred function-like callables, such as lambdas, do not retain the source-level
-                // "explicit return annotation" signal that function literals do. Keep the existing
-                // class-preserving fallback for those cases.
                 CallableTypeKind::FunctionLike
                 | CallableTypeKind::StaticMethodLike
                 | CallableTypeKind::ClassMethodLike => Self::PreserveBinding,

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -77,6 +77,7 @@ impl<'db> BoundMethodType<'db> {
                     .map(|signature| signature.bind_self(db, Some(self_instance))),
             ),
             CallableTypeKind::FunctionLike,
+            function.has_explicit_return_annotation(db),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -81,9 +81,9 @@ impl<'db> BoundMethodType<'db> {
                     .map(|signature| signature.bind_self(db, Some(self_instance))),
             ),
             CallableTypeKind::FunctionLike,
-            Some(CallableFunctionProvenance::from_function_return_annotation(
+            CallableFunctionProvenance::from_function_return_annotation(
                 function.has_explicit_return_annotation(db),
-            )),
+            ),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -6,9 +6,13 @@ use crate::{
     types::{
         CallableType, KnownClass, LiteralValueType, LiteralValueTypeKind, Parameter, Parameters,
         PropertyInstanceType, Signature, StringLiteralType, Type, UnionType,
-        callable::CallableTypeKind, constraints::ConstraintSet, function::FunctionType,
-        known_instance::InternedConstraintSet, relation::TypeRelationChecker,
-        signatures::CallableSignature, visitor,
+        callable::{CallableFunctionProvenance, CallableTypeKind},
+        constraints::ConstraintSet,
+        function::FunctionType,
+        known_instance::InternedConstraintSet,
+        relation::TypeRelationChecker,
+        signatures::CallableSignature,
+        visitor,
     },
 };
 
@@ -77,7 +81,9 @@ impl<'db> BoundMethodType<'db> {
                     .map(|signature| signature.bind_self(db, Some(self_instance))),
             ),
             CallableTypeKind::FunctionLike,
-            function.has_explicit_return_annotation(db),
+            Some(CallableFunctionProvenance::from_function_return_annotation(
+                function.has_explicit_return_annotation(db),
+            )),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -546,7 +546,12 @@ impl<'db> ProtocolMemberKind<'db> {
                 let normalized =
                     curr.signatures(db)
                         .cycle_normalized(db, prev.signatures(db), cycle);
-                Self::Method(CallableType::new(db, normalized, curr.kind(db)))
+                Self::Method(CallableType::new(
+                    db,
+                    normalized,
+                    curr.kind(db),
+                    curr.has_explicit_function_return_annotation(db),
+                ))
             }
             (Self::Property(curr), Self::Property(prev)) => {
                 let getter = match (curr.getter(db), prev.getter(db)) {
@@ -1095,6 +1100,7 @@ fn protocol_bind_self<'db>(
         db,
         callable.signatures(db).bind_self(db, self_type),
         CallableTypeKind::Regular,
+        callable.has_explicit_function_return_annotation(db),
     )
 }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -550,7 +550,7 @@ impl<'db> ProtocolMemberKind<'db> {
                     db,
                     normalized,
                     curr.kind(db),
-                    curr.has_explicit_function_return_annotation(db),
+                    curr.provenance(db),
                 ))
             }
             (Self::Property(curr), Self::Property(prev)) => {
@@ -1100,7 +1100,7 @@ fn protocol_bind_self<'db>(
         db,
         callable.signatures(db).bind_self(db, self_type),
         CallableTypeKind::Regular,
-        callable.has_explicit_function_return_annotation(db),
+        callable.provenance(db),
     )
 }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1221,7 +1221,7 @@ impl<'db> Signature<'db> {
                     )
                 })),
                 CallableTypeKind::ParamSpecValue,
-                false,
+                None,
             ));
             let param_spec_matches = ConstraintSet::constrain_typevar(
                 db,
@@ -1464,7 +1464,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             },
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        false,
+                        None,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -1517,7 +1517,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 }),
                         ),
                         CallableTypeKind::ParamSpecValue,
-                        false,
+                        None,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -1870,7 +1870,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        false,
+                        None,
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -1901,7 +1901,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        false,
+                        None,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2024,7 +2024,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 Type::unknown(),
                             )),
                             CallableTypeKind::ParamSpecValue,
-                            false,
+                            None,
                         ));
                         let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                             db,
@@ -2049,7 +2049,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 Type::unknown(),
                             )),
                             CallableTypeKind::ParamSpecValue,
-                            false,
+                            None,
                         ));
                         let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                             db,
@@ -2084,7 +2084,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        false,
+                        None,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2222,7 +2222,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        false,
+                        None,
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2247,7 +2247,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        false,
+                        None,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2357,7 +2357,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        false,
+                        None,
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                         db,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1221,6 +1221,7 @@ impl<'db> Signature<'db> {
                     )
                 })),
                 CallableTypeKind::ParamSpecValue,
+                false,
             ));
             let param_spec_matches = ConstraintSet::constrain_typevar(
                 db,
@@ -1463,6 +1464,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             },
                         )),
                         CallableTypeKind::ParamSpecValue,
+                        false,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -1515,6 +1517,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 }),
                         ),
                         CallableTypeKind::ParamSpecValue,
+                        false,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -1867,6 +1870,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
+                        false,
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -1897,6 +1901,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
+                        false,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2019,6 +2024,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 Type::unknown(),
                             )),
                             CallableTypeKind::ParamSpecValue,
+                            false,
                         ));
                         let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                             db,
@@ -2043,6 +2049,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 Type::unknown(),
                             )),
                             CallableTypeKind::ParamSpecValue,
+                            false,
                         ));
                         let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                             db,
@@ -2077,6 +2084,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
+                        false,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2214,6 +2222,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
+                        false,
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2238,6 +2247,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
+                        false,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2347,6 +2357,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
+                        false,
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                         db,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -18,7 +18,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{SmallVec, smallvec_inline};
 
 use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
-use crate::types::callable::CallableTypeKind;
+use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
 };
@@ -1221,7 +1221,7 @@ impl<'db> Signature<'db> {
                     )
                 })),
                 CallableTypeKind::ParamSpecValue,
-                None,
+                CallableFunctionProvenance::None,
             ));
             let param_spec_matches = ConstraintSet::constrain_typevar(
                 db,
@@ -1464,7 +1464,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             },
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        None,
+                        CallableFunctionProvenance::None,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -1517,7 +1517,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 }),
                         ),
                         CallableTypeKind::ParamSpecValue,
-                        None,
+                        CallableFunctionProvenance::None,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -1870,7 +1870,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        None,
+                        CallableFunctionProvenance::None,
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -1901,7 +1901,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        None,
+                        CallableFunctionProvenance::None,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2024,7 +2024,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 Type::unknown(),
                             )),
                             CallableTypeKind::ParamSpecValue,
-                            None,
+                            CallableFunctionProvenance::None,
                         ));
                         let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                             db,
@@ -2049,7 +2049,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 Type::unknown(),
                             )),
                             CallableTypeKind::ParamSpecValue,
-                            None,
+                            CallableFunctionProvenance::None,
                         ));
                         let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                             db,
@@ -2084,7 +2084,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        None,
+                        CallableFunctionProvenance::None,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2222,7 +2222,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        None,
+                        CallableFunctionProvenance::None,
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2247,7 +2247,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        None,
+                        CallableFunctionProvenance::None,
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
@@ -2357,7 +2357,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
-                        None,
+                        CallableFunctionProvenance::None,
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar(
                         db,


### PR DESCRIPTION
## Summary

This PR addresses a TODO from #25091 whereby we preserved the class binding for every `Callable`
decorator. We now respect explicit return annotations on `Callable`.

For example, this now remains a replacement rather than being treated as class-preserving:

```python
from typing import Callable, TypeVar

T = TypeVar("T")

def decorator_factory() -> Callable[[type[object]], T]:
    raise NotImplementedError

@decorator_factory()
class Decorated: ...

reveal_type(Decorated)  # Unknown
```
