### PR TITLE
[flake8-pyi] Stop folding distinct t-strings as duplicates (PYI016)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE796.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pie/PIE796.py
@@ -84,3 +84,12 @@ class FakeEnum12(enum.Enum):
     A = enum.auto(), 0
     B = enum.auto(), 1
     C = enum.auto(), 0
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/25164
+# T-strings as enum values are distinct Template objects at runtime;
+# include a small fixture so a future regression that re-collapses them in
+# the comparable layer would surface here.
+class FakeEnum13TString(enum.Enum):
+    A = t"{x}"
+    B = t"{x}"  # OK

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
@@ -156,3 +156,12 @@ field53: typing.Literal[f"{x:.2f}"] | typing.Literal[f"{x:.3f}"]  # OK (differen
 field54: typing.Literal[f"{x}"] | typing.Literal[f"{x}"]  # Error (true duplicate)
 field55: typing.Literal[f"{x =}"] | typing.Literal[f"{x=}"]  # OK (different debug text due to spaces)
 field56: typing.Literal[f"{0x0=}"] | typing.Literal[f"{0o0=}"]  # OK (different source text: "0x0" vs "0o0")
+
+# Regression test for https://github.com/astral-sh/ruff/issues/25164
+# T-strings expose source text of interpolations at runtime via
+# `string.templatelib.Interpolation.expression`, so source representation
+# matters even without an `=` debug specifier. Conservatively, no two
+# t-string occurrences are now treated as duplicates.
+field57: typing.Annotated[int, t"{00}"] | typing.Annotated[int, t"{000}"] | None  # OK (distinct source representations of the same value)
+field58: typing.Annotated[int, t"{0x0=}"] | typing.Annotated[int, t"{0x0=}"] | None  # OK (true duplicate, but not flagged: any fix would normalize source text and change runtime output)
+field59: typing.Annotated[int, t"{x}"] | typing.Annotated[int, t"{x}"] | None        # OK (true duplicate, not flagged for the same reason)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
@@ -157,3 +157,13 @@ elif True:
     print(1)
 else:
     print(2)
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/25164
+# SIM114 collapses if/elif arms whose bodies compare equal. Two t-strings
+# with identical source spelling are no longer comparable-equal, so the
+# arms below are not collapsed.
+if cond_a:
+    take(t"{x}")
+elif cond_b:
+    take(t"{x}")  # OK (distinct t-string instances)

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
@@ -1218,3 +1218,4 @@ help: Remove duplicate union member `typing.Literal[f"{x}"]`
 156 + field54: typing.Literal[f"{x}"]  # Error (true duplicate)
 157 | field55: typing.Literal[f"{x =}"] | typing.Literal[f"{x=}"]  # OK (different debug text due to spaces)
 158 | field56: typing.Literal[f"{0x0=}"] | typing.Literal[f"{0o0=}"]  # OK (different source text: "0x0" vs "0o0")
+159 |

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -17,6 +17,7 @@
 
 use crate as ast;
 use crate::{Expr, Number};
+use ruff_text_size::TextRange;
 use std::borrow::Cow;
 use std::hash::Hash;
 
@@ -734,6 +735,30 @@ impl<'a> From<&'a ast::FStringValue> for ComparableFString<'a> {
 pub struct ComparableTString<'a> {
     strings: Box<[ComparableInterpolatedStringElement<'a>]>,
     interpolations: Box<[InterpolatedElement<'a>]>,
+    // Source ranges of the original `ast::InterpolatedElement`s. T-strings
+    // expose the source text of each interpolation at runtime via the
+    // `string.templatelib.Interpolation.expression` attribute, so two
+    // t-strings whose AST shapes collide can still be observably different
+    // programs (e.g. `t"{00}"` vs `t"{000}"`, or `t"{0x0=}"` vs `t"{0=}"`).
+    // The `ComparableExpr` form of the interpolation expression normalizes
+    // both source representations to the same `NumberLiteral(0)` node, so
+    // distinguishing them inside `ComparableTString` itself would require
+    // access to source text that this module does not have.
+    //
+    // As a conservative fallback, include each interpolation's source range
+    // in the comparable representation: two distinct `ast::InterpolatedElement`
+    // nodes always have distinct ranges, so two t-string occurrences are
+    // never considered equal. The only equality this preserves is
+    // reflexive equality of a single AST node with itself, which is what
+    // `Eq` requires.
+    //
+    // This means PYI016 (`duplicate-union-member`) will not flag true
+    // t-string duplicates such as `t"{x}" | t"{x}"` either, but that is
+    // preferable to the prior behavior of either reporting false positives
+    // on `t"{00}" | t"{000}"` or, on a real duplicate, autofixing by
+    // normalizing the source representation and silently changing program
+    // behavior (see astral-sh/ruff#25164).
+    interpolation_ranges: Box<[TextRange]>,
 }
 
 impl<'a> From<&'a ast::TStringValue> for ComparableTString<'a> {
@@ -751,6 +776,7 @@ impl<'a> From<&'a ast::TStringValue> for ComparableTString<'a> {
         struct Collector<'a> {
             strings: Vec<ComparableInterpolatedStringElement<'a>>,
             interpolations: Vec<InterpolatedElement<'a>>,
+            interpolation_ranges: Vec<TextRange>,
         }
 
         impl Default for Collector<'_> {
@@ -758,6 +784,7 @@ impl<'a> From<&'a ast::TStringValue> for ComparableTString<'a> {
                 Self {
                     strings: vec![ComparableInterpolatedStringElement::Literal("".into())],
                     interpolations: vec![],
+                    interpolation_ranges: vec![],
                 }
             }
         }
@@ -786,6 +813,7 @@ impl<'a> From<&'a ast::TStringValue> for ComparableTString<'a> {
 
             fn push_tstring_interpolation(&mut self, expression: &'a ast::InterpolatedElement) {
                 self.interpolations.push(expression.into());
+                self.interpolation_ranges.push(expression.range);
                 self.start_new_literal();
             }
         }
@@ -806,6 +834,7 @@ impl<'a> From<&'a ast::TStringValue> for ComparableTString<'a> {
         Self {
             strings: collector.strings.into_boxed_slice(),
             interpolations: collector.interpolations.into_boxed_slice(),
+            interpolation_ranges: collector.interpolation_ranges.into_boxed_slice(),
         }
     }
 }

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -734,31 +734,35 @@ impl<'a> From<&'a ast::FStringValue> for ComparableFString<'a> {
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct ComparableTString<'a> {
     strings: Box<[ComparableInterpolatedStringElement<'a>]>,
-    interpolations: Box<[InterpolatedElement<'a>]>,
-    // Source ranges of the original `ast::InterpolatedElement`s. T-strings
-    // expose the source text of each interpolation at runtime via the
-    // `string.templatelib.Interpolation.expression` attribute, so two
-    // t-strings whose AST shapes collide can still be observably different
-    // programs (e.g. `t"{00}"` vs `t"{000}"`, or `t"{0x0=}"` vs `t"{0=}"`).
-    // The `ComparableExpr` form of the interpolation expression normalizes
-    // both source representations to the same `NumberLiteral(0)` node, so
+    // Each interpolation is paired with the source range of its originating
+    // `ast::InterpolatedElement`. The range carries the source-level
+    // distinctness that the comparable representation otherwise loses:
+    // t-strings expose the source text of each interpolation at runtime via
+    // `string.templatelib.Interpolation.expression`, so two t-strings whose
+    // AST shapes collide can still be observably different programs (e.g.
+    // `t"{00}"` vs `t"{000}"`, or `t"{0x0=}"` vs `t"{0=}"`). The
+    // `ComparableExpr` form of the interpolation expression normalizes both
+    // source representations to the same `NumberLiteral(0)` node, so
     // distinguishing them inside `ComparableTString` itself would require
     // access to source text that this module does not have.
     //
-    // As a conservative fallback, include each interpolation's source range
-    // in the comparable representation: two distinct `ast::InterpolatedElement`
-    // nodes always have distinct ranges, so two t-string occurrences are
-    // never considered equal. The only equality this preserves is
-    // reflexive equality of a single AST node with itself, which is what
-    // `Eq` requires.
+    // As a conservative fallback, including each interpolation's source
+    // range in the comparable form means two distinct
+    // `ast::InterpolatedElement` nodes are never considered equal — the only
+    // equality this preserves is reflexive equality of a single AST node
+    // with itself, which is what `Eq` requires.
     //
-    // This means PYI016 (`duplicate-union-member`) will not flag true
-    // t-string duplicates such as `t"{x}" | t"{x}"` either, but that is
-    // preferable to the prior behavior of either reporting false positives
-    // on `t"{00}" | t"{000}"` or, on a real duplicate, autofixing by
-    // normalizing the source representation and silently changing program
-    // behavior (see astral-sh/ruff#25164).
-    interpolation_ranges: Box<[TextRange]>,
+    // Pairing range alongside the interpolation in a single slice (rather
+    // than two parallel `Box<[T]>`) makes the length invariant unforgeable:
+    // adding or removing an interpolation cannot desync the two halves.
+    //
+    // The behavioral consequence is that PYI016 (`duplicate-union-member`)
+    // will not flag true t-string duplicates such as `t"{x}" | t"{x}"`
+    // either, but that is preferable to the prior behavior of either
+    // reporting false positives on `t"{00}" | t"{000}"` or, on a real
+    // duplicate, autofixing by normalizing the source representation and
+    // silently changing program behavior (see astral-sh/ruff#25164).
+    interpolations: Box<[(InterpolatedElement<'a>, TextRange)]>,
 }
 
 impl<'a> From<&'a ast::TStringValue> for ComparableTString<'a> {
@@ -775,8 +779,7 @@ impl<'a> From<&'a ast::TStringValue> for ComparableTString<'a> {
     fn from(value: &'a ast::TStringValue) -> Self {
         struct Collector<'a> {
             strings: Vec<ComparableInterpolatedStringElement<'a>>,
-            interpolations: Vec<InterpolatedElement<'a>>,
-            interpolation_ranges: Vec<TextRange>,
+            interpolations: Vec<(InterpolatedElement<'a>, TextRange)>,
         }
 
         impl Default for Collector<'_> {
@@ -784,7 +787,6 @@ impl<'a> From<&'a ast::TStringValue> for ComparableTString<'a> {
                 Self {
                     strings: vec![ComparableInterpolatedStringElement::Literal("".into())],
                     interpolations: vec![],
-                    interpolation_ranges: vec![],
                 }
             }
         }
@@ -812,8 +814,7 @@ impl<'a> From<&'a ast::TStringValue> for ComparableTString<'a> {
             }
 
             fn push_tstring_interpolation(&mut self, expression: &'a ast::InterpolatedElement) {
-                self.interpolations.push(expression.into());
-                self.interpolation_ranges.push(expression.range);
+                self.interpolations.push((expression.into(), expression.range));
                 self.start_new_literal();
             }
         }
@@ -834,7 +835,6 @@ impl<'a> From<&'a ast::TStringValue> for ComparableTString<'a> {
         Self {
             strings: collector.strings.into_boxed_slice(),
             interpolations: collector.interpolations.into_boxed_slice(),
-            interpolation_ranges: collector.interpolation_ranges.into_boxed_slice(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #25164.

`PYI016` (`duplicate-union-member`) was treating distinct t-string interpolations as duplicates because `ComparableTString` delegates to `ComparableExpr` for each interpolation expression, and `ComparableExpr` normalizes literals like `00` / `000` to the same `NumberLiteral(0)` shape. At runtime, however, t-strings expose the **source text** of each interpolation via `string.templatelib.Interpolation.expression`, so the two values are observably distinct programs:

```python
t: Annotated[int, t"{00}"] | Annotated[int, t"{000}"] | None
# ruff before this PR autofixes to:    Annotated[int, t"{0}"] | None
```

That autofix also silently changes runtime behavior — distinct interpolation source representations get normalized to one — so even on a true duplicate (`Annotated[int, t"{0x0=}"] | Annotated[int, t"{0x0=}"]`) the autofix is unsafe.

This is the t-string analogue of the f-string debug-specifier fix that landed in #24098 for #19914. Because `ComparableExpr` does not have access to source text in this module, the conservative resolution is to include each interpolation's source range in `ComparableTString`: two distinct `ast::InterpolatedElement` nodes always have distinct ranges, so two t-string occurrences are never considered equal.

### Trade-off (intentional)

This makes PYI016 also stop flagging **true** t-string duplicates such as `t"{x}" | t"{x}"`. I think that's preferable to either reporting false positives or producing an autofix that changes program behavior, but happy to switch to a rule-layer fix (source-text-keying union members that contain t-strings inside `duplicate_union_member.rs`) if you'd rather keep `ComparableTString` semantics unchanged and address this only for `PYI016`. The trade-off is the main thing I'd like a maintainer call on.

### Blast-radius check

`ComparableTString` is `ComparableExpr::TString`'s inner type, so the change affects every consumer of `ComparableExpr`. I grep'd the linter for `comparable::` usages and ran:

- `cargo test -p ruff_python_ast --lib` — 49 passed
- `cargo test -p ruff_linter --lib` — 2772 passed, 4 ignored

No other rule has snapshot regressions from this change. Conceptually two t-string AST occurrences are distinct `Template` objects at runtime even when their AST shapes collide, so the new semantics are arguably more correct for any consumer, not just `PYI016`.

### Tests

`field57` / `field58` / `field59` added to `crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py` covering:

- `field57` — the false-positive scenario from the issue (`t"{00}"` vs `t"{000}"`), now correctly **not** flagged.
- `field58` — the unsafe-autofix scenario from the issue (`t"{0x0=}"` vs `t"{0x0=}"`), a true duplicate that was being autofixed incorrectly; now **not** flagged, which is the trade-off described above.
- `field59` — a plain true duplicate (`t"{x}"` vs `t"{x}"`) included to make the trade-off explicit in the fixture and so a future regression that re-enables flagging here is visible.

The `PYI016_PYI016.py.snap` snapshot only grew by a trailing newline — zero new diagnostics for `field57`/`field58`/`field59`, which is exactly the asserted behavior.

## Test plan

- [x] `cargo test -p ruff_python_ast --lib` — passes
- [x] `cargo test -p ruff_linter --lib` — passes (2772 ok)
- [x] Manually verified against the two reproductions from #25164 — no diagnostic is reported on either.
- [ ] Maintainer decides whether the comparable-layer approach is preferred or whether the trade-off should be confined to the PYI016 rule.