### PR TITLE
[`flake8-bugbear`] Flag bare tuples in `B018` (`useless-expression`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B018.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B018.py
@@ -63,3 +63,12 @@ def foo5():
     foo.bar  # Attribute (raise)
     object().__class__  # Attribute (raise)
     "foo" + "bar"  # BinOp (raise)
+
+
+def foo6():
+    # Bare tuples: the wrapping tuple is useless even when elements have side effects.
+    # See https://github.com/astral-sh/ruff/issues/14131
+    foo(),  # single-element trailing-comma tuple wrapping a call
+    foo(), bar()  # multi-element tuple wrapping calls
+    1, 2, 3  # tuple of literals
+    (1, 2, 3)  # parenthesized tuple of literals

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -352,3 +352,8 @@ pub(crate) const fn is_collapsible_if_fix_safe_enabled(settings: &LinterSettings
 pub(crate) const fn is_ruff_ignore_enabled(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()
 }
+
+// https://github.com/astral-sh/ruff/issues/14131
+pub(crate) const fn is_b018_tuple_detection_enabled(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}

--- a/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
@@ -97,6 +97,7 @@ mod tests {
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_9.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_B008.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_1.pyi"))]
+    #[test_case(Rule::UselessExpression, Path::new("B018.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview__{}_{}",

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_expression.rs
@@ -96,6 +96,20 @@ pub(crate) fn useless_expression(checker: &Checker, value: &Expr) {
         return;
     }
 
+    // A tuple expression statement constructs a tuple that is immediately discarded.
+    // Even if the elements have side effects (e.g. `foo(),`), the tuple wrapper itself
+    // is useless and almost always indicates a stray trailing comma. Flag it ahead of
+    // the side-effect check below so those cases are not silently allowed.
+    if value.is_tuple_expr() {
+        checker.report_diagnostic(
+            UselessExpression {
+                kind: Kind::Expression,
+            },
+            value.range(),
+        );
+        return;
+    }
+
     // Ignore statements that have side effects.
     if contains_effect(value, |id| checker.semantic().has_builtin_binding(id)) {
         // Flag attributes as useless expressions, even if they're attached to calls or other

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_expression.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/useless_expression.rs
@@ -5,6 +5,7 @@ use ruff_text_size::Ranged;
 
 use crate::Violation;
 use crate::checkers::ast::Checker;
+use crate::preview::is_b018_tuple_detection_enabled;
 
 use crate::rules::flake8_bugbear::helpers::at_last_top_level_expression_in_cell;
 
@@ -50,6 +51,16 @@ use crate::rules::flake8_bugbear::helpers::at_last_top_level_expression_in_cell;
 /// with errors.ExceptionRaisedContext():
 ///     _ = obj.attribute
 /// ```
+///
+/// ## Preview
+/// When [preview] is enabled, bare tuple expression statements are also flagged,
+/// since the wrapping tuple is discarded and almost always indicates a stray
+/// trailing comma. For example:
+/// ```python
+/// foo(),
+/// ```
+///
+/// [preview]: https://docs.astral.sh/ruff/preview/
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.100")]
 pub(crate) struct UselessExpression {
@@ -65,6 +76,10 @@ impl Violation for UselessExpression {
             }
             Kind::Attribute => {
                 "Found useless attribute access. Either assign it to a variable or remove it."
+                    .to_string()
+            }
+            Kind::Tuple => {
+                "Found useless tuple expression (a stray trailing comma may have created an unintended tuple). Either remove the comma, assign it to a variable, or remove it entirely."
                     .to_string()
             }
         }
@@ -99,14 +114,10 @@ pub(crate) fn useless_expression(checker: &Checker, value: &Expr) {
     // A tuple expression statement constructs a tuple that is immediately discarded.
     // Even if the elements have side effects (e.g. `foo(),`), the tuple wrapper itself
     // is useless and almost always indicates a stray trailing comma. Flag it ahead of
-    // the side-effect check below so those cases are not silently allowed.
-    if value.is_tuple_expr() {
-        checker.report_diagnostic(
-            UselessExpression {
-                kind: Kind::Expression,
-            },
-            value.range(),
-        );
+    // the side-effect check below so those cases are not silently allowed. Gated on
+    // preview because this is a significant expansion to a stable rule.
+    if value.is_tuple_expr() && is_b018_tuple_detection_enabled(checker.settings()) {
+        checker.report_diagnostic(UselessExpression { kind: Kind::Tuple }, value.range());
         return;
     }
 
@@ -137,4 +148,5 @@ pub(crate) fn useless_expression(checker: &Checker, value: &Expr) {
 enum Kind {
     Expression,
     Attribute,
+    Tuple,
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B018_B018.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__B018_B018.py.snap
@@ -281,3 +281,44 @@ B018 Found useless expression. Either assign it to a variable or remove it.
 65 |     "foo" + "bar"  # BinOp (raise)
    |     ^^^^^^^^^^^^^
    |
+
+B018 Found useless expression. Either assign it to a variable or remove it.
+  --> B018.py:71:5
+   |
+69 |     # Bare tuples: the wrapping tuple is useless even when elements have side effects.
+70 |     # See https://github.com/astral-sh/ruff/issues/14131
+71 |     foo(),  # single-element trailing-comma tuple wrapping a call
+   |     ^^^^^^
+72 |     foo(), bar()  # multi-element tuple wrapping calls
+73 |     1, 2, 3  # tuple of literals
+   |
+
+B018 Found useless expression. Either assign it to a variable or remove it.
+  --> B018.py:72:5
+   |
+70 |     # See https://github.com/astral-sh/ruff/issues/14131
+71 |     foo(),  # single-element trailing-comma tuple wrapping a call
+72 |     foo(), bar()  # multi-element tuple wrapping calls
+   |     ^^^^^^^^^^^^
+73 |     1, 2, 3  # tuple of literals
+74 |     (1, 2, 3)  # parenthesized tuple of literals
+   |
+
+B018 Found useless expression. Either assign it to a variable or remove it.
+  --> B018.py:73:5
+   |
+71 |     foo(),  # single-element trailing-comma tuple wrapping a call
+72 |     foo(), bar()  # multi-element tuple wrapping calls
+73 |     1, 2, 3  # tuple of literals
+   |     ^^^^^^^
+74 |     (1, 2, 3)  # parenthesized tuple of literals
+   |
+
+B018 Found useless expression. Either assign it to a variable or remove it.
+  --> B018.py:74:5
+   |
+72 |     foo(), bar()  # multi-element tuple wrapping calls
+73 |     1, 2, 3  # tuple of literals
+74 |     (1, 2, 3)  # parenthesized tuple of literals
+   |     ^^^^^^^^^
+   |

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__preview__B018_B018.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__preview__B018_B018.py.snap
@@ -282,7 +282,29 @@ B018 Found useless expression. Either assign it to a variable or remove it.
    |     ^^^^^^^^^^^^^
    |
 
-B018 Found useless expression. Either assign it to a variable or remove it.
+B018 Found useless tuple expression (a stray trailing comma may have created an unintended tuple). Either remove the comma, assign it to a variable, or remove it entirely.
+  --> B018.py:71:5
+   |
+69 |     # Bare tuples: the wrapping tuple is useless even when elements have side effects.
+70 |     # See https://github.com/astral-sh/ruff/issues/14131
+71 |     foo(),  # single-element trailing-comma tuple wrapping a call
+   |     ^^^^^^
+72 |     foo(), bar()  # multi-element tuple wrapping calls
+73 |     1, 2, 3  # tuple of literals
+   |
+
+B018 Found useless tuple expression (a stray trailing comma may have created an unintended tuple). Either remove the comma, assign it to a variable, or remove it entirely.
+  --> B018.py:72:5
+   |
+70 |     # See https://github.com/astral-sh/ruff/issues/14131
+71 |     foo(),  # single-element trailing-comma tuple wrapping a call
+72 |     foo(), bar()  # multi-element tuple wrapping calls
+   |     ^^^^^^^^^^^^
+73 |     1, 2, 3  # tuple of literals
+74 |     (1, 2, 3)  # parenthesized tuple of literals
+   |
+
+B018 Found useless tuple expression (a stray trailing comma may have created an unintended tuple). Either remove the comma, assign it to a variable, or remove it entirely.
   --> B018.py:73:5
    |
 71 |     foo(),  # single-element trailing-comma tuple wrapping a call
@@ -292,7 +314,7 @@ B018 Found useless expression. Either assign it to a variable or remove it.
 74 |     (1, 2, 3)  # parenthesized tuple of literals
    |
 
-B018 Found useless expression. Either assign it to a variable or remove it.
+B018 Found useless tuple expression (a stray trailing comma may have created an unintended tuple). Either remove the comma, assign it to a variable, or remove it entirely.
   --> B018.py:74:5
    |
 72 |     foo(), bar()  # multi-element tuple wrapping calls


### PR DESCRIPTION
A tuple expression statement constructs a tuple and immediately discards it. The elements may still execute, so a stray `foo(),` does still call `foo`, but the tuple wrapper itself is useless and almost always indicates a trailing-comma typo. `B018` previously bailed early whenever any element had a side effect, so the typical `foo(),` mistake slipped through even though `COM818` already flags the same statement from the formatting side.

This checks for tuple expressions ahead of the side-effect short-circuit and reports them as useless expressions. The new fixture cases cover the single-element trailing-comma tuple, multi-element tuples wrapping calls, and bare and parenthesized literal tuples.

Closes #14131