### PR TITLE
[`flake8-comprehensions`] Skip `C417` for lambdas with positional-only parameters

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C417.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_comprehensions/C417.py
@@ -79,3 +79,7 @@ _ = t"{dict(map(lambda v: (v, v**2), nums))}"
 # See https://github.com/astral-sh/ruff/issues/20198
 # No error: lambda contains `yield`, so map() should not be rewritten
 map(lambda x: (yield x), [1, 2, 3])
+
+# Ok: lambda has a positional-only parameter alongside a regular parameter;
+# total arity is 2, so rewriting to a comprehension is incorrect.
+map(lambda x, /, y: x + y, nums)

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -212,6 +212,13 @@ fn lambda_has_expected_arity(lambda: &ExprLambda) -> bool {
         return false;
     };
 
+    // Reject lambdas that also declare positional-only parameters, e.g. `lambda x, /, y: ...`.
+    // Such a lambda requires two arguments; `map()` over a single iterable is already broken
+    // at runtime and must not be rewritten as a comprehension.
+    if !parameters.posonlyargs.is_empty() {
+        return false;
+    }
+
     if parameter.default.is_some() {
         return false;
     }

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -207,20 +207,18 @@ fn lambda_has_expected_arity(lambda: &ExprLambda) -> bool {
     let Some(parameters) = lambda.parameters.as_deref() else {
         return false;
     };
+
     if parameters.len() != 1 {
         return false;
     }
+
     let [parameter] = &*parameters.args else {
         return false;
     };
+
     if parameter.default.is_some() {
         return false;
     }
-
-    if parameters.vararg.is_some() || parameters.kwarg.is_some() {
-        return false;
-    }
-
     if late_binding(parameters, &lambda.body) {
         return false;
     }

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -207,18 +207,12 @@ fn lambda_has_expected_arity(lambda: &ExprLambda) -> bool {
     let Some(parameters) = lambda.parameters.as_deref() else {
         return false;
     };
-
+    if parameters.len() != 1 {
+        return false;
+    }
     let [parameter] = &*parameters.args else {
         return false;
     };
-
-    // Reject lambdas that also declare positional-only parameters, e.g. `lambda x, /, y: ...`.
-    // Such a lambda requires two arguments; `map()` over a single iterable is already broken
-    // at runtime and must not be rewritten as a comprehension.
-    if !parameters.posonlyargs.is_empty() {
-        return false;
-    }
-
     if parameter.default.is_some() {
         return false;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:
- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

`lambda_has_expected_arity` in the C417 (`UnnecessaryMap`) rule checked
`parameters.args` for exactly one element to confirm the lambda takes a
single argument, but never checked `parameters.posonlyargs`. A lambda
like `lambda x, /, y: x + y` has `posonlyargs = [x]` and `args = [y]`,
so the slice pattern matched `y` as the sole element and the function
incorrectly returned `true`, causing ruff to raise a false C417
diagnostic and offer a broken autofix for a two-parameter lambda.

The fix adds an early return when `parameters.posonlyargs` is non-empty,
ensuring lambdas that combine positional-only and regular parameters are
correctly rejected before the arity check passes.

## Test Plan

Added a new `# Ok` case to `C417.py`:

```python
# Ok: lambda has a positional-only parameter alongside a regular parameter;
# total arity is 2, so rewriting to a comprehension is incorrect.
map(lambda x, /, y: x + y, nums)
```

This line produces no diagnostic after the fix, confirming the false
positive is gone.