### PR TITLE
Set `exclude-newer = "7 days"` in our PEP-723 scripts

### DIFF
--- a/crates/ty_python_semantic/mdtest.py
+++ b/crates/ty_python_semantic/mdtest.py
@@ -5,6 +5,9 @@
 #     "rich",
 #     "watchfiles>=1.1.0",
 # ]
+#
+# [tool.uv]
+# exclude-newer = "7 days"
 # ///
 
 from __future__ import annotations

--- a/crates/ty_python_semantic/mdtest.py.lock
+++ b/crates/ty_python_semantic/mdtest.py.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [manifest]
 requirements = [
     { name = "rich" },

--- a/scripts/setup_primer_project.py
+++ b/scripts/setup_primer_project.py
@@ -4,6 +4,21 @@
 # requires-python = ">=3.11"
 # dependencies = ["mypy-primer"]
 #
+# [tool.uv]
+# # The only direct dependency of this script is mypy-primer,
+# # and mypy-primer is a git dependency, so it is unaffected
+# # by the `exclude-newer` setting:
+# #
+# # > The --exclude-newer option is only applied to packages
+# # > that are read from a registry (as opposed to, e.g., Git dependencies).
+# # -- https://docs.astral.sh/uv/concepts/resolution/#reproducible-resolutions
+# #
+# # That's probably desirable: we usually want the latest
+# # version of mypy-primer anyway. But it's still worth setting
+# # `exclude-newer` here for any transitive dependencies of
+# # mypy-primer.
+# exclude-newer = "7 days"
+#
 # [tool.uv.sources]
 # mypy-primer = { git = "https://github.com/hauntsaninja/mypy_primer" }
 # ///

--- a/scripts/setup_primer_project.py.lock
+++ b/scripts/setup_primer_project.py.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [manifest]
 requirements = [{ name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer" }]
 


### PR DESCRIPTION
## Summary

This helps reduce spurious changes to the lockfile if you run these scripts on a machine that has a global `exclude-newer` value set in a `~/.config/uv.toml` file or similar. It also seems good more generally to set an `exclude-newer` value for these scripts: dependency cooldowns are better for security.

Note that if the machine, hypothetically, also set `UV_DEFAULT_INDEX` as an environment variable to something other than `pypi.org/simple`, there would still be changes to the lockfile, so this change may be necessary but not sufficient for lockfile stability on _certain_ corporate machines.

## Test Plan

I ensured that the `UV_DEFAULT_INDEX` environment variable was set to `pypi.org/simple` on my machine and then ran `mdtest.py` using `uv run`. I didn't run `setup_primer_project.py`, but I did lock it using `uv lock --script`.