### PR TITLE
[ty] Support type aliases in document symbols

### DIFF
--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -248,6 +248,44 @@ class OuterClass:
         ");
     }
 
+    #[test]
+    fn test_document_symbols_type_alias() {
+        let test = cursor_test(
+            "
+type IntList = list[int]
+
+class Aliases:
+    type Item = int
+<CURSOR>",
+        );
+
+        assert_snapshot!(test.document_symbols(), @"
+        info[document-symbols]: SymbolInfo
+         --> main.py:2:6
+          |
+        2 | type IntList = list[int]
+          |      ^^^^^^^
+          |
+        info: Variable IntList
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:4:7
+          |
+        4 | class Aliases:
+          |       ^^^^^^^
+          |
+        info: Class Aliases
+
+        info[document-symbols]: SymbolInfo
+         --> main.py:5:10
+          |
+        5 |     type Item = int
+          |          ^^^^
+          |
+        info: Variable Item
+        ");
+    }
+
     impl CursorTest {
         fn document_symbols(&self) -> String {
             let symbols = document_symbols(&self.db, self.cursor.file).to_hierarchical();

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -818,8 +818,27 @@ impl<'db> SymbolVisitor<'db> {
         symbol_id
     }
 
+    /// Adds a symbol for a name definition.
+    fn add_name_symbol(&mut self, stmt: &ast::Stmt, name: &ast::ExprName, kind: SymbolKind) {
+        let symbol = SymbolTree {
+            parent: None,
+            name: name.id.to_string(),
+            kind,
+            deprecated: false,
+            name_range: name.range(),
+            full_range: stmt.range(),
+            imported_from: None,
+        };
+        self.add_symbol(symbol);
+    }
+
     /// Adds a symbol introduced via an assignment.
-    fn add_assignment(&mut self, stmt: &ast::Stmt, name: &ast::ExprName) -> SymbolId {
+    fn add_assignment(&mut self, stmt: &ast::Stmt, name: &ast::ExprName) {
+        // Include assignments only when we're in global or class scope.
+        if self.in_function {
+            return;
+        }
+
         let kind = if Self::is_constant_name(name.id.as_str()) {
             SymbolKind::Constant
         } else if self
@@ -830,17 +849,7 @@ impl<'db> SymbolVisitor<'db> {
         } else {
             SymbolKind::Variable
         };
-
-        let symbol = SymbolTree {
-            parent: None,
-            name: name.id.to_string(),
-            kind,
-            deprecated: false,
-            name_range: name.range(),
-            full_range: stmt.range(),
-            imported_from: None,
-        };
-        self.add_symbol(symbol)
+        self.add_name_symbol(stmt, name, kind);
     }
 
     /// Adds a symbol introduced via an import `stmt`.
@@ -1278,13 +1287,19 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
                 // Restore the previous class scope state
                 self.in_class = was_in_class;
             }
-            ast::Stmt::Assign(assign) => {
-                self.add_all_assignment(&assign.targets, Some(&assign.value));
-
+            ast::Stmt::TypeAlias(type_alias) => {
                 // Include assignments only when we're in global or class scope
                 if self.in_function {
                     return;
                 }
+                let ast::Expr::Name(name) = &*type_alias.name else {
+                    return;
+                };
+                self.add_name_symbol(stmt, name, SymbolKind::Variable);
+            }
+            ast::Stmt::Assign(assign) => {
+                self.add_all_assignment(&assign.targets, Some(&assign.value));
+
                 for target in &assign.targets {
                     let ast::Expr::Name(name) = target else {
                         continue;
@@ -1298,10 +1313,6 @@ impl<'db> SourceOrderVisitor<'db> for SymbolVisitor<'db> {
                     ann_assign.value.as_deref(),
                 );
 
-                // Include assignments only when we're in global or class scope
-                if self.in_function {
-                    return;
-                }
                 let ast::Expr::Name(name) = &*ann_assign.target else {
                     return;
                 };
@@ -1502,6 +1513,7 @@ mod tests {
 FOO = 1
 foo = 1
 frob: int = 1
+type X = int
 class Foo:
     BAR = 1
 def quux():
@@ -1511,6 +1523,7 @@ def quux():
         FOO :: Constant
         foo :: Variable
         frob :: Variable
+        X :: Variable
         Foo :: Class
         quux :: Function
         ",


### PR DESCRIPTION
## Summary

- teach the `ty_ide` symbol visitor to index PEP 695 type alias statements
- cover type aliases in exported-symbol discovery and document-symbol output


Addresses the type alias item in https://github.com/astral-sh/ty/issues/1771
