### PR TITLE
Fix line-length example for --config option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -554,7 +554,7 @@ Global options:
           Either a path to a TOML configuration file (`pyproject.toml` or
           `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might
           find in a `ruff.toml` configuration file) overriding a specific
-          configuration option (e.g., `--config "lint.line-length = 100"` or
+          configuration option (e.g., `--config "line-length = 100"` or
           `--config "format.quote-style = 'single'"`). Overrides of individual
           settings using this option always take precedence over all
           configuration files, including configuration files that were also


### PR DESCRIPTION
[line-length](https://docs.astral.sh/ruff/settings/#line-length) is a top-level option and is not located in the [lint] section.