### PR TITLE
[ty] Remove Prefect from flaky project list

### DIFF
--- a/crates/ty_python_semantic/resources/primer/flaky.txt
+++ b/crates/ty_python_semantic/resources/primer/flaky.txt
@@ -1,4 +1,3 @@
-prefect
 pydantic
 scikit-build-core
 dd-trace-py


### PR DESCRIPTION
## Summary

Interestingly, it appears that this was "fixed" by https://github.com/astral-sh/ruff/pull/24927 based on a local basic, which suggest that the source of the non-determinism is in the inferred-variance computation, and we now avoid that in Prefect.
