### PR TITLE
View CodSpeed results

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1053,23 +1053,23 @@ impl<'src> Lexer<'src> {
                     .take_while(|&&c| c == b'\\')
                     .count();
 
+                let quote_or_newline = self.cursor.rest().as_bytes()[index];
+
                 // Skip up to the current character.
                 self.cursor.skip_bytes(index);
 
-                // Lookahead because we want to bump only if it's a quote or being escaped.
-                let quote_or_newline = self.cursor.first();
-
                 // If the character is escaped, continue scanning.
                 if num_backslashes % 2 == 1 {
-                    self.cursor.bump();
-                    if quote_or_newline == '\r' {
-                        self.cursor.eat_char('\n');
-                    }
+                    let continuation_len = 1 + usize::from(
+                        quote_or_newline == b'\r'
+                            && self.cursor.rest().as_bytes().get(1) == Some(&b'\n'),
+                    );
+                    self.cursor.skip_bytes(continuation_len);
                     continue;
                 }
 
                 match quote_or_newline {
-                    '\r' | '\n' => {
+                    b'\r' | b'\n' => {
                         self.current_flags |= TokenFlags::UNCLOSED_STRING;
                         self.push_error(LexicalError::new(
                             LexicalErrorType::UnclosedStringError,
@@ -1077,12 +1077,12 @@ impl<'src> Lexer<'src> {
                         ));
                         break self.offset();
                     }
-                    ch if ch == quote => {
+                    ch if ch == quote_byte => {
                         let value_end = self.offset();
-                        self.cursor.bump();
+                        self.cursor.skip_bytes(1);
                         break value_end;
                     }
-                    _ => unreachable!("memchr2 returned an index that is not a quote or a newline"),
+                    _ => unreachable!("memchr3 returned an index that is not a quote or a newline"),
                 }
             }
         };


### PR DESCRIPTION
## Summary

- Preserve the ASCII byte returned by the non-triple-quoted string `memchr3` scan.
- Consume escaped line continuations and closing quotes with `skip_bytes` instead of decoding known ASCII bytes through `Cursor` character operations.
- This is an isolated CodSpeed experiment; local timing is not used because this machine is CPU-contended.

## Assembly

Generated with `cargo rustc --profile profiling -p ruff_python_parser --lib -- --emit=asm`.

| `lex_string` | Instructions | Branches | Loads | UTF-8 high-bit branches |
| --- | ---: | ---: | ---: | ---: |
| `main` (`330a334d`) | 667 | 144 | 70 | 3 |
| This PR | 610 | 122 | 65 | 0 |

The removed high-bit branches were in the non-triple-quoted post-`memchr3` path, where the matched byte is already known to be a quote, `\r`, or `\n`. CodSpeed measurement is requested to determine whether this local assembly improvement affects lexer benchmarks.

## Test Plan

- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ruff_python_parser`
- `uvx prek run --files crates/ruff_python_parser/src/lexer.rs`
- `git diff --check`
- `cargo rustc --profile profiling -p ruff_python_parser --lib -- --emit=asm`