### PR TITLE
Avoid unnecessary parser lookahead for operators

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -272,7 +272,9 @@ impl<'src> Parser<'src> {
                 break;
             }
 
-            let Some(operator) = BinaryLikeOperator::try_from_tokens(current_token, self.peek())
+            let next_token =
+                matches!(current_token, TokenKind::Is | TokenKind::Not).then(|| self.peek());
+            let Some(operator) = BinaryLikeOperator::try_from_tokens(current_token, next_token)
             else {
                 // Not an operator.
                 break;
@@ -1302,7 +1304,9 @@ impl<'src> Parser<'src> {
                 break;
             }
 
-            let Some(next_op) = helpers::token_kind_to_cmp_op([next_token, self.peek()]) else {
+            let next_next_token =
+                matches!(next_token, TokenKind::Is | TokenKind::Not).then(|| self.peek());
+            let Some(next_op) = helpers::token_kind_to_cmp_op(next_token, next_next_token) else {
                 break;
             };
 
@@ -3150,15 +3154,16 @@ enum BinaryLikeOperator {
 }
 
 impl BinaryLikeOperator {
-    /// Attempts to convert the two tokens into the corresponding binary-like operator. Returns
-    /// [None] if it's not a binary-like operator.
-    fn try_from_tokens(current: TokenKind, next: TokenKind) -> Option<BinaryLikeOperator> {
+    /// Attempts to convert the token into the corresponding binary-like operator. `next` is
+    /// required to distinguish `is not` and `not in` from their one-token alternatives.
+    /// Returns [None] if it's not a binary-like operator.
+    fn try_from_tokens(current: TokenKind, next: Option<TokenKind>) -> Option<BinaryLikeOperator> {
         if let Some(bool_op) = current.as_bool_operator() {
             Some(BinaryLikeOperator::Boolean(bool_op))
         } else if let Some(bin_op) = current.as_binary_operator() {
             Some(BinaryLikeOperator::Binary(bin_op))
         } else {
-            helpers::token_kind_to_cmp_op([current, next]).map(BinaryLikeOperator::Comparison)
+            helpers::token_kind_to_cmp_op(current, next).map(BinaryLikeOperator::Comparison)
         }
     }
 

--- a/crates/ruff_python_parser/src/parser/helpers.rs
+++ b/crates/ruff_python_parser/src/parser/helpers.rs
@@ -30,19 +30,24 @@ pub(super) fn set_expr_ctx(expr: &mut Expr, new_ctx: ExprContext) {
     }
 }
 
-/// Converts a [`TokenKind`] array of size 2 to its correspondent [`CmpOp`].
-pub(super) const fn token_kind_to_cmp_op(tokens: [TokenKind; 2]) -> Option<CmpOp> {
-    Some(match tokens {
-        [TokenKind::Is, TokenKind::Not] => CmpOp::IsNot,
-        [TokenKind::Is, _] => CmpOp::Is,
-        [TokenKind::Not, TokenKind::In] => CmpOp::NotIn,
-        [TokenKind::In, _] => CmpOp::In,
-        [TokenKind::EqEqual, _] => CmpOp::Eq,
-        [TokenKind::NotEqual, _] => CmpOp::NotEq,
-        [TokenKind::Less, _] => CmpOp::Lt,
-        [TokenKind::LessEqual, _] => CmpOp::LtE,
-        [TokenKind::Greater, _] => CmpOp::Gt,
-        [TokenKind::GreaterEqual, _] => CmpOp::GtE,
+/// Converts a [`TokenKind`] into its corresponding [`CmpOp`].
+///
+/// `next` is only needed to distinguish `is not` and `not in`.
+pub(super) const fn token_kind_to_cmp_op(
+    current: TokenKind,
+    next: Option<TokenKind>,
+) -> Option<CmpOp> {
+    Some(match (current, next) {
+        (TokenKind::Is, Some(TokenKind::Not)) => CmpOp::IsNot,
+        (TokenKind::Is, _) => CmpOp::Is,
+        (TokenKind::Not, Some(TokenKind::In)) => CmpOp::NotIn,
+        (TokenKind::In, _) => CmpOp::In,
+        (TokenKind::EqEqual, _) => CmpOp::Eq,
+        (TokenKind::NotEqual, _) => CmpOp::NotEq,
+        (TokenKind::Less, _) => CmpOp::Lt,
+        (TokenKind::LessEqual, _) => CmpOp::LtE,
+        (TokenKind::Greater, _) => CmpOp::Gt,
+        (TokenKind::GreaterEqual, _) => CmpOp::GtE,
         _ => return None,
     })
 }


### PR DESCRIPTION
## Summary

We only need to peek ahead two tokens if the first token is `not` or `in`. We can avoid the `peek` in the majority of cases, which apparently speeds up the parser by 20-30%.