### PR TITLE
[ty] Full-scope bidirectional inference for unconstrained container literals

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -202,7 +202,7 @@ static SYMPY: Benchmark = Benchmark::new(
         max_dep_date: "2025-06-17",
         python_version: SupportedPythonVersion::Py312,
     },
-    14150,
+    14250,
 );
 
 static TANJUN: Benchmark = Benchmark::new(

--- a/crates/ruff_python_ast/src/node_index.rs
+++ b/crates/ruff_python_ast/src/node_index.rs
@@ -217,6 +217,18 @@ impl PartialEq for AtomicNodeIndex {
     }
 }
 
+impl PartialEq<NodeIndex> for AtomicNodeIndex {
+    fn eq(&self, other: &NodeIndex) -> bool {
+        self.load() == *other
+    }
+}
+
+impl PartialEq<AtomicNodeIndex> for NodeIndex {
+    fn eq(&self, other: &AtomicNodeIndex) -> bool {
+        *self == other.load()
+    }
+}
+
 impl Clone for AtomicNodeIndex {
     fn clone(&self) -> Self {
         Self(AtomicU32::from(self.0.load(Ordering::Relaxed)))

--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -102,10 +102,12 @@ impl AstIdsBuilder {
     /// Adds `expr` to the use ids map and returns its id.
     pub(super) fn record_use(&mut self, expr: impl Into<ExpressionNodeKey>) -> ScopedUseId {
         let use_id = self.uses_map.len().into();
-
         self.uses_map.insert(expr.into(), use_id);
-
         use_id
+    }
+
+    pub(super) fn try_use_id(&self, key: impl Into<ExpressionNodeKey>) -> Option<ScopedUseId> {
+        self.uses_map.get(&key.into()).copied()
     }
 
     pub(super) fn finish(mut self) -> AstIds {

--- a/crates/ty_python_core/src/ast_node_ref.rs
+++ b/crates/ty_python_core/src/ast_node_ref.rs
@@ -52,7 +52,7 @@ pub struct AstNodeRef<T> {
 }
 
 impl<T> AstNodeRef<T> {
-    pub(crate) fn index(&self) -> NodeIndex {
+    pub fn index(&self) -> NodeIndex {
         self.index
     }
 }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -189,7 +189,7 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     enclosing_lambda_statements: FxHashMap<ExpressionNodeKey, Statement<'db>>,
     // A map from a constraining use of a collection literal to its definition.
     collections_by_use: FxHashMap<ExpressionNodeKey, Definition<'db>>,
-    // A map from a collection literal definition to a statement containing a constraining use.
+    // A map from a collection literal definition to statements containing a constraining use.
     uses_by_collection: FxHashMap<Definition<'db>, Vec<(Statement<'db>, ExpressionNodeKey)>>,
     /// Hashset of all [`FileScopeId`]s that correspond to [generator functions].
     ///
@@ -3498,6 +3498,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     // participants, and the reachability analysis of a given use of the
                     // collection may create dependencies on all previous uses, leading to
                     // significant performance regressions.
+                    //
+                    // Note that built-in collection types do not have methods that explicitly
+                    // return `Never`, so does not have a meaningful semantic impact, except in
+                    // the rare case where a collection is explicitly marked as having elements
+                    // of type `Never`.
                     if !self.source_type.is_stub()
                         && func
                             .as_attribute_expr()
@@ -3580,7 +3585,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                         }
                     }
 
-                    // An annotated assignment involving the collection object to a new binding.
+                    // An annotated assignment assigning the collection object to a new binding.
                     ruff_python_ast::Stmt::AnnAssign(_) => true,
 
                     // A bound-method call on the collection object.

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -151,7 +151,7 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     current_assignments: Vec<CurrentAssignment<'ast, 'db>>,
     /// The statements we're currently visiting, with
     /// the most recent visit at the end of the Vec.
-    current_statements: Vec<CurrentStatement<'ast>>,
+    current_statements: Vec<CurrentStatement<'ast, 'db>>,
     /// The match case we're currently visiting.
     current_match_case: Option<CurrentMatchCase<'ast>>,
     /// The name of the first function parameter of the innermost function that we're currently visiting.
@@ -183,9 +183,14 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
     condition_flow_snapshots_by_node: FxHashMap<ExpressionNodeKey, ConditionFlowSnapshots>,
     statements_by_node: FxHashMap<StatementNodeKey, Statement<'db>>,
-    enclosing_lambda_statements: FxHashMap<ExpressionNodeKey, Statement<'db>>,
     imported_modules: FxHashSet<ModuleName>,
     seen_submodule_imports: FxHashSet<String>,
+    // A map from a lambda expression to its enclosing statement.
+    enclosing_lambda_statements: FxHashMap<ExpressionNodeKey, Statement<'db>>,
+    // A map from a constraining use of a collection literal to its definition.
+    collections_by_use: FxHashMap<ExpressionNodeKey, Definition<'db>>,
+    // A map from a collection literal definition to a statement containing a constraining use.
+    uses_by_collection: FxHashMap<Definition<'db>, Vec<(Statement<'db>, ExpressionNodeKey)>>,
     /// Hashset of all [`FileScopeId`]s that correspond to [generator functions].
     ///
     /// [generator functions]: https://docs.python.org/3/glossary.html#term-generator
@@ -233,6 +238,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             condition_flow_snapshots_by_node: FxHashMap::default(),
             statements_by_node: FxHashMap::default(),
             enclosing_lambda_statements: FxHashMap::default(),
+            collections_by_use: FxHashMap::default(),
+            uses_by_collection: FxHashMap::default(),
 
             seen_submodule_imports: FxHashSet::default(),
             imported_modules: FxHashSet::default(),
@@ -765,9 +772,38 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         &mut self.use_def_maps[scope_id].reachability_constraints
     }
 
-    fn current_ast_ids(&mut self) -> &mut AstIdsBuilder {
+    fn current_ast_ids(&self) -> &AstIdsBuilder {
+        let scope_id = self.current_scope();
+        &self.ast_ids[scope_id]
+    }
+
+    fn current_ast_ids_mut(&mut self) -> &mut AstIdsBuilder {
         let scope_id = self.current_scope();
         &mut self.ast_ids[scope_id]
+    }
+
+    /// If the given expression is a use of an unconstrained collection literal, returns
+    /// the definition of the collection literal.
+    fn unconstrained_collection_literal_binding(
+        &self,
+        collection_use: &ast::Expr,
+    ) -> Option<Definition<'db>> {
+        let use_def = self.current_use_def_map();
+        let use_id = self.current_ast_ids().try_use_id(collection_use)?;
+
+        use_def
+            .bindings_at_use(use_id)
+            .filter_map(|binding| use_def.definition(binding.binding()).definition())
+            .filter(|definition| {
+                definition
+                    .kind(self.db)
+                    .as_unannotated_assignment()
+                    .is_some_and(|assignment| {
+                        is_unconstrained_collection_literal(assignment.value(self.module))
+                    })
+            })
+            .exactly_one()
+            .ok()
     }
 
     /// Try to register a narrowing alias for a simple name assignment.
@@ -1006,7 +1042,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         if let ScopedPlaceId::Symbol(symbol_id) = place_id {
             self.mark_symbol_used(symbol_id);
         }
-        let use_id = self.current_ast_ids().record_use(expr);
+        let use_id = self.current_ast_ids_mut().record_use(expr);
         self.current_use_def_map_mut().record_use(place_id, use_id);
     }
 
@@ -1599,15 +1635,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.current_assignments.last_mut()
     }
 
-    fn push_statement(&mut self, statement: CurrentStatement<'ast>) {
+    fn push_statement(&mut self, statement: CurrentStatement<'ast, 'db>) {
         self.current_statements.push(statement);
     }
 
-    fn pop_statement(&mut self) -> CurrentStatement<'ast> {
+    fn pop_statement(&mut self) -> CurrentStatement<'ast, 'db> {
         self.current_statements.pop().unwrap()
     }
 
-    fn current_statement_mut(&mut self) -> Option<&mut CurrentStatement<'ast>> {
+    fn current_statement_mut(&mut self) -> Option<&mut CurrentStatement<'ast, 'db>> {
         self.current_statements.last_mut()
     }
 
@@ -1792,11 +1828,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ast::Stmt::ClassDef(class) => {
                 Some(Statement::Definition(self.expect_single_definition(class)))
             }
-            ast::Stmt::Expr(expr) => self
-                .expressions_by_node
-                .get(&(&expr.value).into())
-                .copied()
-                .map(Statement::Expression),
+            ast::Stmt::Expr(ast::StmtExpr { value, .. }) => {
+                Some(Statement::Expression(self.add_standalone_expression(value)))
+            }
             ast::Stmt::Assign(assign) => {
                 if let [ast::Expr::Name(name)] = &assign.targets[..] {
                     Some(Statement::Definition(self.expect_single_definition(name)))
@@ -1829,6 +1863,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         self.statements_by_node
             .insert(statement_node.into(), statement);
+
         statement
     }
 
@@ -2196,6 +2231,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.definitions_by_node.shrink_to_fit();
         self.statements_by_node.shrink_to_fit();
         self.enclosing_lambda_statements.shrink_to_fit();
+        self.collections_by_use.shrink_to_fit();
+        self.uses_by_collection.shrink_to_fit();
 
         self.scope_ids_by_scope.shrink_to_fit();
         self.scopes_by_node.shrink_to_fit();
@@ -2214,6 +2251,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             scopes_by_node: self.scopes_by_node,
             use_def_maps,
             enclosing_lambda_statements: self.enclosing_lambda_statements,
+            collections_by_use: self.collections_by_use,
+            uses_by_collection: self.uses_by_collection,
             imported_modules: Arc::new(self.imported_modules),
             has_future_annotations: self.has_future_annotations,
             enclosing_snapshots: self.enclosing_snapshots,
@@ -2304,7 +2343,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // used to collect all the overloaded definitions of a function. This needs to be
                 // done on the `Identifier` node as opposed to `ExprName` because that's what the
                 // AST uses.
-                let use_id = self.current_ast_ids().record_use(name);
+                let use_id = self.current_ast_ids_mut().record_use(name);
                 self.current_use_def_map_mut()
                     .record_use(symbol.into(), use_id);
 
@@ -2634,6 +2673,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 self.visit_expr(&node.value);
 
+                // Unconstrained collection literals must be standalone expressions to participate
+                // in full-scope bidirectional inference.
+                if node.targets.len() == 1 && is_unconstrained_collection_literal(&node.value) {
+                    self.add_standalone_assigned_expression(&node.value, node);
+                }
+
                 // Optimization for the common case: if there's just one target, and it's not an
                 // unpacking, and the target is a simple name, we don't need the RHS to be a
                 // standalone expression at all.
@@ -2930,6 +2975,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 } in items
                 {
                     self.visit_expr(context_expr);
+
                     if let Some(optional_vars) = optional_vars.as_deref() {
                         let context_manager = self.add_standalone_expression(context_expr);
                         self.add_unpackable_assignment(
@@ -3445,7 +3491,21 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 };
 
                 if let Some((func, expr, is_await)) = call_info {
-                    if !self.source_type.is_stub() {
+                    // Avoid creating reachability nodes for calls on unconstrained collection
+                    // literals. Without this short-circuit, performing reachability analysis
+                    // can lead to quadratic blowup of cycle dependencies during full-scope
+                    // collection inference, as Salsa flattens the dependencies of all cycle
+                    // participants, and the reachability analysis of a given use of the
+                    // collection may create dependencies on all previous uses, leading to
+                    // significant performance regressions.
+                    if !self.source_type.is_stub()
+                        && func
+                            .as_attribute_expr()
+                            .and_then(|attribute| {
+                                self.unconstrained_collection_literal_binding(&attribute.value)
+                            })
+                            .is_none()
+                    {
                         let callable = self.add_standalone_expression(func);
                         let call_expr = self.add_standalone_expression(expr);
 
@@ -3495,23 +3555,88 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
 impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
     fn visit_stmt(&mut self, stmt: &'ast ast::Stmt) {
-        self.push_statement(CurrentStatement {
-            lambda_exprs: Vec::new(),
-        });
-
+        self.push_statement(CurrentStatement::default());
         self.visit_stmt_impl(stmt);
+        let mut current_statement = self.pop_statement();
 
-        let current_statement = self.pop_statement();
-        if !current_statement.lambda_exprs.is_empty() {
-            // The body of a lambda expression needs access to the `Callable` type
-            // context the lambda is being inferred with, and so any statement
-            // containing a lambda must be inferable as a standalone statement
-            // to avoid large scope-level cycles.
-            let standalone_stmt = self.add_standalone_statement(stmt);
-            for lambda in current_statement.lambda_exprs {
-                self.enclosing_lambda_statements
-                    .insert(lambda.into(), standalone_stmt);
+        // We currently only consider certain types of statements to introduce constraints
+        // on collection literals. This restriction is mostly for performance reasons, as we
+        // want to avoid "reads" of a collection contributing to the complexity of the cycles
+        // created by full-scope collection inference.
+        current_statement
+            .collection_uses
+            .retain(|(_, use_expression)| {
+                match stmt {
+                    // A return involving the collection object.
+                    ruff_python_ast::Stmt::Return(_) => true,
+
+                    // A subscript assignment on the collection object.
+                    ruff_python_ast::Stmt::Assign(ast::StmtAssign { targets, .. }) => {
+                        match targets.as_slice() {
+                            [ast::Expr::Subscript(ast::ExprSubscript { value, .. })] => {
+                                ExpressionNodeKey::from(value) == *use_expression
+                            }
+                            _ => false,
+                        }
+                    }
+
+                    // An annotated assignment involving the collection object to a new binding.
+                    ruff_python_ast::Stmt::AnnAssign(_) => true,
+
+                    // A bound-method call on the collection object.
+                    ruff_python_ast::Stmt::Expr(ast::StmtExpr { value, .. }) => {
+                        match value.as_ref() {
+                            ast::Expr::Call(ast::ExprCall { func, .. }) => match func.as_ref() {
+                                ruff_python_ast::Expr::Attribute(ast::ExprAttribute {
+                                    value,
+                                    ..
+                                }) => ExpressionNodeKey::from(value) == *use_expression,
+                                _ => false,
+                            },
+                            _ => false,
+                        }
+                    }
+
+                    _ => false,
+                }
+            });
+
+        if current_statement.lambda_expressions.is_empty()
+            && current_statement.collection_uses.is_empty()
+        {
+            return;
+        }
+
+        let standalone_statement = self.add_standalone_statement(stmt);
+
+        // The body of a lambda expression needs access to the `Callable` type
+        // context the lambda is being inferred with, and so any statement
+        // containing a lambda must be inferable as a standalone statement
+        // to avoid large scope-level cycles.
+        for lambda in current_statement.lambda_expressions {
+            self.enclosing_lambda_statements
+                .insert(lambda.into(), standalone_statement);
+        }
+
+        // The inferred element type of collection literal depends on uses of
+        // the collection in its containing scope, and so each use must be part
+        // of an standalone inferable statement to avoid large scope-level cycles.
+        let mut collection_defs = FxHashSet::default();
+        for (collection_def, use_expression) in current_statement.collection_uses {
+            // If the same collection is referenced multiple times in this statement,
+            // we only consider the first occurrence, as collection use constraints are
+            // tracked at the statement level.
+            if !collection_defs.insert(collection_def) {
+                continue;
             }
+
+            self.uses_by_collection
+                .entry(collection_def)
+                .or_default()
+                .push((standalone_statement, use_expression));
+
+            self.collections_by_use
+                .insert(use_expression, collection_def);
         }
     }
 
@@ -3617,12 +3742,25 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
 
                 if let Some((place_expr, is_use, is_definition)) = deferred_effects {
                     let place_id = self.add_place(place_expr);
+
                     if is_use {
                         self.record_place_use(place_id, expr);
+
+                        // Keep track of any uses of collection literals.
+                        if let Some(collection_def) =
+                            self.unconstrained_collection_literal_binding(expr)
+                            && let Some(current_statement) = self.current_statements.last_mut()
+                        {
+                            current_statement
+                                .collection_uses
+                                .push((collection_def, expr.into()));
+                        }
                     }
+
                     if is_definition {
                         self.record_place_definition(place_id, expr);
                     }
+
                     if let Some(unpack_position) = self
                         .current_assignment_mut()
                         .and_then(CurrentAssignment::unpack_position_mut)
@@ -3647,7 +3785,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
             ast::Expr::Lambda(lambda) => {
                 self.current_statement_mut()
                     .expect("every lambda expression is part of a statement")
-                    .lambda_exprs
+                    .lambda_expressions
                     .push(lambda);
 
                 if let Some(parameters) = &lambda.parameters {
@@ -4108,9 +4246,12 @@ impl<'ast> From<&'ast ast::ExprNamed> for CurrentAssignment<'ast, '_> {
     }
 }
 
-struct CurrentStatement<'ast> {
-    /// The lambda expressions part of this statement.
-    lambda_exprs: Vec<&'ast ast::ExprLambda>,
+#[derive(Default)]
+struct CurrentStatement<'ast, 'db> {
+    /// A list of lambda expressions contained in this statement.
+    lambda_expressions: Vec<&'ast ast::ExprLambda>,
+    /// A list of collection definitions whose uses are contained in this statement.
+    collection_uses: Vec<(Definition<'db>, ExpressionNodeKey)>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -4311,4 +4452,13 @@ fn is_if_not_type_checking(expr: &ast::Expr) -> bool {
             ..
         }) if is_if_type_checking(operand)
     )
+}
+
+pub(crate) fn is_unconstrained_collection_literal(expr: &ast::Expr) -> bool {
+    match expr {
+        ast::Expr::List(list) => list.elts.is_empty(),
+        ast::Expr::Set(set) => set.elts.is_empty(),
+        ast::Expr::Dict(dict) => dict.items.is_empty(),
+        _ => false,
+    }
 }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -802,6 +802,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         is_unconstrained_collection_literal(assignment.value(self.module))
                     })
             })
+            // TODO: Support uses that refer to multiple definitions. This currently seems to lead to
+            // cycle-related panics.
             .exactly_one()
             .ok()
     }

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -867,7 +867,7 @@ pub enum DefinitionKind<'db> {
     LoopHeader(LoopHeaderDefinitionKind<'db>),
 }
 
-impl DefinitionKind<'_> {
+impl<'db> DefinitionKind<'db> {
     pub fn is_reexported(&self) -> bool {
         match self {
             DefinitionKind::Import(import) => import.is_reexported(),
@@ -903,6 +903,13 @@ impl DefinitionKind<'_> {
 
     pub const fn is_unannotated_assignment(&self) -> bool {
         matches!(self, DefinitionKind::Assignment(_))
+    }
+
+    pub fn as_unannotated_assignment(&self) -> Option<AssignmentDefinitionKind<'db>> {
+        match self {
+            DefinitionKind::Assignment(assignment) => Some(assignment.clone()),
+            _ => None,
+        }
     }
 
     pub const fn is_function_def(&self) -> bool {
@@ -1494,6 +1501,12 @@ pub struct DefinitionNodeKey(NodeKey);
 impl DefinitionNodeKey {
     pub(crate) fn from_node_ref(node: ast::AnyNodeRef<'_>) -> Self {
         Self(NodeKey::from_node(node))
+    }
+
+    pub fn from_assignment(node: &ast::StmtAssign) -> impl Iterator<Item = DefinitionNodeKey> {
+        node.targets
+            .iter()
+            .map(|target| Self(NodeKey::from_node(target)))
     }
 }
 

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -286,7 +286,7 @@ pub struct SemanticIndex<'db> {
     // Map from a constraining use of a collection literal to its definition.
     collections_by_use: FxHashMap<ExpressionNodeKey, Definition<'db>>,
 
-    // Map from a collection literal definition to a statement containing a constraining use.
+    // Map from a collection literal definition to statements containing a constraining use.
     uses_by_collection: FxHashMap<Definition<'db>, Vec<(Statement<'db>, ExpressionNodeKey)>>,
 
     /// Map from the file-local [`FileScopeId`] to the salsa-ingredient [`ScopeId`].

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -2,6 +2,7 @@ use ruff_python_ast as ast;
 use std::iter::{FusedIterator, once};
 use std::sync::Arc;
 
+use itertools::Itertools;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_index::{IndexSlice, IndexVec};
@@ -282,6 +283,12 @@ pub struct SemanticIndex<'db> {
     /// Map from a lambda expression to its containing statement.
     enclosing_lambda_statements: FxHashMap<ExpressionNodeKey, Statement<'db>>,
 
+    // Map from a constraining use of a collection literal to its definition.
+    collections_by_use: FxHashMap<ExpressionNodeKey, Definition<'db>>,
+
+    // Map from a collection literal definition to a statement containing a constraining use.
+    uses_by_collection: FxHashMap<Definition<'db>, Vec<(Statement<'db>, ExpressionNodeKey)>>,
+
     /// Map from the file-local [`FileScopeId`] to the salsa-ingredient [`ScopeId`].
     scope_ids_by_scope: IndexVec<FileScopeId, ScopeId<'db>>,
 
@@ -454,6 +461,27 @@ impl<'db> SemanticIndex<'db> {
         self.enclosing_lambda_statements.get(&lambda).copied()
     }
 
+    /// If this is a potentially constraining use of an unconstrained collection literal, returns
+    /// its definition.
+    pub fn unconstrained_collection_binding(
+        &self,
+        collection_use: &ast::Expr,
+    ) -> Option<Definition<'db>> {
+        self.collections_by_use.get(&collection_use.into()).copied()
+    }
+
+    /// Returns all potentially constraining uses of the given unnannotated collection literal.
+    pub fn constraining_collection_uses(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> impl Iterator<Item = (Statement<'db>, ExpressionNodeKey)> {
+        self.uses_by_collection
+            .get(&collection_def)
+            .into_iter()
+            .flatten()
+            .copied()
+    }
+
     pub fn is_in_type_checking_block(&self, scope_id: FileScopeId, range: TextRange) -> bool {
         self.ancestor_scopes(scope_id).any(|(scope_id, _)| {
             self.use_def_map(scope_id)
@@ -536,6 +564,18 @@ impl<'db> SemanticIndex<'db> {
             definitions.len()
         );
         definitions[0]
+    }
+
+    pub fn try_definition(
+        &self,
+        definition_key: impl Into<DefinitionNodeKey>,
+    ) -> Option<Definition<'db>> {
+        self.definitions_by_node
+            .get(&definition_key.into())?
+            .iter()
+            .copied()
+            .exactly_one()
+            .ok()
     }
 
     /// Returns the [`Expression`] ingredient for an expression node.

--- a/crates/ty_python_core/src/node_key.rs
+++ b/crates/ty_python_core/src/node_key.rs
@@ -3,7 +3,9 @@ use ruff_python_ast::{HasNodeIndex, NodeIndex};
 use crate::ast_node_ref::AstNodeRef;
 
 /// Compact key for a node for use in a hash map.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, get_size2::GetSize)]
+#[derive(
+    Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, salsa::Update, get_size2::GetSize,
+)]
 pub struct NodeKey(NodeIndex);
 
 impl NodeKey {

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1003,6 +1003,10 @@ impl<'db> UseDefMapBuilder<'db> {
         def_id
     }
 
+    pub(super) fn definition(&self, def_id: ScopedDefinitionId) -> DefinitionState<'db> {
+        self.all_definitions[def_id]
+    }
+
     pub(super) fn mark_unreachable(&mut self) {
         self.reachability = ScopedReachabilityConstraintId::ALWAYS_FALSE;
 
@@ -1102,6 +1106,13 @@ impl<'db> UseDefMapBuilder<'db> {
             place.is_symbol(),
             PreviousDefinitions::AreKept,
         );
+    }
+
+    pub(crate) fn bindings_at_use(
+        &self,
+        use_id: ScopedUseId,
+    ) -> impl Iterator<Item = &LiveBinding> {
+        self.bindings_by_use[use_id].iter()
     }
 
     pub(super) fn add_predicate(

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -761,6 +761,162 @@ async def _():
     reveal_type(x3)  # revealed: list[int | None]
 ```
 
+## Container inference
+
+Empty, unannotated container literals are inferred based on future uses that extend throughout the
+entire scope:
+
+```py
+x1 = []
+x1.append(1)
+x1.append("2")
+reveal_type(x1)  # revealed: list[int | str]
+```
+
+```py
+class X:
+    def __init__(self):
+        self.x = []
+        self.x.append(1)
+        self.x.append("2")
+        reveal_type(self.x)  # revealed: list[int | str]
+```
+
+```py
+def _(flag: bool):
+    if flag:
+        x2 = []
+        x2.append(1)
+        reveal_type(x2)  # revealed: list[int]
+    else:
+        x2 = []
+        x2.append("2")
+        reveal_type(x2)  # revealed: list[str]
+```
+
+```py
+def takes_list_int(x: list[int]): ...
+
+x3 = []
+takes_list_int(x3)
+# TODO: This should reveal `list[int]`, but we do not currently record
+# argument constraints for arbitrary function calls.
+reveal_type(x3)  # revealed: list[Unknown]
+```
+
+```py
+def append[T](x: list[T], y: T):
+    x.append(y)
+
+x4 = []
+append(x4, 1)
+append(x4, "2")
+# TODO: This should reveal `list[int | str]`, but we do not currently record
+# argument constraints for arbitrary function calls.
+reveal_type(x4)  # revealed: list[Unknown]
+```
+
+```py
+x5 = []
+_: list[int] = reveal_type(x5)  # revealed: list[int]
+```
+
+```py
+def _() -> list[int | None]:
+    x6 = []
+    return reveal_type(x6)  # revealed: list[int | None]
+
+def _() -> int:
+    invalid_x6 = []
+    return invalid_x6  # error: [invalid-return-type]
+```
+
+```py
+x7 = []
+x7[:] = [1, "2", 3.0]
+reveal_type(x7)  # revealed: list[int | str | float]
+```
+
+```py
+from typing import Literal
+
+x8 = []
+one: Literal[1] = 1
+x8.append(one)
+reveal_type(x8)  # revealed: list[Literal[1]]
+```
+
+```py
+x9 = []
+x10 = []
+x9.append(1)
+x9.append("2")
+x10.append(3)
+
+reveal_type(x9)  # revealed: list[int | str]
+reveal_type(x10)  # revealed: list[int]
+```
+
+```py
+x11 = []
+x12 = []
+x11.append(1)
+x12.append(x11)
+
+reveal_type(x11)  # revealed: list[int]
+reveal_type(x12)  # revealed: list[list[int]]
+```
+
+```py
+x13 = []
+x13.append(x13)
+reveal_type(x13)  # revealed: list[Divergent]
+```
+
+```py
+x14 = []
+x15 = []
+
+x14.append(x15)
+x15.append(x14)
+
+reveal_type(x14)  # revealed: list[Divergent]
+reveal_type(x15)  # revealed: list[Divergent]
+```
+
+```py
+def _(i):
+    x16 = []
+    x16.append(x16)
+    reveal_type(x16)  # revealed: list[Divergent]
+```
+
+```py
+x17 = {}
+x17.update(a=1)
+reveal_type(x17)  # revealed: dict[str, int]
+```
+
+```py
+x18 = {}
+x18.update({"a": 1})
+reveal_type(x18)  # revealed: dict[str, int]
+```
+
+```py
+x19 = {}
+x19["a"] = 1
+x19["b"] = "2"
+reveal_type(x19)  # revealed: dict[str, int | str]
+```
+
+```py
+x20 = {}
+x20["a"] = len(x20)
+x20.setdefault("b", str(len(x20)))
+reveal_type(x20)  # revealed: dict[str, int | str]
+```
+
 ## Multi-inference diagnostics
 
 Diagnostics unrelated to the type-context are only reported once:

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -919,6 +919,20 @@ x20.setdefault("b", str(len(x20)))
 reveal_type(x20)  # revealed: dict[str, int | str]
 ```
 
+```py
+x21 = []
+_: list[int] = x21  # error: [invalid-assignment]
+
+# TODO: We should error on this `append` instead of the assignment and not union
+# later constraints after the element type has been fully constrained above, to
+# avoid confusing error messages where the type of the collection may be unexpectedly
+# influenced by uses later in the scope.
+x21.append("a")
+
+# TODO: This would then reveal `list[int]`.
+reveal_type(x21)  # revealed: list[int | str]
+```
+
 ## Multi-inference diagnostics
 
 Diagnostics unrelated to the type-context are only reported once:

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -933,6 +933,19 @@ x21.append("a")
 reveal_type(x21)  # revealed: list[int | str]
 ```
 
+```py
+def _(flag: bool):
+    if flag:
+        x22 = []
+    else:
+        x22 = []
+
+    x22.append(1)
+
+    # TODO: This should reveal `list[int]`.
+    reveal_type(x22)  # revealed: list[Unknown]
+```
+
 ## Multi-inference diagnostics
 
 Diagnostics unrelated to the type-context are only reported once:

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -780,6 +780,8 @@ class X:
         self.x.append(1)
         self.x.append("2")
         reveal_type(self.x)  # revealed: list[int | str]
+
+reveal_type(X().x)  # revealed: list[int | str]
 ```
 
 ```py

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -221,3 +221,10 @@ impl IOErrorDiagnostic {
         diag
     }
 }
+
+/// Many type-inference queries union together results from previous iterations to
+/// ensure convergence. However, the first couple iterations are often prone to get
+/// values that will soon converge, but where unioning in the early value causes an
+/// unrecoverable loss of precision. This constant controls how many iterations
+/// are considered likely to produce "tainted" results that should be discarded.
+pub(crate) const TAINTED_CYCLES: u32 = 1;

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1332,7 +1332,7 @@ impl<'db> LoopHeaderReachability<'db> {
     ) -> LoopHeaderReachability<'db> {
         // Avoid losing precision for cycles that are soon to converge.
         // See [`Type::cycle_normalized`] for more details.
-        let reachable_bindings = if cycle.iteration() <= 1 {
+        let reachable_bindings = if cycle.iteration() <= crate::TAINTED_CYCLES {
             self.reachable_bindings
         } else {
             let previous_bindings = previous.reachable_bindings.iter().copied();

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -203,6 +203,7 @@ use crate::{
         infer_narrowing_constraint,
     },
 };
+use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -219,11 +220,11 @@ use ty_python_core::{
     reachability_constraints::{ReachabilityConstraints, ScopedReachabilityConstraintId},
 };
 
-fn singleton_to_type(db: &dyn Db, singleton: ruff_python_ast::Singleton) -> Type<'_> {
+fn singleton_to_type(db: &dyn Db, singleton: ast::Singleton) -> Type<'_> {
     let ty = match singleton {
-        ruff_python_ast::Singleton::None => Type::none(db),
-        ruff_python_ast::Singleton::True => Type::bool_literal(true),
-        ruff_python_ast::Singleton::False => Type::bool_literal(false),
+        ast::Singleton::None => Type::none(db),
+        ast::Singleton::True => Type::bool_literal(true),
+        ast::Singleton::False => Type::bool_literal(false),
     };
     debug_assert!(ty.is_singleton(db));
     ty

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -896,6 +896,13 @@ impl<'db> Type<'db> {
         matches!(self, Type::Divergent(_))
     }
 
+    pub(crate) const fn as_divergent(self) -> Option<DivergentType> {
+        match self {
+            Type::Divergent(divergent) => Some(divergent),
+            _ => None,
+        }
+    }
+
     /// Returns `true` if both `self` and `other` are `Divergent` types originating from the
     /// same cycle (i.e., sharing the same query ID), regardless of materialization state.
     fn same_divergent_marker(self, other: Type<'db>) -> bool {
@@ -1014,7 +1021,7 @@ impl<'db> Type<'db> {
         // So we avoid unioning in the first couple iterations, and just use the later iteration's
         // result directly. We still ensure monotonicity after the first couple iterations, which
         // still ensures convergence in cases that are prone to oscillation.
-        if cycle.iteration() <= 1 {
+        if cycle.iteration() <= crate::TAINTED_CYCLES {
             self
         } else {
             // The current type is unioned to the previous type. Unioning in the reverse order can
@@ -1206,12 +1213,20 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         expected_class: StaticClassLiteral<'_>,
     ) -> Option<Specialization<'db>> {
-        self.specialization_of_optional(db, Some(expected_class))
+        self.nominal_class(db)?
+            .static_class_literal(db)
+            .filter(|(class_literal, _)| *class_literal == expected_class)
+            .and_then(|(_, specialization)| specialization)
     }
 
-    /// If this type is a class instance, returns its specialization.
-    pub(crate) fn class_specialization(self, db: &'db dyn Db) -> Option<Specialization<'db>> {
-        self.specialization_of_optional(db, None)
+    /// If this type is a class instance, returns the class and its specialization.
+    pub(crate) fn class_specialization(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<(StaticClassLiteral<'db>, Specialization<'db>)> {
+        self.nominal_class(db)?
+            .static_class_literal(db)
+            .and_then(|(class_literal, specialization)| Some((class_literal, specialization?)))
     }
 
     /// If this type is a class instance, returns its class.
@@ -1231,21 +1246,6 @@ impl<'db> Type<'db> {
             }
             _ => None,
         }
-    }
-
-    fn specialization_of_optional(
-        self,
-        db: &'db dyn Db,
-        expected_class: Option<StaticClassLiteral<'_>>,
-    ) -> Option<Specialization<'db>> {
-        let class_type = self.nominal_class(db)?;
-
-        let (class_literal, specialization) = class_type.static_class_literal(db)?;
-        if expected_class.is_some_and(|expected_class| expected_class != class_literal) {
-            return None;
-        }
-
-        specialization
     }
 
     /// Returns `true` if this type may contain preferred type mappings when provided as type context
@@ -2083,7 +2083,7 @@ impl<'db> Type<'db> {
         f: &mut dyn FnMut(Type<'db>, TypeVarVariance),
         visitor: &SpecializationVisitor<'db>,
     ) {
-        let Some(specialization) = self.class_specialization(db) else {
+        let Some((_, specialization)) = self.class_specialization(db) else {
             match self {
                 Type::Union(union) => {
                     for element in union.elements(db) {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1698,7 +1698,7 @@ impl<'db> Bindings<'db> {
                                     .as_constructor()
                                     .map(ConstructorBinding::constructed_instance_type)
                                     .and_then(|ty| ty.class_specialization(db))
-                                    .map(|specialization| {
+                                    .map(|(_, specialization)| {
                                         specialization
                                             .generic_context(db)
                                             .default_specialization(db, None)

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -236,7 +236,7 @@ impl<'db> ConstructorBinding<'db> {
         // non-specialized generic class (`C(...)`), it'll be the identity specialization. If we're
         // constructing an already-specialized generic alias (`C[str](...)`), it'll be the
         // specialization of that alias.
-        let class_specialization = constructed_instance_type.class_specialization(db)?;
+        let (_, class_specialization) = constructed_instance_type.class_specialization(db)?;
         let static_class_literal = self
             .constructed_class_literal(db)
             .and_then(ClassLiteral::as_static);
@@ -467,7 +467,7 @@ impl<'db> ConstructorBinding<'db> {
         let Some(class_context) = self
             .constructed_instance_type()
             .class_specialization(db)
-            .map(|specialization| specialization.generic_context(db))
+            .map(|(_, specialization)| specialization.generic_context(db))
         else {
             return specialization;
         };

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3656,7 +3656,7 @@ pub(super) fn note_numbers_module_not_supported<'db>(
 }
 
 fn covariant_supertype_hint<'db>(
-    class: ClassType<'db>,
+    class: StaticClassLiteral<'db>,
     db: &'db dyn Db,
     mismatched_invariant_parameters: &[usize],
 ) -> Option<&'static str> {
@@ -3690,20 +3690,16 @@ pub(super) fn add_invariant_generic_hints<'db>(
     expected_ty: Type<'db>,
     provided_ty: Type<'db>,
 ) {
-    let Some(expected_class) = expected_ty.nominal_class(db) else {
+    let Some((expected_class, expected_specialization)) = expected_ty.class_specialization(db)
+    else {
         return;
     };
-    let Some(provided_class) = provided_ty.nominal_class(db) else {
-        return;
-    };
-    let Some(expected_specialization) = expected_ty.class_specialization(db) else {
-        return;
-    };
-    let Some(provided_specialization) = provided_ty.class_specialization(db) else {
+    let Some((provided_class, provided_specialization)) = provided_ty.class_specialization(db)
+    else {
         return;
     };
 
-    if expected_class.class_literal(db) != provided_class.class_literal(db) {
+    if expected_class != provided_class {
         return;
     }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -825,6 +825,16 @@ impl<'db> GenericContext<'db> {
         self.specialize(db, types)
     }
 
+    /// Returns a specialization of this generic context where each typevar is mapped to the same type.
+    pub(crate) fn repeat_specialization(
+        self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+    ) -> Specialization<'db> {
+        let types: Vec<Type> = self.variables(db).map(|_| ty).collect();
+        self.specialize(db, types)
+    }
+
     pub(crate) fn unknown_specialization(self, db: &'db dyn Db) -> Specialization<'db> {
         match self.len(db) {
             0 => self.specialize(db, &[]),

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -43,13 +43,15 @@
 //! of iterations, so if we fail to converge, Salsa will eventually panic. (This should of course
 //! be considered a bug.)
 
+use std::collections::hash_map::Entry;
+
 use ruff_db::parsed::parsed_module;
-use ruff_text_size::Ranged;
+use ruff_python_ast as ast;
+use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 use salsa;
 use salsa::plumbing::AsId;
 
-use crate::Db;
 use crate::types::diagnostic::TypeCheckDiagnostics;
 use crate::types::function::{FunctionDecorators, FunctionType};
 use crate::types::generics::Specialization;
@@ -57,9 +59,11 @@ use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
     ClassLiteral, KnownClass, StaticClassLiteral, Type, TypeAndQualifiers, TypeQualifiers,
 };
+use crate::{Db, FxIndexSet};
+
 use builder::TypeInferenceBuilder;
 pub(super) use comparisons::UnsupportedComparisonError;
-use ty_python_core::definition::Definition;
+use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::expression::Expression;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::statement::StatementInner;
@@ -81,6 +85,12 @@ bitflags::bitflags! {
 }
 
 impl get_size2::GetSize for TypeExpressionFlags {}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+struct TypeAndRange<'db> {
+    ty: Type<'db>,
+    range: TextRange,
+}
 
 /// Compact immutable key-value entries stored in key order.
 ///
@@ -141,7 +151,7 @@ impl<'a, K, V> IntoIterator for &'a mut FrozenMap<K, V> {
 #[salsa::tracked(
     returns(ref),
     cycle_initial=|db, id, definition: Definition<'db>| {
-        DefinitionInference::cycle_initial(definition.scope(db), Type::divergent(id))
+        DefinitionInference::cycle_initial(db, definition, Type::divergent(id))
     },
     cycle_fn=|db, cycle, previous: &DefinitionInference<'db>, inference: DefinitionInference<'db>, _| {
         inference.cycle_normalized(db, previous, cycle)
@@ -252,7 +262,7 @@ impl<'db> FunctionDecoratorInference<'db> {
 #[salsa::tracked(
     returns(ref),
     cycle_initial=|db, id, definition: Definition<'db>| {
-        DefinitionInference::cycle_initial(definition.scope(db), Type::divergent(id))
+        DefinitionInference::cycle_initial(db, definition, Type::divergent(id))
     },
     cycle_fn=|db, cycle, previous: &DefinitionInference<'db>, inference: DefinitionInference<'db>, _| {
         inference.cycle_normalized(db, previous, cycle)
@@ -758,11 +768,15 @@ pub(crate) struct ScopeInference<'db> {
 struct ScopeInferenceExtra<'db> {
     /// String annotations found in this region
     string_annotations: FxHashSet<ExpressionNodeKey>,
+
     /// Expected types for expression nodes tracked for IDE completion.
     expected_types: FxHashMap<ExpressionNodeKey, Type<'db>>,
 
     /// Metadata for type expressions in this region.
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
+
+    /// The type contexts applicable to every definition in this region.
+    collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
 
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
     cycle_recovery: Option<Type<'db>>,
@@ -791,6 +805,21 @@ impl<'db> ScopeInference<'db> {
         for (expr, ty) in &mut self.expressions {
             let previous_ty = previous_inference.expression_type(*expr);
             *ty = ty.cycle_normalized(db, previous_ty, cycle);
+        }
+
+        if cycle.iteration() > crate::TAINTED_CYCLES
+            && let Some(prev_extra) = &previous_inference.extra
+        {
+            for (collection_def, constraints) in &prev_extra.collection_use_constraints {
+                let extra = self.extra.get_or_insert_default();
+
+                match extra.collection_use_constraints.entry(*collection_def) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(constraints.clone());
+                    }
+                    Entry::Occupied(mut entry) => entry.get_mut().extend(constraints),
+                }
+            }
         }
 
         self
@@ -881,6 +910,7 @@ pub(crate) struct DefinitionInference<'db> {
 struct DefinitionInferenceExtra<'db> {
     /// String annotations found in this region
     string_annotations: FxHashSet<ExpressionNodeKey>,
+
     /// Expected types for expression nodes tracked for IDE completion.
     expected_types: FxHashMap<ExpressionNodeKey, Type<'db>>,
 
@@ -889,6 +919,9 @@ struct DefinitionInferenceExtra<'db> {
 
     /// Metadata for type expressions in this region.
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
+
+    /// The type contexts applicable to every definition in this region.
+    collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
 
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
     cycle_recovery: Option<Type<'db>>,
@@ -908,15 +941,42 @@ struct DefinitionInferenceExtra<'db> {
 }
 
 impl<'db> DefinitionInference<'db> {
-    fn cycle_initial(scope: ScopeId<'db>, cycle_recovery: Type<'db>) -> Self {
-        let _ = scope;
+    fn cycle_initial(
+        db: &'db dyn Db,
+        definition: Definition<'db>,
+        cycle_recovery: Type<'db>,
+    ) -> Self {
+        let mut bindings: Box<[_]> = Box::new([]);
+
+        // Eagerly store more precise types for collection literals to avoid an extra
+        // cycle iteration, i.e., by inferring `list[Divergent]` instead of `Divergent`.
+        if let DefinitionKind::Assignment(assignment) = definition.kind(db) {
+            let module = parsed_module(db, definition.file(db)).load(db);
+            let known_collection = match assignment.value(&module) {
+                ast::Expr::Set(_) => Some(KnownClass::Set),
+                ast::Expr::List(_) => Some(KnownClass::List),
+                ast::Expr::Dict(_) => Some(KnownClass::Dict),
+                _ => None,
+            };
+
+            if let Some(collection_class) = known_collection
+                .and_then(|known_collection| known_collection.try_to_class_literal(db))
+            {
+                let divergent_collection = collection_class
+                    .apply_specialization(db, |generic_context| {
+                        generic_context.repeat_specialization(db, cycle_recovery)
+                    });
+
+                bindings = Box::new([(definition, Type::instance(db, divergent_collection))]);
+            }
+        }
 
         Self {
+            bindings,
             expressions: FrozenMap::default(),
-            bindings: Box::default(),
             declarations: Box::default(),
             #[cfg(debug_assertions)]
-            scope,
+            scope: definition.scope(db),
             extra: Some(Box::new(DefinitionInferenceExtra {
                 cycle_recovery: Some(cycle_recovery),
                 ..DefinitionInferenceExtra::default()
@@ -959,6 +1019,20 @@ impl<'db> DefinitionInference<'db> {
                     declaration_ty.map_type(|decl_ty| decl_ty.recursive_type_normalized(db, cycle));
             }
         }
+        if cycle.iteration() > crate::TAINTED_CYCLES
+            && let Some(prev_extra) = &previous_inference.extra
+        {
+            for (collection_def, constraints) in &prev_extra.collection_use_constraints {
+                let extra = self.extra.get_or_insert_default();
+
+                match extra.collection_use_constraints.entry(*collection_def) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(constraints.clone());
+                    }
+                    Entry::Occupied(mut entry) => entry.get_mut().extend(constraints),
+                }
+            }
+        }
 
         self
     }
@@ -976,6 +1050,16 @@ impl<'db> DefinitionInference<'db> {
             .get(&expression.into())
             .copied()
             .or_else(|| self.fallback_type())
+    }
+
+    pub(crate) fn collection_use_constraints(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> Option<&FxIndexSet<Type<'db>>> {
+        self.extra
+            .as_ref()?
+            .collection_use_constraints
+            .get(&collection_def)
     }
 
     /// Get qualifiers for an annotation expression
@@ -1078,11 +1162,15 @@ pub(crate) struct ExpressionInference<'db> {
 struct ExpressionInferenceExtra<'db> {
     /// String annotations found in this region
     string_annotations: FxHashSet<ExpressionNodeKey>,
+
     /// Expected types for expression nodes tracked for IDE completion.
     expected_types: FxHashMap<ExpressionNodeKey, Type<'db>>,
 
     /// Metadata for type expressions in this region.
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
+
+    /// The type contexts applicable to every definition in this region.
+    collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
 
     /// The types of every binding in this expression region.
     ///
@@ -1129,6 +1217,21 @@ impl<'db> ExpressionInference<'db> {
                     *binding_ty = binding_ty.recursive_type_normalized(db, cycle);
                 }
             }
+
+            if cycle.iteration() > crate::TAINTED_CYCLES
+                && let Some(prev_extra) = &previous.extra
+            {
+                for (collection_def, constraints) in &prev_extra.collection_use_constraints {
+                    let extra = self.extra.get_or_insert_default();
+
+                    match extra.collection_use_constraints.entry(*collection_def) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(constraints.clone());
+                        }
+                        Entry::Occupied(mut entry) => entry.get_mut().extend(constraints),
+                    }
+                }
+            }
         }
 
         for (expr, ty) in &mut self.expressions {
@@ -1154,6 +1257,16 @@ impl<'db> ExpressionInference<'db> {
             .unwrap_or_else(Type::unknown)
     }
 
+    pub(crate) fn collection_use_constraints(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> Option<&FxIndexSet<Type<'db>>> {
+        self.extra
+            .as_ref()?
+            .collection_use_constraints
+            .get(&collection_def)
+    }
+
     fn fallback_type(&self) -> Option<Type<'db>> {
         self.extra.as_ref().and_then(|extra| extra.cycle_recovery)
     }
@@ -1176,6 +1289,23 @@ impl<'db> StatementInference<'db> {
             StatementInference::Expression(inference) => inference.expression_type(expression),
             StatementInference::Definition(inference) => inference.expression_type(expression),
             StatementInference::Other(inference) => inference.expression_type(expression),
+        }
+    }
+
+    pub(crate) fn collection_use_constraints(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> Option<&FxIndexSet<Type<'db>>> {
+        match self {
+            StatementInference::Expression(inference) => {
+                inference.collection_use_constraints(collection_def)
+            }
+            StatementInference::Definition(inference) => {
+                inference.collection_use_constraints(collection_def)
+            }
+            StatementInference::Other(inference) => {
+                inference.collection_use_constraints(collection_def)
+            }
         }
     }
 }
@@ -1211,8 +1341,14 @@ struct StatementInferenceInnerExtra<'db> {
     /// Functions called while inferring this statement.
     called_functions: Box<[FunctionType<'db>]>,
 
+    /// The returned types and their corresponding ranges, if this statement is in a function body.
+    return_types_and_ranges: Box<[TypeAndRange<'db>]>,
+
     /// Metadata for type expressions in this region.
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
+
+    /// The type contexts applicable to every definition in this region.
+    collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
 
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
     cycle_recovery: Option<Type<'db>>,
@@ -1280,6 +1416,20 @@ impl<'db> StatementInferenceInner<'db> {
                     declaration_ty.map_type(|decl_ty| decl_ty.recursive_type_normalized(db, cycle));
             }
         }
+        if cycle.iteration() > crate::TAINTED_CYCLES
+            && let Some(prev_extra) = &previous_inference.extra
+        {
+            for (collection_def, constraints) in &prev_extra.collection_use_constraints {
+                let extra = self.extra.get_or_insert_default();
+
+                match extra.collection_use_constraints.entry(*collection_def) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(constraints.clone());
+                    }
+                    Entry::Occupied(mut entry) => entry.get_mut().extend(constraints),
+                }
+            }
+        }
 
         self
     }
@@ -1297,6 +1447,16 @@ impl<'db> StatementInferenceInner<'db> {
             .get(&expression.into())
             .copied()
             .or_else(|| self.fallback_type())
+    }
+
+    pub(crate) fn collection_use_constraints(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> Option<&FxIndexSet<Type<'db>>> {
+        self.extra
+            .as_ref()?
+            .collection_use_constraints
+            .get(&collection_def)
     }
 
     fn bindings(&self) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -43,8 +43,6 @@
 //! of iterations, so if we fail to converge, Salsa will eventually panic. (This should of course
 //! be considered a bug.)
 
-use std::collections::hash_map::Entry;
-
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange};
@@ -807,21 +805,6 @@ impl<'db> ScopeInference<'db> {
             *ty = ty.cycle_normalized(db, previous_ty, cycle);
         }
 
-        if cycle.iteration() > crate::TAINTED_CYCLES
-            && let Some(prev_extra) = &previous_inference.extra
-        {
-            for (collection_def, constraints) in &prev_extra.collection_use_constraints {
-                let extra = self.extra.get_or_insert_default();
-
-                match extra.collection_use_constraints.entry(*collection_def) {
-                    Entry::Vacant(entry) => {
-                        entry.insert(constraints.clone());
-                    }
-                    Entry::Occupied(mut entry) => entry.get_mut().extend(constraints),
-                }
-            }
-        }
-
         self
     }
 
@@ -1019,20 +1002,6 @@ impl<'db> DefinitionInference<'db> {
                     declaration_ty.map_type(|decl_ty| decl_ty.recursive_type_normalized(db, cycle));
             }
         }
-        if cycle.iteration() > crate::TAINTED_CYCLES
-            && let Some(prev_extra) = &previous_inference.extra
-        {
-            for (collection_def, constraints) in &prev_extra.collection_use_constraints {
-                let extra = self.extra.get_or_insert_default();
-
-                match extra.collection_use_constraints.entry(*collection_def) {
-                    Entry::Vacant(entry) => {
-                        entry.insert(constraints.clone());
-                    }
-                    Entry::Occupied(mut entry) => entry.get_mut().extend(constraints),
-                }
-            }
-        }
 
         self
     }
@@ -1217,21 +1186,6 @@ impl<'db> ExpressionInference<'db> {
                     *binding_ty = binding_ty.recursive_type_normalized(db, cycle);
                 }
             }
-
-            if cycle.iteration() > crate::TAINTED_CYCLES
-                && let Some(prev_extra) = &previous.extra
-            {
-                for (collection_def, constraints) in &prev_extra.collection_use_constraints {
-                    let extra = self.extra.get_or_insert_default();
-
-                    match extra.collection_use_constraints.entry(*collection_def) {
-                        Entry::Vacant(entry) => {
-                            entry.insert(constraints.clone());
-                        }
-                        Entry::Occupied(mut entry) => entry.get_mut().extend(constraints),
-                    }
-                }
-            }
         }
 
         for (expr, ty) in &mut self.expressions {
@@ -1414,20 +1368,6 @@ impl<'db> StatementInferenceInner<'db> {
             } else {
                 *declaration_ty =
                     declaration_ty.map_type(|decl_ty| decl_ty.recursive_type_normalized(db, cycle));
-            }
-        }
-        if cycle.iteration() > crate::TAINTED_CYCLES
-            && let Some(prev_extra) = &previous_inference.extra
-        {
-            for (collection_def, constraints) in &prev_extra.collection_use_constraints {
-                let extra = self.extra.get_or_insert_default();
-
-                match extra.collection_use_constraints.entry(*collection_def) {
-                    Entry::Vacant(entry) => {
-                        entry.insert(constraints.clone());
-                    }
-                    Entry::Occupied(mut entry) => entry.get_mut().extend(constraints),
-                }
             }
         }
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -775,7 +775,7 @@ struct ScopeInferenceExtra<'db> {
     /// Metadata for type expressions in this region.
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
 
-    /// The type contexts applicable to every definition in this region.
+    /// The constraints on any collection literals that are accessed in this region.
     collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
 
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
@@ -920,7 +920,7 @@ struct DefinitionInferenceExtra<'db> {
     /// Metadata for type expressions in this region.
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
 
-    /// The type contexts applicable to every definition in this region.
+    /// The constraints on any collection literals that are accessed in this region.
     collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
 
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
@@ -1169,7 +1169,7 @@ struct ExpressionInferenceExtra<'db> {
     /// Metadata for type expressions in this region.
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
 
-    /// The type contexts applicable to every definition in this region.
+    /// The constraints on any collection literals that are accessed in this region.
     collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
 
     /// The types of every binding in this expression region.
@@ -1347,7 +1347,7 @@ struct StatementInferenceInnerExtra<'db> {
     /// Metadata for type expressions in this region.
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
 
-    /// The type contexts applicable to every definition in this region.
+    /// The constraints on any collection literals that are accessed in this region.
     collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
 
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -244,7 +244,7 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// Only populated for expressions that have non-empty flags.
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
 
-    /// The constraints on any collection literals that accessed in this region.
+    /// The constraints on any collection literals that are accessed in this region.
     //
     // TODO: We should store constraint sets directly here.
     collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
@@ -7973,7 +7973,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let call_result = self.speculate().infer_and_check_argument_types(
                     ArgumentsIter::from_ast(arguments),
                     &mut call_arguments,
-                    // TODO: Reuse the previously inferred types from the initial call on `collection[Divergent].
+                    // TODO: The argument types have already been inferred and stored in `call_arguments`.
+                    // However, `value` would have been inferred to a be a collection with `Divergent`
+                    // element types, meaning the type context for a given argument, by which the inferred
+                    // type is keyed, may not be the same as the type context we get here. It is not immediately
+                    // clear how to retrieve those types, and so we just re-infer the argument expressions
+                    // for simplicity.
                     &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
                     &mut identity_bindings,
                     call_expression_tcx,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -77,9 +77,9 @@ use crate::types::infer::builder::named_tuple::NamedTupleKind;
 use crate::types::infer::builder::paramspec_validation::validate_paramspec_components;
 use crate::types::infer::builder::typed_dict::TypedDictConstructorForm;
 use crate::types::infer::{
-    StatementInference, StatementInferenceInner, StatementInferenceInnerExtra, TypeExpressionFlags,
-    infer_statement_types, nearest_enclosing_class, nearest_enclosing_function,
-    original_class_type,
+    StatementInference, StatementInferenceInner, StatementInferenceInnerExtra, TypeAndRange,
+    TypeExpressionFlags, infer_statement_types, nearest_enclosing_class,
+    nearest_enclosing_function, original_class_type,
 };
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::newtype::NewType;
@@ -141,12 +141,6 @@ mod typed_dict;
 mod typevar;
 
 use super::comparisons::{self, BinaryComparisonVisitor};
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-struct TypeAndRange<'db> {
-    ty: Type<'db>,
-    range: TextRange,
-}
 
 /// A helper to track if we already know that declared and inferred types are the same.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -250,8 +244,14 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// Only populated for expressions that have non-empty flags.
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
 
+    /// The constraints on any collection literals that accessed in this region.
+    //
+    // TODO: We should store constraint sets directly here.
+    collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
+
     /// Expressions that are string annotations
     string_annotations: FxHashSet<ExpressionNodeKey>,
+
     /// Expected types for expression nodes tracked for IDE completion.
     expected_types: FxHashMap<ExpressionNodeKey, Type<'db>>,
 
@@ -358,6 +358,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expression_cache: None,
             qualifiers: FxHashMap::default(),
             type_expression_flags: FxHashMap::default(),
+            collection_use_constraints: FxHashMap::default(),
             string_annotations: FxHashSet::default(),
             expected_types: FxHashMap::default(),
             bindings: VecMap::default(),
@@ -424,6 +425,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.qualifiers.extend(extra.qualifiers.iter());
             self.type_expression_flags
                 .extend(extra.type_expression_flags.iter());
+
+            for (collection_def, constraints) in &extra.collection_use_constraints {
+                self.collection_use_constraints
+                    .entry(*collection_def)
+                    .and_modify(|this| this.extend(constraints))
+                    .or_insert(constraints.clone());
+            }
         }
     }
 
@@ -448,6 +456,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if let Some(extra) = &inference.extra {
             self.called_functions
                 .extend(extra.called_functions.iter().copied());
+            self.return_types_and_ranges
+                .extend(extra.return_types_and_ranges.iter().copied());
             self.extend_cycle_recovery(extra.cycle_recovery);
             self.context.extend(&extra.diagnostics);
             self.deferred.extend(extra.deferred.iter().copied());
@@ -480,6 +490,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.type_expression_flags
                 .extend(extra.type_expression_flags.iter());
 
+            for (collection_def, constraints) in &extra.collection_use_constraints {
+                self.collection_use_constraints
+                    .entry(*collection_def)
+                    .and_modify(|this| this.extend(constraints))
+                    .or_insert(constraints.clone());
+            }
+
             if !matches!(self.region, InferenceRegion::Scope(..)) {
                 self.bindings.extend(extra.bindings.iter().copied());
             }
@@ -498,6 +515,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.expected_types.extend(extra.expected_types.iter());
             self.type_expression_flags
                 .extend(extra.type_expression_flags.iter());
+
+            for (collection_def, constraints) in &extra.collection_use_constraints {
+                self.collection_use_constraints
+                    .entry(*collection_def)
+                    .and_modify(|this| this.extend(constraints))
+                    .or_insert(constraints.clone());
+            }
         }
     }
 
@@ -5103,17 +5127,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
 
         for ((_, argument_types), argument_form, ast_argument) in iter {
-            let argument = match ast_argument {
-                // Splatted arguments are inferred before parameter matching to
-                // determine their length.
-                ast::ArgOrKeyword::Arg(ast::Expr::Starred(_))
-                | ast::ArgOrKeyword::Keyword(ast::Keyword { arg: None, .. }) => continue,
+            // Splatted arguments are inferred before parameter matching to
+            // determine their length.
+            if ast_argument.is_variadic() {
+                continue;
+            }
 
-                ast::ArgOrKeyword::Arg(arg) => arg,
-                ast::ArgOrKeyword::Keyword(ast::Keyword { value, .. }) => value,
-            };
-
-            let ty = self.infer_argument_type(argument, argument_form, TypeContext::default());
+            let ty = self.infer_argument_type(
+                ast_argument.value(),
+                argument_form,
+                TypeContext::default(),
+            );
             argument_types.insert(TypeContext::default(), ty);
         }
     }
@@ -5359,13 +5383,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .zip(ast_arguments.clone())
             .enumerate()
         {
-            let ast_argument = match ast_argument {
-                ast::ArgOrKeyword::Arg(ast::Expr::Starred(_))
-                | ast::ArgOrKeyword::Keyword(ast::Keyword { arg: None, .. }) => continue,
-
-                ast::ArgOrKeyword::Arg(arg) => arg,
-                ast::ArgOrKeyword::Keyword(ast::Keyword { value, .. }) => value,
-            };
+            if ast_argument.is_variadic() {
+                continue;
+            }
+            let ast_argument = ast_argument.value();
 
             if matches!(argument_form, Some(ParameterForm::Type)) {
                 continue;
@@ -5402,17 +5423,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .zip(ast_arguments)
             .enumerate()
         {
-            let ast_argument = match ast_argument {
-                // Splatted arguments are inferred before parameter matching to
-                // determine their length.
-                //
-                // TODO: Re-infer splatted arguments with their type context.
-                ast::ArgOrKeyword::Arg(ast::Expr::Starred(_))
-                | ast::ArgOrKeyword::Keyword(ast::Keyword { arg: None, .. }) => continue,
-
-                ast::ArgOrKeyword::Arg(arg) => arg,
-                ast::ArgOrKeyword::Keyword(ast::Keyword { value, .. }) => value,
-            };
+            // Splatted arguments are inferred before parameter matching to
+            // determine their length.
+            //
+            // TODO: Re-infer splatted arguments with their type context.
+            if ast_argument.is_variadic() {
+                continue;
+            }
+            let ast_argument = ast_argument.value();
 
             // Type-form arguments are inferred without type context, so we can infer the argument type directly.
             if let Some(ParameterForm::Type) = argument_form {
@@ -5516,6 +5534,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             parameter_context.type_context(),
                         ),
                     );
+
                     inferred_by_cache_key.insert(inference_cache_key, inferred_ty);
                     self.union_expected_types(&speculative_builder.expected_types);
                     parameter_context.insert_inferred_type(
@@ -5701,6 +5720,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && ty.is_assignable_to(self.db(), tcx)
         {
             ty = Type::LiteralValue(literal.to_unpromotable());
+        }
+
+        if let Some(tcx) = tcx.annotation
+            && let Some(collection_def) = self.index.unconstrained_collection_binding(expression)
+        {
+            self.collection_use_constraints
+                .entry(collection_def)
+                .or_default()
+                .insert(tcx);
         }
 
         self.store_expression_type(expression, ty);
@@ -6064,10 +6092,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut infer_elt_ty =
             |builder: &mut Self, (_, elt, tcx)| builder.infer_expression(elt, tcx);
 
-        self.infer_collection_literal(KnownClass::List, &elts, &mut infer_elt_ty, tcx)
-            .unwrap_or_else(|| {
-                KnownClass::List.to_specialized_instance(self.db(), &[Type::unknown()])
-            })
+        self.infer_collection_literal(
+            KnownClass::List,
+            Some(list.into()),
+            &elts,
+            &mut infer_elt_ty,
+            tcx,
+        )
+        .unwrap_or_else(|| KnownClass::List.to_specialized_instance(self.db(), &[Type::unknown()]))
     }
 
     fn infer_set_expression(&mut self, set: &ast::ExprSet, tcx: TypeContext<'db>) -> Type<'db> {
@@ -6084,10 +6116,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             builder.infer_set_element(elt, elt_tcx, fallback_tcx)
         };
 
-        self.infer_collection_literal(KnownClass::Set, &elts, &mut infer_elt_ty, tcx)
-            .unwrap_or_else(|| {
-                KnownClass::Set.to_specialized_instance(self.db(), &[Type::unknown()])
-            })
+        self.infer_collection_literal(
+            KnownClass::Set,
+            Some(set.into()),
+            &elts,
+            &mut infer_elt_ty,
+            tcx,
+        )
+        .unwrap_or_else(|| KnownClass::Set.to_specialized_instance(self.db(), &[Type::unknown()]))
     }
 
     /// Infers a set element, optionally with a fallback context for an incomplete `TypedDict` key.
@@ -6249,17 +6285,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .unwrap_or_else(|| builder.infer_expression(elt, tcx))
         };
 
-        self.infer_collection_literal(KnownClass::Dict, &items, &mut infer_elt_ty, tcx)
-            .unwrap_or_else(|| {
-                KnownClass::Dict
-                    .to_specialized_instance(self.db(), &[Type::unknown(), Type::unknown()])
-            })
+        self.infer_collection_literal(
+            KnownClass::Dict,
+            Some(dict.into()),
+            &items,
+            &mut infer_elt_ty,
+            tcx,
+        )
+        .unwrap_or_else(|| {
+            KnownClass::Dict.to_specialized_instance(self.db(), &[Type::unknown(), Type::unknown()])
+        })
     }
 
     // Infer the type of a collection literal expression.
     fn infer_collection_literal<'expr, const N: usize>(
         &mut self,
         collection_class: KnownClass,
+        collection_expr: Option<ast::ExprRef<'_>>,
         elts: &[[Option<&'expr ast::Expr>; N]],
         infer_elt_expression: &mut dyn FnMut(&mut Self, ArgExpr<'db, 'expr>) -> Type<'db>,
         tcx: TypeContext<'db>,
@@ -6278,6 +6320,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Attempt to infer the collection literal using the narrowed type context.
             let inferred_ty = speculative_builder.infer_collection_literal_impl(
                 collection_class,
+                collection_expr,
                 elts,
                 infer_elt_expression,
                 TypeContext::new(Some(narrowed_ty)),
@@ -6302,13 +6345,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        self.infer_collection_literal_impl(collection_class, elts, infer_elt_expression, tcx)
+        self.infer_collection_literal_impl(
+            collection_class,
+            collection_expr,
+            elts,
+            infer_elt_expression,
+            tcx,
+        )
     }
 
     // Infer the type of a collection literal expression.
     fn infer_collection_literal_impl<'expr, const N: usize>(
         &mut self,
         collection_class: KnownClass,
+        collection_expr: Option<ast::ExprRef<'_>>,
         elts: &[[Option<&'expr ast::Expr>; N]],
         infer_elt_expression: &mut dyn FnMut(&mut Self, ArgExpr<'db, 'expr>) -> Type<'db>,
         tcx: TypeContext<'db>,
@@ -6343,6 +6393,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let constraints = ConstraintSetBuilder::new();
         let inferable = generic_context.inferable_typevars(self.db());
+        let identity_instance = Type::instance(self.db(), ClassType::Generic(collection_alias));
 
         // Remove any union elements of that are unrelated to the collection type.
         //
@@ -6355,7 +6406,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Collect type constraints from the declared element types.
         //
-        // We use a forward assignability check (`collection_instance ≤ tcx`) to infer what each
+        // We use a forward assignability check (`identity_instance ≤ tcx`) to infer what each
         // typevar maps to in the type context. For example, if the type context is `list[int]` and
         // `collection_instance` is `list[T]`, the check produces `T = int`.
         let (elt_tcx_constraints, elt_tcx_variance) = {
@@ -6370,10 +6421,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 && tcx.class_specialization(self.db()).is_some()
             {
                 let db = self.db();
-                let collection_instance = Type::instance(db, ClassType::Generic(collection_alias));
 
                 let path_bounds =
-                    collection_instance.assignable_solutions_with_inferable(db, tcx, inferable);
+                    identity_instance.assignable_solutions_with_inferable(db, tcx, inferable);
                 let solutions = path_bounds.solve_with(|typevar, variance, lower, upper| {
                     let identity = typevar.identity(db);
                     elt_tcx_variance
@@ -6482,6 +6532,62 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
+        if tcx.annotation.is_none()
+            && let Some(collection_expr) = collection_expr
+            && let InferenceRegion::Expression(current_expr, _) = self.region
+            && current_expr.node_ref(self.db()).index() == *collection_expr.node_index()
+            && let Some(assignment) = current_expr.assigned_to(self.db())
+            && let Ok(collection_def) =
+                DefinitionNodeKey::from_assignment(assignment.node(self.module())).exactly_one()
+            && let Some(collection_def) = self.index.try_definition(collection_def)
+        {
+            // For unconstrained collection literals, collect any constraints created by later uses
+            // of this definition in the scope.
+            for (statement, use_expression) in
+                self.index.constraining_collection_uses(collection_def)
+            {
+                let statement_use_types = infer_statement_types(self.db(), statement);
+
+                if let Some(divergent) = statement_use_types
+                    .expression_type(use_expression)
+                    .as_divergent()
+                {
+                    // Infer `collection[Divergent]` for the initial cycle result.
+                    let divergent_instance = collection_alias
+                        .origin(self.db())
+                        .apply_specialization(self.db(), |generic_context| {
+                            generic_context
+                                .repeat_specialization(self.db(), Type::Divergent(divergent))
+                        });
+
+                    builder
+                        .infer(
+                            identity_instance,
+                            Type::instance(self.db(), divergent_instance),
+                        )
+                        .ok()?;
+                } else if let Some(constraints) =
+                    statement_use_types.collection_use_constraints(collection_def)
+                {
+                    for constraint in constraints {
+                        if constraint.has_unspecialized_type_var(self.db()) {
+                            continue;
+                        }
+
+                        builder
+                            .infer_map(
+                                identity_instance,
+                                *constraint,
+                                // We promote element literal types in invariant position by default, unless they
+                                // were inferred with an explicit literal annotation.
+                                |(_, _, inferred_ty)| Some(inferred_ty.promote(self.db())),
+                            )
+                            .ok()?;
+                    }
+                }
+            }
+        }
+
         for elts in elts {
             // An unpacking expression for a dictionary.
             if let &[None, Some(value_expr)] = elts.as_slice() {
@@ -6562,8 +6668,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     continue;
                 }
 
-                // Promote types to avoid excessively large unions for large nested list literals,
-                // which the constraint solver struggles with.
+                // We promote element literal types in invariant position by default, unless they were
+                // inferred with an explicit literal annotation.
                 let inferred_elt_ty = inferred_elt_ty.promote(self.db());
 
                 let inferred_type_for_typevar = if elt.is_starred_expr() {
@@ -6752,6 +6858,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn infer_comprehension_specialization<const N: usize>(
         &mut self,
         collection_class: KnownClass,
+        collection_expr: ast::ExprRef<'_>,
         elements: [Option<&ast::Expr>; N],
         inference: &ScopeInference<'db>,
         tcx: TypeContext<'db>,
@@ -6759,7 +6866,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut infer_element_ty =
             |_builder: &mut Self, (_, elt, _)| inference.expression_type(elt);
 
-        self.infer_collection_literal(collection_class, &[elements], &mut infer_element_ty, tcx)
+        self.infer_collection_literal(
+            collection_class,
+            Some(collection_expr),
+            &[elements],
+            &mut infer_element_ty,
+            tcx,
+        )
     }
 
     fn infer_list_comprehension_expression(
@@ -6786,10 +6899,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let inference = infer_scope_types(self.db(), scope, tcx);
         self.extend_scope(inference);
 
-        self.infer_comprehension_specialization(KnownClass::List, [Some(elt)], inference, tcx)
-            .unwrap_or_else(|| {
-                KnownClass::List.to_specialized_instance(self.db(), &[Type::unknown()])
-            })
+        self.infer_comprehension_specialization(
+            KnownClass::List,
+            listcomp.into(),
+            [Some(elt)],
+            inference,
+            tcx,
+        )
+        .unwrap_or_else(|| KnownClass::List.to_specialized_instance(self.db(), &[Type::unknown()]))
     }
 
     fn infer_set_comprehension_expression(
@@ -6816,10 +6933,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let inference = infer_scope_types(self.db(), scope, tcx);
         self.extend_scope(inference);
 
-        self.infer_comprehension_specialization(KnownClass::Set, [Some(elt)], inference, tcx)
-            .unwrap_or_else(|| {
-                KnownClass::Set.to_specialized_instance(self.db(), &[Type::unknown()])
-            })
+        self.infer_comprehension_specialization(
+            KnownClass::Set,
+            setcomp.into(),
+            [Some(elt)],
+            inference,
+            tcx,
+        )
+        .unwrap_or_else(|| KnownClass::Set.to_specialized_instance(self.db(), &[Type::unknown()]))
     }
 
     fn infer_dict_comprehension_expression(
@@ -6849,6 +6970,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.infer_comprehension_specialization(
             KnownClass::Dict,
+            dictcomp.into(),
             [key.as_deref(), Some(value)],
             inference,
             tcx,
@@ -6896,7 +7018,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let elts = [[Some(elt.as_ref())]];
         let mut infer_elt_ty =
             |builder: &mut Self, (_, elt, tcx)| builder.infer_expression(elt, tcx);
-        self.infer_collection_literal(KnownClass::List, &elts, &mut infer_elt_ty, tcx);
+
+        self.infer_collection_literal(
+            KnownClass::List,
+            Some(listcomp.into()),
+            &elts,
+            &mut infer_elt_ty,
+            tcx,
+        );
 
         self.infer_comprehensions(generators);
     }
@@ -6917,7 +7046,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let elts = [[Some(elt.as_ref())]];
         let mut infer_elt_ty =
             |builder: &mut Self, (_, elt, tcx)| builder.infer_expression(elt, tcx);
-        self.infer_collection_literal(KnownClass::Set, &elts, &mut infer_elt_ty, tcx);
+
+        self.infer_collection_literal(
+            KnownClass::Set,
+            Some(setcomp.into()),
+            &elts,
+            &mut infer_elt_ty,
+            tcx,
+        );
 
         self.infer_comprehensions(generators);
     }
@@ -6940,7 +7076,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let elts = [[key.as_deref(), Some(value.as_ref())]];
             let mut infer_elt_ty =
                 |builder: &mut Self, (_, elt, tcx)| builder.infer_expression(elt, tcx);
-            self.infer_collection_literal(KnownClass::Dict, &elts, &mut infer_elt_ty, tcx);
+
+            self.infer_collection_literal(
+                KnownClass::Dict,
+                Some(dictcomp.into()),
+                &elts,
+                &mut infer_elt_ty,
+                tcx,
+            );
         } else {
             // Dict-unpack comprehensions are typed by the outer expression inference. Inferring
             // them through the collection-literal helper here would report the same invalid
@@ -7803,6 +7946,55 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }
                     }
                     _ => {}
+                }
+            }
+        }
+
+        // Record the constraints for the receiver of a bound method call, if the receiver is an
+        // unconstrained collection literal.
+        if let ast::Expr::Attribute(attribute @ ast::ExprAttribute { value, .. }) = func.as_ref() {
+            let value_type = self.expression_type(value);
+
+            if let Some(collection_def) = self.index.unconstrained_collection_binding(value)
+                && let Some((collection_literal, _)) = value_type.class_specialization(self.db())
+            {
+                let identity_instance = Type::instance(
+                    self.db(),
+                    collection_literal.identity_specialization(self.db()),
+                );
+
+                let mut identity_bindings = self
+                    .infer_attribute_load_impl(attribute, identity_instance)
+                    .bindings(self.db())
+                    .match_parameters(self.db(), &call_arguments)
+                    // Perform inference against the type variables on the receiver's generic context.
+                    .with_generic_context(self.db(), collection_literal.generic_context(self.db()));
+
+                let call_result = self.speculate().infer_and_check_argument_types(
+                    ArgumentsIter::from_ast(arguments),
+                    &mut call_arguments,
+                    // TODO: Reuse the previously inferred types from the initial call on `collection[Divergent].
+                    &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
+                    &mut identity_bindings,
+                    call_expression_tcx,
+                );
+
+                if call_result.is_ok() {
+                    for call_specialization in identity_bindings
+                        .iter_flat()
+                        .flat_map(CallableBinding::matching_overloads)
+                        .filter_map(|(_, identity_overload)| identity_overload.specialization())
+                    {
+                        // Record the constraints on the receiver's generic context formed by
+                        // the arguments to this bound method call.
+                        let constraints =
+                            identity_instance.apply_specialization(self.db(), call_specialization);
+
+                        self.collection_use_constraints
+                            .entry(collection_def)
+                            .or_default()
+                            .insert(constraints);
+                    }
                 }
             }
         }
@@ -8746,6 +8938,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     /// Infer the type of a [`ast::ExprAttribute`] expression, assuming a load context.
     fn infer_attribute_load(&mut self, attribute: &ast::ExprAttribute) -> Type<'db> {
+        let value_type =
+            self.infer_maybe_standalone_expression(&attribute.value, TypeContext::default());
+        self.infer_attribute_load_impl(attribute, value_type)
+    }
+
+    /// Infer the type of a [`ast::ExprAttribute`] expression, assuming a load context.
+    fn infer_attribute_load_impl(
+        &mut self,
+        attribute: &ast::ExprAttribute,
+        mut value_type: Type<'db>,
+    ) -> Type<'db> {
         fn union_elements_missing_attribute<'db>(
             db: &'db dyn Db,
             ty: Type<'db>,
@@ -8763,7 +8966,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let ast::ExprAttribute { value, attr, .. } = attribute;
 
-        let mut value_type = self.infer_maybe_standalone_expression(value, TypeContext::default());
         let db = self.db();
         let mut constraint_keys = vec![];
 
@@ -9495,6 +9697,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions,
             qualifiers: _,
             mut type_expression_flags,
+            mut collection_use_constraints,
             mut string_annotations,
             mut expected_types,
             scope,
@@ -9532,6 +9735,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let extra =
             (!string_annotations.is_empty()
                 || !type_expression_flags.is_empty()
+                || !collection_use_constraints.is_empty()
                 || !expected_types.is_empty()
                 || cycle_recovery.is_some()
                 || !bindings.is_empty()
@@ -9547,6 +9751,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 type_expression_flags.shrink_to_fit();
                 expected_types.shrink_to_fit();
                 string_annotations.shrink_to_fit();
+                collection_use_constraints.shrink_to_fit();
                 Box::new(ExpressionInferenceExtra {
                     string_annotations,
                     expected_types,
@@ -9554,6 +9759,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     bindings: bindings.into_boxed_slice(),
                     diagnostics,
                     cycle_recovery,
+                    collection_use_constraints
                 })
             });
 
@@ -9573,6 +9779,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions,
             mut qualifiers,
             mut type_expression_flags,
+            mut collection_use_constraints,
             mut string_annotations,
             mut expected_types,
             scope,
@@ -9581,6 +9788,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred,
             cycle_recovery,
             called_functions,
+            mut return_types_and_ranges,
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
@@ -9592,7 +9800,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred_state: _,
             index: _,
             region: _,
-            return_types_and_ranges: _,
         } = self;
 
         let _ = scope;
@@ -9604,13 +9811,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             || !expected_types.is_empty()
             || !deferred.is_empty()
             || !called_functions.is_empty()
+            || !return_types_and_ranges.is_empty()
             || !qualifiers.is_empty()
-            || !type_expression_flags.is_empty())
+            || !type_expression_flags.is_empty()
+            || !collection_use_constraints.is_empty())
         .then(|| {
+            collection_use_constraints.shrink_to_fit();
             qualifiers.shrink_to_fit();
             expected_types.shrink_to_fit();
             type_expression_flags.shrink_to_fit();
             string_annotations.shrink_to_fit();
+            return_types_and_ranges.shrink_to_fit();
             Box::new(StatementInferenceInnerExtra {
                 string_annotations,
                 expected_types,
@@ -9618,7 +9829,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .into_iter()
                     .collect::<Vec<_>>()
                     .into_boxed_slice(),
+                return_types_and_ranges: return_types_and_ranges.into_boxed_slice(),
                 type_expression_flags,
+                collection_use_constraints,
                 cycle_recovery,
                 deferred: deferred.into_boxed_slice(),
                 diagnostics,
@@ -9686,6 +9899,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             string_annotations: _,
             expected_types: _,
             return_types_and_ranges: _,
+            collection_use_constraints: _,
             dataclass_field_specifiers: _,
             undecorated_type: _,
             typevar_binding_context: _,
@@ -9718,6 +9932,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions,
             mut qualifiers,
             mut type_expression_flags,
+            mut collection_use_constraints,
             mut string_annotations,
             mut expected_types,
             scope,
@@ -9749,8 +9964,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             || !deferred.is_empty()
             || !called_functions.is_empty()
             || !qualifiers.is_empty()
-            || !type_expression_flags.is_empty())
+            || !type_expression_flags.is_empty()
+            || !collection_use_constraints.is_empty())
         .then(|| {
+            collection_use_constraints.shrink_to_fit();
             qualifiers.shrink_to_fit();
             type_expression_flags.shrink_to_fit();
             expected_types.shrink_to_fit();
@@ -9758,6 +9975,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             Box::new(DefinitionInferenceExtra {
                 string_annotations,
                 expected_types,
+                collection_use_constraints,
                 called_functions: called_functions
                     .into_iter()
                     .collect::<Vec<_>>()
@@ -9805,6 +10023,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             mut string_annotations,
             mut expected_types,
             mut type_expression_flags,
+            mut collection_use_constraints,
             expressions,
             scope,
             cycle_recovery,
@@ -9833,18 +10052,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let diagnostics = context.finish();
 
         let extra = (!string_annotations.is_empty()
-            || !type_expression_flags.is_empty()
             || !expected_types.is_empty()
             || !diagnostics.is_empty()
-            || cycle_recovery.is_some())
+            || cycle_recovery.is_some()
+            || !type_expression_flags.is_empty()
+            || !collection_use_constraints.is_empty())
         .then(|| {
             type_expression_flags.shrink_to_fit();
             expected_types.shrink_to_fit();
             string_annotations.shrink_to_fit();
+            collection_use_constraints.shrink_to_fit();
             Box::new(ScopeInferenceExtra {
                 string_annotations,
                 expected_types,
                 type_expression_flags,
+                collection_use_constraints,
                 cycle_recovery,
                 diagnostics,
             })
@@ -9879,6 +10101,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // These fields are type inference results, but do not affect the inference of a given
             // expression.
             context: _,
+            collection_use_constraints: _,
             expressions: _,
             string_annotations: _,
             expected_types: _,
@@ -9919,6 +10142,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             context,
             expressions,
             type_expression_flags,
+            collection_use_constraints,
             string_annotations,
             expected_types,
             scope,
@@ -9966,6 +10190,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if !matches!(self.region, InferenceRegion::Scope(..)) {
             self.bindings
                 .extend(bindings.iter().map(|(def, ty)| (*def, *ty)));
+        }
+
+        for (collection_def, constraints) in &collection_use_constraints {
+            self.collection_use_constraints
+                .entry(*collection_def)
+                .and_modify(|this| this.extend(constraints))
+                .or_insert(constraints.clone());
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -109,6 +109,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         self.infer_collection_literal(
             KnownClass::Dict,
+            None,
             &items,
             &mut infer_elt_ty,
             call_expression_tcx,

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1284,7 +1284,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     ArgumentsIter::synthesized(&ast_arguments),
                     &mut call_arguments,
                     &mut |builder, (_, expr, tcx)| {
-                        // TODO: Reuse the previously inferred types from the initial call on `collection[Divergent].
+                        // TODO: The argument types have already been inferred and stored in `call_arguments`.
+                        // However, `object` would have been inferred to a be a collection with `Divergent`
+                        // element types, meaning the type context for a given argument, by which the inferred
+                        // type is keyed, may not be the same as the type context we get here. It is not immediately
+                        // clear how to retrieve those types, and so we just re-infer the argument expressions
+                        // for simplicity.
                         builder.infer_maybe_standalone_expression(expr, tcx)
                     },
                     &mut identity_bindings,

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -26,10 +26,11 @@ use crate::types::subscript::{LegacyGenericOrigin, SubscriptError, SubscriptErro
 use crate::types::tuple::{Tuple, TupleType};
 use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::{
-    BoundTypeVarInstance, CallArguments, CallDunderError, CycleDetector, DynamicType, InternedType,
-    KnownClass, KnownInstanceType, LintDiagnosticGuard, Parameter, Parameters, SpecialFormType,
-    StaticClassLiteral, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
-    TypeVarBoundOrConstraints, UnionType, UnionTypeInstance, any_over_type, todo_type,
+    BoundTypeVarInstance, CallArguments, CallDunderError, CallableBinding, CycleDetector,
+    DynamicType, InternedType, KnownClass, KnownInstanceType, LintDiagnosticGuard,
+    MemberLookupPolicy, Parameter, Parameters, SpecialFormType, StaticClassLiteral, Type,
+    TypeAliasType, TypeAndQualifiers, TypeContext, TypeVarBoundOrConstraints, UnionType,
+    UnionTypeInstance, any_over_type, todo_type,
 };
 use crate::{Db, FxOrderSet};
 use ty_python_core::SemanticIndex;
@@ -1230,11 +1231,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ctx: _,
         } = target;
 
+        let db = self.db();
+
         let object_ty = self.infer_expression(object, TypeContext::default());
         self.store_typed_dict_key_expected_type(slice, object_ty);
         let mut infer_slice_ty = |builder: &mut Self, tcx| builder.infer_expression(slice, tcx);
 
-        self.validate_subscript_assignment_impl(
+        let is_valid_assignment = self.validate_subscript_assignment_impl(
             target,
             None,
             object_ty,
@@ -1242,7 +1245,73 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             rhs_value,
             infer_rhs_value,
             true,
-        )
+        );
+
+        // Record the constraints for the object of the subscript assignment, if the object is an
+        // unconstrained collection literal.
+        if is_valid_assignment
+            && let Some(collection_def) = self.index.unconstrained_collection_binding(object)
+            && let Some((class_literal, _)) = object_ty.class_specialization(db)
+        {
+            let identity_instance = Type::instance(db, class_literal.identity_specialization(db));
+
+            let ast_arguments = [
+                ArgOrKeyword::Arg(&target.slice),
+                ArgOrKeyword::Arg(rhs_value),
+            ];
+
+            let mut call_arguments = CallArguments::positional([Type::unknown(), Type::unknown()]);
+
+            if let Place::Defined(DefinedPlace {
+                ty: dunder_callable,
+                definedness: boundness,
+                ..
+            }) = identity_instance
+                .member_lookup_with_policy(
+                    db,
+                    "__setitem__".into(),
+                    MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                )
+                .place
+            {
+                let mut identity_bindings = dunder_callable
+                    .bindings(db)
+                    .match_parameters(db, &call_arguments)
+                    // Perform inference against the type variables on the receiver's generic context.
+                    .with_generic_context(db, class_literal.generic_context(db));
+
+                let call_result = self.speculate().infer_and_check_argument_types(
+                    ArgumentsIter::synthesized(&ast_arguments),
+                    &mut call_arguments,
+                    &mut |builder, (_, expr, tcx)| {
+                        // TODO: Reuse the previously inferred types from the initial call on `collection[Divergent].
+                        builder.infer_maybe_standalone_expression(expr, tcx)
+                    },
+                    &mut identity_bindings,
+                    TypeContext::default(),
+                );
+
+                if call_result.is_ok() && boundness == Definedness::AlwaysDefined {
+                    for call_specialization in identity_bindings
+                        .iter_flat()
+                        .flat_map(CallableBinding::matching_overloads)
+                        .filter_map(|(_, identity_overload)| identity_overload.specialization())
+                    {
+                        // Record the constraints on the receiver's generic context formed by
+                        // the arguments to this dunder call.
+                        let constraints =
+                            identity_instance.apply_specialization(db, call_specialization);
+
+                        self.collection_use_constraints
+                            .entry(collection_def)
+                            .or_default()
+                            .insert(constraints);
+                    }
+                }
+            }
+        }
+
+        is_valid_assignment
     }
 
     #[expect(clippy::too_many_arguments)]


### PR DESCRIPTION
Implements full-scope bidirectional inference for collection literals that are not constrained at their definition, e.g.,
```py
x = []
x.append(1)
x.append("2")
reveal_type(x)  # revealed: list[int | str]
```

In particular, this PR considers empty, unannotated collection literals to be unconstrained, e.g., `lst = []`, and looks ahead in their containing scope for potentially constraining uses, which are:
- Return statements involving the collection object, e.g., `return lst`.
- Annotated assignments involving the collection object, e.g., `x: list[int] = lst`.
- Bound-method calls on the collection object, e.g., `lst.append(1)`.
- Subscript assignments on the collection object, e.g., `lst[0] = "hello"`.

The inferred type of the collection literal is the union of all constraints on the element type, collected from all constraining uses in the containing scope. Note that operations through reassignments, arbitrary function calls, augmented assignments, nested bound-method calls, etc., are not currently tracked.

Note that because this PR only considers unconstrained collection literals, for which we previously inferred `Unknown` types, the ecosystem report consists primarily of new diagnostics. These are ideally removing false negatives, but likely introduces many false positives as well, because the heuristic implemented is not perfect. However, this approach is quite easily extended to unannotated collection literals that are not empty, which seems to remove a couple hundred ecosystem diagnostics, but I'd like to intentionally limit the scope of this change (and the performance/memory usage impact).

Part of https://github.com/astral-sh/ty/issues/1473.