### PR TITLE
[ty] Add error context for extra callable parameters

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -298,6 +298,28 @@ error[invalid-assignment]: Object of type `(int, str, /) -> bool` is not assigna
    |             |
    |             Declared type
    |
+info: unexpected extra parameter
+```
+
+Assigning a function with an extra required parameter to a `Callable`:
+
+```py
+def source(x: int, extra: str) -> bool:
+    raise NotImplementedError
+
+target: Callable[[int], bool] = source  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `def source(x: int, extra: str) -> bool` is not assignable to `(int, /) -> bool`
+  --> src/mdtest_snippet.py:16:9
+   |
+16 | target: Callable[[int], bool] = source  # snapshot
+   |         ---------------------   ^^^^^^ Incompatible value of type `def source(x: int, extra: str) -> bool`
+   |         |
+   |         Declared type
+   |
+info: unexpected extra parameter `extra`
 ```
 
 Assigning a class to a `Callable`
@@ -311,9 +333,9 @@ target: Callable[[str], Any] = Number  # snapshot
 
 ```snapshot
 error[invalid-assignment]: Object of type `<class 'Number'>` is not assignable to `(str, /) -> Any`
-  --> src/mdtest_snippet.py:16:9
+  --> src/mdtest_snippet.py:20:9
    |
-16 | target: Callable[[str], Any] = Number  # snapshot
+20 | target: Callable[[str], Any] = Number  # snapshot
    |         --------------------   ^^^^^^ Incompatible value of type `<class 'Number'>`
    |         |
    |         Declared type

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -167,6 +167,7 @@ error[invalid-method-override]: Invalid override of method `method`
  2 |     def method(self, x: int, /): ...
    |         ----------------------- `Super.method` defined here
    |
+info: unexpected extra parameter `y`
 info: This violates the Liskov Substitution Principle
 ```
 

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -100,6 +100,9 @@ pub(crate) enum ErrorContext<'db> {
         target: Type<'db>,
         parameter: ParameterDescription,
     },
+    ExtraRequiredParameter {
+        parameter: ParameterDescription,
+    },
     ParameterNameMismatch {
         source_name: Name,
         target_name: Name,
@@ -265,6 +268,10 @@ impl<'db> ErrorContext<'db> {
                     target = target.display(db),
                 )
             }
+            Self::ExtraRequiredParameter { parameter } => match parameter {
+                ParameterDescription::Named(name) => format!("unexpected extra parameter `{name}`"),
+                ParameterDescription::Index(_) => "unexpected extra parameter".to_string(),
+            },
             Self::ParameterNameMismatch {
                 source_name,
                 target_name,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2628,6 +2628,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         // `target`, then the non-variadic parameters in `source` must have a default
                         // value.
                         if default_type.is_none() {
+                            let parameter =
+                                ParameterDescription::new(target_index, source_parameter.name());
+                            self.provide_context(|| ErrorContext::ExtraRequiredParameter {
+                                parameter,
+                            });
                             return self.never();
                         }
                     }


### PR DESCRIPTION
## Summary

In an invalid assignment like the following ...

```py
def source(x: int, extra: str) -> bool: ...

target: Callable[[int], bool] = source
```

... we now add a new error context hint (last line):

```
error[invalid-assignment]: Object of type `def source(x: int, extra: str) -> bool` is not assignable to `(int, /) -> bool`
  --> src/mdtest_snippet.py:16:9
   |
16 | target: Callable[[int], bool] = source  # snapshot
   |         ---------------------   ^^^^^^ Incompatible value of type `def source(x: int, extra: str) -> bool`
   |         |
   |         Declared type
   |
info: unexpected extra parameter `extra`
```

## Test Plan

New Markdown test
