### PR TITLE
[`ruff`] Document false negative for user-defined types (`RUF013`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -63,36 +63,19 @@ use crate::rules::ruff::typing::type_hint_explicitly_allows_none;
 ///
 /// ## Limitations
 ///
-/// Type aliases are not supported and could result in false negatives.
-/// For example, the following code will not be flagged:
+/// Type aliases and other user-defined types are not supported and could
+/// result in false negatives. For example, the following code will not be
+/// flagged:
+///
 /// ```python
 /// Text = str | bytes
-///
-///
-/// def foo(arg: Text = None):
-///     pass
-/// ```
-///
-/// User-defined types, including subclasses and `Enum` types, are
-/// likewise not flagged. Ruff treats names that it cannot resolve to a
-/// known type as compatible with `None` (since, for example, `Letter`
-/// could be defined as `type Letter = str | None` in scope):
-///
-/// ```python
-/// from enum import Enum
-///
-///
-/// class Letter(Enum):
-///     A = "A"
 ///
 ///
 /// class Custom: ...
 ///
 ///
-/// def f(
-///     letter: Letter = None,  # not flagged
-///     value: Custom = None,  # not flagged
-/// ) -> None: ...
+/// def foo(text_arg: Text = None, custom_arg: Custom = None):
+///     pass
 /// ```
 ///
 /// ## Options

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -73,10 +73,11 @@ use crate::rules::ruff::typing::type_hint_explicitly_allows_none;
 ///     pass
 /// ```
 ///
-/// User-defined types — including subclasses and `Enum` types — are
+/// User-defined types, including subclasses and `Enum` types, are
 /// likewise not flagged. Ruff treats names that it cannot resolve to a
 /// known type as compatible with `None` (since, for example, `Letter`
 /// could be defined as `type Letter = str | None` in scope):
+///
 /// ```python
 /// from enum import Enum
 ///
@@ -90,7 +91,7 @@ use crate::rules::ruff::typing::type_hint_explicitly_allows_none;
 ///
 /// def f(
 ///     letter: Letter = None,  # not flagged
-///     value: Custom = None,   # not flagged
+///     value: Custom = None,  # not flagged
 /// ) -> None: ...
 /// ```
 ///

--- a/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/implicit_optional.rs
@@ -73,6 +73,27 @@ use crate::rules::ruff::typing::type_hint_explicitly_allows_none;
 ///     pass
 /// ```
 ///
+/// User-defined types — including subclasses and `Enum` types — are
+/// likewise not flagged. Ruff treats names that it cannot resolve to a
+/// known type as compatible with `None` (since, for example, `Letter`
+/// could be defined as `type Letter = str | None` in scope):
+/// ```python
+/// from enum import Enum
+///
+///
+/// class Letter(Enum):
+///     A = "A"
+///
+///
+/// class Custom: ...
+///
+///
+/// def f(
+///     letter: Letter = None,  # not flagged
+///     value: Custom = None,   # not flagged
+/// ) -> None: ...
+/// ```
+///
 /// ## Options
 /// - `target-version`
 /// - `lint.future-annotations`


### PR DESCRIPTION
RUF013 silently skips parameters whose annotation is a user-defined class (including any `Enum` subclass) when the default is `None`, e.g. `letter: Letter = None` where `Letter(Enum)` or `value: Custom = None` where `Custom` is just an imported class. The reporter of #14018 ran into both cases and asked whether at least documenting the limitation was reasonable.

In that thread, MichaReiser confirmed the false negative is intentional: Ruff doesn't know what `Letter` resolves to, since a name in scope could be a type alias like `type Letter = str | None` that already includes `None`. dhruvmanila added the implementation context, that the resolver falls back to treating unresolved annotations as `Any`-compatible. The existing "Limitations" section only mentions the `Text = str | bytes` alias case, so I added a second example covering user-defined classes (including `Enum`) in the same style.

Docstring-only. `cargo dev generate-all` and `uvx prek run --from-ref main` both pass.