### PR TITLE
View Codspeed benchmarks

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -342,6 +342,7 @@ impl<'src> Parser<'src> {
     /// is valid in that context. For example, a unary operator is not valid
     /// in an `await` expression in which case the `left_precedence` would
     /// be [`OperatorPrecedence::Await`].
+    #[inline(never)]
     fn parse_lhs_expression(
         &mut self,
         left_precedence: OperatorPrecedence,
@@ -352,6 +353,16 @@ impl<'src> Parser<'src> {
             return self.parse_lhs_expression_inner(left_precedence, context, token);
         }
 
+        self.parse_recursive_lhs_expression(left_precedence, context, token)
+    }
+
+    #[inline(never)]
+    fn parse_recursive_lhs_expression(
+        &mut self,
+        left_precedence: OperatorPrecedence,
+        context: ExpressionContext,
+        token: TokenKind,
+    ) -> ParsedExpr {
         if let Some(result) = self.with_recursion(|parser| {
             parser.parse_lhs_expression_inner(left_precedence, context, token)
         }) {


### PR DESCRIPTION
## Summary

- Measure Codspeed impact of outlining recursive expression parsing.