### PR TITLE
[ty] Follow aliases when resolving stub mappings

### DIFF
--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -262,9 +262,9 @@ bar<CURSOR>()
 ",
             )
             .source("a/__init__.pyi", "def bar() -> None: ...\n")
-            .source("a/__init__.py", "from .b import bar as bar\n")
+            .source("a/__init__.py", "from .impl import bar as bar\n")
             .source(
-                "a/b.py",
+                "a/impl.py",
                 r#"
 def bar() -> None:
     pass
@@ -280,7 +280,7 @@ def bar() -> None:
           | ^^^ Clicking here
           |
         info: Found 1 definition
-         --> a/b.py:2:5
+         --> a/impl.py:2:5
           |
         2 | def bar() -> None:
           |     ---

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -251,6 +251,43 @@ def other_function(): ...
         ");
     }
 
+    #[test]
+    fn goto_definition_stub_map_reexported_function() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                "
+from a import bar
+bar<CURSOR>()
+",
+            )
+            .source("a/__init__.pyi", "def bar() -> None: ...\n")
+            .source("a/__init__.py", "from .b import bar as bar\n")
+            .source(
+                "a/b.py",
+                r#"
+def bar() -> None:
+    pass
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.goto_definition(), @"
+        info[goto-definition]: Go to definition
+         --> main.py:3:1
+          |
+        3 | bar()
+          | ^^^ Clicking here
+          |
+        info: Found 1 definition
+         --> a/b.py:2:5
+          |
+        2 | def bar() -> None:
+          |     ---
+          |
+        ");
+    }
+
     /// goto-definition on a function definition in a .pyi should go to the .py
     #[test]
     fn goto_definition_stub_map_function_def() {

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -2580,9 +2580,9 @@ ba<CURSOR>r
 ",
             )
             .source("a/__init__.pyi", "def bar() -> None: ...\n")
-            .source("a/__init__.py", "from .b import bar as bar\n")
+            .source("a/__init__.py", "from .impl import bar as bar\n")
             .source(
-                "a/b.py",
+                "a/impl.py",
                 r#"
 def bar() -> None:
     """Implementation docstring"""

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -2569,6 +2569,52 @@ def ab(a: str): ...
     }
 
     #[test]
+    fn hover_reexported_stub_definition_implementation_docstring() {
+        let test = CursorTest::builder()
+            .source(
+                "main.py",
+                "
+from a import bar
+
+ba<CURSOR>r
+",
+            )
+            .source("a/__init__.pyi", "def bar() -> None: ...\n")
+            .source("a/__init__.py", "from .b import bar as bar\n")
+            .source(
+                "a/b.py",
+                r#"
+def bar() -> None:
+    """Implementation docstring"""
+"#,
+            )
+            .build();
+
+        assert_snapshot!(test.hover(), @"
+        def bar() -> None
+        ---------------------------------------------
+        Implementation docstring
+
+        ---------------------------------------------
+        ```python
+        def bar() -> None
+        ```
+        ---
+        Implementation docstring
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:4:1
+          |
+        4 | bar
+          | ^^-
+          | | |
+          | | Cursor offset
+          | source
+          |
+        ");
+    }
+
+    #[test]
     fn hover_overload_type_disambiguated2() {
         let test = CursorTest::builder()
             .source(

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1782,7 +1782,14 @@ mod resolve_definition {
                     definitions.extend(
                         find_symbol_in_scope(db, scope, component)
                             .into_iter()
-                            .map(ResolvedDefinition::Definition),
+                            .flat_map(|definition| {
+                                resolve_definition(
+                                    db,
+                                    definition,
+                                    Some(component),
+                                    ImportAliasResolution::ResolveAliases,
+                                )
+                            }),
                     );
                 } else {
                     // We're in the middle of the path, look for scopes that match the current component


### PR DESCRIPTION
## Summary

`map_stub_definition` maps a stub definition to its "real-definition" (the same definition in a `py` file. This PR extends this mapping by resolving aliases. For:

`main.py`:

```py
from a import bar

bar
```

`a/__init__.pyi`:

```py
def bar() -> None: ...
```

`a/__init__.py`:

```py
from .b import bar as bar

```

`a/b.py`:

```py
def bar() -> None:
    """Implementation docstring"""
```

[Playground](https://play.ty.dev/f7255368-b291-4865-b4ca-6cac35a437e8)

Clicking on `bar` in `main.py` performs the following step:

1. Resolve `bar` to `from a import bar` in `main.py`
2. Follow the import to `a/__init__.pyi` where it finds `def bar()`
3. `map_stub_definition` now tries to map `bar` to its implementation. It finds the `from .b import bar as bar` in `a/__init__.py` and **stops here**


The step that is missing, and this PR adds, is that stub mapping must follow the import to the symbol's real definition. 


The same applies when resolving documentation: ty first tries to get the documentation from the stub. If that's missing, ty tries to resolve the documentation from the implementation. However, that requires resolving the import, because the import itself has no docstring.


Closes https://github.com/astral-sh/ty/issues/2150


