### PR TITLE
[ty] Reject incompatible explicit variance in generic base classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variance.md
@@ -293,4 +293,95 @@ equivalent to) each other.
 
 It is not possible to construct a legacy typevar that is explicitly bivariant.
 
+## Inheriting from generic classes with explicit variance
+
+A generic subclass cannot claim a variance that is less restrictive than the variance required by
+one of its specialized bases. This validation also applies after composing nested generic types or
+resolving aliases used as bases.
+
+```py
+from typing import Generic, TypeAlias, TypeVar
+
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
+
+class Invariant(Generic[T]): ...
+class Covariant(Generic[T_co]): ...
+class Contravariant(Generic[T_contra]): ...
+class CoContra(Generic[T_co, T_contra]): ...
+class GoodInvariantInCovariant(Covariant[T]): ...
+class GoodInvariantInContravariant(Contravariant[T]): ...
+class GoodCovariant(Covariant[T_co]): ...
+class GoodContravariant(Contravariant[T_contra]): ...
+class GoodNested(Contravariant[Contravariant[T_co]]): ...
+
+# error: [invalid-generic-class]
+class BadInvariantCo(Invariant[T_co]): ...
+
+# error: [invalid-generic-class]
+class BadInvariantContra(Invariant[T_contra]): ...
+
+# error: [invalid-generic-class]
+class BadCovariant(Covariant[T_contra]): ...
+
+# error: [invalid-generic-class]
+class BadContravariant(Contravariant[T_co]): ...
+
+# error: [invalid-generic-class]
+class BadNested(Contravariant[Covariant[T_co]]): ...
+
+# error: [invalid-generic-class]
+class BadComposed(Contravariant[Covariant[Contravariant[T_contra]]]): ...
+
+# error: [invalid-generic-class]
+class BadSecond(CoContra[T_co, T_co]): ...
+
+# error: [invalid-generic-class]
+class BadFirst(CoContra[T_contra, T_contra]): ...
+
+# error: [invalid-generic-class]
+class BadSecondNested(CoContra[Covariant[T_co], Covariant[T_co]]): ...
+
+InvariantAlias: TypeAlias = Invariant[T_co]
+CovariantAlias: TypeAlias = Covariant[T_co]
+NestedAlias: TypeAlias = Contravariant[T_contra]
+
+class GoodAlias(CovariantAlias[T_co]): ...
+
+# error: [invalid-generic-class]
+class BadAlias(InvariantAlias[T_co]): ...
+
+# error: [invalid-generic-class]
+class BadNestedAlias(NestedAlias[NestedAlias[NestedAlias[T_co]]]): ...
+```
+
+Legacy type variables with inferred variance are validated according to their uses, rather than as
+if they had an explicit invariant declaration.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from ty_extensions import is_assignable_to, static_assert
+from typing import Generic, TypeVar
+
+class A: ...
+class B(A): ...
+
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+T_infer = TypeVar("T_infer", infer_variance=True)
+
+class Invariant(Generic[T]): ...
+class Covariant(Generic[T_co]): ...
+class GoodInferredInvariant(Invariant[T_infer]): ...
+class GoodInferredCovariant(Covariant[T_infer]): ...
+
+static_assert(not is_assignable_to(GoodInferredInvariant[B], GoodInferredInvariant[A]))
+static_assert(not is_assignable_to(GoodInferredInvariant[A], GoodInferredInvariant[B]))
+```
+
 [spec]: https://typing.python.org/en/latest/spec/generics.html#variance

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -15,7 +15,7 @@ use crate::{
     types::{
         CallArguments, ClassBase, ClassLiteral, ClassType, GenericAlias, KnownInstanceType,
         MemberLookupPolicy, MetaclassCandidate, Parameters, Signature, SpecialFormType,
-        StaticClassLiteral, Type, binding_type,
+        StaticClassLiteral, Type, TypeVarVariance, binding_type,
         call::Argument,
         class::{
             AbstractMethod, CodeGeneratorKind, FieldKind, MetaclassErrorKind,
@@ -48,6 +48,7 @@ use crate::{
         overrides,
         tuple::Tuple,
         typevar::TypeVarInstance,
+        variance::VarianceInferable,
         visitor::find_over_type,
     },
 };
@@ -221,6 +222,7 @@ pub(crate) fn check_static_class_definitions<'db>(
     //     - If the class is a NamedTuple class: check for multiple inheritance that isn't `Generic[]`
     let expanded_base_entries =
         expanded_class_base_entries(db, class.known(db), class_node, class_definition);
+    let check_explicit_base_variance = context.is_lint_enabled(&INVALID_GENERIC_CLASS);
     for (i, entry) in expanded_base_entries.iter().enumerate() {
         let source_node = entry.source_node();
         let base_class = entry.ty();
@@ -311,7 +313,30 @@ pub(crate) fn check_static_class_definitions<'db>(
                 continue;
             }
             Type::ClassLiteral(class) => ClassType::NonGeneric(class),
-            Type::GenericAlias(class) => ClassType::Generic(class),
+            Type::GenericAlias(base_alias) => {
+                if check_explicit_base_variance
+                    && let Some(node) = source_node
+                    && let Some(generic_context) = class.generic_context(db)
+                    && let Some(typevar) = generic_context.variables(db).find(|typevar| {
+                        let Some(declared_variance) = typevar.typevar(db).explicit_variance(db)
+                        else {
+                            return false;
+                        };
+                        declared_variance != TypeVarVariance::Invariant
+                            && declared_variance.join(base_alias.variance_of(db, *typevar))
+                                != declared_variance
+                    })
+                    && let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, node)
+                {
+                    builder.into_diagnostic(format_args!(
+                        "Variance of type variable `{}` is incompatible with base class `{}`",
+                        typevar.typevar(db).name(db),
+                        base_alias.origin(db).name(db),
+                    ));
+                }
+
+                ClassType::Generic(base_alias)
+            }
             _ => continue,
         };
 


### PR DESCRIPTION
## Summary

Prior to this change, we accepted legacy generic subclasses whose explicitly declared variance was incompatible with a specialized base class. For example:

```python
from typing import Generic, TypeVar

T = TypeVar("T")
T_co = TypeVar("T_co", covariant=True)

class Invariant(Generic[T]): ...
class Bad(Invariant[T_co]): ...
```

`Bad` claims covariance even though its invariant base requires its type parameter to remain invariant.

This brings `aliases_variance.py` and `generics_variance.py` into conformance.
