### PR TITLE
[`flake8-comprehensions`] Document `RecursionError` edge case in `__len__` (`C416`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -52,6 +52,27 @@ use crate::rules::flake8_comprehensions::fixes;
 /// cannot consistently infer if the iterable type is a sequence or a mapping and cannot suggest
 /// the correct fix for mappings.
 ///
+/// Applying the fix inside an object's `__len__` method can also cause a `RecursionError` at
+/// runtime. CPython's `list()` constructor calls `__length_hint__` (and, in turn, `__len__`)
+/// when iterating over a container, so rewriting `[item for item in self]` to `list(self)` in
+/// `__len__` will recurse infinitely. The same applies to `dict()` and `set()` calls on `self`.
+///
+/// For example:
+///
+/// ```python
+/// class Container:
+///     def __iter__(self):
+///         return iter(self._items)
+///
+///     def __len__(self):
+///         items = [item for item in self]  # safe
+///         # items = list(self)             # RecursionError
+///         ...
+/// ```
+///
+/// Suppress this rule with `# noqa: C416` when the comprehension is reached (directly or
+/// transitively) from `__len__`.
+///
 /// ## Fix safety
 /// Due to the known problem with dictionary comprehensions, this fix is marked as unsafe.
 ///

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -52,31 +52,12 @@ use crate::rules::flake8_comprehensions::fixes;
 /// cannot consistently infer if the iterable type is a sequence or a mapping and cannot suggest
 /// the correct fix for mappings.
 ///
-/// Applying the fix inside an object's `__len__` method can also cause a `RecursionError` at
-/// runtime. CPython's `list()` constructor calls `__length_hint__` (and, in turn, `__len__`)
-/// when iterating over a container, so rewriting `[item for item in self]` to `list(self)` in
-/// `__len__` will recurse infinitely. The same applies to `dict()` and `set()` calls on `self`.
-///
-/// For example:
-///
-/// ```python
-/// class Container:
-///     def __iter__(self):
-///         return iter(self._items)
-///
-///     def __len__(self):
-///         items = [item for item in self]  # safe
-///         # items = list(self)             # RecursionError
-///         ...
-/// ```
-///
-/// Suppress this rule with `# noqa: C416` when the comprehension is reached (directly or
-/// transitively) from `__len__`.
+/// Additionally, rewriting comprehensions inside an object's `__len__` method may cause a
+/// `RecursionError`, as collection constructors can call back into `__len__`.
 ///
 /// ## Fix safety
-/// Due to the known problem with dictionary comprehensions, this fix is marked as unsafe.
-///
-/// Additionally, this fix may drop comments when rewriting the comprehension.
+/// This rule's fix is always marked as unsafe because of the known problems described above and
+/// because comments may be dropped when rewriting the comprehension.
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.73")]
 pub(crate) struct UnnecessaryComprehension {


### PR DESCRIPTION
C416's autofix rewrites a list comprehension like `[item for item in self]` into `list(self)`, but when the original is reached from inside `__len__`, the rewrite recurses: CPython's `list()` constructor probes `__length_hint__` (which dispatches to `__len__`) as a sizing optimization while iterating, so `list(self)` from inside `__len__` calls `__len__` again. The same applies to `dict()` and `set()` calls on `self`.

In #13752, MichaReiser noted that extending the docs would be reasonable and that detecting this control flow isn't the goal. I added a paragraph to the C416 docstring with a runnable example of the failure mode, plus the `# noqa: C416` workaround for when the comprehension is reached (directly or transitively) from `__len__`.

The change is docstring-only. `cargo dev generate-all` and `uvx prek run --from-ref main` both pass.

fixes https://github.com/astral-sh/ruff/issues/13752