### PR TITLE
[parser] Use `allocate_tokens_vec` in `from_source`

### DIFF
--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -20,23 +20,17 @@ pub(crate) struct TokenSource<'src> {
 }
 
 impl<'src> TokenSource<'src> {
-    /// Create a new token source for the given lexer.
-    pub(crate) fn new(lexer: Lexer<'src>) -> Self {
-        // TODO(dhruvmanila): Use `allocate_tokens_vec`
-        TokenSource {
-            lexer,
-            tokens: vec![],
-        }
-    }
-
     /// Create a new token source from the given source code which starts at the given offset.
     pub(crate) fn from_source(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
         let lexer = Lexer::new(source, mode, start_offset);
-        let mut source = TokenSource::new(lexer);
+        let mut token_source = TokenSource {
+            lexer,
+            tokens: allocate_tokens_vec(source),
+        };
 
         // Initialize the token source so that the current token is set correctly.
-        source.do_bump();
-        source
+        token_source.do_bump();
+        token_source
     }
 
     /// Returns the kind of the current token.
@@ -263,7 +257,6 @@ pub(crate) struct TokenSourceCheckpoint {
 /// of `contents`.
 ///
 /// See [#9546](https://github.com/astral-sh/ruff/pull/9546) for a more detailed explanation.
-#[expect(dead_code)]
 fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
     let lower_bound = contents.len().saturating_mul(15) / 100;
     Vec::with_capacity(lower_bound)


### PR DESCRIPTION


## Summary

`TokenSource::from_source` was initializing `tokens` with `vec![]` (zero
capacity), causing repeated reallocations as the parser consumed tokens.

`allocate_tokens_vec` — which pre-sizes the vector using the ~15% heuristic
established in #9546 — was already implemented in the same file but left unused
behind a TODO comment.

This change resolves that TODO by inlining `allocate_tokens_vec` into
`from_source` directly, and removes the now-unused `TokenSource::new` helper.

## Test Plan

Ran the existing parser benchmark with `--sample-size 200` on `large/dataset.py`
(42 KB):

parser/large/dataset.py
  before: 370.71 µs 373.03 µs 375.51 µs    thpt: 108.34 MiB/s 109.06 MiB/s 109.75 MiB/s
  after:  363.40 µs 363.70 µs 364.03 µs    thpt: 111.76 MiB/s 111.86 MiB/s 111.95 MiB/s
  change: -2.7% (p = 0.00)

No correctness changes; all existing tests pass.