### PR TITLE
[ty] Avoid panicking on `__new__` assigned to classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -167,6 +167,92 @@ reveal_type(Foo(1))  # revealed: Foo
 reveal_type(Foo())  # revealed: Foo
 ```
 
+## A class object in place of `__new__`
+
+Regression test for <https://github.com/astral-sh/ty/issues/3491>.
+
+```py
+class C:
+    class __new__(a):  # error: [unresolved-reference]
+        pass
+
+C()
+```
+
+We do not fully model the constructor chain when the callable used as `__new__` is itself a class
+object. These cases document the runtime behavior and the approximation we make today.
+
+If the assigned class returns an outer-class instance that is not also an instance of the assigned
+class, the assigned class's `__init__` is skipped. Here, `D()` calls `Factory.__new__(Factory, D)`,
+which returns a `D`. Python skips `Factory.__init__`, then continues the outer call with
+`D.__init__`. This is what we currently model.
+
+```py
+class Factory:
+    def __new__(cls, outer_cls: type["D"]) -> "D":
+        return object.__new__(D)
+
+    def __init__(self, outer_cls: int) -> None:
+        pass
+
+class D:
+    __new__ = Factory
+
+    def __init__(self, value: int) -> None:
+        pass
+
+# error: [missing-argument] "No argument provided for required parameter `value` of `D.__init__`"
+D()
+```
+
+If the returned outer-class instance is also an instance of the assigned class, the assigned class
+call does continue into `__init__`. Here, `E()` calls `SubclassFactory.__new__(SubclassFactory, E)`,
+which returns an `E`. Since `E` is a `SubclassFactory` subclass and overrides `__init__`, the inner
+`SubclassFactory(E)` call dispatches to `E.__init__(..., E)`. The outer `E()` call then dispatches
+to `E.__init__` again with the outer call arguments. We currently only model that outer call.
+
+```py
+class SubclassFactory:
+    def __new__(cls, outer_cls: type["E"]) -> "E":
+        return object.__new__(E)
+
+    def __init__(self, outer_cls: int) -> None:
+        pass
+
+class E(SubclassFactory):
+    __new__ = SubclassFactory
+
+    def __init__(self, value: int) -> None:
+        pass
+
+# TODO should also be - error: [invalid-argument-type] "Argument to `E.__init__` is incorrect: Expected `int`, found `<class 'E'>`"
+# error: [missing-argument] "No argument provided for required parameter `value` of `E.__init__`"
+E()
+```
+
+If the assigned class returns an instance of itself instead of an outer-class instance, its own
+`__init__` is called and the outer class's `__init__` is skipped. Here, `SelfFactory.__new__`
+returns a `SelfFactory`, so `SelfFactory.__init__` runs inside `ReturnsFactory()` but
+`ReturnsFactory.__init__` does not. We currently do not model that nested `__init__` call.
+
+```py
+class SelfFactory:
+    def __new__(cls, outer_cls: type["ReturnsFactory"]) -> "SelfFactory":
+        return object.__new__(SelfFactory)
+
+    def __init__(self, outer_cls: int) -> None:
+        pass
+
+class ReturnsFactory:
+    __new__ = SelfFactory
+
+    def __init__(self, value: int) -> None:
+        pass
+
+# TODO should be - error: [invalid-argument-type] "Argument to `SelfFactory.__init__` is incorrect: Expected `int`, found `<class 'ReturnsFactory'>`"
+ReturnsFactory()
+```
+
 ## `__new__` is implicitly a static method, but explicitly marking it as one is harmless
 
 ```py

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -173,12 +173,9 @@ impl<'db> ConstructorBinding<'db> {
     where
         F: Fn(CallableBinding<'db>) -> CallableBinding<'db>,
     {
-        // We only ever map constructor bindings before we set their downstream constructor; don't
-        // spend complexity on dead code.
-        assert!(
-            self.downstream_constructor.is_none(),
-            "map should not be used on a ConstructorBinding with downstream constructor"
-        );
+        // TODO: Model the nested constructor chain if we want to support class objects assigned to
+        // `__new__`. For now, map the callable itself and drop its downstream constructor checks
+        // instead of panicking.
         ConstructorBinding {
             entry: f(self.entry),
             constructor_context: self.constructor_context,


### PR DESCRIPTION
## Summary

I added a TODO since I don't think this is worth modeling properly, but we also shouldn't panic on it. I've tried to clearly outline the actual runtime behavior in the mdtests, though it's extremely mind-bending IMO.

Closes https://github.com/astral-sh/ty/issues/3491.