### PR TITLE
[parser] Use SmallVec for indentations stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3449,6 +3449,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "smallvec",
  "static_assertions",
  "unicode-ident",
  "unicode-normalization",

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -23,6 +23,7 @@ compact_str = { workspace = true }
 get-size2 = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
+smallvec = { workspace = true }
 static_assertions = { workspace = true }
 unicode-ident = { workspace = true }
 unicode-normalization = { workspace = true }

--- a/crates/ruff_python_parser/src/lexer/indentation.rs
+++ b/crates/ruff_python_parser/src/lexer/indentation.rs
@@ -1,3 +1,4 @@
+use smallvec::SmallVec;
 use static_assertions::assert_eq_size;
 use std::cmp::Ordering;
 use std::fmt::Debug;
@@ -86,7 +87,9 @@ pub(super) struct UnexpectedIndentation;
 /// [See Indentation](docs.python.org/3/reference/lexical_analysis.html#indentation).
 #[derive(Debug, Clone, Default)]
 pub(super) struct Indentations {
-    stack: Vec<Indentation>,
+    // Inlines up to 8 levels on the stack (8 × 8 = 64 bytes); spills to the heap only for
+    // unusually deeply-nested code. Python's practical nesting depth rarely exceeds 8.
+    stack: SmallVec<[Indentation; 8]>,
 }
 
 impl Indentations {
@@ -135,7 +138,7 @@ impl Indentations {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct IndentationsCheckpoint(Vec<Indentation>);
+pub(crate) struct IndentationsCheckpoint(SmallVec<[Indentation; 8]>);
 
 assert_eq_size!(Indentation, u64);
 


### PR DESCRIPTION


## Summary

`Indentations::stack` and `IndentationsCheckpoint` used `Vec<Indentation>`,
which always allocates on the heap — even for files with no nesting at all.

This changes both to `SmallVec<[Indentation; 8]>`, which stores up to 8
levels inline on the stack. Since `Indentation` is 8 bytes
(`assert_eq_size!(Indentation, u64)` verifies this), the inline buffer is
64 bytes. Python's practical nesting depth rarely exceeds 8 levels, so heap
allocation is avoided for the vast majority of real-world files.

Note: `origin/micha/lexer-checkpoint` is exploring a CoW approach for the
same structs using `Option<Arc<Vec<_>>>`. That approach targets checkpoint
cloning cost whereas this targets the common case of zero heap allocation.
The two are orthogonal and could be combined if that branch lands.

## Test Plan

Ran `cargo test -p ruff_python_parser` — all tests pass.

Ran the lexer and parser benchmarks before and after:

| Benchmark                     | `main`     | this PR    | Δ       |
|--------------------------------|-------------|-------------|---------|
| `lexer/large/dataset.py`       | 148,070 ns | 145,670 ns | **-1.6%** |
| `lexer/pydantic/types.py`      | 65,243 ns  | 64,375 ns  | -1.3% |
| `lexer/numpy/ctypeslib.py`     | 27,184 ns  | 26,820 ns  | -1.3% |
| `lexer/unicode/pypinyin.py`    | 8,639 ns   | 8,447 ns   | -2.2% |
| `lexer/numpy/globals.py`       | 2,356 ns   | 2,329 ns   | -1.1% |
| `parser/pydantic/types.py`     | 143,414 ns | 141,751 ns | -1.2% |
| `parser/numpy/globals.py`      | 5,598 ns   | 5,519 ns   | -1.4% |

The change reduces heap allocation (moving to stack), so memory usage is
expected to improve rather than regress.