### PR TITLE
[ty] Add disjointness for protocol method members

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -1392,6 +1392,76 @@ class FinalFoo:
 static_assert(is_disjoint_from(Proto, FinalFoo))
 ```
 
+Method members establish disjointness when their non-`Never` return types are disjoint. This is a
+pragmatic approximation: strictly speaking, an implementation returning `Never` could satisfy method
+signatures with otherwise disjoint return types.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Literal, Protocol
+from typing_extensions import Never
+from ty_extensions import is_assignable_to, is_disjoint_from, is_subtype_of, static_assert
+
+class HasLengthTwo(Protocol):
+    def __len__(self) -> Literal[2]: ...
+
+class LengthThree:
+    def __len__(self) -> Literal[3]:
+        return 3
+
+class NeverLengthSubclass(LengthThree):
+    def __len__(self) -> Never:
+        raise RuntimeError
+
+static_assert(is_subtype_of(NeverLengthSubclass, LengthThree))
+static_assert(is_subtype_of(NeverLengthSubclass, HasLengthTwo))
+
+# Intentionally unsound: `NeverLengthSubclass` inhabits both operands,
+# but pragmatically, nobody is ever likely to write such a class
+static_assert(is_disjoint_from(LengthThree, HasLengthTwo))
+```
+
+The same pragmatic approximation applies to fixed-length tuple types. A tuple subclass with a
+`Never`-returning override demonstrates that the disjointness assertion here is also intentionally
+unsound:
+
+```py
+class NeverLengthTupleSubclass(tuple[int, int, int]):
+    def __len__(self) -> Never:
+        raise RuntimeError
+
+static_assert(is_subtype_of(NeverLengthTupleSubclass, tuple[int, int, int]))
+static_assert(is_subtype_of(NeverLengthTupleSubclass, HasLengthTwo))
+
+# Intentionally unsound: `NeverLengthTupleSubclass` inhabits both operands.
+static_assert(is_disjoint_from(tuple[int, int, int], HasLengthTwo))
+static_assert(not is_disjoint_from(tuple[int, int], HasLengthTwo))
+```
+
+Methods returning `Never` directly cannot establish this pragmatic disjointness. The same applies
+when the return type is a type alias that resolves to `Never`:
+
+```py
+class NeverLength:
+    def __len__(self) -> Never:
+        raise RuntimeError
+
+static_assert(not is_disjoint_from(NeverLength, HasLengthTwo))
+
+type Bottom = Never
+
+class AliasedNeverLength:
+    def __len__(self) -> Bottom:
+        raise RuntimeError
+
+static_assert(is_assignable_to(AliasedNeverLength, HasLengthTwo))
+static_assert(not is_disjoint_from(AliasedNeverLength, HasLengthTwo))
+```
+
 ## Intersections of protocols with types that have possibly unbound attributes
 
 Note that if a `@final` class has a possibly unbound attribute corresponding to the protocol member,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -902,8 +902,26 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         ty: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
         match &member.kind {
-            // TODO: implement disjointness for property/method members as well as attribute members
-            ProtocolMemberKind::Property(_) | ProtocolMemberKind::Method(_) => self.never(),
+            // TODO: implement disjointness for property members as well as attribute/method members.
+            ProtocolMemberKind::Property(_) => self.never(),
+            ProtocolMemberKind::Method(method) => {
+                let Some(method_return_type) = non_never_callable_return_type(db, *method) else {
+                    return self.never();
+                };
+
+                ty.try_upcast_to_callable_with_policy(db, UpcastPolicy::Sound)
+                    .when_some_and(db, self.constraints, |callables| {
+                        callables.iter().when_all(db, self.constraints, |callable| {
+                            non_never_callable_return_type(db, *callable).when_some_and(
+                                db,
+                                self.constraints,
+                                |return_type| {
+                                    self.check_type_pair(db, method_return_type, return_type)
+                                },
+                            )
+                        })
+                    })
+            }
             ProtocolMemberKind::Other(other_type) => self.check_type_pair(db, ty, *other_type),
         }
     }
@@ -1102,6 +1120,21 @@ fn protocol_bind_self<'db>(
         CallableTypeKind::Regular,
         callable.provenance(db),
     )
+}
+
+/// Return the possible output type of a callable unless any overload returns `Never`.
+///
+/// Return-type disjointness is a pragmatic approximation for method members: a callable returning
+/// `Never` could satisfy otherwise-incompatible signatures, so it must not establish disjointness.
+fn non_never_callable_return_type<'db>(
+    db: &'db dyn Db,
+    callable: CallableType<'db>,
+) -> Option<Type<'db>> {
+    callable
+        .signatures(db)
+        .iter()
+        .all(|signature| !signature.return_ty.resolve_type_alias(db).is_never())
+        .then(|| callable.signatures(db).overload_return_type_or_unknown(db))
 }
 
 /// Protocol compatibility can only succeed if every required member is present.


### PR DESCRIPTION
## Summary

This PR implements disjointness checking for protocols with method members by comparing non-`Never` return types, e.g., we now understand that a fixed-length tuple whose synthesized `__len__` returns `Literal[3]` is disjoint from a protocol requiring `__len__` to return `Literal[2]`:

```python
from typing import Literal, Protocol
from ty_extensions import is_disjoint_from, static_assert

class HasLengthTwo(Protocol):
    def __len__(self) -> Literal[2]: ...

static_assert(is_disjoint_from(tuple[int, int, int], HasLengthTwo))
```

This is a prerequisite for using synthesized exact-length protocols to narrow unions of fixed-length tuples and sequence patterns (see: https://github.com/astral-sh/ruff/pull/22134#issuecomment-4517932605).

Per that comment, this isn't fully sound: a subclass can override an otherwise incompatible method with a `Never`-returning implementation and therefore inhabit both types that we infer to be disjoint.
