### PR TITLE
[`flake8-simplify`] Fix `SIM109` to detect equality comparisons with literal values (`SIM109`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM109.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM109.py
@@ -29,3 +29,15 @@ if (
     or a == c
 ):
     d
+
+# SIM109 (string literals)
+if a == "foo" or a == "bar":
+    d
+
+# SIM109 (integer literals)
+if a == 1 or a == 2:
+    d
+
+# SIM109 (mixed: variable and literal)
+if a == b or a == "baz":
+    d

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -476,10 +476,7 @@ fn match_eq_target(expr: &Expr) -> Option<(&Name, &Expr)> {
     let [comparator] = &**comparators else {
         return None;
     };
-    if !comparator.is_name_expr() {
-        return None;
-    }
-    Some((id, comparator))
+    Some((id, comparator))             // ← literals now pass through
 }
 
 /// SIM109

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -476,7 +476,7 @@ fn match_eq_target(expr: &Expr) -> Option<(&Name, &Expr)> {
     let [comparator] = &**comparators else {
         return None;
     };
-    Some((id, comparator))             // ← literals now pass through
+    Some((id, comparator))
 }
 
 /// SIM109

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
@@ -74,3 +74,21 @@ help: Replace with `a in (b, c)`
 16 |
 17 | # OK
 note: This is an unsafe fix and may change runtime behavior
+
+SIM109 [*] Use `a in ("foo", "bar")` instead of multiple equality comparisons
+  --> SIM109.py:34:4
+   ...
+34 + if a in ("foo", "bar"):
+note: This is an unsafe fix and may change runtime behavior
+
+SIM109 [*] Use `a in (1, 2)` instead of multiple equality comparisons
+  --> SIM109.py:38:4
+   ...
+38 + if a in (1, 2):
+note: This is an unsafe fix and may change runtime behavior
+
+SIM109 [*] Use `a in (b, "baz")` instead of multiple equality comparisons
+  --> SIM109.py:42:4
+   ...
+42 + if a in (b, "baz"):
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
@@ -77,18 +77,55 @@ note: This is an unsafe fix and may change runtime behavior
 
 SIM109 [*] Use `a in ("foo", "bar")` instead of multiple equality comparisons
   --> SIM109.py:34:4
-   ...
+   |
+33 | # SIM109 (string literals)
+34 | if a == "foo" or a == "bar":
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^
+35 |     d
+   |
+help: Replace with `a in ("foo", "bar")`
+31 |     d
+32 |
+33 | # SIM109 (string literals)
+   - if a == "foo" or a == "bar":
 34 + if a in ("foo", "bar"):
+35 |     d
+36 |
+37 | # SIM109 (integer literals)
 note: This is an unsafe fix and may change runtime behavior
 
 SIM109 [*] Use `a in (1, 2)` instead of multiple equality comparisons
   --> SIM109.py:38:4
-   ...
+   |
+37 | # SIM109 (integer literals)
+38 | if a == 1 or a == 2:
+   |    ^^^^^^^^^^^^^^^^
+39 |     d
+   |
+help: Replace with `a in (1, 2)`
+35 |     d
+36 |
+37 | # SIM109 (integer literals)
+   - if a == 1 or a == 2:
 38 + if a in (1, 2):
+39 |     d
+40 |
+41 | # SIM109 (mixed: variable and literal)
 note: This is an unsafe fix and may change runtime behavior
 
 SIM109 [*] Use `a in (b, "baz")` instead of multiple equality comparisons
   --> SIM109.py:42:4
-   ...
+   |
+41 | # SIM109 (mixed: variable and literal)
+42 | if a == b or a == "baz":
+   |    ^^^^^^^^^^^^^^^^^^^^
+43 |     d
+   |
+help: Replace with `a in (b, "baz")`
+39 |     d
+40 |
+41 | # SIM109 (mixed: variable and literal)
+   - if a == b or a == "baz":
 42 + if a in (b, "baz"):
+43 |     d
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

`SIM109` (`CompareWithTuple`) is supposed to flag patterns like
`a == "foo" or a == "bar"` and suggest replacing them with
`a in ("foo", "bar")`. This is even explicitly documented in the
implementation comment inside `compare_with_tuple`:

```rust
// Given `a == "foo" or a == "bar"`, we generate `{"a": [(0, "foo"), (1, "bar")]}`.
```

However, the rule silently ignored all such cases due to an overly
restrictive guard in `match_eq_target`:

```rust
if !comparator.is_name_expr() {
    return None;
}
```

This forced the right-hand side of each equality to be a plain variable
name, excluding string literals, integer literals, and any other
non-name expression. As a result, the most common real-world use case —
`if status == "active" or status == "pending":` — was never flagged.

The fix removes this guard. The downstream `contains_effect` check
already present a few lines below handles the safety concern correctly:
it rejects comparisons whose right-hand side could have side effects
(e.g. `a == f()`). Literal values have no side effects and pass that
check cleanly, so the `is_name_expr` restriction was both redundant and
incorrect.

## Test Plan

Added three new test cases to
`crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM109.py`:

- `if a == "foo" or a == "bar":` — string literal comparators
- `if a == 1 or a == 2:` — integer literal comparators  
- `if a == b or a == "baz":` — mixed variable and literal

Snapshot updated accordingly.