### PR TITLE
[ty] include nested `global`/`nonlocal` bindings in type inference

### DIFF
--- a/crates/ty_ide/src/goto_declaration.rs
+++ b/crates/ty_ide/src/goto_declaration.rs
@@ -1388,11 +1388,15 @@ def outer():
         8 |         return x  # Should find the nonlocal x declaration in outer scope
           |                ^ Clicking here
           |
-        info: Found 1 declaration
+        info: Found 2 declarations
          --> main.py:3:5
           |
         3 |     x = "outer_value"
           |     -
+        4 |
+        5 |     def inner():
+        6 |         nonlocal x
+          |         ----------
           |
         "#);
     }
@@ -1421,11 +1425,15 @@ def outer():
         6 |         nonlocal xy
           |                  ^^ Clicking here
           |
-        info: Found 1 declaration
+        info: Found 2 declarations
          --> main.py:3:5
           |
         3 |     xy = "outer_value"
           |     --
+        4 |
+        5 |     def inner():
+        6 |         nonlocal xy
+          |         -----------
           |
         "#);
     }
@@ -1451,11 +1459,15 @@ def function():
         7 |     return global_var  # Should find the global variable declaration
           |            ^^^^^^^^^^ Clicking here
           |
-        info: Found 1 declaration
+        info: Found 2 declarations
          --> main.py:2:1
           |
         2 | global_var = "global_value"
           | ----------
+        3 |
+        4 | def function():
+        5 |     global global_var
+          |     -----------------
           |
         "#);
     }
@@ -1481,11 +1493,15 @@ def function():
         5 |     global global_var
           |            ^^^^^^^^^^ Clicking here
           |
-        info: Found 1 declaration
+        info: Found 2 declarations
          --> main.py:2:1
           |
         2 | global_var = "global_value"
           | ----------
+        3 |
+        4 | def function():
+        5 |     global global_var
+          |     -----------------
           |
         "#);
     }

--- a/crates/ty_ide/src/goto_declaration.rs
+++ b/crates/ty_ide/src/goto_declaration.rs
@@ -1388,15 +1388,11 @@ def outer():
         8 |         return x  # Should find the nonlocal x declaration in outer scope
           |                ^ Clicking here
           |
-        info: Found 2 declarations
+        info: Found 1 declaration
          --> main.py:3:5
           |
         3 |     x = "outer_value"
           |     -
-        4 |
-        5 |     def inner():
-        6 |         nonlocal x
-          |         ----------
           |
         "#);
     }
@@ -1425,15 +1421,11 @@ def outer():
         6 |         nonlocal xy
           |                  ^^ Clicking here
           |
-        info: Found 2 declarations
+        info: Found 1 declaration
          --> main.py:3:5
           |
         3 |     xy = "outer_value"
           |     --
-        4 |
-        5 |     def inner():
-        6 |         nonlocal xy
-          |         -----------
           |
         "#);
     }
@@ -1459,15 +1451,11 @@ def function():
         7 |     return global_var  # Should find the global variable declaration
           |            ^^^^^^^^^^ Clicking here
           |
-        info: Found 2 declarations
+        info: Found 1 declaration
          --> main.py:2:1
           |
         2 | global_var = "global_value"
           | ----------
-        3 |
-        4 | def function():
-        5 |     global global_var
-          |     -----------------
           |
         "#);
     }
@@ -1493,15 +1481,11 @@ def function():
         5 |     global global_var
           |            ^^^^^^^^^^ Clicking here
           |
-        info: Found 2 declarations
+        info: Found 1 declaration
          --> main.py:2:1
           |
         2 | global_var = "global_value"
           | ----------
-        3 |
-        4 | def function():
-        5 |     global global_var
-          |     -----------------
           |
         "#);
     }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -18,6 +18,7 @@ use ruff_python_parser::semantic_errors::{
     SemanticSyntaxErrorKind, YieldOutsideFunctionKind,
 };
 use ruff_text_size::{Ranged, TextRange};
+use smallvec::SmallVec;
 use ty_module_resolver::{ModuleName, resolve_module};
 
 use crate::HasTrackedScope;
@@ -26,12 +27,13 @@ use crate::ast_ids::node_key::ExpressionNodeKey;
 use crate::ast_node_ref::AstNodeRef;
 use crate::definition::{
     AnnotatedAssignmentDefinitionNodeRef, AssignmentDefinitionNodeRef,
-    ComprehensionDefinitionNodeRef, Definition, DefinitionCategory, DefinitionNodeKey,
-    DefinitionNodeRef, Definitions, DictKeyAssignmentNodeRef, ExceptHandlerDefinitionNodeRef,
-    ForStmtDefinitionNodeRef, ImportDefinitionNodeRef, ImportFromDefinitionNodeRef,
-    ImportFromSubmoduleDefinitionNodeRef, LambdaParameterDefinitionNodeRef,
-    LoopHeaderDefinitionNodeRef, LoopStmtRef, MatchPatternDefinitionNodeRef,
-    ParameterDefinitionNodeRef, StarImportDefinitionNodeRef, WithItemDefinitionNodeRef,
+    ComprehensionDefinitionNodeRef, Definition, DefinitionCategory, DefinitionKind,
+    DefinitionNodeKey, DefinitionNodeRef, Definitions, DictKeyAssignmentNodeRef,
+    ExceptHandlerDefinitionNodeRef, ForStmtDefinitionNodeRef, ImportDefinitionNodeRef,
+    ImportFromDefinitionNodeRef, ImportFromSubmoduleDefinitionNodeRef,
+    LambdaParameterDefinitionNodeRef, LoopHeaderDefinitionNodeRef, LoopStmtRef,
+    MatchPatternDefinitionNodeRef, NestedBindingsDefinitionKind, ParameterDefinitionNodeRef,
+    StarImportDefinitionNodeRef, WithItemDefinitionNodeRef,
 };
 use crate::expression::{Expression, ExpressionKind};
 use crate::frozen::{FrozenMap, FrozenSet};
@@ -54,7 +56,7 @@ use crate::statement::StatementInner;
 use crate::symbol::{ScopedSymbolId, Symbol};
 use crate::unpack::{Unpack, UnpackKind, UnpackPosition, UnpackValue};
 use crate::use_def::{
-    EnclosingSnapshotKey, FlowSnapshot, PreviousDefinitions, ScopedDefinitionId,
+    EnclosingSnapshotKey, FlowSnapshot, FutureDefinitions, PreviousDefinitions, ScopedDefinitionId,
     ScopedEnclosingSnapshotId, UseDefMapBuilder,
 };
 use crate::{Db, Statement, StatementNodeKey};
@@ -105,6 +107,51 @@ struct ScopeInfo<'ast> {
     current_loop: Option<Loop>,
     /// Saved narrowing aliases from the enclosing scope, restored on `pop_scope`.
     narrowing_aliases: FxHashMap<Name, NarrowingAlias<'ast>>,
+    /// `global` and `nonlocal` declarations from scopes nested under this one. This is used for:
+    ///
+    /// 1. Visibility of nested writes. A nested function that binds a variable might affect the
+    ///    inferred type of that variable in an outer scope. After each nested scope is closed, we
+    ///    install synthetic definitions to refer to visible nested writes, which we read from this
+    ///    map. (Note that *which kind* of nested writes is visible isn't necessarily known at that
+    ///    point; we stash both kinds and decide which one to use at inference time.)
+    /// 2. Semantic syntax errors for invalid `nonlocal` declarations. A `nonlocal` declaration is
+    ///    required to resolve to a local variable, and that variable must not be declared `global`
+    ///    or defined in the global scope. (This is why we track all `nonlocal` declarations, even
+    ///    if there's no binding in their scope.)
+    ///
+    /// When we're trying to figure out what scope a `nonlocal` declaration resolves to, we have to
+    /// remember that the definition of a local variable can come after a nested function that
+    /// mentions it. Similarly, when we're trying to figure out whether `global` bindings from a
+    /// nested scopes are visible in the current scope, we have to remember that a `global`
+    /// declaration can also come after nested function definitions. We build up these maps as we
+    /// encounter each `global` and `nonlocal` keyword, but we generally need to wait until scopes
+    /// are popped (or later, at inference time) to analyze them.
+    nested_global_or_nonlocal_declarations: NestedGlobalOrNonlocalDeclarations,
+    /// Text ranges for `global` and `nonlocal` declarations in this scope, which we use to
+    /// populate `nested_global_or_nonlocal_declarations` when we reach end of scope.
+    this_scope_global_or_nonlocal_declarations: FxHashMap<Name, TextRange>,
+}
+
+type NestedGlobalOrNonlocalDeclarations = FxHashMap<Name, SmallVec<[NestedDeclaration; 1]>>;
+
+#[derive(Copy, Clone, Debug, get_size2::GetSize)]
+pub struct NestedDeclaration {
+    pub kind: GlobalOrNonlocal,
+    pub file_scope_id: FileScopeId,
+    pub range: TextRange,
+    pub is_bound: bool,
+}
+
+impl NestedDeclaration {
+    pub fn is_global(&self) -> bool {
+        matches!(self.kind, GlobalOrNonlocal::Global)
+    }
+}
+
+#[derive(Copy, Clone, Debug, get_size2::GetSize)]
+pub enum GlobalOrNonlocal {
+    Global,
+    Nonlocal,
 }
 
 #[derive(Clone)]
@@ -424,6 +471,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             file_scope_id,
             current_loop: None,
             narrowing_aliases: saved_aliases,
+            nested_global_or_nonlocal_declarations: FxHashMap::default(),
+            this_scope_global_or_nonlocal_declarations: FxHashMap::default(),
         });
     }
 
@@ -722,12 +771,17 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         }
     }
 
-    fn pop_scope(&mut self) -> FileScopeId {
+    /// Returns the `NestedGlobalOrNonlocalDeclarations` that are still visible to the enclosing
+    /// scope, including those contributed by `global` and `nonlocal` keywords in the popped scope,
+    /// but excluding nested `nonlocal`s that resolved to the popped scope.
+    fn pop_scope(&mut self) -> NestedGlobalOrNonlocalDeclarations {
         self.try_node_context_stack_manager.exit_scope();
 
         let ScopeInfo {
             file_scope_id: popped_scope_id,
             narrowing_aliases,
+            mut nested_global_or_nonlocal_declarations,
+            this_scope_global_or_nonlocal_declarations,
             ..
         } = self
             .scope_stack
@@ -739,6 +793,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         let popped_scope = &mut self.scopes[popped_scope_id];
         popped_scope.extend_descendants(children_end);
+        let popped_scope_kind = popped_scope.kind();
 
         if popped_scope.is_eager() {
             self.record_eager_snapshots(popped_scope_id);
@@ -746,7 +801,134 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             self.record_lazy_snapshots(popped_scope_id);
         }
 
-        popped_scope_id
+        // If we've popped the module scope, there is no enclosing scope that needs our nested
+        // bindings. Short-circuit here and return an empty map.
+        if popped_scope_kind.is_module() {
+            debug_assert!(self.scope_stack.is_empty());
+            return FxHashMap::default();
+        }
+
+        // In the common case where we don't have any nested `global` or `nonlocal` declarations at
+        // all, short-circuit so that we don't walk the place table for no reason.
+        if nested_global_or_nonlocal_declarations.is_empty()
+            && this_scope_global_or_nonlocal_declarations.is_empty()
+        {
+            return FxHashMap::default();
+        }
+
+        // For each symbol in the (non-module) scope we just popped:
+        // 1. If the popped scope is function-like (not a class body), see whether it resolves any
+        //    `nonlocal` declarations (legally or illegally) from further nested scopes.
+        // 2. See whether it contributes any nested `global` or `nonlocal` declarations to the
+        //    enclosing scope.
+        for symbol in self.place_tables[popped_scope_id].symbols() {
+            // Filter out any nested `nonlocal` declaration that resolve in the popped scope.
+            // Typically these resolve to a defined (bound or declared) symbol, but they can also
+            // resolve (illegally) to an unbound `global` declaration. Remove any resolved
+            // declarations from the `nested_global_or_nonlocal_declarations` map, both so that we
+            // don't try to resolve them again, and so that synthetic nested binding definitions we
+            // install in enclosing scopes don't see them. (Note that this doesn't affect any
+            // synthetic nested binding definitions installed in the popped scope, which have
+            // already recorded these declarations.)
+            if popped_scope_kind.is_function_like()
+                && (symbol.is_local() || symbol.is_global())
+                && let Some(nested_declarations) =
+                    nested_global_or_nonlocal_declarations.get_mut(symbol.name())
+            {
+                nested_declarations.retain(|declaration| {
+                    if matches!(declaration.kind, GlobalOrNonlocal::Nonlocal) {
+                        // It's a syntax error for a `nonlocal` declaration to resolve to a
+                        // `global` statement in an enclosing scope.
+                        if symbol.is_global() {
+                            self.report_semantic_error(SemanticSyntaxError {
+                                kind: SemanticSyntaxErrorKind::NonlocalWithoutBinding(
+                                    symbol.name().to_string(),
+                                ),
+                                range: declaration.range,
+                                python_version: self.python_version,
+                            });
+                        }
+                        // This `nonlocal` is resolved.
+                        false
+                    } else {
+                        // Nested `global` declarations never "resolve" per se. This is both
+                        // because we already know they refer to the global scope, and also because
+                        // they can "pass through" intervening scopes where they're not visible to
+                        // containing scopes where they're visible again.
+                        true
+                    }
+                });
+                // If we've resolved all the nested declarations for a symbol, remove it from the
+                // map entirely. It wouldn't break anything to keep an empty list, but this avoids
+                // pointless allocations in enclosing scopes.
+                if nested_declarations.is_empty() {
+                    nested_global_or_nonlocal_declarations.remove(symbol.name());
+                }
+            }
+
+            // Add in any `global` and `nonlocal` declarations from this (non-module) scope.
+            if symbol.is_global() || symbol.is_nonlocal() {
+                let kind = if symbol.is_global() {
+                    GlobalOrNonlocal::Global
+                } else {
+                    GlobalOrNonlocal::Nonlocal
+                };
+                nested_global_or_nonlocal_declarations
+                    .entry(symbol.name().clone())
+                    .or_default()
+                    .push(NestedDeclaration {
+                        kind,
+                        file_scope_id: popped_scope_id,
+                        range: *this_scope_global_or_nonlocal_declarations
+                            .get(symbol.name())
+                            .expect("should have recorded a TextRange"),
+                        // This `is_bound` flag is why we wait until now to record these,
+                        // rather than doing it when we encounter the keywords.
+                        is_bound: symbol.is_bound(),
+                    });
+            }
+        }
+
+        // If the enclosing scope is the module scope, it's a semantic syntax error error to have
+        // any remaining unresolved `nonlocal` declarations.
+        if self.scope_stack.len() == 1 {
+            debug_assert!(
+                self.scopes[self.scope_stack[0].file_scope_id]
+                    .kind()
+                    .is_module(),
+                "the last remaining scope should be the module scope",
+            );
+            for (name, nested_declarations) in &nested_global_or_nonlocal_declarations {
+                for declaration in nested_declarations {
+                    if matches!(declaration.kind, GlobalOrNonlocal::Nonlocal) {
+                        self.report_semantic_error(SemanticSyntaxError {
+                            kind: SemanticSyntaxErrorKind::NonlocalWithoutBinding(name.to_string()),
+                            range: declaration.range,
+                            python_version: self.python_version,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Now we've updated `nested_global_or_nonlocal_declarations` based on what happened in the
+        // popped scope (resolutions and new declarations). Merge the whole map with the caller's
+        // own `nested_global_or_nonlocal_declarations` here. Note that we'll *also* return it
+        // immediately below, so that the caller can synthesize nested bindings definitions that
+        // only respect the bindings within the popped scope, rather than in all the nested scopes
+        // they've encountered so far.
+        if !popped_scope_kind.is_module() {
+            for (name, declarations) in &nested_global_or_nonlocal_declarations {
+                self.current_scope_info_mut()
+                    .nested_global_or_nonlocal_declarations
+                    .entry(name.clone())
+                    .or_default()
+                    .extend_from_slice(declarations);
+            }
+        }
+
+        // Here's the return described above.
+        nested_global_or_nonlocal_declarations
     }
 
     fn current_place_table(&self) -> &PlaceTableBuilder {
@@ -1255,7 +1437,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 } else {
                     PreviousDefinitions::AreShadowed
                 };
-                use_def.record_binding(place, definition, previous_definitions);
+                use_def.record_binding(
+                    place,
+                    definition,
+                    previous_definitions,
+                    FutureDefinitions::ShadowThisOne,
+                );
                 if !is_loop_header {
                     self.delete_associated_bindings(place);
                 }
@@ -1430,6 +1617,70 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // that. See this section of the Salsa docs:
         // <https://salsa-rs.github.io/salsa/overview.html#specify-the-result-of-tracked-functions-for-particular-structs>
         get_loop_header::specify(self.db, loop_token, loop_header);
+    }
+
+    fn synthesize_nested_binding_definitions(
+        &mut self,
+        nested_bindings: NestedGlobalOrNonlocalDeclarations,
+    ) {
+        for (name, mut declarations) in nested_bindings {
+            // Filter down to only the declarations with `is_bound: true`. If there are none left,
+            // skip synthesizing a definition for this symbol. (The reason we track these at all is
+            // that we reuse some of the same machinery to report semantic syntax errors for
+            // invalid `nonlocal`s, and those don't necessarily need a binding.)
+            declarations.retain(|d| d.is_bound);
+            declarations.shrink_to_fit();
+            if declarations.is_empty() {
+                continue;
+            }
+
+            let place: ScopedPlaceId = self.add_symbol(name.clone()).into();
+            let definition = Definition::new(
+                self.db,
+                self.file,
+                self.current_scope(),
+                place,
+                DefinitionKind::NestedBindings(Box::new(NestedBindingsDefinitionKind {
+                    name,
+                    nested_declarations: declarations,
+                })),
+                false,
+            );
+
+            // Adding a binding typically invalidates narrowing aliases like
+            // `is_int = isinstance(x, int)`. However, for the same reason that we retain both
+            // `global` and `nonlocal` nested writes -- we don't necessarily know yet which ones
+            // are going to be visible in the current scope -- it's also too early to know whether
+            // we should invalidate narrowing aliases. Situations where this matters tend to be
+            // *very* contrived, though, for example:
+            //
+            // ```py
+            // x: int | str = 1
+            // def _(x: int | str):
+            //     is_int = isinstance(x, int)
+            //     def _():
+            //         global x
+            //         x = "hello"
+            //     if is_int:
+            //         # We should narrow `x` to `int` here, because the global `x` is a different variable.
+            //         reveal_type(x)
+            // ```
+            //
+            // TODO: We could be more precise here by delaying invalidation until inference time.
+            self.invalidate_narrowing_aliases_for(place);
+
+            self.current_use_def_map_mut().record_binding(
+                place,
+                definition,
+                // Nested bindings definitions are like loop headers in that they don't shadow
+                // prior bindings, but they're different in that they *also* don't get shadowed by
+                // bindings that come later. The idea is that nested functions can be called at any
+                // time, so these bindings are effectively always visible after their function
+                // definitions.
+                PreviousDefinitions::AreKept,
+                FutureDefinitions::DontShadowThisOne,
+            );
+        }
     }
 
     fn record_expression_narrowing_constraint(
@@ -1875,12 +2126,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         statement
     }
 
-    fn with_type_params(
+    fn with_type_params<T>(
         &mut self,
         with_scope: NodeWithScopeRef,
         type_params: Option<&'ast ast::TypeParams>,
-        nested: impl FnOnce(&mut Self) -> FileScopeId,
-    ) -> FileScopeId {
+        nested: impl FnOnce(&mut Self) -> T,
+    ) -> T {
         if let Some(type_params) = type_params {
             self.push_scope(with_scope);
 
@@ -2281,7 +2532,24 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.visit_decorator(decorator);
                 }
 
-                self.with_type_params(
+                // Evaluate default args before we visit the body. If the default expression ends
+                // up looking at locally bound variables, `nonlocal` or `global` assignments in the
+                // body shouldn't affect their inferred values. For example:
+                // ```
+                // x = 1
+                // def f(y=reveal_type(x)):  # Literal[1]
+                //     global x
+                //     x = 2
+                // reveal_type(x)  # Literal[1, 2]
+                // ```
+                for default in parameters
+                    .iter_non_variadic_params()
+                    .filter_map(|param| param.default.as_deref())
+                {
+                    self.visit_expr(default);
+                }
+
+                let nested_bindings = self.with_type_params(
                     NodeWithScopeRef::FunctionTypeParameters(function_def),
                     type_params.as_deref(),
                     |builder| {
@@ -2309,14 +2577,44 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         builder.pop_scope()
                     },
                 );
-                // The default value of the parameters needs to be evaluated in the
-                // enclosing scope.
-                for default in parameters
-                    .iter_non_variadic_params()
-                    .filter_map(|param| param.default.as_deref())
-                {
-                    self.visit_expr(default);
-                }
+
+                // The nested bindings returned by `pop_scope` are exactly the ones that are
+                // potentially visible at this point. That is, they include `global` and `nonlocal`
+                // declarations in the popped functions body and any nested bodies, but they omit
+                // the ones that resolved to the popped body. Synthesize a definition to record
+                // them. This definition type has special shadowing behavior, so it doesn't shadow
+                // prior bindings, and it remains visible after subsequent bindings. This
+                // represents the fact that the nested function could be called at any time.
+                //
+                // NOTE: This is deliberately somewhat unsound. For example, bindings from parent
+                // functions and sibling functions can also be visible at any point, depending on
+                // when different functions get invoked. However, we really want examples like this
+                // to do what users expect, so we accept the unsoundness here:
+                //
+                //     def f():
+                //         x = 1
+                //         def g():
+                //             nonlocal x
+                //             x = 2
+                //         def h():
+                //             nonlocal x
+                //             x = 3
+                //             # Technically `g` could get called at any time, including right
+                //             # here. But inferring `Literal[2, 3]` here would be confusing.
+                //             reveal_type(x)  # revealed: Literal[3]
+                //          x = 4
+                //          # On the other hand, users probably want to see 2 and 3 here, because
+                //          # they're nested within this scope? Hopefully it's not too confusing.
+                //          reveal_type(x)  # revealed: Literal[2, 3, 4]
+                //
+                // In other cases it can also be unsound that we only consider nested bindings to
+                // be visible after their function definition, when in practice they could be
+                // visible "before" (because nested functions can escape their lexical scope and
+                // get called more than once). For more discussion of all these behaviors, see the
+                // mdtest case "Visibility of `nonlocal` bindings from nested and sibling scopes"
+                // and its `global` counterpart.
+                self.synthesize_nested_binding_definitions(nested_bindings);
+
                 // The symbol for the function name itself has to be evaluated
                 // at the end to match the runtime evaluation of parameter defaults
                 // and return-type annotations.
@@ -2339,7 +2637,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.visit_decorator(decorator);
                 }
 
-                self.with_type_params(
+                let nested_bindings = self.with_type_params(
                     NodeWithScopeRef::ClassTypeParameters(class),
                     class.type_params.as_deref(),
                     |builder| {
@@ -2353,6 +2651,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         builder.pop_scope()
                     },
                 );
+
+                // We currently treat nested `global` and `nonlocal` bindings from class bodies the
+                // same way as ones from function bodies above. That's correct in the common case
+                // where they actually come from a function within the class. But when they appear
+                // directly within a class body, this isn't quite correct, because these synthetic
+                // definitions behave lazily, while class bodies are actually evaluated eagerly.
+                self.synthesize_nested_binding_definitions(nested_bindings);
 
                 // In Python runtime semantics, a class is registered after its scope is evaluated.
                 let symbol = self.add_symbol(class.name.id.clone());
@@ -3325,7 +3630,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 self.mark_unreachable();
             }
             ast::Stmt::Global(ast::StmtGlobal {
-                range: _,
+                range,
                 node_index: _,
                 names,
             }) => {
@@ -3354,15 +3659,33 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             range: name.range,
                             python_version: self.python_version,
                         });
+                        // Never mark a symbol both global and nonlocal, even in this error case.
+                        continue;
+                    }
+                    // Check whether this is the module scope, where `global` has no effect.
+                    let scope_id = self.current_scope();
+                    if scope_id.is_global() {
+                        // It's important that we don't `mark_global` here, because we error on
+                        // type annotations on places that are marked global, but it's actually
+                        // legal to write `global x; x: int = 42` at the module level.
+                        continue;
+                    }
+                    // Assuming none of the rules above are violated, repeated `global`
+                    // declarations are allowed and ignored.
+                    if symbol.is_global() {
+                        continue;
                     }
                     self.current_place_table_mut()
                         .symbol_mut(symbol_id)
                         .mark_global();
+                    self.current_scope_info_mut()
+                        .this_scope_global_or_nonlocal_declarations
+                        .insert(name.id.clone(), *range);
                 }
                 walk_stmt(self, stmt);
             }
             ast::Stmt::Nonlocal(ast::StmtNonlocal {
-                range: _,
+                range,
                 node_index: _,
                 names,
             }) => {
@@ -3389,19 +3712,26 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             range: name.range,
                             python_version: self.python_version,
                         });
+                        // Never mark a symbol both global and nonlocal, even in this error case.
+                        continue;
                     }
-                    // The variable is required to exist in an enclosing scope, but that definition
-                    // might come later. For example, this is example legal, but we can't check
-                    // that here, because we haven't gotten to `x = 1`:
-                    // ```py
-                    // def f():
-                    //     def g():
-                    //         nonlocal x
-                    //     x = 1
-                    // ```
+                    // Check whether this is the module scope, where `nonlocal` isn't allowed.
+                    let scope_id = self.current_scope();
+                    if scope_id.is_global() {
+                        // The SemanticSyntaxChecker will report an error for this.
+                        continue;
+                    }
+                    // Assuming none of the rules above are violated, repeated `nonlocal`
+                    // declarations are allowed and ignored.
+                    if symbol.is_nonlocal() {
+                        continue;
+                    }
                     self.current_place_table_mut()
                         .symbol_mut(symbol_id)
                         .mark_nonlocal();
+                    self.current_scope_info_mut()
+                        .this_scope_global_or_nonlocal_declarations
+                        .insert(name.id.clone(), *range);
                 }
                 walk_stmt(self, stmt);
             }

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -934,9 +934,12 @@ impl<'db> DefinitionKind<'db> {
     }
 
     /// Returns `true` if this definition is user-visible (i.e., not an internal
-    /// control-flow construct like a loop header definition).
+    /// synthetic definition like a loop header or nested bindings definition).
     pub const fn is_user_visible(&self) -> bool {
-        !self.is_loop_header()
+        !matches!(
+            self,
+            DefinitionKind::LoopHeader(_) | DefinitionKind::NestedBindings(_)
+        )
     }
 
     /// Returns the [`TextRange`] of the definition target.

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -3,9 +3,11 @@ use std::ops::Deref;
 use ruff_db::files::{File, FileRange};
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::find_node::covering_node;
+use ruff_python_ast::name::Name;
 use ruff_python_ast::traversal::suite;
 use ruff_python_ast::{self as ast, AnyNodeRef, Expr};
 use ruff_text_size::{Ranged, TextRange, TextSize};
+use smallvec::SmallVec;
 
 use crate::Db;
 use crate::LoopToken;
@@ -870,6 +872,8 @@ pub enum DefinitionKind<'db> {
     ParamSpec(AstNodeRef<ast::TypeParamParamSpec>),
     TypeVarTuple(AstNodeRef<ast::TypeParamTypeVarTuple>),
     LoopHeader(LoopHeaderDefinitionKind<'db>),
+    // Boxing here helps avoid growing the memory footprint of this enum.
+    NestedBindings(Box<NestedBindingsDefinitionKind>),
 }
 
 impl<'db> DefinitionKind<'db> {
@@ -979,6 +983,12 @@ impl<'db> DefinitionKind<'db> {
                 type_var_tuple.node(module).name.range()
             }
             DefinitionKind::LoopHeader(loop_header) => loop_header.range(module),
+            DefinitionKind::NestedBindings(nested_bindings) => {
+                // TODO: We only return the `TextRange` of one of the `nonlocal` or `global`
+                // declarations that affect this variable, even if there's more than one. We could
+                // find a way to return all of them, or split up the synthetic definition somehow.
+                nested_bindings.nested_declarations[0].range
+            }
         }
     }
 
@@ -1028,6 +1038,12 @@ impl<'db> DefinitionKind<'db> {
             DefinitionKind::ParamSpec(param_spec) => param_spec.node(module).range(),
             DefinitionKind::TypeVarTuple(type_var_tuple) => type_var_tuple.node(module).range(),
             DefinitionKind::LoopHeader(loop_header) => loop_header.range(module),
+            DefinitionKind::NestedBindings(nested_bindings) => {
+                // TODO: We only return the `TextRange` of one of the `nonlocal` or `global`
+                // declarations that affect this variable, even if there's more than one. We could
+                // find a way to return all of them, or split up the synthetic definition somehow.
+                nested_bindings.nested_declarations[0].range
+            }
         }
     }
 
@@ -1068,7 +1084,8 @@ impl<'db> DefinitionKind<'db> {
             | DefinitionKind::MatchPattern(_)
             | DefinitionKind::ImportFromSubmodule(_)
             | DefinitionKind::ExceptHandler(_)
-            | DefinitionKind::LoopHeader(_) => DefinitionCategory::Binding,
+            | DefinitionKind::LoopHeader(_)
+            | DefinitionKind::NestedBindings(_) => DefinitionCategory::Binding,
         }
     }
 
@@ -1498,6 +1515,15 @@ impl<'db> LoopHeaderDefinitionKind<'db> {
             LoopStmtKind::For(stmt) => stmt.node(module).range(),
         }
     }
+}
+
+#[derive(Clone, Debug, get_size2::GetSize)]
+pub struct NestedBindingsDefinitionKind {
+    pub name: Name,
+    // Note that in general this can include both `global` and `nonlocal` declarations from
+    // different nested scopes, because we don't necessarily know at synthesis time which of those
+    // kind will be visible in the current scope.
+    pub nested_declarations: SmallVec<[crate::builder::NestedDeclaration; 1]>,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, salsa::Update, get_size2::GetSize)]

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -451,6 +451,46 @@ impl<'db> SemanticIndex<'db> {
         self.place_table(scope).symbol(symbol).is_nonlocal()
     }
 
+    /// Returns `true` if the given symbol in the given scope resolves to the global scope, either
+    /// because:
+    ///
+    /// 1. The given scope *is* the global scope.
+    /// 2. The symbol is explicitly declared `global` in the given scope.
+    /// 3. The symbol is a free variable in the given scope, and no enclosing function scope
+    ///    defines it.
+    ///
+    /// The third case requires walking ancestor scopes until we encounter either a binding or a
+    /// `nonlocal` declaration (those aren't allowed to resolve to the global scope, so we don't
+    /// need to chase them).
+    pub fn symbol_resolves_to_global_scope(
+        &self,
+        symbol: ScopedSymbolId,
+        scope: FileScopeId,
+    ) -> bool {
+        let symbol = self.place_table(scope).symbol(symbol);
+        let name = symbol.name();
+        // Note that `visible_ancestor_scopes` includes the starting scope itself.
+        for (visible_scope_id, _) in self.visible_ancestor_scopes(scope) {
+            if visible_scope_id.is_global() {
+                // We return `true` here even if the global variable isn't actually defined. That
+                // case will be probably a diagnostic elsewhere.
+                return true;
+            }
+            let place_table = self.place_table(visible_scope_id);
+            let Some(visible_symbol_id) = place_table.symbol_id(name) else {
+                continue;
+            };
+            let visible_symbol = place_table.symbol(visible_symbol_id);
+            if visible_symbol.is_global() {
+                return true;
+            }
+            if visible_symbol.is_local() || visible_symbol.is_nonlocal() {
+                return false;
+            }
+        }
+        unreachable!("should return true at the global scope above");
+    }
+
     /// Returns the id of the parent scope.
     pub fn parent_scope_id(&self, scope_id: FileScopeId) -> Option<FileScopeId> {
         let scope = self.scope(scope_id);

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -266,8 +266,8 @@ use crate::{BoundnessAnalysis, EnclosingSnapshotResult, PossiblyNarrowedPlaces, 
 mod place_state;
 
 pub use place_state::LiveBinding;
-pub(super) use place_state::PreviousDefinitions;
 pub use place_state::ScopedDefinitionId;
+pub(super) use place_state::{FutureDefinitions, PreviousDefinitions};
 
 /// Uniquely identifies an interned [`Bindings`] entry in [`UseDefMap::interned_bindings`].
 #[newtype_index]
@@ -1214,6 +1214,7 @@ impl<'db> UseDefMapBuilder<'db> {
         place: ScopedPlaceId,
         binding: Definition<'db>,
         previous_definitions: PreviousDefinitions,
+        can_be_shadowed: FutureDefinitions,
     ) {
         let bindings = match place {
             ScopedPlaceId::Symbol(symbol) => self.symbol_states[symbol].bindings().clone(),
@@ -1239,6 +1240,7 @@ impl<'db> UseDefMapBuilder<'db> {
             self.is_class_scope,
             place.is_symbol(),
             previous_definitions,
+            can_be_shadowed,
         );
 
         let bindings = match place {
@@ -1256,6 +1258,7 @@ impl<'db> UseDefMapBuilder<'db> {
             self.is_class_scope,
             place.is_symbol(),
             PreviousDefinitions::AreKept,
+            can_be_shadowed,
         );
     }
 
@@ -1527,6 +1530,7 @@ impl<'db> UseDefMapBuilder<'db> {
             self.is_class_scope,
             place.is_symbol(),
             PreviousDefinitions::AreShadowed,
+            FutureDefinitions::ShadowThisOne,
         );
 
         let reachable_definitions = match place {
@@ -1545,6 +1549,7 @@ impl<'db> UseDefMapBuilder<'db> {
             self.is_class_scope,
             place.is_symbol(),
             PreviousDefinitions::AreKept,
+            FutureDefinitions::ShadowThisOne,
         );
     }
 
@@ -1561,6 +1566,7 @@ impl<'db> UseDefMapBuilder<'db> {
             self.is_class_scope,
             place.is_symbol(),
             PreviousDefinitions::AreShadowed,
+            FutureDefinitions::ShadowThisOne,
         );
     }
 

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -85,10 +85,23 @@ pub(super) struct LiveDeclaration {
 
 pub(super) type LiveDeclarationsIterator<'a> = std::slice::Iter<'a, LiveDeclaration>;
 
+/// What happens to any preexisting definitions when a new binding of the same place is added.
+/// `AreShadowed` is how normal assignments behave, but we model some features (loop headers,
+/// `nonlocal` writes from nested scopes) as "synthetic" bindings that don't shadow other bindings.
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum PreviousDefinitions {
     AreShadowed,
     AreKept,
+}
+
+/// What will happen to a definition if/when a when a new binding of the same place is added later.
+/// `ShadowThisOne` is how normal assignments behave, and it's also how some "synthetic" bindings
+/// behave (loop headers), but there are other synthetic bindings (nested `nonlocal` writes) that
+/// cannot be shadowed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+pub(crate) enum FutureDefinitions {
+    ShadowThisOne,
+    DontShadowThisOne,
 }
 
 impl PreviousDefinitions {
@@ -231,6 +244,7 @@ impl Bindings {
                     binding: ScopedDefinitionId::UNBOUND,
                     narrowing_constraint: ScopedNarrowingConstraint::ALWAYS_TRUE,
                     reachability_constraint: ScopedReachabilityConstraintId::ALWAYS_TRUE,
+                    can_be_shadowed: FutureDefinitions::ShadowThisOne,
                 }]
             )
     }
@@ -255,6 +269,9 @@ pub struct LiveBinding {
     binding: ScopedDefinitionId,
     narrowing_constraint: ScopedNarrowingConstraint,
     reachability_constraint: ScopedReachabilityConstraintId,
+    // TODO: This extra bit is responsible for 1% of our memory footprint in some projects. We
+    // could pack it into one of the fields above.
+    can_be_shadowed: FutureDefinitions,
 }
 
 impl LiveBinding {
@@ -279,6 +296,7 @@ impl Bindings {
             binding: ScopedDefinitionId::UNBOUND,
             narrowing_constraint: ScopedNarrowingConstraint::ALWAYS_TRUE,
             reachability_constraint,
+            can_be_shadowed: FutureDefinitions::ShadowThisOne,
         };
         Self {
             unbound_narrowing_constraint: None,
@@ -294,21 +312,24 @@ impl Bindings {
         is_class_scope: bool,
         is_place_name: bool,
         previous_definitions: PreviousDefinitions,
+        can_be_shadowed: FutureDefinitions,
     ) {
         // If we are in a class scope, and the unbound name binding was previously visible, but we will
         // now replace it, record the narrowing constraints on it:
         if is_class_scope && is_place_name && self.live_bindings[0].binding.is_unbound() {
             self.unbound_narrowing_constraint = Some(self.live_bindings[0].narrowing_constraint);
         }
-        // The new binding replaces all previous live bindings in this path, and has no
-        // constraints.
+        // If the new binding is a shadowing type, it replaces previous live bindings in this path
+        // (unless they're marked as not shadowable), and has no constraints.
         if previous_definitions.are_shadowed() {
-            self.live_bindings.clear();
+            self.live_bindings
+                .retain(|b| b.can_be_shadowed == FutureDefinitions::DontShadowThisOne);
         }
         self.live_bindings.push(LiveBinding {
             binding,
             narrowing_constraint: ScopedNarrowingConstraint::ALWAYS_TRUE,
             reachability_constraint,
+            can_be_shadowed,
         });
     }
 
@@ -375,10 +396,12 @@ impl Bindings {
                     let reachability_constraint = reachability_constraints
                         .add_or_constraint(a.reachability_constraint, b.reachability_constraint);
 
+                    debug_assert_eq!(a.can_be_shadowed, b.can_be_shadowed);
                     self.live_bindings.push(LiveBinding {
                         binding: a.binding,
                         narrowing_constraint,
                         reachability_constraint,
+                        can_be_shadowed: a.can_be_shadowed,
                     });
                 }
 
@@ -413,6 +436,7 @@ impl PlaceState {
         is_class_scope: bool,
         is_place_name: bool,
         previous_definitions: PreviousDefinitions,
+        can_be_shadowed: FutureDefinitions,
     ) {
         debug_assert_ne!(binding_id, ScopedDefinitionId::UNBOUND);
         self.bindings.record_binding(
@@ -421,6 +445,7 @@ impl PlaceState {
             is_class_scope,
             is_place_name,
             previous_definitions,
+            can_be_shadowed,
         );
     }
 
@@ -542,9 +567,56 @@ mod tests {
             false,
             true,
             PreviousDefinitions::AreShadowed,
+            FutureDefinitions::ShadowThisOne,
         );
 
         assert_bindings(&sym, &[(1, ScopedNarrowingConstraint::ALWAYS_TRUE)]);
+    }
+
+    #[test]
+    fn future_definitions_can_opt_out_of_shadowing() {
+        let mut sym = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
+        sym.record_binding(
+            ScopedDefinitionId::from_u32(1),
+            ScopedReachabilityConstraintId::ALWAYS_TRUE,
+            false,
+            true,
+            PreviousDefinitions::AreKept,
+            FutureDefinitions::DontShadowThisOne,
+        );
+        sym.record_binding(
+            ScopedDefinitionId::from_u32(2),
+            ScopedReachabilityConstraintId::ALWAYS_TRUE,
+            false,
+            true,
+            PreviousDefinitions::AreShadowed,
+            FutureDefinitions::ShadowThisOne,
+        );
+
+        assert_bindings(
+            &sym,
+            &[
+                (1, ScopedNarrowingConstraint::ALWAYS_TRUE),
+                (2, ScopedNarrowingConstraint::ALWAYS_TRUE),
+            ],
+        );
+
+        sym.record_binding(
+            ScopedDefinitionId::from_u32(3),
+            ScopedReachabilityConstraintId::ALWAYS_TRUE,
+            false,
+            true,
+            PreviousDefinitions::AreShadowed,
+            FutureDefinitions::ShadowThisOne,
+        );
+
+        assert_bindings(
+            &sym,
+            &[
+                (1, ScopedNarrowingConstraint::ALWAYS_TRUE),
+                (3, ScopedNarrowingConstraint::ALWAYS_TRUE),
+            ],
+        );
     }
 
     #[test]
@@ -557,6 +629,7 @@ mod tests {
             false,
             true,
             PreviousDefinitions::AreShadowed,
+            FutureDefinitions::ShadowThisOne,
         );
         let atom = reachability_constraints.add_atom(ScopedPredicateId::new(0));
         sym.record_narrowing_constraint(&mut reachability_constraints, atom);
@@ -576,6 +649,7 @@ mod tests {
             false,
             true,
             PreviousDefinitions::AreShadowed,
+            FutureDefinitions::ShadowThisOne,
         );
         let atom0 = reachability_constraints.add_atom(ScopedPredicateId::new(0));
         sym1a.record_narrowing_constraint(&mut reachability_constraints, atom0);
@@ -587,6 +661,7 @@ mod tests {
             false,
             true,
             PreviousDefinitions::AreShadowed,
+            FutureDefinitions::ShadowThisOne,
         );
         sym1b.record_narrowing_constraint(&mut reachability_constraints, atom0);
 
@@ -603,6 +678,7 @@ mod tests {
             false,
             true,
             PreviousDefinitions::AreShadowed,
+            FutureDefinitions::ShadowThisOne,
         );
         let atom1 = reachability_constraints.add_atom(ScopedPredicateId::new(1));
         sym2a.record_narrowing_constraint(&mut reachability_constraints, atom1);
@@ -614,6 +690,7 @@ mod tests {
             false,
             true,
             PreviousDefinitions::AreShadowed,
+            FutureDefinitions::ShadowThisOne,
         );
         let atom2 = reachability_constraints.add_atom(ScopedPredicateId::new(2));
         sym1b.record_narrowing_constraint(&mut reachability_constraints, atom2);
@@ -635,6 +712,7 @@ mod tests {
             false,
             true,
             PreviousDefinitions::AreShadowed,
+            FutureDefinitions::ShadowThisOne,
         );
         let atom3 = reachability_constraints.add_atom(ScopedPredicateId::new(3));
         sym3a.record_narrowing_constraint(&mut reachability_constraints, atom3);

--- a/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/aliased_conditions.md
@@ -378,11 +378,8 @@ def _(x: int | None):
         if is_none:
             reveal_type(x)  # revealed: Literal[42]
 
-    # TODO: should be `int | None`
-    # We don't yet track that `inner()` can modify `x` via `nonlocal`.
-    # (https://github.com/astral-sh/ty/issues/2731)
     if is_none:
-        reveal_type(x)  # revealed: None
+        reveal_type(x)  # revealed: int | None
 
 def _(x: int | None):
     is_none = x is None
@@ -440,11 +437,8 @@ def _(x: int | None):
 
     inner()
 
-    # TODO: should be `int | None`
-    # We don't yet track that `inner()` can modify `is_none` via `nonlocal`.
-    # (https://github.com/astral-sh/ty/issues/2731)
     if is_none:
-        reveal_type(x)  # revealed: None
+        reveal_type(x)  # revealed: int | None
 
 def _(x: int | None):
     is_none = x is None

--- a/crates/ty_python_semantic/resources/mdtest/public_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/public_types.md
@@ -343,25 +343,6 @@ def f(x: A):
     x = A()
 ```
 
-### Assignments to nonlocal variables
-
-Writes to the outer-scope variable are currently not detected:
-
-```py
-def outer() -> None:
-    x = None
-
-    def set_x() -> None:
-        nonlocal x
-        x = 1
-    set_x()
-
-    def inner() -> None:
-        # TODO: this should ideally be `None | Literal[1]`. Mypy and pyright support this.
-        reveal_type(x)  # revealed: None
-    inner()
-```
-
 ## Handling of overloads
 
 ### With implementation

--- a/crates/ty_python_semantic/resources/mdtest/scopes/global.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/global.md
@@ -36,25 +36,19 @@ def f():
     x = ""
 
     global z
-    # error: [invalid-assignment] "Object of type `Literal[""]` is not assignable to `int`"
+    # This binding is currently allowed, because the invalid declaration of `z` below acts like
+    # `z: Unknown`. The end result is similar to what we get in the local case:
+    #
+    #     x = 42  # ok
+    #     x: str  # error
+    #
+    # It would also be acceptable to emit an error here in the future. The important thing is that
+    # at least one of the following two lines should fail.
     z = ""
 
+# This declaration sees the synthetic definition for `z` that we add to this scope after the end of `f`.
+# error: [invalid-declaration] "Cannot declare type `int` for inferred type `Literal[""]`"
 z: int
-```
-
-## Nested intervening scope
-
-A `global` statement causes lookup to skip any bindings in intervening scopes:
-
-```py
-x: int = 1
-
-def outer():
-    x: str = ""
-
-    def inner():
-        global x
-        reveal_type(x)  # revealed: int
 ```
 
 ## Narrowing
@@ -87,8 +81,7 @@ def f():
 ## Nested function after conditional rebinding
 
 A nested function should resolve a `global` name through the enclosing scope, even if that scope
-conditionally rebinds it. Here, the early return means `inner` only sees the original module
-binding:
+conditionally rebinds it:
 
 ```py
 x = 1
@@ -101,26 +94,7 @@ def outer(flag: bool) -> None:
         return
 
     def inner() -> None:
-        reveal_type(x)  # revealed: Literal[1]
-```
-
-Without the early return, the nested function should see both possible bindings. This is a known
-limitation: we currently infer only the rebound value instead of the union of both:
-
-```py
-x = 1
-
-def outer(flag: bool) -> None:
-    global x
-
-    if flag:
-        x = 2
-
-    def inner() -> None:
-        # TODO: should be `Literal[1, 2]`
-        reveal_type(x)  # revealed: Literal[2]
-
-    inner()
+        reveal_type(x)  # revealed: Literal[1, 2]
 ```
 
 ## `nonlocal` and `global`
@@ -233,14 +207,14 @@ x = None
 global x  # error: [invalid-syntax] "name `x` is used prior to global declaration"
 ```
 
-## Local bindings override preceding `global` bindings
+## Local bindings to a `global` shadow the public type
 
 ```py
 x = 42
 
 def f():
     global x
-    reveal_type(x)  # revealed: Literal[42]
+    reveal_type(x)  # revealed: Literal[42, "56"]
     x = "56"
     reveal_type(x)  # revealed: Literal["56"]
 ```
@@ -265,6 +239,15 @@ x: int = 1
 def f():
     global x
     x: str = "foo"  # error: [invalid-syntax] "annotated name `x` can't be global"
+```
+
+However, `global` keywords are allowed (but useless) in the global scope, and it's not an error to
+annotate the variable after that.
+
+```py
+global y
+
+y: int = 42
 ```
 
 ## Global declarations affect the inferred type of the binding
@@ -376,4 +359,331 @@ B = 1
 class B:
     reveal_type(B)  # revealed: Literal[1]
     B = B
+```
+
+## Visibility of `global` bindings from nested and sibling scopes
+
+(`nonlocal` bindings behave similarly and have a similarly named test case in `nonlocal.md`.)
+
+A `global` write from an inner scope can affect the target variable's inferred type in the global
+scope defining scope. For the same reason, reads in a nested function can also see later bindings in
+their own scope:
+
+`global1.py`:
+
+```py
+x = 1
+
+def f():
+    global x
+    # The following assignment of 2 could be visible if this function has been called before.
+    reveal_type(x)  # revealed: Literal[1, 2]
+    x = 2
+    # Once a binding is made in this scope, it shadows bindings from outer scopes.
+    reveal_type(x)  # revealed: Literal[2]
+
+# From now on we assume `f` could be called at any time.
+reveal_type(x)  # revealed: Literal[1, 2]
+```
+
+The example above (hopefully) feels natural, but if we look at it closely, the reveals there are
+making some beefy assumptions. For one, we assume `f` might be called before the final reveal, even
+though in this case we can actually see that it's never called. A "sufficiently smart compiler"
+could've narrowed that to `Literal[1]`, but we don't/can't track what functions are caled when
+(anywhere really, but especially not in the global scope), so we're being conservative. On the other
+hand, the reveal of `Literal[2]` after the binding in `g` is the opposite, an aggressive assumption
+that's not generally sound. Consider this counterexample where `f` and `g` are siblings that both
+assign to `x`:
+
+`global2.py`:
+
+```py
+x = 1
+
+def f():
+    global x
+    x = 2
+    reveal_type(x)  # revealed: Literal[2]
+
+def g():
+    global x
+    x = 3
+    f()
+    # The logic that gives us `Literal[2]` above also gives us `Literal[3]` here, even though
+    # the call to `f()` means that `x` is in fact 2 at runtime. We can only reason locally about
+    # these things; we can't do whole-program control flow analysis or solve the halting
+    # problem. A fully sound typechecker would generally need to infer `Literal[2, 3]` both here
+    # and above. That would be great here -- wrong answers are bad! -- but it would break too
+    # much real-world code that expects `Literal[2]` in simple cases like `f` above.
+    reveal_type(x)  # revealed: Literal[3]
+
+reveal_type(x)  # revealed: Literal[1, 2, 3]
+```
+
+So we're ok with making unsound assumptions to make simple, common cases do what users expect. Fine.
+But then what about the reveal of `Literal[1, 2, 3]` at the end there? We aggressively shadow
+bindings from outer or sibling scopes, but we conservatively include bindings from scopes nested
+within the current one, once we've encountered them (i.e. in a top-to-bottom reading of the code).
+This second behavior is _also_ unsound, because nested functions can "escape" the scope where
+they're defined and affect reads on lines above their definition. But again these are the behaviors
+that users expect. Here's the shadowing behavior in more detail:
+
+`global3.py`:
+
+```py
+x = 1
+# We just defined `x`, and we haven't encountered any nested bindings of it yet.
+reveal_type(x)  # revealed: Literal[1]
+
+def bar():
+    global x
+    # We haven't encountered any local bindings for `x` yet. Its public type is visible to `bar`
+    # here, including `bar`s own assignments of 3 below.
+    reveal_type(x)  # revealed: Literal[1, 2, 3]
+
+    x = 2
+    # Local bindings shadow the whole public type.
+    reveal_type(x)  # revealed: Literal[2]
+
+# We've encountered the nested assignment of 3, so we keep it visible alongside local bindings
+# in this scope.
+reveal_type(x)  # revealed: Literal[1, 2]
+
+x = 3
+# This assignment shadows the previous local bindings, but again nested bindings remain visible.
+reveal_type(x)  # revealed: Literal[2, 3]
+```
+
+## Nested `global` binding hidden by an enclosing local
+
+A synthetic definition for the nested `global x` needs to flow through `outer`, so it can still
+reach the module scope. But it should be ignored when resolving `x` in scopes where the name
+resolves to `outer`'s local binding instead.
+
+```py
+x = 1
+
+def outer():
+    x = 2
+    def inner():
+        def writer():
+            global x
+            x = 3
+        reveal_type(x)  # revealed: Literal[2]
+    reveal_type(x)  # revealed: Literal[2]
+
+reveal_type(x)  # revealed: Literal[1, 3]
+```
+
+## Global `+=` widening works like it does in loops
+
+Using `+=` in a loop usually triggers fixpoint analysis, where after the list of `Literal` values
+reaches an upper limit we widen the type to `int`. The same applies to `global` augmented
+assignments, since the inner function body could run any number of times:
+
+```py
+x = 1
+
+def f():
+    global x
+    x += 1
+
+reveal_type(x)  # revealed: int
+```
+
+## Nested `global` bindings are visible in intervening scopes
+
+```py
+def _():
+    def _():
+        global x
+        x = 1
+    global x
+    x = 2
+    # The binding in the innermost function is visible here because it's nested under this scope,
+    # even though this isn't the defining scope of `x`, and even though this scope doesn't declare `x`
+    # as `global` (instead it uses it as a "free variable").
+    reveal_type(x)  # revealed: Literal[1, 2]
+
+x = 3
+reveal_type(x)  # revealed: Literal[1, 2, 3]
+```
+
+## Conditional narrowing can filter out nested bindings
+
+```py
+x = 42
+
+def hello():
+    global x
+    x = "hello"
+
+reveal_type(x)  # revealed: Literal[42, "hello"]
+
+if isinstance(x, int):
+    reveal_type(x)  # revealed: Literal[42]
+```
+
+## Conditional `global` bindings leave parent scope bindings visible
+
+Normal branching and merging rules apply to the shadowing behavior described in the previous
+section:
+
+```py
+def flag(): ...
+
+x = 1
+
+def foo():
+    global x
+
+    x = 2
+
+    def bar():
+        global x
+
+        if flag():
+            x = 3
+            # The public type of `x` is shadowed here...
+            reveal_type(x)  # revealed: Literal[3]
+
+        # ...but still visible here.
+        reveal_type(x)  # revealed: Literal[3, 1, 2]
+```
+
+## Parameter defaults are evaluated before a function's body
+
+We don't need to think about this ordering in normal execution, since the body of a function doesn't
+get to cause any side effects until the function is called. But we do need to think about it in
+inference, because of the (generally unsound) rule mentioned above about considering nested bindings
+visible after we encounter them. That can matter in unusual sitautions like this one:
+
+```py
+x = 1
+
+# This use of `x` doesn't see `x = 2` below.
+def f(y=reveal_type(x)):  # revealed: Literal[1]
+    global x
+    x = 2
+```
+
+## TODO: `global` writes in class scopes should be applied eagerly
+
+Class bodies are evaluated eagerly, so global bindings in a class scope should behave more like
+normal assignments. Currently we treat them like lazy nested bindings from function scopes, which
+results in types that are wider than they should be:
+
+```py
+x = 1
+
+class C:
+    global x
+    x = 2
+
+# TODO: Should be Literal[2].
+reveal_type(x)  # revealed: Literal[1, 2]
+x = 3
+# TODO: Should be Literal[3].
+reveal_type(x)  # revealed: Literal[2, 3]
+```
+
+However, nested bindings in function scopes within a class are still lazy:
+
+```py
+y = 1
+
+class C:
+    def f():
+        global y
+        y = 2
+
+reveal_type(y)  # revealed: Literal[1, 2]
+y = 3
+reveal_type(y)  # revealed: Literal[2, 3]
+```
+
+Similarly, class bodies within a function scope also behave lazily from the perspective of callers
+of that function:
+
+```py
+z = 1
+
+def f():
+    class C:
+        global z
+        z = 2
+
+reveal_type(z)  # revealed: Literal[1, 2]
+z = 3
+reveal_type(z)  # revealed: Literal[2, 3]
+```
+
+## Interleaving `global` and local/`nonlocal` scopes using the same variable
+
+`nonlocal` declarations aren't allowed to resolve to a scope with a `global` declaration for the
+same variable; that's a semantic syntax error. That means that a `nonlocal` binding can't exactly
+"flow through" a scope where the same name is `global`. (Similarly, free variable uses resolve when
+they see a `global` declaration in an enclosing scope.) However, the reverse is possible: `global`
+bindings can "flow through" intervening scopes where the same name is local/`nonlocal`, as long as
+any `nonlocal` declarations in the picture get resolved legally.
+
+So concretely, if a nested scope contributes a not-yet-resolved `nonlocal` binding, we can safely
+assume that that binding is visible in the current scope. (The only way it wouldn't be is if the
+current scope declares the same name `global`, but that's necessarily a semantic syntax error.)
+However, if a nested scope has a `global` binding, we might not know yet whether it should be
+visible in the current scope. If and only if we encounter a `global` declaration for that name
+before any other uses, then the nested `global` binding is visible. But even in scopes where it's
+not visible, it still needs to "flow through" to other scopes where it might be visible again,
+including the global/module scope.
+
+```py
+x = 1
+
+def _():
+    def _():
+        def global_middle():
+            def _():
+                def _():
+                    def global_inner():
+                        global x
+                        x = 2
+                    # The "free" case: we see the local `x` in the parent scope.
+                    reveal_type(x)  # revealed: Literal[3]
+                x = 3
+            global x
+            # The `global` case: we see the global `x`.
+            reveal_type(x)  # revealed: Literal[2, 1]
+        nonlocal x
+        # The `nonlocal` case: we see the *other* local `x` in the parent scope.
+        reveal_type(x)  # revealed: Literal[4, 5]
+        x = 4
+    x = 5
+
+# The module case: we see the global `x`.
+reveal_type(x)  # revealed: Literal[1, 2]
+```
+
+## Free reads and narrowing constraints
+
+Synthetic nested bindings definitions store both `global` and `nonlocal` nested writes, and we
+decide which of them we respect at inference time. For scopes with "free" reads (i.e. uses but no
+bindings in the current scope), we can _almost_ ignore the question of which nested bindings to
+respect, because inference needs to walk to the defining scope to resolve the free read anyway.
+However, respecting nested bindings in the current scope can still matter if the free read is
+_narrowed_, because the nested bindings might not be. For example:
+
+```py
+x: int | str = 1
+
+def f():
+    def g1():
+        global x
+        x = "g1"
+    if isinstance(x, int):
+        def g2():
+            global x
+            x = "g2"
+        # The narrowing condition covers the nested write from `g1` but not the one from `g2`. To
+        # get this right, we have to detect that nested `global` writes are visible in this scope.
+        reveal_type(x)  # revealed: Literal["g2"] | int
 ```

--- a/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/nonlocal.md
@@ -21,6 +21,26 @@ def f():
 
 ## Skips class scope
 
+Class-scoped symbols aren't visible to nested function-scoped reads, whether they're explicitly
+`nonlocal` or not.
+
+```py
+def f():
+    x = 1
+
+    class C:
+        x = 2
+
+        def g():
+            reveal_type(x)  # revealed: Literal[1]
+
+        def h():
+            nonlocal x
+            reveal_type(x)  # revealed: Literal[1]
+```
+
+A `nonlocal` write also doesn't affect the inferred type of a class-scoped symbol:
+
 ```py
 def f():
     x = 1
@@ -28,7 +48,16 @@ def f():
     class C:
         x = 2
         def g():
-            reveal_type(x)  # revealed: Literal[1]
+            nonlocal x
+            x = 3
+        reveal_type(x)  # revealed: Literal[2]
+
+    class D:
+        def g():
+            nonlocal x
+            x = 3
+        # With no local binding in the class body, the function-scoped `x` is visible.
+        reveal_type(x)  # revealed: Literal[3, 1]
 ```
 
 ## Reads respect annotation-only declarations
@@ -145,30 +174,16 @@ def a():
 
             def d():
                 nonlocal x
-                reveal_type(x)  # revealed: Literal[3, 2]
+                # Note that `d` could be called more than once, so the assignment of 4 below is
+                # already potentially visible. The rules for this are subtle and in fact
+                # intentionally unsound. See "Visibility of `global` and `nonlocal` bindings from
+                # nested and sibling scopes" below for the details.
+                reveal_type(x)  # revealed: Literal[2, 4, 3]
                 x = 4
                 reveal_type(x)  # revealed: Literal[4]
 
                 def e():
-                    reveal_type(x)  # revealed: Literal[4, 3, 2]
-```
-
-However, currently the union of types that we build is incomplete. We walk parent scopes, but not
-sibling scopes, child scopes, second-cousin-once-removed scopes, etc:
-
-```py
-def a():
-    x = 1
-    def b():
-        nonlocal x
-        x = 2
-
-    def c():
-        def d():
-            nonlocal x
-            x = 3
-        # TODO: This should include 2 and 3.
-        reveal_type(x)  # revealed: Literal[1]
+                    reveal_type(x)  # revealed: Literal[2, 4, 3]
 ```
 
 ## Local variable bindings "look ahead" to any assignment in the current scope
@@ -281,6 +296,22 @@ def f():
             x = "goodbye"  # error: [invalid-assignment]
 ```
 
+## `nonlocal` declarations in class scopes are also validated
+
+```py
+class C:
+    nonlocal x  # error: [invalid-syntax] "no binding for nonlocal `x` found"
+
+def f():
+    class C:
+        nonlocal x  # error: [invalid-syntax] "no binding for nonlocal `x` found"
+
+def g():
+    x = 1
+    class C:
+        nonlocal x  # ok
+```
+
 ## `nonlocal` uses the closest binding
 
 ```py
@@ -385,46 +416,6 @@ def f1():
                     y = "string"  # allowed, because `f3`'s `y` is untyped
 ```
 
-## TODO: `nonlocal` affects the inferred type in the outer scope
-
-Without `nonlocal`, `g` can't write to `x`, and the inferred type of `x` in `f`'s scope isn't
-affected by `g`:
-
-```py
-def f():
-    x = 1
-    def g():
-        reveal_type(x)  # revealed: Literal[1]
-    reveal_type(x)  # revealed: Literal[1]
-```
-
-But with `nonlocal`, `g` could write to `x`, and that affects its inferred type in `f`. That's true
-regardless of whether `g` actually writes to `x`. With a write:
-
-```py
-def f():
-    x = 1
-    def g():
-        nonlocal x
-        reveal_type(x)  # revealed: Literal[1]
-        x += 1
-        reveal_type(x)  # revealed: Literal[2]
-    # TODO: should be `Unknown | Literal[1]`
-    reveal_type(x)  # revealed: Literal[1]
-```
-
-Without a write:
-
-```py
-def f():
-    x = 1
-    def g():
-        nonlocal x
-        reveal_type(x)  # revealed: Literal[1]
-    # TODO: should be `Unknown | Literal[1]`
-    reveal_type(x)  # revealed: Literal[1]
-```
-
 ## Annotating a `nonlocal` binding is a syntax error
 
 ```py
@@ -506,4 +497,315 @@ def _(maybe_float: float | None, certain_int: int, flag: bool) -> None:
         assert x is not None
         reveal_type(x)  # revealed: int | float
         +x
+```
+
+## Visibility of `nonlocal` bindings from nested and sibling scopes
+
+(`global` bindings behave similarly and have a similarly named test case in `global.md`.)
+
+A `nonlocal` write from an inner scope can affect the target variable's inferred type in it's
+defining scope. For the same reason, reads in a nested function can also see later bindings in their
+own scope:
+
+```py
+def f():
+    x = 1
+    def g():
+        nonlocal x
+        # The following assignment of 2 could be visible if this function has been called before.
+        reveal_type(x)  # revealed: Literal[1, 2]
+        x = 2
+        # Once a binding is made in this scope, it shadows bindings from outer scopes.
+        reveal_type(x)  # revealed: Literal[2]
+    # From now on we assume `g` could be called at any time.
+    reveal_type(x)  # revealed: Literal[1, 2]
+```
+
+The example above (hopefully) feels natural, but if we look at it closely, the reveals there are
+making some beefy assumptions. For one, we assume `g` might be called before the final reveal, even
+though in this case we can actually see that it's never called. A "sufficiently smart compiler"
+could've narrowed that to `Literal[1]`, but we don't/can't track what functions are caled when, so
+we're being conservative. On the other hand, the reveal of `Literal[2]` after the binding in `g` is
+the opposite, an aggressive assumption that's not generally sound. Consider this counterexample
+where `g` and `h` are siblings that both assign to `x`:
+
+```py
+def f():
+    x = 1
+    def g():
+        nonlocal x
+        x = 2
+        reveal_type(x)  # revealed: Literal[2]
+    def h():
+        nonlocal x
+        x = 3
+        g()
+        # The logic that gives us `Literal[2]` above also gives us `Literal[3]` here, even though
+        # the call to `g()` means that `x` is in fact 2 at runtime. We can only reason locally about
+        # these things; we can't do whole-program control flow analysis or solve the halting
+        # problem. A fully sound typechecker would generally need to infer `Literal[2, 3]` both here
+        # and above. That would be great here -- wrong answers are bad! -- but it would break too
+        # much real-world code that expects `Literal[2]` in simple cases like `g` above.
+        reveal_type(x)  # revealed: Literal[3]
+    reveal_type(x)  # revealed: Literal[1, 2, 3]
+```
+
+So we're ok with making unsound assumptions to make simple, common cases do what users expect. Fine.
+But then what about the reveal of `Literal[1, 2, 3]` at the end there? We aggressively shadow
+bindings from outer or sibling scopes, but we conservatively include bindings from scopes nested
+within the current one, once we've encountered them (i.e. in a top-to-bottom reading of the code).
+This second behavior is _also_ unsound, because nested functions can "escape" the scope where
+they're defined and affect reads on lines above their definition. But again these are the behaviors
+that users expect. Here's the shadowing behavior in more detail:
+
+```py
+def foo():
+    x = 2
+    # We just defined `x`, and we haven't encountered any nested bindings of it yet.
+    reveal_type(x)  # revealed: Literal[2]
+
+    def bar():
+        nonlocal x
+        # We haven't encountered any local bindings for `x` yet. Its public type is visible to `bar`
+        # here, including `bar`s own assignments of 3 below.
+        reveal_type(x)  # revealed: Literal[2, 3, 4]
+
+        x = 3
+        # Local bindings shadow the whole public type.
+        reveal_type(x)  # revealed: Literal[3]
+
+    # We've encountered the nested assignment of 3, so we keep it visible alongside local bindings
+    # in this scope.
+    reveal_type(x)  # revealed: Literal[2, 3]
+
+    x = 4
+    # This assignment shadows the previous local bindings, but again nested bindings remain visible.
+    reveal_type(x)  # revealed: Literal[3, 4]
+```
+
+## Nonlocal `+=` widening works like it does in loops
+
+Using `+=` in a loop usually triggers fixpoint analysis, where after the list of `Literal` values
+reaches an upper limit we widen the type to `int`. The same applies to `nonlocal` augmented
+assignments, since the inner function body could run any number of times:
+
+```py
+def f():
+    x = 1
+    def g():
+        nonlocal x
+        x += 1
+    reveal_type(x)  # revealed: int
+```
+
+## Nested `nonlocal` bindings are visible in intervening scopes
+
+```py
+def _():
+    def _():
+        def _():
+            nonlocal x
+            x = 1
+        nonlocal x
+        x = 2
+        # The binding in `h` is visible here because it's nested under this scope, even though this
+        # isn't the defining scope of `x`, and even though this scope doesn't declare `x` as
+        # `nonlocal` (instead it uses it as a "free variable").
+        reveal_type(x)  # revealed: Literal[1, 2]
+    x = 3
+    reveal_type(x)  # revealed: Literal[1, 2, 3]
+```
+
+## Conditional narrowing can filter out nested bindings
+
+```py
+def _():
+    x = 42
+
+    def hello():
+        nonlocal x
+        x = "hello"
+
+    reveal_type(x)  # revealed: Literal[42, "hello"]
+
+    if isinstance(x, int):
+        reveal_type(x)  # revealed: Literal[42]
+```
+
+## Conditional `nonlocal` bindings leave parent scope bindings visible
+
+Normal branching and merging rules apply to the shadowing behavior described in the previous
+section:
+
+```py
+def flag(): ...
+def foo():
+    x = 2
+
+    def bar():
+        nonlocal x
+
+        if flag():
+            x = 3
+            # The public types of `x` is shadowed here...
+            reveal_type(x)  # revealed: Literal[3]
+
+        # ...but still visible here.
+        reveal_type(x)  # revealed: Literal[3, 2]
+```
+
+## Parameter defaults are evaluated before a function's body
+
+We don't need to think about this ordering in normal execution, since the body of a function doesn't
+get to cause any side effects until the function is called. But we do need to think about it in
+inference, because of the (generally unsound) rule mentioned above about considering nested bindings
+visible after we encounter them. That can matter in unusual sitautions like this one:
+
+```py
+def f():
+    x = 1
+    # This use of `x` doesn't see `x = 2` below.
+    def g(y=reveal_type(x)):  # revealed: Literal[1]
+        nonlocal x
+        x = 2
+```
+
+## TODO: `nonlocal` writes in class scopes should be applied eagerly
+
+Class bodies are evaluated eagerly, so nonlocal bindings in a class scope should behave more like
+normal assignments. Currently we treat them like lazy nested bindings from function scopes, which
+results in types that are wider than they should be:
+
+```py
+def f():
+    x = 1
+
+    class C:
+        nonlocal x
+        x = 2
+
+    # TODO: Should be Literal[2].
+    reveal_type(x)  # revealed: Literal[1, 2]
+    x = 3
+    # TODO: Should be Literal[3].
+    reveal_type(x)  # revealed: Literal[2, 3]
+```
+
+However, nested bindings in function scopes within a class are still lazy:
+
+```py
+def f():
+    x = 1
+
+    class C:
+        def g():
+            nonlocal x
+            x = 2
+
+    reveal_type(x)  # revealed: Literal[1, 2]
+    x = 3
+    reveal_type(x)  # revealed: Literal[2, 3]
+```
+
+Similarly, class bodies within a function scope also behave lazily from the perspective of callers
+of that function:
+
+```py
+def f():
+    x = 1
+
+    def g():
+        class C:
+            nonlocal x
+            x = 2
+
+    reveal_type(x)  # revealed: Literal[1, 2]
+    x = 3
+    reveal_type(x)  # revealed: Literal[2, 3]
+```
+
+## Large reachability constraint graphs fall back to `Unknown`
+
+We have an "excessive complexity" cutoff beyond which we stop considering nested bindings
+definitions for performance reasons, similar to how we handle loop header definitions:
+
+```py
+def f(flag: bool):
+    # A bunch of random bindings of an unrelated variable to trigger the complexity cutoff.
+    x = 0
+    (
+        flag and (x := 1),
+        flag and (x := 2),
+        flag and (x := 3),
+        flag and (x := 4),
+        flag and (x := 5),
+        flag and (x := 6),
+        flag and (x := 7),
+        flag and (x := 8),
+        flag and (x := 9),
+        flag and (x := 10),
+        flag and (x := 11),
+        flag and (x := 12),
+        flag and (x := 13),
+        flag and (x := 14),
+        flag and (x := 15),
+        flag and (x := 16),
+        flag and (x := 17),
+        flag and (x := 18),
+        flag and (x := 19),
+        flag and (x := 20),
+        flag and (x := 21),
+        flag and (x := 22),
+        flag and (x := 23),
+        flag and (x := 24),
+        flag and (x := 25),
+        flag and (x := 26),
+        flag and (x := 27),
+        flag and (x := 28),
+        flag and (x := 29),
+        flag and (x := 30),
+        flag and (x := 31),
+        flag and (x := 32),
+        flag and (x := 33),
+        flag and (x := 34),
+        flag and (x := 35),
+        flag and (x := 36),
+        flag and (x := 37),
+        flag and (x := 38),
+        flag and (x := 36),
+        flag and (x := 36),
+    )
+
+    # Normally this `nonlocal` write would make us infer `int` for `y`, but now we ignore it.
+    y = 0
+    def g():
+        nonlocal y
+        y += 1
+    reveal_type(y)  # revealed: Literal[0] | Unknown
+```
+
+## Free reads and narrowing constraints
+
+Synthetic nested bindings definitions store both `global` and `nonlocal` nested writes, and we
+decide which of them we respect at inference time. For scopes with "free" reads (i.e. uses but no
+bindings in the current scope), we can _almost_ ignore the question of which nested bindings to
+respect, because inference needs to walk to the defining scope to resolve the free read anyway.
+However, respecting nested bindings in the current scope can still matter if the free read is
+_narrowed_, because the nested bindings might not be. For example:
+
+```py
+def _():
+    x: int | str = 1
+    def _():
+        def f1():
+            nonlocal x
+            x = "f1"
+        if isinstance(x, int):
+            def f2():
+                nonlocal x
+                x = "f2"
+            # The narrowing condition covers the nested write from `f1` but not the one from `f2`. To
+            # get this right, we have to detect that nested `nonlocal` writes are visible in this
+            # scope.
+            reveal_type(x)  # revealed: Literal["f2"] | int
 ```

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -16,7 +16,7 @@ use crate::types::{
 use crate::{Db, FxIndexSet, FxOrderSet, Program};
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::narrowing_constraints::ScopedNarrowingConstraint;
-use ty_python_core::place::{PlaceExprRef, ScopedPlaceId};
+use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::predicate::{Predicate, ScopedPredicateId};
 use ty_python_core::reachability_constraints::{
     ReachabilityConstraints, ScopedReachabilityConstraintId,
@@ -369,23 +369,6 @@ pub(crate) fn symbol<'db>(
         db,
         scope,
         name,
-        RequiresExplicitReExport::No,
-        considered_definitions,
-    )
-}
-
-/// Infer the public type of a place (its type as seen from outside its scope) in the given
-/// `scope`.
-pub(crate) fn place<'db>(
-    db: &'db dyn Db,
-    scope: ScopeId<'db>,
-    member: PlaceExprRef,
-    considered_definitions: ConsideredDefinitions,
-) -> PlaceAndQualifiers<'db> {
-    place_impl(
-        db,
-        scope,
-        member,
         RequiresExplicitReExport::No,
         considered_definitions,
     )
@@ -1200,29 +1183,6 @@ fn symbol_impl<'db>(
         .unwrap_or_default()
 }
 
-fn place_impl<'db>(
-    db: &'db dyn Db,
-    scope: ScopeId<'db>,
-    place: PlaceExprRef,
-    requires_explicit_reexport: RequiresExplicitReExport,
-    considered_definitions: ConsideredDefinitions,
-) -> PlaceAndQualifiers<'db> {
-    let _span = tracing::trace_span!("place_impl", ?place).entered();
-
-    place_table(db, scope)
-        .place_id(place)
-        .map(|place| {
-            place_by_id(
-                db,
-                scope,
-                place,
-                requires_explicit_reexport,
-                considered_definitions,
-            )
-        })
-        .unwrap_or_default()
-}
-
 /// Pre-computed reachability analysis for loop-back bindings in a loop header.
 #[salsa::tracked(
     cycle_initial=|db, _, definition| loop_header_reachability_impl(db, definition, true),
@@ -1392,7 +1352,8 @@ fn place_from_bindings_impl<'db>(
     };
 
     let mut first_definition = None;
-    let mut only_loop_header_bindings = true;
+    // special handling for synthetic loop header definitions and nested bindings definitions
+    let mut only_non_shadowing_bindings = true;
 
     let mut types = bindings_with_constraints.filter_map(
         |BindingWithConstraints {
@@ -1495,8 +1456,11 @@ fn place_from_bindings_impl<'db>(
                 if loop_header.reachable_bindings.is_empty() {
                     return None;
                 }
+            } else if matches!(binding.kind(db), DefinitionKind::NestedBindings(_)) {
+                // Nested bindings definitions similar to loop header definitions, synthetic
+                // bindings with special shadowing behavior. They can also coexist with `UNBOUND`.
             } else {
-                only_loop_header_bindings = false;
+                only_non_shadowing_bindings = false;
             }
 
             first_definition.get_or_insert(binding);
@@ -1526,9 +1490,9 @@ fn place_from_bindings_impl<'db>(
         let boundness = match boundness_analysis {
             BoundnessAnalysis::AssumeBound => Definedness::AlwaysDefined,
             BoundnessAnalysis::BasedOnUnboundVisibility => match unbound_visibility() {
-                Some(Truthiness::AlwaysTrue) if only_loop_header_bindings => {
-                    // Loop header definitions don't shadow prior bindings, so UNBOUND can still be
-                    // definitely-visible alongside a loop header binding. See "Use with loop
+                Some(Truthiness::AlwaysTrue) if only_non_shadowing_bindings => {
+                    // Loop header and nested binding definitions don't shadow prior bindings, so
+                    // UNBOUND can still be definitely-visible alongside them. See "Use with loop
                     // header and also `UNBOUND` definitely visible" in `while_loop.md`.
                     Definedness::PossiblyUndefined
                 }

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1883,7 +1883,8 @@ mod resolve_definition {
             | DefinitionKind::TypeVar(_)
             | DefinitionKind::ParamSpec(_)
             | DefinitionKind::TypeVarTuple(_)
-            | DefinitionKind::LoopHeader(_) => {
+            | DefinitionKind::LoopHeader(_)
+            | DefinitionKind::NestedBindings(_) => {
                 // Not yet implemented
                 return Err(());
             }

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -40,6 +40,7 @@ fn should_consider_definition(kind: &DefinitionKind<'_>) -> bool {
         | DefinitionKind::ParamSpec(_)
         | DefinitionKind::TypeVarTuple(_)
         | DefinitionKind::LoopHeader(_) => false,
+        DefinitionKind::NestedBindings(_) => false,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use itertools::Itertools;
-use ruff_db::diagnostic::{Annotation, DiagnosticId, Severity};
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::source_text;
@@ -31,10 +30,10 @@ use super::{
 use crate::diagnostic::format_enumeration;
 use crate::place::{
     ConsideredDefinitions, DefinedPlace, Definedness, LookupError, Place, PlaceAndQualifiers,
-    TypeOrigin, builtins_module_scope, builtins_symbol, class_body_implicit_symbol,
-    explicit_global_symbol, loop_header_reachability, module_type_implicit_global_declaration,
-    module_type_implicit_global_symbol, place, place_from_bindings, place_from_declarations,
-    typing_extensions_symbol,
+    RequiresExplicitReExport, TypeOrigin, builtins_module_scope, builtins_symbol,
+    class_body_implicit_symbol, explicit_global_symbol, loop_header_reachability,
+    module_type_implicit_global_declaration, module_type_implicit_global_symbol, place_by_id,
+    place_from_bindings, place_from_declarations, typing_extensions_symbol,
 };
 use crate::reachability::ReachabilityConstraintsExtension;
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
@@ -107,7 +106,7 @@ use ty_python_core::definition::{
     AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, ComprehensionDefinitionKind,
     Definition, DefinitionKind, DefinitionNodeKey, DefinitionState, ExceptHandlerDefinitionKind,
     ForStmtDefinitionKind, LambdaParameterDefinitionNodeKind, LoopHeaderDefinitionKind,
-    ParameterDefinitionNodeKind, TargetKind, WithItemDefinitionKind,
+    NestedBindingsDefinitionKind, ParameterDefinitionNodeKind, TargetKind, WithItemDefinitionKind,
 };
 use ty_python_core::expression::{Expression, ExpressionKind};
 use ty_python_core::narrowing_constraints::ConstraintKey;
@@ -1067,6 +1066,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             DefinitionKind::LoopHeader(loop_header) => {
                 self.infer_loop_header_definition(loop_header, definition);
             }
+            DefinitionKind::NestedBindings(nested_bindings) => {
+                self.infer_nested_bindings_definition(nested_bindings, definition);
+            }
         }
     }
 
@@ -1203,15 +1205,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     };
 
                     let enclosing_symbol = enclosing_place_table.symbol(enclosing_symbol_id);
-                    if enclosing_symbol.is_nonlocal() {
-                        // The variable is `nonlocal` in this ancestor scope. Keep going.
-                        continue;
-                    }
                     if enclosing_symbol.is_global() {
                         // The variable is `global` in this ancestor scope. This breaks the `nonlocal`
                         // chain, and it's a syntax error in `infer_nonlocal_statement`. Ignore that
                         // here and just bail out of this loop.
                         break;
+                    }
+                    if !enclosing_symbol.is_local() {
+                        // The variable is either explicitly `nonlocal` or just a free read in this
+                        // ancestor scope. Keep going.
+                        continue;
                     }
                     // We found the closest definition. Note that (as in `infer_place_load`) this does
                     // *not* need to be a binding. It could be just a declaration, e.g. `x: int`.
@@ -1680,9 +1683,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ast::Stmt::Raise(raise) => self.infer_raise_statement(raise),
             ast::Stmt::Return(ret) => self.infer_return_statement(ret),
             ast::Stmt::Delete(delete) => self.infer_delete_statement(delete),
-            ast::Stmt::Nonlocal(nonlocal) => self.infer_nonlocal_statement(nonlocal),
             ast::Stmt::Global(global) => self.infer_global_statement(global),
-            ast::Stmt::Break(_)
+            ast::Stmt::Nonlocal(_)
+            | ast::Stmt::Break(_)
             | ast::Stmt::Continue(_)
             | ast::Stmt::Pass(_)
             | ast::Stmt::IpyEscapeCommand(_) => {
@@ -2109,6 +2112,108 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             union.add_in_place(narrowed_ty);
         }
 
+        self.bindings.insert(definition, union.build());
+    }
+
+    fn infer_nested_bindings_definition(
+        &mut self,
+        nested_bindings_kind: &NestedBindingsDefinitionKind,
+        definition: Definition<'db>,
+    ) {
+        const MAX_EXACT_NESTED_BINDING_REACHABILITY_NODES: usize = 2048;
+
+        let db = self.db();
+        let scope = definition.scope(db);
+        let scope_id = scope.file_scope_id(db);
+        let symbol_id = definition
+            .place(db)
+            .as_symbol()
+            .expect("nested bindings definition should be a symbol");
+        let symbol = self.index.place_table(scope_id).symbol(symbol_id);
+
+        // At the point where a nested bindings definition is first synthesized, we don't
+        // necessarily know whether the current scope will see global or nonlocal bindings.
+        // Consider this example:
+        //
+        //     def outer():
+        //         def inner1():
+        //             global x
+        //             x = 1
+        //         def inner2():
+        //             nonlocal x
+        //             x = 2
+        //         # Nested bindings of both kinds are potentially visible here, but we can't
+        //         # actually use both kinds in the same scope. If `print(x)` comes next, we should
+        //         # only see 2. But if `global x; print(x)` comes next, we should only see 1.
+        //         ...
+        //
+        // By the time we get here in type inference, though, we can ask the semantic index whether
+        // the symbol resolves to the global scope or not. (For free variables, this currently
+        // requires walking ancestor scopes.) If so, we see any nested `global` bindings that were
+        // recorded. If not, we see any nested `nonlocal` ones.
+        //
+        // Note that if `x` is a free variable in this scope, then this synthetic binding will not
+        // shadow `UNBOUND`, and `infer_place_load` will walk to the defining scope and see all the
+        // nested bindings from there via the symbol's public type. However, we still want to
+        // respect locally visible nested bindings in that case, because there might be narrowing
+        // constraints that apply to the public type but not these nested bindings.
+        let this_scope_sees_global_bindings = self
+            .index
+            .symbol_resolves_to_global_scope(symbol_id, scope_id);
+
+        // If a function body binds `x`, it's interested in nested `nonlocal` bindings of `x` too,
+        // because those resolve to the same variable. But if a *class* body binds `x`, it does
+        // *not* want to consider nested bindings of `x`, because those do *not* resolve to the
+        // same variable.
+        let this_scope_sees_nonlocal_bindings = !(this_scope_sees_global_bindings
+            || (scope.scope(db).kind().is_class() && symbol.is_local()));
+
+        let mut visible_nested_declarations = nested_bindings_kind
+            .nested_declarations
+            .iter()
+            .filter(|declaration| {
+                if declaration.is_global() {
+                    this_scope_sees_global_bindings
+                } else {
+                    this_scope_sees_nonlocal_bindings
+                }
+            })
+            .peekable();
+        if visible_nested_declarations.peek().is_some()
+            && self
+                .index
+                .use_def_map(scope_id)
+                .reachability_constraints()
+                .used_interiors()
+                .len()
+                > MAX_EXACT_NESTED_BINDING_REACHABILITY_NODES
+        {
+            // As with loop header definitions above, use a reachability cutoff to avoid excessive
+            // perf costs in complicated projects like `isort`.
+            self.bindings.insert(definition, Type::unknown());
+            return;
+        }
+
+        let mut union = UnionBuilder::new(db).recursively_defined(RecursivelyDefined::Yes);
+        for declaration in visible_nested_declarations {
+            assert!(
+                declaration.is_bound,
+                "nested declarations without bindings shouldn't be recorded here",
+            );
+            let nested_place_table = self.index.place_table(declaration.file_scope_id);
+            let nested_symbol_id = nested_place_table
+                .symbol_id(&nested_bindings_kind.name)
+                .unwrap();
+            let use_def = self.index.use_def_map(declaration.file_scope_id);
+            let Some(ty) =
+                place_from_bindings(db, use_def.reachable_bindings(nested_symbol_id.into()))
+                    .place
+                    .raw_type()
+            else {
+                continue;
+            };
+            union.add_in_place(ty);
+        }
         self.bindings.insert(definition, union.build());
     }
 
@@ -4994,75 +5099,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             diag.info(format_args!(
                 "Consider adding a declaration to the global scope, e.g. `{name}: int`"
             ));
-        }
-    }
-
-    fn infer_nonlocal_statement(&mut self, nonlocal: &ast::StmtNonlocal) {
-        let ast::StmtNonlocal {
-            node_index: _,
-            range,
-            names,
-        } = nonlocal;
-        let db = self.db();
-        let scope = self.scope();
-        let file_scope_id = scope.file_scope_id(db);
-
-        'names: for name in names {
-            // Walk up parent scopes looking for a possible enclosing scope that may have a
-            // definition of this name visible to us. Note that we skip the scope containing the
-            // use that we are resolving, since we already looked for the place there up above.
-            for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
-                // Class scopes are not visible to nested scopes, and `nonlocal` cannot refer to
-                // globals, so check only function-like scopes.
-                let enclosing_scope = self.index.scope(enclosing_scope_file_id);
-                if !enclosing_scope.kind().is_function_like() {
-                    continue;
-                }
-                let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-                let Some(enclosing_symbol_id) = enclosing_place_table.symbol_id(name) else {
-                    // This scope doesn't define this name. Keep going.
-                    continue;
-                };
-                let enclosing_symbol = enclosing_place_table.symbol(enclosing_symbol_id);
-                // We've found a definition for this name in an enclosing function-like scope.
-                // Either this definition is the valid place this name refers to, or else we'll
-                // emit a syntax error. Either way, we won't walk any more enclosing scopes. Note
-                // that there are differences here compared to `infer_place_load`: A regular load
-                // (e.g. `print(x)`) is allowed to refer to a global variable (e.g. `x = 1` in the
-                // global scope), and similarly it's allowed to refer to a local variable in an
-                // enclosing function that's declared `global` (e.g. `global x`). However, the
-                // `nonlocal` keyword can't refer to global variables (that's a `SyntaxError`), and
-                // it also can't refer to local variables in enclosing functions that are declared
-                // `global` (also a `SyntaxError`).
-                if enclosing_symbol.is_global() {
-                    // A "chain" of `nonlocal` statements is "broken" by a `global` statement. Stop
-                    // looping and report that this `nonlocal` statement is invalid.
-                    break;
-                }
-                if !enclosing_symbol.is_bound()
-                    && !enclosing_symbol.is_declared()
-                    && !enclosing_symbol.is_nonlocal()
-                {
-                    debug_assert!(enclosing_symbol.is_used());
-                    // The name is only referenced here, not defined. Keep going.
-                    continue;
-                }
-                // We found a definition. We've checked that the name isn't `global` in this scope,
-                // but it's ok if it's `nonlocal`. If a "chain" of `nonlocal` statements fails to
-                // lead to a valid binding, the outermost one will be an error; we don't need to
-                // walk the whole chain for each one.
-                continue 'names;
-            }
-            // There's no matching binding in an enclosing scope. This `nonlocal` statement is
-            // invalid.
-            if let Some(builder) = self
-                .context
-                .report_diagnostic(DiagnosticId::InvalidSyntax, Severity::Error)
-            {
-                builder
-                    .into_diagnostic(format_args!("no binding for nonlocal `{name}` found"))
-                    .annotate(Annotation::primary(self.context.span(*range)));
-            }
         }
     }
 
@@ -8952,12 +8988,49 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            // Walk up parent scopes looking for a possible enclosing scope that may have a
-            // definition of this name visible to us (would be `LOAD_DEREF` at runtime.)
-            // Note that we skip the scope containing the use that we are resolving, since we
-            // already looked for the place there up above.
-            let mut nonlocal_union_builder = UnionBuilder::new(db);
-            let mut found_some_definition = false;
+            // Walk enclosing scopes to resolve a free-variable load (`LOAD_DEREF` at runtime).
+            // There are two main ways we try to model these loads:
+            //
+            // 1. "Snapshots" record the bindings/constraints in the enclosing scope at the point
+            //    just before a nested scope begins. For variables that aren't modified after that
+            //    point, that's the only value that the nested scope can see. If a variable is
+            //    reassigned later, lazy snapshots for that variable can be updated or swept.
+            //
+            // 2. Otherwise, we keep walking until we get to the variable's original defining
+            //    scope, and we use its "public type" there, which respects all reachable bindings,
+            //    not just end-of-scope bindings. That includes the synthetic `NestedBindings`
+            //    definitions that we install after each nested scope is closed, so it has
+            //    a complete view of the nested `global` and `nonlocal` writes beneath it.
+            //
+            // This walk only resolves free variables and explicit `nonlocal`s. A symbol that is
+            // local to the current scope never falls back to an enclosing scope, even if it's only
+            // possibly bound at the current use: Python would raise `UnboundLocalError` instead.
+            //
+            // Note that we only get to this walk via `or_fall_back_to` above. In other words, for
+            // definitely-locally-bound variables, we defer to the current scope's bindings instead
+            // of looking at enclosing scopes. Concretely:
+            //
+            // def f():
+            //     x = None
+            //
+            //     def g():
+            //         nonlocal x
+            //         if flag:
+            //             x = 42
+            //
+            //         # `x` is possibly unbound here, so we walk enclosing scopes and see the
+            //         # public type in `f`.
+            //         reveal_type(x)  # revealed: Literal[42, 99] | None
+            //
+            //         x = 99
+            //         # But now `x` is definitely bound, so we don't do the walk.
+            //         reveal_type(x)  # revealed: Literal[99]
+            //
+            // Importantly, this approach isn't generally sound. The public type could include
+            // nested bindings from sibling scopes, which really could run at any time, and in some
+            // cases we're being too deferential to local bindings. Unfortunately the fully sound
+            // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
+            // which is too frustrating for users in practice.
             for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
                 // If the current enclosing scope is global, no place lookup is performed here,
                 // instead falling back to the module's explicit global lookup below.
@@ -9054,65 +9127,46 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 let enclosing_place = enclosing_place_table.place(enclosing_place_id);
 
-                // Reads of "free" variables terminate at any enclosing scope that marks the
-                // variable `global`, whether or not that scope actually binds the variable. If we
-                // see a `global` declaration, stop walking scopes and proceed to the global
-                // handling below. (If we're walking from a prior/inner scope where this variable
-                // is `nonlocal`, then this is a semantic syntax error, but we don't enforce that
-                // here. See `infer_nonlocal_statement`.)
+                // Reads of "free" or `nonlocal` variables terminate at any enclosing scope that
+                // marks the variable `global`, whether or not that scope actually binds the
+                // variable. If we see a `global` declaration, stop walking scopes and proceed to
+                // the global handling below. (If we're walking from a prior/inner scope where this
+                // variable is `nonlocal`, then this is a semantic syntax error, but we don't
+                // enforce that here. See `SemanticIndexBuilder::pop_scope`.)
                 if enclosing_place.as_symbol().is_some_and(Symbol::is_global) {
                     break;
                 }
 
-                let enclosing_scope_id = enclosing_scope_file_id.to_scope_id(db, self.file());
-
-                // If the name is declared or bound in this scope, figure out its type. This might
-                // resolve the name and end the walk. But if the name is declared `nonlocal` in
-                // this scope, we'll keep walking enclosing scopes and union this type with the
-                // other types we find. (It's a semantic syntax error to declare a type for a
-                // `nonlocal` variable, but we don't enforce that here. See the
-                // `ast::Stmt::AnnAssign` handling in `SemanticIndexBuilder::visit_stmt`.)
-                if enclosing_place.is_bound() || enclosing_place.is_declared() {
-                    let local_place_and_qualifiers = eagerly_resolved_place.unwrap_or_else(|| {
-                        place(
-                            db,
-                            enclosing_scope_id,
-                            place_expr,
-                            ConsideredDefinitions::AllReachable,
-                        )
-                        .map_type(|ty| {
-                            self.narrow_place_with_applicable_constraints(
-                                place_expr,
-                                ty,
-                                &constraint_keys,
-                            )
-                        })
-                    });
-                    // We could have `Place::Undefined` here, despite the checks above, for example if
-                    // this scope contains a `del` statement but no binding or declaration.
-                    if let Place::Defined(DefinedPlace {
-                        ty: type_,
-                        definedness: boundness,
-                        ..
-                    }) = local_place_and_qualifiers.place
-                    {
-                        nonlocal_union_builder.add_in_place(type_);
-                        // `ConsideredDefinitions::AllReachable` never returns PossiblyUnbound
-                        debug_assert_eq!(boundness, Definedness::AlwaysDefined);
-                        found_some_definition = true;
-                    }
-
-                    if !enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
-                        // We've reached a function-like scope that marks this name bound or
-                        // declared but doesn't mark it `nonlocal`. The name is therefore resolved,
-                        // and we won't consider any scopes outside of this one.
-                        return if found_some_definition {
-                            Place::bound(nonlocal_union_builder.build()).into()
-                        } else {
-                            Place::Undefined.into()
-                        };
-                    }
+                // Keep walking until we reach the defining scope of the variable. The synthetic
+                // nested bindings definitions installed there will see everything below it.
+                if enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
+                    continue;
                 }
+                if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
+                    // Note that this check includes members like `x.y` and `x[0]`, which aren't
+                    // symbols and can't be explicitly `nonlocal`.
+                    continue;
+                }
+
+                // We've reached the defining scope of the variable. Infer its public type.
+                debug_assert!(enclosing_place.is_bound() || enclosing_place.is_declared());
+                let enclosing_scope_id = enclosing_scope_file_id.to_scope_id(db, self.file());
+                return eagerly_resolved_place.unwrap_or_else(|| {
+                    place_by_id(
+                        db,
+                        enclosing_scope_id,
+                        enclosing_place_id,
+                        RequiresExplicitReExport::No,
+                        ConsideredDefinitions::AllReachable,
+                    )
+                    .map_type(|ty| {
+                        self.narrow_place_with_applicable_constraints(
+                            place_expr,
+                            ty,
+                            &constraint_keys,
+                        )
+                    })
+                });
             }
 
             PlaceAndQualifiers::default()


### PR DESCRIPTION
Here's the basic `nonlocal` case:

```py
def f():
    x = 42
    def g():
        nonlocal x
        x = "hello"
    g()  # NOTE: Inference doesn't ask whether `g` is actually called here. We assume it could be called.
    reveal_type(x)  # revealed: Literal[42, "hello"]
```

`global` declarations work similarly:

```py
x = 0
def f():
    global x
    x += 1
# NOTE: As above, the fact that `f` isn't actually called doesn't affect inference.
reveal_type(x)  # revealed: int
```

Here's the general behavior, which is deliberately a bit unsound:

- After the close of each function or class scope, we synthesize bindings that refer to all the nested `global` or `nonlocal` bindings transitively within that scope.
- These "synthetic nested binding definitions" don't shadow existing bindings, and they aren't shadowed by subsequent bindings, modeling the fact that nested function bodies can run "at any time".
- Using a variable `x` in scope that doesn't bind it ends up walking to its defining scope and seeing its "public type", which includes all nested bindings in every scope. But if you bind `x` locally, that shadows the public type. On the other hand, synthetic bindings corresponding to scopes nested within the current scope still count as local. (So generally parent and sibling scope bindings will get shadowed, but not child scope bindings.)

For more of the details here see the new mdtests, particularly "Visibility of `nonlocal` bindings from nested and sibling scopes".

### comparison with other typecheckers

No other typechecker currently reports `Literal[42, "hello"]` or similar for the first `x` above. Pyright reports `Literal[42]` and mypy reports `Any`. The closest is pycroscope: it reports `Literal["hello"]`, which is arguably even more correct, but it also incorrectly gives the same answer if the call to `g()` is omitted.

Zuban seems to have the machinery for some of this, but it might be choosing not to use it. It reports `int` for the first example above, but it does better for this very similar example using `None` instead of `int`:

```py
def f():
    x = None
    def g():
        nonlocal x
        x = "hello"
    g()
    reveal_type(x)  # ty_this_pr: None | Literal["hello"], Zuban: str | None
```

On the other hand, Zuban doesn't handle this more complex example, so I'm not sure what to make of it:

```py
def f():
    x = None
    def g():
        nonlocal x
        x = "hello"
        def h():
            nonlocal x
            x = 42
        h()
    g()
    reveal_type(x)  # ty_this_pr: None | Literal[42, "hello"], zuban: str | None
```

Pyright also seems to have some of this machinery for `global`s, but it only uses it in cases where there's no corresponding definition in the global scope (which tends to make most other typecheckers upset):

```py
def f():
    global x
    x = "hello"
def g():
    global x
    x = 42
reveal_type(x)  # ty_this_pr: Literal["hello", 42], Pyright: str | int
```

Pyright also has this machinery for `nonlocal`s, but it only seems to use it from the perspective of other nested function, not in the defining scope of a modified variable:

```py
def f():
    x = 42
    def g():
        nonlocal x
        x = "hello"
    def h():
        reveal_type(x)  # ty_this_pr: Literal[42, "hello"], pyright: int | str
```

A lot of typecheckers report `int` instead of tracking integer literals, so several of the test cases in this PR aren't portable for that reason, but here's an adaptation of "Interleaving `global` and local/`nonlocal` scopes using the same variable" that uses distinct types in each binding to work around that. No other typechecker currently handles this whole thing, even allowing `int` and `str` in place of the literals (though Pyright gets it if the `list`/`set` reveal is moved into a nested function):

```py
x = None
def _():
    def _():
        def global_middle():
            def _():
                def _():
                    def global_inner():
                        global x
                        x = 42
                    reveal_type(x)  # revealed: Literal["hello"]
                x = "hello"
            global x
            reveal_type(x)  # revealed: Literal[42] | None
        nonlocal x
        reveal_type(x)  # revealed: list[int] | set[str]
        x = [1, 2, 3]
    x = {"a", "b", "c"}
reveal_type(x)  # revealed: None | Literal[42]
```