### PR TITLE
Fix generated line-length CLI help example

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -44,7 +44,7 @@ pub struct GlobalConfigArgs {
     /// or a TOML `<KEY> = <VALUE>` pair
     /// (such as you might find in a `ruff.toml` configuration file)
     /// overriding a specific configuration option
-    /// (e.g., `--config "lint.line-length = 100"` or `--config "format.quote-style = 'single'"`).
+    /// (e.g., `--config "line-length = 100"` or `--config "format.quote-style = 'single'"`).
     /// Overrides of individual settings using this option always take precedence
     /// over all configuration files, including configuration files that were also
     /// specified using `--config`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -697,7 +697,7 @@ Global options:
           Either a path to a TOML configuration file (`pyproject.toml` or
           `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might
           find in a `ruff.toml` configuration file) overriding a specific
-          configuration option (e.g., `--config "lint.line-length = 100"` or
+          configuration option (e.g., `--config "line-length = 100"` or
           `--config "format.quote-style = 'single'"`). Overrides of individual
           settings using this option always take precedence over all
           configuration files, including configuration files that were also
@@ -793,7 +793,7 @@ Global options:
           Either a path to a TOML configuration file (`pyproject.toml` or
           `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might
           find in a `ruff.toml` configuration file) overriding a specific
-          configuration option (e.g., `--config "lint.line-length = 100"` or
+          configuration option (e.g., `--config "line-length = 100"` or
           `--config "format.quote-style = 'single'"`). Overrides of individual
           settings using this option always take precedence over all
           configuration files, including configuration files that were also


### PR DESCRIPTION
## Summary

- Update the source `--config` help example to use the top-level `line-length` option.
- Regenerate the remaining CLI help blocks in `docs/configuration.md`.

## Root Cause

PR #25389 corrected one generated copy of this help example directly in
`docs/configuration.md`, but the source text in `crates/ruff/src/args.rs`
still emitted `lint.line-length`. As a result,
`generate_cli_help::tests::test_generate_json_schema` fails when it checks
that the committed generated documentation matches the CLI source.

## Test Plan

- `cargo test -p ruff_dev --bin ruff_dev generate_cli_help::tests::test_generate_json_schema -- --nocapture`
- `uvx --from 'prek==0.3.8' prek run --files crates/ruff/src/args.rs docs/configuration.md`
