### PR TITLE
[ty] Resolve enum names for all '|' arms for literal enum subsets

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -211,6 +211,14 @@ def match_exhaustive_literal_or_pattern(v: Literal[Color.RED, Color.GREEN, Color
         case _:
             assert_never(v)
 
+
+def match_exhaustive_literal_or_non_enum_pattern(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:
+    match v:
+        case Color.RED | Color.GREEN | Color.BLUE | int():
+            pass
+        case _:
+            assert_never(v)
+
 def match_exhaustive_literal_grouped_or_pattern(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:
     match v:
         case (Color.RED | Color.GREEN) | Color.BLUE:

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -225,6 +225,21 @@ def match_exhaustive_literal_grouped_or_pattern(v: Literal[Color.RED, Color.GREE
         case _:
             assert_never(v)
 
+def match_overlapping_or_arm_is_reachable(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:
+    match v:
+        case Color.RED:
+            pass
+        case Color.RED | Color.GREEN | Color.BLUE:
+            assert_never(v)  # error: [type-assertion-failure]
+
+def match_class_pattern_arm_is_reachable(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:
+    match v:
+        case Color.RED | Color.GREEN:
+            pass
+        case Color():
+            assert_never(v)  # error: [type-assertion-failure]
+
+
 def match_non_exhaustive_literal_or_pattern(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:
     match v:
         case Color.RED | Color.GREEN:

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -192,6 +192,41 @@ def match_non_exhaustive(x: Color):
             assert_never(x)  # error: [type-assertion-failure]
 ```
 
+## Checks on enum literal subsets
+
+```py
+from enum import Enum
+from typing import Literal, assert_never
+
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+    ORANGE = 4
+
+def match_exhaustive_literal_or_pattern(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:
+    match v:
+        case Color.RED | Color.GREEN | Color.BLUE:
+            pass
+        case _:
+            assert_never(v)
+
+def match_exhaustive_literal_grouped_or_pattern(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:
+    match v:
+        case (Color.RED | Color.GREEN) | Color.BLUE:
+            pass
+        case _:
+            assert_never(v)
+
+def match_non_exhaustive_literal_or_pattern(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:
+    match v:
+        case Color.RED | Color.GREEN:
+            pass
+        case _:
+            # this diagnostic is correct: inferred type of `v` is `Literal[Color.BLUE]`
+            assert_never(v)  # error: [type-assertion-failure]
+```
+
 ## `isinstance` checks
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -239,7 +239,6 @@ def match_class_pattern_arm_is_reachable(v: Literal[Color.RED, Color.GREEN, Colo
         case Color():
             assert_never(v)  # error: [type-assertion-failure]
 
-
 def match_non_exhaustive_literal_or_pattern(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:
     match v:
         case Color.RED | Color.GREEN:

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -225,6 +225,13 @@ def match_exhaustive_literal_grouped_or_pattern(v: Literal[Color.RED, Color.GREE
         case _:
             assert_never(v)
 
+def match_exhaustive_literal_or_as_pattern(v: Literal[Color.RED, Color.GREEN]) -> None:
+    match v:
+        case (Color.RED | Color.GREEN) as selected:
+            pass
+        case _:
+            assert_never(v)
+
 def match_overlapping_or_arm_is_reachable(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:
     match v:
         case Color.RED:
@@ -237,6 +244,11 @@ def match_class_pattern_arm_is_reachable(v: Literal[Color.RED, Color.GREEN, Colo
         case Color.RED | Color.GREEN:
             pass
         case Color():
+            assert_never(v)  # error: [type-assertion-failure]
+
+def match_mixed_or_arm_is_reachable(v: Literal[Color.RED]) -> None:
+    match v:
+        case Color.BLUE | Color():
             assert_never(v)  # error: [type-assertion-failure]
 
 def match_non_exhaustive_literal_or_pattern(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -211,7 +211,6 @@ def match_exhaustive_literal_or_pattern(v: Literal[Color.RED, Color.GREEN, Color
         case _:
             assert_never(v)
 
-
 def match_exhaustive_literal_or_non_enum_pattern(v: Literal[Color.RED, Color.GREEN, Color.BLUE]) -> None:
     match v:
         case Color.RED | Color.GREEN | Color.BLUE | int():

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -425,6 +425,9 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
 ) -> Option<Truthiness> {
     let (enum_class, mut remaining_names) = enum_literal_subject_names(db, subject_ty)?;
     let current_names = enum_member_pattern_names(db, enum_class, predicate.kind(db));
+    if current_names.is_empty() {
+        return None;
+    }
 
     let mut previous_predicate = predicate;
     while let Some(previous) = previous_predicate.previous_predicate(db) {
@@ -440,7 +443,7 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
         }
     }
 
-    if !remaining_names.is_superset(&current_names) {
+    if remaining_names.is_disjoint(&current_names) {
         return Some(Truthiness::AlwaysFalse);
     }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -396,19 +396,21 @@ fn enum_member_pattern_names<'db>(
     db: &'db dyn Db,
     enum_class: ClassLiteral<'db>,
     kind: &PatternPredicateKind<'db>,
-) -> Option<FxHashSet<Name>> {
+) -> FxHashSet<Name> {
+    let mut names = FxHashSet::default();
     match kind {
         PatternPredicateKind::Or(alts) => {
-            let mut names = FxHashSet::default();
             for alt in alts {
-                names.extend(enum_member_pattern_names(db, enum_class, alt)?);
+                names.extend(enum_member_pattern_names(db, enum_class, alt));
             }
-            Some(names)
         }
-        _ => Some(FxHashSet::from_iter([enum_member_pattern_name(
-            db, enum_class, kind,
-        )?])),
+        _ => {
+            if let Some(name) = enum_member_pattern_name(db, enum_class, kind) {
+                names.insert(name);
+            }
+        }
     }
+    names
 }
 
 /// Determine the static truthiness of a `match` case over a union of enum literals.
@@ -422,7 +424,7 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
     subject_ty: Type<'db>,
 ) -> Option<Truthiness> {
     let (enum_class, mut remaining_names) = enum_literal_subject_names(db, subject_ty)?;
-    let current_names = enum_member_pattern_names(db, enum_class, predicate.kind(db))?;
+    let current_names = enum_member_pattern_names(db, enum_class, predicate.kind(db));
 
     let mut previous_predicate = predicate;
     while let Some(previous) = previous_predicate.previous_predicate(db) {
@@ -432,8 +434,7 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
             continue;
         }
 
-        let previous_names =
-            enum_member_pattern_names(db, enum_class, previous_predicate.kind(db))?;
+        let previous_names = enum_member_pattern_names(db, enum_class, previous_predicate.kind(db));
         for previous_name in previous_names {
             remaining_names.remove(&previous_name);
         }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -405,7 +405,9 @@ fn enum_member_pattern_names<'db>(
             }
             Some(names)
         }
-        _ => Some(FxHashSet::from_iter([enum_member_pattern_name(db, enum_class, kind)?])),
+        _ => Some(FxHashSet::from_iter([enum_member_pattern_name(
+            db, enum_class, kind,
+        )?])),
     }
 }
 
@@ -430,7 +432,8 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
             continue;
         }
 
-        let previous_names = enum_member_pattern_names(db, enum_class, previous_predicate.kind(db))?;
+        let previous_names =
+            enum_member_pattern_names(db, enum_class, previous_predicate.kind(db))?;
         for previous_name in previous_names {
             remaining_names.remove(&previous_name);
         }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -365,7 +365,7 @@ fn enum_literal_subject_names<'db>(
     Some((enum_class?, names))
 }
 
-/// Return the canonical enum-member name matched by a value pattern.
+/// Return the canonical enum-member name matched by a single value pattern.
 ///
 /// This recognizes patterns like `case Color.RED:` only when the pattern expression is
 /// single-valued and belongs to the expected enum class. Enum aliases are resolved to their
@@ -387,6 +387,28 @@ fn enum_member_pattern_name<'db>(
     Some(canonical_name.clone())
 }
 
+/// Returns the set of canonical enum-member names matched by a pattern.
+///
+/// This recognizes patterns like `case Color.RED | Color.GREEN` when the pattern
+/// belongs to the expected enum class. Enum aliases are resolved to their canonical member names
+/// before returning.
+fn enum_member_pattern_names<'db>(
+    db: &'db dyn Db,
+    enum_class: ClassLiteral<'db>,
+    kind: &PatternPredicateKind<'db>,
+) -> Option<FxHashSet<Name>> {
+    match kind {
+        PatternPredicateKind::Or(alts) => {
+            let mut names = FxHashSet::default();
+            for alt in alts {
+                names.extend(enum_member_pattern_names(db, enum_class, alt)?);
+            }
+            Some(names)
+        }
+        _ => Some(FxHashSet::from_iter([enum_member_pattern_name(db, enum_class, kind)?])),
+    }
+}
+
 /// Determine the static truthiness of a `match` case over a union of enum literals.
 ///
 /// The analysis removes enum members already matched by earlier unguarded cases, then decides
@@ -398,7 +420,7 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
     subject_ty: Type<'db>,
 ) -> Option<Truthiness> {
     let (enum_class, mut remaining_names) = enum_literal_subject_names(db, subject_ty)?;
-    let current_name = enum_member_pattern_name(db, enum_class, predicate.kind(db))?;
+    let current_names = enum_member_pattern_names(db, enum_class, predicate.kind(db))?;
 
     let mut previous_predicate = predicate;
     while let Some(previous) = previous_predicate.previous_predicate(db) {
@@ -408,15 +430,17 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
             continue;
         }
 
-        let previous_name = enum_member_pattern_name(db, enum_class, previous_predicate.kind(db))?;
-        remaining_names.remove(&previous_name);
+        let previous_names = enum_member_pattern_names(db, enum_class, previous_predicate.kind(db))?;
+        for previous_name in previous_names {
+            remaining_names.remove(&previous_name);
+        }
     }
 
-    if !remaining_names.contains(&current_name) {
+    if !remaining_names.is_superset(&current_names) {
         return Some(Truthiness::AlwaysFalse);
     }
 
-    if remaining_names.len() == 1 {
+    if remaining_names.is_subset(&current_names) {
         if predicate.guard(db).is_some() {
             Some(Truthiness::Ambiguous)
         } else {

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -387,30 +387,50 @@ fn enum_member_pattern_name<'db>(
     Some(canonical_name.clone())
 }
 
-/// Returns the set of canonical enum-member names matched by a pattern.
+struct EnumMemberPatternCoverage {
+    /// Enum members that this pattern definitely matches.
+    definitely_matched: FxHashSet<Name>,
+    /// Whether the collected coverage is known to represent every possible matching enum member.
+    is_exact: bool,
+}
+
+/// Returns enum-member coverage evidence for a pattern.
 ///
 /// This recognizes patterns like `case Color.RED | Color.GREEN` when the pattern
 /// belongs to the expected enum class. Enum aliases are resolved to their canonical member names
-/// before returning.
-fn enum_member_pattern_names<'db>(
+/// before returning. A pattern with additional alternatives such as `Color.GREEN | Color()`
+/// produces only a lower bound: it definitely matches `Color.GREEN`, but can match other members.
+fn enum_member_pattern_coverage<'db>(
     db: &'db dyn Db,
     enum_class: ClassLiteral<'db>,
     kind: &PatternPredicateKind<'db>,
-) -> FxHashSet<Name> {
-    let mut names = FxHashSet::default();
+) -> EnumMemberPatternCoverage {
+    let mut coverage = EnumMemberPatternCoverage {
+        definitely_matched: FxHashSet::default(),
+        is_exact: true,
+    };
     match kind {
         PatternPredicateKind::Or(alts) => {
             for alt in alts {
-                names.extend(enum_member_pattern_names(db, enum_class, alt));
+                let alt_coverage = enum_member_pattern_coverage(db, enum_class, alt);
+                coverage
+                    .definitely_matched
+                    .extend(alt_coverage.definitely_matched);
+                coverage.is_exact &= alt_coverage.is_exact;
             }
+        }
+        PatternPredicateKind::As(Some(inner), _) => {
+            return enum_member_pattern_coverage(db, enum_class, inner);
         }
         _ => {
             if let Some(name) = enum_member_pattern_name(db, enum_class, kind) {
-                names.insert(name);
+                coverage.definitely_matched.insert(name);
+            } else {
+                coverage.is_exact = false;
             }
         }
     }
-    names
+    coverage
 }
 
 /// Determine the static truthiness of a `match` case over a union of enum literals.
@@ -424,7 +444,8 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
     subject_ty: Type<'db>,
 ) -> Option<Truthiness> {
     let (enum_class, mut remaining_names) = enum_literal_subject_names(db, subject_ty)?;
-    let current_names = enum_member_pattern_names(db, enum_class, predicate.kind(db));
+    let current_coverage = enum_member_pattern_coverage(db, enum_class, predicate.kind(db));
+    let current_names = &current_coverage.definitely_matched;
     if current_names.is_empty() {
         return None;
     }
@@ -437,24 +458,31 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
             continue;
         }
 
-        let previous_names = enum_member_pattern_names(db, enum_class, previous_predicate.kind(db));
-        for previous_name in previous_names {
+        let previous_coverage =
+            enum_member_pattern_coverage(db, enum_class, previous_predicate.kind(db));
+        for previous_name in previous_coverage.definitely_matched {
             remaining_names.remove(&previous_name);
         }
     }
 
-    if remaining_names.is_disjoint(&current_names) {
+    if remaining_names.is_empty() {
         return Some(Truthiness::AlwaysFalse);
     }
 
-    if remaining_names.is_subset(&current_names) {
+    if remaining_names.is_subset(current_names) {
         if predicate.guard(db).is_some() {
             Some(Truthiness::Ambiguous)
         } else {
             Some(Truthiness::AlwaysTrue)
         }
+    } else if current_coverage.is_exact {
+        if remaining_names.is_disjoint(current_names) {
+            Some(Truthiness::AlwaysFalse)
+        } else {
+            Some(Truthiness::Ambiguous)
+        }
     } else {
-        Some(Truthiness::Ambiguous)
+        None
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Fixes https://github.com/astral-sh/ty/issues/3531

Currently, only a single enum value is retrieved when evaluating a match statement against a literal of enum values. This recursively resolves a full `|` union statement to get all the values.

## Test Plan

<!-- How was it tested? -->

- Unit tests
- Built ty and checked against repro in linked issue