### PR TITLE
[`flake8-simplify`] Skip `bool(...)` wrap in `SIM103` for bool-returning conditions

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM103.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM103.py
@@ -159,3 +159,26 @@ def f():
     if a != 10:
         return False
     return True
+
+
+# https://github.com/astral-sh/ruff/issues/15323
+# `and`/`or` chains of bool-returning operands should not be wrapped in `bool(...)`.
+def f():
+    if a == 0 and b == 0:
+        return True
+    else:
+        return False
+
+
+def f():
+    if a == 0 or b == 0:
+        return True
+    else:
+        return False
+
+
+def f():
+    if not a:
+        return True
+    else:
+        return False

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -268,9 +268,9 @@ pub(crate) fn needless_bool(checker: &Checker, stmt: &Stmt) {
                     node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                 })),
             }
-        } else if if_test.is_compare_expr() {
-            // If the condition is a comparison, we can replace it with the condition, since we
-            // know it's a boolean.
+        } else if returns_bool(if_test) {
+            // If the condition is already known to evaluate to a bool, we can replace it with
+            // the condition directly.
             Some(if_test.clone())
         } else if checker.semantic().has_builtin_binding("bool") {
             // Otherwise, we need to wrap the condition in a call to `bool`.
@@ -338,6 +338,22 @@ enum Bool {
 impl From<bool> for Bool {
     fn from(value: bool) -> Self {
         if value { Bool::True } else { Bool::False }
+    }
+}
+
+/// Return true when `expr` is guaranteed to evaluate to a `bool` at runtime,
+/// so the autofix can drop the surrounding `bool(...)` wrapper. This covers
+/// comparisons, `not` expressions, boolean literals, and `and`/`or` chains
+/// whose operands are themselves bool-returning.
+fn returns_bool(expr: &Expr) -> bool {
+    match expr {
+        Expr::Compare(_) | Expr::BooleanLiteral(_) => true,
+        Expr::UnaryOp(ast::ExprUnaryOp {
+            op: ast::UnaryOp::Not,
+            ..
+        }) => true,
+        Expr::BoolOp(ast::ExprBoolOp { values, .. }) => values.iter().all(returns_bool),
+        _ => false,
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM103_SIM103.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM103_SIM103.py.snap
@@ -380,4 +380,77 @@ help: Replace with `return a == 10`
     -         return False
     -     return True
 159 +     return a == 10
+160 |
+161 |
+162 | # https://github.com/astral-sh/ruff/issues/15323
+note: This is an unsafe fix and may change runtime behavior
+
+SIM103 [*] Return the condition `a == 0 and b == 0` directly
+   --> SIM103.py:167:5
+    |
+165 |   # `and`/`or` chains of bool-returning operands should not be wrapped in `bool(...)`.
+166 |   def f():
+167 | /     if a == 0 and b == 0:
+168 | |         return True
+169 | |     else:
+170 | |         return False
+    | |____________________^
+    |
+help: Replace with `return a == 0 and b == 0`
+164 | # https://github.com/astral-sh/ruff/issues/15323
+165 | # `and`/`or` chains of bool-returning operands should not be wrapped in `bool(...)`.
+166 | def f():
+    -     if a == 0 and b == 0:
+    -         return True
+    -     else:
+    -         return False
+167 +     return a == 0 and b == 0
+168 |
+169 |
+170 | def f():
+note: This is an unsafe fix and may change runtime behavior
+
+SIM103 [*] Return the condition `a == 0 or b == 0` directly
+   --> SIM103.py:174:5
+    |
+173 |   def f():
+174 | /     if a == 0 or b == 0:
+175 | |         return True
+176 | |     else:
+177 | |         return False
+    | |____________________^
+    |
+help: Replace with `return a == 0 or b == 0`
+171 |
+172 |
+173 | def f():
+    -     if a == 0 or b == 0:
+    -         return True
+    -     else:
+    -         return False
+174 +     return a == 0 or b == 0
+175 |
+176 |
+177 | def f():
+note: This is an unsafe fix and may change runtime behavior
+
+SIM103 [*] Return the condition `not a` directly
+   --> SIM103.py:181:5
+    |
+180 |   def f():
+181 | /     if not a:
+182 | |         return True
+183 | |     else:
+184 | |         return False
+    | |____________________^
+    |
+help: Replace with `return not a`
+178 |
+179 |
+180 | def f():
+    -     if not a:
+    -         return True
+    -     else:
+    -         return False
+181 +     return not a
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
`SIM103` only avoided wrapping the inlined condition in `bool(...)` when the condition was a single comparison. Conditions that are guaranteed to evaluate to a bool, like `a == 0 and b == 0`, `not x`, boolean literals, and chains thereof, were still wrapped. That produces fixed code such as `return bool(a == 0 and b == 0)` where the `bool(...)` is purely noise.

This adds a `returns_bool` helper covering `Compare`, `not` unary ops, boolean literals, and `and`/`or` chains whose operands are themselves bool-returning, and uses it to gate the `bool(...)` wrap.

Closes #15323