### PR TITLE
[ty] Improve diagnostic for failed assignment to a `Callable` type.

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -340,7 +340,8 @@ error[invalid-assignment]: Object of type `<class 'Number'>` is not assignable t
    |         |
    |         Declared type
    |
-info: the first parameter has an incompatible type: `str` is not assignable to `int`
+info: type `<class 'Number'>` has inferred callable type `(value: int) -> Number`
+info: └── the first parameter has an incompatible type: `str` is not assignable to `int`
 ```
 
 ## Function assignability and overrides

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/error_context.md
@@ -344,6 +344,105 @@ info: type `<class 'Number'>` has inferred callable type `(value: int) -> Number
 info: └── the first parameter has an incompatible type: `str` is not assignable to `int`
 ```
 
+Passing a class to a function expecting a `Callable`:
+
+```py
+from typing import Any, Callable
+
+def accepts_callable(callback: Callable[[Any], Any]) -> None: ...
+
+class Foo:
+    def __init__(self, x: Any, y: Any): ...
+
+accepts_callable(Foo)  # snapshot
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `accepts_callable` is incorrect
+  --> src/mdtest_snippet.py:28:18
+   |
+28 | accepts_callable(Foo)  # snapshot
+   |                  ^^^ Expected `(Any, /) -> Any`, found `<class 'Foo'>`
+   |
+info: type `<class 'Foo'>` has inferred callable type `(x: Any, y: Any) -> Foo`
+info: └── unexpected extra parameter `y`
+info: Function defined here
+  --> src/mdtest_snippet.py:23:5
+   |
+23 | def accepts_callable(callback: Callable[[Any], Any]) -> None: ...
+   |     ^^^^^^^^^^^^^^^^ ------------------------------ Parameter declared here
+   |
+```
+
+Assigning a bound method to a `Callable`:
+
+```py
+class Greeter:
+    def greet(self, name: str, greeting: str = "Hello") -> str:
+        return f"{greeting}, {name}"
+
+greeter = Greeter()
+bound_method_target: Callable[[int], str] = greeter.greet  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `bound method Greeter.greet(name: str, greeting: str = "Hello") -> str` is not assignable to `(int, /) -> str`
+  --> src/mdtest_snippet.py:34:22
+   |
+34 | bound_method_target: Callable[[int], str] = greeter.greet  # snapshot
+   |                      --------------------   ^^^^^^^^^^^^^ Incompatible value of type `bound method Greeter.greet(name: str, greeting: str = "Hello") -> str`
+   |                      |
+   |                      Declared type
+   |
+info: the first parameter has an incompatible type: `int` is not assignable to `str`
+```
+
+Assigning a known bound method to a `Callable`:
+
+```py
+def callable_base(x: int) -> bool:
+    return True
+
+known_bound_method_target: Callable[[str], bool] = callable_base.__call__  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `<method-wrapper '__call__' of function 'callable_base'>` is not assignable to `(str, /) -> bool`
+  --> src/mdtest_snippet.py:38:28
+   |
+38 | known_bound_method_target: Callable[[str], bool] = callable_base.__call__  # snapshot
+   |                            ---------------------   ^^^^^^^^^^^^^^^^^^^^^^ Incompatible value of type `<method-wrapper '__call__' of function 'callable_base'>`
+   |                            |
+   |                            Declared type
+   |
+info: type `<method-wrapper '__call__' of function 'callable_base'>` has inferred callable type `(x: int) -> bool`
+info: └── the first parameter has an incompatible type: `str` is not assignable to `int`
+```
+
+Assigning a `functools.partial` result to a `Callable`:
+
+```py
+from functools import partial
+
+def predicate(x: int, y: str) -> bool:
+    return True
+
+partial_predicate = partial(predicate, 1)
+partial_target: Callable[[bytes], bool] = partial_predicate  # snapshot
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `partial[(y: str) -> bool]` is not assignable to `(bytes, /) -> bool`
+  --> src/mdtest_snippet.py:45:17
+   |
+45 | partial_target: Callable[[bytes], bool] = partial_predicate  # snapshot
+   |                 -----------------------   ^^^^^^^^^^^^^^^^^ Incompatible value of type `partial[(y: str) -> bool]`
+   |                 |
+   |                 Declared type
+   |
+info: the first parameter has an incompatible type: `bytes` is not assignable to `str`
+```
+
 ## Function assignability and overrides
 
 Liskov checks use function-to-function assignability.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -801,6 +801,22 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         result
     }
 
+    fn should_provide_callable_upcast_context(&self, source: Type<'db>) -> bool {
+        if !self.is_context_collection_enabled() {
+            return false;
+        }
+
+        // These displays already expose the signature being compared; wrapping them would
+        // duplicate the lower-level callable mismatch context.
+        !matches!(
+            source,
+            Type::Callable(_)
+                | Type::FunctionLiteral(_)
+                | Type::BoundMethod(_)
+                | Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_))
+        )
+    }
+
     fn with_recursion_guard(
         &self,
         source: Type<'db>,
@@ -1690,11 +1706,24 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             (_, Type::Callable(target_callable)) => {
                 self.with_recursion_guard(source, target, || {
-                    source
+                    let Some(callables) = source
                         .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
-                        .when_some_and(db, self.constraints, |callables| {
-                            self.check_callables_vs_callable(db, &callables, target_callable)
-                        })
+                    else {
+                        return self.never();
+                    };
+
+                    let result = self.check_callables_vs_callable(db, &callables, target_callable);
+
+                    if self.should_provide_callable_upcast_context(source)
+                        && result.is_never_satisfied(db)
+                    {
+                        self.provide_context(|| ErrorContext::InferredCallableType {
+                            source,
+                            callable: callables.into_type(db),
+                        });
+                    }
+
+                    result
                 })
             }
 

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -100,6 +100,10 @@ pub(crate) enum ErrorContext<'db> {
         target: Type<'db>,
         parameter: ParameterDescription,
     },
+    InferredCallableType {
+        source: Type<'db>,
+        callable: Type<'db>,
+    },
     ExtraRequiredParameter {
         parameter: ParameterDescription,
     },
@@ -268,6 +272,11 @@ impl<'db> ErrorContext<'db> {
                     target = target.display(db),
                 )
             }
+            Self::InferredCallableType { source, callable } => format!(
+                "type `{}` has inferred callable type `{}`",
+                source.display(db),
+                callable.display(db),
+            ),
             Self::ExtraRequiredParameter { parameter } => match parameter {
                 ParameterDescription::Named(name) => format!("unexpected extra parameter `{name}`"),
                 ParameterDescription::Index(_) => "unexpected extra parameter".to_string(),

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -265,7 +265,7 @@ impl<'db> ErrorContext<'db> {
                 target,
                 parameter,
             } => {
-                // reversed order due to covariance
+                // reversed order due to contravariance of parameter types
                 format!(
                     "{parameter} has an incompatible type: `{target}` is not assignable to `{source}`",
                     source = source.display(db),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This improves the diagnostic we show when an assignment to a `Callable` type fails. That diagnostic now contains additional context that describes the inferred callable type that failed. The result is that the full explanation of the failed assignment is more coherent.

Closes https://github.com/astral-sh/ty/issues/866.

## Test Plan

Please see updated tests.
<!-- How was it tested? -->
