### PR TITLE
[ty] Ignore rejected member annotations for synthesized bindings

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
@@ -155,6 +155,7 @@ Narrowing is also performed for dictionary unpacking expressions:
 def f1(a: int): ...
 def f2(a: int, b: str): ...
 def f3(a: int, b: str, c: float): ...
+def accepts_inner(inner: dict[str, int]): ...
 
 x1: dict[str, float | str] = {"a": 1, "b": "a"}
 
@@ -216,10 +217,22 @@ def _(x: dict[str, object]):
     # error: [invalid-argument-type]
     f3(**x["inner"])
 
+    # The rejected annotation does not widen the assigned dictionary's value type.
+    # error: [invalid-assignment]
     x["inner"]["c"] = 1.0
-    f3(**x["inner"])  # ok
 
     x["inner"] = {"inner": {"a": 1}}
+    accepts_inner(**x["inner"])  # ok
+    # error: [invalid-argument-type]
+    f1(**x["inner"])
+
+def _(x: dict[str, object]):
+    # An annotation-only subscript likewise cannot declare the nested dictionary's type.
+    # error: [invalid-type-form]
+    x["inner"]: dict[str, float | str]
+
+    x["inner"] = {"inner": {"a": 1}}
+    accepts_inner(**x["inner"])  # ok
     # error: [invalid-argument-type]
     f1(**x["inner"])
 
@@ -287,6 +300,15 @@ def _(normalizing: WithNormalizingDescriptor):
 
 class Y:
     inner: dict[str, object]
+
+def _(y: Y):
+    # error: [invalid-type-form]
+    y.inner: dict[str, float | str] = {"a": 1, "b": "a"}
+
+    y.inner = {"inner": {"a": 1}}
+    accepts_inner(**y.inner)  # ok
+    # error: [invalid-argument-type]
+    f1(**y.inner)
 
 def _(y: Y):
     y.inner = {"a": 1, "b": "a"}

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
@@ -325,3 +325,24 @@ def _(y: Y):
     # error: [invalid-argument-type]
     f1(**y.inner)
 ```
+
+## Rejected annotations in stubs
+
+Annotation-only declarations in stubs are also bindings. A rejected annotation should fall back to
+the type obtained by normal member lookup:
+
+`stub.pyi`:
+
+```pyi
+x: dict[str, object]
+# error: [invalid-type-form]
+x["a"]: int
+reveal_type(x["a"])  # revealed: object
+
+x["b"] = ...
+reveal_type(x["b"])  # revealed: Unknown
+
+# error: [invalid-type-form]
+x["c"]: int = ...
+reveal_type(x["c"])  # revealed: Unknown
+```

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -11,7 +11,7 @@ use crate::reachability::{ReachabilityConstraintsExtension, evaluate_reachabilit
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::{
     DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers, TypeQualifiers,
-    UnionBuilder, UnionType, binding_type, declaration_type, is_discarded_dict_key_assignment,
+    UnionBuilder, UnionType, binding_type, inferred_declaration, is_discarded_dict_key_assignment,
 };
 use crate::{Db, FxIndexSet, FxOrderSet, Program};
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
@@ -1727,11 +1727,12 @@ fn place_from_declarations_impl<'db>(
         if static_reachability.is_always_false() {
             None
         } else {
+            let declared_type = inferred_declaration(db, declaration).declared()?;
             first_declaration.get_or_insert(declaration);
             all_declarations_definitely_reachable =
                 all_declarations_definitely_reachable && static_reachability.is_always_true();
 
-            Some((declaration_type(db, declaration), static_reachability))
+            Some((declared_type, static_reachability))
         }
     });
 

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -17,7 +17,8 @@ use crate::place::implicit_globals::all_implicit_module_globals;
 use crate::types::ide_support::{ImportAliasResolution, definition_for_name};
 use crate::types::list_members::{Member, all_members, all_reachable_members};
 use crate::types::{
-    CycleDetector, Type, TypeQualifiers, binding_type, declaration_type, infer_complete_scope_types,
+    CycleDetector, Type, TypeQualifiers, binding_type, infer_complete_scope_types,
+    inferred_declaration,
 };
 use ty_python_core::definition::Definition;
 use ty_python_core::place_table;
@@ -466,7 +467,10 @@ impl<'db> SemanticModel<'db> {
                 {
                     return TypeQualifiers::empty();
                 }
-                declaration_type(self.db, definition).qualifiers()
+                let Some(declared) = inferred_declaration(self.db, definition).declared() else {
+                    return TypeQualifiers::empty();
+                };
+                declared.qualifiers()
             }
             ExprRef::Attribute(attr) => {
                 let Some(value_ty) = attr.value.inferred_type(self) else {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -27,8 +27,8 @@ pub(crate) use self::cyclic::TypeTransformer;
 pub(crate) use self::diagnostic::register_lints;
 pub use self::diagnostic::{TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
 pub(crate) use self::infer::{
-    TypeContext, infer_complete_scope_types, infer_deferred_types, infer_definition_types,
-    infer_expression_type, infer_expression_types, infer_scope_types,
+    InferredDeclaration, TypeContext, infer_complete_scope_types, infer_deferred_types,
+    infer_definition_types, infer_expression_type, infer_expression_types, infer_scope_types,
     is_discarded_dict_key_assignment,
 };
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
@@ -203,13 +203,13 @@ pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) ->
     inference.binding_type(definition)
 }
 
-/// Infer the type of a declaration.
-pub(crate) fn declaration_type<'db>(
+/// Infer whether a syntactically indexed declaration is a semantic declaration.
+pub(crate) fn inferred_declaration<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
-) -> TypeAndQualifiers<'db> {
+) -> InferredDeclaration<'db> {
     let inference = infer_definition_types(db, definition);
-    inference.declaration_type(definition)
+    inference.inferred_declaration(definition)
 }
 
 /// Infer the type of a (possibly deferred) sub-expression of a [`Definition`].

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -203,7 +203,7 @@ pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) ->
     inference.binding_type(definition)
 }
 
-/// Infer whether a syntactically indexed declaration is a semantic declaration.
+/// Infer the type of a declaration, returning `Rejected` if it is not valid.
 pub(crate) fn inferred_declaration<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -32,7 +32,7 @@ use crate::{
             typed_dict::{TypedDictFields, synthesize_typed_dict_method, typed_dict_class_member},
         },
         context::InferContext,
-        declaration_type, definition_expression_type, determine_upper_bound,
+        definition_expression_type, determine_upper_bound,
         diagnostic::INVALID_DATACLASS_OVERRIDE,
         enums::{enum_metadata, is_enum_class_by_inheritance, try_unwrap_nonmember_value},
         function::{
@@ -41,7 +41,7 @@ use crate::{
         },
         generics::Specialization,
         infer::infer_unpack_types,
-        infer_expression_type,
+        infer_expression_type, inferred_declaration,
         known_instance::DeprecatedInstance,
         member::{Member, class_member},
         mro::{Mro, MroIterator},
@@ -2185,7 +2185,9 @@ impl<'db> StaticClassLiteral<'db> {
                 //     self.name: <annotation>
                 //     self.name: <annotation> = …
 
-                let annotation = declaration_type(db, declaration);
+                let Some(annotation) = inferred_declaration(db, declaration).declared() else {
+                    continue;
+                };
                 let annotation = Place::declared(annotation.inner).with_qualifiers(
                     annotation.qualifiers | TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE,
                 );

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -32,8 +32,8 @@ use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, CallableTypes,
     ClassLiteral, FindLegacyTypeVarsVisitor, IntersectionType, KnownClass, KnownInstanceType,
     MaterializationKind, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
-    TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType, binding_type, declaration_type,
-    infer_definition_types,
+    TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType, binding_type,
+    infer_definition_types, inferred_declaration,
 };
 use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -523,8 +523,9 @@ impl<'db> GenericContext<'db> {
         match type_param_node {
             ast::TypeParam::TypeVar(node) => {
                 let definition = index.expect_single_definition(node);
+                let declared = inferred_declaration(db, definition).declared()?;
                 let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
-                    declaration_type(db, definition).inner_type()
+                    declared.inner_type()
                 else {
                     return None;
                 };
@@ -532,8 +533,9 @@ impl<'db> GenericContext<'db> {
             }
             ast::TypeParam::ParamSpec(node) => {
                 let definition = index.expect_single_definition(node);
+                let declared = inferred_declaration(db, definition).declared()?;
                 let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
-                    declaration_type(db, definition).inner_type()
+                    declared.inner_type()
                 else {
                     return None;
                 };

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -843,6 +843,24 @@ impl<'db> ScopeInference<'db> {
     }
 }
 
+/// The inferred declaration produced by a syntactically indexed declaration.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) enum InferredDeclaration<'db> {
+    /// A semantic declaration with an inferred declared type.
+    Declared(TypeAndQualifiers<'db>),
+    /// A syntactic declaration candidate that is not a valid semantic declaration.
+    Rejected,
+}
+
+impl<'db> InferredDeclaration<'db> {
+    pub(crate) fn declared(self) -> Option<TypeAndQualifiers<'db>> {
+        match self {
+            InferredDeclaration::Declared(declared) => Some(declared),
+            InferredDeclaration::Rejected => None,
+        }
+    }
+}
+
 /// The inferred types for a definition region.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct DefinitionInference<'db> {
@@ -859,12 +877,12 @@ pub(crate) struct DefinitionInference<'db> {
     /// Because of that, use a slice with linear search over a hash map.
     pub(crate) bindings: Box<[(Definition<'db>, Type<'db>)]>,
 
-    /// The types and type qualifiers of every declaration in this region.
+    /// The inferred outcome of every syntactically indexed declaration in this region.
     ///
     /// About 50% of the definition inference regions have no declarations.
     /// The other 50% have less than 10 declarations. Because of that, use a
     /// slice with linear search over a hash map.
-    declarations: Box<[(Definition<'db>, TypeAndQualifiers<'db>)]>,
+    declarations: Box<[(Definition<'db>, InferredDeclaration<'db>)]>,
 
     /// The extra data that is only present for few inference regions.
     extra: Option<Box<DefinitionInferenceExtra<'db>>>,
@@ -973,11 +991,16 @@ impl<'db> DefinitionInference<'db> {
                 *binding_ty = binding_ty.recursive_type_normalized(db, cycle);
             }
         }
-        for (declaration, declaration_ty) in &mut self.declarations {
-            if let Some((_, previous_declaration)) = previous_inference
-                .declarations
-                .iter()
-                .find(|(previous_declaration, _)| previous_declaration == declaration)
+        for (declaration, inferred_declaration) in &mut self.declarations {
+            let InferredDeclaration::Declared(declaration_ty) = inferred_declaration else {
+                continue;
+            };
+
+            if let Some((_, InferredDeclaration::Declared(previous_declaration))) =
+                previous_inference
+                    .declarations
+                    .iter()
+                    .find(|(previous_declaration, _)| previous_declaration == declaration)
             {
                 *declaration_ty = declaration_ty.map_type(|decl_ty| {
                     decl_ty.cycle_normalized(db, previous_declaration.inner_type(), cycle)
@@ -1056,31 +1079,40 @@ impl<'db> DefinitionInference<'db> {
     }
 
     #[track_caller]
-    pub(crate) fn declaration_type(&self, definition: Definition<'db>) -> TypeAndQualifiers<'db> {
+    pub(crate) fn inferred_declaration(
+        &self,
+        definition: Definition<'db>,
+    ) -> InferredDeclaration<'db> {
         self.declarations
             .iter()
-            .find_map(|(def, qualifiers)| {
+            .find_map(|(def, declaration)| {
                 if def == &definition {
-                    Some(*qualifiers)
+                    Some(*declaration)
                 } else {
                     None
                 }
             })
-            .or_else(|| self.fallback_type().map(TypeAndQualifiers::declared))
+            .or_else(|| {
+                self.fallback_type()
+                    .map(TypeAndQualifiers::declared)
+                    .map(InferredDeclaration::Declared)
+            })
             .expect(
                 "definition should belong to this TypeInference region and \
-                TypeInferenceBuilder should have inferred a type for it",
+                    TypeInferenceBuilder should have inferred an outcome for it",
             )
     }
 
-    fn declarations(
-        &self,
-    ) -> impl ExactSizeIterator<Item = (Definition<'db>, TypeAndQualifiers<'db>)> {
-        self.declarations.iter().copied()
+    fn declarations(&self) -> impl Iterator<Item = (Definition<'db>, TypeAndQualifiers<'db>)> + '_ {
+        self.declarations
+            .iter()
+            .filter_map(|(definition, declaration)| Some((*definition, declaration.declared()?)))
     }
 
-    fn declaration_types(&self) -> impl ExactSizeIterator<Item = TypeAndQualifiers<'db>> {
-        self.declarations.iter().map(|(_, qualifiers)| *qualifiers)
+    fn declaration_types(&self) -> impl Iterator<Item = TypeAndQualifiers<'db>> + '_ {
+        self.declarations
+            .iter()
+            .filter_map(|(_, declaration)| declaration.declared())
     }
 
     pub(crate) fn fallback_type(&self) -> Option<Type<'db>> {
@@ -1098,9 +1130,15 @@ impl<'db> DefinitionInference<'db> {
     }
 
     pub(crate) fn function_type(&self, definition: Definition<'db>) -> Option<FunctionType<'db>> {
-        self.undecorated_type()
-            .unwrap_or_else(|| self.declaration_type(definition).inner_type())
-            .as_function_literal()
+        let ty = if let Some(undecorated) = self.undecorated_type() {
+            undecorated
+        } else {
+            self.inferred_declaration(definition)
+                .declared()?
+                .inner_type()
+        };
+
+        ty.as_function_literal()
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -843,12 +843,15 @@ impl<'db> ScopeInference<'db> {
     }
 }
 
-/// The inferred declaration produced by a syntactically indexed declaration.
+/// The result of inferring a declaration recorded by the semantic index.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) enum InferredDeclaration<'db> {
-    /// A semantic declaration with an inferred declared type.
+    /// A valid declaration with an inferred declared type.
     Declared(TypeAndQualifiers<'db>),
-    /// A syntactic declaration candidate that is not a valid semantic declaration.
+    /// An invalid declaration that should not participate in declaration resolution.
+    ///
+    /// For example, `obj.attr: int` when `obj` is not a valid implicit receiver, or
+    /// `items[0]: int`, which is never a valid annotation target.
     Rejected,
 }
 
@@ -877,12 +880,12 @@ pub(crate) struct DefinitionInference<'db> {
     /// Because of that, use a slice with linear search over a hash map.
     pub(crate) bindings: Box<[(Definition<'db>, Type<'db>)]>,
 
-    /// The inferred outcome of every syntactically indexed declaration in this region.
+    /// The types and type qualifiers of every valid declaration in this region.
     ///
     /// About 50% of the definition inference regions have no declarations.
     /// The other 50% have less than 10 declarations. Because of that, use a
     /// slice with linear search over a hash map.
-    declarations: Box<[(Definition<'db>, InferredDeclaration<'db>)]>,
+    declarations: Box<[(Definition<'db>, TypeAndQualifiers<'db>)]>,
 
     /// The extra data that is only present for few inference regions.
     extra: Option<Box<DefinitionInferenceExtra<'db>>>,
@@ -991,16 +994,11 @@ impl<'db> DefinitionInference<'db> {
                 *binding_ty = binding_ty.recursive_type_normalized(db, cycle);
             }
         }
-        for (declaration, inferred_declaration) in &mut self.declarations {
-            let InferredDeclaration::Declared(declaration_ty) = inferred_declaration else {
-                continue;
-            };
-
-            if let Some((_, InferredDeclaration::Declared(previous_declaration))) =
-                previous_inference
-                    .declarations
-                    .iter()
-                    .find(|(previous_declaration, _)| previous_declaration == declaration)
+        for (declaration, declaration_ty) in &mut self.declarations {
+            if let Some((_, previous_declaration)) = previous_inference
+                .declarations
+                .iter()
+                .find(|(previous_declaration, _)| previous_declaration == declaration)
             {
                 *declaration_ty = declaration_ty.map_type(|decl_ty| {
                     decl_ty.cycle_normalized(db, previous_declaration.inner_type(), cycle)
@@ -1078,7 +1076,6 @@ impl<'db> DefinitionInference<'db> {
         self.bindings.iter().copied()
     }
 
-    #[track_caller]
     pub(crate) fn inferred_declaration(
         &self,
         definition: Definition<'db>,
@@ -1087,7 +1084,7 @@ impl<'db> DefinitionInference<'db> {
             .iter()
             .find_map(|(def, declaration)| {
                 if def == &definition {
-                    Some(*declaration)
+                    Some(InferredDeclaration::Declared(*declaration))
                 } else {
                     None
                 }
@@ -1097,22 +1094,17 @@ impl<'db> DefinitionInference<'db> {
                     .map(TypeAndQualifiers::declared)
                     .map(InferredDeclaration::Declared)
             })
-            .expect(
-                "definition should belong to this TypeInference region and \
-                    TypeInferenceBuilder should have inferred an outcome for it",
-            )
+            .unwrap_or(InferredDeclaration::Rejected)
     }
 
-    fn declarations(&self) -> impl Iterator<Item = (Definition<'db>, TypeAndQualifiers<'db>)> + '_ {
-        self.declarations
-            .iter()
-            .filter_map(|(definition, declaration)| Some((*definition, declaration.declared()?)))
+    fn declarations(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (Definition<'db>, TypeAndQualifiers<'db>)> {
+        self.declarations.iter().copied()
     }
 
-    fn declaration_types(&self) -> impl Iterator<Item = TypeAndQualifiers<'db>> + '_ {
-        self.declarations
-            .iter()
-            .filter_map(|(_, declaration)| declaration.declared())
+    fn declaration_types(&self) -> impl ExactSizeIterator<Item = TypeAndQualifiers<'db>> {
+        self.declarations.iter().map(|(_, qualifiers)| *qualifiers)
     }
 
     pub(crate) fn fallback_type(&self) -> Option<Type<'db>> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3583,6 +3583,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         add.insert(self, target_ty);
     }
 
+    fn stub_placeholder_binding_type(&self, value: &ast::Expr) -> Option<Type<'db>> {
+        if self.in_stub() && value.is_ellipsis_literal_expr() {
+            Some(Type::unknown())
+        } else {
+            None
+        }
+    }
+
     fn infer_assignment_definition_impl(
         &mut self,
         assignment: &AssignmentDefinitionKind<'db>,
@@ -3707,10 +3715,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         report_invalid_type_checking_constant(&self.context, target.into());
                     }
                     Type::bool_literal(true)
-                } else if self.in_stub() && value.is_ellipsis_literal_expr() {
-                    Type::unknown()
                 } else {
-                    value_ty
+                    self.stub_placeholder_binding_type(value)
+                        .unwrap_or(value_ty)
                 }
             }
         };
@@ -4375,21 +4382,34 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.declarations
                 .insert(definition, InferredDeclaration::Rejected);
 
-            if let Some(value) = value {
+            if !definition
+                .kind(self.db())
+                .category(self.in_stub(), self.module())
+                .is_binding()
+            {
+                return;
+            }
+
+            let node = target.into();
+            let add = AddBinding {
+                declared_ty: self.fallback_member_declared_type(node),
+                binding: definition,
+                node,
+                qualifiers: TypeQualifiers::empty(),
+                is_local: true,
+            };
+            let target_ty = if let Some(value) = value {
                 // The value remains an ordinary assignment, but normal binding resolution
                 // would consult this rejected annotation as a declaration.
-                let node = target.into();
-                let add = AddBinding {
-                    declared_ty: self.fallback_member_declared_type(node),
-                    binding: definition,
-                    node,
-                    qualifiers: TypeQualifiers::empty(),
-                    is_local: true,
-                };
-                let target_ty = self.infer_maybe_standalone_expression(value, add.type_context());
-                self.store_expression_type(target, target_ty);
-                add.insert(self, target_ty);
-            }
+                let value_ty = self.infer_maybe_standalone_expression(value, add.type_context());
+                self.stub_placeholder_binding_type(value)
+                    .unwrap_or(value_ty)
+            } else {
+                // Annotation-only definitions are bindings in stubs.
+                add.declared_ty.unwrap_or(Type::unknown())
+            };
+            self.store_expression_type(target, target_ty);
+            add.insert(self, target_ty);
 
             return;
         }
@@ -10303,7 +10323,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             bindings: bindings.into_boxed_slice(),
             declarations: declarations
                 .into_iter()
-                .filter_map(|(definition, declaration)| Some((definition, declaration.declared()?)))
+                .filter_map(|(definition, declaration)| {
+                    declaration
+                        .declared()
+                        .map(|declared| (definition, declared))
+                })
                 .collect(),
             extra,
         }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -23,9 +23,9 @@ use ty_python_core::statement::StatementInner;
 
 use super::{
     DefinitionInference, DefinitionInferenceExtra, ExpressionInference, ExpressionInferenceExtra,
-    FrozenMap, FrozenSet, FunctionDecoratorInference, InferenceRegion, InferredDeclaration,
-    ScopeInference, ScopeInferenceExtra, infer_deferred_types, infer_definition_types,
-    infer_expression_types, infer_same_file_expression_type, infer_unpack_types,
+    FrozenMap, FrozenSet, FunctionDecoratorInference, InferenceRegion, ScopeInference,
+    ScopeInferenceExtra, infer_deferred_types, infer_definition_types, infer_expression_types,
+    infer_same_file_expression_type, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -270,10 +270,10 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// The list should only contain one entry per binding at most.
     bindings: VecMap<Definition<'db>, Type<'db>>,
 
-    /// The inferred outcome of every declaration recorded by the semantic index in this region.
+    /// The types and type qualifiers of every valid declaration in this region.
     ///
     /// The list should only contain one entry per declaration at most.
-    declarations: VecMap<Definition<'db>, InferredDeclaration<'db>>,
+    declarations: VecMap<Definition<'db>, TypeAndQualifiers<'db>>,
 
     /// The definitions with deferred sub-parts.
     ///
@@ -424,11 +424,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.expressions
             .extend(inference.expressions.iter().copied());
-        self.declarations.extend(
-            inference.declarations().map(|(definition, declared)| {
-                (definition, InferredDeclaration::Declared(declared))
-            }),
-        );
+        self.declarations.extend(inference.declarations());
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
             self.bindings.extend(inference.bindings());
@@ -469,11 +465,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.expressions
             .extend(inference.expressions.iter().copied());
-        self.declarations.extend(
-            inference.declarations().map(|(definition, declared)| {
-                (definition, InferredDeclaration::Declared(declared))
-            }),
-        );
+        self.declarations.extend(inference.declarations());
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
             self.bindings.extend(inference.bindings());
@@ -846,10 +838,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mut seen_overloaded_places = FxHashSet::default();
             let mut seen_public_functions = FxHashSet::default();
 
-            for (&definition, inferred_declaration) in &self.declarations {
-                let Some(ty_and_quals) = inferred_declaration.declared() else {
-                    continue;
-                };
+            for (&definition, ty_and_quals) in &self.declarations {
                 let ty = ty_and_quals.inner_type();
                 match definition.kind(self.db()) {
                     DefinitionKind::Function(function) => {
@@ -1388,8 +1377,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             TypeAndQualifiers::declared(Type::unknown())
         };
-        self.declarations
-            .insert(declaration, InferredDeclaration::Declared(ty));
+        self.declarations.insert(declaration, ty);
     }
 
     fn add_declaration_with_binding(
@@ -1477,8 +1465,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        self.declarations
-            .insert(definition, InferredDeclaration::Declared(declared_ty));
+        self.declarations.insert(definition, declared_ty);
         self.bindings.insert(definition, inferred_ty);
     }
 
@@ -4379,9 +4366,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let value = assignment.value(self.module());
 
         if !target.is_name_expr() && !self.is_valid_receiver_annotation_target(target) {
-            self.declarations
-                .insert(definition, InferredDeclaration::Rejected);
-
+            // Omit this definition from `self.declarations`; declaration lookup treats an absent
+            // inferred declaration as rejected.
             if !definition
                 .kind(self.db())
                 .category(self.in_stub(), self.module())
@@ -10321,14 +10307,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             #[cfg(debug_assertions)]
             scope,
             bindings: bindings.into_boxed_slice(),
-            declarations: declarations
-                .into_iter()
-                .filter_map(|(definition, declaration)| {
-                    declaration
-                        .declared()
-                        .map(|declared| (definition, declared))
-                })
-                .collect(),
+            declarations: declarations.into_boxed_slice(),
             extra,
         }
     }
@@ -10478,14 +10457,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             #[cfg(debug_assertions)]
             scope,
             bindings: bindings.into_boxed_slice(),
-            declarations: declarations
-                .into_iter()
-                .filter_map(|(definition, declaration)| {
-                    declaration
-                        .declared()
-                        .map(|declared| (definition, declared))
-                })
-                .collect(),
+            declarations: declarations.into_boxed_slice(),
             extra,
         }
     }
@@ -10963,15 +10935,6 @@ impl<'a, K, V> IntoIterator for &'a VecMap<K, V> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
-    }
-}
-
-impl<K, V> IntoIterator for VecMap<K, V> {
-    type Item = (K, V);
-    type IntoIter = std::vec::IntoIter<(K, V)>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -23,9 +23,9 @@ use ty_python_core::statement::StatementInner;
 
 use super::{
     DefinitionInference, DefinitionInferenceExtra, ExpressionInference, ExpressionInferenceExtra,
-    FrozenMap, FrozenSet, FunctionDecoratorInference, InferenceRegion, ScopeInference,
-    ScopeInferenceExtra, infer_deferred_types, infer_definition_types, infer_expression_types,
-    infer_same_file_expression_type, infer_unpack_types,
+    FrozenMap, FrozenSet, FunctionDecoratorInference, InferenceRegion, InferredDeclaration,
+    ScopeInference, ScopeInferenceExtra, infer_deferred_types, infer_definition_types,
+    infer_expression_types, infer_same_file_expression_type, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -270,10 +270,10 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// The list should only contain one entry per binding at most.
     bindings: VecMap<Definition<'db>, Type<'db>>,
 
-    /// The types and type qualifiers of every declaration in this region.
+    /// The inferred outcome of every syntactically indexed declaration in this region.
     ///
     /// The list should only contain one entry per declaration at most.
-    declarations: VecMap<Definition<'db>, TypeAndQualifiers<'db>>,
+    declarations: VecMap<Definition<'db>, InferredDeclaration<'db>>,
 
     /// The definitions with deferred sub-parts.
     ///
@@ -424,7 +424,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.expressions
             .extend(inference.expressions.iter().copied());
-        self.declarations.extend(inference.declarations());
+        self.declarations.extend(
+            inference.declarations().map(|(definition, declared)| {
+                (definition, InferredDeclaration::Declared(declared))
+            }),
+        );
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
             self.bindings.extend(inference.bindings());
@@ -465,7 +469,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.expressions
             .extend(inference.expressions.iter().copied());
-        self.declarations.extend(inference.declarations());
+        self.declarations.extend(
+            inference.declarations().map(|(definition, declared)| {
+                (definition, InferredDeclaration::Declared(declared))
+            }),
+        );
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
             self.bindings.extend(inference.bindings());
@@ -838,7 +846,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mut seen_overloaded_places = FxHashSet::default();
             let mut seen_public_functions = FxHashSet::default();
 
-            for (&definition, ty_and_quals) in &self.declarations {
+            for (&definition, inferred_declaration) in &self.declarations {
+                let Some(ty_and_quals) = inferred_declaration.declared() else {
+                    continue;
+                };
                 let ty = ty_and_quals.inner_type();
                 match definition.kind(self.db()) {
                     DefinitionKind::Function(function) => {
@@ -1267,40 +1278,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             qualifiers,
         } = place_and_quals;
 
-        // If the place is unbound and its an attribute or subscript place, fall back to normal
-        // attribute/subscript inference on the root type.
-        let declared_ty =
-            if resolved_place.is_undefined() && !place_table.place(place_id).is_symbol() {
-                if let AnyNodeRef::ExprAttribute(ast::ExprAttribute { value, attr, .. }) = node {
-                    let value_type =
-                        self.infer_maybe_standalone_expression(value, TypeContext::default());
-                    if let Place::Defined(DefinedPlace {
-                        ty,
-                        definedness: Definedness::AlwaysDefined,
-                        ..
-                    }) = value_type.member(db, attr).place
-                    {
-                        // TODO: also consider qualifiers on the attribute
-                        Some(ty)
-                    } else {
-                        None
-                    }
-                } else if let AnyNodeRef::ExprSubscript(
-                    subscript @ ast::ExprSubscript {
-                        value, slice, ctx, ..
-                    },
-                ) = node
-                {
-                    let value_ty = self.infer_expression(value, TypeContext::default());
-                    let slice_ty = self.infer_expression(slice, TypeContext::default());
-                    Some(self.infer_subscript_expression_types(subscript, value_ty, slice_ty, *ctx))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-            .or_else(|| resolved_place.ignore_possibly_undefined());
+        let declared_ty = if resolved_place.is_undefined() && !place.is_symbol() {
+            self.fallback_member_declared_type(node)
+        } else {
+            None
+        }
+        .or_else(|| resolved_place.ignore_possibly_undefined());
 
         AddBinding {
             declared_ty,
@@ -1308,6 +1291,38 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             node,
             qualifiers,
             is_local,
+        }
+    }
+
+    /// For a member binding without a live place declaration, obtain its declared type from
+    /// normal attribute or subscript lookup on its receiver.
+    fn fallback_member_declared_type(&mut self, node: AnyNodeRef<'_>) -> Option<Type<'db>> {
+        let db = self.db();
+
+        if let AnyNodeRef::ExprAttribute(ast::ExprAttribute { value, attr, .. }) = node {
+            let value_type = self.infer_maybe_standalone_expression(value, TypeContext::default());
+            if let Place::Defined(DefinedPlace {
+                ty,
+                definedness: Definedness::AlwaysDefined,
+                ..
+            }) = value_type.member(db, attr).place
+            {
+                // TODO: also consider qualifiers on the attribute
+                Some(ty)
+            } else {
+                None
+            }
+        } else if let AnyNodeRef::ExprSubscript(
+            subscript @ ast::ExprSubscript {
+                value, slice, ctx, ..
+            },
+        ) = node
+        {
+            let value_ty = self.infer_expression(value, TypeContext::default());
+            let slice_ty = self.infer_expression(slice, TypeContext::default());
+            Some(self.infer_subscript_expression_types(subscript, value_ty, slice_ty, *ctx))
+        } else {
+            None
         }
     }
 
@@ -1373,7 +1388,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             TypeAndQualifiers::declared(Type::unknown())
         };
-        self.declarations.insert(declaration, ty);
+        self.declarations
+            .insert(declaration, InferredDeclaration::Declared(ty));
     }
 
     fn add_declaration_with_binding(
@@ -1461,7 +1477,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        self.declarations.insert(definition, declared_ty);
+        self.declarations
+            .insert(definition, InferredDeclaration::Declared(declared_ty));
         self.bindings.insert(definition, inferred_ty);
     }
 
@@ -4153,6 +4170,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.typevar_binding_context = previous_context;
     }
 
+    fn is_valid_receiver_annotation_target(&self, target: &ast::Expr) -> bool {
+        target
+            .as_attribute_expr()
+            .is_some_and(|target| self.is_receiver_attribute_annotation_target(target))
+    }
+
     fn infer_annotated_assignment_statement(&mut self, assignment: &ast::StmtAnnAssign) {
         if assignment.target.is_name_expr() {
             self.infer_definition(assignment);
@@ -4234,10 +4257,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Disallow annotations on non-name targets unless they are valid receivers (e.g.
             // `self.x: int` or `cls.x: int`).
-            let is_receiver_attribute = target
-                .as_attribute_expr()
-                .is_some_and(|target| self.is_receiver_attribute_annotation_target(target));
-            if !is_receiver_attribute {
+            if !self.is_valid_receiver_annotation_target(target) {
                 let message = match target.as_ref() {
                     ast::Expr::Attribute(_) => {
                         "Type annotations are not allowed on this attribute expression"
@@ -4348,10 +4368,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         assignment: &'db AnnotatedAssignmentDefinitionKind,
         definition: Definition<'db>,
     ) {
-        let annotation = assignment.annotation(self.module());
         let target = assignment.target(self.module());
         let value = assignment.value(self.module());
 
+        if !target.is_name_expr() && !self.is_valid_receiver_annotation_target(target) {
+            self.declarations
+                .insert(definition, InferredDeclaration::Rejected);
+
+            if let Some(value) = value {
+                // The value remains an ordinary assignment, but normal binding resolution
+                // would consult this rejected annotation as a declaration.
+                let node = target.into();
+                let add = AddBinding {
+                    declared_ty: self.fallback_member_declared_type(node),
+                    binding: definition,
+                    node,
+                    qualifiers: TypeQualifiers::empty(),
+                    is_local: true,
+                };
+                let target_ty = self.infer_maybe_standalone_expression(value, add.type_context());
+                self.store_expression_type(target, target_ty);
+                add.insert(self, target_ty);
+            }
+
+            return;
+        }
+
+        let annotation = assignment.annotation(self.module());
         let mut declared = self.infer_annotation_expression_allow_pep_613(
             annotation,
             DeferredExpressionState::from(self.defer_annotations()),
@@ -10258,7 +10301,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             #[cfg(debug_assertions)]
             scope,
             bindings: bindings.into_boxed_slice(),
-            declarations: declarations.into_boxed_slice(),
+            declarations: declarations
+                .into_iter()
+                .filter_map(|(definition, declaration)| Some((definition, declaration.declared()?)))
+                .collect(),
             extra,
         }
     }
@@ -10886,6 +10932,15 @@ impl<'a, K, V> IntoIterator for &'a VecMap<K, V> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+impl<K, V> IntoIterator for VecMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::vec::IntoIter<(K, V)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -270,7 +270,7 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// The list should only contain one entry per binding at most.
     bindings: VecMap<Definition<'db>, Type<'db>>,
 
-    /// The inferred outcome of every syntactically indexed declaration in this region.
+    /// The inferred outcome of every declaration recorded by the semantic index in this region.
     ///
     /// The list should only contain one entry per declaration at most.
     declarations: VecMap<Definition<'db>, InferredDeclaration<'db>>,
@@ -4399,8 +4399,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 is_local: true,
             };
             let target_ty = if let Some(value) = value {
-                // The value remains an ordinary assignment, but normal binding resolution
-                // would consult this rejected annotation as a declaration.
+                // Infer the value as an ordinary assignment without using the rejected annotation
+                // as its declared type.
                 let value_ty = self.infer_maybe_standalone_expression(value, add.type_context());
                 self.stub_placeholder_binding_type(value)
                     .unwrap_or(value_ty)
@@ -10478,7 +10478,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             #[cfg(debug_assertions)]
             scope,
             bindings: bindings.into_boxed_slice(),
-            declarations: declarations.into_boxed_slice(),
+            declarations: declarations
+                .into_iter()
+                .filter_map(|(definition, declaration)| {
+                    declaration
+                        .declared()
+                        .map(|declared| (definition, declared))
+                })
+                .collect(),
             extra,
         }
     }


### PR DESCRIPTION
## Summary

We now emit `invalid-type-form` for an invalid annotation on a non-name target (#25324)... But it turns out that we still allow that annotation to participate in downstream operations, since we create an annotated-assignment definition for it during the indexing pass.

For example:

```python
def accepts_inner(inner: dict[str, int]): ...

def _(x: dict[str, object]):
    x["inner"]: dict[str, float | str] = {"a": 1, "b": "a"}  # error: [invalid-type-form]
    x["inner"]["c"] = 1.0  # error: [invalid-assignment] because we infer from the RHS, not the annotation
    x["inner"] = {"inner": {"a": 1}}
    accepts_inner(**x["inner"])  # ok
```

The rejected annotation should not widen the dictionary assigned to `x["inner"]`, nor should it constrain the later replacement. (The same issue applies to rejected attribute annotations, like `obj.inner: T`.)

We now represent each syntactically indexed declaration outcome as either `Declared(...)` or `Rejected`. Declaration consumers only use `Declared(...)`.
