### PR TITLE
[`ruff`] Restore example code for Python versions before 3.15 (`RUF017`)

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
@@ -39,7 +39,16 @@ use crate::{AlwaysFixableViolation, Edit, Fix};
 /// joined = sum(lists, [])
 /// ```
 ///
-/// Use instead:
+/// On Python 3.14 and earlier, use instead:
+/// ```python
+/// import functools
+/// import operator
+///
+/// lists = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+/// joined = functools.reduce(operator.iadd, lists, [])
+/// ```
+///
+/// On Python 3.15 and later, use instead:
 /// ```python
 /// lists = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 /// joined = [*sublist for sublist in lists]


### PR DESCRIPTION
Summary
--

Closes #25436 by restoring the previous `Use instead:` snippet from before #23789

I thought it would be cool to use the tabs like we have for pyproject.toml vs ruff.toml snippets, but I wasn't sure if that would render well in other contexts where we use rule docs and opted just to have two separate code blocks.