### PR TITLE
View CodSpeed results

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -1099,17 +1099,28 @@ impl<'src> Lexer<'src> {
     /// Numeric lexing. The feast can start!
     fn lex_number(&mut self, first: char) -> TokenKind {
         if first == '0' {
-            if self.cursor.eat_if(|c| matches!(c, 'x' | 'X')).is_some() {
+            if self.eat_ascii(b"xX").is_some() {
                 self.lex_number_radix(Radix::Hex)
-            } else if self.cursor.eat_if(|c| matches!(c, 'o' | 'O')).is_some() {
+            } else if self.eat_ascii(b"oO").is_some() {
                 self.lex_number_radix(Radix::Octal)
-            } else if self.cursor.eat_if(|c| matches!(c, 'b' | 'B')).is_some() {
+            } else if self.eat_ascii(b"bB").is_some() {
                 self.lex_number_radix(Radix::Binary)
             } else {
                 self.lex_decimal_number(first)
             }
         } else {
             self.lex_decimal_number(first)
+        }
+    }
+
+    fn eat_ascii(&mut self, expected: &[u8]) -> Option<char> {
+        debug_assert!(expected.is_ascii());
+        let byte = self.cursor.rest().as_bytes().first().copied()?;
+        if expected.contains(&byte) {
+            self.cursor.skip_bytes(1);
+            Some(char::from(byte))
+        } else {
+            None
         }
     }
 
@@ -1153,10 +1164,10 @@ impl<'src> Lexer<'src> {
             self.radix_run(&mut number, Radix::Decimal);
         }
 
-        let is_float = if first_digit_or_dot == '.' || self.cursor.eat_char('.') {
+        let is_float = if first_digit_or_dot == '.' || self.eat_ascii(b".").is_some() {
             number.push('.');
 
-            if self.cursor.eat_char('_') {
+            if self.eat_ascii(b"_").is_some() {
                 return self.push_error(LexicalError::new(
                     LexicalErrorType::OtherError("Invalid Syntax".to_string().into_boxed_str()),
                     TextRange::new(self.offset() - TextSize::new(1), self.offset()),
@@ -1173,9 +1184,9 @@ impl<'src> Lexer<'src> {
         let is_float = match self.cursor.rest().as_bytes() {
             [b'e' | b'E', b'0'..=b'9', ..] | [b'e' | b'E', b'-' | b'+', b'0'..=b'9', ..] => {
                 // 'e' | 'E'
-                number.push(self.cursor.bump().unwrap());
+                number.push(self.eat_ascii(b"eE").unwrap());
 
-                if let Some(sign) = self.cursor.eat_if(|c| matches!(c, '+' | '-')) {
+                if let Some(sign) = self.eat_ascii(b"+-") {
                     number.push(sign);
                 }
 
@@ -1198,7 +1209,7 @@ impl<'src> Lexer<'src> {
             };
 
             // Parse trailing 'j':
-            if self.cursor.eat_if(|c| matches!(c, 'j' | 'J')).is_some() {
+            if self.eat_ascii(b"jJ").is_some() {
                 self.current_value = TokenValue::Complex {
                     real: 0.0,
                     imag: value,
@@ -1210,7 +1221,7 @@ impl<'src> Lexer<'src> {
             }
         } else {
             // Parse trailing 'j':
-            if self.cursor.eat_if(|c| matches!(c, 'j' | 'J')).is_some() {
+            if self.eat_ascii(b"jJ").is_some() {
                 let imag = f64::from_str(number.as_str()).unwrap();
                 self.current_value = TokenValue::Complex { real: 0.0, imag };
                 TokenKind::Complex
@@ -2195,6 +2206,11 @@ def f(arg=%timeit a = b):
     fn test_numbers() {
         let source = "0x2f 0o12 0b1101 0 123 123_45_67_890 0.2 1e+2 2.1e3 2j 2.2j 000 0x995DC9BBDF1939FA 0x995DC9BBDF1939FA995DC9BBDF1939FA";
         assert_snapshot!(lex_source(source));
+    }
+
+    #[test]
+    fn test_invalid_fractional_separator() {
+        assert_snapshot!(lex_invalid("0._1", Mode::Module));
     }
 
     #[test]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__invalid_fractional_separator.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__invalid_fractional_separator.snap
@@ -1,0 +1,34 @@
+---
+source: crates/ruff_python_parser/src/lexer.rs
+expression: "lex_invalid(\"0._1\", Mode::Module)"
+---
+## Tokens
+```
+[
+    (
+        Unknown,
+        2..3,
+    ),
+    (
+        Int(
+            1,
+        ),
+        3..4,
+    ),
+    (
+        Newline,
+        4..4,
+    ),
+]
+```
+## Errors
+```
+[
+    LexicalError {
+        error: OtherError(
+            "Invalid Syntax",
+        ),
+        location: 2..3,
+    },
+]
+```


### PR DESCRIPTION
## Summary

This is the ASCII numeric-probe experiment for CodSpeed. Numeric token dispatch only accepts ASCII marker bytes, but currently probes them through UTF-8-capable character operations. This change uses a byte-oriented helper for the `0x`/`0o`/`0b`, `.`, `_`, exponent, sign, and `j`/`J` probes.

This intentionally does not include the separate `radix_run` byte-scanning experiment.

### Profiling assembly

Generated on `origin/main` and this branch with:

```console
cargo rustc --profile profiling -p ruff_python_parser --lib -- --emit=asm
```

| Symbol | Variant | Instructions | Branches | Loads | UTF-8 high-bit dispatches |
| --- | ---: | ---: | ---: | ---: | ---: |
| `next_token` | `main` | 2638 | 731 | 313 | 17 |
| `next_token` | this PR | 2525 | 709 | 305 | 14 |
| `lex_decimal_number` | `main` | 811 | 230 | 113 | 5 |
| `lex_decimal_number` | this PR | 679 | 202 | 101 | 0 |

The three removed high-bit dispatches in `next_token` are the inlined numeric-prefix probes. The five removed dispatches in `lex_decimal_number` are the ASCII-only decimal and imaginary probes. `radix_run` remains unchanged at 292 instructions, 90 branches, 28 loads, and one high-bit dispatch in both assemblies.

CodSpeed results are requested because local wall-clock benchmark timing is unreliable while this system is CPU-contended.

## Test Plan

- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ruff_python_parser`
- `uvx prek run --files crates/ruff_python_parser/src/lexer.rs crates/ruff_python_parser/src/snapshots/ruff_python_parser__lexer__tests__invalid_fractional_separator.snap`
- `git diff --check`
- `cargo rustc --profile profiling -p ruff_python_parser --lib -- --emit=asm` and inspect the affected symbols as reported above
