### PR TITLE
[ty] Avoid panic for deferred dataclass field annotations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/initvar.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/initvar.md
@@ -93,6 +93,28 @@ reveal_type(C.__init__)  # revealed: (self: C, a: int, int: int = 0) -> None
 C()  # error: [missing-argument] "No argument provided for required parameter `a`"
 ```
 
+## Deferred annotations
+
+The same case must not fail when annotations are deferred, as they are by default on Python 3.14:
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from dataclasses import InitVar, dataclass
+from ty_extensions import Top
+
+@dataclass
+class C:
+    a: Top[int]
+    int: InitVar[int] = 0
+
+def fn():
+    C()  # error: [missing-argument] "No argument provided for required parameter `a`"
+```
+
 ## Overwritten `InitVar`
 
 We do not emit an error if an `InitVar` attribute is later overwritten on the instance. In that

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2587,6 +2587,10 @@ impl<'db> Type<'db> {
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
         tracing::trace!("class_member: {}.{}", self.display(db), name);
+        if let Some(fallback) = self.materialized_divergent_fallback() {
+            return fallback.class_member_with_policy(db, name, policy);
+        }
+
         match self {
             Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
                 elem.class_member_with_policy(db, name.clone(), policy)


### PR DESCRIPTION
## Summary

I fixed https://github.com/astral-sh/ty/issues/3493 in https://github.com/astral-sh/ruff/pull/25249, but missed the case of deferred evaluation for annotations... For deferred evaluation, when we then checked whether that field was a descriptor, `class_member_with_policy` attempted meta-type lookup on the cycle marker itself and panicked.

E.g., on Python 3.14, where annotations are deferred by default:

```python
from dataclasses import InitVar, dataclass
from ty_extensions import Top

@dataclass
class C:
    a: Top[int]
    int: InitVar[int] = 0

C()
```

We now apply the materialized divergent fallback before class-member lookup, consistent with the other lookup and descriptor operations. (The example reports the expected missing argument for `a` instead of panicking, and is covered under Python 3.14.)

Closes https://github.com/astral-sh/ty/issues/3493.
