### PR TITLE
[ty] Avoid treating metaclass declarations as populated values

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1138,6 +1138,17 @@ class CStoredDescriptor(metaclass=DeclaredCallableMeta):
     # A metaclass declaration constrains access without replacing this stored descriptor.
     factory: ClassVar["staticmethod[[str], str]"] = staticmethod(identity)
 
+class CIncompatibleStoredValue(metaclass=DeclaredCallableMeta):
+    factory: ClassVar[int] = 1  # error: [invalid-assignment]
+
+class CIncompatibleInferredValue(metaclass=DeclaredCallableMeta):
+    factory = 1  # error: [invalid-assignment]
+
+class CIncompatibleDeclaredAccess(metaclass=DeclaredCallableMeta):
+    # TODO: This should be an `invalid-assignment` error, analogous to an incompatible
+    # mutable attribute redeclaration on a subclass.
+    factory: ClassVar[int]
+
 class MethodDeclaredCallableMeta(type):
     def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
         cls.factory: Callable[[str], str]

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1125,6 +1125,19 @@ class CDeclaredAgainstDeclaredMeta(metaclass=DeclaredBroadInitializingMeta):
 
 reveal_type(CDeclaredAgainstDeclaredMeta.attr)  # revealed: str
 
+from collections.abc import Callable
+from typing import ClassVar
+
+class DeclaredCallableMeta(type):
+    factory: Callable[[str], str]
+
+def identity(value: str) -> str:
+    return value
+
+class CStoredDescriptor(metaclass=DeclaredCallableMeta):
+    # A metaclass declaration constrains access without replacing this stored descriptor.
+    factory: ClassVar["staticmethod[[str], str]"] = staticmethod(identity)
+
 class CompatibleInitializingMeta(type):
     def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
         cls.attr: int | str = 1

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1138,6 +1138,13 @@ class CStoredDescriptor(metaclass=DeclaredCallableMeta):
     # A metaclass declaration constrains access without replacing this stored descriptor.
     factory: ClassVar["staticmethod[[str], str]"] = staticmethod(identity)
 
+class MethodDeclaredCallableMeta(type):
+    def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
+        cls.factory: Callable[[str], str]
+
+class CStoredDescriptorAgainstMethodDeclaration(metaclass=MethodDeclaredCallableMeta):
+    factory: ClassVar["staticmethod[[str], str]"] = staticmethod(identity)
+
 class CompatibleInitializingMeta(type):
     def __init__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, object]) -> None:
         cls.attr: int | str = 1

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1060,7 +1060,18 @@ fn check_class_namespace_against_metaclass_members<'db>(
             for member in metaclass_index.place_table(function_scope).members() {
                 if let Some(name) = member.as_instance_attribute() {
                     let name = name.to_string();
-                    metaclass_assigned_members.insert(name.clone());
+                    // A method-scope member may only be declared, as in `cls.attr: int`.
+                    // Only an assignment such as `cls.attr: int = 1` populates a value that
+                    // can replace the corresponding value in the constructed class namespace.
+                    if attribute_assignments(db, metaclass.body_scope(db), name.as_str()).any(
+                        |(bindings, _)| {
+                            bindings
+                                .into_iter()
+                                .any(|binding| binding.binding.definition().is_some())
+                        },
+                    ) {
+                        metaclass_assigned_members.insert(name.clone());
+                    }
                     metaclass_instance_members.insert(name);
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -4,7 +4,7 @@ use ruff_db::{
     source::source_text,
 };
 use ruff_diagnostics::{Edit, Fix};
-use ruff_python_ast as ast;
+use ruff_python_ast::{self as ast, name::Name};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::FxHashSet;
 
@@ -1053,23 +1053,23 @@ fn check_class_namespace_against_metaclass_members<'db>(
         let metaclass_use_def = metaclass_index.use_def_map(body_scope);
 
         for (symbol_id, _) in metaclass_use_def.all_end_of_scope_symbol_declarations() {
-            metaclass_instance_members.insert(metaclass_table.symbol(symbol_id).name().to_string());
+            metaclass_instance_members.insert(metaclass_table.symbol(symbol_id).name().clone());
         }
 
         for function_scope in attribute_scopes(db, metaclass.body_scope(db)) {
             for member in metaclass_index.place_table(function_scope).members() {
                 if let Some(name) = member.as_instance_attribute() {
-                    let name = name.to_string();
                     // A method-scope member may only be declared, as in `cls.attr: int`.
-                    // Only an assignment such as `cls.attr: int = 1` populates a value that
-                    // can replace the corresponding value in the constructed class namespace.
-                    if attribute_assignments(db, metaclass.body_scope(db), name.as_str()).any(
-                        |(bindings, _)| {
+                    // Only an assignment such as `cls.attr: int = 1` writes a value onto the
+                    // newly created class object, potentially overwriting a class-body value.
+                    let is_assigned = attribute_assignments(db, metaclass.body_scope(db), name)
+                        .any(|(bindings, _)| {
                             bindings
                                 .into_iter()
                                 .any(|binding| binding.binding.definition().is_some())
-                        },
-                    ) {
+                        });
+                    let name = Name::new(name);
+                    if is_assigned {
                         metaclass_assigned_members.insert(name.clone());
                     }
                     metaclass_instance_members.insert(name);

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1040,6 +1040,7 @@ fn check_class_namespace_against_metaclass_members<'db>(
     // Metaclass-populated members are generally sparse, while class namespaces such as enums can
     // be large. Collect possible members first rather than probing the metaclass for every binding.
     let mut metaclass_instance_members = FxHashSet::default();
+    let mut metaclass_assigned_members = FxHashSet::default();
     for metaclass in metaclass
         .iter_mro(db)
         .filter_map(ClassBase::into_class)
@@ -1058,7 +1059,9 @@ fn check_class_namespace_against_metaclass_members<'db>(
         for function_scope in attribute_scopes(db, metaclass.body_scope(db)) {
             for member in metaclass_index.place_table(function_scope).members() {
                 if let Some(name) = member.as_instance_attribute() {
-                    metaclass_instance_members.insert(name.to_string());
+                    let name = name.to_string();
+                    metaclass_assigned_members.insert(name.clone());
+                    metaclass_instance_members.insert(name);
                 }
             }
         }
@@ -1104,6 +1107,12 @@ fn check_class_namespace_against_metaclass_members<'db>(
             if reported_incompatible_binding {
                 continue;
             }
+        }
+
+        // A declaration on the metaclass constrains class-object access, but does not itself
+        // populate a replacement value into the constructed class's namespace.
+        if !metaclass_assigned_members.contains(name.as_str()) {
+            continue;
         }
 
         let result =


### PR DESCRIPTION
## Summary

Prior to this change, we conflated a metaclass instance-member declaration with a value populated on each newly created class object.

So in the example below, we correctly validate the stored value `staticmethod(identity)` against the metaclass contract `Callable[[str], str]`, because `C` is an instance of `Meta`. But we then _incorrectly_ performed the reverse validation: we treated `Meta.factory`'s declared `Callable[[str], str]` type as though `Meta` had written a replacement value into `C.factory`, and rejected it against `C.factory`'s declared storage type, `staticmethod[[str], str]`.

```python
from collections.abc import Callable
from typing import ClassVar

class Meta(type):
    factory: Callable[[str], str]

def identity(value: str) -> str:
    return value

class C(metaclass=Meta):
    factory: ClassVar["staticmethod[[str], str]"] = staticmethod(identity)
```

We now distinguish declarations from assignments made to metaclass instance members in methods: bare declarations, including `cls.factory: Callable[[str], str]`, continue to constrain values supplied by the class body, but no longer act as writes that overwrite the constructed class namespace.

Closes https://github.com/astral-sh/ty/issues/3569.
