### PR TITLE
[ty] Speed up include filtering for projects with many literal include patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4605,6 +4605,7 @@ name = "ty_project"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bitvec",
  "camino",
  "colored 3.1.1",
  "crossbeam",

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -6,7 +6,9 @@ use ruff_benchmark::real_world_projects::{
 };
 
 use std::fmt::Write;
+use std::hint::black_box;
 use std::ops::Range;
+use std::sync::Arc;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rayon::ThreadPoolBuilder;
@@ -17,9 +19,9 @@ use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::source::source_text;
 use ruff_db::system::{InMemorySystem, MemoryFileSystem, SystemPath, SystemPathBuf, TestSystem};
-use ty_project::metadata::options::{AnalysisOptions, EnvironmentOptions, Options};
+use ty_project::metadata::options::{AnalysisOptions, EnvironmentOptions, Options, SrcOptions};
 use ty_project::metadata::python_version::SupportedPythonVersion;
-use ty_project::metadata::value::{RangedValue, RelativePathBuf};
+use ty_project::metadata::value::{RangedValue, RelativeGlobPattern, RelativePathBuf, ValueSource};
 use ty_project::watch::{ChangeEvent, ChangedKind};
 use ty_project::{CheckMode, Db, ProjectDatabase, ProjectMetadata};
 
@@ -28,6 +30,11 @@ struct Case {
     fs: MemoryFileSystem,
     file: File,
     file_path: SystemPathBuf,
+}
+
+struct IncludeFilterCase {
+    db: ProjectDatabase,
+    literal_file: SystemPathBuf,
 }
 
 // "https://raw.githubusercontent.com/python/cpython/8e8a4baf652f6e1cee7acde9d78c4b6154539748/Lib/tomllib";
@@ -195,6 +202,50 @@ fn benchmark_cold(criterion: &mut Criterion) {
             },
             BatchSize::SmallInput,
         );
+    });
+}
+
+fn setup_include_filter_case(pattern_count: usize) -> IncludeFilterCase {
+    let system = TestSystem::default();
+    let fs = system.memory_file_system().clone();
+    let project_root = SystemPath::new("/src");
+    let source = ValueSource::File(Arc::new(project_root.join("pyproject.toml")));
+
+    fs.write_file_all(project_root.join("file_0.py"), "")
+        .unwrap();
+
+    let include_patterns = (0..pattern_count)
+        .map(|index| RelativeGlobPattern::new(format!("file_{index}.py"), source.clone()))
+        .collect();
+
+    let mut metadata = ProjectMetadata::discover(project_root, &system).unwrap();
+    metadata.apply_options(Options {
+        src: Some(SrcOptions {
+            include: Some(RangedValue::new(include_patterns, source)),
+            respect_ignore_files: Some(false),
+            ..SrcOptions::default()
+        }),
+        ..Options::default()
+    });
+
+    let db = ProjectDatabase::fallible(metadata, system).unwrap();
+
+    IncludeFilterCase {
+        db,
+        literal_file: project_root.join(format!("file_{}.py", pattern_count - 1)),
+    }
+}
+
+fn benchmark_include_filter_literal_match(criterion: &mut Criterion) {
+    let case = setup_include_filter_case(1024);
+    let project = case.db.project();
+    let literal_file = case.literal_file.as_path();
+
+    criterion.bench_function("ty_include_filter[literal_match_1024]", |b| {
+        b.iter(|| {
+            let included = project.is_file_included(black_box(&case.db), black_box(literal_file));
+            assert!(black_box(included));
+        });
     });
 }
 
@@ -1208,6 +1259,7 @@ fn datetype(criterion: &mut Criterion) {
 criterion_group!(check_file, benchmark_cold, benchmark_incremental);
 criterion_group!(
     micro,
+    benchmark_include_filter_literal_match,
     benchmark_many_string_assignments,
     benchmark_many_tuple_assignments,
     benchmark_tuple_implicit_instance_attributes,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -6,9 +6,7 @@ use ruff_benchmark::real_world_projects::{
 };
 
 use std::fmt::Write;
-use std::hint::black_box;
 use std::ops::Range;
-use std::sync::Arc;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rayon::ThreadPoolBuilder;
@@ -19,9 +17,9 @@ use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::source::source_text;
 use ruff_db::system::{InMemorySystem, MemoryFileSystem, SystemPath, SystemPathBuf, TestSystem};
-use ty_project::metadata::options::{AnalysisOptions, EnvironmentOptions, Options, SrcOptions};
+use ty_project::metadata::options::{AnalysisOptions, EnvironmentOptions, Options};
 use ty_project::metadata::python_version::SupportedPythonVersion;
-use ty_project::metadata::value::{RangedValue, RelativeGlobPattern, RelativePathBuf, ValueSource};
+use ty_project::metadata::value::{RangedValue, RelativePathBuf};
 use ty_project::watch::{ChangeEvent, ChangedKind};
 use ty_project::{CheckMode, Db, ProjectDatabase, ProjectMetadata};
 
@@ -30,11 +28,6 @@ struct Case {
     fs: MemoryFileSystem,
     file: File,
     file_path: SystemPathBuf,
-}
-
-struct IncludeFilterCase {
-    db: ProjectDatabase,
-    literal_file: SystemPathBuf,
 }
 
 // "https://raw.githubusercontent.com/python/cpython/8e8a4baf652f6e1cee7acde9d78c4b6154539748/Lib/tomllib";
@@ -202,50 +195,6 @@ fn benchmark_cold(criterion: &mut Criterion) {
             },
             BatchSize::SmallInput,
         );
-    });
-}
-
-fn setup_include_filter_case(pattern_count: usize) -> IncludeFilterCase {
-    let system = TestSystem::default();
-    let fs = system.memory_file_system().clone();
-    let project_root = SystemPath::new("/src");
-    let source = ValueSource::File(Arc::new(project_root.join("pyproject.toml")));
-
-    fs.write_file_all(project_root.join("file_0.py"), "")
-        .unwrap();
-
-    let include_patterns = (0..pattern_count)
-        .map(|index| RelativeGlobPattern::new(format!("file_{index}.py"), source.clone()))
-        .collect();
-
-    let mut metadata = ProjectMetadata::discover(project_root, &system).unwrap();
-    metadata.apply_options(Options {
-        src: Some(SrcOptions {
-            include: Some(RangedValue::new(include_patterns, source)),
-            respect_ignore_files: Some(false),
-            ..SrcOptions::default()
-        }),
-        ..Options::default()
-    });
-
-    let db = ProjectDatabase::fallible(metadata, system).unwrap();
-
-    IncludeFilterCase {
-        db,
-        literal_file: project_root.join(format!("file_{}.py", pattern_count - 1)),
-    }
-}
-
-fn benchmark_include_filter_literal_match(criterion: &mut Criterion) {
-    let case = setup_include_filter_case(1024);
-    let project = case.db.project();
-    let literal_file = case.literal_file.as_path();
-
-    criterion.bench_function("ty_include_filter[literal_match_1024]", |b| {
-        b.iter(|| {
-            let included = project.is_file_included(black_box(&case.db), black_box(literal_file));
-            assert!(black_box(included));
-        });
     });
 }
 
@@ -1259,7 +1208,6 @@ fn datetype(criterion: &mut Criterion) {
 criterion_group!(check_file, benchmark_cold, benchmark_incremental);
 criterion_group!(
     micro,
-    benchmark_include_filter_literal_match,
     benchmark_many_string_assignments,
     benchmark_many_tuple_assignments,
     benchmark_tuple_implicit_instance_attributes,

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -31,6 +31,7 @@ ty_python_core = { workspace = true, features = ["schemars"] }
 ty_vendored = { workspace = true }
 
 anyhow = { workspace = true }
+bitvec = { workspace = true }
 camino = { workspace = true }
 colored = { workspace = true }
 crossbeam = { workspace = true }

--- a/crates/ty_project/src/glob/include.rs
+++ b/crates/ty_project/src/glob/include.rs
@@ -1,3 +1,5 @@
+use bitvec::prelude::{BitBox, BitVec};
+use get_size2::GetSize;
 use globset::{Glob, GlobBuilder, GlobSet, GlobSetBuilder};
 use regex_automata::dfa;
 use regex_automata::dfa::Automaton;
@@ -36,11 +38,19 @@ pub(crate) struct IncludeFilter {
     #[get_size(ignore)]
     glob_set: GlobSet,
     original_patterns: Box<[Box<str>]>,
-    literal_pattern_indices: Box<[usize]>,
+    /// For each glob in `glob_set`, whether it came from a literal include pattern.
+    #[get_size(size_fn = bit_box_size)]
+    literal_patterns: BitBox,
+    #[get_size(ignore)]
+    has_literal_patterns: bool,
     #[get_size(size_fn = dfa_memory_usage)]
     dfa: Option<dfa::dense::DFA<Vec<u32>>>,
     #[get_size(ignore)]
     matches: Arc<Pool<Vec<usize>>>,
+}
+
+fn bit_box_size(bits: &BitBox) -> usize {
+    bits.as_raw_slice().get_heap_size()
 }
 
 #[expect(clippy::ref_option)]
@@ -53,7 +63,7 @@ impl IncludeFilter {
     pub(crate) fn match_file(&self, path: impl AsRef<SystemPath>) -> MatchFile {
         let path = path.as_ref();
 
-        if self.literal_pattern_indices.is_empty() {
+        if !self.has_literal_patterns {
             return if self.glob_set.is_match(path) {
                 MatchFile::Pattern
             } else {
@@ -68,7 +78,9 @@ impl IncludeFilter {
             MatchFile::No
         } else {
             for match_index in matches.iter() {
-                if self.literal_pattern_indices.contains(match_index) {
+                if *self.literal_patterns.get(*match_index).expect(
+                    "literal-pattern bitset should have one entry per glob added by the builder",
+                ) {
                     return MatchFile::Literal;
                 }
             }
@@ -161,19 +173,19 @@ impl MatchFile {}
 #[derive(Debug)]
 pub(crate) struct IncludeFilterBuilder {
     set: GlobSetBuilder,
-    set_len: usize,
     original_patterns: Vec<Box<str>>,
     regexes: Vec<String>,
-    /// Indices of literal patterns (contain no meta characters).
-    literal_pattern_indices: Vec<usize>,
+    /// For each glob added to `set`, whether it came from a literal include pattern.
+    literal_patterns: BitVec,
+    has_literal_patterns: bool,
 }
 
 impl IncludeFilterBuilder {
     pub(crate) fn new() -> Self {
         Self {
-            literal_pattern_indices: Vec::new(),
+            literal_patterns: BitVec::new(),
+            has_literal_patterns: false,
             set: GlobSetBuilder::new(),
-            set_len: 0,
             original_patterns: Vec::new(),
             regexes: Vec::new(),
         }
@@ -205,15 +217,13 @@ impl IncludeFilterBuilder {
             .backslash_escape(true)
             .build()?;
 
-        let is_literal_pattern = globset::escape(glob_pattern) == glob_pattern;
-
         self.original_patterns.push(input.relative().into());
 
         // `lib` is the same as `lib/**`
         // Add a glob that matches `lib` exactly, change the glob to `lib/**`.
         if glob_pattern.ends_with("**") {
             self.push_prefix_regex(&glob);
-            self.add_glob(glob);
+            self.add_glob(glob, false);
         } else {
             let prefix_glob = GlobBuilder::new(&format!("{glob_pattern}/**"))
                 .literal_separator(true)
@@ -222,26 +232,24 @@ impl IncludeFilterBuilder {
                 .build()?;
 
             self.push_prefix_regex(&prefix_glob);
-            self.add_glob(prefix_glob);
+            self.add_glob(prefix_glob, false);
 
             // The reason we add the exact glob, e.g. `src` when the original pattern was `src/` is
             // so that `match_file` returns true when matching against a file. However, we don't
             // need to do this if this is a pattern that should only match a directory (specifically, its contents).
             if !only_directory {
-                if is_literal_pattern {
-                    self.literal_pattern_indices.push(self.set_len);
-                }
-
-                self.add_glob(glob);
+                let is_literal_pattern = globset::escape(glob_pattern) == glob_pattern;
+                self.add_glob(glob, is_literal_pattern);
             }
         }
 
         Ok(self)
     }
 
-    fn add_glob(&mut self, glob: Glob) {
+    fn add_glob(&mut self, glob: Glob, is_literal_pattern: bool) {
         self.set.add(glob);
-        self.set_len += 1;
+        self.literal_patterns.push(is_literal_pattern);
+        self.has_literal_patterns |= is_literal_pattern;
     }
 
     fn push_prefix_regex(&mut self, glob: &Glob) {
@@ -294,7 +302,8 @@ impl IncludeFilterBuilder {
         Ok(IncludeFilter {
             glob_set,
             dfa,
-            literal_pattern_indices: self.literal_pattern_indices.into(),
+            literal_patterns: self.literal_patterns.into_boxed_bitslice(),
+            has_literal_patterns: self.has_literal_patterns,
             original_patterns: self.original_patterns.into(),
             matches: Arc::new(Pool::new(Vec::new)),
         })

--- a/crates/ty_project/src/glob/include.rs
+++ b/crates/ty_project/src/glob/include.rs
@@ -38,11 +38,8 @@ pub(crate) struct IncludeFilter {
     #[get_size(ignore)]
     glob_set: GlobSet,
     original_patterns: Box<[Box<str>]>,
-    /// For each glob in `glob_set`, whether it came from a literal include pattern.
     #[get_size(size_fn = bit_box_size)]
-    literal_patterns: BitBox,
-    #[get_size(ignore)]
-    has_literal_patterns: bool,
+    literal_pattern_indices: BitBox,
     #[get_size(size_fn = dfa_memory_usage)]
     dfa: Option<dfa::dense::DFA<Vec<u32>>>,
     #[get_size(ignore)]
@@ -63,7 +60,7 @@ impl IncludeFilter {
     pub(crate) fn match_file(&self, path: impl AsRef<SystemPath>) -> MatchFile {
         let path = path.as_ref();
 
-        if !self.has_literal_patterns {
+        if self.literal_pattern_indices.is_empty() {
             return if self.glob_set.is_match(path) {
                 MatchFile::Pattern
             } else {
@@ -78,9 +75,11 @@ impl IncludeFilter {
             MatchFile::No
         } else {
             for match_index in matches.iter() {
-                if *self.literal_patterns.get(*match_index).expect(
-                    "literal-pattern bitset should have one entry per glob added by the builder",
-                ) {
+                if self
+                    .literal_pattern_indices
+                    .get(*match_index)
+                    .is_some_and(|bit| *bit)
+                {
                     return MatchFile::Literal;
                 }
             }
@@ -173,19 +172,19 @@ impl MatchFile {}
 #[derive(Debug)]
 pub(crate) struct IncludeFilterBuilder {
     set: GlobSetBuilder,
+    set_len: usize,
     original_patterns: Vec<Box<str>>,
     regexes: Vec<String>,
-    /// For each glob added to `set`, whether it came from a literal include pattern.
-    literal_patterns: BitVec,
-    has_literal_patterns: bool,
+    /// Indices of literal patterns (contain no meta characters).
+    literal_pattern_indices: BitVec,
 }
 
 impl IncludeFilterBuilder {
     pub(crate) fn new() -> Self {
         Self {
-            literal_patterns: BitVec::new(),
-            has_literal_patterns: false,
+            literal_pattern_indices: BitVec::new(),
             set: GlobSetBuilder::new(),
+            set_len: 0,
             original_patterns: Vec::new(),
             regexes: Vec::new(),
         }
@@ -223,7 +222,7 @@ impl IncludeFilterBuilder {
         // Add a glob that matches `lib` exactly, change the glob to `lib/**`.
         if glob_pattern.ends_with("**") {
             self.push_prefix_regex(&glob);
-            self.add_glob(glob, false);
+            self.add_glob(glob);
         } else {
             let prefix_glob = GlobBuilder::new(&format!("{glob_pattern}/**"))
                 .literal_separator(true)
@@ -232,24 +231,29 @@ impl IncludeFilterBuilder {
                 .build()?;
 
             self.push_prefix_regex(&prefix_glob);
-            self.add_glob(prefix_glob, false);
+            self.add_glob(prefix_glob);
 
             // The reason we add the exact glob, e.g. `src` when the original pattern was `src/` is
             // so that `match_file` returns true when matching against a file. However, we don't
             // need to do this if this is a pattern that should only match a directory (specifically, its contents).
             if !only_directory {
                 let is_literal_pattern = globset::escape(glob_pattern) == glob_pattern;
-                self.add_glob(glob, is_literal_pattern);
+
+                if is_literal_pattern {
+                    self.literal_pattern_indices.resize(self.set_len, false);
+                    self.literal_pattern_indices.push(true);
+                }
+
+                self.add_glob(glob);
             }
         }
 
         Ok(self)
     }
 
-    fn add_glob(&mut self, glob: Glob, is_literal_pattern: bool) {
+    fn add_glob(&mut self, glob: Glob) {
         self.set.add(glob);
-        self.literal_patterns.push(is_literal_pattern);
-        self.has_literal_patterns |= is_literal_pattern;
+        self.set_len += 1;
     }
 
     fn push_prefix_regex(&mut self, glob: &Glob) {
@@ -302,8 +306,7 @@ impl IncludeFilterBuilder {
         Ok(IncludeFilter {
             glob_set,
             dfa,
-            literal_patterns: self.literal_patterns.into_boxed_bitslice(),
-            has_literal_patterns: self.has_literal_patterns,
+            literal_pattern_indices: self.literal_pattern_indices.into_boxed_bitslice(),
             original_patterns: self.original_patterns.into(),
             matches: Arc::new(Pool::new(Vec::new)),
         })


### PR DESCRIPTION
## Summary

- Track literal include globs in a bitset to avoid a linear scan over literal pattern indices.
- Keep the existing fast path when an include filter has no literal patterns.
- Add a ty benchmark that exercises a 1024-literal include set through `Project::is_file_included`.

## Benchmark

Command:

`cargo bench -p ruff_benchmark --bench ty --no-default-features --features ty_instrumented ty_include_filter -- --sample-size 10`

Results:

- `origin/main` with this benchmark added: `[1.4059 us 1.4082 us 1.4100 us]`
- This PR: `[957.18 ns 961.50 ns 965.61 ns]`

This is about 1.46x faster, or a 31.7% reduction in time per literal include match in this benchmark.

## Test Plan

- `cargo test -p ty_project glob::include`
- `cargo check -p ruff_benchmark --benches --no-default-features --features ty_instrumented`
- `cargo bench -p ruff_benchmark --bench ty --no-default-features --features ty_instrumented ty_include_filter -- --sample-size 10`

Refs #25244
