### PR TITLE
[`eradicate`] Fix `ERA001`/`RUF100` conflict when `noqa` is on commented-out code

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_5.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_5.py
@@ -19,3 +19,11 @@ def f():
     data = 1
     # line below should autofix to `return data`
     return data  # noqa: RET504 - intentional incorrect noqa, will be removed
+
+
+# Regression test for https://github.com/astral-sh/ruff/issues/25386
+# )
+# )  # noqa: ERA001
+
+# (
+# (  # noqa: ERA001

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -69,7 +69,7 @@ static POSITIVE_CASES: LazyLock<RegexSet> = LazyLock::new(|| {
         // Multiline assignment
         r"^(?:[(\[]\s*)?(?:\w+\s*,\s*)*\w+\s*([)\]]\s*)?=.*[(\[{]\s*(#.*)?$",
         // Brackets,
-        r"^[()\[\]{}\s]+(\s*#.*)?$",
+        r"^[()\[\]{}\s]+\s*(#.*)?$",
     ])
     .unwrap()
 });
@@ -224,6 +224,7 @@ mod tests {
         assert!(comment_contains_code("# try:", &[]));
         assert!(comment_contains_code("# )  # noqa: ERA001", &[]));
         assert!(comment_contains_code("# \t(  # noqa: ERA001", &[]));
+        assert!(comment_contains_code("# x = [  # noqa: ERA001", &[]));
 
         assert!(!comment_contains_code("# this is = to that :(", &[]));
         assert!(!comment_contains_code("#else", &[]));

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -67,9 +67,9 @@ static POSITIVE_CASES: LazyLock<RegexSet> = LazyLock::new(|| {
         // Partial dictionary
         r#"^['"]\w+['"]\s*:.+[,{]\s*(#.*)?$"#,
         // Multiline assignment
-        r"^(?:[(\[]\s*)?(?:\w+\s*,\s*)*\w+\s*([)\]]\s*)?=.*[(\[{]$",
+        r"^(?:[(\[]\s*)?(?:\w+\s*,\s*)*\w+\s*([)\]]\s*)?=.*[(\[{]\s*(#.*)?$",
         // Brackets,
-        r"^[()\[\]{}\s]+$",
+        r"^[()\[\]{}\s]+(\s*#.*)?$",
     ])
     .unwrap()
 });
@@ -79,7 +79,6 @@ pub(crate) fn comment_contains_code(line: &str, task_tags: &[String]) -> bool {
     let line = line
         .trim_start_matches(|char| char == '#' || is_python_whitespace(char))
         .trim_end();
-    let line = strip_trailing_noqa(line);
 
     // Fast path: if none of the indicators are present, the line is not code.
     if !CODE_INDICATORS.is_match(line) {
@@ -125,18 +124,6 @@ pub(crate) fn comment_contains_code(line: &str, task_tags: &[String]) -> bool {
 
     // Finally, compile the source code.
     parse_module(line).is_ok()
-}
-
-fn strip_trailing_noqa(line: &str) -> &str {
-    let Some((prefix, suffix)) = line.rsplit_once('#') else {
-        return line;
-    };
-
-    if suffix.trim_start().to_ascii_lowercase().starts_with("noqa") {
-        prefix.trim_end()
-    } else {
-        line
-    }
 }
 
 #[cfg(test)]

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -79,6 +79,7 @@ pub(crate) fn comment_contains_code(line: &str, task_tags: &[String]) -> bool {
     let line = line
         .trim_start_matches(|char| char == '#' || is_python_whitespace(char))
         .trim_end();
+    let line = strip_trailing_noqa(line);
 
     // Fast path: if none of the indicators are present, the line is not code.
     if !CODE_INDICATORS.is_match(line) {
@@ -124,6 +125,18 @@ pub(crate) fn comment_contains_code(line: &str, task_tags: &[String]) -> bool {
 
     // Finally, compile the source code.
     parse_module(line).is_ok()
+}
+
+fn strip_trailing_noqa(line: &str) -> &str {
+    let Some((prefix, suffix)) = line.rsplit_once('#') else {
+        return line;
+    };
+
+    if suffix.trim_start().to_ascii_lowercase().starts_with("noqa") {
+        prefix.trim_end()
+    } else {
+        line
+    }
 }
 
 #[cfg(test)]
@@ -222,6 +235,8 @@ mod tests {
         assert!(comment_contains_code("# case 1:", &[]));
         assert!(comment_contains_code("#case 1:", &[]));
         assert!(comment_contains_code("# try:", &[]));
+        assert!(comment_contains_code("# )  # noqa: ERA001", &[]));
+        assert!(comment_contains_code("# \t(  # noqa: ERA001", &[]));
 
         assert!(!comment_contains_code("# this is = to that :(", &[]));
         assert!(!comment_contains_code("#else", &[]));

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_5.snap
@@ -90,3 +90,41 @@ help: Remove unused `noqa` directive
 20 |     # line below should autofix to `return data`
    -     return data  # noqa: RET504 - intentional incorrect noqa, will be removed
 21 +     return data
+22 |
+23 |
+24 | # Regression test for https://github.com/astral-sh/ruff/issues/25386
+
+ERA001 [*] Found commented-out code
+  --> RUF100_5.py:25:1
+   |
+24 | # Regression test for https://github.com/astral-sh/ruff/issues/25386
+25 | # )
+   | ^^^
+26 | # )  # noqa: ERA001
+   |
+help: Remove commented-out code
+22 |
+23 |
+24 | # Regression test for https://github.com/astral-sh/ruff/issues/25386
+   - # )
+25 | # )  # noqa: ERA001
+26 |
+27 | # (
+note: This is a display-only fix and is likely to be incorrect
+
+ERA001 [*] Found commented-out code
+  --> RUF100_5.py:28:1
+   |
+26 | # )  # noqa: ERA001
+27 |
+28 | # (
+   | ^^^
+29 | # (  # noqa: ERA001
+   |
+help: Remove commented-out code
+25 | # )
+26 | # )  # noqa: ERA001
+27 |
+   - # (
+28 | # (  # noqa: ERA001
+note: This is a display-only fix and is likely to be incorrect


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Fixes #25386.

For commented-out code with a trailing `# noqa: ERA001`, Ruff could report both
`ERA001` on one line and `RUF100` (unused `ERA001`) on the next — which is inconsistent.

`ERA001` uses `comment_contains_code()` to decide if a comment is code. That function
was analyzing the full comment body, including trailing `# noqa: ERA001`. The allowlist
treats `noqa` as non-code, so lines like `# )  # noqa: ERA001` were skipped by `ERA001`
while a nearby line without `noqa` still triggered `ERA001`. That made the `noqa`
look unused to `RUF100`.

The fix strips a trailing inline `# noqa...` before ERA001’s code detection, so the
comment is evaluated on its code portion only (e.g. `)`). Suppression and detection
then agree: `noqa: ERA001` is used when it suppresses a real `ERA001` match.

the repro now shows ERA001 diagnostics without incorrectly flagging the paired noqa: ERA001 as unused.

## Test Plan

- Added unit tests in `detection.rs` for `# )  # noqa: ERA001` and `# \t(  # noqa: ERA001`
- Extended `RUF100_5.py` with regression cases from #25386
- Ran `cargo test -p ruff_linter ruf100_5` (snapshot updated)
- Ran `cargo test -p ruff_linter comment_contains_code_with_multiline`
- Ran `uvx prek run --files` on the three changed files