### PR TITLE
[`refurb`] Document `FURB192` exception change for empty sequences

### DIFF
--- a/crates/ruff_linter/src/rules/refurb/rules/sorted_min_max.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/sorted_min_max.rs
@@ -41,6 +41,11 @@ use crate::checkers::ast::Checker;
 /// the same key. However, `min(data, key=itemgetter(0))` will return the _first_
 /// "minimum" element in the list in the same scenario.
 ///
+/// The fix also changes which exception is raised for an empty sequence:
+/// `sorted([])[0]` raises `IndexError`, but `min([])` and `max([])` raise
+/// `ValueError`. Code that catches one specific exception type will need to
+/// be updated after the fix is applied.
+///
 /// As such, this rule's fix is marked as unsafe.
 ///
 /// ## References


### PR DESCRIPTION
`sorted([])[0]` raises `IndexError`, but `min([])` and `max([])` raise `ValueError`. Code that catches one specific exception type breaks after the autofix, so the rule's fix-safety section now calls this out alongside the existing tie-breaking note.

Closes #16964