### PR TITLE
[ty] preserve type aliases during union type building

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -2721,7 +2721,15 @@ fn completion_kind_from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Comp
             | Type::AlwaysTruthy
             | Type::AlwaysFalsy => return None,
             Type::TypeAlias(alias) => {
-                visitor.visit(ty, || imp(db, alias.value_type(db), visitor))?
+                let value = alias.value_type(db);
+                // Salsa cycle normalization can make `value_type(alias)` return
+                // `Type::TypeAlias(alias)` itself for self-referential aliases
+                // (e.g. `type T = T | None`). Treat such opaque self-loops as instance-like.
+                if matches!(value, Type::TypeAlias(inner) if inner == alias) {
+                    CompletionKind::Struct
+                } else {
+                    visitor.visit(ty, || imp(db, value, visitor))?
+                }
             }
         })
     }

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -150,7 +150,7 @@ reveal_type(l)  # revealed: tuple[list[int], list[Any], list[Any], list[str]]
 type IntList = list[int]
 
 m: IntList = [1, 2, 3]
-reveal_type(m)  # revealed: list[int]
+reveal_type(m)  # revealed: IntList
 
 n: list[typing.Literal[1, 2, 3]] = [1, 2, 3]
 reveal_type(n)  # revealed: list[Literal[1, 2, 3]]
@@ -769,7 +769,7 @@ x1: Callable[[Any], bool] = make_callable(0)
 reveal_type(x1)  # revealed: (Any, /) -> bool
 
 x2: AnyToBool = make_callable(0)
-reveal_type(x2)  # revealed: (Any, /) -> bool
+reveal_type(x2)  # revealed: AnyToBool
 
 x3: Callable[[list[Any]], bool] = make_callable([0])
 reveal_type(x3)  # revealed: (list[Any], /) -> bool

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -54,7 +54,7 @@ JSONPrimitive = Union[str, int, float, bool, None]
 JSONValue = TypeAliasType("JSONValue", 'Union[JSONPrimitive, Sequence["JSONValue"], Mapping[str, "JSONValue"]]')
 
 def _(x: JSONValue):
-    reveal_type(x)  # revealed: Sequence[JSONValue] | int | float | None | Mapping[str, JSONValue]
+    reveal_type(x)  # revealed: JSONValue
 ```
 
 ## Self-referential legacy type variables

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -66,8 +66,8 @@ from typing import Literal
 type C[T] = T
 
 def _(a: C[int], b: C[Literal[5]]):
-    reveal_type(a)  # revealed: int
-    reveal_type(b)  # revealed: Literal[5]
+    reveal_type(a)  # revealed: C[int]
+    reveal_type(b)  # revealed: C[Literal[5]]
 ```
 
 The specialization must match the generic types:
@@ -113,7 +113,7 @@ def _(l: List[int][int]):
 type DoubleSpecialization[T] = list[T][T]
 
 def _(d: DoubleSpecialization[int]):
-    reveal_type(d)  # revealed: Unknown
+    reveal_type(d)  # revealed: DoubleSpecialization[int]
 
 type Tuple = tuple[int, str]
 
@@ -193,11 +193,11 @@ reveal_type(BoundedByUnion[int | str])  # revealed: <type alias 'BoundedByUnion[
 type TupleOfIntAndStr[T: int, U: str] = tuple[T, U]
 
 def _(x: TupleOfIntAndStr[int, str]):
-    reveal_type(x)  # revealed: tuple[int, str]
+    reveal_type(x)  # revealed: TupleOfIntAndStr[int, str]
 
 # error: [invalid-type-arguments] "Type `int` is not assignable to upper bound `str` of type variable `U@TupleOfIntAndStr`"
 def _(x: TupleOfIntAndStr[int, int]):
-    reveal_type(x)  # revealed: tuple[int, Unknown]
+    reveal_type(x)  # revealed: TupleOfIntAndStr[int, Unknown]
 ```
 
 If the type variable is constrained, the specialized type must satisfy those constraints:
@@ -223,11 +223,11 @@ reveal_type(Constrained[object])  # revealed: <type alias 'Constrained[Unknown]'
 type TupleOfIntOrStr[T: (int, str), U: (int, str)] = tuple[T, U]
 
 def _(x: TupleOfIntOrStr[int, str]):
-    reveal_type(x)  # revealed: tuple[int, str]
+    reveal_type(x)  # revealed: TupleOfIntOrStr[int, str]
 
 # error: [invalid-type-arguments] "Type `object` does not satisfy constraints `int`, `str` of type variable `U@TupleOfIntOrStr`"
 def _(x: TupleOfIntOrStr[int, object]):
-    reveal_type(x)  # revealed: tuple[int, Unknown]
+    reveal_type(x)  # revealed: TupleOfIntOrStr[int, Unknown]
 ```
 
 If the type variable has a default, it can be omitted:
@@ -245,7 +245,7 @@ If the type alias is not specialized explicitly, it is implicitly specialized to
 type G[T] = list[T]
 
 def _(g: G):
-    reveal_type(g)  # revealed: list[Unknown]
+    reveal_type(g)  # revealed: G
 ```
 
 Unless a type default was provided:
@@ -254,7 +254,7 @@ Unless a type default was provided:
 type G[T = int] = list[T]
 
 def _(g: G):
-    reveal_type(g)  # revealed: list[int]
+    reveal_type(g)  # revealed: G
 ```
 
 Bare generic aliases used inside another specialized alias are also specialized with their defaults:
@@ -264,7 +264,7 @@ type Defaulted[T = int] = T
 type Outer[U] = Defaulted
 
 def _(x: Outer[str]):
-    reveal_type(x)  # revealed: int
+    reveal_type(x)  # revealed: Outer[str]
     y: int = x
 ```
 
@@ -387,7 +387,7 @@ r5: RecursiveList[int] = [1, ["a"]]
 
 def _(x: RecursiveList[int]):
     if isinstance(x, list):
-        reveal_type(x[0])  # revealed: int | list[RecursiveList[int]]
+        reveal_type(x[0])  # revealed: RecursiveList[int]
     if isinstance(x, list) and isinstance(x[0], list):
         reveal_type(x[0])  # revealed: list[RecursiveList[int]]
 ```
@@ -422,7 +422,7 @@ d1: DivergentList[int] = []
 d2: DivergentList[int] = [1]
 # error: [invalid-assignment]
 d3: DivergentList[int] = ["a"]
-# error: [invalid-assignment] "Object of type `list[list[DivergentList[int]] | list[list[DivergentList[int]] | int]]` is not assignable to `DivergentList[int]`"
+# error: [invalid-assignment] "Object of type `list[DivergentList[int] | list[DivergentList[int] | int]]` is not assignable to `DivergentList[int]`"
 d4: DivergentList[int] = [[1]]
 
 def _(x: DivergentList[int]):

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -491,7 +491,7 @@ from typing import Callable, Concatenate
 type Foo[**P, R] = Callable[Concatenate[int, P], R]
 
 def _(f: Foo[[str], bool]) -> None:
-    reveal_type(f)  # revealed: (int, str, /) -> bool
+    reveal_type(f)  # revealed: Foo[(str, /), bool]
 ```
 
 ### Using `TypeAlias`

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -273,7 +273,7 @@ def _[T](
 ):
     reveal_type(a)  # revealed: Unknown
     reveal_type(b)  # revealed: Unknown
-    reveal_type(c)  # revealed: int
+    reveal_type(c)  # revealed: Positive[int]
 ```
 
 ## Invalid uses

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -251,10 +251,10 @@ ManualIntOrStr = TypeAliasType("ManualIntOrStr", Union[int, str])
 ManualOrBytes = ManualIntOrStr | bytes
 BytesOrManual = bytes | ManualIntOrStr
 
-reveal_type(Pep695OrBytes)  # revealed: <types.UnionType special-form 'int | str | bytes'>
-reveal_type(BytesOrPep695)  # revealed: <types.UnionType special-form 'bytes | int | str'>
-reveal_type(ManualOrBytes)  # revealed: <types.UnionType special-form 'int | str | bytes'>
-reveal_type(BytesOrManual)  # revealed: <types.UnionType special-form 'bytes | int | str'>
+reveal_type(Pep695OrBytes)  # revealed: <types.UnionType special-form 'Pep695IntOrStr | bytes'>
+reveal_type(BytesOrPep695)  # revealed: <types.UnionType special-form 'bytes | Pep695IntOrStr'>
+reveal_type(ManualOrBytes)  # revealed: <types.UnionType special-form 'ManualIntOrStr | bytes'>
+reveal_type(BytesOrManual)  # revealed: <types.UnionType special-form 'bytes | ManualIntOrStr'>
 
 def _(
     pep695_or_bytes: Pep695OrBytes,
@@ -262,10 +262,10 @@ def _(
     manual_or_bytes: ManualOrBytes,
     bytes_or_manual: BytesOrManual,
 ):
-    reveal_type(pep695_or_bytes)  # revealed: int | str | bytes
-    reveal_type(bytes_or_pep695)  # revealed: bytes | int | str
-    reveal_type(manual_or_bytes)  # revealed: int | str | bytes
-    reveal_type(bytes_or_manual)  # revealed: bytes | int | str
+    reveal_type(pep695_or_bytes)  # revealed: Pep695IntOrStr | bytes
+    reveal_type(bytes_or_pep695)  # revealed: bytes | Pep695IntOrStr
+    reveal_type(manual_or_bytes)  # revealed: ManualIntOrStr | bytes
+    reveal_type(bytes_or_manual)  # revealed: bytes | ManualIntOrStr
 ```
 
 When constructing something nonsensical like `int | 1`, we emit a diagnostic for the expression

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -368,7 +368,7 @@ class C:
 
     def f(self) -> None:
         for item in self.values:
-            reveal_type(item)  # revealed: A | B
+            reveal_type(item)  # revealed: U
             # error: [unresolved-attribute] "Attribute `do_b_thing` is not defined on `A` in union `U`"
             item.do_b_thing()
 ```

--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -20,7 +20,7 @@ x: IntOrStr = 1
 reveal_type(x)  # revealed: Literal[1]
 
 def f() -> None:
-    reveal_type(x)  # revealed: int | str
+    reveal_type(x)  # revealed: IntOrStr
 ```
 
 ## `__value__` attribute
@@ -79,7 +79,7 @@ type IntOrStrOrBytes = IntOrStr | bytes
 x: IntOrStrOrBytes = 1
 
 def f() -> None:
-    reveal_type(x)  # revealed: int | str | bytes
+    reveal_type(x)  # revealed: IntOrStrOrBytes
 ```
 
 ## Aliased type aliases
@@ -92,6 +92,19 @@ x: MyIntOrStr = 1
 
 # error: [invalid-assignment]
 y: MyIntOrStr = None
+```
+
+## Union containing both an alias and its value type collapses
+
+The redundancy check within a union type is first-win, meaning the compatible type added later is
+considered redundant.
+
+```py
+type Alias = int
+
+def f(x: Alias | int, y: int | Alias):
+    reveal_type(x)  # revealed: Alias
+    reveal_type(y)  # revealed: int
 ```
 
 ## Unpacking from a type alias
@@ -114,7 +127,7 @@ eager) nested scope.
 type Alias = Foo | str
 
 def f(x: Alias):
-    reveal_type(x)  # revealed: Foo | str
+    reveal_type(x)  # revealed: Alias
 
 class Foo:
     pass
@@ -128,7 +141,7 @@ def _(flag: bool):
     if t is not None:
         type Alias = t | str
         def f(x: Alias):
-            reveal_type(x)  # revealed: int | str
+            reveal_type(x)  # revealed: Alias
 ```
 
 ## Generic type aliases
@@ -142,7 +155,7 @@ def _(cond: bool):
     Generic = ListOrSet if cond else Tuple1
 
     def _(x: Generic[int]):
-        reveal_type(x)  # revealed: list[int] | set[int] | tuple[int]
+        reveal_type(x)  # revealed: ListOrSet[int] | Tuple1[int]
 
 try:
     class Foo[T]:
@@ -169,7 +182,7 @@ Stringifying the right-hand side of a type alias is redundant, but allowed:
 type X = "int | str"
 
 def f(obj: X):
-    reveal_type(obj)  # revealed: int | str
+    reveal_type(obj)  # revealed: X
 ```
 
 The right-hand side of a PEP-695 type alias will not usually be executed, but can be if the user
@@ -181,7 +194,7 @@ stringified alias values:
 type Y = "int" | str
 
 def g(obj: Y):
-    reveal_type(obj)  # revealed: int | str
+    reveal_type(obj)  # revealed: Y
 ```
 
 ```snapshot
@@ -223,13 +236,13 @@ def f(condition: bool):
     while condition:
         type Right = str
         alias |= Right
-        reveal_type(alias)  # revealed: <types.UnionType special-form 'int | str'>
+        reveal_type(alias)  # revealed: <types.UnionType special-form 'Left | Right'>
 
-    reveal_type(alias)  # revealed: TypeAliasType | <types.UnionType special-form 'int | str'>
+    reveal_type(alias)  # revealed: TypeAliasType | <types.UnionType special-form 'Left | Right'>
 
     # it would be okay to emit an `invalid-type-form` error here
     def inner(x: alias):
-        reveal_type(x)  # revealed: int | str
+        reveal_type(x)  # revealed: Left | Right
 ```
 
 ## Multiple layers of union aliases
@@ -344,7 +357,7 @@ reveal_type(IntOrStr)  # revealed: TypeAliasType
 reveal_type(IntOrStr.__name__)  # revealed: Literal["IntOrStr"]
 
 def f(x: IntOrStr) -> None:
-    reveal_type(x)  # revealed: int | str
+    reveal_type(x)  # revealed: IntOrStr
 ```
 
 ### Generic example
@@ -427,10 +440,10 @@ A = TypeAliasType("A", Union[str, "B"])
 B = TypeAliasType("B", list[A])
 
 def f(x: A) -> None:
-    reveal_type(x)  # revealed: str | list[A]
+    reveal_type(x)  # revealed: A
 
 def g(x: B) -> None:
-    reveal_type(x)  # revealed: list[A]
+    reveal_type(x)  # revealed: B
 ```
 
 ## Cyclic aliases
@@ -441,26 +454,27 @@ def g(x: B) -> None:
 type OptNestedInt = int | tuple[OptNestedInt, ...] | None
 
 def f(x: OptNestedInt) -> None:
-    reveal_type(x)  # revealed: int | tuple[OptNestedInt, ...] | None
+    reveal_type(x)  # revealed: OptNestedInt
     if x is not None:
         reveal_type(x)  # revealed: int | tuple[OptNestedInt, ...]
 
 type RecursiveList = list[RecursiveList]
 
 def g(x: RecursiveList):
-    reveal_type(x[0])  # revealed: list[RecursiveList]
+    reveal_type(x[0])  # revealed: RecursiveList
 ```
 
 ### Invalid self-referential
 
 ```py
-# TODO emit a diagnostic on these two lines
+# TODO emit a diagnostic on the `IntOr` line too
 type IntOr = int | IntOr
+# error: [cyclic-type-alias-definition] "Cyclic definition of `OrInt`"
 type OrInt = OrInt | int
 
 def f(x: IntOr, y: OrInt):
-    reveal_type(x)  # revealed: int
-    reveal_type(y)  # revealed: int
+    reveal_type(x)  # revealed: IntOr
+    reveal_type(y)  # revealed: OrInt
     if not isinstance(x, int):
         reveal_type(x)  # revealed: Never
     if not isinstance(y, int):
@@ -474,7 +488,7 @@ def foo(
     Itself: Itself,
 ):
     x: Itself
-    reveal_type(Itself)  # revealed: Divergent
+    reveal_type(Itself)  # revealed: Itself
 
 # A type alias defined with invalid recursion behaves as a dynamic type.
 foo(42)
@@ -487,7 +501,7 @@ type B = A
 
 def bar(B: B):
     x: B
-    reveal_type(B)  # revealed: Divergent
+    reveal_type(B)  # revealed: B
 
 # error: [cyclic-type-alias-definition] "Cyclic definition of `G`"
 type G[T] = G[T]
@@ -504,7 +518,7 @@ type Foo[T] = list[T] | Bar[T]
 type Bar[T] = int | Foo[T]
 
 def _(x: Bar[int]):
-    reveal_type(x)  # revealed: int | list[int]
+    reveal_type(x)  # revealed: Bar[int]
 ```
 
 ### With legacy generic
@@ -524,7 +538,7 @@ class B(A[Alias]):
 
 def f(b: B):
     reveal_type(b)  # revealed: B
-    reveal_type(b.attr)  # revealed: list[Alias] | int
+    reveal_type(b.attr)  # revealed: Alias
 ```
 
 ### Mutually recursive
@@ -541,7 +555,7 @@ def f(x: A):
             reveal_type(y)  # revealed: tuple[A]
 
 def g(x: A | B):
-    reveal_type(x)  # revealed: tuple[B] | None
+    reveal_type(x)  # revealed: A
 
 from ty_extensions import Intersection
 
@@ -557,7 +571,7 @@ from typing import Callable
 type C = Callable[[], C | None]
 
 def _(x: C):
-    reveal_type(x)  # revealed: () -> C | None
+    reveal_type(x)  # revealed: C
 ```
 
 ### Subtyping of materializations of cyclic aliases
@@ -649,9 +663,9 @@ from typing import Union
 type A = list[Union["A", str]]
 
 def f(x: A):
-    reveal_type(x)  # revealed: list[A | str]
+    reveal_type(x)  # revealed: A
     for item in x:
-        reveal_type(item)  # revealed: list[A | str] | str
+        reveal_type(item)  # revealed: A | str
 ```
 
 #### With new-style union
@@ -660,9 +674,9 @@ def f(x: A):
 type A = list[A | str]
 
 def f(x: A):
-    reveal_type(x)  # revealed: list[A | str]
+    reveal_type(x)  # revealed: A
     for item in x:
-        reveal_type(item)  # revealed: list[A | str] | str
+        reveal_type(item)  # revealed: A | str
 ```
 
 #### With Optional
@@ -673,9 +687,9 @@ from typing import Optional, Union
 type A = list[Optional[Union["A", str]]]
 
 def f(x: A):
-    reveal_type(x)  # revealed: list[A | str | None]
+    reveal_type(x)  # revealed: A
     for item in x:
-        reveal_type(item)  # revealed: list[A | str | None] | str | None
+        reveal_type(item)  # revealed: A | str | None
 ```
 
 ### Tuple comparison

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -224,7 +224,7 @@ def get_aliased_segment() -> Segment:
     return (0, 1)
 
 aliased_segments = [get_aliased_segment(), (1, 2), (3, 4, 5)]
-reveal_type(aliased_segments)  # revealed: list[tuple[int, int] | tuple[int, int, int]]
+reveal_type(aliased_segments)  # revealed: list[Segment | tuple[int, int, int]]
 aliased_segments.append((6, 7, 8, 9))  # error: [invalid-argument-type]
 
 def get_newtype_segment() -> NewTypeSegment:
@@ -449,7 +449,7 @@ x11: list[Literal[1] | Literal[2] | Literal[3]] = [1, 2, 3]
 reveal_type(x11)  # revealed: list[Literal[1, 2, 3]]
 
 x12: Y[Y[Literal[1]]] = [[1]]
-reveal_type(x12)  # revealed: list[Y[Literal[1]]]
+reveal_type(x12)  # revealed: Y[Y[Literal[1]]]
 
 x13: list[tuple[Literal[1], Literal[2], Literal[3]]] = [(1, 2, 3)]
 reveal_type(x13)  # revealed: list[tuple[Literal[1], Literal[2], Literal[3]]]
@@ -661,7 +661,7 @@ def _(x: tuple[Literal["hello"]]):
 type X = Literal["hello"]
 
 x4: X = "hello"
-reveal_type(x4)  # revealed: Literal["hello"]
+reveal_type(x4)  # revealed: X
 reveal_type([x4])  # revealed: list[X]
 
 class MyEnum(Enum):
@@ -717,8 +717,8 @@ def _(flag: bool):
 type X = Literal[b"bar"]
 
 def _(x1: X | None, x2: X):
-    reveal_type([x1, x2])  # revealed: list[Literal[b"bar"] | None]
-    reveal_type([x1 or x2])  # revealed: list[Literal[b"bar"]]
+    reveal_type([x1, x2])  # revealed: list[X | None]
+    reveal_type([x1 or x2])  # revealed: list[X]
 ```
 
 ## Negative intersection elements are removed

--- a/crates/ty_python_semantic/resources/mdtest/type_display/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_display/callable.md
@@ -101,16 +101,16 @@ reveal_type(Foo().f)  # revealed: bound method Foo.f(x: Scalar | Array1d) -> Non
 
 type ArrayNd = Scalar | list[ArrayNd] | tuple[ArrayNd]
 
-def g(x: Scalar | ArrayNd) -> None:
+def g(x: ArrayNd) -> None:
     pass
 
-reveal_type(g)  # revealed: def g(x: Scalar | ArrayNd) -> None
+reveal_type(g)  # revealed: def g(x: ArrayNd) -> None
 
 class Bar:
-    def g(self, x: Scalar | ArrayNd) -> None:
+    def g(self, x: ArrayNd) -> None:
         pass
 
-reveal_type(Bar().g)  # revealed: bound method Bar.g(x: Scalar | ArrayNd) -> None
+reveal_type(Bar().g)  # revealed: bound method Bar.g(x: ArrayNd) -> None
 
 type GenericArray1d[T] = list[T] | tuple[T]
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3461,7 +3461,7 @@ class TD2(TD1):
 type TD2Alias = TD2
 
 def func_alias(**kwargs: Unpack[TD2Alias]) -> None:
-    reveal_type(kwargs)  # revealed: TD2
+    reveal_type(kwargs)  # revealed: TD2Alias
 ```
 
 ### Stringified annotations are followed
@@ -4833,7 +4833,7 @@ def test_in(x: ThingWithBaz):
     if "baz" not in x:
         reveal_type(x)  # revealed: Foo
     else:
-        reveal_type(x)  # revealed: Foo | Baz
+        reveal_type(x)  # revealed: ThingWithBaz
 ```
 
 Nested PEP 695 type aliases (an alias referring to another alias) also work:
@@ -4862,7 +4862,7 @@ def test_nested_in(x: OuterWithBaz):
     if "baz" not in x:
         reveal_type(x)  # revealed: Foo
     else:
-        reveal_type(x)  # revealed: Foo | Baz
+        reveal_type(x)  # revealed: OuterWithBaz
 ```
 
 ## Only annotated declarations are allowed in the class body

--- a/crates/ty_python_semantic/resources/mdtest/union_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/union_types.md
@@ -232,23 +232,23 @@ def _(
     bytes_or_falsy: bytes | AlwaysFalsy,
     falsy_or_bytes: AlwaysFalsy | bytes,
 ):
-    reveal_type(strings_or_truthy)  # revealed: Literal[""] | AlwaysTruthy
-    reveal_type(truthy_or_strings)  # revealed: AlwaysTruthy | Literal[""]
+    reveal_type(strings_or_truthy)  # revealed: strings | AlwaysTruthy
+    reveal_type(truthy_or_strings)  # revealed: AlwaysTruthy | strings
 
-    reveal_type(strings_or_falsy)  # revealed: Literal["foo"] | AlwaysFalsy
-    reveal_type(falsy_or_strings)  # revealed: AlwaysFalsy | Literal["foo"]
+    reveal_type(strings_or_falsy)  # revealed: strings | AlwaysFalsy
+    reveal_type(falsy_or_strings)  # revealed: AlwaysFalsy | strings
 
-    reveal_type(ints_or_truthy)  # revealed: Literal[0] | AlwaysTruthy
-    reveal_type(truthy_or_ints)  # revealed: AlwaysTruthy | Literal[0]
+    reveal_type(ints_or_truthy)  # revealed: ints | AlwaysTruthy
+    reveal_type(truthy_or_ints)  # revealed: AlwaysTruthy | ints
 
-    reveal_type(ints_or_falsy)  # revealed: Literal[1] | AlwaysFalsy
-    reveal_type(falsy_or_ints)  # revealed: AlwaysFalsy | Literal[1]
+    reveal_type(ints_or_falsy)  # revealed: ints | AlwaysFalsy
+    reveal_type(falsy_or_ints)  # revealed: AlwaysFalsy | ints
 
-    reveal_type(bytes_or_truthy)  # revealed: Literal[b""] | AlwaysTruthy
-    reveal_type(truthy_or_bytes)  # revealed: AlwaysTruthy | Literal[b""]
+    reveal_type(bytes_or_truthy)  # revealed: bytes | AlwaysTruthy
+    reveal_type(truthy_or_bytes)  # revealed: AlwaysTruthy | bytes
 
-    reveal_type(bytes_or_falsy)  # revealed: Literal[b"foo"] | AlwaysFalsy
-    reveal_type(falsy_or_bytes)  # revealed: AlwaysFalsy | Literal[b"foo"]
+    reveal_type(bytes_or_falsy)  # revealed: bytes | AlwaysFalsy
+    reveal_type(falsy_or_bytes)  # revealed: AlwaysFalsy | bytes
 
 type SA = Union[Literal[""], AlwaysTruthy, Literal["foo"]]
 static_assert(is_equivalent_to(SA, Literal[""] | AlwaysTruthy))
@@ -286,8 +286,8 @@ type SC = SA | SB
 type SD = SB | SA
 
 def _(c: SC, d: SD):
-    reveal_type(c)  # revealed: Literal[""]
-    reveal_type(d)  # revealed: Literal[""]
+    reveal_type(c)  # revealed: SC
+    reveal_type(d)  # revealed: SD
 
 type IA = Literal[0]
 type IB = Intersection[Literal[0], Any]
@@ -295,8 +295,8 @@ type IC = IA | IB
 type ID = IB | IA
 
 def _(c: IC, d: ID):
-    reveal_type(c)  # revealed: Literal[0]
-    reveal_type(d)  # revealed: Literal[0]
+    reveal_type(c)  # revealed: IC
+    reveal_type(d)  # revealed: ID
 
 type BA = Literal[b""]
 type BB = Intersection[Literal[b""], Any]
@@ -304,8 +304,8 @@ type BC = BA | BB
 type BD = BB | BA
 
 def _(c: BC, d: BD):
-    reveal_type(c)  # revealed: Literal[b""]
-    reveal_type(d)  # revealed: Literal[b""]
+    reveal_type(c)  # revealed: BC
+    reveal_type(d)  # revealed: BD
 ```
 
 ## Unions of tuples

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1371,7 +1371,12 @@ impl<'db> Type<'db> {
     /// underlying value type. Otherwise, returns `self` unchanged.
     pub(crate) fn resolve_type_alias(self, db: &'db dyn Db) -> Type<'db> {
         let mut ty = self;
+        let mut seen: smallvec::SmallVec<[TypeAliasType<'db>; 2]> = smallvec::SmallVec::new();
         while let Type::TypeAlias(alias) = ty {
+            if seen.contains(&alias) {
+                break;
+            }
+            seen.push(alias);
             ty = alias.value_type(db);
         }
         ty
@@ -5787,7 +5792,7 @@ impl<'db> Type<'db> {
                 Type::PropertyInstance(property.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             }
 
-            Type::Union(union) => union.map_leave_aliases(db, |element| {
+            Type::Union(union) => union.map(db, |element| {
                 element.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
             }),
             Type::Intersection(intersection) => {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6353,7 +6353,17 @@ impl<'db> Type<'db> {
                 )),
             },
 
-            Self::TypeAlias(alias) => alias.value_type(db).definition(db),
+            Self::TypeAlias(alias) => {
+                // Salsa cycle normalization can make `value_type(alias)` return
+                // `Type::TypeAlias(alias)` itself for self-referential aliases
+                // (e.g. `type T = T | None`). Guard against the resulting infinite recursion.
+                let value = alias.value_type(db);
+                if matches!(value, Type::TypeAlias(inner) if inner == *alias) {
+                    Some(TypeDefinition::TypeAlias(alias.definition(db)))
+                } else {
+                    value.definition(db)
+                }
+            }
             Self::NewTypeInstance(newtype) => Some(TypeDefinition::NewType(newtype.definition(db))),
 
             Self::PropertyInstance(property) => property

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4192,7 +4192,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                             if var_types.is_empty() {
                                 None
                             } else {
-                                Some(UnionType::from_elements_leave_aliases(db, var_types))
+                                Some(UnionType::from_elements(db, var_types))
                             }
                         };
 
@@ -4206,8 +4206,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                             if positional_types.is_empty() {
                                 break;
                             }
-                            argument_types_vec
-                                .push(UnionType::from_elements_leave_aliases(db, positional_types));
+                            argument_types_vec.push(UnionType::from_elements(db, positional_types));
                         }
 
                         let length = if any_variable || argument_types_vec.len() > min_len {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -337,7 +337,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             }
                         }
 
-                        UnionType::from_elements_leave_aliases(self.db(), [left_ty, right_ty])
+                        UnionType::from_elements(self.db(), [left_ty, right_ty])
                     }
                     // anything else is an invalid annotation:
                     op => {
@@ -1188,7 +1188,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let parameters_ty = match self.infer_expression(value, TypeContext::default()) {
                     Type::SpecialForm(SpecialFormType::Union) => match &**parameters {
                         ast::Expr::Tuple(tuple) => {
-                            let ty = UnionType::from_elements_leave_aliases(
+                            let ty = UnionType::from_elements(
                                 self.db(),
                                 tuple
                                     .iter()
@@ -1901,11 +1901,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             },
             SpecialFormType::Optional => {
                 let param_type = self.infer_type_expression(arguments_slice);
-                UnionType::from_elements_leave_aliases(db, [param_type, Type::none(db)])
+                UnionType::from_elements(db, [param_type, Type::none(db)])
             }
             SpecialFormType::Union => match arguments_slice {
                 ast::Expr::Tuple(t) => {
-                    let union_ty = UnionType::from_elements_leave_aliases(
+                    let union_ty = UnionType::from_elements(
                         db,
                         t.iter().map(|elt| self.infer_type_expression(elt)),
                     );

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -987,21 +987,39 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }),
 
             // Annotation unions retain type aliases so recursive aliases can be represented.
-            // Normalize direct alias elements together before checking the union so reductions
-            // that depend on multiple elements, such as all members of an enum, are visible.
+            // Unpack direct alias elements and rebuild before checking, so reductions that
+            // depend on multiple elements—such as a union of literal-enum aliases collapsing
+            // to the enum itself—are visible. If the rebuild produces the same union (the
+            // aliases were already unpacked or are recursive), don't recurse into ourselves;
+            // skipping that early return would let `with_recursion_guard` fall back to the
+            // trivial satisfiable result and mask real assignability failures.
             (_, Type::Union(union))
                 if union
                     .elements(db)
                     .iter()
                     .any(|element| matches!(element, Type::TypeAlias(_))) =>
             {
-                self.with_recursion_guard(source, target, || {
-                    self.check_type_pair(
-                        db,
-                        source,
-                        UnionType::from_elements(db, union.elements(db).iter().copied()),
-                    )
-                })
+                let unpacked = UnionType::from_elements(
+                    db,
+                    union.elements(db).iter().map(|elem| match *elem {
+                        Type::TypeAlias(alias) => alias.value_type(db),
+                        other => other,
+                    }),
+                );
+                if unpacked != target {
+                    self.with_recursion_guard(source, target, || {
+                        self.check_type_pair(db, source, unpacked)
+                    })
+                } else {
+                    // No progress from unpacking; treat this as a standard union target and
+                    // check each element individually.
+                    union
+                        .elements(db)
+                        .iter()
+                        .when_any(db, self.constraints, |&elem_ty| {
+                            self.check_type_pair(db, source, elem_ty)
+                        })
+                }
             }
 
             (Type::EnumComplement(complement), Type::LiteralValue(_) | Type::Union(_)) => {

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -78,21 +78,6 @@ impl<'db> UnionType<'db> {
         UnionBuilder::new(db).add(a).add(b).build()
     }
 
-    /// Create a union from a list of elements without unpacking type aliases.
-    pub(crate) fn from_elements_leave_aliases<I, T>(db: &'db dyn Db, elements: I) -> Type<'db>
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<Type<'db>>,
-    {
-        elements
-            .into_iter()
-            .fold(
-                UnionBuilder::new(db).unpack_aliases(false),
-                |builder, element| builder.add(element.into()),
-            )
-            .build()
-    }
-
     pub(crate) fn from_elements_cycle_recovery<I, T>(db: &'db dyn Db, elements: I) -> Type<'db>
     where
         I: IntoIterator<Item = T>,
@@ -136,34 +121,6 @@ impl<'db> UnionType<'db> {
         mapped
     }
 
-    /// A version of [`UnionType::map`] that does not unpack type aliases.
-    pub(crate) fn map_leave_aliases(
-        self,
-        db: &'db dyn Db,
-        mut transform_fn: impl FnMut(&Type<'db>) -> Type<'db>,
-    ) -> Type<'db> {
-        let elements = self.elements(db);
-        let mut iter = elements.iter().enumerate();
-        while let Some((i, ty)) = iter.next() {
-            let new_ty = transform_fn(ty);
-            if &new_ty != ty {
-                let mut builder = UnionBuilder::new(db).unpack_aliases(false);
-                for prev in &elements[..i] {
-                    builder = builder.add(*prev);
-                }
-                builder = builder.add(new_ty);
-                for (_, element) in iter {
-                    builder = builder.add(transform_fn(element));
-                }
-                return builder
-                    .recursively_defined(self.recursively_defined(db))
-                    .build();
-            }
-        }
-
-        Type::Union(self)
-    }
-
     /// A fallible version of [`UnionType::map`].
     ///
     /// For each element in `self`, `transform_fn` is called on that element.
@@ -189,7 +146,7 @@ impl<'db> UnionType<'db> {
         let mut iter = elements.iter().enumerate();
         while let Some((i, ty)) = iter.next() {
             let new_ty = transform_fn(ty)?;
-            if &new_ty != ty || matches!(new_ty, Type::TypeAlias(_)) {
+            if &new_ty != ty {
                 let mut builder = elements[..i]
                     .iter()
                     .copied()
@@ -338,7 +295,6 @@ impl<'db> UnionType<'db> {
         nested: bool,
     ) -> Option<Type<'db>> {
         let mut builder = UnionBuilder::new(db)
-            .unpack_aliases(false)
             .cycle_recovery(true)
             .recursively_defined(self.recursively_defined(db));
         let mut empty = true;

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -435,7 +435,6 @@ const MAX_NON_RECURSIVE_UNION_ENUM_LITERALS: usize = 8192;
 pub(crate) struct UnionBuilder<'db> {
     elements: Vec<UnionElement<'db>>,
     db: &'db dyn Db,
-    unpack_aliases: bool,
     /// This is enabled when joining types in a `cycle_recovery` function.
     /// Since a cycle cannot be created within a `cycle_recovery` function,
     /// execution of `is_redundant_with` is skipped.
@@ -504,22 +503,13 @@ impl<'db> UnionBuilder<'db> {
         Self {
             db,
             elements: vec![],
-            unpack_aliases: true,
             cycle_recovery: false,
             recursively_defined: RecursivelyDefined::No,
         }
     }
 
-    pub(crate) fn unpack_aliases(mut self, val: bool) -> Self {
-        self.unpack_aliases = val;
-        self
-    }
-
     pub(crate) fn cycle_recovery(mut self, val: bool) -> Self {
         self.cycle_recovery = val;
-        if self.cycle_recovery {
-            self.unpack_aliases = false;
-        }
         self
     }
 
@@ -538,7 +528,7 @@ impl<'db> UnionBuilder<'db> {
         self.elements.push(UnionElement::Type(Type::object()));
     }
 
-    fn widen_literal_types(&mut self, seen_aliases: &mut Vec<Type<'db>>) {
+    fn widen_literal_types(&mut self) {
         let mut replace_with = vec![];
         for elem in &self.elements {
             match elem {
@@ -559,7 +549,7 @@ impl<'db> UnionBuilder<'db> {
             }
         }
         for ty in replace_with {
-            self.add_in_place_impl(ty, seen_aliases);
+            self.add_in_place(ty);
         }
     }
 
@@ -571,10 +561,6 @@ impl<'db> UnionBuilder<'db> {
 
     /// Adds a type to this union.
     pub(crate) fn add_in_place(&mut self, ty: Type<'db>) {
-        self.add_in_place_impl(ty, &mut vec![]);
-    }
-
-    pub(crate) fn add_in_place_impl(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
         let cycle_recovery = self.cycle_recovery;
         let should_widen = |literals, recursively_defined: RecursivelyDefined| {
             if recursively_defined.is_yes() && cycle_recovery {
@@ -592,7 +578,7 @@ impl<'db> UnionBuilder<'db> {
                 let new_elements = union.elements(self.db);
                 self.elements.reserve(new_elements.len());
                 for element in new_elements {
-                    self.add_in_place_impl(*element, seen_aliases);
+                    self.add_in_place(*element);
                 }
                 self.recursively_defined = self
                     .recursively_defined
@@ -606,21 +592,12 @@ impl<'db> UnionBuilder<'db> {
                         UnionElement::Type(_) => acc,
                     });
                     if should_widen(literals, self.recursively_defined) {
-                        self.widen_literal_types(seen_aliases);
+                        self.widen_literal_types();
                     }
                 }
             }
             // Adding `Never` to a union is a no-op.
             Type::Never => {}
-            Type::TypeAlias(alias) if self.unpack_aliases => {
-                if seen_aliases.contains(&ty) {
-                    // Union contains itself recursively via a type alias. This is an error, just
-                    // leave out the recursive alias. TODO surface this error.
-                } else {
-                    seen_aliases.push(ty);
-                    self.add_in_place_impl(alias.value_type(self.db), seen_aliases);
-                }
-            }
             Type::LiteralValue(literal) => {
                 self.recursively_defined =
                     self.recursively_defined.or(literal.recursively_defined());
@@ -637,7 +614,7 @@ impl<'db> UnionBuilder<'db> {
                                 UnionElement::StringLiterals(literals) => {
                                     if should_widen(literals.len(), self.recursively_defined) {
                                         let replace_with = KnownClass::Str.to_instance(self.db);
-                                        self.add_in_place_impl(replace_with, seen_aliases);
+                                        self.add_in_place(replace_with);
                                         return;
                                     }
                                     found = Some(literals);
@@ -684,7 +661,7 @@ impl<'db> UnionBuilder<'db> {
                                 UnionElement::BytesLiterals(literals) => {
                                     if should_widen(literals.len(), self.recursively_defined) {
                                         let replace_with = KnownClass::Bytes.to_instance(self.db);
-                                        self.add_in_place_impl(replace_with, seen_aliases);
+                                        self.add_in_place(replace_with);
                                         return;
                                     }
                                     found = Some(literals);
@@ -733,7 +710,7 @@ impl<'db> UnionBuilder<'db> {
                                 UnionElement::IntLiterals(literals) => {
                                     if should_widen(literals.len(), self.recursively_defined) {
                                         let replace_with = KnownClass::Int.to_instance(self.db);
-                                        self.add_in_place_impl(replace_with, seen_aliases);
+                                        self.add_in_place(replace_with);
                                         return;
                                     }
                                     found = Some(literals);
@@ -787,10 +764,7 @@ impl<'db> UnionBuilder<'db> {
                         let metadata = enum_metadata(self.db, enum_class);
 
                         if metadata.is_some_and(|metadata| metadata.members.len() == 1) {
-                            self.add_in_place_impl(
-                                enum_member_to_add.enum_class_instance(self.db),
-                                seen_aliases,
-                            );
+                            self.add_in_place(enum_member_to_add.enum_class_instance(self.db));
                             return;
                         }
 
@@ -816,7 +790,7 @@ impl<'db> UnionBuilder<'db> {
                                     if literals.len() >= enum_literals_limit {
                                         let (literal, _) = literals.first().unwrap();
                                         let replace_with = literal.enum_class_instance(self.db);
-                                        self.add_in_place_impl(replace_with, seen_aliases);
+                                        self.add_in_place(replace_with);
                                         return;
                                     }
                                     found = Some(literals);
@@ -850,9 +824,8 @@ impl<'db> UnionBuilder<'db> {
                                     if metadata.is_some_and(|metadata| {
                                         found.len() == metadata.members.len()
                                     }) {
-                                        self.add_in_place_impl(
+                                        self.add_in_place(
                                             enum_member_to_add.enum_class_instance(self.db),
-                                            seen_aliases,
                                         );
                                         return;
                                     }
@@ -874,16 +847,16 @@ impl<'db> UnionBuilder<'db> {
                             self.elements.swap_remove(index);
                         }
                     }
-                    _ => self.push_type(ty, seen_aliases),
+                    _ => self.push_type(ty),
                 }
             }
             // Adding `object` to a union results in `object`.
             ty if ty.is_object() => self.collapse_to_object(),
-            _ => self.push_type(ty, seen_aliases),
+            _ => self.push_type(ty),
         }
     }
 
-    fn push_type(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
+    fn push_type(&mut self, ty: Type<'db>) {
         let mut ty = ty;
         let bool_pair = |ty: Type<'db>| {
             if let Some(LiteralValueTypeKind::Bool(b)) = ty.as_literal_value_kind() {
@@ -892,11 +865,6 @@ impl<'db> UnionBuilder<'db> {
                 None
             }
         };
-
-        // If an alias gets here, it means we aren't unpacking aliases, and we also
-        // shouldn't try to simplify aliases out of the union, because that will require
-        // unpacking them.
-        let should_simplify_full = !matches!(ty, Type::TypeAlias(_)) && !self.cycle_recovery;
 
         let mut ty_negated: Option<Type> = None;
         let mut to_remove = SmallVec::<[usize; 2]>::new();
@@ -935,7 +903,7 @@ impl<'db> UnionBuilder<'db> {
                 .zip(bool_pair(ty))
                 .is_some_and(|(element, pair)| element == pair)
             {
-                self.add_in_place_impl(KnownClass::Bool.to_instance(self.db), seen_aliases);
+                self.add_in_place(KnownClass::Bool.to_instance(self.db));
                 return;
             }
 
@@ -947,7 +915,7 @@ impl<'db> UnionBuilder<'db> {
                 continue;
             }
 
-            if should_simplify_full && !matches!(element_type, Type::TypeAlias(_)) {
+            if !self.cycle_recovery {
                 if ty.is_redundant_with(self.db, element_type) {
                     return;
                 }
@@ -992,7 +960,6 @@ impl<'db> UnionBuilder<'db> {
 
     pub(crate) fn try_build(self) -> Option<Type<'db>> {
         let db = self.db;
-        let unpack_aliases = self.unpack_aliases;
         let cycle_recovery = self.cycle_recovery;
         let recursively_defined = self.recursively_defined;
 
@@ -1038,7 +1005,6 @@ impl<'db> UnionBuilder<'db> {
 
         if normalize_enum_complement_unions(db, &mut types) {
             let builder = UnionBuilder::new(db)
-                .unpack_aliases(unpack_aliases)
                 .cycle_recovery(cycle_recovery)
                 .recursively_defined(recursively_defined);
             return types
@@ -1089,11 +1055,7 @@ impl<'db> IntersectionBuilder<'db> {
         self.add_positive_impl(ty, &mut vec![])
     }
 
-    pub(crate) fn add_positive_impl(
-        mut self,
-        ty: Type<'db>,
-        seen_aliases: &mut Vec<Type<'db>>,
-    ) -> Self {
+    fn add_positive_impl(mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) -> Self {
         match ty {
             Type::TypeAlias(alias) => {
                 if seen_aliases.contains(&ty) {
@@ -1155,12 +1117,8 @@ impl<'db> IntersectionBuilder<'db> {
         self.add_negative_impl(ty, &mut vec![])
     }
 
-    pub(crate) fn add_negative_impl(
-        mut self,
-        ty: Type<'db>,
-        seen_aliases: &mut Vec<Type<'db>>,
-    ) -> Self {
-        // See comments above in `add_positive`; this is just the negated version.
+    fn add_negative_impl(mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) -> Self {
+        // See comments above in `add_positive_impl`; this is just the negated version.
         match ty {
             Type::TypeAlias(alias) => {
                 if seen_aliases.contains(&ty) {
@@ -1805,10 +1763,6 @@ mod tests {
             expected
         );
         assert_eq!(
-            union.map_leave_aliases(&db, |ty| map_marker(ty, marker, widening_literal)),
-            expected
-        );
-        assert_eq!(
             union.try_map(&db, |ty| Some(map_marker(ty, marker, widening_literal))),
             Some(expected)
         );
@@ -1829,14 +1783,11 @@ mod tests {
 
         let alias = Type::TypeAlias(TypeAliasType::PEP695(alias));
         let str_instance = KnownClass::Str.to_instance(&db);
-        let union_ty = UnionType::from_elements_leave_aliases(&db, [alias, str_instance]);
+        let union_ty = UnionType::from_elements(&db, [alias, str_instance]);
         let union = union_ty.expect_union();
-        let unpacked =
-            UnionType::from_elements(&db, [KnownClass::Int.to_instance(&db), str_instance]);
 
-        assert_eq!(union.map(&db, |ty| *ty), unpacked);
-        assert_eq!(union.try_map(&db, |ty| Some(*ty)), Some(unpacked));
-        assert_eq!(union.map_leave_aliases(&db, |ty| *ty), union_ty);
+        assert_eq!(union.map(&db, |ty| *ty), union_ty);
+        assert_eq!(union.try_map(&db, |ty| Some(*ty)), Some(union_ty));
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -686,8 +686,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                 // suffix.
                 let mut elements = self.iter_all_elements();
                 let prefix: Vec<_> = elements.by_ref().take(prefix).collect();
-                let variable =
-                    UnionType::from_elements_leave_aliases(db, elements.by_ref().take(variable));
+                let variable = UnionType::from_elements(db, elements.by_ref().take(variable));
                 let suffix = elements.by_ref().take(suffix);
                 Ok(VariableLengthTuple::mixed(prefix, variable, suffix))
             }
@@ -1067,7 +1066,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                 // For example, `tuple[I0, *tuple[I1, ...], I2]` unpacked as
                 // `[a, b, *c]` means `b` could be `I1` (variable non-empty) or
                 // `I2` (variable empty, suffix shifts left), so it should be `I1 | I2`.
-                let variable = UnionType::from_elements_leave_aliases(
+                let variable = UnionType::from_elements(
                     db,
                     self.iter_prefix_elements()
                         .skip(prefix_length)
@@ -1177,7 +1176,7 @@ impl<'db> PyIndex<'db> for &VariableLengthTuple<Type<'db>> {
                 // large enough that it lands in the variable-length portion. It might also be
                 // small enough to land in the suffix.
                 let index_past_prefix = index - self.prefix_elements().len() + 1;
-                Ok(UnionType::from_elements_leave_aliases(
+                Ok(UnionType::from_elements(
                     db,
                     std::iter::once(self.variable()).chain(
                         self.suffix_elements()
@@ -1200,7 +1199,7 @@ impl<'db> PyIndex<'db> for &VariableLengthTuple<Type<'db>> {
                 // large enough that it lands in the variable-length portion. It might also be
                 // small enough to land in the prefix.
                 let index_past_suffix = index_from_end - self.suffix_elements().len() + 1;
-                Ok(UnionType::from_elements_leave_aliases(
+                Ok(UnionType::from_elements(
                     db,
                     (self.prefix_elements().iter().rev().copied())
                         .take(index_past_suffix)
@@ -1307,7 +1306,7 @@ impl<T> Tuple<T> {
 
 impl<'db> Tuple<Type<'db>> {
     pub(crate) fn homogeneous_element_type(&self, db: &'db dyn Db) -> Type<'db> {
-        UnionType::from_elements_leave_aliases(db, self.all_elements())
+        UnionType::from_elements(db, self.all_elements())
     }
 
     /// Resizes this tuple to a different length, if possible. If this tuple cannot satisfy the
@@ -1745,7 +1744,7 @@ impl<'db> TupleSpecBuilder<'db> {
                 },
                 TupleSpec::Variable(right),
             ) => {
-                let variable = UnionType::from_elements_leave_aliases(
+                let variable = UnionType::from_elements(
                     db,
                     left_suffix
                         .iter()
@@ -1790,7 +1789,7 @@ impl<'db> TupleSpecBuilder<'db> {
                 if our_elements.len() == new_elements.len() =>
             {
                 for (existing, new) in our_elements.iter_mut().zip(new_elements.all_elements()) {
-                    *existing = UnionType::from_elements_leave_aliases(db, [*existing, *new]);
+                    *existing = UnionType::from_elements(db, [*existing, *new]);
                 }
                 self
             }
@@ -1803,10 +1802,8 @@ impl<'db> TupleSpecBuilder<'db> {
             // would actually lead to more precise inference, so it's probably not worth the
             // complexity.
             _ => {
-                let unioned = UnionType::from_elements_leave_aliases(
-                    db,
-                    self.all_elements().chain(other.all_elements()),
-                );
+                let unioned =
+                    UnionType::from_elements(db, self.all_elements().chain(other.all_elements()));
                 TupleSpecBuilder::Variable {
                     prefix: vec![],
                     variable: unioned,

--- a/crates/ty_python_semantic/src/types/tuple/promotion.rs
+++ b/crates/ty_python_semantic/src/types/tuple/promotion.rs
@@ -187,9 +187,7 @@ impl<'db> Type<'db> {
             return self;
         }
 
-        let mut builder = UnionBuilder::new(db)
-            .unpack_aliases(false)
-            .recursively_defined(union.recursively_defined(db));
+        let mut builder = UnionBuilder::new(db).recursively_defined(union.recursively_defined(db));
 
         for element in other_union_elements {
             builder = builder.add(element);

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -51,7 +51,7 @@ impl<'db> PEP695TypeAliasType<'db> {
 
     /// The RHS type of a PEP-695 style type alias with specialization applied.
     ///
-    /// Salsa-tracked separately from [`raw_value_type`]: the latter caches the unspecialized
+    /// Salsa-tracked separately from [`Self::raw_value_type`]: the latter caches the unspecialized
     /// RHS, but a recursive `is_redundant_with -> has_relation_to -> unwrap alias -> value_type`
     /// chain re-enters `value_type` at a specialized `(alias, spec)` key, which is a distinct
     /// Salsa query from `raw_value_type`. Without tracking here, every call would re-run

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -50,6 +50,20 @@ impl<'db> PEP695TypeAliasType<'db> {
     }
 
     /// The RHS type of a PEP-695 style type alias with specialization applied.
+    ///
+    /// Salsa-tracked separately from [`raw_value_type`]: the latter caches the unspecialized
+    /// RHS, but a recursive `is_redundant_with -> has_relation_to -> unwrap alias -> value_type`
+    /// chain re-enters `value_type` at a specialized `(alias, spec)` key, which is a distinct
+    /// Salsa query from `raw_value_type`. Without tracking here, every call would re-run
+    /// `apply_function_specialization` with a fresh `ApplyTypeMappingVisitor`, leaving the
+    /// recursive chain unguarded and driving the redundancy cycle into oscillation.
+    #[salsa::tracked(
+        cycle_initial=|_, id, _| Type::divergent(id),
+        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _| {
+            value.cycle_normalized(db, *previous, cycle)
+        },
+        heap_size=ruff_memory_usage::heap_size
+    )]
     pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
         self.apply_function_specialization(db, self.raw_value_type(db))
     }


### PR DESCRIPTION
## Summary

There's an issue with whether or not to unpack type aliases when building union types. We didn't have a consistent principle for this, and instead used different functions with varying behavior, such as `UnionType::{from_elements, from_elements_leave_aliases}` or `UnionType::{map, map_leave_aliases}`, depending on the situation. This PR unifies all of these to the behavior of "leave_aliases". This also eliminates the need for flags like `UnionBuilder::unpack_aliases`, resulting in a simpler codebase.

This PR changes how type aliases are displayed. For example, previously `type Foo = int; def f(x: Foo): reveal_type(x)` displayed `int`, but now it will display `Foo`. Opinions may differ on which display is preferable, but I prefer `Foo`. This is because type aliases are often defined to explain the intent of complex types.

```python
from typing import Literal

type Month = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]

def f(x: Month):
    reveal_type(x)  # Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] -> Month
```

In any case, internally, type aliases and resolved types are treated the same, so apart from the difference in display, there is no difference in the results of type inference.

This PR includes measures to suppress panics related to recursive aliases, but these may become unnecessary with the ongoing fixes to recursive type handling, so we may wait for those merges before marking this PR as ready.

## Test Plan

mdtest updated
