### PR TITLE
Recover incomplete list comprehension elements

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/incomplete_attribute_before_for_in_delimiter.py
+++ b/crates/ruff_python_parser/resources/inline/err/incomplete_attribute_before_for_in_delimiter.py
@@ -1,0 +1,6 @@
+[item. for item in xs]
+[item. async for item in xs]
+{item. for item in xs}
+(item. for item in xs)
+[item for item. in xs]
+for item. in xs: ...

--- a/crates/ruff_python_parser/resources/valid/expressions/list.py
+++ b/crates/ruff_python_parser/resources/valid/expressions/list.py
@@ -32,3 +32,4 @@
 # Random expressions
 [1 + 2, [1, 2, 3, 4], (a, b + c, d), {a, b, c}, {a: 1}, x := 2]
 [call1(call2(value.attr()) for element in iter)]
+[item in xs]

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -483,10 +483,10 @@ impl<'src> Parser<'src> {
             _ => {}
         }
 
-        let lhs = self.parse_atom();
+        let lhs = self.parse_atom(context);
 
         ParsedExpr {
-            expr: self.parse_postfix_expression(lhs.expr, start),
+            expr: self.parse_postfix_expression(lhs.expr, start, context),
             is_parenthesized: lhs.is_parenthesized,
         }
     }
@@ -532,8 +532,8 @@ impl<'src> Parser<'src> {
     /// field will be [`ExprContext::Invalid`].
     ///
     /// See: <https://docs.python.org/3/reference/expressions.html#atom-identifiers>
-    pub(super) fn parse_name(&mut self) -> ast::ExprName {
-        let identifier = self.parse_identifier();
+    pub(super) fn parse_name(&mut self, context: ExpressionContext) -> ast::ExprName {
+        let identifier = self.parse_identifier_with_context(context);
 
         let ctx = if identifier.is_valid() {
             ExprContext::Load
@@ -566,6 +566,10 @@ impl<'src> Parser<'src> {
     ///
     /// See: <https://docs.python.org/3/reference/expressions.html#atom-identifiers>
     pub(super) fn parse_identifier(&mut self) -> ast::Identifier {
+        self.parse_identifier_with_context(ExpressionContext::default())
+    }
+
+    fn parse_identifier_with_context(&mut self, context: ExpressionContext) -> ast::Identifier {
         let range = self.current_token_range();
 
         if self.at(TokenKind::Name) {
@@ -587,6 +591,21 @@ impl<'src> Parser<'src> {
                 range,
                 node_index: AtomicNodeIndex::NONE,
             };
+        }
+
+        // test_err incomplete_attribute_before_for_in_delimiter
+        // [item. for item in xs]
+        // [item. async for item in xs]
+        // {item. for item in xs}
+        // (item. for item in xs)
+        // [item for item. in xs]
+        // for item. in xs: ...
+        if (context.is_for_excluded())
+            && (self.at(TokenKind::For)
+                || (self.at(TokenKind::Async) && self.peek() == TokenKind::For))
+            || (context.is_in_excluded() && self.at(TokenKind::In))
+        {
+            return self.parse_missing_identifier();
         }
 
         if self.current_token_kind().is_keyword() {
@@ -627,7 +646,7 @@ impl<'src> Parser<'src> {
     /// Parses an atom.
     ///
     /// See: <https://docs.python.org/3/reference/expressions.html#atoms>
-    fn parse_atom(&mut self) -> ParsedExpr {
+    fn parse_atom(&mut self, context: ExpressionContext) -> ParsedExpr {
         let start = self.node_start();
 
         let lhs = match self.current_token_kind() {
@@ -692,7 +711,7 @@ impl<'src> Parser<'src> {
                     node_index: AtomicNodeIndex::NONE,
                 })
             }
-            TokenKind::Name => Expr::Name(self.parse_name()),
+            TokenKind::Name => Expr::Name(self.parse_name(context)),
             TokenKind::IpyEscapeCommand => {
                 Expr::IpyEscapeCommand(self.parse_ipython_escape_command_expression())
             }
@@ -707,7 +726,7 @@ impl<'src> Parser<'src> {
 
             kind => {
                 if kind.is_keyword() {
-                    Expr::Name(self.parse_name())
+                    Expr::Name(self.parse_name(context))
                 } else {
                     self.add_error(
                         ParseErrorType::ExpectedExpression,
@@ -732,7 +751,12 @@ impl<'src> Parser<'src> {
     /// expression, `[` for a subscript expression, or `.` for an attribute expression.
     ///
     /// This method does nothing if the current token is not a candidate for a postfix expression.
-    pub(super) fn parse_postfix_expression(&mut self, mut lhs: Expr, start: TextSize) -> Expr {
+    pub(super) fn parse_postfix_expression(
+        &mut self,
+        mut lhs: Expr,
+        start: TextSize,
+        context: ExpressionContext,
+    ) -> Expr {
         loop {
             lhs = match self.current_token_kind() {
                 TokenKind::Lpar => {
@@ -749,7 +773,9 @@ impl<'src> Parser<'src> {
                     }
                     Expr::Subscript(self.parse_subscript_expression(lhs, start))
                 }
-                TokenKind::Dot => Expr::Attribute(self.parse_attribute_expression(lhs, start)),
+                TokenKind::Dot => {
+                    Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
+                }
                 _ => break lhs,
             };
         }
@@ -1183,10 +1209,11 @@ impl<'src> Parser<'src> {
         &mut self,
         value: Expr,
         start: TextSize,
+        context: ExpressionContext,
     ) -> ast::ExprAttribute {
         self.bump(TokenKind::Dot);
 
-        let attr = self.parse_identifier();
+        let attr = self.parse_identifier_with_context(context);
 
         ast::ExprAttribute {
             value: Box::new(value),
@@ -2113,8 +2140,9 @@ impl<'src> Parser<'src> {
         }
 
         // Parse the first element with a more general rule and limit it later.
-        let first_element =
-            self.parse_named_expression_or_higher(ExpressionContext::starred_bitwise_or());
+        let first_element = self.parse_named_expression_or_higher(
+            ExpressionContext::starred_bitwise_or().with_for_excluded(),
+        );
 
         match self.current_token_kind() {
             TokenKind::Async | TokenKind::For => {
@@ -2250,8 +2278,9 @@ impl<'src> Parser<'src> {
         // For dictionary expressions, the key uses the `expression` rule while for
         // set expressions, the element uses the `star_expression` rule. So, use the
         // one that is more general and limit it later.
-        let key_or_element =
-            self.parse_named_expression_or_higher(ExpressionContext::starred_bitwise_or());
+        let key_or_element = self.parse_named_expression_or_higher(
+            ExpressionContext::starred_bitwise_or().with_for_excluded(),
+        );
 
         match self.current_token_kind() {
             TokenKind::Async | TokenKind::For => {
@@ -2367,8 +2396,9 @@ impl<'src> Parser<'src> {
 
         // Use the more general rule of the three to parse the first element
         // and limit it later.
-        let mut parsed_expr =
-            self.parse_named_expression_or_higher(ExpressionContext::yield_or_starred_bitwise_or());
+        let mut parsed_expr = self.parse_named_expression_or_higher(
+            ExpressionContext::yield_or_starred_bitwise_or().with_for_excluded(),
+        );
 
         match self.current_token_kind() {
             TokenKind::Comma => {
@@ -3214,6 +3244,10 @@ bitflags! {
         /// parsing of a yield expression as it will be parsed nevertheless. But, if it is not
         /// allowed, an error is reported.
         const ALLOW_YIELD_EXPRESSION = 1 << 3;
+
+        /// This flag is set when the `for` keyword, or `async` starting `async for`, should be
+        /// excluded from an expression.
+        const EXCLUDE_FOR = 1 << 4;
     }
 }
 
@@ -3266,6 +3300,11 @@ impl ExpressionContext {
         ExpressionContext(self.0 | ExpressionContextFlags::EXCLUDE_IN)
     }
 
+    /// Returns a new [`ExpressionContext`] which excludes `for` from an expression.
+    fn with_for_excluded(self) -> Self {
+        ExpressionContext(self.0 | ExpressionContextFlags::EXCLUDE_FOR)
+    }
+
     /// Returns `true` if the `in` keyword should be excluded from a comparison expression.
     const fn is_in_excluded(self) -> bool {
         self.0.contains(ExpressionContextFlags::EXCLUDE_IN)
@@ -3281,6 +3320,11 @@ impl ExpressionContext {
     const fn is_yield_expression_allowed(self) -> bool {
         self.0
             .contains(ExpressionContextFlags::ALLOW_YIELD_EXPRESSION)
+    }
+
+    /// Returns `true` if `for` should be excluded from the expression.
+    const fn is_for_excluded(self) -> bool {
+        self.0.contains(ExpressionContextFlags::EXCLUDE_FOR)
     }
 
     /// Returns the [`StarredExpressionPrecedence`] for the context, regardless of whether starred

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -525,7 +525,7 @@ impl Parser<'_> {
                         //     case case.bar: ...
                         //     case type.bar: ...
                         //     case match.case.type.bar.type.case.match: ...
-                        let id = Expr::Name(self.parse_name());
+                        let id = Expr::Name(self.parse_name(ExpressionContext::default()));
 
                         let attribute = self.parse_attr_expr_for_match_pattern(id, start);
 
@@ -638,7 +638,11 @@ impl Parser<'_> {
     /// Parses an attribute expression until the current token is not a `.`.
     fn parse_attr_expr_for_match_pattern(&mut self, mut lhs: Expr, start: TextSize) -> Expr {
         while self.current_token_kind() == TokenKind::Dot {
-            lhs = Expr::Attribute(self.parse_attribute_expression(lhs, start));
+            lhs = Expr::Attribute(self.parse_attribute_expression(
+                lhs,
+                start,
+                ExpressionContext::default(),
+            ));
         }
 
         lhs

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -1037,7 +1037,7 @@ impl<'src> Parser<'src> {
             type_range,
         );
 
-        let mut name = Expr::Name(self.parse_name());
+        let mut name = Expr::Name(self.parse_name(ExpressionContext::default()));
         helpers::set_expr_ctx(&mut name, ExprContext::Store);
 
         let type_params = self.try_parse_type_params();

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_missing_target.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_missing_target.py.snap
@@ -18,8 +18,8 @@ Module(
                     target: Name(
                         ExprName {
                             node_index: NodeIndex(None),
-                            range: 4..6,
-                            id: Name("in"),
+                            range: 3..3,
+                            id: Name(""),
                             ctx: Store,
                         },
                     ),
@@ -56,11 +56,5 @@ Module(
 
   |
 1 | for in x: ...
-  |     ^^ Syntax Error: Expected an identifier, but found a keyword `in` that cannot be used here
-  |
-
-
-  |
-1 | for in x: ...
-  |        ^ Syntax Error: Expected `in`, found name
+  |     ^^ Syntax Error: Expected an identifier
   |

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@incomplete_attribute_before_for_in_delimiter.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@incomplete_attribute_before_for_in_delimiter.py.snap
@@ -1,0 +1,401 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/incomplete_attribute_before_for_in_delimiter.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        node_index: NodeIndex(None),
+        range: 0..142,
+        body: [
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 0..22,
+                    value: ListComp(
+                        ExprListComp {
+                            node_index: NodeIndex(None),
+                            range: 0..22,
+                            elt: Attribute(
+                                ExprAttribute {
+                                    node_index: NodeIndex(None),
+                                    range: 1..6,
+                                    value: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 1..5,
+                                            id: Name("item"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    attr: Identifier {
+                                        id: Name(""),
+                                        range: 6..6,
+                                        node_index: NodeIndex(None),
+                                    },
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 7..21,
+                                    node_index: NodeIndex(None),
+                                    target: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 11..15,
+                                            id: Name("item"),
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 19..21,
+                                            id: Name("xs"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 23..51,
+                    value: ListComp(
+                        ExprListComp {
+                            node_index: NodeIndex(None),
+                            range: 23..51,
+                            elt: Attribute(
+                                ExprAttribute {
+                                    node_index: NodeIndex(None),
+                                    range: 24..29,
+                                    value: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 24..28,
+                                            id: Name("item"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    attr: Identifier {
+                                        id: Name(""),
+                                        range: 29..29,
+                                        node_index: NodeIndex(None),
+                                    },
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 30..50,
+                                    node_index: NodeIndex(None),
+                                    target: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 40..44,
+                                            id: Name("item"),
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 48..50,
+                                            id: Name("xs"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: true,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 52..74,
+                    value: SetComp(
+                        ExprSetComp {
+                            node_index: NodeIndex(None),
+                            range: 52..74,
+                            elt: Attribute(
+                                ExprAttribute {
+                                    node_index: NodeIndex(None),
+                                    range: 53..58,
+                                    value: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 53..57,
+                                            id: Name("item"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    attr: Identifier {
+                                        id: Name(""),
+                                        range: 58..58,
+                                        node_index: NodeIndex(None),
+                                    },
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 59..73,
+                                    node_index: NodeIndex(None),
+                                    target: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 63..67,
+                                            id: Name("item"),
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 71..73,
+                                            id: Name("xs"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 75..97,
+                    value: Generator(
+                        ExprGenerator {
+                            node_index: NodeIndex(None),
+                            range: 75..97,
+                            elt: Attribute(
+                                ExprAttribute {
+                                    node_index: NodeIndex(None),
+                                    range: 76..81,
+                                    value: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 76..80,
+                                            id: Name("item"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    attr: Identifier {
+                                        id: Name(""),
+                                        range: 81..81,
+                                        node_index: NodeIndex(None),
+                                    },
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 82..96,
+                                    node_index: NodeIndex(None),
+                                    target: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 86..90,
+                                            id: Name("item"),
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 94..96,
+                                            id: Name("xs"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                            parenthesized: true,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 98..120,
+                    value: ListComp(
+                        ExprListComp {
+                            node_index: NodeIndex(None),
+                            range: 98..120,
+                            elt: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 99..103,
+                                    id: Name("item"),
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 104..119,
+                                    node_index: NodeIndex(None),
+                                    target: Attribute(
+                                        ExprAttribute {
+                                            node_index: NodeIndex(None),
+                                            range: 108..113,
+                                            value: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 108..112,
+                                                    id: Name("item"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            attr: Identifier {
+                                                id: Name(""),
+                                                range: 113..113,
+                                                node_index: NodeIndex(None),
+                                            },
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 117..119,
+                                            id: Name("xs"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+            For(
+                StmtFor {
+                    node_index: NodeIndex(None),
+                    range: 121..141,
+                    is_async: false,
+                    target: Attribute(
+                        ExprAttribute {
+                            node_index: NodeIndex(None),
+                            range: 125..130,
+                            value: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 125..129,
+                                    id: Name("item"),
+                                    ctx: Load,
+                                },
+                            ),
+                            attr: Identifier {
+                                id: Name(""),
+                                range: 130..130,
+                                node_index: NodeIndex(None),
+                            },
+                            ctx: Store,
+                        },
+                    ),
+                    iter: Name(
+                        ExprName {
+                            node_index: NodeIndex(None),
+                            range: 134..136,
+                            id: Name("xs"),
+                            ctx: Load,
+                        },
+                    ),
+                    body: [
+                        Expr(
+                            StmtExpr {
+                                node_index: NodeIndex(None),
+                                range: 138..141,
+                                value: EllipsisLiteral(
+                                    ExprEllipsisLiteral {
+                                        node_index: NodeIndex(None),
+                                        range: 138..141,
+                                    },
+                                ),
+                            },
+                        ),
+                    ],
+                    orelse: [],
+                },
+            ),
+        ],
+    },
+)
+```
+## Errors
+
+  |
+1 | [item. for item in xs]
+  |        ^^^ Syntax Error: Expected an identifier
+2 | [item. async for item in xs]
+3 | {item. for item in xs}
+  |
+
+
+  |
+1 | [item. for item in xs]
+2 | [item. async for item in xs]
+  |        ^^^^^ Syntax Error: Expected an identifier
+3 | {item. for item in xs}
+4 | (item. for item in xs)
+  |
+
+
+  |
+1 | [item. for item in xs]
+2 | [item. async for item in xs]
+3 | {item. for item in xs}
+  |        ^^^ Syntax Error: Expected an identifier
+4 | (item. for item in xs)
+5 | [item for item. in xs]
+  |
+
+
+  |
+2 | [item. async for item in xs]
+3 | {item. for item in xs}
+4 | (item. for item in xs)
+  |        ^^^ Syntax Error: Expected an identifier
+5 | [item for item. in xs]
+6 | for item. in xs: ...
+  |
+
+
+  |
+3 | {item. for item in xs}
+4 | (item. for item in xs)
+5 | [item for item. in xs]
+  |                 ^^ Syntax Error: Expected an identifier
+6 | for item. in xs: ...
+  |
+
+
+  |
+4 | (item. for item in xs)
+5 | [item for item. in xs]
+6 | for item. in xs: ...
+  |           ^^ Syntax Error: Expected an identifier
+  |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list.py.snap
@@ -8,7 +8,7 @@ input_file: crates/ruff_python_parser/resources/valid/expressions/list.py
 Module(
     ModModule {
         node_index: NodeIndex(None),
-        range: 0..384,
+        range: 0..397,
         body: [
             Expr(
                 StmtExpr {
@@ -911,6 +911,48 @@ Module(
                                             ],
                                             keywords: [],
                                         },
+                                    },
+                                ),
+                            ],
+                            ctx: Load,
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 384..396,
+                    value: List(
+                        ExprList {
+                            node_index: NodeIndex(None),
+                            range: 384..396,
+                            elts: [
+                                Compare(
+                                    ExprCompare {
+                                        node_index: NodeIndex(None),
+                                        range: 385..395,
+                                        left: Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 385..389,
+                                                id: Name("item"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        ops: [
+                                            In,
+                                        ],
+                                        comparators: [
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 393..395,
+                                                    id: Name("xs"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        ],
                                     },
                                 ),
                             ],

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3515,6 +3515,42 @@ def frob(): ...
     }
 
     #[test]
+    fn list_comprehension_member() {
+        completion_test_builder(
+            "\
+items: list[str] = []
+[item.<CURSOR> for item in items]
+",
+        )
+        .build()
+        .contains("upper");
+    }
+
+    #[test]
+    fn set_comprehension_member() {
+        completion_test_builder(
+            "\
+items: list[str] = []
+{item.<CURSOR> for item in items}
+",
+        )
+        .build()
+        .contains("upper");
+    }
+
+    #[test]
+    fn generator_expression_member() {
+        completion_test_builder(
+            "\
+items: list[str] = []
+(item.<CURSOR> for item in items)
+",
+        )
+        .build()
+        .contains("upper");
+    }
+
+    #[test]
     fn lambda_prefix1() {
         let builder = completion_test_builder(
             "\

--- a/crates/ty_python_semantic/resources/mdtest/comprehensions/invalid_syntax.md
+++ b/crates/ty_python_semantic/resources/mdtest/comprehensions/invalid_syntax.md
@@ -13,8 +13,7 @@
 
 # Missing iteration variable
 
-# error: [invalid-syntax] "Expected an identifier, but found a keyword `in` that cannot be used here"
-# error: [invalid-syntax] "Expected `in`, found name"
+# error: [invalid-syntax] "Expected an identifier"
 # error: [unresolved-reference]
 # revealed: Unknown
 [reveal_type(b) for in range(3)]


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2365.

The parser eats keywords if they appear in a name position. For example, the parser's error recovery eats the `async` keyword in:

```py
a = async
```

because the user could be in the middle of ty ping `asyncio`. 

However, this behavior can sometimes be too eager and result in worse recovery. For example, if we have:

```py
for <CURSOR>in list:
	...
```

It's way more likely that the user is in the middle of typing the for target than that `in` is the intended target name. This PR extends the parser recovery by intentionally leaving certain keyword tokens in place, if they're expected in this context. The ideal parse tree for the above is a for statement with a missing target.

This is implemented by adding two flags to `ExpressionContext` that inform the identifier parsing to not eat a `for` or `in` keyword. This improves error recovery in comprehensions and for loops.


## Test Plan

Added parser tests