### PR TITLE
[ty] Use diagnostic message as tie breaker when sorting

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -551,7 +551,7 @@ impl Ord for RenderingSortKey<'_> {
     // We sort diagnostics in a way that keeps them in source order
     // and grouped by file. After that, we fall back to severity
     // (with fatal messages sorting before info messages) and then
-    // finally the diagnostic ID.
+    // finally the diagnostic ID and concise message.
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         if let (Some(span1), Some(span2)) = (
             self.diagnostic.primary_span(),
@@ -578,7 +578,15 @@ impl Ord for RenderingSortKey<'_> {
         if order.is_ne() {
             return order;
         }
-        self.diagnostic.id().cmp(&other.diagnostic.id())
+        let order = self.diagnostic.id().cmp(&other.diagnostic.id());
+        if order.is_ne() {
+            return order;
+        }
+
+        self.diagnostic
+            .concise_message()
+            .to_str()
+            .cmp(&other.diagnostic.concise_message().to_str())
     }
 }
 

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -2539,6 +2539,28 @@ watermelon
         );
     }
 
+    #[test]
+    fn diagnostics_without_primary_spans_sort_by_concise_message() {
+        let env = TestEnvironment::new();
+        let mut diagnostics = [
+            Diagnostic::new(DiagnosticId::Panic, Severity::Fatal, "checking mod.py"),
+            Diagnostic::new(DiagnosticId::Panic, Severity::Fatal, "checking main.py"),
+        ];
+
+        diagnostics.sort_by(|left, right| {
+            left.rendering_sort_key(&env.db)
+                .cmp(&right.rendering_sort_key(&env.db))
+        });
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(Diagnostic::primary_message)
+                .collect::<Vec<_>>(),
+            ["checking main.py", "checking mod.py"]
+        );
+    }
+
     /// A small harness for setting up an environment specifically for testing
     /// diagnostic rendering.
     pub(super) struct TestEnvironment {

--- a/crates/ruff_db/src/diagnostic/render.rs
+++ b/crates/ruff_db/src/diagnostic/render.rs
@@ -2540,11 +2540,16 @@ watermelon
     }
 
     #[test]
-    fn diagnostics_without_primary_spans_sort_by_concise_message() {
-        let env = TestEnvironment::new();
+    fn diagnostics_with_equal_locations_sort_by_concise_message() {
+        let mut env = TestEnvironment::new();
+        env.add("fruits", FRUITS);
         let mut diagnostics = [
-            Diagnostic::new(DiagnosticId::Panic, Severity::Fatal, "checking mod.py"),
-            Diagnostic::new(DiagnosticId::Panic, Severity::Fatal, "checking main.py"),
+            env.invalid_syntax("checking mod.py")
+                .primary("fruits", "1", "1", "")
+                .build(),
+            env.invalid_syntax("checking main.py")
+                .primary("fruits", "1", "1", "")
+                .build(),
         ];
 
         diagnostics.sort_by(|left, right| {

--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -935,6 +935,22 @@ def test(f: Intersection[IntCaller, StrCaller] | BytesCaller):
 ```
 
 ```snapshot
+error[invalid-argument-type]: Argument to bound method `BytesCaller.__call__` is incorrect
+  --> src/mdtest_snippet.py:21:7
+   |
+21 |     f(None)
+   |       ^^^^ Expected `bytes`, found `None`
+   |
+info: Method defined here
+  --> src/mdtest_snippet.py:13:9
+   |
+13 |     def __call__(self, x: bytes) -> bytes:
+   |         ^^^^^^^^       -------- Parameter declared here
+   |
+info: Union variant `BytesCaller` is incompatible with this call site
+info: Attempted to call union type `(IntCaller & StrCaller) | BytesCaller`
+
+
 error[invalid-argument-type]: Argument to bound method `IntCaller.__call__` is incorrect
   --> src/mdtest_snippet.py:21:7
    |
@@ -949,22 +965,6 @@ info: Method defined here
   |
 info: Intersection element `IntCaller` is incompatible with this call site
 info: Attempted to call intersection type `IntCaller & StrCaller`
-info: Attempted to call union type `(IntCaller & StrCaller) | BytesCaller`
-
-
-error[invalid-argument-type]: Argument to bound method `BytesCaller.__call__` is incorrect
-  --> src/mdtest_snippet.py:21:7
-   |
-21 |     f(None)
-   |       ^^^^ Expected `bytes`, found `None`
-   |
-info: Method defined here
-  --> src/mdtest_snippet.py:13:9
-   |
-13 |     def __call__(self, x: bytes) -> bytes:
-   |         ^^^^^^^^       -------- Parameter declared here
-   |
-info: Union variant `BytesCaller` is incompatible with this call site
 info: Attempted to call union type `(IntCaller & StrCaller) | BytesCaller`
 
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Unknown_key_for_all_…_(8a0f0e8ceccc51b2).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Unknown_key_for_all_…_(8a0f0e8ceccc51b2).snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ty_test/src/lib.rs
+source: crates/mdtest/src/lib.rs
 expression: snapshot
 ---
 
@@ -32,18 +32,6 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/subscript/assignment_dia
 # Diagnostics
 
 ```
-error[invalid-key]: Unknown key "nane" for TypedDict `Person`
-  --> src/mdtest_snippet.py:14:5
-   |
-14 |     being["nane"] = "unknown"
-   |     ----- ^^^^^^ Unknown key "nane"
-   |     |
-   |     TypedDict `Person` in union type `Person | Animal`
-   |
-
-```
-
-```
 error[invalid-key]: Unknown key "nane" for TypedDict `Animal`
   --> src/mdtest_snippet.py:14:5
    |
@@ -51,6 +39,18 @@ error[invalid-key]: Unknown key "nane" for TypedDict `Animal`
    |     ----- ^^^^^^ Unknown key "nane"
    |     |
    |     TypedDict `Animal` in union type `Person | Animal`
+   |
+
+```
+
+```
+error[invalid-key]: Unknown key "nane" for TypedDict `Person`
+  --> src/mdtest_snippet.py:14:5
+   |
+14 |     being["nane"] = "unknown"
+   |     ----- ^^^^^^ Unknown key "nane"
+   |     |
+   |     TypedDict `Person` in union type `Person | Animal`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ty_test/src/lib.rs
+source: crates/mdtest/src/lib.rs
 expression: snapshot
 ---
 
@@ -119,35 +119,6 @@ info: The definition of class `Foo` will raise `TypeError` at runtime
 ```
 
 ```
-error[duplicate-base]: Duplicate base class `Spam`
-  --> src/mdtest_snippet.py:16:7
-   |
-16 |   class Ham(
-   |  _______^
-17 | |     Spam,
-18 | |     Eggs,
-19 | |     Bar,
-20 | |     Baz,
-21 | |     Spam,
-22 | |     Eggs,
-23 | | ): ...
-   | |_^
-   |
-info: The definition of class `Ham` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:17:5
-   |
-17 |     Spam,
-   |     ---- Class `Spam` first included in bases list here
-18 |     Eggs,
-19 |     Bar,
-20 |     Baz,
-21 |     Spam,
-   |     ^^^^ Class `Spam` later repeated here
-   |
-
-```
-
-```
 error[duplicate-base]: Duplicate base class `Eggs`
   --> src/mdtest_snippet.py:16:7
    |
@@ -172,6 +143,35 @@ info: The definition of class `Ham` will raise `TypeError` at runtime
 21 |     Spam,
 22 |     Eggs,
    |     ^^^^ Class `Eggs` later repeated here
+   |
+
+```
+
+```
+error[duplicate-base]: Duplicate base class `Spam`
+  --> src/mdtest_snippet.py:16:7
+   |
+16 |   class Ham(
+   |  _______^
+17 | |     Spam,
+18 | |     Eggs,
+19 | |     Bar,
+20 | |     Baz,
+21 | |     Spam,
+22 | |     Eggs,
+23 | | ): ...
+   | |_^
+   |
+info: The definition of class `Ham` will raise `TypeError` at runtime
+  --> src/mdtest_snippet.py:17:5
+   |
+17 |     Spam,
+   |     ---- Class `Spam` first included in bases list here
+18 |     Eggs,
+19 |     Bar,
+20 |     Baz,
+21 |     Spam,
+   |     ^^^^ Class `Spam` later repeated here
    |
 
 ```


### PR DESCRIPTION
## Nondeterminism

When ty checks files in parallel, non-panic diagnostics with the same rendered source location, severity, and diagnostic ID can be printed in worker-completion order instead of a canonical order. This manifests as nondeterminism on the homeassistant/core project.

## Root Cause

`CollectReporter` receives checked-file diagnostics as Rayon workers finish, then sorts them with `Diagnostic::rendering_sort_key`. The existing key compared primary file/range, severity, and diagnostic ID, but not the visible diagnostic message. In `core`, the two diagnostics had the same primary span and tied on error `DiagnosticId::InvalidArgumentType`, so the sort key considered visibly different diagnostics equal and Rust's stable sort preserved the race-dependent arrival order.

## Fix

Use the concise rendered message as the final tie-breaker.
