### PR TITLE
Further improve instructions for agents for working on ty

### DIFF
--- a/.agents/.claude-plugin/marketplace.json
+++ b/.agents/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "ty-skills",
       "source": "./",
-      "description": "Local skills for ty diagnostics and ecosystem workflows"
+      "description": "Local skills for working on ty in the Ruff repository"
     }
   ]
 }

--- a/.agents/skills/adding-ty-diagnostics/SKILL.md
+++ b/.agents/skills/adding-ty-diagnostics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adding-ty-diagnostics
-description: Use when adding, updating, or reviewing ty checks, diagnostics, diagnostic messages, subdiagnostics, or concise output behavior.
+description: Use when a user says "add a ty diagnostic", "write this new ty diagnostic", "change a ty error message", "review ty diagnostics", or asks to add, update, or review ty checks, diagnostic messages, subdiagnostics, or concise output behavior.
 ---
 
 # Adding Ty Diagnostics

--- a/.agents/skills/minimizing-ty-ecosystem-changes/SKILL.md
+++ b/.agents/skills/minimizing-ty-ecosystem-changes/SKILL.md
@@ -1,25 +1,83 @@
 ---
 name: minimizing-ty-ecosystem-changes
-description: Use when reproducing, investigating, or minimizing behavior changes in ty ecosystem or primer projects.
+description: Use when a user says "minimize this ty ecosystem change", "reproduce this ecosystem result", "investigate a primer difference", or asks to reproduce, investigate, or minimize behavior changes in ty ecosystem or primer projects.
 ---
 
 # Minimizing Ty Ecosystem Changes
 
 Use this skill when asked to reproduce a ty ecosystem change, investigate a behavior difference in a primer project, or minimize a reproducer from a ty ecosystem project.
 
-## Reproduce First
+## Building ty
 
-From the repository root, clone the project and install its dependencies into `.venv`:
+Build ty on both the PR branch and the PR's merge base by running `cargo build --package ty --profile profiling` from the repository root on both refs, matching ecosystem CI. Copy each built executable to a stable path before checking out the other ref; otherwise, the second build overwrites `target/profiling/ty`.
 
-```sh
-uv run scripts/setup_primer_project.py <project-name> <some-temp-dir>
+From the PR branch, also copy `.github/ty-ecosystem.toml` to a stable path before checking out another ref. Use that copied file for every comparison, matching ecosystem CI's behavior of reusing the PR config.
+
+Before checking out another ref, inspect the working tree. If `git status --short` shows any staged, unstaged, or untracked changes, abort immediately and ask the user how to proceed.
+
+For example:
+
+```bash
+set -euo pipefail
+
+if [[ -n "$(git status --short)" ]]; then
+    git status --short
+    echo "working tree is not clean; stop and ask the user how to proceed" >&2
+    exit 1
+fi
+
+mkdir -p target/ty-ecosystem-bins
+cp .github/ty-ecosystem.toml target/ty-ecosystem-bins/ty-ecosystem.toml
+export TY_CONFIG_FILE="$PWD/target/ty-ecosystem-bins/ty-ecosystem.toml"
+
+git checkout <merge-base>
+cargo build --package ty --profile profiling
+cp target/profiling/ty target/ty-ecosystem-bins/ty-base
+
+git checkout <pr-branch-or-sha>
+cargo build --package ty --profile profiling
+cp target/profiling/ty target/ty-ecosystem-bins/ty-pr
 ```
 
-Confirm the behavior difference reproduces before minimizing or explaining it.
+On Windows, adapt the shell commands and executable paths as necessary.
+
+You should only need to build ty twice at the start of the investigation. Reuse the copied executables when determining if the behavior difference still reproduces.
+
+## Reproduce First
+
+From the repository root, export the ecosystem config that was copied from the PR branch, then use the following script to clone the ecosystem project, check out the relevant revision, and install its dependencies into `.venv`. Keep `TY_CONFIG_FILE` set when running ty comparisons; this applies the same rule configuration as ecosystem CI without overwriting the user's ty config. Shell exports may not persist between agent tool calls, so re-export `TY_CONFIG_FILE` in every new shell before invoking either ty binary.
+
+If `target/ty-ecosystem-bins/ty-ecosystem.toml` does not exist yet, check out the PR branch and copy `.github/ty-ecosystem.toml` from there before continuing. Do not copy `.github/ty-ecosystem.toml` while on the merge base, because ecosystem CI compares both binaries with the PR branch's config.
+
+```bash
+set -euo pipefail
+
+export TY_CONFIG_FILE="$PWD/target/ty-ecosystem-bins/ty-ecosystem.toml"
+test -f "$TY_CONFIG_FILE" || { echo "missing $TY_CONFIG_FILE" >&2; exit 1; }
+uv run --no-project scripts/setup_primer_project.py <project-name> <some-temp-dir> --revision <report-revision> --exclude-newer <report-timestamp>
+```
+
+ALWAYS confirm the behavior difference reproduces before minimizing or explaining it.
+ALWAYS use this script before attempting to reproduce the change.
+NEVER try to confirm the behaviour difference without first setting up the project's virtual environment using this script.
+
+When comparing the copied ty binaries, pass the cloned project's virtual environment explicitly with `--python`:
+
+```bash
+project_dir="$PWD/<some-temp-dir>"
+ty_base="$PWD/target/ty-ecosystem-bins/ty-base"
+ty_pr="$PWD/target/ty-ecosystem-bins/ty-pr"
+
+cd "$project_dir"
+"$ty_base" check --python .venv --output-format concise
+"$ty_pr" check --python .venv --output-format concise
+```
+
+If the ecosystem report gives an exact project revision, pass it to the script with `--revision`. If the report gives a timestamp, pass it to the script with `--exclude-newer`. Do not install dependencies before checking out the report revision. Do not use current upstream or the current mypy-primer revision as evidence for a historical report when the report provides a pinned revision. If running `ecosystem-analyzer` directly, also pass the report timestamp as `--exclude-newer`, matching ecosystem CI.
 
 ## Minimize
 
-When asked to minimize an ecosystem change, start from the reproduced project. Reduce the Python code until only the smallest code needed to demonstrate the behavior difference remains. Even if the cause looks obvious, **do not skip ahead** to an explanation or a hand-written reproducer. Use a rigorous, systematic process and verify after each reduction that the behavior difference still reproduces.
+When asked to minimize an ecosystem change, start from the reproduced project. Reduce the Python code until only the smallest code needed to demonstrate the behavior difference remains. DO NOT look at conversation or analysis in other PR comments: your analysis should start from a clean slate. Even if the cause looks obvious, DO NOT skip ahead to an explanation or a hand-written reproducer. Use a rigorous, systematic process and verify after each reduction that the behavior difference still reproduces.
 
 An ideal minimized reproducer:
 
@@ -37,11 +95,13 @@ Available minimization tools include:
 
 1. Remove files that are not needed for the difference.
 2. Strip imports, definitions, and statements from the remaining files.
-3. Cut and paste definitions from one file into another file to reduce first-party or third-party imports.
-4. Inline the relevant parts of third-party dependencies into first-party code to reduce third-party imports.
-5. Inline the relevant parts of stdlib definitions from typeshed into first-party code to reduce stdlib imports.
+3. Cut and paste definitions from one file into another file to reduce first-party imports.
+4. Copy installed third-party dependency files from the project's `.venv` into the project as first-party files so that you can convert third-party imports into first-party imports. If you must clone a dependency instead, use the exact installed version rather than the dependency's current default branch.
+5. Inline the relevant parts of stdlib definitions from ty's vendored typeshed stubs into first-party code to reduce stdlib imports. ty's vendored typeshed stubs are the single source of truth for ty regarding the Python standard library, and they are found in `./crates/ty_vendored`.
 
-After applying a minimization tool, re-run the comparison between the feature branch and `main`.
+After applying a minimization tool, re-run the comparison between the PR branch and the PR's merge base.
 Keep a reduction only when the behavior difference still reproduces.
 
-Stop looping only when no further reductions could be applied without making the behavior difference disappear.
+DO NOT stop looping until no further reductions could be applied without making the behavior difference disappear.
+
+If the minimized behavior change is a diagnostic change, the final minimized Python snippet MUST include the full diagnostic message and error code on both branches, as a comment above or on the relevant line of code.

--- a/.agents/skills/minimizing-ty-ecosystem-changes/SKILL.md
+++ b/.agents/skills/minimizing-ty-ecosystem-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: minimizing-ty-ecosystem-changes
-description: Use when a user says "minimize this ty ecosystem change", "reproduce this ecosystem result", "investigate a primer difference", or asks to reproduce, investigate, or minimize behavior changes in ty ecosystem or primer projects.
+description: Use when a user says "minimize this ty ecosystem change", "reproduce this ecosystem result", "investigate a primer difference", "investigate a mypy_primer difference", "investigate a mypy-primer difference", or asks to reproduce, investigate, or minimize behavior changes in ty ecosystem/primer/mypy_primer/mypy-primer projects.
 ---
 
 # Minimizing Ty Ecosystem Changes
@@ -9,7 +9,7 @@ Use this skill when asked to reproduce a ty ecosystem change, investigate a beha
 
 ## Building ty
 
-Build ty on both the PR branch and the PR's merge base by running `cargo build --package ty --profile profiling` from the repository root on both refs, matching ecosystem CI. Copy each built executable to a stable path before checking out the other ref; otherwise, the second build overwrites `target/profiling/ty`.
+Build ty on both the PR branch and the PR's merge base by running `CARGO_PROFILE_PROFILING_DEBUG=line-tables-only cargo build --package ty --profile profiling` from the repository root on both refs, matching ecosystem CI. Copy each built executable to a stable path before checking out the other ref; otherwise, the second build overwrites `target/profiling/ty`.
 
 From the PR branch, also copy `.github/ty-ecosystem.toml` to a stable path before checking out another ref. Use that copied file for every comparison, matching ecosystem CI's behavior of reusing the PR config.
 
@@ -29,6 +29,7 @@ fi
 mkdir -p target/ty-ecosystem-bins
 cp .github/ty-ecosystem.toml target/ty-ecosystem-bins/ty-ecosystem.toml
 export TY_CONFIG_FILE="$PWD/target/ty-ecosystem-bins/ty-ecosystem.toml"
+export CARGO_PROFILE_PROFILING_DEBUG=line-tables-only
 
 git checkout <merge-base>
 cargo build --package ty --profile profiling
@@ -61,16 +62,21 @@ ALWAYS confirm the behavior difference reproduces before minimizing or explainin
 ALWAYS use this script before attempting to reproduce the change.
 NEVER try to confirm the behaviour difference without first setting up the project's virtual environment using this script.
 
-When comparing the copied ty binaries, pass the cloned project's virtual environment explicitly with `--python`:
+When comparing the copied ty binaries, use the project-specific ty command printed by `setup_primer_project.py`. That command includes the project's mypy-primer metadata such as `paths` and any custom `ty_cmd`, matching ecosystem CI. Keep `TY_CONFIG_FILE` exported in the same shell that runs the comparison, and set `ty_binary` to each copied binary before running the printed command:
 
 ```bash
+export TY_CONFIG_FILE="$PWD/target/ty-ecosystem-bins/ty-ecosystem.toml"
+test -f "$TY_CONFIG_FILE" || { echo "missing $TY_CONFIG_FILE" >&2; exit 1; }
+
 project_dir="$PWD/<some-temp-dir>"
 ty_base="$PWD/target/ty-ecosystem-bins/ty-base"
 ty_pr="$PWD/target/ty-ecosystem-bins/ty-pr"
 
 cd "$project_dir"
-"$ty_base" check --python .venv --output-format concise
-"$ty_pr" check --python .venv --output-format concise
+ty_binary="$ty_base"
+<project-specific ty command printed by setup_primer_project.py>
+ty_binary="$ty_pr"
+<project-specific ty command printed by setup_primer_project.py>
 ```
 
 If the ecosystem report gives an exact project revision, pass it to the script with `--revision`. If the report gives a timestamp, pass it to the script with `--exclude-newer`. Do not install dependencies before checking out the report revision. Do not use current upstream or the current mypy-primer revision as evidence for a historical report when the report provides a pinned revision. If running `ecosystem-analyzer` directly, also pass the report timestamp as `--exclude-newer`, matching ecosystem CI.
@@ -89,7 +95,7 @@ An ideal minimized reproducer:
 - Uses an absolute minimum of "advanced"/complex typing or language features. For example, if the original code
   uses a walrus operator, but the behavior difference still reproduces without it, remove the walrus operator. If the original code uses a `Protocol` from `typing_extensions`, but the behavior difference still reproduces without it, remove the `Protocol`.
 
-Use a systematic loop. You do not need to apply every tool in every iteration, but keep looping until none of the available minimization tools can reduce the reproducer further while preserving the behavior difference.
+Use a systematic loop. You do not need to apply every tool in every iteration, but keep looping until none of the available minimization tools can reduce the reproducer further while preserving the behavior difference. Your clones of ecosystem projects and/or their dependencies should be treated as transient artifacts of the investigation: they should be deleted after the minimization is complete, and you SHOULD NOT ask for permission to modify them during the minimization process. If the user has asked for an ecosystem change to be minimized, ANY of the changes below should be understood as automatically having been approved by the user.
 
 Available minimization tools include:
 

--- a/.agents/skills/summarise-ecosystem-results/SKILL.md
+++ b/.agents/skills/summarise-ecosystem-results/SKILL.md
@@ -58,6 +58,6 @@ For each retained minimization, include:
 - The minimized code.
 - The commands or comparison method used to verify the minimization.
 
-ALL references to exact line numbers in source code should use GitHub permalinks so that readers can jump to the exact line in the original source code that led to the diagnostic changing. The finished report should NEVER include "raw" URL links; it should ALWAYS use inline Markdown links with square brackets and parentheses.
+ALL references to exact line numbers in source code should use GitHub/GitLab/Codeberg/etc. permalinks so that readers can jump to the exact line in the original source code that led to the diagnostic changing. The finished report should NEVER include "raw" URL links; it should ALWAYS use inline Markdown links with square brackets and parentheses.
 
 Present `PR_<number>_ECOSYSTEM_SUMMARY.md` as the finished product.

--- a/.agents/skills/summarise-ecosystem-results/SKILL.md
+++ b/.agents/skills/summarise-ecosystem-results/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: summarise-ecosystem-results
-description: Use when asked to summarise or summarize ty ecosystem results for a Ruff PR, including from a PR number, PR URL, GitHub ecosystem-results comment, or full detailed HTML report.
+description: Use when a user says "summarise ecosystem results", "summarize this ty ecosystem report", "what changed in this ecosystem run?", or asks to summarise or summarize ty ecosystem results for a Ruff PR from a PR number, PR URL, GitHub ecosystem-results comment, or detailed HTML report.
 ---
 
 # Summarise Ecosystem Results
@@ -26,7 +26,7 @@ Use the PR comment as the change list and the full detailed HTML report as the s
 
 Before minimizing, load and apply the `minimizing-ty-ecosystem-changes` skill to each ecosystem change.
 
-If possible, use subagents to parallelize this work. Decide how to batch changes so the overall task finishes as quickly as possible while still allowing each subagent to work methodically. Reasonable batching strategies include grouping related changes by project, diagnostic code, suspected cause, or report section, while keeping large groups split enough to avoid one slow subagent blocking the whole task.
+If possible, use subagents to parallelize this work. Decide how to batch changes so the overall task finishes as quickly as possible while still allowing each subagent to work methodically. Reasonable batching strategies include grouping related changes by project, diagnostic code, suspected cause, or report section, while keeping large groups split enough to avoid one slow subagent blocking the whole task. DO NOT spawn more subagents than you can run in parallel.
 
 If subagents are not available, batch the minimization work manually and minimize the batches sequentially. Keep batches small enough that each pass can still be checked carefully.
 
@@ -37,7 +37,7 @@ Give each subagent a self-contained assignment:
 - The requirement to use the `minimizing-ty-ecosystem-changes` process rigorously.
 - The expected Markdown output format for each minimized change.
 
-Each subagent should proceed methodically through all assigned changes. If a subagent moves on to a new change and that change appears very similar to one it has already minimized, it may skip the new change, but it must record why the skipped change appears to demonstrate the same behavior.
+Each subagent should proceed methodically through all assigned changes. If a subagent moves on to a new change and that change appears very similar to one it has already minimized, it may skip the new change without completing the full minimisation skill, but it must record why the skipped change appears to demonstrate the same behavior.
 
 ## Collect Results
 
@@ -57,6 +57,7 @@ For each retained minimization, include:
 - The diagnostic or behavior change on `main` versus the PR.
 - The minimized code.
 - The commands or comparison method used to verify the minimization.
-- Any source links needed to trace the example back to the PR comment or full report.
+
+ALL references to exact line numbers in source code should use GitHub permalinks so that readers can jump to the exact line in the original source code that led to the diagnostic changing. The finished report should NEVER include "raw" URL links; it should ALWAYS use inline Markdown links with square brackets and parentheses.
 
 Present `PR_<number>_ECOSYSTEM_SUMMARY.md` as the finished product.

--- a/.agents/skills/working-on-ty/SKILL.md
+++ b/.agents/skills/working-on-ty/SKILL.md
@@ -31,8 +31,10 @@ Adding `#[salsa::tracked]` to a function or method means that the Salsa framewor
 This can sometimes be done for performance reasons, and can also be done to ensure incremental computation in an
 IDE context.
 
-ANY method that accesses `.node()` must be `#[salsa::tracked]`, or it will break incrementality.
-Prefer higher-level semantic APIs over raw AST access.
+Methods that access `.node()` should usually be `#[salsa::tracked]`, or ty's incrementality will suffer:
+we don't want to accidentally introduce a dependency on module `a`'s AST in a Salsa query that would be
+called when type-checking module `b`. Prefer higher-level semantic APIs over raw AST access where possible,
+but ask for guidance from the user if this would require significant refactoring.
 
 ### Reduce memory usage where possible
 

--- a/.agents/skills/working-on-ty/SKILL.md
+++ b/.agents/skills/working-on-ty/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: working-on-ty
+description: Use when a user says "work on ty", "fix this ty issue", "debug ty", "update this ty PR", or asks about ty type checker changes, issues, branches, failing tests, or PRs in the Ruff repository.
+---
+
+# Working on ty
+
+## Related skills
+
+When the task matches a more specific ty workflow, also read and follow that skill from the repository root:
+
+- Diagnostic changes, diagnostic message changes, or diagnostic reviews: `.agents/skills/adding-ty-diagnostics/SKILL.md`.
+- Ecosystem report summaries: `.agents/skills/summarise-ecosystem-results/SKILL.md`.
+- Reproducing, investigating, or minimizing ecosystem or primer differences: `.agents/skills/minimizing-ty-ecosystem-changes/SKILL.md`.
+
+## PR conventions
+
+When working on ty, PR titles should start with `[ty]`. Add the `ty` GitHub label if you have permission to do so;
+if you don't, however, automation should add it anyway, so there's no need to worry about it. Similarly, add the `server`
+label if your change only affects the LSP server and you have permission to add that label.
+
+## The `db` parameter
+
+For free functions and associated functions without a `self` parameter, `db` should be the first parameter. For methods with a `self` parameter, `db` should come immediately after `self`.
+
+## Salsa tips
+
+### Tracked functions and methods
+
+Adding `#[salsa::tracked]` to a function or method means that the Salsa framework will cache the function/method.
+This can sometimes be done for performance reasons, and can also be done to ensure incremental computation in an
+IDE context.
+
+ANY method that accesses `.node()` must be `#[salsa::tracked]`, or it will break incrementality.
+Prefer higher-level semantic APIs over raw AST access.
+
+### Reduce memory usage where possible
+
+For Salsa-cached values, avoid retaining excess collection capacity. Prefer boxed slices; otherwise shrink collections that may have spare capacity before returning them. In particular, inspect `HashMap` and `HashSet` values constructed via `extend`, `collect`, explicit reservation, or removal, since those operations can leave capacity that insert-only construction does not.
+
+Salsa caching can occur due to a function/method having `#[salsa::tracked]` on it, or due to a struct with `#[salsa::interned]` being constructed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,7 @@ Run ty:
 cargo run --bin ty -- check path/to/file.py
 ```
 
-## Pull Requests
-
-When working on ty, PR titles should start with `[ty]` and be tagged with the `ty` GitHub label.
+When working on ty, first read `.agents/skills/working-on-ty/SKILL.md`, then also read and follow any more specific ty skills it points to.
 
 ## Development Guidelines
 
@@ -72,9 +70,7 @@ When working on ty, PR titles should start with `[ty]` and be tagged with the `t
 - Prefer let chains (`if let` combined with `&&`) over nested `if let` statements to reduce indentation and improve readability. At the end of a task, always check your work to see if you missed opportunities to use `let` chains.
 - If you *have* to suppress a Clippy lint, prefer to use `#[expect()]` over `[allow()]`, where possible. But if a lint is complaining about unused/dead code, it's usually best to just delete the unused code.
 - Use comments purposefully. Don't use comments to narrate code, but do use them to explain invariants and why something unusual was done a particular way.
-- **Salsa incrementality (ty):** Any method that accesses `.node()` must be `#[salsa::tracked]`, or it will break incrementality. Prefer higher-level semantic APIs over raw AST access.
 - Run `cargo dev generate-all` after changing configuration options, CLI arguments, lint rules, or environment variable definitions, as these changes require regeneration of schemas, docs, and CLI references.
 - Don't prefix tests with `test_`.
 - Don't separate struct definitions from their `impl` blocks unless the `impl` is deliberately placed in a separate file, as for large structs.
-- The `db` parameter should always be the first, or second, if it's a method taking a `self` argument
-- For Salsa-cached values, avoid retaining excess collection capacity. Prefer boxed slices; otherwise shrink collections that may have spare capacity before returning them. In particular, inspect `HashMap` and `HashSet` values constructed via `extend`, `collect`, explicit reservation, or removal, since those operations can leave capacity that insert-only construction does not.
+- Avoid running `uv run` for any scripts from the repository root unless you use `--no-project`, `--script` or similar. Using `uv run` from the Ruff repo root without these flags will build Ruff from source, which is very slow and usually unnecessary.

--- a/scripts/setup_primer_project.py
+++ b/scripts/setup_primer_project.py
@@ -57,6 +57,30 @@ def _project_not_found(name: str, projects: list[Project]) -> NoReturn:
     sys.exit(1)
 
 
+class _FormatMap:
+    def __init__(self, **values: str | list[str] | None) -> None:
+        self.values = values
+
+    def __getitem__(self, key: str) -> str:
+        if key not in self.values:
+            raise KeyError(key)
+        value = self.values[key]
+        if value is None:
+            raise ValueError(f"Required {key} to be specified")
+        if isinstance(value, list):
+            return " ".join(value)
+        return value
+
+
+def get_ty_command(project: Project, *, ty_binary: str, venv_dir: Path) -> str:
+    ty_cmd = project.ty_cmd
+    if ty_cmd is None:
+        ty_cmd = "{ty} check {paths}" if project.paths else "{ty} check"
+    assert "{ty}" in ty_cmd
+    ty_cmd = ty_cmd.format_map(_FormatMap(ty=ty_binary, paths=project.paths))
+    return f"{ty_cmd} --python {shlex.quote(str(venv_dir))} --output-format concise"
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("project", help="Name of a mypy-primer project")
@@ -131,6 +155,9 @@ def main() -> None:
 
     print(f"\nDone! Project set up at {target_dir}")
     print(f"Activate the venv with: source {venv_dir}/bin/activate")
+    print("\nProject-specific ty command:")
+    print("  ty_binary=/path/to/ty")
+    print(f"  {get_ty_command(project, ty_binary='"$ty_binary"', venv_dir=venv_dir)}")
 
 
 if __name__ == "__main__":

--- a/scripts/setup_primer_project.py
+++ b/scripts/setup_primer_project.py
@@ -25,7 +25,7 @@
 
 """Clone a mypy-primer project and set up a virtualenv with its dependencies installed.
 
-Usage: uv run scripts/setup_primer_project.py <project-name> [directory]
+Usage: uv run --no-project scripts/setup_primer_project.py <project-name> [directory] [options]
 """
 
 from __future__ import annotations
@@ -65,13 +65,22 @@ def main() -> None:
         nargs="?",
         help="Directory to clone into (default: project name)",
     )
+    parser.add_argument(
+        "--revision",
+        help="Git revision to check out before installing dependencies",
+    )
+    parser.add_argument(
+        "--exclude-newer",
+        help="Limit dependency resolution to packages uploaded before this timestamp",
+    )
     args = parser.parse_args()
 
     project = find_project(args.project)
+    revision = args.revision or project.revision
 
     target_dir = Path(args.directory or project.name).resolve()
 
-    # Clone (shallow if no pinned revision, same as primer)
+    # Use a full clone only when a historical ecosystem report revision must be checked out.
     clone_cmd = [
         "git",
         "clone",
@@ -79,15 +88,18 @@ def main() -> None:
         project.location,
         str(target_dir),
     ]
-    if not project.revision:
+    if not revision:
         clone_cmd += ["--depth", "1"]
     print(f"Cloning {project.location} into {target_dir}...")
     subprocess.run(clone_cmd, check=True)
 
-    if project.revision:
-        print(f"Checking out revision {project.revision}...")
+    if revision:
+        print(f"Checking out revision {revision}...")
+        subprocess.run(["git", "checkout", revision], cwd=target_dir, check=True)
         subprocess.run(
-            ["git", "checkout", project.revision], cwd=target_dir, check=True
+            ["git", "submodule", "update", "--init", "--recursive"],
+            cwd=target_dir,
+            check=True,
         )
 
     # Create venv (matching primer's Venv.make_venv())
@@ -100,12 +112,16 @@ def main() -> None:
 
     venv_python = venv_dir / "bin" / "python"
     install_base = f"uv pip install --python {shlex.quote(str(venv_python))}"
+    if args.exclude_newer:
+        install_base += f" --exclude-newer {shlex.quote(args.exclude_newer)}"
 
     # Run custom install command if the project defines one (matching primer's setup())
     if project.install_cmd:
+        assert "{install}" in project.install_cmd
         install_cmd = project.install_cmd.format(install=install_base)
         print(f"Running install command: {install_cmd}")
-        subprocess.run(shlex.split(install_cmd), cwd=target_dir, check=True)
+        # Primer install commands are trusted project metadata and may use shell syntax.
+        subprocess.run(install_cmd, cwd=target_dir, shell=True, check=True)  # noqa: S602
 
     # Install listed dependencies (matching primer's setup())
     if project.deps:


### PR DESCRIPTION
## Summary

A bunch of followup changes from https://github.com/astral-sh/ruff/pull/25422. Mostly triggered by using the skill for the first time to analyze the report in https://github.com/astral-sh/ruff/pull/24761.

- Move ty-specific guidance from `AGENTS.md` to a new local `working-on-ty` skill. Link to the other ty-specific skills from that skill.
- Add more keyword triggers to various skills so that agents are more likely to automatically figure out that a skill is appropriate (suggested by @dhruvmanila).
- Add more guidance to the ecosystem-minimization skill (and tweak the script for setting up a primer project) so that agents are likely to reproduce results in a deterministic and helpful way.

## Test Plan

I repeatedly ran `/review` with Codex on this until the only remaining issues were trivial.