### PR TITLE
[ty] Infer class attributes assigned by metaclass initialization

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1045,13 +1045,63 @@ class CCreated(metaclass=InitializingMeta): ...
 reveal_type(CCreated.attr)  # revealed: int
 
 class CInitialized(metaclass=InitializingMeta):
-    # TODO: This should be an `invalid-assignment` error
+    # error: [invalid-assignment] "Object of type `Literal["initial class value"]` is not assignable to attribute `attr` of type `int`"
     attr = "initial class value"
 
 reveal_type(CInitialized.attr)  # revealed: int
 CInitialized.attr = 2
 # error: [invalid-assignment] "Object of type `Literal["invalid"]` is not assignable to attribute `attr` of type `int`"
 CInitialized.attr = "invalid"
+
+class LiteralInitializingMeta(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.attr: Literal[1] = 1
+
+class CAugmentedInitialized(metaclass=LiteralInitializingMeta):
+    attr = 1
+    attr += 1  # error: [invalid-assignment]
+
+class CLoopInitialized(metaclass=LiteralInitializingMeta):
+    for attr in ("invalid",):  # error: [invalid-assignment]
+        pass
+
+class CNamedInitialized(metaclass=LiteralInitializingMeta):
+    if attr := "invalid":  # error: [invalid-assignment]
+        pass
+
+class InvalidContextManager:
+    def __enter__(self) -> str:
+        return "invalid"
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        pass
+
+class CWithInitialized(metaclass=LiteralInitializingMeta):
+    with InvalidContextManager() as attr:  # error: [invalid-assignment]
+        pass
+
+class CAnnotatedInitialized(metaclass=InitializingMeta):
+    attr: str = "invalid"  # error: [invalid-assignment]
+
+class CMethodInitialized(metaclass=InitializingMeta):
+    # error: [invalid-assignment]
+    def attr(self) -> None:
+        pass
+
+class CNestedClassInitialized(metaclass=InitializingMeta):
+    # error: [invalid-assignment]
+    class attr:
+        pass
+
+class CImportInitialized(metaclass=InitializingMeta):
+    import sys as attr  # error: [invalid-assignment]
+
+# Exception-handler targets are removed from the namespace on leaving the handler.
+class CExceptionBindingCleared(metaclass=InitializingMeta):
+    try:
+        raise RuntimeError
+    except RuntimeError as attr:
+        pass
 
 class BroadInitializingMeta(type):
     def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1114,6 +1114,15 @@ class CDeclared(metaclass=BroadInitializingMeta):
 # A class-body declaration is a contract for an attribute populated by metaclass initialization.
 reveal_type(CDeclared.attr)  # revealed: str
 
+class DeclaredBroadInitializingMeta(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.attr: object = object()
+
+class CDeclaredAgainstDeclaredMeta(metaclass=DeclaredBroadInitializingMeta):
+    attr: str  # error: [invalid-assignment]
+
+reveal_type(CDeclaredAgainstDeclaredMeta.attr)  # revealed: str
+
 class CompatibleInitializingMeta(type):
     def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
         cls.attr: int | str = 1
@@ -1121,10 +1130,51 @@ class CompatibleInitializingMeta(type):
 def _(flag: bool):
     class CConditionallyDeclared(metaclass=CompatibleInitializingMeta):
         if flag:
-            attr: str = "class value"
+            attr: str = "class value"  # error: [invalid-assignment]
 
     # On paths without the class-body value, the metaclass-populated value remains available.
     reveal_type(CConditionallyDeclared.attr)  # revealed: int | str
+
+class ReplacingMethodsMeta(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.factory = lambda: object()
+        cls.arguments = lambda: ()
+
+class MethodsReplacedAtConstruction(metaclass=ReplacingMethodsMeta):
+    def factory(self, value: int) -> str:
+        return ""
+
+    def arguments(self, value: int) -> str:
+        return ""
+
+class TypedReplacingMethodsMeta(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.factory: object = object()
+
+class MethodReplacedByTypedMeta(metaclass=TypedReplacingMethodsMeta):
+    def factory(self) -> str:
+        return ""
+
+class PopulatingMetaclass(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.populated_on_meta: int = 1
+
+class PopulatedMeta(type, metaclass=PopulatingMetaclass): ...
+class ConstructedByPopulatedMeta(metaclass=PopulatedMeta): ...
+
+reveal_type(PopulatedMeta.populated_on_meta)  # revealed: int
+reveal_type(ConstructedByPopulatedMeta.populated_on_meta)  # revealed: int
+
+class DerivedInitializingMeta(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.inherited_attr: int = 1
+
+class DeclaringBase:
+    inherited_attr: str
+
+class InitializedDerived(DeclaringBase, metaclass=DerivedInitializingMeta): ...
+
+reveal_type(InitializedDerived.inherited_attr)  # revealed: int
 ```
 
 However, the metaclass attribute only takes precedence over a class-level attribute if it is a data

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1105,11 +1105,11 @@ class CExceptionBindingCleared(metaclass=InitializingMeta):
 
 class BroadInitializingMeta(type):
     def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
-        value: object = "initial value"
+        value: object = object()
         cls.attr = value
 
 class CDeclared(metaclass=BroadInitializingMeta):
-    attr: str
+    attr: str  # error: [invalid-assignment]
 
 # A class-body declaration is a contract for an attribute populated by metaclass initialization.
 reveal_type(CDeclared.attr)  # revealed: str

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1031,6 +1031,28 @@ class C1(metaclass=Meta1): ...
 reveal_type(C1.attr)  # revealed: Literal["metaclass value"]
 ```
 
+Assignments in instance methods of a metaclass are also attributes on its class-object instances. In
+particular, a metaclass `__init__` assignment happens after the initial class namespace has been
+converted into a class object, so it shadows an attribute from that namespace:
+
+```py
+class InitializingMeta(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.attr: int = 1
+
+class CCreated(metaclass=InitializingMeta): ...
+
+reveal_type(CCreated.attr)  # revealed: int
+
+class CInitialized(metaclass=InitializingMeta):
+    attr = "initial class value"
+
+reveal_type(CInitialized.attr)  # revealed: int
+CInitialized.attr = 2
+# error: [invalid-assignment] "Object of type `Literal["invalid"]` is not assignable to attribute `attr` of type `int`"
+CInitialized.attr = "invalid"
+```
+
 However, the metaclass attribute only takes precedence over a class-level attribute if it is a data
 descriptor. If it is a non-data descriptor or a normal attribute, the class-level attribute is used
 instead (see the [descriptor protocol tests] for data/non-data descriptor attributes):

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1113,6 +1113,18 @@ class CDeclared(metaclass=BroadInitializingMeta):
 
 # A class-body declaration is a contract for an attribute populated by metaclass initialization.
 reveal_type(CDeclared.attr)  # revealed: str
+
+class CompatibleInitializingMeta(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.attr: int | str = 1
+
+def _(flag: bool):
+    class CConditionallyDeclared(metaclass=CompatibleInitializingMeta):
+        if flag:
+            attr: str = "class value"
+
+    # On paths without the class-body value, the metaclass-populated value remains available.
+    reveal_type(CConditionallyDeclared.attr)  # revealed: int | str
 ```
 
 However, the metaclass attribute only takes precedence over a class-level attribute if it is a data

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1045,6 +1045,7 @@ class CCreated(metaclass=InitializingMeta): ...
 reveal_type(CCreated.attr)  # revealed: int
 
 class CInitialized(metaclass=InitializingMeta):
+    # TODO: This should be an `invalid-assignment` error
     attr = "initial class value"
 
 reveal_type(CInitialized.attr)  # revealed: int

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1051,6 +1051,17 @@ reveal_type(CInitialized.attr)  # revealed: int
 CInitialized.attr = 2
 # error: [invalid-assignment] "Object of type `Literal["invalid"]` is not assignable to attribute `attr` of type `int`"
 CInitialized.attr = "invalid"
+
+class BroadInitializingMeta(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        value: object = "initial value"
+        cls.attr = value
+
+class CDeclared(metaclass=BroadInitializingMeta):
+    attr: str
+
+# A class-body declaration is a contract for an attribute populated by metaclass initialization.
+reveal_type(CDeclared.attr)  # revealed: str
 ```
 
 However, the metaclass attribute only takes precedence over a class-level attribute if it is a data

--- a/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
+++ b/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
@@ -243,6 +243,25 @@ def f(x: type[E[str]]):
     static_assert(has_member(x, "initialized_attr"))
 ```
 
+### Generic metaclasses
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from ty_extensions import has_member, static_assert
+
+class InitializingMeta[T](type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.initialized_attr: int = 1
+
+class Initialized(metaclass=InitializingMeta[int]): ...
+
+static_assert(has_member(Initialized, "initialized_attr"))
+```
+
 ### `type[Any]` and `Any`
 
 `type[Any]` has all members of `type`.

--- a/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
+++ b/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
@@ -193,6 +193,20 @@ def _[T: D](x: type[T]):
     static_assert(has_member(x, "meta_attr"))
     static_assert(has_member(x, "base_attr"))
     static_assert(has_member(x, "class_attr"))
+
+class InitializingMeta(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.initialized_attr: int = 1
+
+class Initialized(metaclass=InitializingMeta): ...
+
+static_assert(has_member(Initialized, "initialized_attr"))
+
+def _(x: type[Initialized]):
+    static_assert(has_member(x, "initialized_attr"))
+
+def _[T: Initialized](x: type[T]):
+    static_assert(has_member(x, "initialized_attr"))
 ```
 
 ### Generic classes
@@ -216,12 +230,17 @@ Generic classes can also have metaclasses:
 class Meta(type):
     FOO = 42
 
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.initialized_attr: int = 1
+
 class E(Generic[T], metaclass=Meta): ...
 
 static_assert(has_member(E[int], "FOO"))
+static_assert(has_member(E[int], "initialized_attr"))
 
 def f(x: type[E[str]]):
     static_assert(has_member(x, "FOO"))
+    static_assert(has_member(x, "initialized_attr"))
 ```
 
 ### `type[Any]` and `Any`

--- a/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
+++ b/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
@@ -260,6 +260,12 @@ class InitializingMeta[T](type):
 class Initialized(metaclass=InitializingMeta[int]): ...
 
 static_assert(has_member(Initialized, "initialized_attr"))
+
+def _(x: type[Initialized]):
+    static_assert(has_member(x, "initialized_attr"))
+
+def _[T: Initialized](x: type[T]):
+    static_assert(has_member(x, "initialized_attr"))
 ```
 
 ### `type[Any]` and `Any`

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2566,6 +2566,10 @@ impl<'db> Type<'db> {
                 }
             }
 
+            Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => self
+                .to_meta_type(db)
+                .class_object_member(db, name.as_str(), policy),
+
             _ => self
                 .to_meta_type(db)
                 .find_name_in_mro_with_policy(db, name.as_str(), policy)
@@ -2590,17 +2594,29 @@ impl<'db> Type<'db> {
             "Calling `class_object_member` on class literals and subclass-of types should always find an MRO",
         );
 
-        // A definitely-declared class attribute is the contract for values populated by
-        // metaclass initialization, analogous to a declared instance attribute initialized in
-        // `__init__`. Nothing from the metaclass changes the type exposed for this attribute.
-        if matches!(
-            class_attr.place,
-            Place::Defined(DefinedPlace {
-                origin: TypeOrigin::Declared,
-                definedness: Definedness::AlwaysDefined,
+        let own_class = match self {
+            Type::SubclassOf(subclass_of) => subclass_of.subclass_of().into_class(db),
+            _ => self.to_class_type(db),
+        };
+        let own_class_attr = own_class.map(|class| class.own_class_member(db, None, name).inner);
+
+        // A definitely-declared attribute in this class's own namespace is the contract for
+        // values populated by metaclass initialization, analogous to a declared instance
+        // attribute initialized in `__init__`. An inherited declaration does not mask a value
+        // that the metaclass stores directly on the newly constructed subclass.
+        let own_declaration_definedness = match own_class_attr {
+            Some(PlaceAndQualifiers {
+                place:
+                    Place::Defined(DefinedPlace {
+                        origin: TypeOrigin::Declared,
+                        definedness,
+                        ..
+                    }),
                 ..
-            })
-        ) {
+            }) => Some(definedness),
+            _ => None,
+        };
+        if own_declaration_definedness == Some(Definedness::AlwaysDefined) {
             return class_attr;
         }
 
@@ -2609,13 +2625,7 @@ impl<'db> Type<'db> {
         };
         let metaclass_attr = metaclass_instance.instance_member(db, name);
 
-        if matches!(
-            class_attr.place,
-            Place::Defined(DefinedPlace {
-                origin: TypeOrigin::Declared,
-                ..
-            })
-        ) {
+        if own_declaration_definedness.is_some() {
             // A conditionally-declared attribute is a contract only on paths where that
             // declaration is present; the metaclass value is the fallback on other paths.
             class_attr.or_fall_back_to(db, || metaclass_attr)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2591,9 +2591,22 @@ impl<'db> Type<'db> {
         );
 
         if let Some(metaclass_instance) = self.to_meta_type(db).to_instance(db) {
-            metaclass_instance
-                .instance_member(db, name)
-                .or_fall_back_to(db, || class_attr)
+            let metaclass_attr = metaclass_instance.instance_member(db, name);
+
+            // A declaration on the class object is its contract for values populated by
+            // metaclass initialization, analogous to a declared instance attribute initialized
+            // in `__init__`. A bound class-body value can still be overwritten by the metaclass.
+            if matches!(
+                class_attr.place,
+                Place::Defined(DefinedPlace {
+                    origin: TypeOrigin::Declared,
+                    ..
+                })
+            ) {
+                class_attr.or_fall_back_to(db, || metaclass_attr)
+            } else {
+                metaclass_attr.or_fall_back_to(db, || class_attr)
+            }
         } else {
             class_attr
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2590,25 +2590,37 @@ impl<'db> Type<'db> {
             "Calling `class_object_member` on class literals and subclass-of types should always find an MRO",
         );
 
-        if let Some(metaclass_instance) = self.to_meta_type(db).to_instance(db) {
-            let metaclass_attr = metaclass_instance.instance_member(db, name);
+        // A definitely-declared class attribute is the contract for values populated by
+        // metaclass initialization, analogous to a declared instance attribute initialized in
+        // `__init__`. Nothing from the metaclass changes the type exposed for this attribute.
+        if matches!(
+            class_attr.place,
+            Place::Defined(DefinedPlace {
+                origin: TypeOrigin::Declared,
+                definedness: Definedness::AlwaysDefined,
+                ..
+            })
+        ) {
+            return class_attr;
+        }
 
-            // A declaration on the class object is its contract for values populated by
-            // metaclass initialization, analogous to a declared instance attribute initialized
-            // in `__init__`. A bound class-body value can still be overwritten by the metaclass.
-            if matches!(
-                class_attr.place,
-                Place::Defined(DefinedPlace {
-                    origin: TypeOrigin::Declared,
-                    ..
-                })
-            ) {
-                class_attr.or_fall_back_to(db, || metaclass_attr)
-            } else {
-                metaclass_attr.or_fall_back_to(db, || class_attr)
-            }
+        let Some(metaclass_instance) = self.to_meta_type(db).to_instance(db) else {
+            return class_attr;
+        };
+        let metaclass_attr = metaclass_instance.instance_member(db, name);
+
+        if matches!(
+            class_attr.place,
+            Place::Defined(DefinedPlace {
+                origin: TypeOrigin::Declared,
+                ..
+            })
+        ) {
+            // A conditionally-declared attribute is a contract only on paths where that
+            // declaration is present; the metaclass value is the fallback on other paths.
+            class_attr.or_fall_back_to(db, || metaclass_attr)
         } else {
-            class_attr
+            metaclass_attr.or_fall_back_to(db, || class_attr)
         }
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2575,6 +2575,30 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Look up attributes stored in the namespace of a class object.
+    ///
+    /// Besides attributes present in the class MRO, this includes attributes assigned to
+    /// instances of its metaclass. For example, `cls.x = ...` in `Meta.__init__` stores `x`
+    /// on each class object constructed by `Meta`.
+    fn class_object_instance_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        policy: MemberLookupPolicy,
+    ) -> PlaceAndQualifiers<'db> {
+        let class_attr = self.find_name_in_mro_with_policy(db, name, policy).expect(
+            "Calling `class_object_instance_member` on class literals and subclass-of types should always find an MRO",
+        );
+
+        if let Some(metaclass_instance) = self.to_meta_type(db).to_instance(db) {
+            metaclass_instance
+                .instance_member(db, name)
+                .or_fall_back_to(db, || class_attr)
+        } else {
+            class_attr
+        }
+    }
+
     /// This function roughly corresponds to looking up an attribute in the `__dict__` of an object.
     /// For instance-like types, this goes through the classes MRO and discovers attribute assignments
     /// in methods, as well as class-body declarations that we consider to be evidence for the presence
@@ -3587,9 +3611,7 @@ impl<'db> Type<'db> {
                     .into();
                 }
 
-                let class_attr_plain = self.find_name_in_mro_with_policy(db, name_str, policy).expect(
-                    "Calling `find_name_in_mro` on class literals and subclass-of types should always return `Some`",
-                );
+                let class_attr_plain = self.class_object_instance_member(db, name_str, policy);
 
                 let self_instance = self
                     .to_instance(db)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2580,14 +2580,14 @@ impl<'db> Type<'db> {
     /// Besides attributes present in the class MRO, this includes attributes assigned to
     /// instances of its metaclass. For example, `cls.x = ...` in `Meta.__init__` stores `x`
     /// on each class object constructed by `Meta`.
-    fn class_object_instance_member(
+    fn class_object_member(
         self,
         db: &'db dyn Db,
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
         let class_attr = self.find_name_in_mro_with_policy(db, name, policy).expect(
-            "Calling `class_object_instance_member` on class literals and subclass-of types should always find an MRO",
+            "Calling `class_object_member` on class literals and subclass-of types should always find an MRO",
         );
 
         if let Some(metaclass_instance) = self.to_meta_type(db).to_instance(db) {
@@ -3624,7 +3624,7 @@ impl<'db> Type<'db> {
                     .into();
                 }
 
-                let class_attr_plain = self.class_object_instance_member(db, name_str, policy);
+                let class_attr_plain = self.class_object_member(db, name_str, policy);
 
                 let self_instance = self
                     .to_instance(db)

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3887,7 +3887,7 @@ pub(super) fn report_invalid_assignment<'db>(
 
 pub(super) fn report_invalid_attribute_assignment(
     context: &InferContext,
-    node: AnyNodeRef,
+    range: TextRange,
     target_ty: Type,
     source_ty: Type,
     attribute_name: &'_ str,
@@ -3899,7 +3899,7 @@ pub(super) fn report_invalid_attribute_assignment(
 
     let Some(mut diag) = report_invalid_assignment_with_message(
         context,
-        node,
+        range,
         target_ty,
         format_args!(
             "Object of type `{}` is not assignable to attribute `{attribute_name}` of type `{}`",

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3308,11 +3308,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 | Type::TypeGuard(_)
                 | Type::TypedDict(_)
                 | Type::NewTypeInstance(_) => object_ty.instance_member(db, attribute),
-                Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
-                    object_ty.find_name_in_mro(db, attribute).expect(
-                        "called on Type::ClassLiteral, Type::GenericAlias, or Type::SubclassOf",
-                    )
-                }
+                Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => object_ty
+                    .class_object_instance_member(db, attribute, MemberLookupPolicy::default()),
                 Type::Union(..)
                 | Type::Intersection(..)
                 | Type::TypeAlias(..)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3308,8 +3308,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 | Type::TypeGuard(_)
                 | Type::TypedDict(_)
                 | Type::NewTypeInstance(_) => object_ty.instance_member(db, attribute),
-                Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => object_ty
-                    .class_object_instance_member(db, attribute, MemberLookupPolicy::default()),
+                Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
+                    object_ty.class_object_member(db, attribute, MemberLookupPolicy::default())
+                }
                 Type::Union(..)
                 | Type::Intersection(..)
                 | Type::TypeAlias(..)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2355,7 +2355,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if !assignable && emit_diagnostics {
                     report_invalid_attribute_assignment(
                         &builder.context,
-                        target.into(),
+                        target.range(),
                         attr_ty,
                         value_ty,
                         attribute,
@@ -3040,7 +3040,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         if emit_diagnostics {
                             report_invalid_attribute_assignment(
                                 &self.context,
-                                target.into(),
+                                target.range(),
                                 attr_ty,
                                 value_ty,
                                 attribute,

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -10,11 +10,11 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 use crate::{
     Db, TypeQualifiers,
     diagnostic::format_enumeration,
-    place::{place_from_bindings, place_from_declarations},
+    place::{DefinedPlace, Place, TypeOrigin, place_from_bindings, place_from_declarations},
     types::{
-        CallArguments, ClassBase, ClassLiteral, ClassType, KnownInstanceType, MemberLookupPolicy,
-        MetaclassCandidate, Parameters, Signature, SpecialFormType, StaticClassLiteral, Type,
-        TypeVarVariance, binding_type,
+        CallArguments, ClassBase, ClassLiteral, ClassType, KnownClass, KnownInstanceType,
+        MemberLookupPolicy, MetaclassCandidate, Parameters, Signature, SpecialFormType,
+        StaticClassLiteral, Type, TypeVarVariance, binding_type,
         call::Argument,
         class::{
             AbstractMethod, CodeGeneratorKind, FieldKind, MetaclassErrorKind,
@@ -31,9 +31,9 @@ use crate::{
             SUBCLASS_OF_DATACLASS_WITH_ORDER, SUBCLASS_OF_FINAL_CLASS, UNKNOWN_ARGUMENT,
             report_bad_frozen_dataclass_inheritance, report_conflicting_metaclass_from_bases,
             report_duplicate_bases, report_inconsistent_generic_bases,
-            report_instance_layout_conflict, report_invalid_or_unsupported_base,
-            report_invalid_total_ordering, report_invalid_type_param_order,
-            report_invalid_typevar_default_reference,
+            report_instance_layout_conflict, report_invalid_attribute_assignment,
+            report_invalid_or_unsupported_base, report_invalid_total_ordering,
+            report_invalid_type_param_order, report_invalid_typevar_default_reference,
             report_named_tuple_field_with_leading_underscore,
             report_namedtuple_field_without_default_after_field_with_default,
             report_shadowed_type_variable,
@@ -983,10 +983,13 @@ pub(crate) fn check_static_class_definitions<'db>(
     // and for violations of other rules relating to invalid overrides of some sort.
     overrides::check_class(context, class);
 
-    // (14) Check for unimplemented abstract methods on final classes.
+    // (14) Check class namespace values against declared metaclass attributes.
+    check_class_bindings_against_metaclass_instance_declarations(context, class, index);
+
+    // (15) Check for unimplemented abstract methods on final classes.
     check_final_class_abstract_methods(context, class, class_node);
 
-    // (15) Check for Final-qualified declarations without a value.
+    // (16) Check for Final-qualified declarations without a value.
     check_class_final_without_value(context, class, index);
 
     if let Some(protocol) = class.into_protocol_class(db) {
@@ -998,6 +1001,64 @@ pub(crate) fn check_static_class_definitions<'db>(
     }
 
     class.validate_members(context);
+}
+
+/// Check values in a class namespace against attributes declared on its metaclass instance.
+///
+/// A binding in a class body is passed through the namespace used to construct the class object
+/// before a metaclass can initialize that same attribute. If the metaclass declares a type for
+/// that attribute, an incompatible class-body value violates that contract.
+fn check_class_bindings_against_metaclass_instance_declarations<'db>(
+    context: &InferContext<'db, '_>,
+    class: StaticClassLiteral<'db>,
+    index: &SemanticIndex<'db>,
+) {
+    let db = context.db();
+    let metaclass = class.metaclass(db);
+    if metaclass == KnownClass::Type.to_class_literal(db) {
+        return;
+    }
+
+    let Some(metaclass_instance) = metaclass.to_instance(db) else {
+        return;
+    };
+
+    let scope = class.body_scope(db).file_scope_id(db);
+    let table = index.place_table(scope);
+    let use_def = index.use_def_map(scope);
+
+    for (symbol_id, bindings) in use_def.all_end_of_scope_symbol_bindings() {
+        let name = table.symbol(symbol_id).name();
+        let Place::Defined(DefinedPlace {
+            ty: declared_ty,
+            origin: TypeOrigin::Declared,
+            ..
+        }) = metaclass_instance.instance_member(db, name.as_str()).place
+        else {
+            continue;
+        };
+
+        for binding in bindings {
+            let Some(definition) = binding.binding.definition() else {
+                continue;
+            };
+            let definition_kind = definition.kind(db);
+            if !definition_kind.is_user_visible() {
+                continue;
+            }
+
+            let assigned_ty = binding_type(db, definition);
+            if !assigned_ty.is_assignable_to(db, declared_ty) {
+                report_invalid_attribute_assignment(
+                    context,
+                    definition_kind.target_range(context.module()),
+                    declared_ty,
+                    assigned_ty,
+                    name.as_str(),
+                );
+            }
+        }
+    }
 }
 
 fn ordered_dataclass_base_class<'db>(

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -6,6 +6,7 @@ use ruff_db::{
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange, TextSize};
+use rustc_hash::FxHashSet;
 
 use crate::{
     Db, TypeQualifiers,
@@ -53,7 +54,9 @@ use crate::{
     },
 };
 use crate::{attribute_assignments, types::diagnostic::abstract_method_span};
-use ty_python_core::{SemanticIndex, definition::DefinitionKind, scope::ScopeId};
+use ty_python_core::{
+    SemanticIndex, attribute_scopes, definition::DefinitionKind, scope::ScopeId, semantic_index,
+};
 
 /// Iterate over all static class definitions (created using `class` statements) to check that
 /// the definition is semantically valid and will not cause an exception to be raised at runtime.
@@ -1027,8 +1030,42 @@ fn check_class_bindings_against_metaclass_instance_declarations<'db>(
     let table = index.place_table(scope);
     let use_def = index.use_def_map(scope);
 
-    for (symbol_id, bindings) in use_def.all_end_of_scope_symbol_bindings() {
-        let name = table.symbol(symbol_id).name();
+    let Some(metaclass) = metaclass.to_class_type(db) else {
+        return;
+    };
+
+    // Metaclass declarations are generally sparse, while class namespaces such as enums can be
+    // large. Collect possible contracts first rather than probing the metaclass for every binding.
+    let mut metaclass_instance_declarations = FxHashSet::default();
+    for metaclass in metaclass
+        .iter_mro(db)
+        .filter_map(ClassBase::into_class)
+        .filter_map(|class| class.static_class_literal(db).map(|(literal, _)| literal))
+    {
+        let body_scope = metaclass.body_scope(db);
+        let metaclass_index = semantic_index(db, body_scope.file(db));
+        let body_scope = body_scope.file_scope_id(db);
+        let metaclass_table = metaclass_index.place_table(body_scope);
+        let metaclass_use_def = metaclass_index.use_def_map(body_scope);
+
+        for (symbol_id, _) in metaclass_use_def.all_end_of_scope_symbol_declarations() {
+            metaclass_instance_declarations
+                .insert(metaclass_table.symbol(symbol_id).name().to_string());
+        }
+
+        for function_scope in attribute_scopes(db, metaclass.body_scope(db)) {
+            for member in metaclass_index.place_table(function_scope).members() {
+                if let Some(name) = member.as_instance_attribute() {
+                    metaclass_instance_declarations.insert(name.to_string());
+                }
+            }
+        }
+    }
+
+    for name in metaclass_instance_declarations {
+        let Some(symbol_id) = table.symbol_id(name.as_str()) else {
+            continue;
+        };
         let Place::Defined(DefinedPlace {
             ty: declared_ty,
             origin: TypeOrigin::Declared,
@@ -1038,7 +1075,7 @@ fn check_class_bindings_against_metaclass_instance_declarations<'db>(
             continue;
         };
 
-        for binding in bindings {
+        for binding in use_def.end_of_scope_symbol_bindings(symbol_id) {
             let Some(definition) = binding.binding.definition() else {
                 continue;
             };

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -986,8 +986,8 @@ pub(crate) fn check_static_class_definitions<'db>(
     // and for violations of other rules relating to invalid overrides of some sort.
     overrides::check_class(context, class);
 
-    // (14) Check class namespace values against declared metaclass attributes.
-    check_class_bindings_against_metaclass_instance_declarations(context, class, index);
+    // (14) Check compatibility between class namespace values and metaclass-populated attributes.
+    check_class_namespace_against_metaclass_members(context, class, index);
 
     // (15) Check for unimplemented abstract methods on final classes.
     check_final_class_abstract_methods(context, class, class_node);
@@ -1006,12 +1006,15 @@ pub(crate) fn check_static_class_definitions<'db>(
     class.validate_members(context);
 }
 
-/// Check values in a class namespace against attributes declared on its metaclass instance.
+/// Check compatibility between class namespace values and attributes populated by its metaclass.
 ///
 /// A binding in a class body is passed through the namespace used to construct the class object
 /// before a metaclass can initialize that same attribute. If the metaclass declares a type for
 /// that attribute, an incompatible class-body value violates that contract.
-fn check_class_bindings_against_metaclass_instance_declarations<'db>(
+///
+/// Conversely, a declaration in the class body constrains an inferred value populated by
+/// metaclass initialization.
+fn check_class_namespace_against_metaclass_members<'db>(
     context: &InferContext<'db, '_>,
     class: StaticClassLiteral<'db>,
     index: &SemanticIndex<'db>,
@@ -1066,34 +1069,65 @@ fn check_class_bindings_against_metaclass_instance_declarations<'db>(
         let Some(symbol_id) = table.symbol_id(name.as_str()) else {
             continue;
         };
-        let Place::Defined(DefinedPlace {
-            ty: declared_ty,
-            origin: TypeOrigin::Declared,
-            ..
-        }) = metaclass_instance.instance_member(db, name.as_str()).place
-        else {
-            continue;
-        };
+        match metaclass_instance.instance_member(db, name.as_str()).place {
+            Place::Defined(DefinedPlace {
+                ty: declared_ty,
+                origin: TypeOrigin::Declared,
+                ..
+            }) => {
+                for binding in use_def.end_of_scope_symbol_bindings(symbol_id) {
+                    let Some(definition) = binding.binding.definition() else {
+                        continue;
+                    };
+                    let definition_kind = definition.kind(db);
+                    if !definition_kind.is_user_visible() {
+                        continue;
+                    }
 
-        for binding in use_def.end_of_scope_symbol_bindings(symbol_id) {
-            let Some(definition) = binding.binding.definition() else {
-                continue;
-            };
-            let definition_kind = definition.kind(db);
-            if !definition_kind.is_user_visible() {
-                continue;
+                    let assigned_ty = binding_type(db, definition);
+                    if !assigned_ty.is_assignable_to(db, declared_ty) {
+                        report_invalid_attribute_assignment(
+                            context,
+                            definition_kind.target_range(context.module()),
+                            declared_ty,
+                            assigned_ty,
+                            name.as_str(),
+                        );
+                    }
+                }
             }
-
-            let assigned_ty = binding_type(db, definition);
-            if !assigned_ty.is_assignable_to(db, declared_ty) {
-                report_invalid_attribute_assignment(
-                    context,
-                    definition_kind.target_range(context.module()),
-                    declared_ty,
-                    assigned_ty,
-                    name.as_str(),
+            Place::Defined(DefinedPlace {
+                ty: initialized_ty,
+                origin: TypeOrigin::Inferred,
+                ..
+            }) => {
+                let result = place_from_declarations(
+                    db,
+                    use_def.end_of_scope_symbol_declarations(symbol_id),
                 );
+                let Some(definition) = result.first_declaration else {
+                    continue;
+                };
+                let Place::Defined(DefinedPlace {
+                    ty: declared_ty, ..
+                }) = result.ignore_conflicting_declarations().place
+                else {
+                    continue;
+                };
+                let definition_kind = definition.kind(db);
+                if definition_kind.is_user_visible()
+                    && !initialized_ty.is_assignable_to(db, declared_ty)
+                {
+                    report_invalid_attribute_assignment(
+                        context,
+                        definition_kind.target_range(context.module()),
+                        declared_ty,
+                        initialized_ty,
+                        name.as_str(),
+                    );
+                }
             }
+            _ => {}
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1012,8 +1012,8 @@ pub(crate) fn check_static_class_definitions<'db>(
 /// before a metaclass can initialize that same attribute. If the metaclass declares a type for
 /// that attribute, an incompatible class-body value violates that contract.
 ///
-/// Conversely, a declaration in the class body constrains an inferred value populated by
-/// metaclass initialization.
+/// Independently, an explicit attribute declaration in the class body constrains a value
+/// populated by metaclass initialization.
 fn check_class_namespace_against_metaclass_members<'db>(
     context: &InferContext<'db, '_>,
     class: StaticClassLiteral<'db>,
@@ -1037,9 +1037,9 @@ fn check_class_namespace_against_metaclass_members<'db>(
         return;
     };
 
-    // Metaclass declarations are generally sparse, while class namespaces such as enums can be
-    // large. Collect possible contracts first rather than probing the metaclass for every binding.
-    let mut metaclass_instance_declarations = FxHashSet::default();
+    // Metaclass-populated members are generally sparse, while class namespaces such as enums can
+    // be large. Collect possible members first rather than probing the metaclass for every binding.
+    let mut metaclass_instance_members = FxHashSet::default();
     for metaclass in metaclass
         .iter_mro(db)
         .filter_map(ClassBase::into_class)
@@ -1052,82 +1052,86 @@ fn check_class_namespace_against_metaclass_members<'db>(
         let metaclass_use_def = metaclass_index.use_def_map(body_scope);
 
         for (symbol_id, _) in metaclass_use_def.all_end_of_scope_symbol_declarations() {
-            metaclass_instance_declarations
-                .insert(metaclass_table.symbol(symbol_id).name().to_string());
+            metaclass_instance_members.insert(metaclass_table.symbol(symbol_id).name().to_string());
         }
 
         for function_scope in attribute_scopes(db, metaclass.body_scope(db)) {
             for member in metaclass_index.place_table(function_scope).members() {
                 if let Some(name) = member.as_instance_attribute() {
-                    metaclass_instance_declarations.insert(name.to_string());
+                    metaclass_instance_members.insert(name.to_string());
                 }
             }
         }
     }
 
-    for name in metaclass_instance_declarations {
+    for name in metaclass_instance_members {
         let Some(symbol_id) = table.symbol_id(name.as_str()) else {
             continue;
         };
-        match metaclass_instance.instance_member(db, name.as_str()).place {
-            Place::Defined(DefinedPlace {
-                ty: declared_ty,
-                origin: TypeOrigin::Declared,
-                ..
-            }) => {
-                for binding in use_def.end_of_scope_symbol_bindings(symbol_id) {
-                    let Some(definition) = binding.binding.definition() else {
-                        continue;
-                    };
-                    let definition_kind = definition.kind(db);
-                    if !definition_kind.is_user_visible() {
-                        continue;
-                    }
+        let Place::Defined(DefinedPlace {
+            ty: metaclass_member_ty,
+            origin,
+            ..
+        }) = metaclass_instance.instance_member(db, name.as_str()).place
+        else {
+            continue;
+        };
 
-                    let assigned_ty = binding_type(db, definition);
-                    if !assigned_ty.is_assignable_to(db, declared_ty) {
-                        report_invalid_attribute_assignment(
-                            context,
-                            definition_kind.target_range(context.module()),
-                            declared_ty,
-                            assigned_ty,
-                            name.as_str(),
-                        );
-                    }
-                }
-            }
-            Place::Defined(DefinedPlace {
-                ty: initialized_ty,
-                origin: TypeOrigin::Inferred,
-                ..
-            }) => {
-                let result = place_from_declarations(
-                    db,
-                    use_def.end_of_scope_symbol_declarations(symbol_id),
-                );
-                let Some(definition) = result.first_declaration else {
-                    continue;
-                };
-                let Place::Defined(DefinedPlace {
-                    ty: declared_ty, ..
-                }) = result.ignore_conflicting_declarations().place
-                else {
+        if origin == TypeOrigin::Declared {
+            let mut reported_incompatible_binding = false;
+            for binding in use_def.end_of_scope_symbol_bindings(symbol_id) {
+                let Some(definition) = binding.binding.definition() else {
                     continue;
                 };
                 let definition_kind = definition.kind(db);
-                if definition_kind.is_user_visible()
-                    && !initialized_ty.is_assignable_to(db, declared_ty)
-                {
+                if !definition_kind.is_user_visible() {
+                    continue;
+                }
+
+                let assigned_ty = binding_type(db, definition);
+                if !assigned_ty.is_assignable_to(db, metaclass_member_ty) {
+                    reported_incompatible_binding = true;
                     report_invalid_attribute_assignment(
                         context,
                         definition_kind.target_range(context.module()),
-                        declared_ty,
-                        initialized_ty,
+                        metaclass_member_ty,
+                        assigned_ty,
                         name.as_str(),
                     );
                 }
             }
-            _ => {}
+
+            if reported_incompatible_binding {
+                continue;
+            }
+        }
+
+        let result =
+            place_from_declarations(db, use_def.end_of_scope_symbol_declarations(symbol_id));
+        let Some(definition) = result.first_declaration else {
+            continue;
+        };
+        let Place::Defined(DefinedPlace {
+            ty: class_declared_ty,
+            ..
+        }) = result.ignore_conflicting_declarations().place
+        else {
+            continue;
+        };
+        let definition_kind = definition.kind(db);
+        // A metaclass may intentionally replace an ordinary class namespace value during class
+        // creation. Only an explicit attribute annotation constrains the replacement value.
+        if !matches!(definition_kind, DefinitionKind::AnnotatedAssignment(_)) {
+            continue;
+        }
+        if !metaclass_member_ty.is_assignable_to(db, class_declared_ty) {
+            report_invalid_attribute_assignment(
+                context,
+                definition_kind.target_range(context.module()),
+                class_declared_ty,
+                metaclass_member_ty,
+                name.as_str(),
+            );
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -241,9 +241,7 @@ impl<'db> AllMembers<'db> {
             Type::ClassLiteral(class_literal) => {
                 self.extend_with_class_members(db, ty, class_literal);
                 self.extend_with_synthetic_members(db, ty, class_literal, None);
-                if let Type::ClassLiteral(metaclass) = class_literal.metaclass(db) {
-                    self.extend_with_class_members(db, ty, metaclass);
-                }
+                self.extend_with_metaclass_members(db, ty, class_literal.metaclass(db));
             }
 
             Type::GenericAlias(generic_alias) => {
@@ -255,9 +253,7 @@ impl<'db> AllMembers<'db> {
                     ClassLiteral::Static(class_literal),
                     None,
                 );
-                if let Type::ClassLiteral(metaclass) = class_literal.metaclass(db) {
-                    self.extend_with_class_members(db, ty, metaclass);
-                }
+                self.extend_with_metaclass_members(db, ty, class_literal.metaclass(db));
             }
 
             Type::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
@@ -280,9 +276,7 @@ impl<'db> AllMembers<'db> {
                                 ClassLiteral::Static(class_literal),
                                 specialization,
                             );
-                            if let Type::ClassLiteral(metaclass) = class_literal.metaclass(db) {
-                                self.extend_with_class_members(db, ty, metaclass);
-                            }
+                            self.extend_with_metaclass_members(db, ty, class_literal.metaclass(db));
                         }
                     }
                 }
@@ -492,6 +486,26 @@ impl<'db> AllMembers<'db> {
                     ty,
                 });
             }
+        }
+    }
+
+    /// Extend a class object's members with members inherited from its metaclass.
+    ///
+    /// A static metaclass can also assign attributes onto the class objects that it creates,
+    /// so those implicit instance members are available on the class object as well.
+    fn extend_with_metaclass_members(
+        &mut self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        metaclass: Type<'db>,
+    ) {
+        let Type::ClassLiteral(metaclass) = metaclass else {
+            return;
+        };
+
+        self.extend_with_class_members(db, ty, metaclass);
+        if let ClassLiteral::Static(metaclass) = metaclass {
+            self.extend_with_instance_members(db, ty, metaclass);
         }
     }
 

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -499,12 +499,12 @@ impl<'db> AllMembers<'db> {
         ty: Type<'db>,
         metaclass: Type<'db>,
     ) {
-        let Type::ClassLiteral(metaclass) = metaclass else {
+        let Some(metaclass) = metaclass.to_class_type(db) else {
             return;
         };
 
-        self.extend_with_class_members(db, ty, metaclass);
-        if let ClassLiteral::Static(metaclass) = metaclass {
+        self.extend_with_class_members(db, ty, metaclass.class_literal(db));
+        if let Some((metaclass, _)) = metaclass.static_class_literal(db) {
             self.extend_with_instance_members(db, ty, metaclass);
         }
     }

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -489,7 +489,7 @@ impl<'db> AllMembers<'db> {
         }
     }
 
-    /// Extend a class object's members with members inherited from its metaclass.
+    /// Extend a class object's members with members set by its metaclass.
     ///
     /// A static metaclass can also assign attributes onto the class objects that it creates,
     /// so those implicit instance members are available on the class object as well.


### PR DESCRIPTION
## Summary

Prior to this change, we didn't recognize class-object attributes populated by a metaclass during class initialization. For example:

```python
class Meta(type):
    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
        cls.attr: int = 1

class C(metaclass=Meta): ...

reveal_type(C.attr)  # revealed: int
```

We now recognize attributes that a metaclass adds to a class while creating it. If the metaclass overwrites an existing class-body value, we use the overwritten value's type. If the class provides an annotation for the generated attribute, we preserve that annotation as its public type.

For example, if the class body initially gives attr a value, the metaclass assignment happens later at runtime and overwrites it:

```python
class Meta(type):
    def __init__(cls, name, bases, namespace):
        cls.attr: int = 1

class C(metaclass=Meta):
    attr = "initial value"

reveal_type(C.attr)  # int
```

Closes https://github.com/astral-sh/ty/issues/1138.
