### PR TITLE
[ty] Full-scope bidirectional inference for non-empty collection literals

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -987,9 +987,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         &mut self.ast_ids[scope_id]
     }
 
-    /// If the given expression is a use of an unconstrained collection literal, returns
+    /// If the given expression is a use of an unannotated collection literal, returns
     /// the definition of the collection literal.
-    fn unconstrained_collection_literal_binding(
+    fn unannotated_collection_literal_binding(
         &self,
         collection_use: &ast::Expr,
     ) -> Option<Definition<'db>> {
@@ -1003,9 +1003,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 definition
                     .kind(self.db)
                     .as_unannotated_assignment()
-                    .is_some_and(|assignment| {
-                        is_unconstrained_collection_literal(assignment.value(self.module))
-                    })
+                    .is_some_and(|assignment| is_collection_literal(assignment.value(self.module)))
             })
             // TODO: Support uses that refer to multiple definitions. This currently seems to lead to
             // cycle-related panics.
@@ -3005,9 +3003,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 self.visit_expr(&node.value);
 
-                // Unconstrained collection literals must be standalone expressions to participate
+                // Unannotated collection literals must be standalone expressions to participate
                 // in full-scope bidirectional inference.
-                if node.targets.len() == 1 && is_unconstrained_collection_literal(&node.value) {
+                if node.targets.len() == 1 && is_collection_literal(&node.value) {
                     self.add_standalone_assigned_expression(&node.value, node);
                 }
 
@@ -3879,7 +3877,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 };
 
                 if let Some((func, expr, is_await)) = call_info {
-                    // Avoid creating reachability nodes for calls on unconstrained collection
+                    // Avoid creating reachability nodes for calls on unannotated collection
                     // literals. Without this short-circuit, performing reachability analysis
                     // can lead to quadratic blowup of cycle dependencies during full-scope
                     // collection inference, as Salsa flattens the dependencies of all cycle
@@ -3895,7 +3893,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         && func
                             .as_attribute_expr()
                             .and_then(|attribute| {
-                                self.unconstrained_collection_literal_binding(&attribute.value)
+                                self.unannotated_collection_literal_binding(&attribute.value)
                             })
                             .is_none()
                     {
@@ -4141,9 +4139,9 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                     if is_use {
                         self.record_place_use(place_id, expr);
 
-                        // Keep track of any uses of collection literals.
+                        // Keep track of any uses of unannotated collection literals.
                         if let Some(collection_def) =
-                            self.unconstrained_collection_literal_binding(expr)
+                            self.unannotated_collection_literal_binding(expr)
                             && let Some(current_statement) = self.current_statements.last_mut()
                         {
                             current_statement
@@ -4864,11 +4862,6 @@ fn is_if_not_type_checking(expr: &ast::Expr) -> bool {
     )
 }
 
-pub(crate) fn is_unconstrained_collection_literal(expr: &ast::Expr) -> bool {
-    match expr {
-        ast::Expr::List(list) => list.elts.is_empty(),
-        ast::Expr::Set(set) => set.elts.is_empty(),
-        ast::Expr::Dict(dict) => dict.items.is_empty(),
-        _ => false,
-    }
+pub(crate) fn is_collection_literal(expr: &ast::Expr) -> bool {
+    expr.is_list_expr() || expr.is_set_expr() || expr.is_dict_expr()
 }

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -544,9 +544,9 @@ impl<'db> SemanticIndex<'db> {
         self.enclosing_lambda_statements.get(&lambda).copied()
     }
 
-    /// If this is a potentially constraining use of an unconstrained collection literal, returns
+    /// If this is a potentially constraining use of an unannotated collection literal, returns
     /// its definition.
-    pub fn unconstrained_collection_binding(
+    pub fn unannotated_collection_literal(
         &self,
         collection_use: &ast::Expr,
     ) -> Option<Definition<'db>> {

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -485,9 +485,8 @@ reveal_type(x13)  # revealed: dict[str, list[str | None]]
 x14: Mapping[str, list[int | None]] | Mapping[str, list[str | None]] = {"a": ["b"]}
 reveal_type(x14)  # revealed: dict[str, list[str | None]]
 
-x15 = [{"a": [1], "b": 1}, {"a": [1]}]
-x15.append(reveal_type({"b": 1}))  # revealed: dict[str, list[int] | int]
-reveal_type(x15)  # revealed: list[dict[str, list[int] | int] | dict[str, list[int]]]
+def _(x15: list[dict[str, list[int] | int] | dict[str, list[int]]]):
+    x15.append(reveal_type({"b": 1}))  # revealed: dict[str, list[int] | int]
 
 type EitherList = list[int | str] | list[int | None]
 
@@ -1009,9 +1008,8 @@ reveal_type(x4)  # revealed: dict[str, list[str | None]]
 x5: Mapping[str, list[int | None]] | Mapping[str, list[str | None]] = dict([("a", ["b"])])
 reveal_type(x5)  # revealed: dict[str, list[str | None]]
 
-x6 = [dict([("a", list((1,))), ("b", 1)]), dict([("a", list((1,)))])]
-x6.append(reveal_type(dict([("b", 1)])))  # revealed: dict[str, list[int] | int]
-reveal_type(x6)  # revealed: list[dict[str, list[int] | int] | dict[str, list[int]]]
+def _(x6: list[dict[str, list[int] | int] | dict[str, list[int]]]):
+    x6.append(reveal_type(dict([("b", 1)])))  # revealed: dict[str, list[int] | int]
 
 type EitherList = list[int | str] | list[int | None]
 

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1092,6 +1092,20 @@ def _(flag: bool):
     reveal_type(x22)  # revealed: list[Unknown]
 ```
 
+```py
+x23 = [None, None, None]
+x23[0] = 1
+x23[1] = "2"
+x23[2] = 3.0
+reveal_type(x23)  # revealed: list[int | str | float | None]
+```
+
+```py
+x24 = {"a": 1}
+x24[1] = "b"
+reveal_type(x24)  # revealed: dict[int | str, str | int]
+```
+
 ## Multi-inference diagnostics
 
 Diagnostics unrelated to the type-context are only reported once:

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -125,7 +125,6 @@ coordinates = {
     "palm-tree": (10, 8),
 }
 reveal_type(coordinates)  # revealed: dict[str, tuple[int, int]]
-coordinates["treasure"] = (5, 6, -10)  # error: [invalid-assignment]
 ```
 
 Heterogeneous tuples are not widened.
@@ -187,15 +186,12 @@ def get_segments_by_name() -> dict[str, tuple[int, int]]:
 
 segments = [get_segment(), (1, 2), (3, 4, 5)]
 reveal_type(segments)  # revealed: list[tuple[int] | tuple[int, int, int, int] | tuple[int, int] | tuple[int, int, int]]
-segments.append((6, 7, 8, 9, 10))  # error: [invalid-argument-type]
 
 starred_segments = [*get_segments(), (1, 2), (3, 4, 5)]
 reveal_type(starred_segments)  # revealed: list[tuple[int, int] | tuple[int, int, int]]
-starred_segments.append((6, 7, 8, 9))  # error: [invalid-argument-type]
 
 mapping_segments = {**get_segments_by_name(), "start": (1, 2), "end": (3, 4, 5)}
 reveal_type(mapping_segments)  # revealed: dict[str, tuple[int, int] | tuple[int, int, int]]
-mapping_segments["bad"] = (6, 7, 8, 9)  # error: [invalid-assignment]
 ```
 
 This also applies when the non-literal tuple type is hidden behind a type alias or a type variable,
@@ -225,53 +221,45 @@ def get_aliased_segment() -> Segment:
 
 aliased_segments = [get_aliased_segment(), (1, 2), (3, 4, 5)]
 reveal_type(aliased_segments)  # revealed: list[tuple[int, int] | tuple[int, int, int]]
-aliased_segments.append((6, 7, 8, 9))  # error: [invalid-argument-type]
 
 def get_newtype_segment() -> NewTypeSegment:
     return NewTypeSegment((0, 1))
 
 newtype_segments = [get_newtype_segment(), (1, 2), (3, 4, 5)]
 reveal_type(newtype_segments)  # revealed: list[tuple[int, int] | tuple[int, int, int]]
-newtype_segments.append((6, 7, 8, 9))  # error: [invalid-argument-type]
 
 def check_bound_typevar_segment(segment: BoundSegment) -> None:
     bound_typevar_segments = [segment, (1, 2), (3, 4, 5)]
     reveal_type(bound_typevar_segments)  # revealed: list[tuple[int, int] | tuple[int, int, int]]
-    bound_typevar_segments.append((6, 7, 8, 9))  # error: [invalid-argument-type]
 
 def check_constrained_typevar_segment(segment: ConstrainedSegment) -> None:
     constrained_typevar_segments = [segment, (1, 2), (3, 4, 5)]
     # revealed: list[ConstrainedSegment@check_constrained_typevar_segment | tuple[int, int] | tuple[int, int, int]]
     reveal_type(constrained_typevar_segments)
-    constrained_typevar_segments.append((6, 7, 8, 9))  # error: [invalid-argument-type]
 
 def get_subsumed_segment() -> tuple[bool, bool]:
     return (True, False)
 
 subsumed_segments = [get_subsumed_segment(), (1, 2), (3, 4, 5)]
 reveal_type(subsumed_segments)  # revealed: list[tuple[int, int] | tuple[int, int, int]]
-subsumed_segments.append((6, 7, 8, 9))  # error: [invalid-argument-type]
 
 def get_short_subsumed_segment() -> tuple[bool]:
     return (True,)
 
 short_subsumed_segments = [get_short_subsumed_segment(), (1, 2), (3, 4, 5)]
 reveal_type(short_subsumed_segments)  # revealed: list[tuple[bool] | tuple[int, int] | tuple[int, int, int]]
-short_subsumed_segments.append((6, 7, 8, 9))  # error: [invalid-argument-type]
 
 def get_heterogeneous_subsumed_segment() -> tuple[bool, int]:
     return (True, 0)
 
 heterogeneous_subsumed_segments = [get_heterogeneous_subsumed_segment(), (1, 2), (3, 4, 5)]
 reveal_type(heterogeneous_subsumed_segments)  # revealed: list[tuple[int, int] | tuple[int, int, int]]
-heterogeneous_subsumed_segments.append((6, 7, 8, 9))  # error: [invalid-argument-type]
 
 def check_intersection_segment(segment: tuple[int, int]) -> None:
     if is_p(segment):
         reveal_type(segment)  # revealed: tuple[int, int] & P
         intersection_segments = [segment, (1, 2), (3, 4, 5)]
         reveal_type(intersection_segments)  # revealed: list[tuple[int, int] | tuple[int, int, int]]
-        intersection_segments.append((6, 7, 8, 9))  # error: [invalid-argument-type]
 ```
 
 No promotion occurs when a covariant collection type context provides a fixed-length tuple.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6105,7 +6105,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         if let Some(tcx) = tcx.annotation
-            && let Some(collection_def) = self.index.unconstrained_collection_binding(expression)
+            && let Some(collection_def) = self.index.unannotated_collection_literal(expression)
         {
             self.collection_use_constraints
                 .entry(collection_def)
@@ -7178,7 +7178,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 DefinitionNodeKey::from_assignment(assignment.node(self.module())).exactly_one()
             && let Some(collection_def) = self.index.try_definition(collection_def)
         {
-            // For unconstrained collection literals, collect any constraints created by later uses
+            // For unannotated collection literals, collect any constraints created by later uses
             // of this definition in the scope.
             for (statement, use_expression) in
                 self.index.constraining_collection_uses(collection_def)
@@ -8754,11 +8754,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         // Record the constraints for the receiver of a bound method call, if the receiver is an
-        // unconstrained collection literal.
+        // unannotated collection literal.
         if let ast::Expr::Attribute(attribute @ ast::ExprAttribute { value, .. }) = func.as_ref() {
             let value_type = self.expression_type(value);
 
-            if let Some(collection_def) = self.index.unconstrained_collection_binding(value)
+            if let Some(collection_def) = self.index.unannotated_collection_literal(value)
                 && let Some((collection_literal, _)) = value_type.class_specialization(self.db())
             {
                 let identity_instance = Type::instance(

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1253,9 +1253,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
 
         // Record the constraints for the object of the subscript assignment, if the object is an
-        // unconstrained collection literal.
+        // unannotated collection literal.
         if is_valid_assignment
-            && let Some(collection_def) = self.index.unconstrained_collection_binding(object)
+            && let Some(collection_def) = self.index.unannotated_collection_literal(object)
             && let Some((class_literal, _)) = object_ty.class_specialization(db)
         {
             let identity_instance = Type::instance(db, class_literal.identity_specialization(db));


### PR DESCRIPTION
Extends https://github.com/astral-sh/ruff/pull/25279 to support full-scope inference for all unannotated collection literals, even those that are non-empty, e.g.,
```py
x = [1]
x.append("2")
reveal_type(x) # revealed: list[int | str]
```