### PR TITLE
[`pyupgrade`] Clarify fix safety docs (`UP007`, `UP045`)

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -43,12 +43,20 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 /// while `UP045` checks for `typing.Optional`.
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe, as it may lead to runtime errors when
-/// alongside libraries that rely on runtime type annotations, like Pydantic,
-/// on Python versions prior to Python 3.10, or as it may remove comments if they
-/// are present within the type annotation being rewritten. It may also lead to
-/// runtime errors in unusual and likely incorrect type annotations where the type
-/// does not  support the `|` operator.
+/// The fix is safe when [`target-version`] is Python 3.10 or later (where
+/// `X | Y` is native syntax) **and** the original annotation contains no
+/// comments. Otherwise it is marked unsafe, for one of these reasons:
+///
+/// - On Python versions earlier than 3.10, the `X | Y` form is not
+///   evaluable at runtime, so libraries that introspect annotations at
+///   runtime (such as Pydantic) may raise `TypeError` once the rewrite is
+///   applied.
+/// - Comments inside the original `Union[...]` would be dropped by the
+///   rewrite.
+///
+/// The fix may also produce a runtime error in unusual and likely
+/// incorrect type annotations whose inner expression does not support the
+/// `|` operator.
 ///
 /// ## Options
 /// - `target-version`
@@ -101,12 +109,20 @@ impl Violation for NonPEP604AnnotationUnion {
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe, as it may lead to runtime errors
-/// using libraries that rely on runtime type annotations, like Pydantic,
-/// on Python versions prior to Python 3.10, or as it may remove comments if they
-/// are present within the type annotation being rewritten. It may also lead to runtime
-/// errors in unusual and likely incorrect type annotations where the type does not
-/// support the `|` operator.
+/// The fix is safe when [`target-version`] is Python 3.10 or later (where
+/// `X | None` is native syntax) **and** the original annotation contains
+/// no comments. Otherwise it is marked unsafe, for one of these reasons:
+///
+/// - On Python versions earlier than 3.10, the `X | None` form is not
+///   evaluable at runtime, so libraries that introspect annotations at
+///   runtime (such as Pydantic) may raise `TypeError` once the rewrite is
+///   applied.
+/// - Comments inside the original `Optional[...]` would be dropped by the
+///   rewrite.
+///
+/// The fix may also produce a runtime error in unusual and likely
+/// incorrect type annotations whose inner expression does not support the
+/// `|` operator.
 ///
 /// ## Options
 /// - `target-version`

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -43,20 +43,12 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 /// while `UP045` checks for `typing.Optional`.
 ///
 /// ## Fix safety
-/// The fix is safe when [`target-version`] is Python 3.10 or later (where
-/// `X | Y` is native syntax) **and** the original annotation contains no
-/// comments. Otherwise it is marked unsafe, for one of these reasons:
-///
-/// - On Python versions earlier than 3.10, the `X | Y` form is not
-///   evaluable at runtime, so libraries that introspect annotations at
-///   runtime (such as Pydantic) may raise `TypeError` once the rewrite is
-///   applied.
-/// - Comments inside the original `Union[...]` would be dropped by the
-///   rewrite.
-///
-/// The fix may also produce a runtime error in unusual and likely
-/// incorrect type annotations whose inner expression does not support the
-/// `|` operator.
+/// This rule's fix is marked as unsafe on Python versions prior to 3.10 because
+/// using the PEP-604 syntax may lead to runtime errors in libraries that rely
+/// on runtime type annotations, like Pydantic, or in unusual and likely
+/// incorrect type annotations where the type does not support the `|`
+/// operator. The fix is also marked as unsafe when it would remove comments
+/// present within the type annotation being rewritten.
 ///
 /// ## Options
 /// - `target-version`
@@ -109,20 +101,12 @@ impl Violation for NonPEP604AnnotationUnion {
 /// ```
 ///
 /// ## Fix safety
-/// The fix is safe when [`target-version`] is Python 3.10 or later (where
-/// `X | None` is native syntax) **and** the original annotation contains
-/// no comments. Otherwise it is marked unsafe, for one of these reasons:
-///
-/// - On Python versions earlier than 3.10, the `X | None` form is not
-///   evaluable at runtime, so libraries that introspect annotations at
-///   runtime (such as Pydantic) may raise `TypeError` once the rewrite is
-///   applied.
-/// - Comments inside the original `Optional[...]` would be dropped by the
-///   rewrite.
-///
-/// The fix may also produce a runtime error in unusual and likely
-/// incorrect type annotations whose inner expression does not support the
-/// `|` operator.
+/// This rule's fix is marked as unsafe on Python versions prior to 3.10 because
+/// using the PEP-604 syntax may lead to runtime errors in libraries that rely
+/// on runtime type annotations, like Pydantic, or in unusual and likely
+/// incorrect type annotations where the type does not support the `|`
+/// operator. The fix is also marked as unsafe when it would remove comments
+/// present within the type annotation being rewritten.
 ///
 /// ## Options
 /// - `target-version`


### PR DESCRIPTION
The current UP007 "Fix safety" paragraph reads "This rule's fix is marked as unsafe, as it may lead to runtime errors when alongside libraries that rely on runtime type annotations, like Pydantic, on Python versions prior to Python 3.10..." The filer of #17062 hit the fix on Python 3.10+ (where the source explicitly marks the fix safe) and was confused about what the docs were warning about.

In the thread, ntBre clarified the actual semantics ("the fix is marked unsafe on Python versions prior to Python 3.10 but safe on and after 3.10") and pjonsson suggested flipping the sentence around. I rewrote the paragraph to mirror the code: the fix is safe when target is 3.10+ and there are no comments, otherwise it's unsafe for one of two reasons (pre-3.10 runtime introspection like Pydantic can `TypeError` on `X | Y`, or comments inside the original would be dropped during rewrite). The unusual-inner-expression caveat is kept. I applied the same rewrite to UP045's docstring because it had the same wording.

Docstring-only. `cargo dev generate-all` and `uvx prek run --from-ref main` both pass.

fixes #17062 