### PR TITLE
[`pylint`] Narrow diagnostic range and exclude cases without exception handlers (`PLW0717`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pylint/too-many-statements-in-try-clause.md
+++ b/crates/ruff_linter/resources/mdtest/pylint/too-many-statements-in-try-clause.md
@@ -1,0 +1,60 @@
+# `too-many-statements-in-try-clause` (`PLW0717`)
+
+```toml
+[lint]
+preview = true
+select = ["PLW0717"]
+```
+
+## Diagnostic range
+
+Avoid marking the entire `try` statement:
+
+```py
+# snapshot: too-many-statements-in-try-clause
+try:
+    call1()
+    call2()
+    call3()
+    call4()
+    call5()
+    call6()
+except:
+    ...
+```
+
+```snapshot
+error[PLW0717]: Try clause contains too many statements (6 > 5)
+  --> src/mdtest_snippet.py:2:1
+   |
+ 2 | / try:
+ 3 | |     call1()
+ 4 | |     call2()
+ 5 | |     call3()
+ 6 | |     call4()
+ 7 | |     call5()
+ 8 | |     call6()
+ 9 | | except:
+10 | |     ...
+   | |_______^
+   |
+```
+
+## Context managers
+
+Avoid emitting a diagnostic when the `try` statement is being used like a context manager, i.e. it
+catches no exceptions and just ensures that some kind of cleanup is run in a `finally` clause:
+
+```py
+# TODO false positive
+# error: [too-many-statements-in-try-clause]
+try:
+    call1()
+    call2()
+    call3()
+    call4()
+    call5()
+    call6()
+finally:
+    cleanup()
+```

--- a/crates/ruff_linter/resources/mdtest/pylint/too-many-statements-in-try-clause.md
+++ b/crates/ruff_linter/resources/mdtest/pylint/too-many-statements-in-try-clause.md
@@ -38,8 +38,6 @@ Avoid emitting a diagnostic when the `try` statement is being used like a contex
 catches no exceptions and just ensures that some kind of cleanup is run in a `finally` clause:
 
 ```py
-# TODO false positive
-# error: [too-many-statements-in-try-clause]
 try:
     call1()
     call2()

--- a/crates/ruff_linter/resources/mdtest/pylint/too-many-statements-in-try-clause.md
+++ b/crates/ruff_linter/resources/mdtest/pylint/too-many-statements-in-try-clause.md
@@ -25,19 +25,11 @@ except:
 
 ```snapshot
 error[PLW0717]: Try clause contains too many statements (6 > 5)
-  --> src/mdtest_snippet.py:2:1
-   |
- 2 | / try:
- 3 | |     call1()
- 4 | |     call2()
- 5 | |     call3()
- 6 | |     call4()
- 7 | |     call5()
- 8 | |     call6()
- 9 | | except:
-10 | |     ...
-   | |_______^
-   |
+ --> src/mdtest_snippet.py:2:1
+  |
+2 | try:
+  | ^^^
+  |
 ```
 
 ## Context managers

--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -1341,8 +1341,7 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.is_rule_enabled(Rule::TooManyStatementsInTryClause) {
                 pylint::rules::too_many_try_statements(
                     checker,
-                    stmt,
-                    body,
+                    try_stmt,
                     checker.settings().pylint.max_statements_in_try,
                 );
             }

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_try_statements.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_try_statements.rs
@@ -1,5 +1,5 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::Stmt;
+use ruff_python_ast::StmtTry;
 use ruff_text_size::{Ranged, TextLen, TextRange};
 
 use crate::Violation;
@@ -89,18 +89,23 @@ impl Violation for TooManyStatementsInTryClause {
 /// W0717
 pub(crate) fn too_many_try_statements(
     checker: &Checker,
-    stmt: &Stmt,
-    body: &[Stmt],
+    try_stmt: &StmtTry,
     max_statements: usize,
 ) {
-    let statements = num_statements(body);
+    // Ignore cases with only `finally` clauses and no `except` handlers. These can't accidentally
+    // catch the wrong exception and are instead being used more like context managers.
+    if try_stmt.handlers.is_empty() {
+        return;
+    }
+
+    let statements = num_statements(&try_stmt.body);
     if statements > max_statements {
         checker.report_diagnostic(
             TooManyStatementsInTryClause {
                 statements,
                 max_statements,
             },
-            TextRange::at(stmt.start(), "try".text_len()),
+            TextRange::at(try_stmt.start(), "try".text_len()),
         );
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/too_many_try_statements.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/too_many_try_statements.rs
@@ -1,6 +1,6 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::Stmt;
-use ruff_python_ast::identifier::Identifier;
+use ruff_text_size::{Ranged, TextLen, TextRange};
 
 use crate::Violation;
 
@@ -100,7 +100,7 @@ pub(crate) fn too_many_try_statements(
                 statements,
                 max_statements,
             },
-            stmt.identifier(),
+            TextRange::at(stmt.start(), "try".text_len()),
         );
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0717_too_many_try_statements.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0717_too_many_try_statements.py.snap
@@ -4,16 +4,10 @@ source: crates/ruff_linter/src/rules/pylint/mod.rs
 PLW0717 Try clause contains too many statements (6 > 5)
   --> too_many_try_statements.py:63:1
    |
-61 |       print()
+61 |     print()
 62 |
-63 | / try:  # Too many try statements (6/5)
-64 | |     print()
-65 | |     print()
-66 | |     print()
-67 | |     print()
-68 | |     print()
-69 | |     print()
-70 | | except Exception:
-71 | |     raise
-   | |_________^
+63 | try:  # Too many try statements (6/5)
+   | ^^^
+64 |     print()
+65 |     print()
    |


### PR DESCRIPTION
Summary
--

This PR fixes #25438 by narrowing the diagnostic range from the entire `try` statement to only the
`try` keyword. This was one of the two alternatives mentioned on #25438, and I thought this looked a
bit nicer than only narrowing the range to the `try` body. I think this is also consistent with the
range for `too-many-statements` (`PLR0915`), which marks the function name:

https://play.ruff.rs/dafe23a1-2e89-48a5-b4d7-b0825b737152

I'm happy to reconsider, though. Another possible alternative along these lines is marking the first
statement that exceeds the limit, or the last statement, or something like that.

This PR also fixes #25390 by limiting the rule to `try` statements with `except` handlers. Either an
`except` or a `finally` clause is required, so this avoids emitting diagnostics for
context-manager-like cases, such as the one reported in the issue:

```py
session = ...
try:
    print()
    print()
    print()
    print()
    print()
    print()
finally:
    session.close()
```

where the `try` is just ensuring that some cleanup is performed and can't actually trigger the bad
behavior described in the rule docs of mistakenly catching the wrong exception.

Test Plan
--

New mdtests based on the issues
