### PR TITLE
[ty] Accept complete enum-literal alias unions as enums

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -249,6 +249,51 @@ from ty_extensions import is_equivalent_to, static_assert
 static_assert(is_equivalent_to(Y, A | B | C | D))
 ```
 
+## Unions of enum literal aliases
+
+A union of aliases covering every member of an enum is equivalent to the enum itself, including when
+the aliases occur inside a larger type.
+
+```py
+from enum import Enum
+from typing import Literal
+
+class Choice(Enum):
+    A = "A"
+    B = "B"
+
+type A = Literal[Choice.A]
+type B = Literal[Choice.B]
+type Either = A | B
+type Selector = A | B | tuple[A, B]
+
+def accept_either(value: Either) -> None: ...
+def accept_optional_either(value: Either | None) -> None: ...
+def accept_selector(value: Selector) -> None: ...
+
+class Config:
+    either: Either
+    selector: Selector
+
+def _(choice: Choice, config: Config) -> None:
+    direct: Either = choice
+    accept_either(choice)
+    accept_optional_either(config.either)
+    values: list[Selector] = []
+    accept_selector(config.selector)
+
+class ExtendedChoice(Enum):
+    A = "A"
+    B = "B"
+    C = "C"
+
+type ExtendedA = Literal[ExtendedChoice.A]
+type ExtendedB = Literal[ExtendedChoice.B]
+
+def _(choice: ExtendedChoice) -> None:
+    partial: ExtendedA | ExtendedB = choice  # error: [invalid-assignment]
+```
+
 ## In binary ops
 
 ```py

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -986,6 +986,24 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.check_type_pair(db, source, target_alias.value_type(db))
             }),
 
+            // Annotation unions retain type aliases so recursive aliases can be represented.
+            // Normalize direct alias elements together before checking the union so reductions
+            // that depend on multiple elements, such as all members of an enum, are visible.
+            (_, Type::Union(union))
+                if union
+                    .elements(db)
+                    .iter()
+                    .any(|element| matches!(element, Type::TypeAlias(_))) =>
+            {
+                self.with_recursion_guard(source, target, || {
+                    self.check_type_pair(
+                        db,
+                        source,
+                        UnionType::from_elements(db, union.elements(db).iter().copied()),
+                    )
+                })
+            }
+
             (Type::EnumComplement(complement), Type::LiteralValue(_) | Type::Union(_)) => {
                 self.check_type_pair(db, complement.remaining_literal_union(db), target)
             }


### PR DESCRIPTION
## Summary

Relation checking needs to normalize PEP 695 unions together, so that we can recognize that (e.g.) a union of aliases covering every member of an enum is equal to the enum itself.

Closes https://github.com/astral-sh/ty/issues/3446.