### PR TITLE
docs: fix typo in unraw_re_pattern doc comment (sting -> string)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
@@ -247,7 +247,7 @@ fn check_bytes(checker: &Checker, literal: &BytesLiteral, module: RegexModule, f
     ));
 }
 
-/// Check how same it is to prepend the `r` prefix to the byte sting.
+/// Check how same it is to prepend the `r` prefix to the byte string.
 ///
 /// ## Returns
 ///  * `None` if the prefix cannot be added,


### PR DESCRIPTION
> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix a typo in the doc comment for `check_bytes` in
`crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs` —
`byte sting` → `byte string`. Doc-comment only, no behavioural change.

## Why

Small `///` doc-comment cleanup for the helper that decides whether to
prepend an `r` prefix to a byte string literal.

## How verified

Single-character insertion in a `///` Rust doc comment. The function it
documents (`check_bytes`) is untouched.

## Maintainer note

Feel free to close if not worth the review cycle.
