### PR TITLE
Reduce memory usage by dropping token-excess capacity and improve performance by approximating the initial tokens vec size

### DIFF
--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -265,6 +265,6 @@ pub(crate) struct TokenSourceCheckpoint {
 ///
 /// See [#9546](https://github.com/astral-sh/ruff/pull/9546) for a more detailed explanation.
 fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
-    let lower_bound = contents.len().saturating_mul(5) / 100;
+    let lower_bound = contents.len().saturating_mul(10) / 100;
     Vec::with_capacity(lower_bound)
 }

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -265,6 +265,6 @@ pub(crate) struct TokenSourceCheckpoint {
 ///
 /// See [#9546](https://github.com/astral-sh/ruff/pull/9546) for a more detailed explanation.
 fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
-    let lower_bound = contents.len().saturating_mul(15) / 100;
+    let lower_bound = contents.len().saturating_mul(5) / 100;
     Vec::with_capacity(lower_bound)
 }

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -249,6 +249,8 @@ impl<'src> TokenSource<'src> {
             assert_eq!(last.kind(), TokenKind::EndOfFile);
         }
 
+        self.tokens.shrink_to_fit();
+
         (self.tokens, self.lexer.finish())
     }
 }

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -21,17 +21,17 @@ pub(crate) struct TokenSource<'src> {
 
 impl<'src> TokenSource<'src> {
     /// Create a new token source for the given lexer.
-    pub(crate) fn new(lexer: Lexer<'src>, source: &str) -> Self {
+    pub(crate) fn new(lexer: Lexer<'src>, source: &str, start_offset: TextSize) -> Self {
         TokenSource {
             lexer,
-            tokens: allocate_tokens_vec(source),
+            tokens: allocate_tokens_vec(&source[start_offset.to_usize()..]),
         }
     }
 
     /// Create a new token source from the given source code which starts at the given offset.
     pub(crate) fn from_source(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
         let lexer = Lexer::new(source, mode, start_offset);
-        let mut source = TokenSource::new(lexer, source);
+        let mut source = TokenSource::new(lexer, source, start_offset);
 
         // Initialize the token source so that the current token is set correctly.
         source.do_bump();
@@ -267,4 +267,25 @@ pub(crate) struct TokenSourceCheckpoint {
 fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
     let lower_bound = contents.len().saturating_mul(15) / 100;
     Vec::with_capacity(lower_bound)
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_text_size::TextSize;
+
+    use super::{TokenSource, allocate_tokens_vec};
+    use crate::Mode;
+
+    #[test]
+    fn initial_capacity_excludes_source_before_start_offset() {
+        let source = format!("{}value", " ".repeat(1_000));
+        let start_offset = TextSize::new(1_000);
+        let token_source = TokenSource::from_source(&source, Mode::Expression, start_offset);
+
+        assert_eq!(
+            token_source.tokens.capacity(),
+            allocate_tokens_vec(&source[start_offset.to_usize()..]).capacity()
+        );
+        assert!(token_source.tokens.capacity() < allocate_tokens_vec(&source).capacity());
+    }
 }

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -260,11 +260,20 @@ pub(crate) struct TokenSourceCheckpoint {
     tokens_position: usize,
 }
 
-/// Allocates a [`Vec`] with an approximated capacity to fit all tokens
-/// of `contents`.
-///
-/// See [#9546](https://github.com/astral-sh/ruff/pull/9546) for a more detailed explanation.
+/// Allocates a token buffer with a capacity intended to skip early grows.
 fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
-    let lower_bound = contents.len().saturating_mul(15) / 100;
-    Vec::with_capacity(lower_bound)
+    // In sampled ruff-ecosystem projects, about three quarters of Python files contain at least
+    // one token per eight source bytes. Intentionally underestimate the final token count to avoid
+    // over-reserving for token-sparse files.
+    const BYTES_PER_PREALLOCATED_TOKEN: usize = 8;
+    const MIN_INITIAL_CAPACITY: usize = 128;
+
+    let capacity_hint = contents.len() / BYTES_PER_PREALLOCATED_TOKEN;
+    if capacity_hint < MIN_INITIAL_CAPACITY {
+        return Vec::new();
+    }
+
+    // Stay on a power-of-two bucket so that later geometric growth does not preserve an
+    // arbitrary capacity offset.
+    Vec::with_capacity(1 << capacity_hint.ilog2())
 }

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -21,18 +21,17 @@ pub(crate) struct TokenSource<'src> {
 
 impl<'src> TokenSource<'src> {
     /// Create a new token source for the given lexer.
-    pub(crate) fn new(lexer: Lexer<'src>) -> Self {
-        // TODO(dhruvmanila): Use `allocate_tokens_vec`
+    pub(crate) fn new(lexer: Lexer<'src>, source: &str) -> Self {
         TokenSource {
             lexer,
-            tokens: vec![],
+            tokens: allocate_tokens_vec(source),
         }
     }
 
     /// Create a new token source from the given source code which starts at the given offset.
     pub(crate) fn from_source(source: &'src str, mode: Mode, start_offset: TextSize) -> Self {
         let lexer = Lexer::new(source, mode, start_offset);
-        let mut source = TokenSource::new(lexer);
+        let mut source = TokenSource::new(lexer, source);
 
         // Initialize the token source so that the current token is set correctly.
         source.do_bump();
@@ -263,7 +262,6 @@ pub(crate) struct TokenSourceCheckpoint {
 /// of `contents`.
 ///
 /// See [#9546](https://github.com/astral-sh/ruff/pull/9546) for a more detailed explanation.
-#[expect(dead_code)]
 fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
     let lower_bound = contents.len().saturating_mul(15) / 100;
     Vec::with_capacity(lower_bound)

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -265,6 +265,6 @@ pub(crate) struct TokenSourceCheckpoint {
 ///
 /// See [#9546](https://github.com/astral-sh/ruff/pull/9546) for a more detailed explanation.
 fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
-    let lower_bound = contents.len().saturating_mul(10) / 100;
+    let lower_bound = contents.len().saturating_mul(15) / 100;
     Vec::with_capacity(lower_bound)
 }

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -268,24 +268,3 @@ fn allocate_tokens_vec(contents: &str) -> Vec<Token> {
     let lower_bound = contents.len().saturating_mul(15) / 100;
     Vec::with_capacity(lower_bound)
 }
-
-#[cfg(test)]
-mod tests {
-    use ruff_text_size::TextSize;
-
-    use super::{TokenSource, allocate_tokens_vec};
-    use crate::Mode;
-
-    #[test]
-    fn initial_capacity_excludes_source_before_start_offset() {
-        let source = format!("{}value", " ".repeat(1_000));
-        let start_offset = TextSize::new(1_000);
-        let token_source = TokenSource::from_source(&source, Mode::Expression, start_offset);
-
-        assert_eq!(
-            token_source.tokens.capacity(),
-            allocate_tokens_vec(&source[start_offset.to_usize()..]).capacity()
-        );
-        assert!(token_source.tokens.capacity() < allocate_tokens_vec(&source).capacity());
-    }
-}


### PR DESCRIPTION
## Summary

This PR plugs the existing `allocate_tokens_vec(contents)` heuristic into our parser. The idea of `allocate_tokens_vec` is to approximate the size of the allocations Vec based on the source text size instead of starting from an empty Vec, to reduce the number of regrows during lexing. Reducing the allocations helps with performance. However, this isn't a zero-cost optimization because it increases memory usage when we over-approximate. This PR adds a `shrink_to_fit` call once parsing's finished to mitigate the memory usage increase to peak-memory usage only. However, `shrink_to_fit` also isn't free; it can require a reallocation, depending on the amount of excess capacity. However, calling `shrink_to_fit` shows that it does reduce ty's memory usage.


The parser memory usage benchmarks look very concerning. I think they're a bit overdramatic. What they show is that peak memory usage increases, which is accurate. However, for most benchmarks, the number of allocations reduces. Which includes many ty full-project runs, which I consider more meaningful. 

For most benchmarks, performance increases by 1-2%. There are very few for which performance decreases by 1-2%. There are two parser benchmarks that stand out: One for which performance increases by 10% and one for which performance decreases by 5%. 

Overall, I'm leaning towards landing this change, because it allows us to reduce memory usage in ty, while still suggesting a small perf improvement over all.