### PR TITLE
View CodSpeed results

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -823,6 +823,7 @@ impl<'src> Lexer<'src> {
     }
 
     /// Lex an f-string or t-string middle or end token.
+    #[inline(never)]
     fn lex_interpolated_string_middle_or_end(&mut self) -> Option<TokenKind> {
         // SAFETY: Safe because the function is only called when `self.fstrings` is not empty.
         let interpolated_string = self.interpolated_strings.current().unwrap();


### PR DESCRIPTION
## Summary

This is the no-inline interpolated-string experiment for measuring lexer performance with CodSpeed.

Marking `Lexer::lex_interpolated_string_middle_or_end` as `#[inline(never)]` keeps the interpolated-string middle/end state machine out of the ordinary `Lexer::next_token` body.

Optimized profiling assembly generated from current `main` shows:

- `next_token` shrinks from 2,638 to 1,582 instructions.
- `next_token` now calls an out-of-line `lex_interpolated_string_middle_or_end` function.
- The out-of-line interpolated-string function is 1,135 instructions.

The possible tradeoff is that f-string- or t-string-heavy inputs may pay the added call boundary and lose cross-boundary optimization. Local timing is intentionally omitted because this machine is CPU-contended; collecting CodSpeed data is the purpose of this PR.

## Test Plan

- `uvx prek run --files crates/ruff_python_parser/src/lexer.rs`
- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG=line-tables-only MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ruff_python_parser`
- `cargo rustc --profile profiling -p ruff_python_parser --lib -- --emit=asm`
