### PR TITLE
[ty] Avoid re-querying enum metadata

### DIFF
--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -200,9 +200,9 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, SpecialFormType,
+        CallableTypes, EnumClassLiteral, IntersectionBuilder, NarrowingConstraint, SpecialFormType,
         Type, TypeContext, UnionType, callable_pattern_type, definite_match_pattern_type,
-        enum_metadata, equality_truthiness, expand_type, infer_narrowing_constraints,
+        equality_truthiness, expand_type, infer_narrowing_constraints,
         infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
         singleton_pattern_type,
     },
@@ -286,15 +286,15 @@ fn type_narrowed_by_pattern<'db>(
 fn enum_literal_subject_names<'db>(
     db: &'db dyn Db,
     subject_ty: Type<'db>,
-) -> Option<(ClassLiteral<'db>, FxHashSet<Name>)> {
+) -> Option<(EnumClassLiteral<'db>, FxHashSet<Name>)> {
     fn add_enum_literal<'db>(
         db: &'db dyn Db,
-        enum_class: &mut Option<ClassLiteral<'db>>,
+        enum_class: &mut Option<EnumClassLiteral<'db>>,
         names: &mut FxHashSet<Name>,
         ty: Type<'db>,
     ) -> Option<()> {
         let enum_literal = ty.as_enum_literal()?;
-        let class = enum_literal.enum_class(db);
+        let class = enum_literal.enum_class_literal(db);
 
         if let Some(existing_class) = *enum_class {
             if existing_class != class {
@@ -304,9 +304,8 @@ fn enum_literal_subject_names<'db>(
             *enum_class = Some(class);
         }
 
-        let metadata = enum_metadata(db, class)?;
         let name = enum_literal.name(db);
-        let canonical_name = metadata.resolve_member(name).unwrap_or(name);
+        let canonical_name = class.resolve_member(db, name)?;
         names.insert(canonical_name.clone());
         Some(())
     }
@@ -337,18 +336,17 @@ fn enum_literal_subject_names<'db>(
 /// canonical member names before returning.
 fn enum_member_pattern_name<'db>(
     db: &'db dyn Db,
-    enum_class: ClassLiteral<'db>,
+    enum_class: EnumClassLiteral<'db>,
     kind: &PatternPredicateKind<'db>,
 ) -> Option<Name> {
     let value_ty = definite_match_pattern_type(db, kind);
     let enum_literal = value_ty.as_enum_literal()?;
-    if enum_literal.enum_class(db) != enum_class {
+    if enum_literal.enum_class_literal(db) != enum_class {
         return None;
     }
 
-    let metadata = enum_metadata(db, enum_class)?;
     let name = enum_literal.name(db);
-    let canonical_name = metadata.resolve_member(name).unwrap_or(name);
+    let canonical_name = enum_class.resolve_member(db, name)?;
     Some(canonical_name.clone())
 }
 
@@ -367,7 +365,7 @@ struct EnumMemberPatternCoverage {
 /// produces only a lower bound: it definitely matches `Color.GREEN`, but can match other members.
 fn enum_member_pattern_coverage<'db>(
     db: &'db dyn Db,
-    enum_class: ClassLiteral<'db>,
+    enum_class: EnumClassLiteral<'db>,
     kind: &PatternPredicateKind<'db>,
 ) -> EnumMemberPatternCoverage {
     let mut coverage = EnumMemberPatternCoverage {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -66,7 +66,7 @@ use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::context::{LintDiagnosticGuard, LintDiagnosticGuardBuilder};
 use crate::types::diagnostic::{INVALID_AWAIT, INVALID_TYPE_FORM};
 pub use crate::types::display::{DisplaySettings, TypeDetail, TypeDisplayDetails};
-pub(crate) use crate::types::enums::{EnumComplementType, enum_metadata};
+pub(crate) use crate::types::enums::{EnumClassLiteral, EnumComplementType, enum_metadata};
 pub(crate) use crate::types::equality::equality_truthiness;
 use crate::types::function::{
     DataclassTransformerFlags, DataclassTransformerParams, FunctionDecorators, FunctionSpans,
@@ -3968,24 +3968,23 @@ impl<'db> Type<'db> {
                         }) =>
                 {
                     let enum_literal = literal.as_enum().unwrap();
-                    let enum_class = enum_literal.enum_class(db);
-                    let is_enum_subclass = Type::ClassLiteral(enum_class)
+                    let enum_class = enum_literal.enum_class_literal(db);
+                    let is_enum_subclass = Type::ClassLiteral(enum_class.class_literal(db))
                         .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db));
 
-                    enum_metadata(db, enum_class)
-                        .and_then(|metadata| match name_str {
-                            "name" if is_enum_subclass => {
-                                metadata.name_type(db, enum_literal.name(db))
-                            }
-                            "_name_" => metadata.name_type(db, enum_literal.name(db)),
-                            "value" if is_enum_subclass => {
-                                metadata.value_type(db, enum_literal.name(db))
-                            }
-                            "_value_" => metadata.value_type(db, enum_literal.name(db)),
-                            _ => None,
-                        })
-                        .map_or_else(|| Place::Undefined, Place::bound)
-                        .into()
+                    (match name_str {
+                        "name" if is_enum_subclass => {
+                            enum_class.name_type(db, enum_literal.name(db))
+                        }
+                        "_name_" => enum_class.name_type(db, enum_literal.name(db)),
+                        "value" if is_enum_subclass => {
+                            enum_class.value_type(db, enum_literal.name(db))
+                        }
+                        "_value_" => enum_class.value_type(db, enum_literal.name(db)),
+                        _ => None,
+                    })
+                    .map_or_else(|| Place::Undefined, Place::bound)
+                    .into()
                 }
 
                 Type::TypeVar(typevar) if name_str == "args" && typevar.is_paramspec(db) => {
@@ -4080,10 +4079,15 @@ impl<'db> Type<'db> {
 
                     // Enum members can be accessed through enum instances and other enum members,
                     // e.g. `answer.YES` or `Answer.YES.NO`.
-                    if let Some(enum_class) =
-                        this.nominal_class(db).map(|class| class.class_literal(db))
-                        && let Some(metadata) = enum_metadata(db, enum_class)
-                        && let Some(resolved_name) = metadata.resolve_member(&name)
+                    if let Some(enum_class) = match this {
+                        Type::LiteralValue(literal) => literal
+                            .as_enum()
+                            .map(|enum_literal| enum_literal.enum_class_literal(db)),
+                        _ => this
+                            .nominal_class(db)
+                            .map(|class| class.class_literal(db))
+                            .and_then(|class| class.into_enum_class(db)),
+                    } && let Some(resolved_name) = enum_class.resolve_member(db, &name)
                     {
                         return Place::bound(Type::enum_literal(EnumLiteralType::new(
                             db,
@@ -4117,16 +4121,15 @@ impl<'db> Type<'db> {
 
                 Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
                     let enum_class = match this {
-                        Type::ClassLiteral(literal) => Some(literal),
+                        Type::ClassLiteral(literal) => literal.into_enum_class(db),
                         Type::SubclassOf(subclass_of) => subclass_of
                             .subclass_of()
                             .into_class(db)
-                            .map(|class| class.class_literal(db)),
+                            .and_then(|class| class.class_literal(db).into_enum_class(db)),
                         _ => None,
                     };
                     if let Some(enum_class) = enum_class
-                        && let Some(metadata) = enum_metadata(db, enum_class)
-                        && let Some(resolved_name) = metadata.resolve_member(&name)
+                        && let Some(resolved_name) = enum_class.resolve_member(db, &name)
                     {
                         return Place::bound(Type::enum_literal(EnumLiteralType::new(
                             db,

--- a/crates/ty_python_semantic/src/types/class/enum_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/enum_literal.rs
@@ -245,10 +245,10 @@ impl<'db> DynamicEnumLiteral<'db> {
                 .members(db)
                 .iter()
                 .any(|(member_name, _)| member_name == name)
+            && let Some(enum_class) = ClassLiteral::DynamicEnum(self).into_enum_class(db)
         {
-            let class_lit = ClassLiteral::DynamicEnum(self);
             let enum_lit =
-                crate::types::literal::EnumLiteralType::new(db, class_lit, Name::new(name));
+                crate::types::literal::EnumLiteralType::new(db, enum_class, Name::new(name));
             return Member::definitely_declared(Type::enum_literal(enum_lit));
         }
         Member::unbound()

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -198,6 +198,89 @@ pub(super) fn class_defines_property<'db>(
     false
 }
 
+/// An enum class literal with its canonical members, value types, and aliases.
+///
+/// This keeps the enum-specific information used by enum literals and enum complements alongside
+/// the underlying class literal.
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+pub struct EnumClassLiteral<'db> {
+    pub(crate) class_literal: ClassLiteral<'db>,
+    #[returns(ref)]
+    pub(crate) members: Box<[(Name, Type<'db>)]>,
+    #[returns(ref)]
+    pub(crate) aliases: Box<[(Name, Name)]>,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for EnumClassLiteral<'_> {}
+
+impl<'db> ClassLiteral<'db> {
+    pub(crate) fn into_enum_class(self, db: &'db dyn Db) -> Option<EnumClassLiteral<'db>> {
+        enum_class_literal(db, self)
+    }
+}
+
+#[salsa::tracked(cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+fn enum_class_literal<'db>(
+    db: &'db dyn Db,
+    class: ClassLiteral<'db>,
+) -> Option<EnumClassLiteral<'db>> {
+    let metadata = enum_metadata(db, class)?;
+    let members = metadata
+        .members
+        .keys()
+        .map(|name| metadata.value_type(db, name).map(|ty| (name.clone(), ty)))
+        .collect::<Option<Box<[_]>>>()?;
+    let mut aliases: Vec<_> = metadata
+        .aliases
+        .iter()
+        .map(|(alias, member)| (alias.clone(), member.clone()))
+        .collect();
+    aliases.sort_unstable();
+
+    Some(EnumClassLiteral::new(
+        db,
+        class,
+        members,
+        aliases.into_boxed_slice(),
+    ))
+}
+
+impl<'db> EnumClassLiteral<'db> {
+    pub(crate) fn member_count(self, db: &'db dyn Db) -> usize {
+        self.members(db).len()
+    }
+
+    pub(crate) fn member_names(self, db: &'db dyn Db) -> impl Iterator<Item = &'db Name> {
+        self.members(db).iter().map(|(name, _)| name)
+    }
+
+    pub(crate) fn resolve_member(self, db: &'db dyn Db, name: &Name) -> Option<&'db Name> {
+        self.member_names(db)
+            .find(|member| *member == name)
+            .or_else(|| {
+                self.aliases(db)
+                    .iter()
+                    .find_map(|(alias, member)| (alias == name).then_some(member))
+            })
+    }
+
+    /// Returns the type of `.name`/`._name_` for a given enum member.
+    ///
+    /// This is always a string literal of the member name.
+    pub(crate) fn name_type(self, db: &'db dyn Db, name: &Name) -> Option<Type<'db>> {
+        self.resolve_member(db, name)
+            .map(|name| Type::string_literal(db, name.as_str()))
+    }
+
+    pub(crate) fn value_type(self, db: &'db dyn Db, name: &Name) -> Option<Type<'db>> {
+        let name = self.resolve_member(db, name)?;
+        self.members(db)
+            .iter()
+            .find_map(|(member, value_type)| (member == name).then_some(*value_type))
+    }
+}
+
 /// Look up an instance member on the finite enum literals represented by a complement.
 ///
 /// The enum-owned `.name`/`.value` attributes can often be answered directly. Other members
@@ -295,7 +378,6 @@ impl<'db> EnumMetadata<'db> {
     /// constructors, a literal is preserved when its runtime class matches the inherited `_value_`
     /// annotation; otherwise, the annotation describes the normalized value.
     pub(crate) fn value_type(&self, db: &'db dyn Db, member_name: &Name) -> Option<Type<'db>> {
-        let member_name = self.resolve_member(member_name)?;
         let declared_value = self.members.get(member_name).copied()?;
 
         if let Some(EnumValueAnnotation::UserDefined(annotation)) = self.value_annotation {
@@ -332,15 +414,6 @@ impl<'db> EnumMetadata<'db> {
     pub(crate) fn member_value_may_be_transformed(&self, member_name: &Name) -> bool {
         self.value_construction
             .member_value_may_be_transformed(self.auto_members.contains(member_name))
-    }
-
-    /// Returns the type of `.name`/`._name_` for a given enum member.
-    ///
-    /// This is always a string literal of the member name.
-    pub(crate) fn name_type(&self, db: &'db dyn Db, member_name: &Name) -> Option<Type<'db>> {
-        self.members
-            .contains_key(member_name)
-            .then(|| Type::string_literal(db, member_name.as_str()))
     }
 
     /// Returns the type of `.value`/`._value_` for an enum instance that is not
@@ -391,14 +464,6 @@ impl<'db> EnumMetadata<'db> {
             .build();
         Some(union)
     }
-
-    pub(crate) fn resolve_member<'a>(&'a self, name: &'a Name) -> Option<&'a Name> {
-        if self.members.contains_key(name) {
-            Some(name)
-        } else {
-            self.aliases.get(name)
-        }
-    }
 }
 
 /// A compact representation of an enum type with excluded members.
@@ -421,7 +486,7 @@ impl<'db> EnumMetadata<'db> {
 /// ```
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct EnumComplementType<'db> {
-    pub(crate) enum_class: ClassLiteral<'db>,
+    pub(crate) enum_class_literal: EnumClassLiteral<'db>,
     /// Canonical enum-member names excluded by this complement.
     #[returns(ref)]
     pub(crate) excluded_names: FxOrderSet<Name>,
@@ -452,59 +517,53 @@ impl<'db> EnumComplementType<'db> {
                 continue;
             };
 
-            let class = instance.class_literal(db);
-            if enum_metadata(db, class).is_none() {
+            let Some(enum_class_literal) = instance.class_literal(db).into_enum_class(db) else {
                 rest.push(*positive);
                 continue;
-            }
+            };
 
-            if enum_class.replace(class).is_some() {
+            if enum_class.replace(enum_class_literal).is_some() {
                 return None;
             }
         }
 
-        let enum_class = enum_class?;
-        let metadata = enum_metadata(db, enum_class)?;
-
+        let enum_class_literal = enum_class?;
         let mut excluded_names = FxHashSet::default();
         for negative in negative {
             let enum_literal = negative.as_enum_literal()?;
-            if enum_literal.enum_class(db) != enum_class {
+            if enum_literal.enum_class_literal(db) != enum_class_literal {
                 return None;
             }
 
             let name = enum_literal.name(db);
-            let canonical_name = metadata.resolve_member(name).unwrap_or(name);
+            let canonical_name = enum_class_literal.resolve_member(db, name)?;
             excluded_names.insert(canonical_name.clone());
         }
 
         (!excluded_names.is_empty()).then(|| {
-            let excluded_names: FxOrderSet<Name> = metadata
-                .members
-                .keys()
+            let excluded_names: FxOrderSet<Name> = enum_class_literal
+                .member_names(db)
                 .filter(|name| excluded_names.contains(*name))
                 .cloned()
                 .collect();
             let rest: FxOrderSet<Type<'db>> = rest.into_iter().collect();
-            Self::new(db, enum_class, excluded_names, rest)
+            Self::new(db, enum_class_literal, excluded_names, rest)
         })
     }
 
-    /// Return metadata for the enum class whose members are represented by this complement.
-    pub(crate) fn metadata(self, db: &'db dyn Db) -> &'db EnumMetadata<'db> {
-        enum_metadata(db, self.enum_class(db)).expect("Enum complement class is an enum")
+    pub(crate) fn enum_class(self, db: &'db dyn Db) -> ClassLiteral<'db> {
+        self.enum_class_literal(db).class_literal(db)
     }
 
     fn remaining_member_names(self, db: &'db dyn Db) -> impl Iterator<Item = &'db Name> {
-        self.metadata(db)
-            .members
-            .keys()
+        self.enum_class_literal(db)
+            .member_names(db)
             .filter(move |name| !self.excluded_names(db).contains(*name))
     }
 
     /// Count the canonical enum members still represented by this complement.
     fn remaining_member_count(self, db: &'db dyn Db) -> usize {
-        self.metadata(db).members.len() - self.excluded_names(db).len()
+        self.enum_class_literal(db).member_count(db) - self.excluded_names(db).len()
     }
 
     /// Return `true` when this complement represents exactly one enum literal.
@@ -566,7 +625,8 @@ impl<'db> EnumComplementType<'db> {
 
     /// Build the type for one remaining canonical member, preserving any positive rest components.
     fn remaining_literal_type(self, db: &'db dyn Db, name: Name) -> Type<'db> {
-        let literal = Type::enum_literal(EnumLiteralType::new(db, self.enum_class(db), name));
+        let literal =
+            Type::enum_literal(EnumLiteralType::new(db, self.enum_class_literal(db), name));
         if self.rest(db).is_empty() {
             return literal;
         }
@@ -604,7 +664,7 @@ impl<'db> EnumComplementType<'db> {
     /// This handles `.name`, `.value`, `._name_`, and `._value_` by unioning the corresponding
     /// attribute type from each remaining canonical enum member.
     pub(crate) fn member_type(self, db: &'db dyn Db, member_name: &str) -> Option<Type<'db>> {
-        let metadata = self.metadata(db);
+        let enum_class_literal = self.enum_class_literal(db);
         let is_enum_subclass = Type::ClassLiteral(self.enum_class(db))
             .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db));
         let mut builder = UnionBuilder::new(db);
@@ -612,10 +672,10 @@ impl<'db> EnumComplementType<'db> {
 
         for name in self.remaining_member_names(db) {
             let member_ty = (match member_name {
-                "name" if is_enum_subclass => metadata.name_type(db, name),
-                "_name_" => metadata.name_type(db, name),
-                "value" if is_enum_subclass => metadata.value_type(db, name),
-                "_value_" => metadata.value_type(db, name),
+                "name" if is_enum_subclass => enum_class_literal.name_type(db, name),
+                "_name_" => enum_class_literal.name_type(db, name),
+                "value" if is_enum_subclass => enum_class_literal.value_type(db, name),
+                "_value_" => enum_class_literal.value_type(db, name),
                 _ => None,
             })?;
 
@@ -645,7 +705,7 @@ impl<'db> EnumComplementType<'db> {
         for name in self.excluded_names(db) {
             negative.insert(Type::enum_literal(EnumLiteralType::new(
                 db,
-                enum_class,
+                self.enum_class_literal(db),
                 name.clone(),
             )));
         }
@@ -1167,13 +1227,15 @@ pub(crate) fn enum_member_literals<'a, 'db: 'a>(
     class: ClassLiteral<'db>,
     exclude_member: Option<&'a Name>,
 ) -> Option<impl Iterator<Item = Type<'a>> + 'a> {
-    enum_metadata(db, class).map(|metadata| {
-        metadata
-            .members
-            .keys()
+    let enum_class_literal = class.into_enum_class(db)?;
+    Some(
+        enum_class_literal
+            .member_names(db)
             .filter(move |name| Some(*name) != exclude_member)
-            .map(move |name| Type::enum_literal(EnumLiteralType::new(db, class, name.clone())))
-    })
+            .map(move |name| {
+                Type::enum_literal(EnumLiteralType::new(db, enum_class_literal, name.clone()))
+            }),
+    )
 }
 
 pub(crate) fn is_single_member_enum<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -255,14 +255,23 @@ impl<'db> EnumClassLiteral<'db> {
         self.members(db).iter().map(|(name, _)| name)
     }
 
+    fn resolve_member_entry(self, db: &'db dyn Db, name: &Name) -> Option<&'db (Name, Type<'db>)> {
+        let members = self.members(db);
+        if let Some(member) = members.iter().find(|(member, _)| member == name) {
+            return Some(member);
+        }
+
+        let aliases = self.aliases(db);
+        let alias_index = aliases
+            .binary_search_by(|(alias, _)| alias.cmp(name))
+            .ok()?;
+        let canonical_name = &aliases[alias_index].1;
+        members.iter().find(|(member, _)| member == canonical_name)
+    }
+
     pub(crate) fn resolve_member(self, db: &'db dyn Db, name: &Name) -> Option<&'db Name> {
-        self.member_names(db)
-            .find(|member| *member == name)
-            .or_else(|| {
-                self.aliases(db)
-                    .iter()
-                    .find_map(|(alias, member)| (alias == name).then_some(member))
-            })
+        self.resolve_member_entry(db, name)
+            .map(|(member, _)| member)
     }
 
     /// Returns the type of `.name`/`._name_` for a given enum member.
@@ -274,10 +283,8 @@ impl<'db> EnumClassLiteral<'db> {
     }
 
     pub(crate) fn value_type(self, db: &'db dyn Db, name: &Name) -> Option<Type<'db>> {
-        let name = self.resolve_member(db, name)?;
-        self.members(db)
-            .iter()
-            .find_map(|(member, value_type)| (member == name).then_some(*value_type))
+        self.resolve_member_entry(db, name)
+            .map(|(_, value_type)| *value_type)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -646,8 +646,6 @@ fn enum_literal_constraint<'db>(
     let LiteralValueTypeKind::Enum(right) = right.as_literal_value_kind()? else {
         return None;
     };
-    let enum_class = right.enum_class(db);
-
     if !is_same_enum_domain(db, left, right)
         || KnownComparisonSemantics::of_instance(db, right.enum_class_instance(db), operator)
             .is_none()
@@ -655,9 +653,11 @@ fn enum_literal_constraint<'db>(
         return None;
     }
 
-    let metadata = enum_metadata(db, enum_class)?;
-    let name = metadata.resolve_member(right.name(db))?.clone();
-    let equal_to_right = Type::enum_literal(EnumLiteralType::new(db, enum_class, name));
+    let enum_class_literal = right.enum_class_literal(db);
+    let name = enum_class_literal
+        .resolve_member(db, right.name(db))?
+        .clone();
+    let equal_to_right = Type::enum_literal(EnumLiteralType::new(db, enum_class_literal, name));
     Some(equal_to_right.negate_if(db, !condition_expects_equality))
 }
 
@@ -1373,8 +1373,9 @@ fn known_literal_equality<'db>(
 ///
 /// Custom enum construction can replace the declared value, so members of such enums return `None`.
 fn enum_literal_value<'db>(db: &'db dyn Db, literal: EnumLiteralType<'db>) -> Option<Type<'db>> {
-    let metadata = enum_metadata(db, literal.enum_class(db))?;
-    let name = metadata.resolve_member(literal.name(db))?;
+    let enum_class_literal = literal.enum_class_literal(db);
+    let metadata = enum_metadata(db, enum_class_literal.class_literal(db))?;
+    let name = enum_class_literal.resolve_member(db, literal.name(db))?;
     if metadata.member_value_may_be_transformed(name) {
         return None;
     }
@@ -1391,11 +1392,10 @@ fn same_enum_member<'db>(
     left: EnumLiteralType<'db>,
     right: EnumLiteralType<'db>,
 ) -> bool {
-    if left.enum_class(db) != right.enum_class(db) {
+    let enum_class_literal = left.enum_class_literal(db);
+    if enum_class_literal != right.enum_class_literal(db) {
         return false;
     }
-    let Some(metadata) = enum_metadata(db, left.enum_class(db)) else {
-        return left == right;
-    };
-    metadata.resolve_member(left.name(db)) == metadata.resolve_member(right.name(db))
+    enum_class_literal.resolve_member(db, left.name(db))
+        == enum_class_literal.resolve_member(db, right.name(db))
 }

--- a/crates/ty_python_semantic/src/types/literal.rs
+++ b/crates/ty_python_semantic/src/types/literal.rs
@@ -3,6 +3,7 @@ use compact_str::CompactString;
 use ruff_python_ast::name::Name;
 
 use crate::Db;
+use crate::types::enums::EnumClassLiteral;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::{ClassLiteral, KnownClass, Type};
 use ty_python_core::definition::Definition;
@@ -385,8 +386,8 @@ impl<'db> BytesLiteralType<'db> {
 /// ```
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct EnumLiteralType<'db> {
-    /// A reference to the enum class this literal belongs to
-    pub(crate) enum_class: ClassLiteral<'db>,
+    /// The enum class this literal belongs to.
+    pub(crate) enum_class_literal: EnumClassLiteral<'db>,
     /// The name of the enum member
     #[returns(ref)]
     pub(crate) name: Name,
@@ -396,6 +397,10 @@ pub struct EnumLiteralType<'db> {
 impl get_size2::GetSize for EnumLiteralType<'_> {}
 
 impl<'db> EnumLiteralType<'db> {
+    pub(crate) fn enum_class(self, db: &'db dyn Db) -> ClassLiteral<'db> {
+        self.enum_class_literal(db).class_literal(db)
+    }
+
     pub(crate) fn enum_class_instance(self, db: &'db dyn Db) -> Type<'db> {
         self.enum_class(db).to_non_generic_instance(db)
     }

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -161,14 +161,15 @@ impl Ty {
             Ty::BooleanLiteral(b) => Type::bool_literal(b),
             Ty::LiteralString => Type::literal_string(),
             Ty::BytesLiteral(s) => Type::bytes_literal(db, s.as_bytes()),
-            Ty::EnumLiteral(name) => Type::enum_literal(EnumLiteralType::new(
-                db,
-                known_module_symbol(db, KnownModule::Uuid, "SafeUUID")
+            Ty::EnumLiteral(name) => {
+                let enum_class = known_module_symbol(db, KnownModule::Uuid, "SafeUUID")
                     .place
                     .expect_type()
-                    .expect_class_literal(),
-                Name::new(name),
-            )),
+                    .expect_class_literal()
+                    .into_enum_class(db)
+                    .expect("`uuid.SafeUUID` is an enum");
+                Type::enum_literal(EnumLiteralType::new(db, enum_class, Name::new(name)))
+            }
             Ty::SingleMemberEnumLiteral => {
                 let ty = known_module_symbol(db, KnownModule::Dataclasses, "MISSING")
                     .place

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -37,7 +37,7 @@
 //! (unless exactly the same literal type), we can avoid many unnecessary redundancy checks.
 
 use super::RecursivelyDefined;
-use crate::types::enums::{EnumComplement, enum_metadata};
+use crate::types::enums::EnumComplement;
 use crate::types::set_theoretic::expand_intersection_typevars_and_newtypes;
 use crate::types::{
     BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType, KnownClass,
@@ -165,7 +165,7 @@ fn normalize_enum_complement_unions<'db>(db: &'db dyn Db, types: &mut Vec<Type<'
             continue;
         };
         let enum_class = complement.enum_class(db);
-        let metadata = enum_metadata(db, enum_class).expect("Enum complement class is an enum");
+        let enum_class_literal = complement.enum_class_literal(db);
         let mut shared_excluded_names: FxHashSet<_> =
             complement.excluded_names(db).iter().cloned().collect();
 
@@ -197,7 +197,8 @@ fn normalize_enum_complement_unions<'db>(db: &'db dyn Db, types: &mut Vec<Type<'
                 continue;
             }
 
-            let Some(canonical_name) = metadata.resolve_member(enum_literal.name(db)) else {
+            let Some(canonical_name) = enum_class_literal.resolve_member(db, enum_literal.name(db))
+            else {
                 continue;
             };
             shared_excluded_names.remove(canonical_name);
@@ -210,14 +211,13 @@ fn normalize_enum_complement_unions<'db>(db: &'db dyn Db, types: &mut Vec<Type<'
             for rest in complement.rest(db) {
                 builder = builder.add_positive(*rest);
             }
-            for name in metadata
-                .members
-                .keys()
+            for name in enum_class_literal
+                .member_names(db)
                 .filter(|name| shared_excluded_names.contains(*name))
             {
                 builder = builder.add_negative(Type::enum_literal(EnumLiteralType::new(
                     db,
-                    enum_class,
+                    complement.enum_class_literal(db),
                     name.clone(),
                 )));
             }
@@ -788,18 +788,11 @@ impl<'db> UnionBuilder<'db> {
                         }
                     }
                     LiteralValueTypeKind::Enum(enum_member_to_add) => {
-                        let enum_class = enum_member_to_add.enum_class(self.db);
+                        let enum_class_literal = enum_member_to_add.enum_class_literal(self.db);
+                        let enum_class = enum_class_literal.class_literal(self.db);
+                        let enum_member_count = enum_class_literal.member_count(self.db);
 
-                        // We generally expect that a `Type::LiteralValue(LiteralValueTypeKind::Enum)`
-                        // value is in fact in enum, i.e., that `enum_metadata` returns `Some(...)`.
-                        // However, during cycle recovery, it's possible (empirically) to end up
-                        // in an inconsistent state. The metadata is only required for simplification
-                        // and not for correctness, so we treat it as optional here.
-                        // TODO: Come up with a design, either to enum metadata or the cycle
-                        // handling more broadly, that avoids this inconsistency.
-                        let metadata = enum_metadata(self.db, enum_class);
-
-                        if metadata.is_some_and(|metadata| metadata.members.len() == 1) {
+                        if enum_member_count == 1 {
                             self.add_in_place_impl(
                                 enum_member_to_add.enum_class_instance(self.db),
                                 seen_aliases,
@@ -852,9 +845,7 @@ impl<'db> UnionBuilder<'db> {
                                 ordermap::map::Entry::Vacant(entry) => {
                                     entry.insert(literal.is_promotable());
 
-                                    if metadata.is_some_and(|metadata| {
-                                        found.len() == metadata.members.len()
-                                    }) {
+                                    if found.len() == enum_member_count {
                                         self.add_in_place_impl(
                                             enum_member_to_add.enum_class_instance(self.db),
                                             seen_aliases,
@@ -1305,8 +1296,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 continue;
             };
 
-            let enum_class = instance.class_literal(db);
-            let Some(metadata) = enum_metadata(db, enum_class) else {
+            let Some(enum_class_literal) = instance.class_literal(db).into_enum_class(db) else {
                 continue;
             };
 
@@ -1315,12 +1305,14 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let Some(enum_literal) = negative.as_enum_literal() else {
                     continue;
                 };
-                if enum_literal.enum_class(db) != enum_class {
+                if enum_literal.enum_class_literal(db) != enum_class_literal {
                     continue;
                 }
 
                 let name = enum_literal.name(db);
-                let canonical_name = metadata.resolve_member(name).unwrap_or(name);
+                let Some(canonical_name) = enum_class_literal.resolve_member(db, name) else {
+                    continue;
+                };
                 excluded_names.insert(canonical_name.clone());
             }
 
@@ -1328,9 +1320,8 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 continue;
             }
 
-            if metadata
-                .members
-                .keys()
+            if enum_class_literal
+                .member_names(db)
                 .all(|name| excluded_names.contains(name))
             {
                 return true;


### PR DESCRIPTION
## Summary

On `main`, `EnumLiteralType` and `EnumComplementType` store a plain `ClassLiteral`. That identifies the class, but doesn't retain the fact that enum recognition "succeeded" or any of the enum data we need later on. So member lookup, union and intersection normalization, exhaustiveness checking, and alias resolution call `enum_metadata` again to recover the member set, aliases, and value types.

Those repeated queries are problematic because `enum_metadata` depends on inference, while inference itself performs normalization and member lookup on enum literals and complements. Querying the metadata again from those derived types can add a dependency back into the computation that created them, introducing a Salsa cycle. 

During cycle recovery, callers can observe unavailable or provisional metadata even though they already have an enum-specific type; `UnionBuilder` already has fallback logic and a TODO for this.

This PR introduces `EnumClassLiteral`, which pairs the underlying `ClassLiteral` with the canonical member names, member value types, and aliases captured when the class is recognized as an enum. `ClassLiteral::into_enum_class` becomes the recognition and materialization boundary, and `EnumLiteralType` and `EnumComplementType` store the resulting witness instead of a bare class literal.
