### PR TITLE
[ty] Rebalance benchmark shards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1137,9 +1137,30 @@ jobs:
       matrix:
         benchmark:
           - name: "check_file|micro-core"
-            filter: "check_file|many_string_assignments|many_tuple_assignments|complex_constrained_attributes|many_enum_members|many_protocol_members_mismatch|gradual_vararg_call|vararg_parameter_type_accumulation|typevar_mapping_small_accumulations|very_large_tuple|large_isinstance_narrowing|literal_match_fallthrough|literal_equality_fallthrough_guarded_any|typeis_narrowing|pandas_tdd"
+            filter:
+              - check_file
+              - many_string_assignments
+              - many_tuple_assignments
+              - complex_constrained_attributes
+              - many_enum_members
+              - many_protocol_members_mismatch
+              - gradual_vararg_call
+              - vararg_parameter_type_accumulation
+              - typevar_mapping_small_accumulations
+              - very_large_tuple
+              - large_isinstance_narrowing
+              - literal_match_fallthrough
+              - literal_equality_fallthrough_guarded_any
+              - typeis_narrowing
+              - pandas_tdd
           - name: "anyio|attrs|hydra|datetype|micro-heavy"
-            filter: "anyio|attrs|hydra|datetype|typevar_mapping_accumulation|large_union_narrowing"
+            filter:
+              - anyio
+              - attrs
+              - hydra
+              - datetype
+              - typevar_mapping_accumulation
+              - large_union_narrowing
         mode:
           - simulation
           - memory
@@ -1171,7 +1192,7 @@ jobs:
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4.15.1
         with:
           mode: ${{ matrix.mode }}
-          run: cargo codspeed run --bench ty "${{ matrix.benchmark.filter }}"
+          run: cargo codspeed run --bench ty "${{ join(matrix.benchmark.filter, '|') }}"
 
   benchmarks-walltime-build:
     name: "benchmarks walltime (build)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1125,7 +1125,7 @@ jobs:
           retention-days: 1
 
   benchmarks-instrumented-ty-run:
-    name: "benchmarks instrumented ty (${{matrix.mode}}: ${{ matrix.benchmark.name }})"
+    name: "benchmarks instrumented ty (${{matrix.mode}}: ${{ matrix.benchmark }})"
     runs-on: ubuntu-24.04
     needs: benchmarks-instrumented-ty-build
     timeout-minutes: 20
@@ -1136,31 +1136,8 @@ jobs:
       fail-fast: false
       matrix:
         benchmark:
-          - name: "check_file|micro-core"
-            filter:
-              - check_file
-              - many_string_assignments
-              - many_tuple_assignments
-              - complex_constrained_attributes
-              - many_enum_members
-              - many_protocol_members_mismatch
-              - gradual_vararg_call
-              - vararg_parameter_type_accumulation
-              - typevar_mapping_small_accumulations
-              - very_large_tuple
-              - large_isinstance_narrowing
-              - literal_match_fallthrough
-              - literal_equality_fallthrough_guarded_any
-              - typeis_narrowing
-              - pandas_tdd
-          - name: "anyio|attrs|hydra|datetype|micro-heavy"
-            filter:
-              - anyio
-              - attrs
-              - hydra
-              - datetype
-              - typevar_mapping_accumulation
-              - large_union_narrowing
+          - micro
+          - "check_file|anyio|attrs|hydra|datetype"
         mode:
           - simulation
           - memory
@@ -1192,7 +1169,7 @@ jobs:
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4.15.1
         with:
           mode: ${{ matrix.mode }}
-          run: cargo codspeed run --bench ty "${{ join(matrix.benchmark.filter, '|') }}"
+          run: cargo codspeed run --bench ty "${{ matrix.benchmark }}"
 
   benchmarks-walltime-build:
     name: "benchmarks walltime (build)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1136,8 +1136,8 @@ jobs:
       fail-fast: false
       matrix:
         benchmark:
-          - "check_file|micro|anyio"
-          - "attrs|hydra|datetype"
+          - "check_file|micro"
+          - "anyio|attrs|hydra|datetype"
         mode:
           - simulation
           - memory
@@ -1232,10 +1232,10 @@ jobs:
     strategy:
       matrix:
         benchmark:
-          - colour_science
-          - "pandas|tanjun|altair"
-          - "static_frame|sympy"
-          - "pydantic|multithreaded|freqtrade"
+          - sympy
+          - "pandas|tanjun"
+          - "colour_science|static_frame"
+          - "pydantic|freqtrade|multithreaded|altair"
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1125,7 +1125,7 @@ jobs:
           retention-days: 1
 
   benchmarks-instrumented-ty-run:
-    name: "benchmarks instrumented ty (${{matrix.mode}}: ${{ matrix.benchmark }})"
+    name: "benchmarks instrumented ty (${{matrix.mode}}: ${{ matrix.benchmark.name }})"
     runs-on: ubuntu-24.04
     needs: benchmarks-instrumented-ty-build
     timeout-minutes: 20
@@ -1136,8 +1136,10 @@ jobs:
       fail-fast: false
       matrix:
         benchmark:
-          - "check_file|micro"
-          - "anyio|attrs|hydra|datetype"
+          - name: "check_file|micro-core"
+            filter: "check_file|many_string_assignments|many_tuple_assignments|complex_constrained_attributes|many_enum_members|many_protocol_members_mismatch|gradual_vararg_call|vararg_parameter_type_accumulation|typevar_mapping_small_accumulations|very_large_tuple|large_isinstance_narrowing|literal_match_fallthrough|literal_equality_fallthrough_guarded_any|typeis_narrowing|pandas_tdd"
+          - name: "anyio|attrs|hydra|datetype|micro-heavy"
+            filter: "anyio|attrs|hydra|datetype|typevar_mapping_accumulation|large_union_narrowing"
         mode:
           - simulation
           - memory
@@ -1169,7 +1171,7 @@ jobs:
         uses: CodSpeedHQ/action@3194d9a39c4d46684cb44bf7207fc56626aad8fd # v4.15.1
         with:
           mode: ${{ matrix.mode }}
-          run: cargo codspeed run --bench ty "${{ matrix.benchmark }}"
+          run: cargo codspeed run --bench ty "${{ matrix.benchmark.filter }}"
 
   benchmarks-walltime-build:
     name: "benchmarks walltime (build)"


### PR DESCRIPTION
## Summary

Rebalance the ty benchmark CI shards to reduce the longest benchmark job wall time.

### Instrumented ty

| Job | Main shard | Main wall time | PR shard | PR wall time |
|---|---|---:|---|---:|
| simulation shard 1 | check_file + micro + anyio | 513s | micro | 382s |
| simulation shard 2 | attrs + hydra + datetype | 252s | check_file + anyio + attrs + hydra + datetype | 346s |
| memory shard 1 | check_file + micro + anyio | 372s | micro | 287s |
| memory shard 2 | attrs + hydra + datetype | 208s | check_file + anyio + attrs + hydra + datetype | 256s |
| **Wall time across all jobs** |  | **513s** |  | **382s** |

### Ty walltime

| Job | Main shard | Main wall time | PR shard | PR wall time |
|---|---|---:|---|---:|
| shard 1 | colour_science | 166s | sympy | 237s |
| shard 2 | pandas + tanjun + altair | 271s | pandas + tanjun | 235s |
| shard 3 | static_frame + sympy | 309s | colour_science + static_frame | 238s |
| shard 4 | pydantic + multithreaded + freqtrade | 230s | pydantic + freqtrade + multithreaded + altair | 254s |
| **Wall time across all jobs** |  | **309s** |  | **254s** |

The main runtimes are from PR #25324. The PR runtimes are measured from this PR's CI run 26328970684.

## Test

`uvx prek run --files .github/workflows/ci.yaml`
