### PR TITLE
[ty] Retain recursively-defined state in binary expressions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -100,6 +100,18 @@ reveal_type(C().FINAL_D)  # revealed: Literal[1]
 reveal_type(C().FINAL_E)  # revealed: int
 ```
 
+### Recursive bare `Final` instance attribute
+
+```py
+from __future__ import annotations
+
+from typing import Final
+
+class ScopeChain:
+    def __init__(self, parent: ScopeChain | None = None) -> None:
+        self.depth: Final = 1 if parent is None else parent.depth + 1
+```
+
 ## Not modifiable
 
 ### Names

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -8,6 +8,7 @@ use crate::types::cyclic::CycleDetector;
 use crate::types::diagnostic::{
     DIVISION_BY_ZERO, report_unsupported_augmented_assignment, report_unsupported_binary_operation,
 };
+use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::typevar::TypeVarConstraints;
 use crate::types::{
     DynamicType, InternedConstraintSet, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -550,7 +551,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             (Type::Never, _, _) | (_, Type::Never, _) => Some(Type::Never),
 
             (Type::LiteralValue(left), Type::LiteralValue(right), _) => {
-                match (left.kind(), right.kind(), op) {
+                let recursively_defined = if left.recursively_defined().is_yes()
+                    || right.recursively_defined().is_yes()
+                {
+                    RecursivelyDefined::Yes
+                } else {
+                    RecursivelyDefined::No
+                };
+                let result = match (left.kind(), right.kind(), op) {
                     (
                         LiteralValueTypeKind::Int(n),
                         LiteralValueTypeKind::Int(m),
@@ -827,7 +835,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
 
                     _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
-                }
+                };
+
+                result.map(|result| match result {
+                    Type::LiteralValue(literal) => {
+                        Type::LiteralValue(literal.with_recursively_defined(recursively_defined))
+                    }
+                    _ => result,
+                })
             }
 
             (


### PR DESCRIPTION
## Summary

Prior to this change, a recursive implicit attribute like:

```python
from __future__ import annotations
from typing import Final

class ScopeChain:
    def __init__(self, parent: ScopeChain | None = None) -> None:
        self.depth: Final = 1 if parent is None else parent.depth + 1
```

...could fail to converge during type inference. We now preserve the recursive-definition marker when literal binary operations produce a new literal result, so recursive literal unions continue through the existing widening path instead of accumulating results indefinitely.

Note: in the above snippet, the bare `Final` exposes the issue because we infer the RHS to get the type, as opposed to relying on the annotation, but in theory it needn't be specific to `Final`... Codex believes this is the only way to trigger that panic as of now, though because it's the only site where we create a recursive attribute lookup _and_ retain the exact RHS literal type (e.g., the non-`Final` version, `self.depth = 1 if parent is None else parent.depth + 1`, promotes those literals).

Closes https://github.com/astral-sh/ty/issues/3499.
