### PR TITLE
[ty] Consider `self` type in hover,  inlay hints, and signature help when resolving overloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,5 @@ When working on ty, PR titles should start with `[ty]` and be tagged with the `t
 - When adding new ty checks, it's important to make error messages concise. Think about how an error message would look on a narrow terminal screen. Sometimes more detail can be provided in subdiagnostics or secondary annotations, but it's also important to make sure that the diagnostic is understandable if the user has passed `--output-format=concise`.
 - **Salsa incrementality (ty):** Any method that accesses `.node()` must be `#[salsa::tracked]`, or it will break incrementality. Prefer higher-level semantic APIs over raw AST access.
 - Run `cargo dev generate-all` after changing configuration options, CLI arguments, lint rules, or environment variable definitions, as these changes require regeneration of schemas, docs, and CLI references.
+- Don't prefix tests with `test_`.
+- Don't separate struct definitions from their impl blocks.

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -1445,6 +1445,87 @@ mod tests {
         ");
     }
 
+    #[test]
+    fn hover_bound_method_overload_self_type() {
+        let string = hover_test(
+            r#"
+        def f(string: str):
+            string.removesuf<CURSOR>fix("suffix")
+        "#,
+        );
+
+        assert_snapshot!(string.hover(), @r#"
+        def removesuffix(suffix: str, /) -> str
+        ---------------------------------------------
+        Return a str with the given suffix string removed if present.
+
+        If the string ends with the suffix string and that suffix is not empty,
+        return string[:-len(suffix)]. Otherwise, return a copy of the original
+        string.
+
+        ---------------------------------------------
+        ```python
+        def removesuffix(suffix: str, /) -> str
+        ```
+        ---
+        Return a str with the given suffix string removed if present.<HB>
+        <HB>
+        If the string ends with the suffix string and that suffix is not empty,<HB>
+        return string[:-len(suffix)]. Otherwise, return a copy of the original<HB>
+        string.
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:3:12
+          |
+        3 |     string.removesuffix("suffix")
+          |            ^^^^^^^^^-^^
+          |            |        |
+          |            |        Cursor offset
+          |            source
+          |
+        "#);
+
+        let literal_string = hover_test(
+            r#"
+            from typing_extensions import LiteralString
+
+            def f(string: LiteralString):
+                string.removesuf<CURSOR>fix("suffix")
+            "#,
+        );
+
+        assert_snapshot!(literal_string.hover(), @r#"
+        def removesuffix(suffix: LiteralString, /) -> LiteralString
+        ---------------------------------------------
+        Return a str with the given suffix string removed if present.
+
+        If the string ends with the suffix string and that suffix is not empty,
+        return string[:-len(suffix)]. Otherwise, return a copy of the original
+        string.
+
+        ---------------------------------------------
+        ```python
+        def removesuffix(suffix: LiteralString, /) -> LiteralString
+        ```
+        ---
+        Return a str with the given suffix string removed if present.<HB>
+        <HB>
+        If the string ends with the suffix string and that suffix is not empty,<HB>
+        return string[:-len(suffix)]. Otherwise, return a copy of the original<HB>
+        string.
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:5:12
+          |
+        5 |     string.removesuffix("suffix")
+          |            ^^^^^^^^^-^^
+          |            |        |
+          |            |        Cursor offset
+          |            source
+          |
+        "#);
+    }
+
     /// When the resolved overload has no docstring and neither does the
     /// implementation, we fall back to showing a sibling overload's docstring.
     #[test]
@@ -6070,7 +6151,9 @@ except <CURSOR># Trigger completion/hover here
         fn hover(&self) -> String {
             use std::fmt::Write;
 
-            let Some(hover) = hover(&self.db, self.cursor.file, self.cursor.offset) else {
+            let Some(hover) = salsa::attach(&self.db, || {
+                hover(&self.db, self.cursor.file, self.cursor.offset)
+            }) else {
                 return "Hover provided no content".to_string();
             };
 

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -4552,6 +4552,82 @@ Source with applied edits:
     }
 
     #[test]
+    fn instance_method_overload_self_type() {
+        let mut test = inlay_hint_test(
+            r#"
+            from typing import overload
+
+            class Parent:
+                @overload
+                def choose(self: "Child", child_value: int) -> None: ...
+                @overload
+                def choose(self: "Parent", parent_value: int) -> None: ...
+                def choose(self, value: int) -> None: ...
+
+            class Child(Parent): pass
+
+            def f(parent: Parent, child: Child):
+                parent.choose(1)
+                child.choose(2)"#,
+        );
+
+        assert_snapshot!(test.inlay_hints(), @r#"
+
+        from typing import overload
+
+        class Parent:
+            @overload
+            def choose(self: "Child", child_value: int) -> None: ...
+            @overload
+            def choose(self: "Parent", parent_value: int) -> None: ...
+            def choose(self, value: int) -> None: ...
+
+        class Child(Parent): pass
+
+        def f(parent: Parent, child: Child):
+            parent.choose([parent_value=]1)
+            child.choose([child_value=]2)
+        ---------------------------------------------
+        info[inlay-hint-location]: Inlay Hint Target
+         --> main.py:8:32
+          |
+        8 |     def choose(self: "Parent", parent_value: int) -> None: ...
+          |                                ^^^^^^^^^^^^
+          |
+        info: Source
+          --> main2.py:14:20
+           |
+        14 |     parent.choose([parent_value=]1)
+           |                    ^^^^^^^^^^^^
+           |
+
+        info[inlay-hint-location]: Inlay Hint Target
+         --> main.py:6:31
+          |
+        6 |     def choose(self: "Child", child_value: int) -> None: ...
+          |                               ^^^^^^^^^^^
+          |
+        info: Source
+          --> main2.py:15:19
+           |
+        15 |     child.choose([child_value=]2)
+           |                   ^^^^^^^^^^^
+           |
+
+        ---------------------------------------------
+        info[inlay-hint-edit]: Inlay hint edits
+        --> main.py:1:1
+        11 | class Child(Parent): pass
+        12 |
+        13 | def f(parent: Parent, child: Child):
+           -     parent.choose(1)
+           -     child.choose(2)
+        14 +     parent.choose(parent_value=1)
+        15 +     child.choose(child_value=2)
+        "#);
+    }
+
+    #[test]
     fn test_class_method_call() {
         let mut test = inlay_hint_test(
             "

--- a/crates/ty_ide/src/signature_help.rs
+++ b/crates/ty_ide/src/signature_help.rs
@@ -354,6 +354,40 @@ mod tests {
     }
 
     #[test]
+    fn signature_help_bound_method_overload_self_type() {
+        let test = cursor_test(
+            r#"
+        def f(string: str):
+            string.removesuffix("suffix"<CURSOR>)
+        "#,
+        );
+
+        assert_snapshot!(test.signature_help_render(), @"
+
+        ============== active signature =============
+        (suffix: str, /) -> str
+        ---------------------------------------------
+
+        -------------- active parameter -------------
+        suffix: str
+        ---------------------------------------------
+
+        =============== other signature =============
+        (suffix: LiteralString, /) -> LiteralString
+        ---------------------------------------------
+        Return a str with the given suffix string removed if present.
+
+        If the string ends with the suffix string and that suffix is not empty,
+        return string[:-len(suffix)]. Otherwise, return a copy of the original
+        string.
+
+        -------------- active parameter -------------
+        suffix: LiteralString
+        ---------------------------------------------
+        ");
+    }
+
+    #[test]
     fn signature_help_nested_function_calls() {
         let test = cursor_test(
             r#"
@@ -576,21 +610,21 @@ def ab(a: str):
         assert_snapshot!(test.signature_help_render(), @"
 
         ============== active signature =============
-        (a: int) -> Unknown
-        ---------------------------------------------
-        the int overload
-
-        -------------- active parameter -------------
-        a: int
-        ---------------------------------------------
-
-        =============== other signature =============
         (a: str) -> Unknown
         ---------------------------------------------
         the str overload
 
         -------------- active parameter -------------
         a: str
+        ---------------------------------------------
+
+        =============== other signature =============
+        (a: int) -> Unknown
+        ---------------------------------------------
+        the int overload
+
+        -------------- active parameter -------------
+        a: int
         ---------------------------------------------
         ");
     }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -238,6 +238,106 @@ impl<'db> CallableItem<'db> {
     }
 }
 
+/// One checked overload, as it appears at the call site.
+///
+/// Checking a bound method call needs to include the implicit receiver. For example, when the user
+/// writes `child.choose(1)`, overload resolution checks a signature such as
+/// `choose(self: Child, child_value: int)` against both `child` and `1`. IDE features should show
+/// and reason about only what the user wrote: `choose(child_value: int)` and the mapping from `1`
+/// to `child_value`.
+///
+/// This type provides that call-site view while retaining the original checked binding privately
+/// for information such as inferred specializations and matching errors.
+#[derive(Debug)]
+pub(crate) struct CallSiteBinding<'a, 'db> {
+    /// The signature visible at the written call site.
+    ///
+    /// For a bound method, this omits the implicit receiver parameter. For a constructor, this may
+    /// use the effective constructed return type.
+    signature: Signature<'db>,
+
+    /// The checked semantic binding from which this call-site view is derived.
+    ///
+    /// Its signature is not necessarily equal to `self.signature`: it retains implicit arguments
+    /// needed during call matching. Keep this private so consumers cannot combine its semantic
+    /// signature with the source-coordinate argument matches below.
+    semantic_binding: &'a Binding<'db>,
+
+    /// Argument matches in written-call coordinates.
+    ///
+    /// Unlike `semantic_binding.argument_matches()`, this excludes an implicit bound receiver and
+    /// refers to parameter indexes in `self.signature`.
+    argument_matches: Vec<MatchedArgument<'db>>,
+}
+
+impl<'a, 'db> CallSiteBinding<'a, 'db> {
+    fn new(db: &'db dyn Db, item: &CallableItem<'db>, binding: &'a Binding<'db>) -> Self {
+        let callable = item.callable();
+        let mut signature = binding.signature.clone();
+        let mut argument_matches = binding.argument_matches().to_vec();
+
+        if let Some(bound_type) = callable.bound_type {
+            let displayed_signature = signature.bind_self(db, Some(bound_type));
+            let parameter_offset =
+                usize::from(signature.parameters().len() != displayed_signature.parameters().len());
+
+            // Matching includes the implicit receiver as its first argument. `bind_self` removes
+            // an ordinary receiver parameter, but leaves a leading `*args` parameter visible.
+            argument_matches = argument_matches
+                .into_iter()
+                .skip(1)
+                .map(|mut argument_match| {
+                    argument_match.parameters = argument_match
+                        .parameters
+                        .into_iter()
+                        .filter_map(|parameter_index| parameter_index.checked_sub(parameter_offset))
+                        .collect();
+                    argument_match
+                })
+                .collect();
+            signature = displayed_signature;
+        }
+
+        if matches!(item, CallableItem::Constructor(_)) {
+            signature = signature.with_return_type(item.return_type(db));
+        }
+
+        Self {
+            signature,
+            semantic_binding: binding,
+            argument_matches,
+        }
+    }
+
+    pub(crate) fn signature(&self) -> &Signature<'db> {
+        &self.signature
+    }
+
+    pub(crate) fn into_signature(self) -> Signature<'db> {
+        self.signature
+    }
+
+    pub(crate) fn argument_matches(&self) -> &[MatchedArgument<'db>] {
+        &self.argument_matches
+    }
+
+    pub(crate) fn specialization(&self) -> Option<Specialization<'db>> {
+        self.semantic_binding.specialization()
+    }
+
+    pub(crate) fn matches_call(&self) -> bool {
+        !self
+            .semantic_binding
+            .has_errors_affecting_overload_resolution()
+    }
+
+    pub(crate) fn into_signature_and_argument_matches(
+        self,
+    ) -> (Signature<'db>, Vec<MatchedArgument<'db>>) {
+        (self.signature, self.argument_matches)
+    }
+}
+
 /// A single element in a union of callables.
 /// This could be a single callable or an intersection of callables.
 /// If there are multiple items, they form an intersection.
@@ -652,6 +752,40 @@ impl<'db> Bindings<'db> {
         self.elements
             .iter_mut()
             .flat_map(BindingsElement::callables_mut)
+    }
+
+    /// Returns call-site views of all checked overload bindings.
+    ///
+    /// Unlike the underlying semantic bindings, each view expresses its signature and argument
+    /// mapping in terms of arguments written at the call site.
+    pub(crate) fn call_site_bindings<'a>(
+        &'a self,
+        db: &'db dyn Db,
+    ) -> impl Iterator<Item = CallSiteBinding<'a, 'db>> + 'a
+    where
+        'db: 'a,
+    {
+        self.iter_callable_items().flat_map(move |item| {
+            item.callable()
+                .overloads()
+                .iter()
+                .map(move |overload| CallSiteBinding::new(db, item, overload))
+        })
+    }
+
+    /// Returns call-site views of overload bindings matched by semantic call checking.
+    pub(crate) fn matching_call_site_bindings<'a>(
+        &'a self,
+        db: &'db dyn Db,
+    ) -> impl Iterator<Item = CallSiteBinding<'a, 'db>> + 'a
+    where
+        'db: 'a,
+    {
+        self.iter_callable_items().flat_map(move |item| {
+            item.callable()
+                .matching_overloads()
+                .map(move |(_, overload)| CallSiteBinding::new(db, item, overload))
+        })
     }
 
     fn iter_callable_items(&self) -> impl Iterator<Item = &CallableItem<'db>> {

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::FxIndexSet;
 use crate::place::builtins_module_scope;
 use crate::reachability::is_range_reachable;
+use crate::types::call::bind::CallSiteBinding;
 use crate::types::call::{CallArguments, CallError, MatchedArgument};
 use crate::types::class::{DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor};
 use crate::types::constraints::ConstraintSetBuilder;
@@ -580,6 +581,9 @@ pub struct CallSignatureDetails<'db> {
     /// Mapping from argument indices to displayed parameter indices. This accounts for
     /// displayed signatures that synthesize parameters, like bare `ParamSpec` signatures.
     pub argument_to_displayed_parameter_mapping: Vec<Option<usize>>,
+
+    /// Whether full semantic call matching kept this displayed signature as a valid candidate.
+    matches_call: bool,
 }
 
 /// A single displayed parameter in a callable signature for IDE support.
@@ -605,10 +609,12 @@ pub struct CallSignatureParameter<'db> {
 }
 
 impl<'db> CallSignatureDetails<'db> {
-    fn from_binding(db: &'db dyn Db, binding: &crate::types::call::Binding<'db>) -> Self {
-        let argument_to_parameter_mapping = binding.argument_matches().to_vec();
+    fn from_call_site_binding(db: &'db dyn Db, binding: CallSiteBinding<'_, 'db>) -> Self {
         let specialization = binding.specialization();
-        let signature = binding.signature.clone();
+        let matches_call = binding.matches_call();
+        let (signature, argument_to_parameter_mapping) =
+            binding.into_signature_and_argument_matches();
+
         let display_details = signature.display(db).to_string_parts();
         let (parameters, parameter_to_displayed_parameter_mapping) =
             displayed_parameters_for_signature(db, &signature, &display_details, specialization);
@@ -631,6 +637,7 @@ impl<'db> CallSignatureDetails<'db> {
             parameters,
             argument_to_parameter_mapping,
             argument_to_displayed_parameter_mapping,
+            matches_call,
         }
     }
 }
@@ -747,76 +754,26 @@ pub fn call_signature_details<'db>(
     };
 
     let db = model.db();
+    let bindings = full_type_bindings_for_call(model, func_type, call_expr);
 
-    // Use into_callable to handle all the complex type conversions
-    if let Some(callable_type) = func_type
-        .try_upcast_to_callable(db)
-        .map(|callables| callables.into_type(db))
-    {
-        // Use from_arguments_typed so that check_types can infer TypeVar
-        // specializations from the actual argument types at this call site.
-        let call_arguments =
-            CallArguments::from_arguments_typed(&call_expr.arguments, |splatted_value| {
-                splatted_value
-                    .inferred_type(model)
-                    .unwrap_or(Type::unknown())
-            });
-        let mut bindings = callable_type
-            .bindings(db)
-            .match_parameters(db, &call_arguments);
-
-        // Run type checking to resolve TypeVar bindings from argument types.
-        // For example, calling `dict[str, int].get("a")` resolves the `_KT`
-        // TypeVar to `str`. We ignore errors since we still want signature
-        // details even if the call has type errors.
-        let constraints = ConstraintSetBuilder::new();
-        let _ = bindings.check_types_impl(
-            db,
-            &constraints,
-            &call_arguments,
-            TypeContext::default(),
-            &[],
-        );
-
-        // Extract signature details from all callable bindings
-        bindings
-            .iter_flat()
-            .flatten()
-            .map(|binding| CallSignatureDetails::from_binding(db, binding))
-            .collect()
-    } else {
-        // Type is not callable, return empty signatures
-        vec![]
-    }
+    bindings
+        .call_site_bindings(db)
+        .map(|binding| CallSignatureDetails::from_call_site_binding(db, binding))
+        .collect()
 }
 
-/// Resolve overloads for a callable type using call arguments,
+/// Resolve overloads for a callee type using call arguments,
 /// returning the single matching signature if exactly one matches.
 fn resolve_single_overload<'db>(
     model: &SemanticModel<'db>,
-    callable_type: Type<'db>,
+    func_type: Type<'db>,
     call_expr: &ast::ExprCall,
 ) -> Option<Signature<'db>> {
     let db = model.db();
-    let bindings = callable_type.bindings(db);
-
-    let args = CallArguments::from_arguments_typed(&call_expr.arguments, |splatted_value| {
-        splatted_value
-            .inferred_type(model)
-            .unwrap_or(Type::unknown())
-    });
-
-    let constraints = ConstraintSetBuilder::new();
+    let bindings = type_checked_bindings_for_call(model, func_type, call_expr).ok()?;
     let mut resolved: Vec<_> = bindings
-        .match_parameters(db, &args)
-        .check_types(db, &constraints, &args, TypeContext::default(), &[])
-        .iter()
-        .flat_map(super::call::bind::Bindings::iter_flat)
-        .flat_map(|binding| {
-            binding
-                .matching_overloads()
-                .map(|(_, overload)| overload.signature.clone())
-        })
+        .matching_call_site_bindings(db)
+        .map(CallSiteBinding::into_signature)
         .collect();
 
     if resolved.len() != 1 {
@@ -834,16 +791,15 @@ pub enum CallArgumentForm {
     Type,
 }
 
-/// Fully binds and type-checks a call expression against the given callee type.
+/// Matches and type-checks a call expression against the original callee type.
 ///
-/// This is the expensive path for call-argument form analysis: it matches call-site arguments to
-/// parameters, checks argument types, and preserves the resulting bindings even when the call is
-/// invalid so IDE features can inspect the best available binding information.
-fn full_type_bindings_for_call<'db>(
+/// In particular, this does not first convert a bound method into its callable representation:
+/// the implicit receiver remains in the binding operation and can constrain overload selection.
+fn type_checked_bindings_for_call<'db>(
     model: &SemanticModel<'db>,
     func_type: Type<'db>,
     call_expr: &ast::ExprCall,
-) -> crate::types::call::Bindings<'db> {
+) -> Result<crate::types::call::Bindings<'db>, CallError<'db>> {
     let db = model.db();
     let call_arguments =
         CallArguments::from_arguments_typed(&call_expr.arguments, |splatted_value| {
@@ -863,19 +819,28 @@ fn full_type_bindings_for_call<'db>(
             TypeContext::default(),
             &[],
         )
+}
+
+/// Fully binds and type-checks a call expression, retaining failed bindings for IDE fallback.
+fn full_type_bindings_for_call<'db>(
+    model: &SemanticModel<'db>,
+    func_type: Type<'db>,
+    call_expr: &ast::ExprCall,
+) -> crate::types::call::Bindings<'db> {
+    type_checked_bindings_for_call(model, func_type, call_expr)
         .unwrap_or_else(|CallError(_, bindings)| *bindings)
 }
 
-/// Returns the form for a single argument from a successful binding.
-fn argument_form_from_successful_binding(
-    binding: &crate::types::call::Binding<'_>,
+/// Returns the form for a single argument from an overload that matches the call.
+fn argument_form_from_matching_binding(
+    binding: &CallSiteBinding<'_, '_>,
     argument_index: usize,
 ) -> CallArgumentForm {
     if let Some(argument_match) = binding.argument_matches().get(argument_index)
         && argument_match.matched
         && let [parameter_index] = argument_match.parameters.as_slice()
     {
-        return match binding.signature.parameters()[*parameter_index].form {
+        return match binding.signature().parameters()[*parameter_index].form {
             ParameterForm::Value => CallArgumentForm::Value,
             ParameterForm::Type => CallArgumentForm::Type,
         };
@@ -915,15 +880,12 @@ pub fn call_argument_forms(
 
     let mut argument_forms = vec![CallArgumentForm::Unknown; argument_count];
 
-    // If any bindings are successful, limit analysis to those bindings.
-    let successful_bindings: Vec<_> = bindings
-        .iter_flat()
-        .flatten()
-        .filter(|binding| binding.errors().is_empty())
-        .collect();
+    // If any overloads match the call, limit analysis to those overloads. Other diagnostics on a
+    // matching overload do not change whether its parameters receive values or type expressions.
+    let matching_bindings: Vec<_> = bindings.matching_call_site_bindings(model.db()).collect();
 
-    let Some((first_binding, remaining_bindings)) = successful_bindings.split_first() else {
-        // If no binding succeeds, fall back to the merged non-conflicting forms from the full
+    let Some((first_binding, remaining_bindings)) = matching_bindings.split_first() else {
+        // If no overload matches, fall back to the merged non-conflicting forms from the full
         // binding result so callers still get the best conservative answer available.
         for (arg_index, form) in bindings.non_conflicting_argument_forms().enumerate() {
             let Some(argument_form) = argument_forms.get_mut(arg_index) else {
@@ -937,16 +899,17 @@ pub fn call_argument_forms(
         return argument_forms;
     };
 
-    // If all successful bindings agree on the argument form, use the agreed-upon form; otherwise,
+    // If all matching overloads agree on the argument form, use the agreed-upon form; otherwise,
     // fall back to `CallArgumentForm::Unknown`.
     for (arg_index, resolved_argument_form) in argument_forms.iter_mut().enumerate() {
-        let argument_form = argument_form_from_successful_binding(first_binding, arg_index);
+        let argument_form = argument_form_from_matching_binding(first_binding, arg_index);
         if argument_form == CallArgumentForm::Unknown {
             continue;
         }
-        if remaining_bindings.iter().all(|binding| {
-            argument_form_from_successful_binding(binding, arg_index) == argument_form
-        }) {
+        if remaining_bindings
+            .iter()
+            .all(|binding| argument_form_from_matching_binding(binding, arg_index) == argument_form)
+        {
             *resolved_argument_form = argument_form;
         }
     }
@@ -972,16 +935,14 @@ pub fn call_type_simplified_by_overloads(
     let db = model.db();
     let func_type = call_expr.func.inferred_type(model)?;
 
-    let callable_type = func_type.try_upcast_to_callable(db)?.into_type(db);
-
     // If the callable is trivial this analysis is useless, bail out
-    if let Some(binding) = callable_type.bindings(db).single_element()
+    if let Some(binding) = func_type.bindings(db).single_element()
         && binding.overloads().len() < 2
     {
         return None;
     }
 
-    let signature = resolve_single_overload(model, callable_type, call_expr)?;
+    let signature = resolve_single_overload(model, func_type, call_expr)?;
     Some(
         signature
             .display_with(db, DisplaySettings::default().multiline())
@@ -1094,14 +1055,27 @@ fn promote_for_self<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
 }
 
 /// Find the active signature index from `CallSignatureDetails`.
-/// The active signature is the first signature where all arguments present in the call
-/// have valid mappings to parameters (i.e., none of the mappings are None).
+///
+/// Prefer the first signature selected by semantic call matching. If matching fails for every
+/// candidate, fall back to the best source-argument-to-parameter mapping for incomplete or
+/// invalid calls.
 pub fn find_active_signature_from_details(
     signature_details: &[CallSignatureDetails],
 ) -> Option<usize> {
     let first = signature_details.first()?;
 
-    // If there are no arguments in the mapping, just return the first signature.
+    // When full call resolution succeeds, prefer its first matching overload. This accounts for
+    // constraints on implicit receiver arguments, which do not appear in the displayed argument
+    // mapping, as well as ordinary argument-type overload resolution.
+    if let Some(index) = signature_details
+        .iter()
+        .position(|details| details.matches_call)
+    {
+        return Some(index);
+    }
+
+    // When the call is incomplete or invalid, fall back to source argument mapping so signature
+    // help can still identify the best active candidate while the user is editing.
     if first.argument_to_parameter_mapping.is_empty() {
         return Some(0);
     }
@@ -1144,27 +1118,12 @@ pub fn resolved_call_signature<'db>(
 ) -> Option<CallSignatureDetails<'db>> {
     let db = model.db();
     let func_type = call_expr.func.inferred_type(model)?;
-    let callable_type = func_type.try_upcast_to_callable(db)?.into_type(db);
-
-    let args = CallArguments::from_arguments_typed(&call_expr.arguments, |splatted_value| {
-        splatted_value
-            .inferred_type(model)
-            .unwrap_or(Type::unknown())
-    });
-
-    // Extract the `Bindings` regardless of whether type checking succeeded or failed.
-    let constraints = ConstraintSetBuilder::new();
-    let bindings = callable_type
-        .bindings(db)
-        .match_parameters(db, &args)
-        .check_types(db, &constraints, &args, TypeContext::default(), &[])
-        .unwrap_or_else(|CallError(_, bindings)| *bindings);
+    let bindings = full_type_bindings_for_call(model, func_type, call_expr);
 
     // First, try to find the matching overload after full type checking.
     let type_checked_details: Vec<_> = bindings
-        .iter_flat()
-        .flat_map(|binding| binding.matching_overloads().map(|(_, overload)| overload))
-        .map(|binding| CallSignatureDetails::from_binding(db, binding))
+        .matching_call_site_bindings(db)
+        .map(|binding| CallSignatureDetails::from_call_site_binding(db, binding))
         .collect();
 
     if !type_checked_details.is_empty() {
@@ -1176,9 +1135,8 @@ pub fn resolved_call_signature<'db>(
     // `matching_overloads()` returns empty. Fall back to arity-based matching
     // across all overloads to pick the best candidate for showing hints.
     let all_details: Vec<_> = bindings
-        .iter_flat()
-        .flatten()
-        .map(|binding| CallSignatureDetails::from_binding(db, binding))
+        .call_site_bindings(db)
+        .map(|binding| CallSignatureDetails::from_call_site_binding(db, binding))
         .collect();
 
     if all_details.is_empty() {
@@ -2174,7 +2132,7 @@ pub fn constructor_signature(model: &SemanticModel, call_expr: &ast::ExprCall) -
             .map(|overload| display_sig(&overload.signature));
     }
 
-    if let Some(signature) = resolve_single_overload(model, callable_type, call_expr) {
+    if let Some(signature) = resolve_single_overload(model, function_ty, call_expr) {
         return Some(display_sig(&signature));
     }
 


### PR DESCRIPTION
## Summary

```py
def f(s: str):
    trimmed = s.removesuffix("suffix")
    reveal_type(trimmed) # Revealed type: `str`
```

where `removesuffix` has two overloads:

```py
  @overload
  def removesuffix(self: LiteralString, suffix: LiteralString, /) -> LiteralString:
      """Return a str with the given suffix string removed if present.

      If the string ends with the suffix string and that suffix is not empty,
      return string[:-len(suffix)]. Otherwise, return a copy of the original
      string.
      """
  @overload
  def removesuffix(self, suffix: str, /) -> str: ...  # type: ignore[misc]
```

The first only matches if `self` is a `LiteralString`, which isn't the case for the example above, because today's hover, signature help etc. strips the self type before matching the call arguments. 

This PR fixes this. Instead of using `try_upcast_to_callable`, it now uses `ty.bindings()`, the same infrastructure that `Type::call` uses. However, simply using `bindings isn't enough because the `Signature`s returned by `bindings` include `self` in their display representation, which we don't want. If you hover `removesuffix`, you want to see the arguments excluding `self` (at least that's our current behavior and I decided not to change this here). This requires patching up the `Signature` after binding. This PR introduces a new `CallSiteBinding` for this. It's one `Binding` but in the shape at the call site, not where the function is defined. 

I also used this PR as an opportunity to unify our call binding in the LSP, so that we now go through this new API instead of using one-off solutions in many places.




Fixes astral-sh/ty#3502.

Preserve bound receivers while resolving IDE call signatures.

## Test Plan

Added integration tests.
