### PR TITLE
Update Rust toolchain to 1.96 and MSRV to 1.94

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 # Please update rustfmt.toml when bumping the Rust edition
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.94"
 homepage = "https://docs.astral.sh/ruff"
 documentation = "https://docs.astral.sh/ruff"
 repository = "https://github.com/astral-sh/ruff"

--- a/crates/ruff_annotate_snippets/src/renderer/display_list.rs
+++ b/crates/ruff_annotate_snippets/src/renderer/display_list.rs
@@ -1266,12 +1266,6 @@ fn format_snippet<'m>(
     body
 }
 
-#[inline]
-// TODO: option_zip
-fn zip_opt<A, B>(a: Option<A>, b: Option<B>) -> Option<(A, B)> {
-    a.and_then(|a| b.map(|b| (a, b)))
-}
-
 fn format_header<'a>(
     origin: Option<&'a str>,
     main_range: Option<usize>,
@@ -1285,7 +1279,7 @@ fn format_header<'a>(
         DisplayHeaderType::Continuation
     };
 
-    if let Some((main_range, path)) = zip_opt(main_range, origin) {
+    if let Some((main_range, path)) = main_range.zip(origin) {
         let mut col = 1;
         let mut line_offset = 1;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95"
+channel = "1.96"


### PR DESCRIPTION
## Summary

- Update the pinned Rust toolchain from 1.95 to 1.96.
- Raise Ruff's minimum supported Rust version from 1.93 to 1.94, following the N-2 policy.
- Replace the now-unnecessary `zip_opt` helper with `Option::zip`, as Rust 1.96's Clippy flags the manual implementation.

## Test plan

`cargo clippy --workspace --all-targets --all-features -- -D warnings`
