### PR TITLE
[ty] Cache narrowed binding types across local place loads

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -968,8 +968,8 @@ fn benchmark_large_union_narrowing(criterion: &mut Criterion) {
 ///         ...
 /// ```
 fn benchmark_repeated_match_narrowed_loads(criterion: &mut Criterion) {
-    const NUM_CLASSES: usize = 30;
-    const NUM_MATCH_BRANCHES: usize = 29;
+    const NUM_CLASSES: usize = 16;
+    const NUM_MATCH_BRANCHES: usize = 15;
 
     setup_rayon();
 

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1015,6 +1015,105 @@ fn benchmark_repeated_match_narrowed_loads(criterion: &mut Criterion) {
     });
 }
 
+/// Benchmark for declaration reachability through a long chain of class-pattern arms.
+///
+/// This is modeled after event rendering code that assigns the rendered output in each arm of a
+/// large `match` over a union of event classes.
+fn class_match_assignment_reachability_code(
+    num_classes: usize,
+    num_match_branches: usize,
+    wrapped_singleton_alternative: Option<&str>,
+) -> String {
+    let mut code = String::new();
+
+    for i in 0..num_classes {
+        writeln!(&mut code, "class Event{i}:\n    value: int\n").ok();
+    }
+    if wrapped_singleton_alternative.is_some() {
+        code.push_str("class OtherEvent:\n    value: int\n\n");
+    }
+
+    code.push_str("Event = ");
+    for i in 0..num_classes {
+        if i > 0 {
+            code.push_str(" | ");
+        }
+        write!(&mut code, "Event{i}").ok();
+    }
+    code.push_str("\n\n");
+
+    code.push_str("def render(event: Event) -> int:\n    match event:\n");
+    for i in 0..num_match_branches {
+        let pattern = if let Some(alternative) = wrapped_singleton_alternative {
+            format!("(Event{i}() | OtherEvent() | {alternative}) as matched")
+        } else {
+            format!("Event{i}()")
+        };
+        writeln!(
+            &mut code,
+            "        case {pattern}:\n            data = event.value"
+        )
+        .ok();
+    }
+    code.push_str("        case _:\n            data = event.value\n    return data\n\n");
+
+    code
+}
+
+fn benchmark_class_match_assignment_reachability(criterion: &mut Criterion) {
+    const NUM_CLASSES: usize = 48;
+    const NUM_MATCH_BRANCHES: usize = 47;
+
+    setup_rayon();
+
+    let code = class_match_assignment_reachability_code(NUM_CLASSES, NUM_MATCH_BRANCHES, None);
+    criterion.bench_function("ty_micro[class_match_assignment_reachability]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    let as_or_none_alternative_code =
+        class_match_assignment_reachability_code(NUM_CLASSES, NUM_MATCH_BRANCHES, Some("None"));
+    criterion.bench_function(
+        "ty_micro[class_as_or_none_alternative_match_assignment_reachability]",
+        |b| {
+            b.iter_batched_ref(
+                || setup_micro_case(&as_or_none_alternative_code),
+                |case| {
+                    let Case { db, .. } = case;
+                    let result = db.check();
+                    assert_eq!(result.len(), 0);
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+
+    let as_or_false_alternative_code =
+        class_match_assignment_reachability_code(NUM_CLASSES, NUM_MATCH_BRANCHES, Some("False"));
+    criterion.bench_function(
+        "ty_micro[class_as_or_false_alternative_match_assignment_reachability]",
+        |b| {
+            b.iter_batched_ref(
+                || setup_micro_case(&as_or_false_alternative_code),
+                |case| {
+                    let Case { db, .. } = case;
+                    let result = db.check();
+                    assert_eq!(result.len(), 0);
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+}
+
 /// Benchmark for narrowing through a long `isinstance` elif chain.
 ///
 /// This pattern is common in visitor-style dispatch code (e.g. koda-validate's
@@ -1573,6 +1672,7 @@ fn datetype(criterion: &mut Criterion) {
 criterion_group!(check_file, benchmark_cold, benchmark_incremental);
 criterion_group!(
     micro,
+    benchmark_class_match_assignment_reachability,
     benchmark_complex_constrained_attributes_1,
     benchmark_complex_constrained_attributes_2,
     benchmark_complex_constrained_attributes_3,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1066,26 +1066,25 @@ fn benchmark_class_match_assignment_reachability(criterion: &mut Criterion) {
 
     setup_rayon();
 
-    let code = class_match_assignment_reachability_code(NUM_CLASSES, NUM_MATCH_BRANCHES, None);
-    criterion.bench_function("ty_micro[class_match_assignment_reachability]", |b| {
-        b.iter_batched_ref(
-            || setup_micro_case(&code),
-            |case| {
-                let Case { db, .. } = case;
-                let result = db.check();
-                assert_eq!(result.len(), 0);
-            },
-            BatchSize::LargeInput,
+    for (name, wrapped_singleton_alternative) in [
+        ("ty_micro[class_match_assignment_reachability]", None),
+        (
+            "ty_micro[class_as_or_none_alternative_match_assignment_reachability]",
+            Some("None"),
+        ),
+        (
+            "ty_micro[class_as_or_false_alternative_match_assignment_reachability]",
+            Some("False"),
+        ),
+    ] {
+        let code = class_match_assignment_reachability_code(
+            NUM_CLASSES,
+            NUM_MATCH_BRANCHES,
+            wrapped_singleton_alternative,
         );
-    });
-
-    let as_or_none_alternative_code =
-        class_match_assignment_reachability_code(NUM_CLASSES, NUM_MATCH_BRANCHES, Some("None"));
-    criterion.bench_function(
-        "ty_micro[class_as_or_none_alternative_match_assignment_reachability]",
-        |b| {
+        criterion.bench_function(name, |b| {
             b.iter_batched_ref(
-                || setup_micro_case(&as_or_none_alternative_code),
+                || setup_micro_case(&code),
                 |case| {
                     let Case { db, .. } = case;
                     let result = db.check();
@@ -1093,25 +1092,8 @@ fn benchmark_class_match_assignment_reachability(criterion: &mut Criterion) {
                 },
                 BatchSize::LargeInput,
             );
-        },
-    );
-
-    let as_or_false_alternative_code =
-        class_match_assignment_reachability_code(NUM_CLASSES, NUM_MATCH_BRANCHES, Some("False"));
-    criterion.bench_function(
-        "ty_micro[class_as_or_false_alternative_match_assignment_reachability]",
-        |b| {
-            b.iter_batched_ref(
-                || setup_micro_case(&as_or_false_alternative_code),
-                |case| {
-                    let Case { db, .. } = case;
-                    let result = db.check();
-                    assert_eq!(result.len(), 0);
-                },
-                BatchSize::LargeInput,
-            );
-        },
-    );
+        });
+    }
 }
 
 /// Benchmark for narrowing through a long `isinstance` elif chain.
@@ -1672,31 +1654,31 @@ fn datetype(criterion: &mut Criterion) {
 criterion_group!(check_file, benchmark_cold, benchmark_incremental);
 criterion_group!(
     micro,
-    benchmark_class_match_assignment_reachability,
+    benchmark_many_string_assignments,
+    benchmark_many_tuple_assignments,
+    benchmark_tuple_implicit_instance_attributes,
     benchmark_complex_constrained_attributes_1,
     benchmark_complex_constrained_attributes_2,
     benchmark_complex_constrained_attributes_3,
-    benchmark_gradual_vararg_call,
-    benchmark_large_isinstance_narrowing,
-    benchmark_large_union_narrowing,
-    benchmark_literal_equality_fallthrough_guarded_any,
-    benchmark_literal_match_fallthrough,
-    benchmark_literal_match_fallthrough_guarded_any,
     benchmark_many_enum_members,
     benchmark_many_enum_members_2,
     benchmark_many_protocol_members_mismatch,
-    benchmark_many_string_assignments,
-    benchmark_many_tuple_assignments,
+    benchmark_gradual_vararg_call,
+    benchmark_vararg_parameter_type_accumulation,
+    benchmark_typevar_mapping_large_accumulation,
+    benchmark_typevar_mapping_small_accumulations,
+    benchmark_very_large_tuple,
+    benchmark_large_union_narrowing,
+    benchmark_large_isinstance_narrowing,
+    benchmark_literal_match_fallthrough,
+    benchmark_literal_match_fallthrough_guarded_any,
+    benchmark_literal_equality_fallthrough_guarded_any,
+    benchmark_typeis_narrowing,
     benchmark_pandas_tdd,
     benchmark_recursive_typed_dict_union_contextual_inference,
     benchmark_pydantic_core_schema_dict,
     benchmark_repeated_match_narrowed_loads,
-    benchmark_tuple_implicit_instance_attributes,
-    benchmark_typeis_narrowing,
-    benchmark_typevar_mapping_large_accumulation,
-    benchmark_typevar_mapping_small_accumulations,
-    benchmark_vararg_parameter_type_accumulation,
-    benchmark_very_large_tuple,
+    benchmark_class_match_assignment_reachability,
 );
 criterion_group!(project, anyio, attrs, hydra, datetype);
 criterion_main!(check_file, micro, project);

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -946,6 +946,75 @@ fn benchmark_large_union_narrowing(criterion: &mut Criterion) {
     });
 }
 
+/// Benchmark for loading the same narrowed binding many times in large match arms.
+///
+/// This is modeled after event rendering code that narrows a large event union
+/// with class patterns, then accesses several attributes on the event in each
+/// match arm.
+///
+/// Sample code structure:
+/// ```python
+/// class Event0:
+///     value: int
+///     detail: str
+/// ...
+///
+/// Event = Event0 | Event1 | ...
+///
+/// def render(event: Event) -> object:
+///     match event:
+///         case Event0():
+///             return event.value, event.detail, event.value
+///         ...
+/// ```
+fn benchmark_repeated_match_narrowed_loads(criterion: &mut Criterion) {
+    const NUM_CLASSES: usize = 30;
+    const NUM_MATCH_BRANCHES: usize = 29;
+
+    setup_rayon();
+
+    let mut code = "from __future__ import annotations\n\n".to_string();
+
+    for i in 0..NUM_CLASSES {
+        writeln!(
+            &mut code,
+            "class Event{i}:\n    value: int\n    detail: str\n    index: int\n"
+        )
+        .ok();
+    }
+
+    code.push_str("Event = ");
+    for i in 0..NUM_CLASSES {
+        if i > 0 {
+            code.push_str(" | ");
+        }
+        write!(&mut code, "Event{i}").ok();
+    }
+    code.push_str("\n\n");
+
+    code.push_str("def render(event: Event) -> object:\n    match event:\n");
+    for i in 0..NUM_MATCH_BRANCHES {
+        writeln!(
+            &mut code,
+            "        case Event{i}():\n            return event.value, event.detail, event.index, event.value, event.detail"
+        )
+        .ok();
+    }
+    code.push_str("        case _:\n            return None\n\n");
+
+    criterion.bench_function("ty_micro[repeated_match_narrowed_loads]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 /// Benchmark for narrowing through a long `isinstance` elif chain.
 ///
 /// This pattern is common in visitor-style dispatch code (e.g. koda-validate's
@@ -1504,29 +1573,30 @@ fn datetype(criterion: &mut Criterion) {
 criterion_group!(check_file, benchmark_cold, benchmark_incremental);
 criterion_group!(
     micro,
-    benchmark_many_string_assignments,
-    benchmark_many_tuple_assignments,
-    benchmark_tuple_implicit_instance_attributes,
     benchmark_complex_constrained_attributes_1,
     benchmark_complex_constrained_attributes_2,
     benchmark_complex_constrained_attributes_3,
+    benchmark_gradual_vararg_call,
+    benchmark_large_isinstance_narrowing,
+    benchmark_large_union_narrowing,
+    benchmark_literal_equality_fallthrough_guarded_any,
+    benchmark_literal_match_fallthrough,
+    benchmark_literal_match_fallthrough_guarded_any,
     benchmark_many_enum_members,
     benchmark_many_enum_members_2,
     benchmark_many_protocol_members_mismatch,
-    benchmark_gradual_vararg_call,
-    benchmark_vararg_parameter_type_accumulation,
-    benchmark_typevar_mapping_large_accumulation,
-    benchmark_typevar_mapping_small_accumulations,
-    benchmark_very_large_tuple,
-    benchmark_large_union_narrowing,
-    benchmark_large_isinstance_narrowing,
-    benchmark_literal_match_fallthrough,
-    benchmark_literal_match_fallthrough_guarded_any,
-    benchmark_literal_equality_fallthrough_guarded_any,
-    benchmark_typeis_narrowing,
+    benchmark_many_string_assignments,
+    benchmark_many_tuple_assignments,
     benchmark_pandas_tdd,
     benchmark_recursive_typed_dict_union_contextual_inference,
     benchmark_pydantic_core_schema_dict,
+    benchmark_repeated_match_narrowed_loads,
+    benchmark_tuple_implicit_instance_attributes,
+    benchmark_typeis_narrowing,
+    benchmark_typevar_mapping_large_accumulation,
+    benchmark_typevar_mapping_small_accumulations,
+    benchmark_vararg_parameter_type_accumulation,
+    benchmark_very_large_tuple,
 );
 criterion_group!(project, anyio, attrs, hydra, datetype);
 criterion_main!(check_file, micro, project);

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -89,6 +89,25 @@ def exhaustive_pattern_with_guard(x: A, flag: bool) -> None:
             reveal_type(x)  # revealed: A
 ```
 
+## Class pattern after collectively exhaustive singleton patterns
+
+```py
+class A: ...
+
+def _(x: bool | A):
+    match x:
+        case True:
+            y = 1
+        case False:
+            y = 2
+        case A():
+            y = 3
+        case _:
+            y = 4
+
+    reveal_type(y)  # revealed: Literal[1, 2, 3]
+```
+
 ## Class patterns with generic classes
 
 ```toml

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -2,6 +2,7 @@ use itertools::Either;
 use ruff_db::files::File;
 use ruff_index::IndexSlice;
 use ruff_python_ast::PythonVersion;
+use rustc_hash::FxHashMap;
 use ty_module_resolver::{
     KnownModule, Module, ModuleName, file_to_module, resolve_module_confident,
 };
@@ -676,8 +677,12 @@ pub(super) fn place_from_bindings<'db>(
         bindings_with_constraints,
         RequiresExplicitReExport::No,
         None,
+        None,
     )
 }
+
+pub(super) type NarrowedBindingTypes<'db> =
+    FxHashMap<(Definition<'db>, ScopedNarrowingConstraint), Type<'db>>;
 
 pub(super) fn place_from_bindings_with_reachability_cache<'db>(
     db: &'db dyn Db,
@@ -689,6 +694,22 @@ pub(super) fn place_from_bindings_with_reachability_cache<'db>(
         bindings_with_constraints,
         RequiresExplicitReExport::No,
         Some(reachability_cache),
+        None,
+    )
+}
+
+pub(super) fn place_from_bindings_with_caches<'db>(
+    db: &'db dyn Db,
+    bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
+    reachability_cache: &ReachabilityEvaluationCache<'db>,
+    narrowed_bindings: &mut NarrowedBindingTypes<'db>,
+) -> PlaceWithDefinition<'db> {
+    place_from_bindings_impl(
+        db,
+        bindings_with_constraints,
+        RequiresExplicitReExport::No,
+        Some(reachability_cache),
+        Some(narrowed_bindings),
     )
 }
 
@@ -1017,7 +1038,7 @@ pub(crate) fn place_by_id<'db>(
     // inferred type, without unioning with `Unknown`, because it cannot be modified.
     if let Some(qualifiers) = declared.is_bare_final() {
         let bindings = all_considered_bindings();
-        return place_from_bindings_impl(db, bindings, requires_explicit_reexport, None)
+        return place_from_bindings_impl(db, bindings, requires_explicit_reexport, None, None)
             .place
             .with_qualifiers(qualifiers);
     }
@@ -1037,7 +1058,9 @@ pub(crate) fn place_by_id<'db>(
             qualifiers,
         } if qualifiers.contains(TypeQualifiers::CLASS_VAR) => {
             let bindings = all_considered_bindings();
-            match place_from_bindings_impl(db, bindings, requires_explicit_reexport, None).place {
+            match place_from_bindings_impl(db, bindings, requires_explicit_reexport, None, None)
+                .place
+            {
                 Place::Defined(DefinedPlace {
                     ty: inferred,
                     origin,
@@ -1085,7 +1108,8 @@ pub(crate) fn place_by_id<'db>(
         } => {
             let bindings = all_considered_bindings();
             let boundness_analysis = bindings.boundness_analysis();
-            let inferred = place_from_bindings_impl(db, bindings, requires_explicit_reexport, None);
+            let inferred =
+                place_from_bindings_impl(db, bindings, requires_explicit_reexport, None, None);
 
             let place = match inferred.place {
                 // Place is possibly undeclared and definitely unbound
@@ -1131,7 +1155,7 @@ pub(crate) fn place_by_id<'db>(
             let bindings = all_considered_bindings();
             let boundness_analysis = bindings.boundness_analysis();
             let mut inferred =
-                place_from_bindings_impl(db, bindings, requires_explicit_reexport, None).place;
+                place_from_bindings_impl(db, bindings, requires_explicit_reexport, None, None).place;
 
             if boundness_analysis == BoundnessAnalysis::AssumeBound {
                 if let Place::Defined(defined) = inferred {
@@ -1470,6 +1494,7 @@ fn place_from_bindings_impl<'db>(
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
     requires_explicit_reexport: RequiresExplicitReExport,
     reachability_cache: Option<&ReachabilityEvaluationCache<'db>>,
+    mut narrowed_bindings: Option<&mut NarrowedBindingTypes<'db>>,
 ) -> PlaceWithDefinition<'db> {
     let predicates = bindings_with_constraints.predicates();
     let reachability_constraints = bindings_with_constraints.reachability_constraints();
@@ -1632,10 +1657,16 @@ fn place_from_bindings_impl<'db>(
             first_definition.get_or_insert(binding);
             provenance = provenance.or(Provenance::SingleDefinition(binding));
             let binding_ty = binding_type(db, binding);
-            Some((
-                narrowing_constraint.narrow(db, binding_ty, binding.place(db)),
-                static_reachability,
-            ))
+            let narrowed_ty = if let Some(narrowed_bindings) = &mut narrowed_bindings {
+                *narrowed_bindings
+                    .entry((binding, narrowing_constraint.constraint()))
+                    .or_insert_with(|| {
+                        narrowing_constraint.narrow(db, binding_ty, binding.place(db))
+                    })
+            } else {
+                narrowing_constraint.narrow(db, binding_ty, binding.place(db))
+            };
+            Some((narrowed_ty, static_reachability))
         },
     );
 

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1155,7 +1155,8 @@ pub(crate) fn place_by_id<'db>(
             let bindings = all_considered_bindings();
             let boundness_analysis = bindings.boundness_analysis();
             let mut inferred =
-                place_from_bindings_impl(db, bindings, requires_explicit_reexport, None, None).place;
+                place_from_bindings_impl(db, bindings, requires_explicit_reexport, None, None)
+                    .place;
 
             if boundness_analysis == BoundnessAnalysis::AssumeBound {
                 if let Place::Defined(defined) = inferred {

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -200,10 +200,11 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, SpecialFormType,
-        Type, TypeContext, UnionType, callable_pattern_type, definite_match_pattern_type,
-        enum_metadata, infer_narrowing_constraints, infer_same_file_expression_type,
-        mapping_pattern_type, sequence_pattern_type_builder, singleton_pattern_type,
+        CallableTypes, ClassLiteral, FiniteAlternativeCoverage, IntersectionBuilder,
+        NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType, callable_pattern_type,
+        definite_match_pattern_type, enum_metadata, infer_narrowing_constraints,
+        infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
+        singleton_pattern_type,
     },
 };
 use ruff_index::{Idx, IndexSlice};
@@ -454,13 +455,13 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
     }
 }
 
-/// Return the exactly represented types matched by supported simple patterns or a composition of
-/// OR-patterns and `as` wrappers made exclusively from those alternatives.
+/// Return the exact types matched by supported simple patterns or a composition of OR-patterns and
+/// `as` wrappers made exclusively from those alternatives.
 ///
 /// Ordinary nominal class patterns and singleton patterns have an exact excluded type in
 /// [`definite_match_pattern_type`]. Refutable or otherwise approximate patterns are intentionally
 /// rejected.
-fn supported_exact_pattern_types<'db>(
+fn exact_pattern_alternatives<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
 ) -> Option<Vec<Type<'db>>> {
@@ -498,35 +499,21 @@ fn supported_exact_pattern_types<'db>(
     Some(types)
 }
 
-/// Prove that a supported exact pattern composition over a union of nominal instances remains
-/// ambiguous after earlier supported pattern compositions fall through.
+/// Analyze an exact pattern composition over a subject with finite alternatives.
 ///
-/// This avoids materializing a large intersection in the common event-dispatch shape. It only
-/// returns a result when both outcomes are witnessed using the same subtype and disjointness
-/// relations as the general intersection analysis:
+/// This avoids materializing a large residual intersection in common finite-domain dispatch shapes.
+/// It uses the same subtype and disjointness relations as the general intersection analysis:
 ///
-/// * one remaining union element can overlap the current pattern; and
-/// * one remaining union element is not a subtype of the current pattern.
-///
-/// Any case that could be statically true or false is handled by the general analysis below.
-fn prove_ambiguous_nominal_class_union_pattern_predicate<'db>(
+/// * no remaining alternative overlaps the current pattern: always false;
+/// * every remaining alternative is covered by the current pattern: always true unless guarded; or
+/// * at least one remaining alternative can match and one can fall through: ambiguous.
+fn analyze_finite_alternative_pattern_predicate<'db>(
     db: &'db dyn Db,
     predicate: PatternPredicate<'db>,
     subject_ty: Type<'db>,
 ) -> Option<Truthiness> {
-    let Type::Union(subject_union) = subject_ty else {
-        return None;
-    };
-    if !subject_union
-        .elements(db)
-        .iter()
-        .all(|element| matches!(element, Type::NominalInstance(_)))
-    {
-        return None;
-    }
-
-    let current_types = supported_exact_pattern_types(db, predicate.kind(db))?;
-    let current_ty = UnionType::from_elements(db, current_types.iter().copied());
+    let current_ty =
+        UnionType::from_elements(db, exact_pattern_alternatives(db, predicate.kind(db))?);
 
     let mut previous_types = Vec::new();
     let mut previous_predicate = predicate;
@@ -537,41 +524,21 @@ fn prove_ambiguous_nominal_class_union_pattern_predicate<'db>(
             continue;
         }
 
-        let types = supported_exact_pattern_types(db, previous_predicate.kind(db))?;
-        previous_types.extend(types);
+        previous_types.extend(exact_pattern_alternatives(db, previous_predicate.kind(db))?);
     }
-    let previous_ty = UnionType::from_elements(db, previous_types.iter().copied());
+    let previous_ty = UnionType::from_elements(db, previous_types);
 
-    // Discard any alternative that was already completely handled by an earlier arm. If all
-    // alternatives were handled, this case can be statically unreachable; leave that result to
-    // the general analysis.
-    let remaining_current_types = current_types
-        .iter()
-        .copied()
-        .filter(|current_ty| !current_ty.is_subtype_of(db, previous_ty))
-        .collect::<Vec<_>>();
-    if remaining_current_types.is_empty() {
-        return None;
-    }
-
-    let mut can_match = false;
-    let mut can_fall_through = false;
-    for subject_element in subject_union.elements(db) {
-        if subject_element.is_subtype_of(db, previous_ty) {
-            continue;
+    match subject_ty.finite_alternative_coverage_after_excluding(db, previous_ty, current_ty)? {
+        FiniteAlternativeCoverage::Empty => Some(Truthiness::AlwaysFalse),
+        FiniteAlternativeCoverage::Covered => {
+            if predicate.guard(db).is_some() {
+                Some(Truthiness::Ambiguous)
+            } else {
+                Some(Truthiness::AlwaysTrue)
+            }
         }
-
-        can_match |= remaining_current_types
-            .iter()
-            .any(|current_ty| !subject_element.is_disjoint_from(db, *current_ty));
-        can_fall_through |= !subject_element.is_subtype_of(db, current_ty);
-
-        if can_match && can_fall_through {
-            return Some(Truthiness::Ambiguous);
-        }
+        FiniteAlternativeCoverage::Partial => Some(Truthiness::Ambiguous),
     }
-
-    None
 }
 
 /// Analyze a pattern predicate to determine its static truthiness.
@@ -595,7 +562,7 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
     }
 
     if let Some(truthiness) =
-        prove_ambiguous_nominal_class_union_pattern_predicate(db, predicate, subject_ty)
+        analyze_finite_alternative_pattern_predicate(db, predicate, subject_ty)
     {
         return truthiness;
     }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -454,6 +454,132 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
     }
 }
 
+/// Return the exactly represented types matched by supported simple patterns or a composition of
+/// OR-patterns and `as` wrappers made exclusively from those alternatives.
+///
+/// Ordinary nominal class patterns and singleton patterns have an exact excluded type in
+/// [`definite_match_pattern_type`]. Refutable or otherwise approximate patterns are intentionally
+/// rejected.
+fn supported_exact_pattern_types<'db>(
+    db: &'db dyn Db,
+    kind: &PatternPredicateKind<'db>,
+) -> Option<Vec<Type<'db>>> {
+    fn collect<'db>(
+        db: &'db dyn Db,
+        kind: &PatternPredicateKind<'db>,
+        types: &mut Vec<Type<'db>>,
+    ) -> Option<()> {
+        match kind {
+            PatternPredicateKind::Class(_, class_kind) if class_kind.is_irrefutable() => {
+                let ty = definite_match_pattern_type(db, kind);
+                if !matches!(ty, Type::NominalInstance(_)) {
+                    return None;
+                }
+                types.push(ty);
+                Some(())
+            }
+            PatternPredicateKind::Singleton(_) => {
+                types.push(definite_match_pattern_type(db, kind));
+                Some(())
+            }
+            PatternPredicateKind::Or(predicates) if !predicates.is_empty() => {
+                for predicate in predicates {
+                    collect(db, predicate, types)?;
+                }
+                Some(())
+            }
+            PatternPredicateKind::As(Some(pattern), _) => collect(db, pattern, types),
+            _ => None,
+        }
+    }
+
+    let mut types = Vec::new();
+    collect(db, kind, &mut types)?;
+    Some(types)
+}
+
+/// Prove that a supported exact pattern composition over a union of nominal instances remains
+/// ambiguous after earlier supported pattern compositions fall through.
+///
+/// This avoids materializing a large intersection in the common event-dispatch shape. It only
+/// returns a result when both outcomes are witnessed using the same subtype and disjointness
+/// relations as the general intersection analysis:
+///
+/// * one remaining union element can overlap the current pattern; and
+/// * one remaining union element is not a subtype of the current pattern.
+///
+/// Any case that could be statically true or false is handled by the general analysis below.
+fn prove_ambiguous_nominal_class_union_pattern_predicate<'db>(
+    db: &'db dyn Db,
+    predicate: PatternPredicate<'db>,
+    subject_ty: Type<'db>,
+) -> Option<Truthiness> {
+    let Type::Union(subject_union) = subject_ty else {
+        return None;
+    };
+    if !subject_union
+        .elements(db)
+        .iter()
+        .all(|element| matches!(element, Type::NominalInstance(_)))
+    {
+        return None;
+    }
+
+    let current_types = supported_exact_pattern_types(db, predicate.kind(db))?;
+    let current_ty = UnionType::from_elements(db, current_types.iter().copied());
+
+    let mut previous_types = Vec::new();
+    let mut previous_predicate = predicate;
+    while let Some(previous) = previous_predicate.previous_predicate(db) {
+        previous_predicate = *previous;
+
+        if previous_predicate.guard(db).is_some() {
+            continue;
+        }
+
+        let types = supported_exact_pattern_types(db, previous_predicate.kind(db))?;
+        previous_types.push(UnionType::from_elements(db, types));
+    }
+
+    // Discard any alternative that was already completely handled by an earlier arm. If all
+    // alternatives were handled, this case can be statically unreachable; leave that result to
+    // the general analysis.
+    let remaining_current_types = current_types
+        .iter()
+        .copied()
+        .filter(|current_ty| {
+            !previous_types
+                .iter()
+                .any(|previous_ty| current_ty.is_subtype_of(db, *previous_ty))
+        })
+        .collect::<Vec<_>>();
+    if remaining_current_types.is_empty() {
+        return None;
+    }
+
+    let mut can_match = false;
+    let mut can_fall_through = false;
+    for subject_element in subject_union.elements(db) {
+        if previous_types
+            .iter()
+            .any(|previous_ty| subject_element.is_subtype_of(db, *previous_ty))
+        {
+            continue;
+        }
+
+        can_match |= remaining_current_types
+            .iter()
+            .any(|current_ty| !subject_element.is_disjoint_from(db, *current_ty));
+        can_fall_through |= !subject_element.is_subtype_of(db, current_ty);
+
+        if can_match && can_fall_through {
+            return Some(Truthiness::Ambiguous);
+        }
+    }
+
+    None
+}
+
 /// Analyze a pattern predicate to determine its static truthiness.
 ///
 /// This is a Salsa tracked function to enable memoization. Without memoization, for a match
@@ -470,6 +596,12 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
 
     if let Some(truthiness) =
         analyze_enum_literal_union_pattern_predicate(db, predicate, subject_ty)
+    {
+        return truthiness;
+    }
+
+    if let Some(truthiness) =
+        prove_ambiguous_nominal_class_union_pattern_predicate(db, predicate, subject_ty)
     {
         return truthiness;
     }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -538,8 +538,9 @@ fn prove_ambiguous_nominal_class_union_pattern_predicate<'db>(
         }
 
         let types = supported_exact_pattern_types(db, previous_predicate.kind(db))?;
-        previous_types.push(UnionType::from_elements(db, types));
+        previous_types.extend(types);
     }
+    let previous_ty = UnionType::from_elements(db, previous_types.iter().copied());
 
     // Discard any alternative that was already completely handled by an earlier arm. If all
     // alternatives were handled, this case can be statically unreachable; leave that result to
@@ -547,11 +548,7 @@ fn prove_ambiguous_nominal_class_union_pattern_predicate<'db>(
     let remaining_current_types = current_types
         .iter()
         .copied()
-        .filter(|current_ty| {
-            !previous_types
-                .iter()
-                .any(|previous_ty| current_ty.is_subtype_of(db, *previous_ty))
-        })
+        .filter(|current_ty| !current_ty.is_subtype_of(db, previous_ty))
         .collect::<Vec<_>>();
     if remaining_current_types.is_empty() {
         return None;
@@ -560,10 +557,7 @@ fn prove_ambiguous_nominal_class_union_pattern_predicate<'db>(
     let mut can_match = false;
     let mut can_fall_through = false;
     for subject_element in subject_union.elements(db) {
-        if previous_types
-            .iter()
-            .any(|previous_ty| subject_element.is_subtype_of(db, *previous_ty))
-        {
+        if subject_element.is_subtype_of(db, previous_ty) {
             continue;
         }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -40,6 +40,7 @@ pub(crate) use self::match_pattern::{
     singleton_pattern_type, starred_sequence_pattern_type,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
+pub(crate) use self::set_theoretic::FiniteAlternativeCoverage;
 use self::set_theoretic::KnownUnion;
 pub(crate) use self::set_theoretic::builder::{
     IntersectionBuilder, UnionAccumulator, UnionBuilder,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -29,12 +29,12 @@ use super::{
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
-    ConsideredDefinitions, DefinedPlace, Definedness, LookupError, Place, PlaceAndQualifiers,
-    RequiresExplicitReExport, TypeOrigin, builtins_module_scope, builtins_symbol,
-    class_body_implicit_symbol, explicit_global_symbol, loop_header_reachability,
+    ConsideredDefinitions, DefinedPlace, Definedness, LookupError, NarrowedBindingTypes, Place,
+    PlaceAndQualifiers, RequiresExplicitReExport, TypeOrigin, builtins_module_scope,
+    builtins_symbol, class_body_implicit_symbol, explicit_global_symbol, loop_header_reachability,
     module_type_implicit_global_declaration, module_type_implicit_global_symbol, place_by_id,
-    place_from_bindings_with_reachability_cache, place_from_declarations_with_reachability_cache,
-    typing_extensions_symbol,
+    place_from_bindings_with_caches, place_from_bindings_with_reachability_cache,
+    place_from_declarations_with_reachability_cache, typing_extensions_symbol,
 };
 use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_with_cache};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
@@ -247,6 +247,9 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// during multi-inference can reuse predicate truthiness computed by the parent builder.
     reachability_cache: Rc<ReachabilityEvaluationCache<'db>>,
 
+    /// Narrowed binding types reused across local place loads in this inference region.
+    narrowed_binding_types: RefCell<NarrowedBindingTypes<'db>>,
+
     /// Type qualifiers (`Required`, `NotRequired`, etc.) for annotation expressions.
     /// Only populated for expressions that have non-empty qualifiers.
     qualifiers: FxHashMap<ExpressionNodeKey, TypeQualifiers>,
@@ -384,6 +387,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 scope,
                 reachability_constraints,
             )),
+            narrowed_binding_types: RefCell::default(),
             qualifiers: FxHashMap::default(),
             type_expression_flags: FxHashMap::default(),
             collection_use_constraints: FxHashMap::default(),
@@ -9158,10 +9162,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             let use_id = expr_ref.scoped_use_id(db, self.file());
-            let place = place_from_bindings_with_reachability_cache(
+            let place = place_from_bindings_with_caches(
                 db,
                 use_def.bindings_at_use(use_id),
                 &self.reachability_cache,
+                &mut self.narrowed_binding_types.borrow_mut(),
             )
             .place;
 
@@ -10492,6 +10497,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // builder only state
             expression_cache: _,
             reachability_cache: _,
+            narrowed_binding_types: _,
             typevar_binding_context: _,
             deferred_state: _,
             called_functions: _,
@@ -10574,6 +10580,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // builder only state
             expression_cache: _,
             reachability_cache: _,
+            narrowed_binding_types: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10669,6 +10676,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             called_functions,
             expression_cache: _,
             reachability_cache: _,
+            narrowed_binding_types: _,
             declarations: _,
             deferred: _,
             scope: _,
@@ -10724,6 +10732,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // builder only state
             expression_cache: _,
             reachability_cache: _,
+            narrowed_binding_types: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10817,6 +10826,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Builder only state
             expression_cache: _,
             reachability_cache: _,
+            narrowed_binding_types: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10873,6 +10883,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             typevar_binding_context,
             ref expression_cache,
             ref reachability_cache,
+            narrowed_binding_types: _,
             ref return_types_and_ranges,
             ref dataclass_field_specifiers,
 
@@ -10939,6 +10950,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // builder only state
             expression_cache: _,
             reachability_cache: _,
+            narrowed_binding_types: _,
             typevar_binding_context: _,
             deferred_state: _,
             called_functions,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -440,51 +440,13 @@ impl<'db> Conjunctions<'db> {
     }
 
     fn evaluate_constraint_type(self, db: &'db dyn Db) -> Type<'db> {
-        const MIN_DEFERRED_DISTRIBUTION_ELEMENTS: usize = 16;
-
         if self.conjuncts.len() == 1 {
             return self.conjuncts[0];
         }
 
-        // Once IntersectionBuilder sees a union, it maintains one intersection per union
-        // element. For large unions, add non-union conjuncts first so their simplification work
-        // happens once before that state is distributed, instead of once per union element.
-        // Retain insertion order for small unions to avoid presentation churn for marginal wins.
-        let deferred_union = self.conjuncts.iter().find_map(|conjunct| {
-            let Type::Union(union) = conjunct else {
-                return None;
-            };
-            (union.elements(db).len() >= MIN_DEFERRED_DISTRIBUTION_ELEMENTS)
-                .then_some(Type::Union(*union))
-        });
-
-        let mut intersection = IntersectionBuilder::new(db);
-        if let Some(deferred_union) = deferred_union {
-            // A single-valued conjunct cannot partially reduce a union: it either survives or
-            // makes the entire conjunction impossible. Check that before materializing one
-            // `Never` intersection per union element, e.g. for `(A | B | C) & None`.
-            if self.conjuncts.iter().copied().any(|conjunct| {
-                conjunct != deferred_union
-                    && conjunct.is_single_valued(db)
-                    && deferred_union.is_disjoint_from(db, conjunct)
-            }) {
-                return Type::Never;
-            }
-
-            for &conjunct in self
-                .conjuncts
-                .iter()
-                .filter(|conjunct| !conjunct.is_union())
-                .chain(self.conjuncts.iter().filter(|conjunct| conjunct.is_union()))
-            {
-                intersection = intersection.add_positive(conjunct);
-            }
-        } else {
-            for conjunct in self.conjuncts {
-                intersection = intersection.add_positive(conjunct);
-            }
-        }
-        intersection.build()
+        IntersectionBuilder::new(db)
+            .positive_conjunction(self.conjuncts)
+            .build()
     }
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -440,13 +440,49 @@ impl<'db> Conjunctions<'db> {
     }
 
     fn evaluate_constraint_type(self, db: &'db dyn Db) -> Type<'db> {
+        const MIN_DEFERRED_DISTRIBUTION_ELEMENTS: usize = 16;
+
         if self.conjuncts.len() == 1 {
             return self.conjuncts[0];
         }
 
+        // Once IntersectionBuilder sees a union, it maintains one intersection per union
+        // element. For large unions, add non-union conjuncts first so their simplification work
+        // happens once before that state is distributed, instead of once per union element.
+        // Retain insertion order for small unions to avoid presentation churn for marginal wins.
+        let deferred_union = self.conjuncts.iter().find_map(|conjunct| {
+            let Type::Union(union) = conjunct else {
+                return None;
+            };
+            (union.elements(db).len() >= MIN_DEFERRED_DISTRIBUTION_ELEMENTS)
+                .then_some(Type::Union(*union))
+        });
+
         let mut intersection = IntersectionBuilder::new(db);
-        for conjunct in self.conjuncts {
-            intersection = intersection.add_positive(conjunct);
+        if let Some(deferred_union) = deferred_union {
+            // A single-valued conjunct cannot partially reduce a union: it either survives or
+            // makes the entire conjunction impossible. Check that before materializing one
+            // `Never` intersection per union element, e.g. for `(A | B | C) & None`.
+            if self.conjuncts.iter().copied().any(|conjunct| {
+                conjunct != deferred_union
+                    && conjunct.is_single_valued(db)
+                    && deferred_union.is_disjoint_from(db, conjunct)
+            }) {
+                return Type::Never;
+            }
+
+            for &conjunct in self
+                .conjuncts
+                .iter()
+                .filter(|conjunct| !conjunct.is_union())
+                .chain(self.conjuncts.iter().filter(|conjunct| conjunct.is_union()))
+            {
+                intersection = intersection.add_positive(conjunct);
+            }
+        } else {
+            for conjunct in self.conjuncts {
+                intersection = intersection.add_positive(conjunct);
+            }
         }
         intersection.build()
     }

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -15,6 +15,13 @@ pub(crate) mod builder;
 
 pub(crate) use builder::{IntersectionBuilder, UnionBuilder};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FiniteAlternativeCoverage {
+    Empty,
+    Covered,
+    Partial,
+}
+
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct UnionType<'db> {
     /// The union type includes values in any of these types.
@@ -37,6 +44,64 @@ pub(crate) fn walk_union<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for UnionType<'_> {}
+
+impl<'db> Type<'db> {
+    /// Return the exact finite alternatives represented by this type, if available.
+    ///
+    /// This represents a type-level finite domain, not necessarily a finite set of runtime values:
+    /// a nominal instance alternative like `A` can still have many inhabitants, but it is one exact
+    /// element in a finite union.
+    pub(crate) fn finite_alternatives(self, db: &'db dyn Db) -> Option<Vec<Type<'db>>> {
+        match self {
+            Type::Never => Some(Vec::new()),
+            Type::Union(union) => {
+                let mut alternatives = Vec::new();
+                for element in union.elements(db) {
+                    match element.finite_alternatives(db) {
+                        Some(nested) => alternatives.extend(nested),
+                        None => alternatives.push(*element),
+                    }
+                }
+                Some(alternatives)
+            }
+            Type::Intersection(intersection) => intersection.finite_alternatives(db),
+            Type::EnumComplement(complement) => Some(complement.remaining_literal_types(db)),
+            _ => None,
+        }
+    }
+
+    /// Classify how `target` covers this type's finite alternatives after excluding `excluded`.
+    pub(crate) fn finite_alternative_coverage_after_excluding(
+        self,
+        db: &'db dyn Db,
+        excluded: Type<'db>,
+        target: Type<'db>,
+    ) -> Option<FiniteAlternativeCoverage> {
+        let alternatives = self.finite_alternatives(db)?;
+
+        let mut can_match = false;
+        let mut can_fall_through = false;
+
+        for alternative in alternatives {
+            if alternative.is_subtype_of(db, excluded) {
+                continue;
+            }
+
+            can_match |= !alternative.is_disjoint_from(db, target);
+            can_fall_through |= !alternative.is_subtype_of(db, target);
+
+            if can_match && can_fall_through {
+                return Some(FiniteAlternativeCoverage::Partial);
+            }
+        }
+
+        if can_match {
+            Some(FiniteAlternativeCoverage::Covered)
+        } else {
+            Some(FiniteAlternativeCoverage::Empty)
+        }
+    }
+}
 
 #[salsa::tracked]
 impl<'db> UnionType<'db> {

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1246,7 +1246,7 @@ impl<'db> IntersectionBuilder<'db> {
     /// element. For large unions, add non-union conjuncts first so their simplification work
     /// happens once before that state is distributed, instead of once per union element. Retain
     /// insertion order for small unions to avoid presentation churn for marginal wins.
-    pub(crate) fn positive_conjunction(mut self, conjuncts: SmallVec<[Type<'db>; 2]>) -> Self {
+    pub(crate) fn positive_conjunction(self, conjuncts: SmallVec<[Type<'db>; 2]>) -> Self {
         let deferred_union = conjuncts.iter().find_map(|conjunct| {
             let Type::Union(union) = conjunct else {
                 return None;
@@ -1255,31 +1255,28 @@ impl<'db> IntersectionBuilder<'db> {
                 .then_some(Type::Union(*union))
         });
 
-        if let Some(deferred_union) = deferred_union {
-            // A single-valued conjunct cannot partially reduce a union: it either survives or
-            // makes the entire conjunction impossible. Check that before materializing one
-            // `Never` intersection per union element, e.g. for `(A | B | C) & None`.
-            if conjuncts.iter().copied().any(|conjunct| {
-                conjunct != deferred_union
-                    && conjunct.is_single_valued(self.db)
-                    && deferred_union.is_disjoint_from(self.db, conjunct)
-            }) {
-                return self.add_positive(Type::Never);
-            }
+        let Some(deferred_union) = deferred_union else {
+            return self.positive_elements(conjuncts);
+        };
 
-            for &conjunct in conjuncts
+        // A single-valued conjunct cannot partially reduce a union: it either survives or
+        // makes the entire conjunction impossible. Check that before materializing one
+        // `Never` intersection per union element, e.g. for `(A | B | C) & None`.
+        if conjuncts.iter().copied().any(|conjunct| {
+            conjunct != deferred_union
+                && conjunct.is_single_valued(self.db)
+                && deferred_union.is_disjoint_from(self.db, conjunct)
+        }) {
+            return self.add_positive(Type::Never);
+        }
+
+        self.positive_elements(
+            conjuncts
                 .iter()
                 .filter(|conjunct| !conjunct.is_union())
                 .chain(conjuncts.iter().filter(|conjunct| conjunct.is_union()))
-            {
-                self = self.add_positive(conjunct);
-            }
-        } else {
-            for conjunct in conjuncts {
-                self = self.add_positive(conjunct);
-            }
-        }
-        self
+                .copied(),
+        )
     }
 
     pub(crate) fn build(self) -> Type<'db> {

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -48,6 +48,8 @@ use crate::{Db, FxOrderMap, FxOrderSet};
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 
+const MIN_DEFERRED_DISTRIBUTION_ELEMENTS: usize = 16;
+
 /// Extract `(core, guard)` from truthiness-guarded intersections.
 ///
 /// e.g.
@@ -1238,6 +1240,48 @@ impl<'db> IntersectionBuilder<'db> {
         self
     }
 
+    /// Adds a batch of positive elements that are known to form a single conjunction.
+    ///
+    /// Once `IntersectionBuilder` sees a union, it maintains one intersection per union
+    /// element. For large unions, add non-union conjuncts first so their simplification work
+    /// happens once before that state is distributed, instead of once per union element. Retain
+    /// insertion order for small unions to avoid presentation churn for marginal wins.
+    pub(crate) fn positive_conjunction(mut self, conjuncts: SmallVec<[Type<'db>; 2]>) -> Self {
+        let deferred_union = conjuncts.iter().find_map(|conjunct| {
+            let Type::Union(union) = conjunct else {
+                return None;
+            };
+            (union.elements(self.db).len() >= MIN_DEFERRED_DISTRIBUTION_ELEMENTS)
+                .then_some(Type::Union(*union))
+        });
+
+        if let Some(deferred_union) = deferred_union {
+            // A single-valued conjunct cannot partially reduce a union: it either survives or
+            // makes the entire conjunction impossible. Check that before materializing one
+            // `Never` intersection per union element, e.g. for `(A | B | C) & None`.
+            if conjuncts.iter().copied().any(|conjunct| {
+                conjunct != deferred_union
+                    && conjunct.is_single_valued(self.db)
+                    && deferred_union.is_disjoint_from(self.db, conjunct)
+            }) {
+                return self.add_positive(Type::Never);
+            }
+
+            for &conjunct in conjuncts
+                .iter()
+                .filter(|conjunct| !conjunct.is_union())
+                .chain(conjuncts.iter().filter(|conjunct| conjunct.is_union()))
+            {
+                self = self.add_positive(conjunct);
+            }
+        } else {
+            for conjunct in conjuncts {
+                self = self.add_positive(conjunct);
+            }
+        }
+        self
+    }
+
     pub(crate) fn build(self) -> Type<'db> {
         UnionType::from_elements(
             self.db,
@@ -1775,7 +1819,8 @@ impl<'db> InnerIntersectionBuilder<'db> {
 #[cfg(test)]
 mod tests {
     use super::{
-        IntersectionBuilder, MAX_NON_RECURSIVE_UNION_LITERALS, Type, UnionBuilder, UnionType,
+        IntersectionBuilder, MAX_NON_RECURSIVE_UNION_LITERALS, MIN_DEFERRED_DISTRIBUTION_ELEMENTS,
+        Type, UnionBuilder, UnionType,
     };
 
     use crate::db::tests::{TestDb, setup_db};
@@ -1785,6 +1830,7 @@ mod tests {
     use crate::types::{KnownClass, KnownInstanceType, Truthiness};
 
     use ruff_db::system::DbWithWritableSystem as _;
+    use smallvec::smallvec;
     use ty_module_resolver::KnownModule;
 
     #[test]
@@ -1877,6 +1923,25 @@ mod tests {
 
         let intersection = IntersectionBuilder::new(&db).build();
         assert_eq!(intersection, Type::object());
+    }
+
+    #[test]
+    fn positive_conjunction_short_circuits_disjoint_singleton_for_large_union() {
+        let db = setup_db();
+
+        let union = UnionType::from_elements(
+            &db,
+            (0_i64..)
+                .take(MIN_DEFERRED_DISTRIBUTION_ELEMENTS)
+                .map(Type::int_literal),
+        )
+        .expect_union();
+
+        let intersection = IntersectionBuilder::new(&db)
+            .positive_conjunction(smallvec![Type::Union(union), Type::none(&db)])
+            .build();
+
+        assert_eq!(intersection, Type::Never);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -82,6 +82,33 @@ fn todo_types() {
 }
 
 #[test]
+fn finite_alternative_coverage_after_excluding() {
+    let db = setup_db();
+
+    let int = KnownClass::Int.to_instance(&db);
+    let str = KnownClass::Str.to_instance(&db);
+    let bytes = KnownClass::Bytes.to_instance(&db);
+    let subject = UnionType::from_elements(&db, [int, str, bytes]);
+
+    assert_eq!(
+        subject.finite_alternative_coverage_after_excluding(&db, str, str),
+        Some(FiniteAlternativeCoverage::Empty)
+    );
+    assert_eq!(
+        subject.finite_alternative_coverage_after_excluding(&db, str, int),
+        Some(FiniteAlternativeCoverage::Partial)
+    );
+    assert_eq!(
+        subject.finite_alternative_coverage_after_excluding(
+            &db,
+            str,
+            UnionType::from_elements(&db, [int, bytes])
+        ),
+        Some(FiniteAlternativeCoverage::Covered)
+    );
+}
+
+#[test]
 fn divergent_type() {
     let db = setup_db();
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));


### PR DESCRIPTION
## Summary

We cache narrowed binding types across local place loads in an inference region. Match-heavy control flow can revisit the same binding under the same narrowing constraint many times, so this reuses the narrowed result instead of recomputing it for each load.

Validation: `cargo build --profile profiling --bin ty`, `cargo test -p ty_python_semantic`, and `uvx prek run --files crates/ty_python_semantic/src/place.rs crates/ty_python_semantic/src/types/infer/builder.rs`.
