### PR TITLE
[`pyflakes`] Fix false positive for class-scope generators (`F821`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35.py
@@ -1,0 +1,31 @@
+# Regression test for https://github.com/astral-sh/ruff/issues/23364
+
+
+class Foo:
+    BAR = [1, 2, 3]
+    BAZ = [4, 5, 6]
+
+    # No F821: a generator body and its non-first iterables are evaluated after the
+    # class is defined, so `Foo` is bound by then.
+    a = ((x, y) for x in BAR for y in Foo.BAZ)
+    b = (Foo.BAZ for x in BAR)
+
+    # F821: a list comprehension is evaluated eagerly in the class body.
+    c = [(x, y) for x in BAR for y in Foo.BAZ]
+
+    # F821: the first iterable of a generator is also evaluated eagerly.
+    d = (x for x in Foo.BAZ)
+
+    # F821: a name that is never bound is still reported in a deferred generator body.
+    e = (undefined for x in BAR)
+
+    def method(self):
+        # No F821: the generator runs when consumed, after `Foo` is bound.
+        return (Foo.BAZ for _ in range(3))
+
+
+def uses_walrus(items):
+    # No F821: an assignment expression binds `seen` in this scope (PEP 572), so the
+    # generator is evaluated eagerly and `seen` is visible afterward.
+    matches = (x for x in items if (seen := x) > 1)
+    return seen, matches

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35.py
@@ -24,6 +24,14 @@ class Foo:
         return (Foo.BAZ for _ in range(3))
 
 
+class WalrusInLambda:
+    values = (0,)
+
+    # No F821: the generator is deferred, so the class name resolves. The walrus binds in the
+    # lambda scope rather than the class scope, so it does not force eager evaluation.
+    generated = ((WalrusInLambda, lambda: (seen := 1)) for _ in values)
+
+
 def uses_walrus(items):
     # No F821: an assignment expression binds `seen` in this scope (PEP 572), so the
     # generator is evaluated eagerly and `seen` is visible afterward.

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_35.py
@@ -29,3 +29,24 @@ def uses_walrus(items):
     # generator is evaluated eagerly and `seen` is visible afterward.
     matches = (x for x in items if (seen := x) > 1)
     return seen, matches
+
+
+def generator_uses_exception_name():
+    # No F821: the generator is consumed before the except block ends, so `e` is
+    # still bound.
+    try:
+        pass
+    except Exception as e:
+        if any(s in str(e) for s in ("a", "b")):
+            pass
+
+
+GENERATOR_USES_DELETED_NAME = ["x", "y"]
+GENERATOR_USES_DELETED_NAME_DEFAULTS = {"x": 1, "y": 2}
+GENERATOR_USES_DELETED_NAME_REPR = ", ".join(
+    # No F821: the checker visits this generator eagerly, before
+    # `GENERATOR_USES_DELETED_NAME_DEFAULTS` is deleted below.
+    f"{n}={GENERATOR_USES_DELETED_NAME_DEFAULTS[n]!r}"
+    for n in GENERATOR_USES_DELETED_NAME
+)
+del GENERATOR_USES_DELETED_NAME_DEFAULTS

--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F841_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F841_0.py
@@ -187,3 +187,12 @@ class NonlocalDunderClass:
     def foo():
         nonlocal __class__
         __class__ = 1
+
+
+# OK, `e` is used inside a generator expression in the except handler body.
+def except_name_used_in_generator():
+    try:
+        pass
+    except Exception as e:
+        if any(s in str(e) for s in ("a", "b")):
+            pass

--- a/crates/ruff_linter/src/checkers/ast/deferred.rs
+++ b/crates/ruff_linter/src/checkers/ast/deferred.rs
@@ -11,6 +11,7 @@ pub(crate) struct Visit<'a> {
     pub(crate) type_param_definitions: Vec<(&'a Expr, Snapshot)>,
     pub(crate) functions: Vec<Snapshot>,
     pub(crate) lambdas: Vec<Snapshot>,
+    pub(crate) generators: Vec<Snapshot>,
     /// N.B. This field should always be empty unless it's a stub file
     pub(crate) class_bases: Vec<(&'a Expr, Snapshot)>,
 }
@@ -23,6 +24,7 @@ impl Visit<'_> {
             && self.type_param_definitions.is_empty()
             && self.functions.is_empty()
             && self.lambdas.is_empty()
+            && self.generators.is_empty()
             && self.class_bases.is_empty()
     }
 }

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1758,8 +1758,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                 node_index: _,
                 parenthesized: _,
             }) => {
-                self.visit_generators(GeneratorKind::Generator, generators);
-                self.visit_expr(elt);
+                self.visit_generator(elt, generators);
             }
             Expr::DictComp(ast::ExprDictComp {
                 key,
@@ -2465,15 +2464,11 @@ impl<'a> Checker<'a> {
     }
 
     /// Visit a list of [`Comprehension`] nodes, assumed to be the comprehensions that compose a
-    /// generator expression, like a list or set comprehension.
+    /// list, set, or dict comprehension.
     fn visit_generators(&mut self, kind: GeneratorKind, generators: &'a [Comprehension]) {
-        let mut iterator = generators.iter();
-
-        let Some(generator) = iterator.next() else {
+        let Some(generator) = generators.first() else {
             unreachable!("Generator expression must contain at least one generator");
         };
-
-        let flags = self.semantic.flags;
 
         // Generators are compiled as nested functions. (This may change with PEP 709.)
         // As such, the `iter` of the first generator is evaluated in the outer scope, while all
@@ -2509,6 +2504,56 @@ impl<'a> Checker<'a> {
                 .iter()
                 .any(|comprehension| comprehension.is_async),
         });
+
+        self.visit_comprehensions(generators);
+    }
+
+    /// Visit a generator expression.
+    ///
+    /// A generator expression is evaluated when it is consumed, not when it is created, which can
+    /// happen after the surrounding scope has finished executing. We therefore defer its body and
+    /// non-first iterables, like a lambda body, so that forward references (for example, to an
+    /// enclosing class name) resolve against bindings introduced later. As in
+    /// [`Checker::visit_generators`], the first iterable is evaluated eagerly in the enclosing
+    /// scope, so it is not deferred.
+    ///
+    /// A generator that contains an assignment expression (`:=`) is the exception: per
+    /// [PEP 572](https://peps.python.org/pep-0572/#scope-of-the-target) the target binds in the
+    /// enclosing scope, so the binding must be created eagerly and the generator is visited in
+    /// full here.
+    fn visit_generator(&mut self, elt: &'a Expr, generators: &'a [Comprehension]) {
+        let Some(generator) = generators.first() else {
+            unreachable!("Generator expression must contain at least one generator");
+        };
+
+        self.visit_expr(&generator.iter);
+        self.semantic.push_scope(ScopeKind::Generator {
+            kind: GeneratorKind::Generator,
+            is_async: generators
+                .iter()
+                .any(|comprehension| comprehension.is_async),
+        });
+
+        if contains_assignment_expression(elt, generators) {
+            self.visit_comprehensions(generators);
+            self.visit_expr(elt);
+        } else {
+            self.visit.generators.push(self.semantic.snapshot());
+        }
+    }
+
+    /// Visit the parts of a comprehension that are evaluated in the generator scope: the first
+    /// generator's target and conditions, then every subsequent generator in full.
+    ///
+    /// The caller is responsible for visiting the first generator's iterable in the enclosing
+    /// scope before pushing the generator scope and calling this method.
+    fn visit_comprehensions(&mut self, generators: &'a [Comprehension]) {
+        let flags = self.semantic.flags;
+        let mut iterator = generators.iter();
+
+        let Some(generator) = iterator.next() else {
+            return;
+        };
 
         self.visit_expr(&generator.target);
         self.semantic.flags = flags;
@@ -3201,15 +3246,41 @@ impl<'a> Checker<'a> {
         self.semantic.restore(snapshot);
     }
 
+    /// After initial traversal of the source tree, visit all deferred generator expressions. The
+    /// body and non-first iterables of a generator expression are deferred for the same reason as
+    /// lambda bodies: they are not evaluated until the generator is consumed, which can happen
+    /// after the surrounding scope has finished executing.
+    fn visit_deferred_generators(&mut self) {
+        let snapshot = self.semantic.snapshot();
+        while !self.visit.generators.is_empty() {
+            let generators = std::mem::take(&mut self.visit.generators);
+            for snapshot in generators {
+                self.semantic.restore(snapshot);
+
+                let Some(Expr::Generator(ast::ExprGenerator {
+                    elt, generators, ..
+                })) = self.semantic.current_expression()
+                else {
+                    unreachable!("Expected Expr::Generator");
+                };
+
+                self.visit_comprehensions(generators);
+                self.visit_expr(elt);
+            }
+        }
+        self.semantic.restore(snapshot);
+    }
+
     /// After initial traversal of the source tree has been completed,
     /// recursively visit all AST nodes that were deferred on the first pass.
-    /// This includes lambdas, functions, type parameters, and type annotations.
+    /// This includes lambdas, functions, generators, type parameters, and type annotations.
     fn visit_deferred(&mut self) {
         while !self.visit.is_empty() {
             self.visit_deferred_class_bases();
             self.visit_deferred_functions();
             self.visit_deferred_type_param_definitions();
             self.visit_deferred_lambdas();
+            self.visit_deferred_generators();
             self.visit_deferred_future_type_definitions();
             self.visit_deferred_string_type_definitions();
         }
@@ -3309,6 +3380,23 @@ impl<'a> ParsedAnnotationsCache<'a> {
     fn clear(&self) {
         self.by_offset.borrow_mut().clear();
     }
+}
+
+/// Returns `true` if the body or any iterable or condition of `generators` contains an assignment
+/// expression (`:=`).
+///
+/// Per [PEP 572](https://peps.python.org/pep-0572/#scope-of-the-target), an assignment expression
+/// inside a generator binds its target in the enclosing scope rather than the generator scope.
+/// That binding has to be created eagerly, so a generator that contains one cannot be deferred.
+fn contains_assignment_expression(elt: &Expr, generators: &[Comprehension]) -> bool {
+    fn contains_named(expr: &Expr) -> bool {
+        helpers::any_over_expr(expr, Expr::is_named_expr)
+    }
+
+    contains_named(elt)
+        || generators.iter().any(|generator| {
+            contains_named(&generator.iter) || generator.ifs.iter().any(contains_named)
+        })
 }
 
 #[expect(clippy::too_many_arguments)]

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -2511,20 +2511,26 @@ impl<'a> Checker<'a> {
     /// Visit a generator expression.
     ///
     /// A generator expression is evaluated when it is consumed, not when it is created, which can
-    /// happen after the surrounding scope has finished executing. We therefore defer its body and
-    /// non-first iterables, like a lambda body, so that forward references (for example, to an
-    /// enclosing class name) resolve against bindings introduced later. As in
-    /// [`Checker::visit_generators`], the first iterable is evaluated eagerly in the enclosing
-    /// scope, so it is not deferred.
+    /// happen after the surrounding scope has finished executing. When the immediately enclosing
+    /// scope is a class body, we defer the generator's body and non-first iterables, like a
+    /// lambda body, so that forward references (for example, to the class name) resolve against
+    /// bindings introduced later. As in [`Checker::visit_generators`], the first iterable is
+    /// evaluated eagerly in the enclosing scope, so it is not deferred.
     ///
-    /// A generator that contains an assignment expression (`:=`) is the exception: per
+    /// In a function or module scope we visit the generator eagerly. The deferred pass runs
+    /// after the surrounding statements, so names bound in positions that the checker rebinds at
+    /// end-of-scope (an `except ... as e:` handler) or removes (a later `del`) would no longer
+    /// resolve, turning valid references into F821 false positives.
+    ///
+    /// A generator that contains an assignment expression (`:=`) is also visited eagerly: per
     /// [PEP 572](https://peps.python.org/pep-0572/#scope-of-the-target) the target binds in the
-    /// enclosing scope, so the binding must be created eagerly and the generator is visited in
-    /// full here.
+    /// enclosing scope, so the binding must be created before the surrounding code is analyzed.
     fn visit_generator(&mut self, elt: &'a Expr, generators: &'a [Comprehension]) {
         let Some(generator) = generators.first() else {
             unreachable!("Generator expression must contain at least one generator");
         };
+
+        let in_class_scope = self.semantic.current_scope().kind.is_class();
 
         self.visit_expr(&generator.iter);
         self.semantic.push_scope(ScopeKind::Generator {
@@ -2534,7 +2540,7 @@ impl<'a> Checker<'a> {
                 .any(|comprehension| comprehension.is_async),
         });
 
-        if contains_assignment_expression(elt, generators) {
+        if !in_class_scope || contains_assignment_expression(elt, generators) {
             self.visit_comprehensions(generators);
             self.visit_expr(elt);
         } else {

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -2522,9 +2522,10 @@ impl<'a> Checker<'a> {
     /// end-of-scope (an `except ... as e:` handler) or removes (a later `del`) would no longer
     /// resolve, turning valid references into F821 false positives.
     ///
-    /// A generator that contains an assignment expression (`:=`) is also visited eagerly: per
-    /// [PEP 572](https://peps.python.org/pep-0572/#scope-of-the-target) the target binds in the
-    /// enclosing scope, so the binding must be created before the surrounding code is analyzed.
+    /// A class-scope generator never needs to create an enclosing-scope binding eagerly: per
+    /// [PEP 572](https://peps.python.org/pep-0572/#scope-of-the-target) an assignment expression
+    /// that would bind into a class-scope comprehension is a syntax error, and one nested in a
+    /// lambda binds in the lambda rather than the enclosing scope.
     fn visit_generator(&mut self, elt: &'a Expr, generators: &'a [Comprehension]) {
         let Some(generator) = generators.first() else {
             unreachable!("Generator expression must contain at least one generator");
@@ -2540,11 +2541,11 @@ impl<'a> Checker<'a> {
                 .any(|comprehension| comprehension.is_async),
         });
 
-        if !in_class_scope || contains_assignment_expression(elt, generators) {
+        if in_class_scope {
+            self.visit.generators.push(self.semantic.snapshot());
+        } else {
             self.visit_comprehensions(generators);
             self.visit_expr(elt);
-        } else {
-            self.visit.generators.push(self.semantic.snapshot());
         }
     }
 
@@ -3386,23 +3387,6 @@ impl<'a> ParsedAnnotationsCache<'a> {
     fn clear(&self) {
         self.by_offset.borrow_mut().clear();
     }
-}
-
-/// Returns `true` if the body or any iterable or condition of `generators` contains an assignment
-/// expression (`:=`).
-///
-/// Per [PEP 572](https://peps.python.org/pep-0572/#scope-of-the-target), an assignment expression
-/// inside a generator binds its target in the enclosing scope rather than the generator scope.
-/// That binding has to be created eagerly, so a generator that contains one cannot be deferred.
-fn contains_assignment_expression(elt: &Expr, generators: &[Comprehension]) -> bool {
-    fn contains_named(expr: &Expr) -> bool {
-        helpers::any_over_expr(expr, Expr::is_named_expr)
-    }
-
-    contains_named(elt)
-        || generators.iter().any(|generator| {
-            contains_named(&generator.iter) || generator.ifs.iter().any(contains_named)
-        })
 }
 
 #[expect(clippy::too_many_arguments)]

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -172,6 +172,7 @@ mod tests {
     #[test_case(Rule::UndefinedName, Path::new("F821_32.pyi"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_33.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_34.pyi"))]
+    #[test_case(Rule::UndefinedName, Path::new("F821_35.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.pyi"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_1.py"))]

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_35.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_35.py.snap
@@ -1,0 +1,32 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+F821 Undefined name `Foo`
+  --> F821_35.py:14:39
+   |
+13 |     # F821: a list comprehension is evaluated eagerly in the class body.
+14 |     c = [(x, y) for x in BAR for y in Foo.BAZ]
+   |                                       ^^^
+15 |
+16 |     # F821: the first iterable of a generator is also evaluated eagerly.
+   |
+
+F821 Undefined name `Foo`
+  --> F821_35.py:17:21
+   |
+16 |     # F821: the first iterable of a generator is also evaluated eagerly.
+17 |     d = (x for x in Foo.BAZ)
+   |                     ^^^
+18 |
+19 |     # F821: a name that is never bound is still reported in a deferred generator body.
+   |
+
+F821 Undefined name `undefined`
+  --> F821_35.py:20:10
+   |
+19 |     # F821: a name that is never bound is still reported in a deferred generator body.
+20 |     e = (undefined for x in BAR)
+   |          ^^^^^^^^^
+21 |
+22 |     def method(self):
+   |


### PR DESCRIPTION
## Summary

F821 fires on a class name used inside a generator expression at class scope:

```python
class Foo:
    BAR = [1, 2, 3]
    BAZ = [4, 5, 6]
    QUX = ((a, b) for a in BAR for b in Foo.BAZ)  # `Foo` reported
```

But the name resolves at runtime. A generator runs when it is consumed, not when it is created, so `Foo` is already bound by the time the body and its non-first iterables are evaluated. The checker visited those parts eagerly, during the class body, before the class name existed in the enclosing scope.

The fix defers them like lambda bodies, which are already deferred for the same reason. The first iterable stays eager, since Python evaluates it in the enclosing scope when the generator is created, and list, set, and dict comprehensions are left alone because they run eagerly. There is no walrus carve-out. A `:=` that would bind into a class-scope comprehension is a syntax error, and one nested in a lambda binds in the lambda, not the enclosing scope.

Fixes #23364

## Test Plan

`cargo test -p ruff_linter pyflakes`

Added `F821_35.py` with the generator cases that should no longer flag and the comprehension and first-iterable cases that still should.
