### PR TITLE
[ty] Ignore and reject annotations on non-name targets

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/string.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/string.md
@@ -169,6 +169,7 @@ class Foo:
         self.x: "int" | "str" = 42
 
 d = {}
+# error: [invalid-type-form]
 d[0]: "int" | "str" = 42
 
 # error: [unsupported-operator]

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -555,6 +555,8 @@ reveal_type(C().declared_and_bound)  # revealed: str | None
 class C:
     def __init__(self) -> None:
         this = self
+        # error: [invalid-type-form]
+        # error: [unresolved-attribute]
         this.declared_and_bound: str | None = "a"
 
 # This would ideally be `str | None`, but mypy/pyright don't support this either,
@@ -2597,6 +2599,8 @@ reveal_type(C().x)  # revealed: int
 class C:
     def __init__(self) -> None:
         def set_attribute(value: str):
+            # error: [invalid-type-form]
+            # error: [unresolved-attribute]
             self.x: str = value
         set_attribute("a")
 

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2599,14 +2599,39 @@ reveal_type(C().x)  # revealed: int
 class C:
     def __init__(self) -> None:
         def set_attribute(value: str):
-            # error: [invalid-type-form]
-            # error: [unresolved-attribute]
             self.x: str = value
         set_attribute("a")
 
 # TODO: ideally, this would be `str`. Mypy supports this, pyright does not.
 # error: [unresolved-attribute]
 reveal_type(C().x)  # revealed: Unknown
+```
+
+### Non-receiver annotated assignments from nested functions
+
+```py
+class Other:
+    x: str
+
+receiver = Other()
+
+class C:
+    def __init__(self) -> None:
+        def set_shadowed(self: Other, value: str) -> None:
+            # error: [invalid-type-form]
+            self.x: str = value
+
+    @staticmethod
+    def set_static(self: Other) -> None:
+        def nested(value: str) -> None:
+            # error: [invalid-type-form]
+            self.x: str = value
+
+    def set_global(receiver) -> None:
+        def nested(value: str) -> None:
+            global receiver
+            # error: [invalid-type-form]
+            receiver.x: str = value
 ```
 
 ### Accessing attributes on `Never`

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
@@ -90,7 +90,8 @@ class C:
 
     @classmethod
     def initialize(cls):
-        cls.class_attr: int = 1  # fine
+        cls.class_attr1: str = None  # snapshot: invalid-assignment
+        cls.class_attr2: int = 1  # fine
 ```
 
 ```snapshot
@@ -101,6 +102,16 @@ error[invalid-assignment]: Object of type `None` is not assignable to `str`
   |                    ---   ^^^^ Incompatible value of type `None`
   |                    |
   |                    Declared type
+  |
+
+
+error[invalid-assignment]: Object of type `None` is not assignable to `str`
+ --> src/mdtest_snippet.py:8:26
+  |
+8 |         cls.class_attr1: str = None  # snapshot: invalid-assignment
+  |                          ---   ^^^^ Incompatible value of type `None`
+  |                          |
+  |                          Declared type
   |
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
@@ -79,13 +79,18 @@ error[invalid-attribute-access]: Cannot assign to instance attribute `attr` from
 
 ## Invalid annotated assignment to attribute
 
-Annotated assignments to attributes on `self` should be validated against their annotation.
+Annotated assignments to attributes on method receivers should be validated against their
+annotation.
 
 ```py
 class C:
     def __init__(self):
         self.attr: str = None  # snapshot: invalid-assignment
         self.attr2: int = 1  # fine
+
+    @classmethod
+    def initialize(cls):
+        cls.class_attr: int = 1  # fine
 ```
 
 ```snapshot
@@ -97,6 +102,43 @@ error[invalid-assignment]: Object of type `None` is not assignable to `str`
   |                    |
   |                    Declared type
   |
+```
+
+Annotations on other attribute targets are ignored, and the assignment is checked against the
+attribute already declared on the object's type.
+
+```py
+class C:
+    declared: int
+
+instance = C()
+
+# error: [invalid-type-form]
+# error: [invalid-assignment]
+instance.declared: str = "wrong"
+
+# error: [invalid-type-form]
+# error: [unresolved-attribute]
+instance.missing: str = "wrong"
+
+class Other:
+    declared: int
+
+class Static:
+    @staticmethod
+    def assign(other: Other):
+        # error: [invalid-type-form]
+        # error: [invalid-assignment]
+        other.declared: str = "wrong"
+
+class WithNew:
+    declared: int
+
+    def __new__(cls):
+        # error: [invalid-type-form]
+        # error: [invalid-assignment]
+        cls.declared: str = "wrong"
+        return super().__new__(cls)
 ```
 
 ## `ClassVar`s

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
@@ -124,7 +124,7 @@ class C:
 
 instance = C()
 
-# error: [invalid-type-form]
+# error: [invalid-type-form] "Type annotations are not allowed on this attribute expression"
 # error: [invalid-assignment]
 instance.declared: str = "wrong"
 

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
@@ -208,6 +208,7 @@ x3["inner"] = {"inner": {"a": 1}}
 f1(**x3["inner"])
 
 def _(x: dict[str, object]):
+    # error: [invalid-type-form]
     x["inner"]: dict[str, float | str] = {"a": 1, "b": "a"}
 
     f2(**x["inner"])  # ok

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Annotated_subscript_…_(98082f2161ea366f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Annotated_subscript_…_(98082f2161ea366f).snap
@@ -32,7 +32,7 @@ error[invalid-assignment]: Invalid subscript assignment with key of type `Litera
 ```
 
 ```
-error[invalid-type-form]: Annotations are not allowed on this assignment target
+error[invalid-type-form]: Type annotations are not allowed on subscripted expressions
  --> src/mdtest_snippet.py:4:13
   |
 4 | numbers[0]: str = "three"

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Annotated_subscript_…_(98082f2161ea366f).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Annotated_subscript_…_(98082f2161ea366f).snap
@@ -1,0 +1,42 @@
+---
+source: crates/mdtest/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: assignment_diagnostics.md - Subscript assignment diagnostics - Annotated subscript targets
+mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_diagnostics.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | numbers: list[int] = []
+2 | # error: [invalid-type-form]
+3 | # error: [invalid-assignment]
+4 | numbers[0]: str = "three"
+```
+
+# Diagnostics
+
+```
+error[invalid-assignment]: Invalid subscript assignment with key of type `Literal[0]` and value of type `Literal["three"]` on object of type `list[int]`
+ --> src/mdtest_snippet.py:4:1
+  |
+4 | numbers[0]: str = "three"
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+
+```
+
+```
+error[invalid-type-form]: Annotations are not allowed on this assignment target
+ --> src/mdtest_snippet.py:4:13
+  |
+4 | numbers[0]: str = "three"
+  |             ^^^
+  |
+
+```

--- a/crates/ty_python_semantic/resources/mdtest/subscript/assignment_diagnostics.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/assignment_diagnostics.md
@@ -18,6 +18,18 @@ config: dict[str, int] = {}
 config["retries"] = "three"  # error: [invalid-assignment]
 ```
 
+## Annotated subscript targets
+
+Annotations on subscript targets are ignored, and the assignment is checked against the collection's
+element type.
+
+```py
+numbers: list[int] = []
+# error: [invalid-type-form]
+# error: [invalid-assignment]
+numbers[0]: str = "three"
+```
+
 ## Invalid key type
 
 ### For a `list`

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1557,10 +1557,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .map(|node_ref| node_ref.node(self.module()))
     }
 
-    fn current_function_type(&self) -> Option<FunctionType<'db>> {
-        let function = self.current_function_definition()?;
+    fn function_type(&self, function: &ast::StmtFunctionDef) -> Option<FunctionType<'db>> {
         let definition = self.index.expect_single_definition(function);
         infer_definition_types(self.db(), definition).function_type(definition)
+    }
+
+    fn current_function_type(&self) -> Option<FunctionType<'db>> {
+        self.function_type(self.current_function_definition()?)
     }
 
     fn function_decorator_types<'a>(
@@ -4110,7 +4113,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // the non-name targets that are valid Python syntax.
             let is_receiver_attribute = target
                 .as_attribute_expr()
-                .is_some_and(|target| self.is_instance_attribute_assignment(target));
+                .is_some_and(|target| self.is_receiver_attribute_annotation_target(target));
             if !is_receiver_attribute {
                 match target.as_ref() {
                     ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4106,25 +4106,41 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
+            // Disallow annotations on non-receiver targets while preserving assignment checks for
+            // the non-name targets that are valid Python syntax.
             let is_receiver_attribute = target
                 .as_attribute_expr()
                 .is_some_and(|target| self.is_instance_attribute_assignment(target));
-
             if !is_receiver_attribute {
-                if let Some(builder) = self
-                    .context
-                    .report_lint(&INVALID_TYPE_FORM, annotation.as_ref())
-                {
-                    builder
-                        .into_diagnostic("Annotations are not allowed on this assignment target");
-                }
+                match target.as_ref() {
+                    ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
+                        // For syntactically valid non-name targets, reject the annotation and
+                        // validate any accompanying assignment.
+                        if let Some(builder) = self
+                            .context
+                            .report_lint(&INVALID_TYPE_FORM, annotation.as_ref())
+                        {
+                            builder.into_diagnostic(
+                                "Annotations are not allowed on this assignment target",
+                            );
+                        }
 
-                if let Some(value) = value {
-                    self.infer_target(target, value, &|builder, tcx| {
-                        builder.infer_maybe_standalone_expression(value, tcx)
-                    });
-                } else {
-                    self.infer_expression(target, TypeContext::default());
+                        if let Some(value) = value {
+                            self.infer_target(target, value, &|builder, tcx| {
+                                builder.infer_maybe_standalone_expression(value, tcx)
+                            });
+                        } else {
+                            self.infer_expression(target, TypeContext::default());
+                        }
+                    }
+                    _ => {
+                        // For parser-recovered invalid targets, the syntax diagnostic is
+                        // sufficient.
+                        if let Some(value) = value {
+                            self.infer_maybe_standalone_expression(value, TypeContext::default());
+                        }
+                        self.infer_expression(target, TypeContext::default());
+                    }
                 }
                 return;
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4109,32 +4109,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            // Disallow annotations on non-receiver targets while preserving assignment checks for
-            // the non-name targets that are valid Python syntax.
+            // Disallow annotations on non-name targets unless they are valid receivers (e.g.
+            // `self.x: int` or `cls.x: int`).
             let is_receiver_attribute = target
                 .as_attribute_expr()
                 .is_some_and(|target| self.is_receiver_attribute_annotation_target(target));
             if !is_receiver_attribute {
-                match target.as_ref() {
-                    ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
-                        // For syntactically valid non-name targets, reject the annotation and
-                        // validate any accompanying assignment.
-                        if let Some(builder) = self
-                            .context
-                            .report_lint(&INVALID_TYPE_FORM, annotation.as_ref())
-                        {
-                            builder.into_diagnostic(
-                                "Annotations are not allowed on this assignment target",
-                            );
-                        }
-
-                        if let Some(value) = value {
-                            self.infer_target(target, value, &|builder, tcx| {
-                                builder.infer_maybe_standalone_expression(value, tcx)
-                            });
-                        } else {
-                            self.infer_expression(target, TypeContext::default());
-                        }
+                let message = match target.as_ref() {
+                    ast::Expr::Attribute(_) => {
+                        "Type annotations are not allowed on this attribute expression"
+                    }
+                    ast::Expr::Subscript(_) => {
+                        "Type annotations are not allowed on subscripted expressions"
                     }
                     _ => {
                         // For parser-recovered invalid targets, the syntax diagnostic is
@@ -4143,7 +4129,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             self.infer_maybe_standalone_expression(value, TypeContext::default());
                         }
                         self.infer_expression(target, TypeContext::default());
+                        return;
                     }
+                };
+
+                // For syntactically valid non-name targets, reject the annotation and validate
+                // any accompanying assignment.
+                if let Some(builder) = self
+                    .context
+                    .report_lint(&INVALID_TYPE_FORM, annotation.as_ref())
+                {
+                    builder.into_diagnostic(message);
+                }
+
+                if let Some(value) = value {
+                    self.infer_target(target, value, &|builder, tcx| {
+                        builder.infer_maybe_standalone_expression(value, tcx)
+                    });
+                } else {
+                    self.infer_expression(target, TypeContext::default());
                 }
                 return;
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1557,6 +1557,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .map(|node_ref| node_ref.node(self.module()))
     }
 
+    fn current_function_type(&self) -> Option<FunctionType<'db>> {
+        let function = self.current_function_definition()?;
+        let definition = self.index.expect_single_definition(function);
+        infer_definition_types(self.db(), definition).function_type(definition)
+    }
+
     fn function_decorator_types<'a>(
         &'a self,
         function: &'a ast::StmtFunctionDef,
@@ -4098,6 +4104,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ));
                     }
                 }
+            }
+
+            let is_receiver_attribute = target
+                .as_attribute_expr()
+                .is_some_and(|target| self.is_instance_attribute_assignment(target));
+
+            if !is_receiver_attribute {
+                if let Some(builder) = self
+                    .context
+                    .report_lint(&INVALID_TYPE_FORM, annotation.as_ref())
+                {
+                    builder
+                        .into_diagnostic("Annotations are not allowed on this assignment target");
+                }
+
+                if let Some(value) = value {
+                    self.infer_target(target, value, &|builder, tcx| {
+                        builder.infer_maybe_standalone_expression(value, tcx)
+                    });
+                } else {
+                    self.infer_expression(target, TypeContext::default());
+                }
+                return;
             }
 
             let value_ty = value.as_ref().map(|value| {
@@ -8930,9 +8959,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let first_parameter_name = first_parameter.name();
 
-        let function_definition = self.index.expect_single_definition(current_function);
-        let Type::FunctionLiteral(function_type) = binding_type(self.db(), function_definition)
-        else {
+        let Some(function_type) = self.current_function_type() else {
             return;
         };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -94,9 +94,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// in intermediate scopes. We additionally check that the enclosing function has an implicit
     /// receiver, since static methods still have a first parameter.
     pub(super) fn is_instance_attribute_assignment(&self, target: &ast::ExprAttribute) -> bool {
-        if !self
+        if self
             .current_function_type()
-            .is_some_and(|function| function.has_implicit_receiver(self.db()))
+            .is_none_or(|function| !function.has_implicit_receiver(self.db()))
         {
             return false;
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -112,6 +112,60 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         place_table.member(member_id).is_instance_attribute()
     }
 
+    /// Check whether an annotated attribute target uses an implicit receiver.
+    ///
+    /// This includes direct captures from enclosing methods: these are not implicit-attribute
+    /// definition scopes, but their annotations were accepted before non-name target validation.
+    pub(super) fn is_receiver_attribute_annotation_target(
+        &self,
+        target: &ast::ExprAttribute,
+    ) -> bool {
+        if self.is_instance_attribute_assignment(target) {
+            return true;
+        }
+
+        let Some(receiver) = target.value.as_name_expr() else {
+            return false;
+        };
+        let receiver_name = receiver.id.as_str();
+        let current_scope_id = self.scope().file_scope_id(self.db());
+        let Some((receiver_scope_id, receiver_scope, receiver_symbol)) = self
+            .index
+            .visible_ancestor_scopes(current_scope_id)
+            .find_map(|(scope_id, scope)| {
+                self.index
+                    .place_table(scope_id)
+                    .symbol_by_name(receiver_name)
+                    .filter(|symbol| symbol.is_local() || symbol.is_global())
+                    .map(|symbol| (scope_id, scope, symbol))
+            })
+        else {
+            return false;
+        };
+        if receiver_symbol.is_global() || receiver_scope_id == current_scope_id {
+            return false;
+        }
+        let Some(function) = receiver_scope
+            .node()
+            .as_function()
+            .map(|node| node.node(self.module()))
+        else {
+            return false;
+        };
+
+        self.index
+            .class_definition_of_method(receiver_scope_id)
+            .is_some()
+            && function
+                .parameters
+                .iter_non_variadic_params()
+                .next()
+                .is_some_and(|parameter| parameter.name() == receiver_name)
+            && self
+                .function_type(function)
+                .is_some_and(|function| function.has_implicit_receiver(self.db()))
+    }
+
     pub(super) fn invalid_assignment_to_final_attribute(
         &self,
         object_ty: Type<'db>,

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -89,10 +89,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Check if the target attribute expression (e.g. `self.x`) is an instance attribute
     /// assignment, i.e. the object is the implicit `self`/`cls` receiver.
     ///
-    /// This delegates to the `is_instance_attribute` flag computed during semantic indexing,
-    /// which checks that the object expression refers to the first parameter of the
-    /// enclosing method and has not been shadowed in intermediate scopes.
-    fn is_instance_attribute_assignment(&self, target: &ast::ExprAttribute) -> bool {
+    /// The `is_instance_attribute` flag computed during semantic indexing checks that the object
+    /// expression refers to the first parameter of the enclosing method and has not been shadowed
+    /// in intermediate scopes. We additionally check that the enclosing function has an implicit
+    /// receiver, since static methods still have a first parameter.
+    pub(super) fn is_instance_attribute_assignment(&self, target: &ast::ExprAttribute) -> bool {
+        if !self
+            .current_function_type()
+            .is_some_and(|function| function.has_implicit_receiver(self.db()))
+        {
+            return false;
+        }
+
         let Some(place_expr) = PlaceExpr::try_from_expr(target) else {
             return false;
         };


### PR DESCRIPTION
## Summary

Like Mypy and Pyright, we now ignore annotations on non-name (i.e., subscript and attribute) targets, and emit a diagnostic for the invalid annotation -- with the exception of annotated assignments on `self` and class attributes (i.e., receivers).

Closes https://github.com/astral-sh/ty/issues/509.
