### PR TITLE
[ty] Find references for synthesized fields

### DIFF
--- a/crates/ty_ide/src/find_references.rs
+++ b/crates/ty_ide/src/find_references.rs
@@ -1260,6 +1260,125 @@ TD(f<CURSOR>=1)
     }
 
     #[test]
+    fn references_typeddict_field_from_class_definition() {
+        let test = cursor_test(
+            r#"
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title<CURSOR>: str
+
+movie: Movie = {"title": "Alien"}
+print(movie["title"])
+"#,
+        );
+
+        assert_snapshot!(test.references(), @r#"
+        info[references]: Found 3 references
+         --> main.py:5:5
+          |
+        5 |     title: str
+          |     -----
+        6 |
+        7 | movie: Movie = {"title": "Alien"}
+          |                 -------
+        8 | print(movie["title"])
+          |             -------
+          |
+        "#);
+    }
+
+    #[test]
+    fn references_typeddict_field_from_string_literal_key() {
+        let test = cursor_test(
+            r#"
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title: str
+
+movie: Movie = {"title": "Alien"}
+print(movie["ti<CURSOR>tle"])
+"#,
+        );
+
+        assert_snapshot!(test.references(), @r#"
+        info[references]: Found 3 references
+         --> main.py:5:5
+          |
+        5 |     title: str
+          |     -----
+        6 |
+        7 | movie: Movie = {"title": "Alien"}
+          |                 -------
+        8 | print(movie["title"])
+          |             -------
+          |
+        "#);
+    }
+
+    #[test]
+    fn references_typeddict_field_from_dict_literal_key() {
+        let test = cursor_test(
+            r#"
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title: str
+
+movie: Movie = {"ti<CURSOR>tle": "Alien"}
+print(movie["title"])
+"#,
+        );
+
+        assert_snapshot!(test.references(), @r#"
+        info[references]: Found 3 references
+         --> main.py:5:5
+          |
+        5 |     title: str
+          |     -----
+        6 |
+        7 | movie: Movie = {"title": "Alien"}
+          |                 -------
+        8 | print(movie["title"])
+          |             -------
+          |
+        "#);
+    }
+
+    #[test]
+    fn references_typeddict_field_ignores_plain_dict_key() {
+        let test = cursor_test(
+            r#"
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title<CURSOR>: str
+
+movie: Movie = {"title": "Alien"}
+plain = {"title": "Aliens"}
+print(movie["title"])
+print(plain["title"])
+"#,
+        );
+
+        assert_snapshot!(test.references(), @r#"
+        info[references]: Found 3 references
+         --> main.py:5:5
+          |
+        5 |     title: str
+          |     -----
+        6 |
+        7 | movie: Movie = {"title": "Alien"}
+          |                 -------
+        8 | plain = {"title": "Aliens"}
+        9 | print(movie["title"])
+          |             -------
+          |
+        "#);
+    }
+
+    #[test]
     fn references_keyword_argument_namedtuple_field() {
         let test = cursor_test(
             "
@@ -1283,6 +1402,139 @@ NT(f=1)
         7 |
         8 | NT(f=1)
           |    -
+          |
+        ");
+    }
+
+    #[test]
+    fn references_namedtuple_field_from_class_definition() {
+        let test = cursor_test(
+            "
+from typing import NamedTuple
+
+class Point(NamedTuple):
+    x<CURSOR>: int
+    y: int
+
+point = Point(x=1, y=2)
+print(point.x)
+print(point[0])
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 4 references
+          --> main.py:5:5
+           |
+         5 |     x: int
+           |     -
+         6 |     y: int
+         7 |
+         8 | point = Point(x=1, y=2)
+           |               -
+         9 | print(point.x)
+           |             -
+        10 | print(point[0])
+           |             -
+           |
+        ");
+    }
+
+    #[test]
+    fn references_namedtuple_field_from_index() {
+        let test = cursor_test(
+            "
+from typing import NamedTuple
+
+class Point(NamedTuple):
+    x: int
+    y: int
+
+point = Point(x=1, y=2)
+print(point.x)
+print(point[0<CURSOR>])
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 4 references
+          --> main.py:5:5
+           |
+         5 |     x: int
+           |     -
+         6 |     y: int
+         7 |
+         8 | point = Point(x=1, y=2)
+           |               -
+         9 | print(point.x)
+           |             -
+        10 | print(point[0])
+           |             -
+           |
+        ");
+    }
+
+    #[test]
+    fn references_namedtuple_field_from_negative_index() {
+        let test = cursor_test(
+            "
+from typing import NamedTuple
+
+class Point(NamedTuple):
+    x: int
+    y: int
+
+point = Point(x=1, y=2)
+print(point.y)
+print(point[-1<CURSOR>])
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 4 references
+          --> main.py:6:5
+           |
+         6 |     y: int
+           |     -
+         7 |
+         8 | point = Point(x=1, y=2)
+           |                    -
+         9 | print(point.y)
+           |             -
+        10 | print(point[-1])
+           |             --
+           |
+        ");
+    }
+
+    #[test]
+    fn references_namedtuple_field_ignores_out_of_bounds_index() {
+        let test = cursor_test(
+            "
+from typing import NamedTuple
+
+class Point(NamedTuple):
+    x<CURSOR>: int
+    y: int
+
+point = Point(x=1, y=2)
+print(point.x)
+print(point[2])
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 3 references
+         --> main.py:5:5
+          |
+        5 |     x: int
+          |     -
+        6 |     y: int
+        7 |
+        8 | point = Point(x=1, y=2)
+          |               -
+        9 | print(point.x)
+          |             -
           |
         ");
     }

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -1244,7 +1244,7 @@ impl GotoTarget<'_> {
                         _ => node.as_expr_ref().map(GotoTarget::Expression),
                     }
                 } else if let Some(target) =
-                    typed_dict_dict_literal_key_target(model, covering_node, string_expr)
+                    dict_string_literal_key_target(covering_node, string_expr)
                 {
                     Some(target)
                 } else {
@@ -1334,32 +1334,37 @@ fn named_tuple_subscript_target<'a>(
     })
 }
 
-fn typed_dict_dict_literal_key_target<'a>(
-    model: &SemanticModel,
+fn dict_string_literal_key_target<'a>(
     covering_node: &CoveringNode<'a>,
     string_expr: &'a ast::ExprStringLiteral,
 ) -> Option<GotoTarget<'a>> {
-    let dict = covering_node.ancestors().find_map(|ancestor| {
-        let AnyNodeRef::ExprDict(dict) = ancestor else {
-            return None;
-        };
-        dict.items
-            .iter()
-            .any(|item| {
-                item.key
-                    .as_ref()
-                    .is_some_and(|key| key.range() == string_expr.range())
-            })
-            .then_some(dict)
-    })?;
-
-    let key = string_expr.value.to_str();
-    typed_dict_dict_literal_key_definition(model, dict, key)?;
+    let dict = enclosing_dict_with_key(covering_node, string_expr)?;
 
     Some(GotoTarget::DictStringLiteralKey {
         dict,
         string_expr,
-        literal_key: key,
+        literal_key: string_expr.value.to_str(),
+    })
+}
+
+fn enclosing_dict_with_key<'a>(
+    covering_node: &CoveringNode<'a>,
+    string_expr: &ast::ExprStringLiteral,
+) -> Option<&'a ast::ExprDict> {
+    covering_node
+        .ancestors()
+        .find_map(|ancestor| match ancestor {
+            AnyNodeRef::ExprDict(dict) if dict_has_key(dict, string_expr) => Some(dict),
+            _ => None,
+        })
+}
+
+fn dict_has_key(dict: &ast::ExprDict, key: &ast::ExprStringLiteral) -> bool {
+    let key_range = key.range();
+    dict.items.iter().any(|item| {
+        item.key
+            .as_ref()
+            .is_some_and(|item_key| item_key.range() == key_range)
     })
 }
 

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -19,7 +19,7 @@ use ty_python_semantic::types::Type;
 use ty_python_semantic::types::ide_support::{
     call_signature_details, call_type_simplified_by_overloads, constructor_signature,
     definitions_and_overloads_for_function, definitions_for_keyword_argument,
-    typed_dict_key_definition,
+    named_tuple_field_target, typed_dict_dict_literal_key_definition, typed_dict_key_definition,
 };
 use ty_python_semantic::{
     HasDefinition, HasType, ImportAliasResolution, SemanticModel, TypeQualifiers,
@@ -238,6 +238,19 @@ pub(crate) enum GotoTarget<'a> {
     SubscriptStringLiteralKey {
         subscript: &'a ast::ExprSubscript,
         literal_key: &'a str,
+    },
+
+    /// Go to on a string-literal key in a `TypedDict` dict literal (e.g. `{"name": "Alice"}`).
+    DictStringLiteralKey {
+        dict: &'a ast::ExprDict,
+        literal_key: &'a str,
+        key_range: TextRange,
+    },
+
+    /// Go to on an integer-literal subscript for a `NamedTuple` field (e.g. `point[0]`).
+    SubscriptNamedTupleField {
+        subscript: &'a ast::ExprSubscript,
+        field_name: String,
     },
 }
 
@@ -508,6 +521,10 @@ impl GotoTarget<'_> {
                 Some(ty)
             }
             GotoTarget::SubscriptStringLiteralKey { subscript, .. } => {
+                subscript.inferred_type(model)
+            }
+            GotoTarget::DictStringLiteralKey { .. } => None,
+            GotoTarget::SubscriptNamedTupleField { subscript, .. } => {
                 subscript.inferred_type(model)
             }
             // TODO: Support identifier targets
@@ -801,6 +818,14 @@ impl GotoTarget<'_> {
                 literal_key,
             } => typed_dict_key_definition(model, subscript, literal_key)
                 .map(|definition| vec![definition]),
+            GotoTarget::DictStringLiteralKey {
+                dict, literal_key, ..
+            } => typed_dict_dict_literal_key_definition(model, dict, literal_key)
+                .map(|definition| vec![definition]),
+            GotoTarget::SubscriptNamedTupleField { subscript, .. } => {
+                named_tuple_field_target(model, subscript)
+                    .map(|target| vec![ResolvedDefinition::Definition(target.definition)])
+            }
         };
         definitions.map(Definitions::new)
     }
@@ -866,9 +891,16 @@ impl GotoTarget<'_> {
             }
             GotoTarget::NonLocal { identifier, .. } => Some(Cow::Borrowed(identifier.as_str())),
             GotoTarget::Globals { identifier, .. } => Some(Cow::Borrowed(identifier.as_str())),
-            GotoTarget::BinOp { .. }
-            | GotoTarget::UnaryOp { .. }
-            | GotoTarget::SubscriptStringLiteralKey { .. } => None,
+            GotoTarget::SubscriptNamedTupleField { field_name, .. } => {
+                Some(Cow::Borrowed(field_name.as_str()))
+            }
+            GotoTarget::SubscriptStringLiteralKey { literal_key, .. } => {
+                Some(Cow::Borrowed(literal_key))
+            }
+            GotoTarget::DictStringLiteralKey { literal_key, .. } => {
+                Some(Cow::Borrowed(literal_key))
+            }
+            GotoTarget::BinOp { .. } | GotoTarget::UnaryOp { .. } => None,
         }
     }
 
@@ -939,6 +971,12 @@ impl GotoTarget<'_> {
                         literal_key: key,
                     });
                 }
+                if let Some(target) = named_tuple_field_target(model, subscript) {
+                    return Some(GotoTarget::SubscriptNamedTupleField {
+                        subscript,
+                        field_name: target.name.to_string(),
+                    });
+                }
                 return Some(GotoTarget::Expression(subscript.into()));
             }
 
@@ -951,6 +989,12 @@ impl GotoTarget<'_> {
                 && unary_op.operand.range() == expr.range()
                 && let Some(subscript) = enclosing_subscript_with_slice_range(unary_op.range())
             {
+                if let Some(target) = named_tuple_field_target(model, subscript) {
+                    return Some(GotoTarget::SubscriptNamedTupleField {
+                        subscript,
+                        field_name: target.name.to_string(),
+                    });
+                }
                 return Some(GotoTarget::Expression(subscript.into()));
             }
 
@@ -1201,6 +1245,10 @@ impl GotoTarget<'_> {
                         }
                         _ => node.as_expr_ref().map(GotoTarget::Expression),
                     }
+                } else if let Some(target) =
+                    typed_dict_dict_literal_key_target(model, covering_node, string_expr)
+                {
+                    Some(target)
                 } else {
                     node.as_expr_ref().map(GotoTarget::Expression)
                 }
@@ -1271,8 +1319,39 @@ impl Ranged for GotoTarget<'_> {
             GotoTarget::BinOp { operator_range, .. }
             | GotoTarget::UnaryOp { operator_range, .. } => *operator_range,
             GotoTarget::SubscriptStringLiteralKey { subscript, .. } => subscript.slice.range(),
+            GotoTarget::DictStringLiteralKey { key_range, .. } => *key_range,
+            GotoTarget::SubscriptNamedTupleField { subscript, .. } => subscript.slice.range(),
         }
     }
+}
+
+fn typed_dict_dict_literal_key_target<'a>(
+    model: &SemanticModel,
+    covering_node: &CoveringNode<'a>,
+    string_expr: &'a ast::ExprStringLiteral,
+) -> Option<GotoTarget<'a>> {
+    let dict = covering_node.ancestors().find_map(|ancestor| {
+        let AnyNodeRef::ExprDict(dict) = ancestor else {
+            return None;
+        };
+        dict.items
+            .iter()
+            .any(|item| {
+                item.key
+                    .as_ref()
+                    .is_some_and(|key| key.range() == string_expr.range())
+            })
+            .then_some(dict)
+    })?;
+
+    let key = string_expr.value.to_str();
+    typed_dict_dict_literal_key_definition(model, dict, key)?;
+
+    Some(GotoTarget::DictStringLiteralKey {
+        dict,
+        literal_key: key,
+        key_range: string_expr.range(),
+    })
 }
 
 /// If a function is a property setter or deleter (e.g., decorated with

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -243,8 +243,8 @@ pub(crate) enum GotoTarget<'a> {
     /// Go to on a string-literal key in a `TypedDict` dict literal (e.g. `{"name": "Alice"}`).
     DictStringLiteralKey {
         dict: &'a ast::ExprDict,
+        string_expr: &'a ast::ExprStringLiteral,
         literal_key: &'a str,
-        key_range: TextRange,
     },
 
     /// Go to on an integer-literal subscript for a `NamedTuple` field (e.g. `point[0]`).
@@ -1317,7 +1317,7 @@ impl Ranged for GotoTarget<'_> {
             GotoTarget::BinOp { operator_range, .. }
             | GotoTarget::UnaryOp { operator_range, .. } => *operator_range,
             GotoTarget::SubscriptStringLiteralKey { subscript, .. } => subscript.slice.range(),
-            GotoTarget::DictStringLiteralKey { key_range, .. } => *key_range,
+            GotoTarget::DictStringLiteralKey { string_expr, .. } => string_expr.range(),
             GotoTarget::SubscriptNamedTupleField { subscript, .. } => subscript.slice.range(),
         }
     }
@@ -1358,8 +1358,8 @@ fn typed_dict_dict_literal_key_target<'a>(
 
     Some(GotoTarget::DictStringLiteralKey {
         dict,
+        string_expr,
         literal_key: key,
-        key_range: string_expr.range(),
     })
 }
 

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -418,6 +418,10 @@ impl<'db> Definitions<'db> {
         self.iter().any(|definition| other.0.contains(definition))
     }
 
+    pub(crate) fn contains(&self, definition: &ResolvedDefinition<'db>) -> bool {
+        self.0.contains(definition)
+    }
+
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, ResolvedDefinition<'db>> {
         self.0.iter()
     }
@@ -971,11 +975,8 @@ impl GotoTarget<'_> {
                         literal_key: key,
                     });
                 }
-                if let Some(target) = named_tuple_field_target(model, subscript) {
-                    return Some(GotoTarget::SubscriptNamedTupleField {
-                        subscript,
-                        field_name: target.name.to_string(),
-                    });
+                if let Some(target) = named_tuple_subscript_target(model, subscript) {
+                    return Some(target);
                 }
                 return Some(GotoTarget::Expression(subscript.into()));
             }
@@ -989,11 +990,8 @@ impl GotoTarget<'_> {
                 && unary_op.operand.range() == expr.range()
                 && let Some(subscript) = enclosing_subscript_with_slice_range(unary_op.range())
             {
-                if let Some(target) = named_tuple_field_target(model, subscript) {
-                    return Some(GotoTarget::SubscriptNamedTupleField {
-                        subscript,
-                        field_name: target.name.to_string(),
-                    });
+                if let Some(target) = named_tuple_subscript_target(model, subscript) {
+                    return Some(target);
                 }
                 return Some(GotoTarget::Expression(subscript.into()));
             }
@@ -1323,6 +1321,17 @@ impl Ranged for GotoTarget<'_> {
             GotoTarget::SubscriptNamedTupleField { subscript, .. } => subscript.slice.range(),
         }
     }
+}
+
+fn named_tuple_subscript_target<'a>(
+    model: &SemanticModel,
+    subscript: &'a ast::ExprSubscript,
+) -> Option<GotoTarget<'a>> {
+    let target = named_tuple_field_target(model, subscript)?;
+    Some(GotoTarget::SubscriptNamedTupleField {
+        subscript,
+        field_name: target.name.to_string(),
+    })
 }
 
 fn typed_dict_dict_literal_key_target<'a>(

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -2201,6 +2201,39 @@ TD(f<CURSOR>=1)
     }
 
     #[test]
+    fn goto_definition_typeddict_dict_literal_key() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                r#"
+from typing import TypedDict
+
+class TD(TypedDict):
+    f: int
+    g: str
+
+td: TD = {"f<CURSOR>": 1, "g": ""}
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @r#"
+        info[goto-definition]: Go to definition
+         --> main.py:8:11
+          |
+        8 | td: TD = {"f": 1, "g": ""}
+          |           ^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:5:5
+          |
+        5 |     f: int
+          |     -
+          |
+        "#);
+    }
+
+    #[test]
     fn goto_definition_keyword_argument_typeddict_update() {
         let test = CursorTest::builder()
             .source(
@@ -2297,6 +2330,74 @@ NT(f<CURSOR>=1)
          --> main.py:5:5
           |
         5 |     f: int
+          |     -
+          |
+        ");
+    }
+
+    #[test]
+    fn goto_definition_namedtuple_index() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                "
+from typing import NamedTuple
+
+class Point(NamedTuple):
+    x: int
+    y: int
+
+point = Point(x=1, y=2)
+print(point[0<CURSOR>])
+",
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> main.py:9:13
+          |
+        9 | print(point[0])
+          |             ^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:5:5
+          |
+        5 |     x: int
+          |     -
+          |
+        ");
+    }
+
+    #[test]
+    fn goto_definition_namedtuple_negative_index() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                "
+from typing import NamedTuple
+
+class Point(NamedTuple):
+    x: int
+    y: int
+
+point = Point(x=1, y=2)
+print(point[-1<CURSOR>])
+",
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> main.py:9:13
+          |
+        9 | print(point[-1])
+          |             ^^ Clicking here
+          |
+        info: Found 1 definition
+         --> main.py:6:5
+          |
+        6 |     y: int
           |     -
           |
         ");

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -545,11 +545,7 @@ impl<'a> LocalReferencesFinder<'a> {
             return;
         };
 
-        if !self
-            .target_definitions
-            .iter()
-            .any(|definition| definition == &current_definition)
-        {
+        if !self.target_definitions.contains(&current_definition) {
             return;
         }
 
@@ -594,11 +590,7 @@ impl<'a> LocalReferencesFinder<'a> {
             return;
         };
 
-        if !self
-            .target_definitions
-            .iter()
-            .any(|definition| definition == &current_definition)
-        {
+        if !self.target_definitions.contains(&current_definition) {
             return;
         }
 

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -548,7 +548,7 @@ impl<'a> LocalReferencesFinder<'a> {
             return;
         };
 
-        self.push_typed_dict_string_key_reference(string_expr, current_definition);
+        self.push_typed_dict_string_key_reference(string_expr, &current_definition);
     }
 
     fn check_typed_dict_dict_literal_key(&mut self, string_expr: &ast::ExprStringLiteral) {
@@ -567,7 +567,7 @@ impl<'a> LocalReferencesFinder<'a> {
             return;
         };
 
-        self.push_typed_dict_string_key_reference(string_expr, current_definition);
+        self.push_typed_dict_string_key_reference(string_expr, &current_definition);
     }
 
     fn enclosing_dict_with_key(
@@ -595,9 +595,9 @@ impl<'a> LocalReferencesFinder<'a> {
     fn push_typed_dict_string_key_reference(
         &mut self,
         string_expr: &ast::ExprStringLiteral,
-        current_definition: ResolvedDefinition<'a>,
+        current_definition: &ResolvedDefinition<'a>,
     ) {
-        if !self.target_definitions.contains(&current_definition) {
+        if !self.target_definitions.contains(current_definition) {
             return;
         }
 

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -452,7 +452,7 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
                 self.check_declaration_identifier(&param_var.name);
             }
             AnyNodeRef::ExprStringLiteral(string_expr) => {
-                self.check_typed_dict_string_literal_key(string_expr);
+                self.check_typed_dict_dict_literal_key(string_expr);
 
                 // Highlight the sub-AST of a string annotation
                 if let Some((sub_ast, sub_model)) = self.model.enter_string_annotation(string_expr)
@@ -469,8 +469,9 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
                     sub_finder.visit_expr(sub_ast.expr());
                 }
             }
-            AnyNodeRef::ExprNumberLiteral(number_expr) => {
-                self.check_named_tuple_subscript_index(number_expr);
+            AnyNodeRef::ExprSubscript(subscript) => {
+                self.check_typed_dict_subscript_key(subscript);
+                self.check_named_tuple_subscript_index(subscript);
             }
             AnyNodeRef::Alias(alias) => {
                 // Handle import alias declarations
@@ -533,43 +534,50 @@ impl<'a> LocalReferencesFinder<'a> {
         self.check_identifier(identifier, OccurrenceKind::Declaration);
     }
 
-    fn check_typed_dict_string_literal_key(&mut self, string_expr: &ast::ExprStringLiteral) {
+    fn check_typed_dict_subscript_key(&mut self, subscript: &ast::ExprSubscript) {
+        let Some(string_expr) = subscript.slice.as_string_literal_expr() else {
+            return;
+        };
+
         let key = string_expr.value.to_str();
         if key != self.target_text {
             return;
         }
 
+        let Some(current_definition) = typed_dict_key_definition(self.model, subscript, key) else {
+            return;
+        };
+
+        self.push_typed_dict_string_key_reference(string_expr, current_definition);
+    }
+
+    fn check_typed_dict_dict_literal_key(&mut self, string_expr: &ast::ExprStringLiteral) {
+        let key = string_expr.value.to_str();
+        if key != self.target_text {
+            return;
+        }
+
+        let Some(dict) = self.enclosing_dict_with_key(string_expr) else {
+            return;
+        };
+
         let Some(current_definition) =
-            self.typed_dict_key_definition_for_string_literal(string_expr, key)
+            typed_dict_dict_literal_key_definition(self.model, dict, key)
         else {
             return;
         };
 
-        if !self.target_definitions.contains(&current_definition) {
-            return;
-        }
-
-        self.references.push(ReferenceTarget::new(
-            self.model.file(),
-            string_expr.range(),
-            ReferenceKind::Read,
-        ));
+        self.push_typed_dict_string_key_reference(string_expr, current_definition);
     }
 
-    fn typed_dict_key_definition_for_string_literal(
+    fn enclosing_dict_with_key(
         &self,
         string_expr: &ast::ExprStringLiteral,
-        key: &str,
-    ) -> Option<ResolvedDefinition<'a>> {
+    ) -> Option<&'a ast::ExprDict> {
         self.ancestors
             .iter()
             .rev()
             .find_map(|ancestor| match ancestor {
-                AnyNodeRef::ExprSubscript(subscript)
-                    if subscript.slice.range() == string_expr.range() =>
-                {
-                    typed_dict_key_definition(self.model, subscript, key)
-                }
                 AnyNodeRef::ExprDict(dict)
                     if dict.items.iter().any(|item| {
                         item.key
@@ -577,22 +585,25 @@ impl<'a> LocalReferencesFinder<'a> {
                             .is_some_and(|item_key| item_key.range() == string_expr.range())
                     }) =>
                 {
-                    typed_dict_dict_literal_key_definition(self.model, dict, key)
+                    Some(*dict)
                 }
+                AnyNodeRef::ExprSubscript(_) => None,
                 _ => None,
             })
     }
 
-    fn check_named_tuple_subscript_index(&mut self, number_expr: &ast::ExprNumberLiteral) {
-        let Some((current_definition, range)) =
-            self.named_tuple_field_definition_for_number_literal(number_expr)
-        else {
-            return;
-        };
-
+    fn push_typed_dict_string_key_reference(
+        &mut self,
+        string_expr: &ast::ExprStringLiteral,
+        current_definition: ResolvedDefinition<'a>,
+    ) {
         if !self.target_definitions.contains(&current_definition) {
             return;
         }
+
+        let Some(range) = self.string_literal_reference_range(string_expr) else {
+            return;
+        };
 
         self.references.push(ReferenceTarget::new(
             self.model.file(),
@@ -601,23 +612,46 @@ impl<'a> LocalReferencesFinder<'a> {
         ));
     }
 
-    fn named_tuple_field_definition_for_number_literal(
+    fn string_literal_reference_range(
         &self,
-        number_expr: &ast::ExprNumberLiteral,
-    ) -> Option<(ResolvedDefinition<'a>, TextRange)> {
-        self.ancestors.iter().rev().find_map(|ancestor| {
-            let AnyNodeRef::ExprSubscript(subscript) = ancestor else {
-                return None;
-            };
-            if !subscript.slice.range().contains_range(number_expr.range()) {
-                return None;
+        string_expr: &ast::ExprStringLiteral,
+    ) -> Option<TextRange> {
+        match self.mode {
+            ReferencesMode::Rename | ReferencesMode::RenameMultiFile => {
+                Some(string_expr.as_single_part_string()?.content_range())
             }
-            let target = named_tuple_field_target(self.model, subscript)?;
-            Some((
-                ResolvedDefinition::Definition(target.definition),
-                subscript.slice.range(),
-            ))
-        })
+            ReferencesMode::References
+            | ReferencesMode::ReferencesSkipDeclaration
+            | ReferencesMode::DocumentHighlights => Some(string_expr.range()),
+        }
+    }
+
+    fn check_named_tuple_subscript_index(&mut self, subscript: &ast::ExprSubscript) {
+        if matches!(
+            self.mode,
+            ReferencesMode::Rename | ReferencesMode::RenameMultiFile
+        ) {
+            return;
+        }
+
+        if !is_number_literal_subscript(subscript) {
+            return;
+        }
+
+        let Some(target) = named_tuple_field_target(self.model, subscript) else {
+            return;
+        };
+
+        let current_definition = ResolvedDefinition::Definition(target.definition);
+        if !self.target_definitions.contains(&current_definition) {
+            return;
+        }
+
+        self.references.push(ReferenceTarget::new(
+            self.model.file(),
+            subscript.slice.range(),
+            ReferenceKind::Read,
+        ));
     }
 
     fn check_identifier(&mut self, identifier: &ast::Identifier, kind: OccurrenceKind) {
@@ -723,6 +757,18 @@ impl<'a> LocalReferencesFinder<'a> {
                     DefinitionState::Deleted | DefinitionState::Undefined
                 )
             })
+    }
+}
+
+fn is_number_literal_subscript(subscript: &ast::ExprSubscript) -> bool {
+    match &*subscript.slice {
+        ast::Expr::NumberLiteral(_) => true,
+        ast::Expr::UnaryOp(unary_op)
+            if matches!(unary_op.op, ast::UnaryOp::USub | ast::UnaryOp::UAdd) =>
+        {
+            matches!(&*unary_op.operand, ast::Expr::NumberLiteral(_))
+        }
+        _ => false,
     }
 }
 

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -19,9 +19,12 @@ use ruff_python_ast::{
     self as ast, AnyNodeRef,
     visitor::source_order::{SourceOrderVisitor, TraversalSignal},
 };
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange};
 use ty_python_core::definition::{Definition, DefinitionState};
 use ty_python_core::scope::ScopeKind;
+use ty_python_semantic::types::ide_support::{
+    named_tuple_field_target, typed_dict_dict_literal_key_definition, typed_dict_key_definition,
+};
 use ty_python_semantic::{ImportAliasResolution, ResolvedDefinition, SemanticModel};
 
 /// Mode for references search behavior
@@ -449,6 +452,8 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
                 self.check_declaration_identifier(&param_var.name);
             }
             AnyNodeRef::ExprStringLiteral(string_expr) => {
+                self.check_typed_dict_string_literal_key(string_expr);
+
                 // Highlight the sub-AST of a string annotation
                 if let Some((sub_ast, sub_model)) = self.model.enter_string_annotation(string_expr)
                 {
@@ -463,6 +468,9 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
                     };
                     sub_finder.visit_expr(sub_ast.expr());
                 }
+            }
+            AnyNodeRef::ExprNumberLiteral(number_expr) => {
+                self.check_named_tuple_subscript_index(number_expr);
             }
             AnyNodeRef::Alias(alias) => {
                 // Handle import alias declarations
@@ -523,6 +531,101 @@ impl<'a> LocalReferencesFinder<'a> {
     /// Checks an identifier that's part of a declaration, e.g. the name of the class.
     fn check_declaration_identifier(&mut self, identifier: &ast::Identifier) {
         self.check_identifier(identifier, OccurrenceKind::Declaration);
+    }
+
+    fn check_typed_dict_string_literal_key(&mut self, string_expr: &ast::ExprStringLiteral) {
+        let key = string_expr.value.to_str();
+        if key != self.target_text {
+            return;
+        }
+
+        let Some(current_definition) =
+            self.typed_dict_key_definition_for_string_literal(string_expr, key)
+        else {
+            return;
+        };
+
+        if !self
+            .target_definitions
+            .iter()
+            .any(|definition| definition == &current_definition)
+        {
+            return;
+        }
+
+        self.references.push(ReferenceTarget::new(
+            self.model.file(),
+            string_expr.range(),
+            ReferenceKind::Read,
+        ));
+    }
+
+    fn typed_dict_key_definition_for_string_literal(
+        &self,
+        string_expr: &ast::ExprStringLiteral,
+        key: &str,
+    ) -> Option<ResolvedDefinition<'a>> {
+        self.ancestors
+            .iter()
+            .rev()
+            .find_map(|ancestor| match ancestor {
+                AnyNodeRef::ExprSubscript(subscript)
+                    if subscript.slice.range() == string_expr.range() =>
+                {
+                    typed_dict_key_definition(self.model, subscript, key)
+                }
+                AnyNodeRef::ExprDict(dict)
+                    if dict.items.iter().any(|item| {
+                        item.key
+                            .as_ref()
+                            .is_some_and(|item_key| item_key.range() == string_expr.range())
+                    }) =>
+                {
+                    typed_dict_dict_literal_key_definition(self.model, dict, key)
+                }
+                _ => None,
+            })
+    }
+
+    fn check_named_tuple_subscript_index(&mut self, number_expr: &ast::ExprNumberLiteral) {
+        let Some((current_definition, range)) =
+            self.named_tuple_field_definition_for_number_literal(number_expr)
+        else {
+            return;
+        };
+
+        if !self
+            .target_definitions
+            .iter()
+            .any(|definition| definition == &current_definition)
+        {
+            return;
+        }
+
+        self.references.push(ReferenceTarget::new(
+            self.model.file(),
+            range,
+            ReferenceKind::Read,
+        ));
+    }
+
+    fn named_tuple_field_definition_for_number_literal(
+        &self,
+        number_expr: &ast::ExprNumberLiteral,
+    ) -> Option<(ResolvedDefinition<'a>, TextRange)> {
+        self.ancestors.iter().rev().find_map(|ancestor| {
+            let AnyNodeRef::ExprSubscript(subscript) = ancestor else {
+                return None;
+            };
+            if !subscript.slice.range().contains_range(number_expr.range()) {
+                return None;
+            }
+            let target = named_tuple_field_target(self.model, subscript)?;
+            Some((
+                ResolvedDefinition::Definition(target.definition),
+                subscript.slice.range(),
+            ))
+        })
     }
 
     fn check_identifier(&mut self, identifier: &ast::Identifier, kind: OccurrenceKind) {

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -1,4 +1,4 @@
-use crate::goto::find_goto_target;
+use crate::goto::{GotoTarget, find_goto_target};
 use crate::references::{ReferencesMode, references};
 use crate::{Db, ReferenceTarget};
 use ruff_db::files::File;
@@ -14,10 +14,10 @@ pub fn can_rename(db: &dyn Db, file: File, offset: TextSize) -> Option<ruff_text
     // Get the definitions for the symbol at the offset
     let goto_target = find_goto_target(&model, &module, offset)?;
 
-    // Don't allow renaming of import module components
+    // Don't allow renaming of import module components or index-based field references.
     if matches!(
         goto_target,
-        crate::goto::GotoTarget::ImportModuleComponent { .. }
+        GotoTarget::ImportModuleComponent { .. } | GotoTarget::SubscriptNamedTupleField { .. }
     ) {
         return None;
     }
@@ -43,7 +43,7 @@ pub fn can_rename(db: &dyn Db, file: File, offset: TextSize) -> Option<ruff_text
         }
     }
 
-    Some(goto_target.range())
+    Some(rename_range(goto_target)?)
 }
 
 /// Perform a rename operation on the symbol at the given position.
@@ -86,6 +86,22 @@ pub fn rename(
 /// Helper function to check if a file is included in the project.
 fn is_file_in_project(db: &dyn Db, file: File) -> bool {
     file.path(db).is_system_virtual_path() || db.project().files(db).contains(&file)
+}
+
+fn rename_range(goto_target: GotoTarget<'_>) -> Option<ruff_text_size::TextRange> {
+    match goto_target {
+        GotoTarget::SubscriptStringLiteralKey { subscript, .. } => Some(
+            subscript
+                .slice
+                .as_string_literal_expr()?
+                .as_single_part_string()?
+                .content_range(),
+        ),
+        GotoTarget::DictStringLiteralKey { string_expr, .. } => {
+            Some(string_expr.as_single_part_string()?.content_range())
+        }
+        _ => Some(goto_target.range()),
+    }
 }
 
 #[cfg(test)]
@@ -1248,6 +1264,81 @@ TD(f<CURSOR>=1)
     }
 
     #[test]
+    fn rename_typeddict_field_string_keys() {
+        let test = cursor_test(
+            r#"
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title<CURSOR>: str
+
+movie: Movie = {"title": "Alien"}
+print(movie["title"])
+"#,
+        );
+
+        assert_snapshot!(test.rename("name"), @r#"
+        info[rename]: Rename symbol (found 3 locations)
+         --> main.py:5:5
+          |
+        5 |     title: str
+          |     ^^^^^
+        6 |
+        7 | movie: Movie = {"title": "Alien"}
+          |                  -----
+        8 | print(movie["title"])
+          |              -----
+          |
+        "#);
+    }
+
+    #[test]
+    fn rename_typeddict_field_from_string_key() {
+        let test = cursor_test(
+            r#"
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title: str
+
+movie: Movie = {"title": "Alien"}
+print(movie["ti<CURSOR>tle"])
+"#,
+        );
+
+        assert_snapshot!(test.rename("name"), @r#"
+        info[rename]: Rename symbol (found 3 locations)
+         --> main.py:5:5
+          |
+        5 |     title: str
+          |     ^^^^^
+        6 |
+        7 | movie: Movie = {"title": "Alien"}
+          |                  -----
+        8 | print(movie["title"])
+          |              -----
+          |
+        "#);
+    }
+
+    #[test]
+    fn prepare_rename_typeddict_field_from_string_key() {
+        let test = cursor_test(
+            r#"
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title: str
+
+movie: Movie = {"title": "Alien"}
+print(movie["ti<CURSOR>tle"])
+"#,
+        );
+
+        assert_snapshot!(test.prepare_rename(), @"Can rename symbol at range 118..123");
+    }
+
+    #[test]
     fn rename_keyword_argument_namedtuple_field() {
         let test = cursor_test(
             "
@@ -1257,22 +1348,44 @@ class NT(NamedTuple):
     f<CURSOR>: int
     g: str
 
-NT(f=1)
+nt = NT(f=1, g=\"\")
+print(nt.f)
+print(nt[0])
 ",
         );
 
-        assert_snapshot!(test.rename("z"), @"
-        info[rename]: Rename symbol (found 2 locations)
+        assert_snapshot!(test.rename("z"), @r#"
+        info[rename]: Rename symbol (found 3 locations)
          --> main.py:5:5
           |
         5 |     f: int
           |     ^
         6 |     g: str
         7 |
-        8 | NT(f=1)
-          |    -
+        8 | nt = NT(f=1, g="")
+          |         -
+        9 | print(nt.f)
+          |          -
           |
-        ");
+        "#);
+    }
+
+    #[test]
+    fn prepare_rename_namedtuple_index() {
+        let test = cursor_test(
+            "
+from typing import NamedTuple
+
+class NT(NamedTuple):
+    f: int
+    g: str
+
+nt = NT(f=1, g=\"\")
+print(nt[0<CURSOR>])
+",
+        );
+
+        assert_snapshot!(test.prepare_rename(), @"Cannot rename");
     }
 
     #[test]

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -43,7 +43,7 @@ pub fn can_rename(db: &dyn Db, file: File, offset: TextSize) -> Option<ruff_text
         }
     }
 
-    Some(rename_range(goto_target)?)
+    rename_range(&goto_target)
 }
 
 /// Perform a rename operation on the symbol at the given position.
@@ -88,7 +88,7 @@ fn is_file_in_project(db: &dyn Db, file: File) -> bool {
     file.path(db).is_system_virtual_path() || db.project().files(db).contains(&file)
 }
 
-fn rename_range(goto_target: GotoTarget<'_>) -> Option<ruff_text_size::TextRange> {
+fn rename_range(goto_target: &GotoTarget<'_>) -> Option<ruff_text_size::TextRange> {
     match goto_target {
         GotoTarget::SubscriptStringLiteralKey { subscript, .. } => Some(
             subscript

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -446,6 +446,15 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
         self.fields(db).iter().find(|field| field.name == *name)
     }
 
+    /// Returns the field declared directly at the given index on this dynamic named tuple, if any.
+    pub(crate) fn field_at_index(
+        self,
+        db: &'db dyn Db,
+        index: usize,
+    ) -> Option<&'db NamedTupleField<'db>> {
+        self.fields(db).get(index)
+    }
+
     pub(super) fn has_known_fields(self, db: &'db dyn Db) -> bool {
         self.spec(db).has_known_fields(db)
     }

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -5,13 +5,13 @@ use crate::place::builtins_module_scope;
 use crate::reachability::is_range_reachable;
 use crate::types::call::{CallArguments, CallError, MatchedArgument};
 use crate::types::class::{
-    ClassLiteral, CodeGeneratorKind, DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor,
+    CodeGeneratorKind, DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor,
 };
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::signatures::{ParameterForm, ParametersKind, Signature};
 use crate::types::{
-    CallDunderError, CallableTypes, ClassBase, ClassType, KnownClass, KnownUnion, Type,
-    TypeContext, UnionType,
+    CallDunderError, CallableTypes, ClassBase, ClassLiteral, ClassType, KnownClass, KnownUnion,
+    Type, TypeContext, UnionType,
 };
 use crate::{Db, DisplaySettings, HasDefinition, HasType, SemanticModel};
 use itertools::Either;

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -4,12 +4,14 @@ use crate::FxIndexSet;
 use crate::place::builtins_module_scope;
 use crate::reachability::is_range_reachable;
 use crate::types::call::{CallArguments, CallError, MatchedArgument};
-use crate::types::class::{DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor};
+use crate::types::class::{
+    ClassLiteral, CodeGeneratorKind, DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor,
+};
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::signatures::{ParameterForm, ParametersKind, Signature};
 use crate::types::{
-    CallDunderError, CallableTypes, ClassBase, ClassLiteral, ClassType, KnownClass, KnownUnion,
-    Type, TypeContext, UnionType,
+    CallDunderError, CallableTypes, ClassBase, ClassType, KnownClass, KnownUnion, Type,
+    TypeContext, UnionType,
 };
 use crate::{Db, DisplaySettings, HasDefinition, HasType, SemanticModel};
 use itertools::Either;
@@ -437,6 +439,11 @@ pub struct TypedDictKeyHover<'db> {
     pub docstring: Option<String>,
 }
 
+pub struct NamedTupleFieldTarget<'db> {
+    pub name: Name,
+    pub definition: Definition<'db>,
+}
+
 pub fn typed_dict_key_definition<'db>(
     model: &SemanticModel<'db>,
     subscript: &ast::ExprSubscript,
@@ -444,6 +451,17 @@ pub fn typed_dict_key_definition<'db>(
 ) -> Option<ResolvedDefinition<'db>> {
     let value_ty = subscript.value.inferred_type(model)?;
     let typed_dict = value_ty.as_typed_dict()?;
+    let field = typed_dict.items(model.db()).get(key)?;
+    let definition = field.first_declaration()?;
+    Some(ResolvedDefinition::Definition(definition))
+}
+
+pub fn typed_dict_dict_literal_key_definition<'db>(
+    model: &SemanticModel<'db>,
+    dict: &ast::ExprDict,
+    key: &str,
+) -> Option<ResolvedDefinition<'db>> {
+    let typed_dict = dict.inferred_type(model)?.as_typed_dict()?;
     let field = typed_dict.items(model.db()).get(key)?;
     let definition = field.first_declaration()?;
     Some(ResolvedDefinition::Definition(definition))
@@ -471,6 +489,72 @@ pub fn typed_dict_key_hover<'db>(
         declared_ty: field.declared_ty,
         docstring,
     })
+}
+
+pub fn named_tuple_field_target<'db>(
+    model: &SemanticModel<'db>,
+    subscript: &ast::ExprSubscript,
+) -> Option<NamedTupleFieldTarget<'db>> {
+    let index = named_tuple_field_index(model, subscript)?;
+    let value_ty = subscript.value.inferred_type(model)?;
+    let instance = value_ty.as_nominal_instance()?;
+    let class = instance.class(model.db());
+    let (class_literal, specialization) = class.class_literal_and_specialization(model.db());
+
+    match class_literal {
+        ClassLiteral::Static(class) => {
+            if !CodeGeneratorKind::NamedTuple.matches(model.db(), class.into(), specialization) {
+                return None;
+            }
+
+            let (name, field) = class
+                .fields(model.db(), specialization, CodeGeneratorKind::NamedTuple)
+                .iter()
+                .nth(index)?;
+            Some(NamedTupleFieldTarget {
+                name: name.clone(),
+                definition: field.first_declaration?,
+            })
+        }
+        ClassLiteral::DynamicNamedTuple(named_tuple) => {
+            let field = named_tuple.field_at_index(model.db(), index)?;
+            Some(NamedTupleFieldTarget {
+                name: field.name.clone(),
+                definition: field.definition?,
+            })
+        }
+        ClassLiteral::Dynamic(_)
+        | ClassLiteral::DynamicTypedDict(_)
+        | ClassLiteral::DynamicEnum(_) => None,
+    }
+}
+
+fn named_tuple_field_index(
+    model: &SemanticModel<'_>,
+    subscript: &ast::ExprSubscript,
+) -> Option<usize> {
+    let index = subscript.slice.inferred_type(model)?.as_int_literal()?;
+    let tuple_len = subscript
+        .value
+        .inferred_type(model)?
+        .as_nominal_instance()?
+        .tuple_spec(model.db())?
+        .len();
+    let (field_count, Some(max_field_count)) = tuple_len.size_hint() else {
+        return None;
+    };
+    if field_count != max_field_count {
+        return None;
+    }
+
+    let normalized = if index < 0 {
+        i64::try_from(field_count).ok()? + index
+    } else {
+        index
+    };
+    usize::try_from(normalized)
+        .ok()
+        .filter(|index| *index < field_count)
 }
 
 /// Returns definitions for a keyword argument in a call expression.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Closes https://github.com/astral-sh/ty/issues/3369

Adds support for finding references of synthesised fields in typed dicts and named tuples.

Also adds goto support for named tuple indexes like '[0]' and '[-1]'. This is related to the references, so I think it is okay to include in this PR.

Now, for finding references to typed dict keys or named tuple fields, we do the following:
- when we find a string literal (`typed_dict_key_definition_for_string_literal`) we now check if we are in a literal dict expression `{"title": "Alien"}`, or if we are in a subscript `["title"]` we check if the value `movie` in `movie["title"]` is a typed dictionary instance, and return the field definition we find.
- when we find a number literal (`named_tuple_field_definition_for_number_literal`), we check if we are in subscript `[0]`, if we are, we check if the value `point` in `point[0]` is a named tuple instance and return the field definition that we find.

## Test Plan

Add goto and reference ty_ide tests
