### PR TITLE
[flake8-pyi] Stop folding distinct t-strings as duplicates (PYI016)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI016.py
@@ -156,3 +156,14 @@ field53: typing.Literal[f"{x:.2f}"] | typing.Literal[f"{x:.3f}"]  # OK (differen
 field54: typing.Literal[f"{x}"] | typing.Literal[f"{x}"]  # Error (true duplicate)
 field55: typing.Literal[f"{x =}"] | typing.Literal[f"{x=}"]  # OK (different debug text due to spaces)
 field56: typing.Literal[f"{0x0=}"] | typing.Literal[f"{0o0=}"]  # OK (different source text: "0x0" vs "0o0")
+
+# Regression test for https://github.com/astral-sh/ruff/issues/25164
+# T-strings expose source text of interpolations at runtime via
+# `string.templatelib.Interpolation.expression`, so for union members
+# containing t-strings the rule keys on source text instead of AST shape.
+# We also intentionally skip the autofix when a t-string is present,
+# because the AST generator can normalize source-level distinctions
+# inside the interpolation and silently change runtime output.
+field57: typing.Annotated[int, t"{00}"] | typing.Annotated[int, t"{000}"] | None  # OK (distinct source text "00" vs "000")
+field58: typing.Annotated[int, t"{0x0=}"] | typing.Annotated[int, t"{0x0=}"] | None  # Error (true duplicate; no autofix offered)
+field59: typing.Annotated[int, t"{x}"] | typing.Annotated[int, t"{x}"] | None        # Error (true duplicate; no autofix offered)

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::comparable::ComparableExpr;
+use ruff_python_ast::helpers::any_over_expr;
 use ruff_python_ast::{AtomicNodeIndex, Expr, ExprBinOp, ExprNoneLiteral, Operator, PythonVersion};
 use ruff_python_semantic::analyze::typing::traverse_union_and_optional;
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -10,6 +11,31 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 use super::generate_union_fix;
 use crate::checkers::ast::Checker;
 use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
+
+/// Key for deduplicating union members.
+///
+/// For most expressions, two members are duplicates when their [`ComparableExpr`]
+/// representations are equal — that is, when they have the same AST shape.
+///
+/// T-strings break this assumption: they expose the source text of each
+/// interpolation at runtime via `string.templatelib.Interpolation.expression`,
+/// so `t"{00}"` and `t"{000}"` are observably distinct programs even though
+/// `ComparableExpr` normalizes both to the same `NumberLiteral(0)` node. For
+/// union members that contain any t-string, we therefore key on the raw source
+/// text instead, which preserves source-level distinctness without
+/// destabilizing equality semantics for any other rule that uses
+/// [`ComparableExpr`].
+///
+/// See: <https://github.com/astral-sh/ruff/issues/25164>
+#[derive(PartialEq, Eq, Hash)]
+enum DedupKey<'a> {
+    Shape(ComparableExpr<'a>),
+    SourceText(&'a str),
+}
+
+fn contains_tstring(expr: &Expr) -> bool {
+    any_over_expr(expr, &|e: &Expr| matches!(e, Expr::TString(_)))
+}
 
 /// ## What it does
 /// Checks for duplicate union members.
@@ -59,12 +85,13 @@ impl Violation for DuplicateUnionMember {
 
 /// PYI016
 pub(crate) fn duplicate_union_member<'a>(checker: &Checker, expr: &'a Expr) {
-    let mut seen_nodes: HashSet<ComparableExpr<'_>, _> = FxHashSet::default();
+    let mut seen_nodes: HashSet<DedupKey<'_>, _> = FxHashSet::default();
     let mut unique_nodes: Vec<&Expr> = Vec::new();
     let mut diagnostics = Vec::new();
 
     let mut union_type = UnionKind::TypingUnion;
     let mut optional_present = false;
+    let mut tstring_present = false;
     // Adds a member to `literal_exprs` if it is a `Literal` annotation
     let mut check_for_duplicate_members = |expr: &'a Expr, parent: &'a Expr| {
         if matches!(parent, Expr::BinOp(_)) {
@@ -79,14 +106,31 @@ pub(crate) fn duplicate_union_member<'a>(checker: &Checker, expr: &'a Expr) {
             expr
         };
 
+        // Key by source text for t-string-bearing members; see `DedupKey`.
+        let has_tstring = contains_tstring(virtual_expr);
+        let key = if has_tstring {
+            tstring_present = true;
+            DedupKey::SourceText(checker.locator().slice(virtual_expr.range()))
+        } else {
+            DedupKey::Shape(virtual_expr.into())
+        };
+
         // If we've already seen this union member, raise a violation.
-        if seen_nodes.insert(virtual_expr.into()) {
+        if seen_nodes.insert(key) {
             unique_nodes.push(virtual_expr);
         } else {
+            // Use the source text for the duplicate name label when the
+            // member contains a t-string, because the generator may
+            // normalize interpolation source text (e.g. `t"{0x0=}"` ->
+            // `t"{0=}"`) and that normalized label would mislead the
+            // reader about what their source actually says.
+            let duplicate_name = if has_tstring {
+                checker.locator().slice(virtual_expr.range()).to_string()
+            } else {
+                checker.generator().expr(virtual_expr)
+            };
             diagnostics.push(checker.report_diagnostic(
-                DuplicateUnionMember {
-                    duplicate_name: checker.generator().expr(virtual_expr),
-                },
+                DuplicateUnionMember { duplicate_name },
                 // Use the real expression's range for diagnostics.
                 expr.range(),
             ));
@@ -104,6 +148,15 @@ pub(crate) fn duplicate_union_member<'a>(checker: &Checker, expr: &'a Expr) {
     // e.g. `isinstance(None, Union[None, None])`, if reduced to `isinstance(None, None)`, causes
     // `TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union` to throw.
     if unique_nodes.iter().all(|expr| expr.is_none_literal_expr()) && !optional_present {
+        return;
+    }
+
+    // Do not offer an autofix when any union member contains a t-string: the
+    // ast generator may normalize source-level distinctions inside the
+    // interpolation (e.g. rewriting `t"{0x0=}"` as `t"{0=}"`), which would
+    // silently change the program's runtime output. The diagnostic still
+    // surfaces; the user can resolve it by hand. See #25164.
+    if tstring_present {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -26,6 +26,14 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 /// destabilizing equality semantics for any other rule that uses
 /// [`ComparableExpr`].
 ///
+/// Trade-off: source-text keying is strict about insignificant whitespace.
+/// Two members like `Annotated[int, t"{x}"]` and `Annotated[int,  t"{x}"]`
+/// (extra space) source-text-key differently and so are not detected as
+/// duplicates, even though `ComparableExpr` would have considered them equal.
+/// Stub files almost never carry that kind of duplication and the cost of a
+/// false negative here (a missed cleanup suggestion) is much smaller than the
+/// cost of the false positive / unsafe autofix that motivated this change.
+///
 /// See: <https://github.com/astral-sh/ruff/issues/25164>
 #[derive(PartialEq, Eq, Hash)]
 enum DedupKey<'a> {
@@ -107,7 +115,10 @@ pub(crate) fn duplicate_union_member<'a>(checker: &Checker, expr: &'a Expr) {
         };
 
         // Key by source text for t-string-bearing members; see `DedupKey`.
-        let has_tstring = contains_tstring(virtual_expr);
+        // T-strings are syntactically invalid before Python 3.14, so on
+        // older targets we can skip the tree walk entirely.
+        let has_tstring = checker.target_version() >= PythonVersion::PY314
+            && contains_tstring(virtual_expr);
         let key = if has_tstring {
             tstring_present = true;
             DedupKey::SourceText(checker.locator().slice(virtual_expr.range()))

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI016_PYI016.py.snap
@@ -1218,3 +1218,25 @@ help: Remove duplicate union member `typing.Literal[f"{x}"]`
 156 + field54: typing.Literal[f"{x}"]  # Error (true duplicate)
 157 | field55: typing.Literal[f"{x =}"] | typing.Literal[f"{x=}"]  # OK (different debug text due to spaces)
 158 | field56: typing.Literal[f"{0x0=}"] | typing.Literal[f"{0o0=}"]  # OK (different source text: "0x0" vs "0o0")
+159 |
+
+PYI016 Duplicate union member `typing.Annotated[int, t"{0x0=}"]`
+   --> PYI016.py:168:45
+    |
+166 | # inside the interpolation and silently change runtime output.
+167 | field57: typing.Annotated[int, t"{00}"] | typing.Annotated[int, t"{000}"] | None  # OK (distinct source text "00" vs "000")
+168 | field58: typing.Annotated[int, t"{0x0=}"] | typing.Annotated[int, t"{0x0=}"] | None  # Error (true duplicate; no autofix offered)
+    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+169 | field59: typing.Annotated[int, t"{x}"] | typing.Annotated[int, t"{x}"] | None        # Error (true duplicate; no autofix offered)
+    |
+help: Remove duplicate union member `typing.Annotated[int, t"{0x0=}"]`
+
+PYI016 Duplicate union member `typing.Annotated[int, t"{x}"]`
+   --> PYI016.py:169:42
+    |
+167 | field57: typing.Annotated[int, t"{00}"] | typing.Annotated[int, t"{000}"] | None  # OK (distinct source text "00" vs "000")
+168 | field58: typing.Annotated[int, t"{0x0=}"] | typing.Annotated[int, t"{0x0=}"] | None  # Error (true duplicate; no autofix offered)
+169 | field59: typing.Annotated[int, t"{x}"] | typing.Annotated[int, t"{x}"] | None        # Error (true duplicate; no autofix offered)
+    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+help: Remove duplicate union member `typing.Annotated[int, t"{x}"]`


### PR DESCRIPTION
## Summary

Closes #25164. Supersedes #25307 (closed by @MichaReiser with feedback that the prior comparable-layer approach was too broad).

This revision moves the t-string handling **into the PYI016 rule itself** and leaves `ComparableTString` / `comparable.rs` untouched, so every other consumer of `ComparableExpr` keeps its current semantics.

### What changes in `duplicate_union_member.rs`

- Introduce a small `DedupKey` enum with two variants:
  - `Shape(ComparableExpr<'a>)` — the existing path, used for every union member that does **not** contain a t-string.
  - `SourceText(&'a str)` — used when the member contains a t-string anywhere in its subtree. Source-text keying matches `Template.expression`'s runtime semantics exactly (two t-strings are equal iff their source bytes are equal), without destabilizing `ComparableExpr` equality for any other rule.
- When any union member contains a t-string, **do not** offer an autofix. The AST generator can normalize source-level distinctions inside the interpolation (e.g. rewriting `t"{0x0=}"` as `t"{0=}"`) and silently change the program's runtime output, which is the same family of bugs the issue describes. The diagnostic still surfaces so the user can resolve it by hand.
- For the diagnostic label of a t-string-bearing duplicate, use the raw source text rather than `checker.generator().expr(...)`, so the message faithfully shows the source (e.g. ``Duplicate union member `typing.Annotated[int, t"{0x0=}"]` `` rather than the generator-normalized ``t"{0=}"``).

### Test fixtures

Three regression cases added to `PYI016.py`:

| Field | Source | Expected | Why |
|---|---|---|---|
| `field57` | `Annotated[int, t"{00}"] \| Annotated[int, t"{000}"] \| None` | not flagged | distinct source text → distinct values at runtime |
| `field58` | `Annotated[int, t"{0x0=}"] \| Annotated[int, t"{0x0=}"] \| None` | flagged, no autofix | true duplicate; label preserves `{0x0=}` |
| `field59` | `Annotated[int, t"{x}"] \| Annotated[int, t"{x}"] \| None` | flagged, no autofix | true duplicate |

Snapshot grows by exactly two diagnostics (`field58` + `field59`), zero on `field57` — matches the asserted behavior.

### Blast radius

- `comparable.rs` is **not** modified in this PR.
- `cargo test -p ruff_linter --lib` → 2772 passed, 4 ignored.
- `cargo test -p ruff_python_ast --lib` → 49 passed (no changes there either).

### Test plan

- [x] Reproduces #25164's two scenarios are handled correctly (field57 not flagged; field58 flagged without normalization).
- [x] No autofix is offered for t-string-bearing union members.
- [x] All `ruff_linter` snapshot tests pass.