### PR TITLE
[ty] Remove excess capacity from more Salsa cached collections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,4 +77,4 @@ When working on ty, PR titles should start with `[ty]` and be tagged with the `t
 - Don't prefix tests with `test_`.
 - Don't separate struct definitions from their `impl` blocks unless the `impl` is deliberately placed in a separate file, as for large structs.
 - The `db` parameter should always be the first, or second, if it's a method taking a `self` argument
-- For Salsa cached functions, prefer boxed slices or call `shrink_to_fit` on collections to reduce memory usage.
+- For Salsa-cached values, avoid retaining excess collection capacity. Prefer boxed slices; otherwise shrink collections that may have spare capacity before returning them. In particular, inspect `HashMap` and `HashSet` values constructed via `extend`, `collect`, explicit reservation, or removal, since those operations can leave capacity that insert-only construction does not.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,5 @@ When working on ty, PR titles should start with `[ty]` and be tagged with the `t
 - Run `cargo dev generate-all` after changing configuration options, CLI arguments, lint rules, or environment variable definitions, as these changes require regeneration of schemas, docs, and CLI references.
 - Don't prefix tests with `test_`.
 - Don't separate struct definitions from their `impl` blocks unless the `impl` is deliberately placed in a separate file, as for large structs.
+- The `db` parameter should always be the first, or second, if it's a method taking a `self` argument
+- For Salsa cached functions, prefer boxed slices or call `shrink_to_fit` on collections to reduce memory usage.

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -792,6 +792,10 @@ impl<'db> SymbolVisitor<'db> {
             remap.push(Some(new_id));
             new.push(symbol);
         }
+
+        new.shrink_to_fit();
+        self.all_names.shrink_to_fit();
+
         FlatSymbols {
             symbols: new,
             all_names: self.all_origin.map(|_| self.all_names),

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -794,11 +794,13 @@ impl<'db> SymbolVisitor<'db> {
         }
 
         new.shrink_to_fit();
-        self.all_names.shrink_to_fit();
 
         FlatSymbols {
             symbols: new,
-            all_names: self.all_origin.map(|_| self.all_names),
+            all_names: self.all_origin.map(|_| {
+                self.all_names.shrink_to_fit();
+                self.all_names
+            }),
         }
     }
 

--- a/crates/ty_module_resolver/src/list.rs
+++ b/crates/ty_module_resolver/src/list.rs
@@ -10,7 +10,7 @@ use crate::resolve::{ModuleResolveMode, ResolverContext, resolve_file_module, se
 
 /// List all available modules, including all sub-modules, sorted in lexicographic order.
 pub fn all_modules(db: &dyn Db) -> Vec<Module<'_>> {
-    let mut modules = list_modules(db);
+    let mut modules = list_modules(db).to_vec();
     let mut stack = modules.clone();
     while let Some(module) = stack.pop() {
         for &submodule in module.all_submodules(db) {
@@ -23,8 +23,8 @@ pub fn all_modules(db: &dyn Db) -> Vec<Module<'_>> {
 }
 
 /// List all available top-level modules.
-#[salsa::tracked]
-pub fn list_modules(db: &dyn Db) -> Vec<Module<'_>> {
+#[salsa::tracked(returns(deref))]
+pub fn list_modules(db: &dyn Db) -> Box<[Module<'_>]> {
     let mut modules: BTreeMap<&ModuleName, ListedModule<'_>> = BTreeMap::new();
     for search_path in search_paths(db, ModuleResolveMode::StubsAllowed) {
         for new in list_modules_in(db, SearchPathIngredient::new(db, search_path.clone())) {
@@ -463,7 +463,7 @@ mod tests {
     }
 
     fn sorted_list(db: &dyn Db) -> Vec<Module<'_>> {
-        let mut modules = list_modules(db);
+        let mut modules = list_modules(db).to_vec();
         modules.sort_by(|m1, m2| m1.name(db).cmp(m2.name(db)));
         modules
     }

--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -97,9 +97,7 @@ impl<'db> Module<'db> {
     /// The names returned correspond to the "base" name of the module.
     /// That is, `{self.name}.{basename}` should give the full module name.
     pub fn all_submodules(self, db: &'db dyn Db) -> &'db [Module<'db>] {
-        all_submodule_names_for_package(db, self)
-            .as_deref()
-            .unwrap_or_default()
+        all_submodule_names_for_package(db, self).unwrap_or_default()
     }
 }
 
@@ -118,12 +116,11 @@ impl std::fmt::Debug for Module<'_> {
     }
 }
 
-#[allow(clippy::ref_option)]
-#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(returns(as_deref), heap_size=ruff_memory_usage::heap_size)]
 fn all_submodule_names_for_package<'db>(
     db: &'db dyn Db,
     module: Module<'db>,
-) -> Option<Vec<Module<'db>>> {
+) -> Option<Box<[Module<'db>]>> {
     fn is_submodule(
         is_dir: bool,
         is_file: bool,

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -370,7 +370,7 @@ pub fn search_paths(db: &dyn Db, resolve_mode: ModuleResolveMode) -> SearchPathI
 ///
 /// We exclude `__init__.py(i)` dirs to avoid truncating packages.
 #[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
-fn absolute_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<Vec<SearchPath>> {
+fn absolute_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<Box<[SearchPath]>> {
     let system = db.system();
     let importing_path = importing_file.path(db).as_system_path()?;
 
@@ -425,7 +425,7 @@ fn absolute_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<
     if search_paths.is_empty() {
         None
     } else {
-        Some(search_paths)
+        Some(search_paths.into_boxed_slice())
     }
 }
 

--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -110,9 +110,7 @@ impl AstIdsBuilder {
         self.uses_map.get(&key.into()).copied()
     }
 
-    pub(super) fn finish(mut self) -> AstIds {
-        self.uses_map.shrink_to_fit();
-
+    pub(super) fn finish(self) -> AstIds {
         AstIds {
             uses_map: self.uses_map,
         }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1420,8 +1420,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
         }
 
-        loop_header.bindings.shrink_to_fit();
-
         // The `LoopHeader` needs to be visible to uses within the loop body that we've already
         // walked, but all our Salsa state is generally immutable. `specify` is how we work around
         // that. See this section of the Salsa docs:
@@ -2233,17 +2231,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         place_tables.shrink_to_fit();
         use_def_maps.shrink_to_fit();
         ast_ids.shrink_to_fit();
-        self.expressions_by_node.shrink_to_fit();
-        self.definitions_by_node.shrink_to_fit();
-        self.statements_by_node.shrink_to_fit();
-        self.enclosing_lambda_statements.shrink_to_fit();
-        self.collections_by_use.shrink_to_fit();
-        self.uses_by_collection.shrink_to_fit();
+
         self.imported_modules.shrink_to_fit();
-        self.alias_predicates.shrink_to_fit();
         self.scope_ids_by_scope.shrink_to_fit();
-        self.scopes_by_node.shrink_to_fit();
-        self.generator_functions.shrink_to_fit();
         self.enclosing_snapshots.shrink_to_fit();
 
         let mut semantic_syntax_errors = self.semantic_syntax_errors.into_inner();

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1419,6 +1419,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     .mark_used(live_binding.narrowing_constraint());
             }
         }
+
+        loop_header.bindings.shrink_to_fit();
+
         // The `LoopHeader` needs to be visible to uses within the loop body that we've already
         // walked, but all our Salsa state is generally immutable. `specify` is how we work around
         // that. See this section of the Salsa docs:
@@ -2230,16 +2233,21 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         place_tables.shrink_to_fit();
         use_def_maps.shrink_to_fit();
         ast_ids.shrink_to_fit();
+        self.expressions_by_node.shrink_to_fit();
         self.definitions_by_node.shrink_to_fit();
         self.statements_by_node.shrink_to_fit();
         self.enclosing_lambda_statements.shrink_to_fit();
         self.collections_by_use.shrink_to_fit();
         self.uses_by_collection.shrink_to_fit();
-
+        self.imported_modules.shrink_to_fit();
+        self.alias_predicates.shrink_to_fit();
         self.scope_ids_by_scope.shrink_to_fit();
         self.scopes_by_node.shrink_to_fit();
         self.generator_functions.shrink_to_fit();
         self.enclosing_snapshots.shrink_to_fit();
+
+        let mut semantic_syntax_errors = self.semantic_syntax_errors.into_inner();
+        semantic_syntax_errors.shrink_to_fit();
 
         SemanticIndex {
             place_tables,
@@ -2258,7 +2266,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             imported_modules: Arc::new(self.imported_modules),
             has_future_annotations: self.has_future_annotations,
             enclosing_snapshots: self.enclosing_snapshots,
-            semantic_syntax_errors: self.semantic_syntax_errors.into_inner(),
+            semantic_syntax_errors,
             generator_functions: self.generator_functions,
             narrowing_alias_predicates: self.alias_predicates,
         }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1419,7 +1419,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     .mark_used(live_binding.narrowing_constraint());
             }
         }
-
         // The `LoopHeader` needs to be visible to uses within the loop body that we've already
         // walked, but all our Salsa state is generally immutable. `specify` is how we work around
         // that. See this section of the Salsa docs:
@@ -2231,7 +2230,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         place_tables.shrink_to_fit();
         use_def_maps.shrink_to_fit();
         ast_ids.shrink_to_fit();
-
+        self.enclosing_lambda_statements.shrink_to_fit();
         self.imported_modules.shrink_to_fit();
         self.scope_ids_by_scope.shrink_to_fit();
         self.enclosing_snapshots.shrink_to_fit();
@@ -3618,10 +3617,12 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
         // context the lambda is being inferred with, and so any statement
         // containing a lambda must be inferable as a standalone statement
         // to avoid large scope-level cycles.
-        for lambda in current_statement.lambda_expressions {
-            self.enclosing_lambda_statements
-                .insert(lambda.into(), standalone_statement);
-        }
+        self.enclosing_lambda_statements.extend(
+            current_statement
+                .lambda_expressions
+                .into_iter()
+                .map(|lambda| (lambda.into(), standalone_statement)),
+        );
 
         // The inferred element type of collection literal depends on uses of
         // the collection in its containing scope, and so each use must be part

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1683,10 +1683,7 @@ impl<'db> UseDefMapBuilder<'db> {
         self.reachable_symbol_definitions.shrink_to_fit();
         self.reachable_member_definitions.shrink_to_fit();
         self.bindings_by_use.shrink_to_fit();
-        self.multi_bindings_by_use.shrink_to_fit();
         self.range_reachability.shrink_to_fit();
-        self.declarations_by_binding.shrink_to_fit();
-        self.bindings_by_definition.shrink_to_fit();
         self.enclosing_snapshots.shrink_to_fit();
 
         let mut interned_bindings = IndexVec::with_capacity(self.bindings_by_definition.len());
@@ -1808,7 +1805,6 @@ impl<'db> UseDefMapBuilder<'db> {
             interned_ids_by_definition.insert(definition, interned_id);
         }
 
-        interned_ids_by_definition.shrink_to_fit();
         interned_ids_by_definition
     }
 
@@ -1832,7 +1828,6 @@ impl<'db> UseDefMapBuilder<'db> {
             interned_ids_by_binding.insert(binding, interned_id);
         }
 
-        interned_ids_by_binding.shrink_to_fit();
         interned_ids_by_binding
     }
 

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -1,10 +1,9 @@
-use std::collections::BTreeSet;
-
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_ast::{self as ast};
+use rustc_hash::FxHashSet;
 use ty_module_resolver::{ModuleName, resolve_module};
 
 use crate::Db;
@@ -13,17 +12,15 @@ use ty_python_core::{SemanticIndex, Truthiness, semantic_index};
 
 /// Returns a set of names in the `__all__` variable for `file`, [`None`] if it is not defined or
 /// if it contains invalid elements.
-#[salsa::tracked(returns(as_deref), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
-pub(crate) fn dunder_all_names(db: &dyn Db, file: File) -> Option<Box<[Name]>> {
+#[salsa::tracked(returns(as_ref), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+pub(crate) fn dunder_all_names(db: &dyn Db, file: File) -> Option<FxHashSet<Name>> {
     let _span = tracing::trace_span!("dunder_all_names", file=?file.path(db)).entered();
 
     let module = parsed_module(db, file).load(db);
     let index = semantic_index(db, file);
     let mut collector = DunderAllNamesCollector::new(db, file, index);
     collector.visit_body(module.suite());
-    collector
-        .into_names()
-        .map(|names| names.into_iter().collect())
+    collector.into_names()
 }
 
 /// A visitor that collects the names in the `__all__` variable of a module.
@@ -42,7 +39,7 @@ struct DunderAllNamesCollector<'db> {
     invalid: bool,
 
     /// A set of names found in `__all__` for the current module.
-    names: BTreeSet<Name>,
+    names: FxHashSet<Name>,
 }
 
 impl<'db> DunderAllNamesCollector<'db> {
@@ -53,7 +50,7 @@ impl<'db> DunderAllNamesCollector<'db> {
             index,
             origin: None,
             invalid: false,
-            names: BTreeSet::default(),
+            names: FxHashSet::default(),
         }
     }
 
@@ -158,7 +155,7 @@ impl<'db> DunderAllNamesCollector<'db> {
     fn dunder_all_names_for_import_from(
         &self,
         import_from: &ast::StmtImportFrom,
-    ) -> Option<&'db [Name]> {
+    ) -> Option<&'db FxHashSet<Name>> {
         let module_name =
             ModuleName::from_import_statement(self.db, self.file, import_from).ok()?;
         let module = resolve_module(self.db, self.file, &module_name)?;
@@ -199,13 +196,14 @@ impl<'db> DunderAllNamesCollector<'db> {
     ///
     /// Returns [`None`] if `__all__` is not defined in the current module or if it contains
     /// invalid elements.
-    fn into_names(self) -> Option<BTreeSet<Name>> {
+    fn into_names(mut self) -> Option<FxHashSet<Name>> {
         if self.origin.is_none() {
             None
         } else if self.invalid {
             tracing::debug!("Invalid `__all__` in `{}`", self.file.path(self.db));
             None
         } else {
+            self.names.shrink_to_fit();
             Some(self.names)
         }
     }

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashSet;
+use std::collections::BTreeSet;
 
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
@@ -13,15 +13,17 @@ use ty_python_core::{SemanticIndex, Truthiness, semantic_index};
 
 /// Returns a set of names in the `__all__` variable for `file`, [`None`] if it is not defined or
 /// if it contains invalid elements.
-#[salsa::tracked(returns(as_ref), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
-pub(crate) fn dunder_all_names(db: &dyn Db, file: File) -> Option<FxHashSet<Name>> {
+#[salsa::tracked(returns(as_deref), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+pub(crate) fn dunder_all_names(db: &dyn Db, file: File) -> Option<Box<[Name]>> {
     let _span = tracing::trace_span!("dunder_all_names", file=?file.path(db)).entered();
 
     let module = parsed_module(db, file).load(db);
     let index = semantic_index(db, file);
     let mut collector = DunderAllNamesCollector::new(db, file, index);
     collector.visit_body(module.suite());
-    collector.into_names()
+    collector
+        .into_names()
+        .map(|names| names.into_iter().collect())
 }
 
 /// A visitor that collects the names in the `__all__` variable of a module.
@@ -40,7 +42,7 @@ struct DunderAllNamesCollector<'db> {
     invalid: bool,
 
     /// A set of names found in `__all__` for the current module.
-    names: FxHashSet<Name>,
+    names: BTreeSet<Name>,
 }
 
 impl<'db> DunderAllNamesCollector<'db> {
@@ -51,7 +53,7 @@ impl<'db> DunderAllNamesCollector<'db> {
             index,
             origin: None,
             invalid: false,
-            names: FxHashSet::default(),
+            names: BTreeSet::default(),
         }
     }
 
@@ -156,7 +158,7 @@ impl<'db> DunderAllNamesCollector<'db> {
     fn dunder_all_names_for_import_from(
         &self,
         import_from: &ast::StmtImportFrom,
-    ) -> Option<&'db FxHashSet<Name>> {
+    ) -> Option<&'db [Name]> {
         let module_name =
             ModuleName::from_import_statement(self.db, self.file, import_from).ok()?;
         let module = resolve_module(self.db, self.file, &module_name)?;
@@ -197,7 +199,7 @@ impl<'db> DunderAllNamesCollector<'db> {
     ///
     /// Returns [`None`] if `__all__` is not defined in the current module or if it contains
     /// invalid elements.
-    fn into_names(self) -> Option<FxHashSet<Name>> {
+    fn into_names(self) -> Option<BTreeSet<Name>> {
         if self.origin.is_none() {
             None
         } else if self.invalid {

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -119,7 +119,8 @@ impl<'db> SemanticModel<'db> {
         let is_typing_extensions_available = self.file.is_stub(self.db)
             || resolve_real_shadowable_module(self.db, self.file, &typing_extensions).is_some();
         list_modules(self.db)
-            .into_iter()
+            .iter()
+            .copied()
             .filter(|module| {
                 is_typing_extensions_available || module.name(self.db) != &typing_extensions
             })

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6883,7 +6883,7 @@ fn self_typevar_owner_class_literal<'db>(
 fn class_mro_literals<'db>(
     db: &'db dyn Db,
     class_literal: ClassLiteral<'db>,
-) -> Vec<ClassLiteral<'db>> {
+) -> Box<[ClassLiteral<'db>]> {
     class_literal
         .iter_mro(db)
         .filter_map(ClassBase::into_class)

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1165,6 +1165,8 @@ impl<'db> ClassType<'db> {
             }
         }
 
+        abstract_methods.shrink_to_fit();
+
         abstract_methods
     }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1746,7 +1746,8 @@ impl<'db> StaticClassLiteral<'db> {
             "Collecting `fields` for NamedTuples should short-circuit in `fields()`"
         );
 
-        self.iter_mro(db, specialization)
+        let mut map: FxIndexMap<_, _> = self
+            .iter_mro(db, specialization)
             .rev()
             .filter_map(|superclass| {
                 let class = superclass.into_class()?;
@@ -1792,7 +1793,10 @@ impl<'db> StaticClassLiteral<'db> {
             // they cannot shadow an inherited field with the same name.
             .filter(|(_, field)| !field.is_kw_only_sentinel(db))
             // We collect into a FxOrderMap here to deduplicate attributes
-            .collect()
+            .collect();
+
+        map.shrink_to_fit();
+        map
     }
 
     pub(crate) fn validate_members(self, context: &InferContext<'db, '_>) {
@@ -2034,6 +2038,8 @@ impl<'db> StaticClassLiteral<'db> {
                 attributes.insert(symbol.name().clone(), field);
             }
         }
+
+        attributes.shrink_to_fit();
 
         attributes
     }

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -691,7 +691,12 @@ impl<'db> ConstraintSetBuilder<'db> {
         // the original builder aren't relevant to the new builder, and don't need to be retained.
         let constraint = f(&self);
         let node = constraint.node;
-        let storage = self.storage.into_inner();
+        let mut storage = self.storage.into_inner();
+
+        storage.nodes.shrink_to_fit();
+        storage.typevars.shrink_to_fit();
+        storage.constraints.shrink_to_fit();
+
         OwnedConstraintSet {
             node,
             constraints: storage.constraints,
@@ -2855,7 +2860,7 @@ impl<'db> Type<'db> {
 pub(crate) enum PathBounds<'db> {
     Unsatisfiable,
     Unconstrained,
-    Constrained(Vec<Vec<TypeVarBounds<'db>>>),
+    Constrained(Box<[Box<[TypeVarBounds<'db>]>]>),
 }
 
 impl<'db> PathBounds<'db> {
@@ -2923,7 +2928,7 @@ impl<'db> PathBounds<'db> {
             result.push(path_bounds);
         }
 
-        PathBounds::Constrained(result)
+        PathBounds::Constrained(result.into_boxed_slice())
     }
 
     pub(crate) fn solve(

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -594,6 +594,9 @@ pub(crate) fn enum_metadata<'db>(
                 }
                 members.insert(name.clone(), *ty);
             }
+            members.shrink_to_fit();
+            aliases.shrink_to_fit();
+
             return Some(EnumMetadata {
                 members,
                 aliases,

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -595,7 +595,6 @@ pub(crate) fn enum_metadata<'db>(
                 members.insert(name.clone(), *ty);
             }
             members.shrink_to_fit();
-            aliases.shrink_to_fit();
 
             return Some(EnumMetadata {
                 members,
@@ -840,8 +839,6 @@ pub(crate) fn enum_metadata<'db>(
     });
 
     members.shrink_to_fit();
-    aliases.shrink_to_fit();
-    auto_members.shrink_to_fit();
 
     Some(EnumMetadata {
         members,

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -644,7 +644,7 @@ pub(crate) fn enum_metadata<'db>(
 
     let mut aliases = FxHashMap::default();
 
-    let members = use_def_map
+    let mut members = use_def_map
         .all_end_of_scope_symbol_bindings()
         .filter_map(|(symbol_id, bindings)| {
             let name = table.symbol(symbol_id).name();
@@ -838,6 +838,10 @@ pub(crate) fn enum_metadata<'db>(
             inherited_value_annotation(db, class)
         }
     });
+
+    members.shrink_to_fit();
+    aliases.shrink_to_fit();
+    auto_members.shrink_to_fit();
 
     Some(EnumMetadata {
         members,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -232,11 +232,13 @@ pub(crate) enum InferableTypeVars<'db> {
 impl<'db> InferableTypeVars<'db> {
     pub(crate) fn from_typevars(
         db: &'db dyn Db,
-        typevars: FxOrderSet<BoundTypeVarIdentity<'db>>,
+        mut typevars: FxOrderSet<BoundTypeVarIdentity<'db>>,
     ) -> Self {
         if typevars.is_empty() {
             return InferableTypeVars::None;
         }
+
+        typevars.shrink_to_fit();
         Self::Some(InferableTypeVarsInner::new_internal(db, typevars))
     }
 }
@@ -370,13 +372,13 @@ impl<'db> GenericContext<'db> {
         db: &'db dyn Db,
         type_params: impl IntoIterator<Item = BoundTypeVarInstance<'db>>,
     ) -> Self {
-        Self::new_internal(
-            db,
-            type_params
-                .into_iter()
-                .map(|variable| (variable.identity(db), variable))
-                .collect::<FxOrderMap<_, _>>(),
-        )
+        let mut type_params = type_params
+            .into_iter()
+            .map(|variable| (variable.identity(db), variable))
+            .collect::<FxOrderMap<_, _>>();
+
+        type_params.shrink_to_fit();
+        Self::new_internal(db, type_params)
     }
 
     /// Merge this generic context with another, returning a new generic context that

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -372,13 +372,13 @@ impl<'db> GenericContext<'db> {
         db: &'db dyn Db,
         type_params: impl IntoIterator<Item = BoundTypeVarInstance<'db>>,
     ) -> Self {
-        let mut type_params = type_params
-            .into_iter()
-            .map(|variable| (variable.identity(db), variable))
-            .collect::<FxOrderMap<_, _>>();
-
-        type_params.shrink_to_fit();
-        Self::new_internal(db, type_params)
+        Self::new_internal(
+            db,
+            type_params
+                .into_iter()
+                .map(|variable| (variable.identity(db), variable))
+                .collect::<FxOrderMap<_, _>>(),
+        )
     }
 
     /// Merge this generic context with another, returning a new generic context that

--- a/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
@@ -45,7 +45,7 @@ pub enum UnreachableKind {
 /// `ALWAYS_FALSE` constraints are classified as unconditional; all others are
 /// unreachable only under the current analysis.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-pub fn unreachable_ranges(db: &dyn Db, file: File) -> Vec<UnreachableRange> {
+pub fn unreachable_ranges(db: &dyn Db, file: File) -> Box<[UnreachableRange]> {
     let index = semantic_index(db, file);
     let mut unreachable = Vec::new();
 
@@ -70,7 +70,7 @@ pub fn unreachable_ranges(db: &dyn Db, file: File) -> Vec<UnreachableRange> {
     merge_overlapping_ranges(unreachable)
 }
 
-fn merge_overlapping_ranges(mut ranges: Vec<UnreachableRange>) -> Vec<UnreachableRange> {
+fn merge_overlapping_ranges(mut ranges: Vec<UnreachableRange>) -> Box<[UnreachableRange]> {
     ranges.sort_unstable_by_key(|range| (range.range.start(), range.range.end(), range.kind));
 
     ranges

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -71,7 +71,7 @@ pub struct UnusedBinding {
 /// without broader reference analysis. Bare local annotations (`x: int`) are also
 /// reported, but only if the symbol is neither bound nor used elsewhere in the scope.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-pub fn unused_bindings(db: &dyn Db, file: ruff_db::files::File) -> Vec<UnusedBinding> {
+pub fn unused_bindings(db: &dyn Db, file: ruff_db::files::File) -> Box<[UnusedBinding]> {
     let parsed = parsed_module(db, file).load(db);
     let is_stub_file = file.is_stub(db);
     let index = semantic_index(db, file);
@@ -180,7 +180,7 @@ pub fn unused_bindings(db: &dyn Db, file: ruff_db::files::File) -> Vec<UnusedBin
     unused.sort_unstable_by_key(|binding| (binding.range.start(), binding.range.end()));
     unused.dedup_by_key(|binding| binding.range);
 
-    unused
+    unused.into_boxed_slice()
 }
 
 #[cfg(test)]

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -170,9 +170,9 @@ impl<'db> CallableSignature<'db> {
     where
         I: IntoIterator<Item = Signature<'db>>,
     {
-        let mut overloads: SmallVec<_> = overloads.into_iter().collect();
-        overloads.shrink_to_fit();
-        Self { overloads }
+        Self {
+            overloads: overloads.into_iter().collect(),
+        }
     }
 
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, Signature<'db>> {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -170,9 +170,9 @@ impl<'db> CallableSignature<'db> {
     where
         I: IntoIterator<Item = Signature<'db>>,
     {
-        Self {
-            overloads: overloads.into_iter().collect(),
-        }
+        let mut overloads: SmallVec<_> = overloads.into_iter().collect();
+        overloads.shrink_to_fit();
+        Self { overloads }
     }
 
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, Signature<'db>> {
@@ -3152,6 +3152,8 @@ impl<'db> Parameters<'db> {
                 _ => {}
             }
         }
+
+        value.shrink_to_fit();
 
         Parameters { value, kind }
     }

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -480,7 +480,7 @@ struct ModuleInconsistency<'db> {
 /// `list_module`.
 fn run_module_resolution_consistency_test(db: &db::Db) -> Result<(), Vec<ModuleInconsistency<'_>>> {
     let mut errs = vec![];
-    for from_list in list_modules(db) {
+    for from_list in list_modules(db).iter().copied() {
         // TODO: For now list_modules does not partake in desperate module resolution so
         // only compare against confident module resolution.
         errs.push(match resolve_module_confident(db, from_list.name(db)) {


### PR DESCRIPTION
## Summary

This PR drops container excess capacities in more places for Salsa cached queries by using a boxed slice or calling `shrink_to_fit`.

This PR also removes a few unnecessary `shrink_to_fit` calls. For maps, calling `shrink_to_fit` is only necessary after `extend`ing or when elements were removed. A map that was built by only using `insert` or `entry` never shrinks its capacity. This helps improve performance a little.