### PR TITLE
Reproduce Airflow formatter ecosystem error

### DIFF
--- a/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
+++ b/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
@@ -55,3 +55,51 @@ jobs:
           if grep -q "project error" ecosystem-result-format-stable ecosystem-result-format-preview; then
             exit 1
           fi
+
+      - name: "Checkout Airflow revision from the failed ecosystem run"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: apache/airflow
+          # This was Airflow main until 19:53 UTC; #25330 failed at 19:41 UTC.
+          ref: eca91dc5c2cab36b3a8e6d53772cf13716d98a8d
+          path: failed-airflow
+          persist-credentials: false
+
+      - name: "Run formatter comparison on the failed Airflow revision"
+        env:
+          RUFF_BIN: ${{ github.workspace }}/target/debug/ruff
+        working-directory: failed-airflow
+        run: |
+          git config user.email "ecosystem@astral.sh"
+          git config user.name "Ecosystem Bot"
+
+          python - <<'PY'
+          import asyncio
+          import os
+          from pathlib import Path
+
+          from ruff_ecosystem.defaults import DEFAULT_TARGETS
+          from ruff_ecosystem.format import FormatComparison, compare_format
+          from ruff_ecosystem.projects import ClonedRepository
+
+
+          async def run() -> None:
+              target = next(
+                  target
+                  for target in DEFAULT_TARGETS
+                  if target.repo.fullname == "apache/airflow"
+              ).with_preview_enabled()
+              repository = await ClonedRepository.from_path(Path("."), target.repo)
+              ruff = Path(os.environ["RUFF_BIN"])
+              await compare_format(
+                  ruff,
+                  ruff,
+                  target.format_options,
+                  target.config_overrides,
+                  repository,
+                  FormatComparison.ruff_and_ruff,
+              )
+
+
+          asyncio.run(run())
+          PY

--- a/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
+++ b/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
@@ -28,6 +28,15 @@ jobs:
       - name: "Build Ruff"
         run: cargo build --bin ruff
 
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.14"
+          activate-environment: true
+          version: "0.11.15"
+
+      - name: "Install ruff-ecosystem"
+        run: uv pip install ./python/ruff-ecosystem
+
       - name: "Checkout apache/airflow"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -39,6 +48,41 @@ jobs:
       - name: "Report Airflow revision"
         run: git -C checkouts/airflow rev-parse HEAD
 
-      - name: "Run `ruff format --preview`"
+      - name: "Run Airflow formatter ecosystem comparison"
+        env:
+          RUFF_BIN: ${{ github.workspace }}/target/debug/ruff
         working-directory: checkouts/airflow
-        run: '"$GITHUB_WORKSPACE/target/debug/ruff" format --preview .'
+        run: |
+          git config user.email "ecosystem@astral.sh"
+          git config user.name "Ecosystem Bot"
+
+          python - <<'PY'
+          import asyncio
+          import os
+          from pathlib import Path
+
+          from ruff_ecosystem.defaults import DEFAULT_TARGETS
+          from ruff_ecosystem.format import FormatComparison, compare_format
+          from ruff_ecosystem.projects import ClonedRepository
+
+
+          async def run() -> None:
+              target = next(
+                  target
+                  for target in DEFAULT_TARGETS
+                  if target.repo.fullname == "apache/airflow"
+              ).with_preview_enabled()
+              repository = await ClonedRepository.from_path(Path("."), target.repo)
+              ruff = Path(os.environ["RUFF_BIN"])
+              await compare_format(
+                  ruff,
+                  ruff,
+                  target.format_options,
+                  target.config_overrides,
+                  repository,
+                  FormatComparison.ruff_and_ruff,
+              )
+
+
+          asyncio.run(run())
+          PY

--- a/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
+++ b/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
@@ -72,6 +72,7 @@ jobs:
         run: |
           git config user.email "ecosystem@astral.sh"
           git config user.name "Ecosystem Bot"
+          git update-ref refs/remotes/origin/main HEAD
 
           python - <<'PY'
           import asyncio

--- a/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
+++ b/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   reproduce:
-    name: "ruff format --preview on apache/airflow"
+    name: "formatter ecosystem comparison"
     runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-latest-8' || 'ubuntu-latest' }}
     env:
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
@@ -37,52 +37,21 @@ jobs:
       - name: "Install ruff-ecosystem"
         run: uv pip install ./python/ruff-ecosystem
 
-      - name: "Checkout apache/airflow"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: apache/airflow
-          ref: main
-          path: checkouts/airflow
-          persist-credentials: false
-
-      - name: "Report Airflow revision"
-        run: git -C checkouts/airflow rev-parse HEAD
-
-      - name: "Run Airflow formatter ecosystem comparison"
-        env:
-          RUFF_BIN: ${{ github.workspace }}/target/debug/ruff
-        working-directory: checkouts/airflow
+      - name: "Run `ruff format` stable ecosystem check"
         run: |
-          git config user.email "ecosystem@astral.sh"
-          git config user.name "Ecosystem Bot"
+          set -eo pipefail
+          ruff-ecosystem format ./target/debug/ruff ./target/debug/ruff --cache ./checkouts --output-format markdown | tee ecosystem-result-format-stable
 
-          python - <<'PY'
-          import asyncio
-          import os
-          from pathlib import Path
+      - name: "Report cached Airflow revision"
+        run: git -C './checkouts/apache:airflow' rev-parse HEAD
 
-          from ruff_ecosystem.defaults import DEFAULT_TARGETS
-          from ruff_ecosystem.format import FormatComparison, compare_format
-          from ruff_ecosystem.projects import ClonedRepository
+      - name: "Run `ruff format` preview ecosystem check"
+        run: |
+          set -eo pipefail
+          ruff-ecosystem format ./target/debug/ruff ./target/debug/ruff --cache ./checkouts --output-format markdown --force-preview | tee ecosystem-result-format-preview
 
-
-          async def run() -> None:
-              target = next(
-                  target
-                  for target in DEFAULT_TARGETS
-                  if target.repo.fullname == "apache/airflow"
-              ).with_preview_enabled()
-              repository = await ClonedRepository.from_path(Path("."), target.repo)
-              ruff = Path(os.environ["RUFF_BIN"])
-              await compare_format(
-                  ruff,
-                  ruff,
-                  target.format_options,
-                  target.config_overrides,
-                  repository,
-                  FormatComparison.ruff_and_ruff,
-              )
-
-
-          asyncio.run(run())
-          PY
+      - name: "Fail on ecosystem errors"
+        run: |
+          if grep -q "project error" ecosystem-result-format-stable ecosystem-result-format-preview; then
+            exit 1
+          fi

--- a/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
+++ b/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
@@ -1,0 +1,44 @@
+name: Reproduce Airflow formatter ecosystem error
+
+permissions: {}
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml"
+  workflow_dispatch:
+
+jobs:
+  reproduce:
+    name: "ruff format --preview on apache/airflow"
+    runs-on: ${{ github.repository == 'astral-sh/ruff' && 'depot-ubuntu-latest-8' || 'ubuntu-latest' }}
+    env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Install Rust toolchain"
+        run: rustup show
+
+      - name: "Install mold"
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+
+      - name: "Build Ruff"
+        run: cargo build --bin ruff
+
+      - name: "Checkout apache/airflow"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: apache/airflow
+          ref: main
+          path: checkouts/airflow
+          persist-credentials: false
+
+      - name: "Report Airflow revision"
+        run: git -C checkouts/airflow rev-parse HEAD
+
+      - name: "Run `ruff format --preview`"
+        working-directory: checkouts/airflow
+        run: '"$GITHUB_WORKSPACE/target/debug/ruff" format --preview .'

--- a/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
+++ b/.github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml
@@ -92,14 +92,17 @@ jobs:
               ).with_preview_enabled()
               repository = await ClonedRepository.from_path(Path("."), target.repo)
               ruff = Path(os.environ["RUFF_BIN"])
-              await compare_format(
-                  ruff,
-                  ruff,
-                  target.format_options,
-                  target.config_overrides,
-                  repository,
-                  FormatComparison.ruff_and_ruff,
-              )
+              for attempt in range(1, 101):
+                  print(f"Running pinned Airflow comparison attempt {attempt}", flush=True)
+                  await repository.reset()
+                  await compare_format(
+                      ruff,
+                      ruff,
+                      target.format_options,
+                      target.config_overrides,
+                      repository,
+                      FormatComparison.ruff_and_ruff,
+                  )
 
 
           asyncio.run(run())

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -1,3 +1,4 @@
+// Trigger the standard formatter ecosystem CI job for #25331.
 //! Infrastructure for code formatting
 //!
 //! This module defines [`FormatElement`], an IR to format code documents and provides a means to print


### PR DESCRIPTION
## Summary

Add a diagnostic CI reproducer for the formatter ecosystem failure from #25330 and an inert `crates/ruff_formatter` source marker so the repository standard `CI / ecosystem` job is scheduled instead of skipped.

## Results

The error did not reproduce.

- The standard `CI / ecosystem` job ran on the formatter-trigger commit and both the stable and preview `ruff format` ecosystem steps passed: https://github.com/astral-sh/ruff/actions/runs/26328327993/job/77509969905
- The full diagnostic stable-then-preview formatter sequence against current Airflow passed.
- 100 `ruff-and-ruff` comparisons against historical Airflow `eca91dc5c2ca`, which was `apache/airflow` `main` when #25330 failed at 19:41 UTC on May 22, 2026, passed: https://github.com/astral-sh/ruff/actions/runs/26328096194/job/77509339724

The original `No such file or directory (os error 2)` error appears transient, or dependent on runner/check-out state not preserved in the failing log.

## Test Plan

- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ruff_formatter`
- `uvx prek run --files crates/ruff_formatter/src/lib.rs .github/workflows/reproduce-airflow-formatter-ecosystem-error.yaml`