### PR TITLE
[ty] Add dd-trace-py to flaky.txt

### DIFF
--- a/crates/ty_python_semantic/resources/primer/flaky.txt
+++ b/crates/ty_python_semantic/resources/primer/flaky.txt
@@ -1,3 +1,4 @@
 prefect
 pydantic
 scikit-build-core
+dd-trace-py


### PR DESCRIPTION
Unfortunately this project is now flaky following https://github.com/astral-sh/ruff/commit/95eec58af266ba0f98bb923cf204f442523e813d. Adding it to flaky.txt means we don't get spurious/confusing diffs like https://github.com/astral-sh/ruff/pull/25017#issuecomment-4390844917 anymore, because ecosystem-analyzer will run the project several times to ensure that newly reported diagnostic diffs are not flaky. The cost is that ecosystem-analyzer will take a little longer in CI