### PR TITLE
View CodSpeed results

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -609,7 +609,7 @@ impl<'src> Lexer<'src> {
             }
             ',' => TokenKind::Comma,
             '.' => {
-                if self.cursor.first().is_ascii_digit() {
+                if matches!(self.cursor.rest().as_bytes().first(), Some(b'0'..=b'9')) {
                     self.lex_decimal_number('.')
                 } else if self.cursor.eat_char2('.', '.') {
                     TokenKind::Ellipsis


### PR DESCRIPTION
## Summary

- Test whether byte lookahead for the digit after `.` improves dot-prefixed number lexing.
- Avoid calling UTF-8-capable `Cursor::first()` solely to decide whether the next byte is an ASCII digit.
- Keep dot and ellipsis handling otherwise unchanged.

Profiling AArch64 assembly: the `.` arm replaces its `Cursor::first()` call with an EOF check plus `ldrb`; `next_token` changes from 2638 to 2640 instructions, 732 to 732 branch instructions, and 316 to 317 load instructions. This PR exists to measure whether removing the callee work from `.123` is beneficial in CodSpeed.

## Test Plan

- `cargo rustc --profile profiling -p ruff_python_parser --lib -- --emit=asm,llvm-ir` before and after the patch; inspected emitted AArch64 assembly.
- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ruff_python_parser`
- `uvx prek run --files crates/ruff_python_parser/src/lexer.rs`
- `git diff --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
