### PR TITLE
[ty] Treat Python notebook text documents as Python source

### DIFF
--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -125,11 +125,19 @@ impl LSPSystem {
     ) -> Option<PySourceType> {
         match document {
             Document::Text(text) => match text.language_id() {
-                LanguageId::Python => Some(
-                    extension
+                LanguageId::Python => {
+                    let source_type = extension
                         .and_then(PySourceType::try_from_extension)
-                        .unwrap_or(PySourceType::Python),
-                ),
+                        .unwrap_or(PySourceType::Python);
+
+                    // JupyterLab presents notebook virtual documents to language servers as
+                    // simple text files rather than serialized `.ipynb` contents. See:
+                    // https://github.com/jupyterlab/jupyterlab/blob/f51404192bf6d0ff79187c884f21e1f91b928146/packages/lsp/src/virtual/document.ts#L308-L314
+                    Some(match source_type {
+                        PySourceType::Ipynb => PySourceType::Python,
+                        source_type => source_type,
+                    })
+                }
                 LanguageId::Other => None,
             },
             Document::Notebook(_) => Some(PySourceType::Ipynb),

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -482,6 +482,36 @@ def foo() -> str:
     Ok(())
 }
 
+/// JupyterLab presents notebook virtual documents to language servers as simple text files:
+/// <https://github.com/jupyterlab/jupyterlab/blob/f51404192bf6d0ff79187c884f21e1f91b928146/packages/lsp/src/virtual/document.ts#L308-L314>
+#[test]
+fn on_did_open_ipynb_file_with_python_language() -> Result<()> {
+    let foo = SystemPath::new("src/foo.ipynb");
+    let foo_content = "\
+def foo() -> str:
+    return 42
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(SystemPath::new("src"), None)?
+        .enable_pull_diagnostics(false)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+    let diagnostics = server.await_notification::<PublishDiagnostics>();
+    let [diagnostic] = diagnostics.diagnostics.as_slice() else {
+        panic!("expected one diagnostic, got {diagnostics:#?}");
+    };
+
+    insta::assert_snapshot!(
+        diagnostic.message,
+        @"Return type does not match returned value: expected `str`, found `Literal[42]`"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn changing_language_of_file_without_extension() -> Result<()> {
     let foo = SystemPath::new("src/foo");

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -482,7 +482,7 @@ def foo() -> str:
     Ok(())
 }
 
-/// JupyterLab presents notebook virtual documents to language servers as simple text files:
+/// `JupyterLab` presents notebook virtual documents to language servers as simple text files:
 /// <https://github.com/jupyterlab/jupyterlab/blob/f51404192bf6d0ff79187c884f21e1f91b928146/packages/lsp/src/virtual/document.ts#L308-L314>
 #[test]
 fn on_did_open_ipynb_file_with_python_language() -> Result<()> {


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/2605

The jupyterlab-lsp server doesn't support the LSPs notebook feature. Instead, it does the same as ty, it concatenates the notebook and opens it as a regular text document but the URI still uses the `.ipynb` extension. However, ty didn't support this. It simply assumed that the document must be a notebook based on the extension. 

ty already uses the open documents to classify whether a file is a notebook or not (e.g. you can open a `test.txt` as a notebook in your editor and ty will also handle it as a notebook). However, the text document case always prioritized the extension over the document type in the LSPs index (text document vs notebook).

This PR changes the priority. ty now never maps a `TextDocument` to a notebook. Instead, it maps them to `Python` if the document's language id was `python`.

## Test Plan
Added E2E test