### PR TITLE
[parser] Add fast path for ASCII whitespace skipping in lexer

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -369,6 +369,10 @@ impl<'src> Lexer<'src> {
     }
 
     fn skip_whitespace(&mut self) -> Result<(), LexicalError> {
+        // Fast path: consume a run of spaces and tabs directly from the byte slice,
+        // avoiding the per-character `Chars` clone+decode in the loop below.
+        self.cursor.skip_ascii_whitespace();
+
         loop {
             match self.cursor.first() {
                 ' ' => {

--- a/crates/ruff_python_parser/src/lexer/cursor.rs
+++ b/crates/ruff_python_parser/src/lexer/cursor.rs
@@ -144,6 +144,25 @@ impl<'src> Cursor<'src> {
         }
     }
 
+    /// Advances past a leading run of ASCII spaces and tabs using a raw byte scan.
+    ///
+    /// This avoids the per-character `Chars` clone and UTF-8 decode cost of the
+    /// general `eat_while` loop for the common case of space/tab-separated tokens.
+    #[inline]
+    pub(super) fn skip_ascii_whitespace(&mut self) {
+        let bytes = self.chars.as_str().as_bytes();
+
+        let n = bytes
+            .iter()
+            .take_while(|&&b| b == b' ' || b == b'\t')
+            .count();
+
+        if n > 0 {
+            // SAFETY: all skipped bytes are ASCII (single-byte UTF-8 code points).
+            self.chars = self.chars.as_str()[n..].chars();
+        }
+    }
+
     /// Eats symbols while predicate returns true or until the end of file is reached.
     #[inline]
     pub(super) fn eat_while(&mut self, mut predicate: impl FnMut(char) -> bool) {


### PR DESCRIPTION
## Summary

`skip_whitespace` iterated one character at a time via `Cursor::first()`,
incurring per-character iterator and UTF-8 decoding overhead.

For the common case of plain spaces and tabs between tokens, this overhead is unnecessary.

This adds `Cursor::skip_ascii_whitespace`, which scans the raw byte slice to
consume a leading run of spaces and tabs in a single pass before falling back
to the existing character-based loop for backslash-continuations and form feeds.

## Test Plan

Ran the lexer benchmark with `--sample-size 200`:

```text
lexer/numpy/ctypeslib.py
  before: 27.951 µs 28.124 µs 28.324 µs    thpt: 587.89 MiB/s 592.05 MiB/s 595.73 MiB/s
  after:  27.164 µs 27.294 µs 27.435 µs    thpt: 606.93 MiB/s 610.07 MiB/s 612.99 MiB/s
  change: -5.1% (p = 0.00)

lexer/large/dataset.py
  before: 151.20 µs 151.95 µs 152.83 µs    thpt: 266.21 MiB/s 267.74 MiB/s 269.08 MiB/s
  after:  149.34 µs 149.48 µs 149.63 µs    thpt: 271.90 MiB/s 272.16 MiB/s 272.43 MiB/s
  change: -2.1% (p = 0.00)
```

No correctness changes; all existing tests pass.