### PR TITLE
[ty] Use `TypeForm` in `ty_extensions`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -269,7 +269,7 @@ def _(
     reveal_type(i)  # revealed: object
 ```
 
-## Cannot use an argument as both a value and a type form
+## A `TypeForm` parameter is a value parameter
 
 ```py
 from ty_extensions import is_singleton
@@ -279,7 +279,7 @@ def _(flag: bool):
         f = repr
     else:
         f = is_singleton
-    # error: [conflicting-argument-forms] "Argument is used as both a value and a type form in call"
+    # `int` is both a regular value for `repr` and a valid `TypeForm` value for `is_singleton`.
     reveal_type(f(int))  # revealed: str | Literal[False]
 ```
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3911,46 +3911,6 @@ impl<'db> Type<'db> {
             .into(),
 
             Type::FunctionLiteral(function_type) => match function_type.known(db) {
-                Some(
-                    KnownFunction::IsEquivalentTo
-                    | KnownFunction::IsAssignableTo
-                    | KnownFunction::IsSubtypeOf
-                    | KnownFunction::IsDisjointFrom,
-                ) => Binding::single(
-                    self,
-                    Signature::new(
-                        Parameters::new(
-                            db,
-                            [
-                                Parameter::positional_only(Some(Name::new_static("a")))
-                                    .type_form()
-                                    .with_annotated_type(Type::any()),
-                                Parameter::positional_only(Some(Name::new_static("b")))
-                                    .type_form()
-                                    .with_annotated_type(Type::any()),
-                            ],
-                        ),
-                        KnownClass::ConstraintSet.to_instance(db),
-                    ),
-                )
-                .into(),
-
-                Some(KnownFunction::IsSingleton | KnownFunction::IsSingleValued) => {
-                    Binding::single(
-                        self,
-                        Signature::new(
-                            Parameters::new(
-                                db,
-                                [Parameter::positional_only(Some(Name::new_static("a")))
-                                    .type_form()
-                                    .with_annotated_type(Type::any())],
-                            ),
-                            KnownClass::Bool.to_instance(db),
-                        ),
-                    )
-                    .into()
-                }
-
                 Some(KnownFunction::AssertType) => {
                     let val_ty = BoundTypeVarInstance::synthetic(
                         db,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -69,6 +69,20 @@ use ty_python_core::{EvaluationMode, semantic_index};
 
 pub(crate) use self::constructor::ConstructorCallableKind;
 
+fn type_form_argument<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+    match ty {
+        Type::TypeForm(type_form) => type_form.type_argument(db),
+        Type::SpecialForm(special_form) => special_form.type_form_argument(db).unwrap_or(ty),
+        Type::KnownInstance(instance) if instance.is_type_form_value() => {
+            instance.type_form_argument(db).unwrap_or(ty)
+        }
+        Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => {
+            ty.to_instance(db).unwrap_or(ty)
+        }
+        _ => ty,
+    }
+}
+
 /// Priority levels for call errors in intersection types.
 /// Higher values indicate more specific errors that should take precedence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -1768,9 +1782,11 @@ impl<'db> Bindings<'db> {
                     Type::FunctionLiteral(function_type) => match function_type.known(db) {
                         Some(KnownFunction::IsEquivalentTo) => {
                             if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                let ty_a = type_form_argument(db, *ty_a);
+                                let ty_b = type_form_argument(db, *ty_b);
                                 let constraints = ConstraintSetBuilder::new();
                                 let result = constraints.into_owned(|constraints| {
-                                    ty_a.when_equivalent_to(db, *ty_b, constraints)
+                                    ty_a.when_equivalent_to(db, ty_b, constraints)
                                 });
                                 let tracked = InternedConstraintSet::new(db, result);
                                 overload.set_return_type(Type::KnownInstance(
@@ -1781,11 +1797,13 @@ impl<'db> Bindings<'db> {
 
                         Some(KnownFunction::IsSubtypeOf) => {
                             if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                let ty_a = type_form_argument(db, *ty_a);
+                                let ty_b = type_form_argument(db, *ty_b);
                                 let constraints = ConstraintSetBuilder::new();
                                 let result = constraints.into_owned(|constraints| {
                                     ty_a.when_subtype_of(
                                         db,
-                                        *ty_b,
+                                        ty_b,
                                         constraints,
                                         InferableTypeVars::None,
                                     )
@@ -1799,11 +1817,13 @@ impl<'db> Bindings<'db> {
 
                         Some(KnownFunction::IsAssignableTo) => {
                             if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                let ty_a = type_form_argument(db, *ty_a);
+                                let ty_b = type_form_argument(db, *ty_b);
                                 let constraints = ConstraintSetBuilder::new();
                                 let result = constraints.into_owned(|constraints| {
                                     ty_a.when_assignable_to(
                                         db,
-                                        *ty_b,
+                                        ty_b,
                                         constraints,
                                         InferableTypeVars::None,
                                     )
@@ -1817,11 +1837,13 @@ impl<'db> Bindings<'db> {
 
                         Some(KnownFunction::IsDisjointFrom) => {
                             if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                let ty_a = type_form_argument(db, *ty_a);
+                                let ty_b = type_form_argument(db, *ty_b);
                                 let constraints = ConstraintSetBuilder::new();
                                 let result = constraints.into_owned(|constraints| {
                                     ty_a.when_disjoint_from(
                                         db,
-                                        *ty_b,
+                                        ty_b,
                                         constraints,
                                         InferableTypeVars::None,
                                     )
@@ -1835,14 +1857,17 @@ impl<'db> Bindings<'db> {
 
                         Some(KnownFunction::IsSingleton) => {
                             if let [Some(ty)] = overload.parameter_types() {
-                                overload.set_return_type(Type::bool_literal(ty.is_singleton(db)));
+                                overload.set_return_type(Type::bool_literal(
+                                    type_form_argument(db, *ty).is_singleton(db),
+                                ));
                             }
                         }
 
                         Some(KnownFunction::IsSingleValued) => {
                             if let [Some(ty)] = overload.parameter_types() {
-                                overload
-                                    .set_return_type(Type::bool_literal(ty.is_single_valued(db)));
+                                overload.set_return_type(Type::bool_literal(
+                                    type_form_argument(db, *ty).is_single_valued(db),
+                                ));
                             }
                         }
 
@@ -2383,20 +2408,19 @@ impl<'db> Bindings<'db> {
                     },
 
                     Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetRange) => {
-                        let [Some(lower), Some(Type::TypeVar(typevar)), Some(upper)] =
-                            overload.parameter_types()
+                        let [Some(lower), Some(typevar), Some(upper)] = overload.parameter_types()
                         else {
+                            return;
+                        };
+                        let lower = type_form_argument(db, *lower);
+                        let typevar = type_form_argument(db, *typevar);
+                        let upper = type_form_argument(db, *upper);
+                        let Type::TypeVar(typevar) = typevar else {
                             return;
                         };
                         let constraints = ConstraintSetBuilder::new();
                         let result = constraints.into_owned(|constraints| {
-                            ConstraintSet::constrain_typevar(
-                                db,
-                                constraints,
-                                *typevar,
-                                *lower,
-                                *upper,
-                            )
+                            ConstraintSet::constrain_typevar(db, constraints, typevar, lower, upper)
                         });
                         let tracked = InternedConstraintSet::new(db, result);
                         overload.set_return_type(Type::KnownInstance(
@@ -2436,12 +2460,14 @@ impl<'db> Bindings<'db> {
                         let [Some(ty_a), Some(ty_b)] = overload.parameter_types() else {
                             continue;
                         };
+                        let ty_a = type_form_argument(db, *ty_a);
+                        let ty_b = type_form_argument(db, *ty_b);
 
                         let constraints = ConstraintSetBuilder::new();
                         let result = constraints.into_owned(|constraints| {
                             ty_a.when_subtype_of_assuming(
                                 db,
-                                *ty_b,
+                                ty_b,
                                 constraints.load(db, tracked.constraints(db)),
                                 constraints,
                                 InferableTypeVars::None,
@@ -2498,8 +2524,12 @@ impl<'db> Bindings<'db> {
                         let inferable = match overload.parameter_types() {
                             // Caller did not provide argument, so no typevars are inferable.
                             [None] => InferableTypeVars::None,
-                            [Some(Type::NominalInstance(instance))] => {
-                                match extract_inferable(instance) {
+                            [Some(ty)] => {
+                                let Type::NominalInstance(instance) = type_form_argument(db, *ty)
+                                else {
+                                    continue;
+                                };
+                                match extract_inferable(&instance) {
                                     Some(inferable) => inferable,
                                     None => continue,
                                 }

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -5,7 +5,7 @@ use crate::{
     Db,
     types::{
         CallableType, KnownClass, LiteralValueType, LiteralValueTypeKind, Parameter, Parameters,
-        PropertyInstanceType, Signature, StringLiteralType, Type, UnionType,
+        PropertyInstanceType, Signature, StringLiteralType, Type, TypeFormType, UnionType,
         callable::{CallableFunctionProvenance, CallableTypeKind},
         constraints::ConstraintSet,
         function::FunctionType,
@@ -256,6 +256,8 @@ impl<'db> KnownBoundMethodType<'db> {
     ///
     /// If the bound method type is overloaded, it may have multiple signatures.
     pub(super) fn signatures(self, db: &'db dyn Db) -> impl Iterator<Item = Signature<'db>> {
+        let object_type_form = || TypeFormType::from_type_expression(db, Type::object());
+
         match self {
             // Here, we dynamically model the overloaded function signature of `types.FunctionType.__get__`.
             // This is required because we need to return more precise types than what the signature in
@@ -377,14 +379,11 @@ impl<'db> KnownBoundMethodType<'db> {
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("lower_bound")))
-                                .type_form()
-                                .with_annotated_type(Type::any()),
+                                .with_annotated_type(object_type_form()),
                             Parameter::positional_only(Some(Name::new_static("typevar")))
-                                .type_form()
-                                .with_annotated_type(Type::any()),
+                                .with_annotated_type(object_type_form()),
                             Parameter::positional_only(Some(Name::new_static("upper_bound")))
-                                .type_form()
-                                .with_annotated_type(Type::any()),
+                                .with_annotated_type(object_type_form()),
                         ],
                     ),
                     KnownClass::ConstraintSet.to_instance(db),
@@ -405,11 +404,9 @@ impl<'db> KnownBoundMethodType<'db> {
                         db,
                         [
                             Parameter::positional_only(Some(Name::new_static("ty")))
-                                .type_form()
-                                .with_annotated_type(Type::any()),
+                                .with_annotated_type(object_type_form()),
                             Parameter::positional_only(Some(Name::new_static("of")))
-                                .type_form()
-                                .with_annotated_type(Type::any()),
+                                .with_annotated_type(object_type_form()),
                         ],
                     ),
                     KnownClass::ConstraintSet.to_instance(db),
@@ -432,10 +429,12 @@ impl<'db> KnownBoundMethodType<'db> {
                     Parameters::new(
                         db,
                         [Parameter::keyword_only(Name::new_static("inferable"))
-                            .type_form()
                             .with_annotated_type(UnionType::from_two_elements(
                                 db,
-                                Type::homogeneous_tuple(db, Type::any()),
+                                TypeFormType::from_type_expression(
+                                    db,
+                                    Type::homogeneous_tuple(db, Type::object()),
+                                ),
                                 Type::none(db),
                             ))
                             .with_default_type(Type::none(db))],

--- a/crates/ty_vendored/ty_extensions/ty_extensions.pyi
+++ b/crates/ty_vendored/ty_extensions/ty_extensions.pyi
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from enum import Enum
 from typing import Any, ClassVar, Protocol, _SpecialForm
 
-from typing_extensions import LiteralString, Self  # noqa: UP035
+from typing_extensions import LiteralString, Self, TypeForm  # noqa: UP035
 
 # Special operations
 def static_assert(condition: object, msg: LiteralString | None = None) -> None: ...
@@ -114,7 +114,11 @@ type JustComplex = TypeOf[1.0j]
 # Constraints
 class ConstraintSet:
     @staticmethod
-    def range(lower_bound: Any, typevar: Any, upper_bound: Any) -> Self:
+    def range(
+        lower_bound: TypeForm[object],
+        typevar: TypeForm[object],
+        upper_bound: TypeForm[object],
+    ) -> Self:
         """
         Returns a constraint set that requires `typevar` to specialize to a type
         that is a supertype of `lower_bound` and a subtype of `upper_bound`.
@@ -128,7 +132,7 @@ class ConstraintSet:
     def never() -> Self:
         """Returns a constraint set that is never satisfied"""
 
-    def implies_subtype_of(self, ty: Any, of: Any) -> Self:
+    def implies_subtype_of(self, ty: TypeForm[object], of: TypeForm[object]) -> Self:
         """
         Returns a constraint set that is satisfied when `ty` is a `subtype`_ of
         `of`, assuming that all of the constraints in `self` hold.
@@ -144,7 +148,7 @@ class ConstraintSet:
         """
 
     def satisfied_by_all_typevars(
-        self, *, inferable: tuple[Any, ...] | None = None
+        self, *, inferable: TypeForm[tuple[object, ...]] | None = None
     ) -> bool:
         """
         Returns whether this constraint set is satisfied by all of the typevars
@@ -170,38 +174,39 @@ class Specialization:
     """A mapping of typevars to specific types"""
 
 # Predicates on types
-#
-# Ideally, these would be annotated using `TypeForm`, but that has not been
-# standardized yet (https://peps.python.org/pep-0747).
-def is_equivalent_to(type_a: Any, type_b: Any) -> ConstraintSet:
+def is_equivalent_to(
+    type_a: TypeForm[object], type_b: TypeForm[object]
+) -> ConstraintSet:
     """Returns a constraint set that is satisfied when `type_a` and `type_b` are
     `equivalent`_ types.
 
     .. _equivalent: https://typing.python.org/en/latest/spec/glossary.html#term-equivalent
     """
 
-def is_subtype_of(ty: Any, of: Any) -> ConstraintSet:
+def is_subtype_of(ty: TypeForm[object], of: TypeForm[object]) -> ConstraintSet:
     """Returns a constraint set that is satisfied when `ty` is a `subtype`_ of `of`.
 
     .. _subtype: https://typing.python.org/en/latest/spec/concepts.html#subtype-supertype-and-type-equivalence
     """
 
-def is_assignable_to(ty: Any, to: Any) -> ConstraintSet:
+def is_assignable_to(ty: TypeForm[object], to: TypeForm[object]) -> ConstraintSet:
     """Returns a constraint set that is satisfied when `ty` is `assignable`_ to `to`.
 
     .. _assignable: https://typing.python.org/en/latest/spec/concepts.html#the-assignable-to-or-consistent-subtyping-relation
     """
 
-def is_disjoint_from(type_a: Any, type_b: Any) -> ConstraintSet:
+def is_disjoint_from(
+    type_a: TypeForm[object], type_b: TypeForm[object]
+) -> ConstraintSet:
     """Returns a constraint set that is satisfied when `type_a` and `type_b` are disjoint types.
 
     Two types are disjoint if they have no inhabitants in common.
     """
 
-def is_singleton(ty: Any) -> bool:
+def is_singleton(ty: TypeForm[object]) -> bool:
     """Returns `True` if `ty` is a singleton type with exactly one inhabitant."""
 
-def is_single_valued(ty: Any) -> bool:
+def is_single_valued(ty: TypeForm[object]) -> bool:
     """Returns `True` if `ty` is non-empty and all inhabitants compare equal to each other."""
 
 def generic_context(ty: Any) -> GenericContext | None:

--- a/crates/ty_vendored/ty_extensions/ty_extensions.pyi
+++ b/crates/ty_vendored/ty_extensions/ty_extensions.pyi
@@ -209,19 +209,20 @@ def is_singleton(ty: TypeForm[object]) -> bool:
 def is_single_valued(ty: TypeForm[object]) -> bool:
     """Returns `True` if `ty` is non-empty and all inhabitants compare equal to each other."""
 
-def generic_context(ty: Any) -> GenericContext | None:
-    """Returns the generic context of a type as a tuple of typevars.
+def generic_context(input: Any) -> GenericContext | None:
+    """Returns the generic context of the input (a class, a function, a method, a type alias, ..)
+    as a tuple of typevars.
 
-    Returns `None` if the type is not generic.
+    Returns `None` if the input is not generic.
     """
 
-def into_callable(ty: Any) -> Any:
+def into_callable(value: Any) -> Any:
     """Converts a value into a `Callable`, if possible.
 
     This is the value equivalent of `CallableTypeOf`, which operates on types.
     """
 
-def into_regular_callable(ty: Any) -> Any:
+def into_regular_callable(value: Any) -> Any:
     """Converts a value into a regular `Callable`, if possible.
 
     This is the value equivalent of `RegularCallableTypeOf`, which operates on types.


### PR DESCRIPTION
## Summary

I saw that TypeForm support landed, and I remembered @dcreager saying that we could simplify some things once we had that.

## Test Plan

Updated tests, this is mostly intended to be an internal refactor.