### PR TITLE
View CodSpeed results

### DIFF
--- a/crates/ruff_python_parser/src/lexer/cursor.rs
+++ b/crates/ruff_python_parser/src/lexer/cursor.rs
@@ -111,6 +111,25 @@ impl<'src> Cursor<'src> {
     }
 
     pub(super) fn eat_char2(&mut self, c1: char, c2: char) -> bool {
+        let bytes = self.chars.as_str().as_bytes();
+        if let Some(&first) = bytes.first()
+            && first.is_ascii()
+        {
+            if char::from(first) != c1 {
+                return false;
+            }
+            let Some(&second) = bytes.get(1) else {
+                return false;
+            };
+            if second.is_ascii() {
+                if char::from(second) != c2 {
+                    return false;
+                }
+                self.skip_bytes(2);
+                return true;
+            }
+        }
+
         let mut chars = self.chars.clone();
         if chars.next() == Some(c1) && chars.next() == Some(c2) {
             self.bump();


### PR DESCRIPTION
## Summary

- Measure an ASCII source-byte fast path in `Cursor::eat_char2` while preserving its Unicode fallback.
- Profiling assembly leaves `lex_string` unchanged and `next_token` effectively unchanged; the helper body grows for the fallback, while ordinary ASCII paths avoid iterator decode work.

## Test Plan

- `cargo rustc --profile profiling -p ruff_python_parser --lib -- --emit=asm,llvm-ir` (baseline and patch)
- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ruff_python_parser`
- `uvx prek run --files crates/ruff_python_parser/src/lexer/cursor.rs`
- `cargo clippy -p ruff_python_parser --all-targets --all-features -- -D warnings`
- `git diff --check`