### PR TITLE
[ty] Show `LiteralString` when hovering the inline of a literal string

### DIFF
--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -5291,10 +5291,10 @@ Source with applied edits:
         my_func(x="hello")
         ---------------------------------------------
         info[inlay-hint-location]: Inlay Hint Target
-           --> stdlib/builtins.pyi:914:7
+           --> stdlib/typing_extensions.pyi:549:9
             |
-        914 | class str(Sequence[str]):
-            |       ^^^
+        549 |         LiteralString as LiteralString,
+            |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             |
         info: Source
          --> main2.py:4:9

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1221,14 +1221,9 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         string.display_with(self.db, self.settings.clone()),
                     )
                 }
-                // an alternative would be to use `Type::SpecialForm(SpecialFormType::LiteralString)` here,
-                // which would mean users would be able to jump to the definition of `LiteralString` from the
-                // inlay hint, but that seems less useful than the definition of `str` for a variable that is
-                // inferred as an *inhabitant* of `LiteralString` (since that variable will just be a string
-                // at runtime)
-                LiteralValueTypeKind::LiteralString => {
-                    f.with_type(self.ty).write_str("LiteralString")
-                }
+                LiteralValueTypeKind::LiteralString => f
+                    .with_type(Type::SpecialForm(SpecialFormType::LiteralString))
+                    .write_str("LiteralString"),
                 LiteralValueTypeKind::Bytes(bytes) => {
                     let escape =
                         AsciiEscape::with_preferred_quote(bytes.value(self.db), Quote::Double);

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1221,6 +1221,10 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         string.display_with(self.db, self.settings.clone()),
                     )
                 }
+                // We used to return `str` as the type here because that feels generally more useful.
+                // However, the inoncistency between the type shown in the inlay hint and its hover, and the
+                // inconsistency to what's shown when hovering the backed inlay hint of a `LiteralString`
+                // convinvced us that we should change the type to `LiteralString`.
                 LiteralValueTypeKind::LiteralString => f
                     .with_type(Type::SpecialForm(SpecialFormType::LiteralString))
                     .write_str("LiteralString"),


### PR DESCRIPTION
## Summary

Today, ty showed the hover for `str` when hovering the inlay of a `LiteralString` type:

```py
from typing import LiteralString
def my_func(x: LiteralString):
    y[: LiteralString] = x
my_func(x="hello")
```

Hovering the inlay of `y` (`[: LiteralString]` is the inlay) showed the hover of `str`. 

We argued in https://github.com/astral-sh/ruff/pull/21548 that `str` is generally the more useful type in this position. I sort of agree, but I think it's more important that the inlay and the hover show the same type. I also think that it's important that the hover is consistent with when we "bake" the inlay, e.g. hovering `LiteralString` now also shows `LiteralString` and not `str`

```py
from typing import LiteralString
def my_func(x: LiteralString):
    y: LiteralString = x
my_func(x="hello")
```

Closes https://github.com/astral-sh/ty/issues/2860

## Test Plan

Updated test