### PR TITLE
Return code action for `codeAction/resolve` requests that contain no or no valid URL

### DIFF
--- a/crates/ruff_server/src/server/api.rs
+++ b/crates/ruff_server/src/server/api.rs
@@ -51,9 +51,9 @@ pub(super) fn request(req: server::Request) -> Task {
         request::CodeActions::METHOD => {
             background_request_task::<request::CodeActions>(req, BackgroundSchedule::Worker)
         }
-        request::CodeActionResolve::METHOD => background_session_request_task::<
-            request::CodeActionResolve,
-        >(req, BackgroundSchedule::Worker),
+        request::CodeActionResolve::METHOD => {
+            background_request_task::<request::CodeActionResolve>(req, BackgroundSchedule::Worker)
+        }
         request::DocumentDiagnostic::METHOD => {
             background_request_task::<request::DocumentDiagnostic>(req, BackgroundSchedule::Worker)
         }
@@ -156,15 +156,15 @@ where
     }))
 }
 
-fn background_request_task<R: traits::BackgroundDocumentRequestHandler>(
+fn background_request_task<R: traits::BackgroundRequestHandler>(
     req: server::Request,
     schedule: BackgroundSchedule,
 ) -> Result<Task>
 where
     <<R as RequestHandler>::RequestType as Request>::Params: UnwindSafe,
+    R::Snapshot: UnwindSafe,
 {
     let (id, params) = cast_request::<R>(req)?;
-    let url = R::document_url(&params).into_owned();
 
     Ok(Task::background(schedule, move |session: &Session| {
         let cancellation_token = session
@@ -173,10 +173,7 @@ where
             .cancellation_token(&id)
             .expect("request should have been tested for cancellation before scheduling");
 
-        let Some(snapshot) = session.take_snapshot(url.clone()) else {
-            tracing::warn!("Ignoring request because snapshot for path `{url:?}` doesn't exist.");
-            return Box::new(|_| {});
-        };
+        let snapshot = R::snapshot(session, &params);
 
         Box::new(move |client| {
             let _span = tracing::debug_span!("request", %id, method = R::METHOD).entered();
@@ -196,57 +193,6 @@ where
 
             let result =
                 std::panic::catch_unwind(|| R::run_with_snapshot(snapshot, client, params));
-
-            let response = request_result_to_response::<R>(result);
-            respond::<R>(&id, response, client);
-        })
-    }))
-}
-
-fn background_session_request_task<R: traits::BackgroundRequestHandler>(
-    req: server::Request,
-    schedule: BackgroundSchedule,
-) -> Result<Task>
-where
-    <<R as RequestHandler>::RequestType as Request>::Params: UnwindSafe,
-    R::BackgroundContext: UnwindSafe,
-{
-    let (id, params) = cast_request::<R>(req)?;
-
-    Ok(Task::background(schedule, move |session: &Session| {
-        let cancellation_token = session
-            .request_queue()
-            .incoming()
-            .cancellation_token(&id)
-            .expect("request should have been tested for cancellation before scheduling");
-
-        let context = match R::prepare(session, &params) {
-            Ok(Some(context)) => context,
-            Ok(None) => return Box::new(|_| {}),
-            Err(error) => {
-                return Box::new(move |client| {
-                    let result: Result<<<R as RequestHandler>::RequestType as Request>::Result> =
-                        Err(error);
-                    if let Err(err) = client.respond(&id, result) {
-                        tracing::error!("Failed to send response: {err}");
-                    }
-                });
-            }
-        };
-
-        Box::new(move |client| {
-            let _span = tracing::debug_span!("request", %id, method = R::METHOD).entered();
-
-            if cancellation_token.is_cancelled() {
-                tracing::trace!(
-                    "Ignoring request id={id} method={} because it was cancelled",
-                    R::METHOD
-                );
-                return;
-            }
-
-            let result = std::panic::catch_unwind(|| R::run_with_context(context, client, params));
-
             let response = request_result_to_response::<R>(result);
             respond::<R>(&id, response, client);
         })

--- a/crates/ruff_server/src/server/api.rs
+++ b/crates/ruff_server/src/server/api.rs
@@ -8,10 +8,7 @@ use requests as request;
 
 use crate::{
     server::{
-        api::traits::{
-            BackgroundDocumentNotificationHandler, BackgroundDocumentRequestHandler,
-            SyncNotificationHandler,
-        },
+        api::traits::{BackgroundDocumentNotificationHandler, SyncNotificationHandler},
         schedule::Task,
     },
     session::{Client, Session},
@@ -33,10 +30,8 @@ use super::{Result, schedule::BackgroundSchedule};
 /// that is of type [`lsp_types::Url`].
 macro_rules! define_document_url {
     ($params:ident: &$p:ty) => {
-        fn document_url(
-            $params: &$p,
-        ) -> crate::server::Result<std::borrow::Cow<'_, lsp_types::Url>> {
-            Ok(std::borrow::Cow::Borrowed(&$params.text_document.uri))
+        fn document_url($params: &$p) -> std::borrow::Cow<'_, lsp_types::Url> {
+            std::borrow::Cow::Borrowed(&$params.text_document.uri)
         }
     };
 }
@@ -56,9 +51,9 @@ pub(super) fn request(req: server::Request) -> Task {
         request::CodeActions::METHOD => {
             background_request_task::<request::CodeActions>(req, BackgroundSchedule::Worker)
         }
-        request::CodeActionResolve::METHOD => {
-            background_request_task::<request::CodeActionResolve>(req, BackgroundSchedule::Worker)
-        }
+        request::CodeActionResolve::METHOD => background_session_request_task::<
+            request::CodeActionResolve,
+        >(req, BackgroundSchedule::Worker),
         request::DocumentDiagnostic::METHOD => {
             background_request_task::<request::DocumentDiagnostic>(req, BackgroundSchedule::Worker)
         }
@@ -169,14 +164,7 @@ where
     <<R as RequestHandler>::RequestType as Request>::Params: UnwindSafe,
 {
     let (id, params) = cast_request::<R>(req)?;
-    let url = match R::document_url(&params) {
-        Ok(url) => url.into_owned(),
-        Err(error) => {
-            let result: Result<<<R as RequestHandler>::RequestType as Request>::Result> =
-                Err(error);
-            return Ok(Task::immediate(id, result));
-        }
-    };
+    let url = R::document_url(&params).into_owned();
 
     Ok(Task::background(schedule, move |session: &Session| {
         let cancellation_token = session
@@ -215,6 +203,56 @@ where
     }))
 }
 
+fn background_session_request_task<R: traits::BackgroundRequestHandler>(
+    req: server::Request,
+    schedule: BackgroundSchedule,
+) -> Result<Task>
+where
+    <<R as RequestHandler>::RequestType as Request>::Params: UnwindSafe,
+    R::BackgroundContext: UnwindSafe,
+{
+    let (id, params) = cast_request::<R>(req)?;
+
+    Ok(Task::background(schedule, move |session: &Session| {
+        let cancellation_token = session
+            .request_queue()
+            .incoming()
+            .cancellation_token(&id)
+            .expect("request should have been tested for cancellation before scheduling");
+
+        let context = match R::prepare(session, &params) {
+            Ok(Some(context)) => context,
+            Ok(None) => return Box::new(|_| {}),
+            Err(error) => {
+                return Box::new(move |client| {
+                    let result: Result<<<R as RequestHandler>::RequestType as Request>::Result> =
+                        Err(error);
+                    if let Err(err) = client.respond(&id, result) {
+                        tracing::error!("Failed to send response: {err}");
+                    }
+                });
+            }
+        };
+
+        Box::new(move |client| {
+            let _span = tracing::debug_span!("request", %id, method = R::METHOD).entered();
+
+            if cancellation_token.is_cancelled() {
+                tracing::trace!(
+                    "Ignoring request id={id} method={} because it was cancelled",
+                    R::METHOD
+                );
+                return;
+            }
+
+            let result = std::panic::catch_unwind(|| R::run_with_context(context, client, params));
+
+            let response = request_result_to_response::<R>(result);
+            respond::<R>(&id, response, client);
+        })
+    }))
+}
+
 fn request_result_to_response<R>(
     result: std::result::Result<
         Result<<<R as RequestHandler>::RequestType as Request>::Result>,
@@ -222,7 +260,7 @@ fn request_result_to_response<R>(
     >,
 ) -> Result<<<R as RequestHandler>::RequestType as Request>::Result>
 where
-    R: BackgroundDocumentRequestHandler,
+    R: RequestHandler,
 {
     match result {
         Ok(response) => response,

--- a/crates/ruff_server/src/server/api.rs
+++ b/crates/ruff_server/src/server/api.rs
@@ -26,15 +26,17 @@ use self::traits::{NotificationHandler, RequestHandler};
 
 use super::{Result, schedule::BackgroundSchedule};
 
-/// Defines the `document_url` method for implementers of [`Notification`] and [`Request`], given
-/// the request or notification parameter type.
+/// Defines the `document_url` method for implementers of [`Request`], given the request parameter
+/// type.
 ///
 /// This would only work if the parameter type has a `text_document` field with a `uri` field
 /// that is of type [`lsp_types::Url`].
 macro_rules! define_document_url {
     ($params:ident: &$p:ty) => {
-        fn document_url($params: &$p) -> std::borrow::Cow<'_, lsp_types::Url> {
-            std::borrow::Cow::Borrowed(&$params.text_document.uri)
+        fn document_url(
+            $params: &$p,
+        ) -> crate::server::Result<std::borrow::Cow<'_, lsp_types::Url>> {
+            Ok(std::borrow::Cow::Borrowed(&$params.text_document.uri))
         }
     };
 }
@@ -167,6 +169,14 @@ where
     <<R as RequestHandler>::RequestType as Request>::Params: UnwindSafe,
 {
     let (id, params) = cast_request::<R>(req)?;
+    let url = match R::document_url(&params) {
+        Ok(url) => url.into_owned(),
+        Err(error) => {
+            let result: Result<<<R as RequestHandler>::RequestType as Request>::Result> =
+                Err(error);
+            return Ok(Task::immediate(id, result));
+        }
+    };
 
     Ok(Task::background(schedule, move |session: &Session| {
         let cancellation_token = session
@@ -175,9 +185,7 @@ where
             .cancellation_token(&id)
             .expect("request should have been tested for cancellation before scheduling");
 
-        let url = R::document_url(&params).into_owned();
-
-        let Some(snapshot) = session.take_snapshot(R::document_url(&params).into_owned()) else {
+        let Some(snapshot) = session.take_snapshot(url.clone()) else {
             tracing::warn!("Ignoring request because snapshot for path `{url:?}` doesn't exist.");
             return Box::new(|_| {});
         };

--- a/crates/ruff_server/src/server/api/requests.rs
+++ b/crates/ruff_server/src/server/api/requests.rs
@@ -9,7 +9,10 @@ mod shutdown;
 
 use super::{
     define_document_url,
-    traits::{BackgroundDocumentRequestHandler, RequestHandler, SyncRequestHandler},
+    traits::{
+        BackgroundDocumentRequestHandler, BackgroundRequestHandler, RequestHandler,
+        SyncRequestHandler,
+    },
 };
 pub(super) use code_action::CodeActions;
 pub(super) use code_action_resolve::CodeActionResolve;

--- a/crates/ruff_server/src/server/api/requests/code_action.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action.rs
@@ -23,11 +23,20 @@ impl super::RequestHandler for CodeActions {
 
 impl super::BackgroundDocumentRequestHandler for CodeActions {
     super::define_document_url!(params: &types::CodeActionParams);
+
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         _client: &Client,
         params: types::CodeActionParams,
     ) -> Result<Option<types::CodeActionResponse>> {
+        let snapshot = match snapshot {
+            Ok(snapshot) => snapshot,
+            Err(url) => {
+                tracing::warn!("Returning no code actions because document `{url}` isn't open.");
+                return Ok(None);
+            }
+        };
+
         let mut response: types::CodeActionResponse = types::CodeActionResponse::default();
 
         let query = snapshot.query();

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -19,30 +19,25 @@ impl super::RequestHandler for CodeActionResolve {
 }
 
 impl super::BackgroundRequestHandler for CodeActionResolve {
-    type BackgroundContext = DocumentSnapshot;
+    type Snapshot = Option<DocumentSnapshot>;
 
-    fn prepare(
-        session: &Session,
-        params: &types::CodeAction,
-    ) -> crate::server::Result<Option<Self::BackgroundContext>> {
-        let data = params
+    fn snapshot(session: &Session, action: &types::CodeAction) -> Self::Snapshot {
+        action
             .data
             .clone()
-            .ok_or_else(|| anyhow::anyhow!("Code action is missing Ruff's document URI payload"))
-            .with_failure_code(ErrorCode::InternalError)?;
-        let uri: lsp_types::Url = serde_json::from_value(data)
-            .map_err(|err| {
-                anyhow::anyhow!("Code action has an invalid Ruff document URI payload: {err}")
-            })
-            .with_failure_code(ErrorCode::InternalError)?;
-        Ok(session.take_snapshot(uri))
+            .and_then(|data| serde_json::from_value(data).ok())
+            .and_then(|uri| session.take_snapshot(uri))
     }
 
-    fn run_with_context(
-        snapshot: Self::BackgroundContext,
+    fn run_with_snapshot(
+        snapshot: Self::Snapshot,
         _client: &Client,
         mut action: types::CodeAction,
     ) -> Result<types::CodeAction> {
+        let Some(snapshot) = snapshot else {
+            return Ok(action);
+        };
+
         let query = snapshot.query();
 
         let code_actions = SupportedCodeAction::from_kind(

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use lsp_server::ErrorCode;
 use lsp_types::{self as types, request as req};
 
@@ -12,7 +10,7 @@ use crate::server::Result;
 use crate::server::SupportedCodeAction;
 use crate::server::api::LSPResult;
 use crate::session::Client;
-use crate::session::{DocumentQuery, DocumentSnapshot, ResolvedClientCapabilities};
+use crate::session::{DocumentQuery, DocumentSnapshot, ResolvedClientCapabilities, Session};
 
 pub(crate) struct CodeActionResolve;
 
@@ -20,20 +18,28 @@ impl super::RequestHandler for CodeActionResolve {
     type RequestType = req::CodeActionResolveRequest;
 }
 
-impl super::BackgroundDocumentRequestHandler for CodeActionResolve {
-    fn document_url(params: &types::CodeAction) -> crate::server::Result<Cow<'_, types::Url>> {
+impl super::BackgroundRequestHandler for CodeActionResolve {
+    type BackgroundContext = DocumentSnapshot;
+
+    fn prepare(
+        session: &Session,
+        params: &types::CodeAction,
+    ) -> crate::server::Result<Option<Self::BackgroundContext>> {
         let data = params
             .data
             .clone()
-            .ok_or_else(|| anyhow::anyhow!("Code action is missing its document URI"))
-            .with_failure_code(ErrorCode::InvalidParams)?;
+            .ok_or_else(|| anyhow::anyhow!("Code action is missing Ruff's document URI payload"))
+            .with_failure_code(ErrorCode::InternalError)?;
         let uri: lsp_types::Url = serde_json::from_value(data)
-            .map_err(|err| anyhow::anyhow!("Code action has an invalid document URI: {err}"))
-            .with_failure_code(ErrorCode::InvalidParams)?;
-        Ok(Cow::Owned(uri))
+            .map_err(|err| {
+                anyhow::anyhow!("Code action has an invalid Ruff document URI payload: {err}")
+            })
+            .with_failure_code(ErrorCode::InternalError)?;
+        Ok(session.take_snapshot(uri))
     }
-    fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+
+    fn run_with_context(
+        snapshot: Self::BackgroundContext,
         _client: &Client,
         mut action: types::CodeAction,
     ) -> Result<types::CodeAction> {

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -21,10 +21,16 @@ impl super::RequestHandler for CodeActionResolve {
 }
 
 impl super::BackgroundDocumentRequestHandler for CodeActionResolve {
-    fn document_url(params: &types::CodeAction) -> Cow<'_, types::Url> {
-        let uri: lsp_types::Url = serde_json::from_value(params.data.clone().unwrap_or_default())
-            .expect("code actions should have a URI in their data fields");
-        Cow::Owned(uri)
+    fn document_url(params: &types::CodeAction) -> crate::server::Result<Cow<'_, types::Url>> {
+        let data = params
+            .data
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Code action is missing its document URI"))
+            .with_failure_code(ErrorCode::InvalidParams)?;
+        let uri: lsp_types::Url = serde_json::from_value(data)
+            .map_err(|err| anyhow::anyhow!("Code action has an invalid document URI: {err}"))
+            .with_failure_code(ErrorCode::InvalidParams)?;
+        Ok(Cow::Owned(uri))
     }
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,

--- a/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/ruff_server/src/server/api/requests/code_action_resolve.rs
@@ -19,14 +19,20 @@ impl super::RequestHandler for CodeActionResolve {
 }
 
 impl super::BackgroundRequestHandler for CodeActionResolve {
-    type Snapshot = Option<DocumentSnapshot>;
+    type Snapshot = std::result::Result<DocumentSnapshot, String>;
 
     fn snapshot(session: &Session, action: &types::CodeAction) -> Self::Snapshot {
-        action
+        let data = action
             .data
             .clone()
-            .and_then(|data| serde_json::from_value(data).ok())
-            .and_then(|uri| session.take_snapshot(uri))
+            .ok_or_else(|| "it doesn't contain Ruff's document URI payload".to_string())?;
+
+        let uri: lsp_types::Url = serde_json::from_value(data)
+            .map_err(|err| format!("its Ruff document URI payload is invalid: {err}"))?;
+
+        session
+            .take_snapshot(uri.clone())
+            .ok_or_else(|| format!("document `{uri}` isn't open"))
     }
 
     fn run_with_snapshot(
@@ -34,8 +40,12 @@ impl super::BackgroundRequestHandler for CodeActionResolve {
         _client: &Client,
         mut action: types::CodeAction,
     ) -> Result<types::CodeAction> {
-        let Some(snapshot) = snapshot else {
-            return Ok(action);
+        let snapshot = match snapshot {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                tracing::warn!("Returning code action unchanged because {err}.");
+                return Ok(action);
+            }
         };
 
         let query = snapshot.query();

--- a/crates/ruff_server/src/server/api/requests/diagnostic.rs
+++ b/crates/ruff_server/src/server/api/requests/diagnostic.rs
@@ -1,5 +1,4 @@
 use crate::server::api::diagnostics::generate_diagnostics;
-use crate::session::DocumentSnapshot;
 use crate::{server::Result, session::Client};
 use lsp_types::{self as types, request as req};
 use types::{
@@ -15,11 +14,24 @@ impl super::RequestHandler for DocumentDiagnostic {
 
 impl super::BackgroundDocumentRequestHandler for DocumentDiagnostic {
     super::define_document_url!(params: &types::DocumentDiagnosticParams);
+
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         _client: &Client,
         _params: types::DocumentDiagnosticParams,
     ) -> Result<DocumentDiagnosticReportResult> {
+        let diagnostics = match snapshot {
+            Ok(snapshot) => generate_diagnostics(&snapshot)
+                .into_iter()
+                .next()
+                .map(|(_, diagnostics)| diagnostics)
+                .unwrap_or_default(),
+            Err(url) => {
+                tracing::warn!("Returning no diagnostics because document `{url}` isn't open.");
+                Vec::new()
+            }
+        };
+
         Ok(DocumentDiagnosticReportResult::Report(
             types::DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
                 related_documents: None,
@@ -28,11 +40,7 @@ impl super::BackgroundDocumentRequestHandler for DocumentDiagnostic {
                     result_id: None,
                     // Pull diagnostic requests are only called for text documents.
                     // Since diagnostic requests generate
-                    items: generate_diagnostics(&snapshot)
-                        .into_iter()
-                        .next()
-                        .map(|(_, diagnostics)| diagnostics)
-                        .unwrap_or_default(),
+                    items: diagnostics,
                 },
             }),
         ))

--- a/crates/ruff_server/src/server/api/requests/format.rs
+++ b/crates/ruff_server/src/server/api/requests/format.rs
@@ -21,11 +21,22 @@ impl super::RequestHandler for Format {
 
 impl super::BackgroundDocumentRequestHandler for Format {
     super::define_document_url!(params: &types::DocumentFormattingParams);
+
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         client: &Client,
         _params: types::DocumentFormattingParams,
     ) -> Result<super::FormatResponse> {
+        let snapshot = match snapshot {
+            Ok(snapshot) => snapshot,
+            Err(url) => {
+                tracing::warn!(
+                    "Returning no formatting edits because document `{url}` isn't open."
+                );
+                return Ok(None);
+            }
+        };
+
         format_document(&snapshot, client)
     }
 }

--- a/crates/ruff_server/src/server/api/requests/format_range.rs
+++ b/crates/ruff_server/src/server/api/requests/format_range.rs
@@ -16,11 +16,22 @@ impl super::RequestHandler for FormatRange {
 
 impl super::BackgroundDocumentRequestHandler for FormatRange {
     super::define_document_url!(params: &types::DocumentRangeFormattingParams);
+
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         _client: &Client,
         params: types::DocumentRangeFormattingParams,
     ) -> Result<super::FormatResponse> {
+        let snapshot = match snapshot {
+            Ok(snapshot) => snapshot,
+            Err(url) => {
+                tracing::warn!(
+                    "Returning no range formatting edits because document `{url}` isn't open."
+                );
+                return Ok(None);
+            }
+        };
+
         format_document_range(&snapshot, params.range)
     }
 }

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -16,8 +16,12 @@ impl super::RequestHandler for Hover {
 }
 
 impl super::BackgroundDocumentRequestHandler for Hover {
-    fn document_url(params: &types::HoverParams) -> std::borrow::Cow<'_, lsp_types::Url> {
-        std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
+    fn document_url(
+        params: &types::HoverParams,
+    ) -> crate::server::Result<std::borrow::Cow<'_, lsp_types::Url>> {
+        Ok(std::borrow::Cow::Borrowed(
+            &params.text_document_position_params.text_document.uri,
+        ))
     }
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -19,11 +19,22 @@ impl super::BackgroundDocumentRequestHandler for Hover {
     fn document_url(params: &types::HoverParams) -> std::borrow::Cow<'_, lsp_types::Url> {
         std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
+
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         _client: &Client,
         params: types::HoverParams,
     ) -> Result<Option<types::Hover>> {
+        let snapshot = match snapshot {
+            Ok(snapshot) => snapshot,
+            Err(url) => {
+                tracing::warn!(
+                    "Returning no hover information because document `{url}` isn't open."
+                );
+                return Ok(None);
+            }
+        };
+
         Ok(hover(&snapshot, &params.text_document_position_params))
     }
 }

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -16,12 +16,8 @@ impl super::RequestHandler for Hover {
 }
 
 impl super::BackgroundDocumentRequestHandler for Hover {
-    fn document_url(
-        params: &types::HoverParams,
-    ) -> crate::server::Result<std::borrow::Cow<'_, lsp_types::Url>> {
-        Ok(std::borrow::Cow::Borrowed(
-            &params.text_document_position_params.text_document.uri,
-        ))
+    fn document_url(params: &types::HoverParams) -> std::borrow::Cow<'_, lsp_types::Url> {
+        std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,

--- a/crates/ruff_server/src/server/api/traits.rs
+++ b/crates/ruff_server/src/server/api/traits.rs
@@ -62,7 +62,7 @@ pub(super) trait BackgroundDocumentRequestHandler: RequestHandler {
     /// [`define_document_url`]: super::define_document_url
     fn document_url(
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
-    ) -> std::borrow::Cow<'_, lsp_types::Url>;
+    ) -> crate::server::Result<std::borrow::Cow<'_, lsp_types::Url>>;
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,

--- a/crates/ruff_server/src/server/api/traits.rs
+++ b/crates/ruff_server/src/server/api/traits.rs
@@ -55,17 +55,17 @@ pub(super) trait SyncRequestHandler: RequestHandler {
 ///
 /// Unlike [`BackgroundDocumentRequestHandler`], this handler does not assume that it can derive a
 /// document URL from the LSP request parameters. Implementations are responsible for extracting
-/// any state they need from the [`Session`] during [`Self::prepare`].
+/// any state they need from the [`Session`] during [`Self::snapshot`].
 pub(super) trait BackgroundRequestHandler: RequestHandler {
-    type BackgroundContext: Send + 'static;
+    type Snapshot: Send + 'static;
 
-    fn prepare(
+    fn snapshot(
         session: &Session,
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
-    ) -> crate::server::Result<Option<Self::BackgroundContext>>;
+    ) -> Self::Snapshot;
 
-    fn run_with_context(
-        context: Self::BackgroundContext,
+    fn run_with_snapshot(
+        snapshot: Self::Snapshot,
         client: &Client,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> super::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
@@ -74,7 +74,9 @@ pub(super) trait BackgroundRequestHandler: RequestHandler {
 /// A request handler that can be run on a background thread.
 ///
 /// This handler is specific to requests that operate on a single document.
-pub(super) trait BackgroundDocumentRequestHandler: RequestHandler {
+pub(super) trait BackgroundDocumentRequestHandler:
+    BackgroundRequestHandler<Snapshot = std::result::Result<DocumentSnapshot, lsp_types::Url>>
+{
     /// Returns the URL of the document that this request handler operates on.
     ///
     /// This method can be implemented automatically using the [`define_document_url`] macro.
@@ -85,10 +87,33 @@ pub(super) trait BackgroundDocumentRequestHandler: RequestHandler {
     ) -> std::borrow::Cow<'_, lsp_types::Url>;
 
     fn run_with_snapshot(
-        snapshot: DocumentSnapshot,
+        snapshot: Self::Snapshot,
         client: &Client,
         params: <<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> super::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
+}
+
+impl<T> BackgroundRequestHandler for T
+where
+    T: BackgroundDocumentRequestHandler,
+{
+    type Snapshot = std::result::Result<DocumentSnapshot, lsp_types::Url>;
+
+    fn snapshot(
+        session: &Session,
+        params: &<<Self as RequestHandler>::RequestType as Request>::Params,
+    ) -> Self::Snapshot {
+        let url = Self::document_url(params).into_owned();
+        session.take_snapshot(url.clone()).ok_or(url)
+    }
+
+    fn run_with_snapshot(
+        snapshot: Self::Snapshot,
+        client: &Client,
+        params: <<Self as RequestHandler>::RequestType as Request>::Params,
+    ) -> super::Result<<<Self as RequestHandler>::RequestType as Request>::Result> {
+        <T as BackgroundDocumentRequestHandler>::run_with_snapshot(snapshot, client, params)
+    }
 }
 
 /// A supertrait for any server notification handler.

--- a/crates/ruff_server/src/server/api/traits.rs
+++ b/crates/ruff_server/src/server/api/traits.rs
@@ -53,6 +53,26 @@ pub(super) trait SyncRequestHandler: RequestHandler {
 
 /// A request handler that can be run on a background thread.
 ///
+/// Unlike [`BackgroundDocumentRequestHandler`], this handler does not assume that it can derive a
+/// document URL from the LSP request parameters. Implementations are responsible for extracting
+/// any state they need from the [`Session`] during [`Self::prepare`].
+pub(super) trait BackgroundRequestHandler: RequestHandler {
+    type BackgroundContext: Send + 'static;
+
+    fn prepare(
+        session: &Session,
+        params: &<<Self as RequestHandler>::RequestType as Request>::Params,
+    ) -> crate::server::Result<Option<Self::BackgroundContext>>;
+
+    fn run_with_context(
+        context: Self::BackgroundContext,
+        client: &Client,
+        params: <<Self as RequestHandler>::RequestType as Request>::Params,
+    ) -> super::Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
+}
+
+/// A request handler that can be run on a background thread.
+///
 /// This handler is specific to requests that operate on a single document.
 pub(super) trait BackgroundDocumentRequestHandler: RequestHandler {
     /// Returns the URL of the document that this request handler operates on.
@@ -62,7 +82,7 @@ pub(super) trait BackgroundDocumentRequestHandler: RequestHandler {
     /// [`define_document_url`]: super::define_document_url
     fn document_url(
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
-    ) -> crate::server::Result<std::borrow::Cow<'_, lsp_types::Url>>;
+    ) -> std::borrow::Cow<'_, lsp_types::Url>;
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,

--- a/crates/ruff_server/tests/e2e/code_action.rs
+++ b/crates/ruff_server/tests/e2e/code_action.rs
@@ -5,6 +5,22 @@ use lsp_types::{CodeAction, CodeActionKind, request::CodeActionResolveRequest};
 
 use crate::{AwaitResponseError, TestServerBuilder};
 
+fn assert_code_action_resolve_internal_error(
+    server: &mut crate::TestServer,
+    action: CodeAction,
+    expected_message: &str,
+) {
+    let request_id = server.send_request::<CodeActionResolveRequest>(action);
+
+    let error = match server.try_await_response::<CodeActionResolveRequest>(&request_id, None) {
+        Err(AwaitResponseError::RequestFailed(error)) => error,
+        result => panic!("Expected an InternalError response, got {result:?}"),
+    };
+
+    assert_eq!(error.code, ErrorCode::InternalError as i32);
+    assert_eq!(error.message, expected_message);
+}
+
 #[test]
 fn no_code_actions_for_markdown() -> Result<()> {
     let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
@@ -72,25 +88,47 @@ fn code_actions_for_python() -> Result<()> {
 }
 
 #[test]
-fn invalid_code_action_resolve_data_returns_invalid_params() -> Result<()> {
+fn missing_code_action_resolve_data_returns_internal_error() -> Result<()> {
     let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
 
-    let request_id = server.send_request::<CodeActionResolveRequest>(CodeAction {
+    let action = CodeAction {
         title: "Ruff: Fix all auto-fixable problems".to_string(),
         kind: Some(CodeActionKind::from("source.fixAll.ruff")),
         ..Default::default()
-    });
+    };
+
+    assert_code_action_resolve_internal_error(
+        &mut server,
+        action,
+        "Code action is missing Ruff's document URI payload",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn invalid_code_action_resolve_data_returns_internal_error() -> Result<()> {
+    let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
+
+    let action = CodeAction {
+        title: "Ruff: Fix all auto-fixable problems".to_string(),
+        kind: Some(CodeActionKind::from("source.fixAll.ruff")),
+        data: Some(serde_json::json!("not-a-url")),
+        ..Default::default()
+    };
+
+    let request_id = server.send_request::<CodeActionResolveRequest>(action);
 
     let error = match server.try_await_response::<CodeActionResolveRequest>(&request_id, None) {
         Err(AwaitResponseError::RequestFailed(error)) => error,
-        result => panic!("Expected an InvalidParams error response, got {result:?}"),
+        result => panic!("Expected an InternalError response, got {result:?}"),
     };
 
-    assert_eq!(error.code, ErrorCode::InvalidParams as i32);
+    assert_eq!(error.code, ErrorCode::InternalError as i32);
     assert_json_snapshot!(error, @r#"
     {
-      "code": -32602,
-      "message": "Code action is missing its document URI"
+      "code": -32603,
+      "message": "Code action has an invalid Ruff document URI payload: relative URL without a base: \"not-a-url\""
     }
     "#);
 

--- a/crates/ruff_server/tests/e2e/code_action.rs
+++ b/crates/ruff_server/tests/e2e/code_action.rs
@@ -79,12 +79,12 @@ fn code_actions_for_python() -> Result<()> {
 }
 
 #[test]
-fn missing_code_action_resolve_data_returns_unchanged_action() -> Result<()> {
+fn code_action_without_valid_url_returns_unchanged_action() -> Result<()> {
     let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
 
     let action = CodeAction {
-        title: "Ruff: Fix all auto-fixable problems".to_string(),
-        kind: Some(CodeActionKind::from("source.fixAll.ruff")),
+        title: "Some other code action".to_string(),
+        kind: Some(CodeActionKind::QUICKFIX),
         ..Default::default()
     };
 
@@ -101,22 +101,6 @@ fn invalid_code_action_resolve_data_returns_unchanged_action() -> Result<()> {
         title: "Ruff: Fix all auto-fixable problems".to_string(),
         kind: Some(CodeActionKind::from("source.fixAll.ruff")),
         data: Some(serde_json::json!("not-a-url")),
-        ..Default::default()
-    };
-
-    assert_code_action_resolve_unchanged(&mut server, &action);
-
-    Ok(())
-}
-
-#[test]
-fn unavailable_code_action_resolve_document_returns_unchanged_action() -> Result<()> {
-    let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
-
-    let action = CodeAction {
-        title: "Ruff: Fix all auto-fixable problems".to_string(),
-        kind: Some(CodeActionKind::from("source.fixAll.ruff")),
-        data: Some(serde_json::to_value(server.file_uri("not-open.py"))?),
         ..Default::default()
     };
 

--- a/crates/ruff_server/tests/e2e/code_action.rs
+++ b/crates/ruff_server/tests/e2e/code_action.rs
@@ -1,24 +1,15 @@
 use anyhow::Result;
 use insta::assert_json_snapshot;
-use lsp_server::ErrorCode;
 use lsp_types::{CodeAction, CodeActionKind, request::CodeActionResolveRequest};
 
-use crate::{AwaitResponseError, TestServerBuilder};
+use crate::TestServerBuilder;
 
-fn assert_code_action_resolve_internal_error(
-    server: &mut crate::TestServer,
-    action: CodeAction,
-    expected_message: &str,
-) {
-    let request_id = server.send_request::<CodeActionResolveRequest>(action);
-
-    let error = match server.try_await_response::<CodeActionResolveRequest>(&request_id, None) {
-        Err(AwaitResponseError::RequestFailed(error)) => error,
-        result => panic!("Expected an InternalError response, got {result:?}"),
-    };
-
-    assert_eq!(error.code, ErrorCode::InternalError as i32);
-    assert_eq!(error.message, expected_message);
+fn assert_code_action_resolve_unchanged(server: &mut crate::TestServer, action: &CodeAction) {
+    let request_id = server.send_request::<CodeActionResolveRequest>(action.clone());
+    assert_eq!(
+        &server.await_response::<CodeActionResolveRequest>(&request_id),
+        action
+    );
 }
 
 #[test]
@@ -88,7 +79,7 @@ fn code_actions_for_python() -> Result<()> {
 }
 
 #[test]
-fn missing_code_action_resolve_data_returns_internal_error() -> Result<()> {
+fn missing_code_action_resolve_data_returns_unchanged_action() -> Result<()> {
     let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
 
     let action = CodeAction {
@@ -97,17 +88,13 @@ fn missing_code_action_resolve_data_returns_internal_error() -> Result<()> {
         ..Default::default()
     };
 
-    assert_code_action_resolve_internal_error(
-        &mut server,
-        action,
-        "Code action is missing Ruff's document URI payload",
-    );
+    assert_code_action_resolve_unchanged(&mut server, &action);
 
     Ok(())
 }
 
 #[test]
-fn invalid_code_action_resolve_data_returns_internal_error() -> Result<()> {
+fn invalid_code_action_resolve_data_returns_unchanged_action() -> Result<()> {
     let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
 
     let action = CodeAction {
@@ -117,20 +104,23 @@ fn invalid_code_action_resolve_data_returns_internal_error() -> Result<()> {
         ..Default::default()
     };
 
-    let request_id = server.send_request::<CodeActionResolveRequest>(action);
+    assert_code_action_resolve_unchanged(&mut server, &action);
 
-    let error = match server.try_await_response::<CodeActionResolveRequest>(&request_id, None) {
-        Err(AwaitResponseError::RequestFailed(error)) => error,
-        result => panic!("Expected an InternalError response, got {result:?}"),
+    Ok(())
+}
+
+#[test]
+fn unavailable_code_action_resolve_document_returns_unchanged_action() -> Result<()> {
+    let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
+
+    let action = CodeAction {
+        title: "Ruff: Fix all auto-fixable problems".to_string(),
+        kind: Some(CodeActionKind::from("source.fixAll.ruff")),
+        data: Some(serde_json::to_value(server.file_uri("not-open.py"))?),
+        ..Default::default()
     };
 
-    assert_eq!(error.code, ErrorCode::InternalError as i32);
-    assert_json_snapshot!(error, @r#"
-    {
-      "code": -32603,
-      "message": "Code action has an invalid Ruff document URI payload: relative URL without a base: \"not-a-url\""
-    }
-    "#);
+    assert_code_action_resolve_unchanged(&mut server, &action);
 
     Ok(())
 }

--- a/crates/ruff_server/tests/e2e/code_action.rs
+++ b/crates/ruff_server/tests/e2e/code_action.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use insta::assert_json_snapshot;
+use lsp_server::ErrorCode;
+use lsp_types::{CodeAction, CodeActionKind, request::CodeActionResolveRequest};
 
-use crate::TestServerBuilder;
+use crate::{AwaitResponseError, TestServerBuilder};
 
 #[test]
 fn no_code_actions_for_markdown() -> Result<()> {
@@ -65,6 +67,32 @@ fn code_actions_for_python() -> Result<()> {
     ]
     "#
     );
+
+    Ok(())
+}
+
+#[test]
+fn invalid_code_action_resolve_data_returns_invalid_params() -> Result<()> {
+    let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
+
+    let request_id = server.send_request::<CodeActionResolveRequest>(CodeAction {
+        title: "Ruff: Fix all auto-fixable problems".to_string(),
+        kind: Some(CodeActionKind::from("source.fixAll.ruff")),
+        ..Default::default()
+    });
+
+    let error = match server.try_await_response::<CodeActionResolveRequest>(&request_id, None) {
+        Err(AwaitResponseError::RequestFailed(error)) => error,
+        result => panic!("Expected an InvalidParams error response, got {result:?}"),
+    };
+
+    assert_eq!(error.code, ErrorCode::InvalidParams as i32);
+    assert_json_snapshot!(error, @r#"
+    {
+      "code": -32602,
+      "message": "Code action is missing its document URI"
+    }
+    "#);
 
     Ok(())
 }

--- a/crates/ruff_server/tests/e2e/hover.rs
+++ b/crates/ruff_server/tests/e2e/hover.rs
@@ -51,3 +51,14 @@ fn hover_for_python_noqa() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn unavailable_document_returns_empty_response() -> Result<()> {
+    let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
+
+    let result = server.hover_request("not-open.py", Position::default());
+
+    assert!(result.is_none());
+
+    Ok(())
+}

--- a/crates/ruff_server/tests/e2e/workspace.rs
+++ b/crates/ruff_server/tests/e2e/workspace.rs
@@ -103,3 +103,22 @@ ignore = ["F401"]
 
     Ok(())
 }
+
+#[test]
+fn unavailable_document_diagnostic_returns_empty_response() -> Result<()> {
+    let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
+
+    let diagnostics = server.document_diagnostic_request("not-open.py", None);
+
+    assert_json_snapshot!(
+        diagnostics,
+        @r#"
+    {
+      "kind": "full",
+      "items": []
+    }
+    "#
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #25364.

## Summary

Handle invalid `codeAction/resolve` document URIs before scheduling a background request.

This changes the background document request path to extract document URLs fallibly and return an `InvalidParams` response when the request payload is malformed, instead of panicking while preparing the task. For `CodeActionResolve`, missing or invalid `CodeAction.data` is now reported as an invalid document URI.

## Test Plan

Added integration tests
