### PR TITLE
[ty] Infer `bool` for `not` applied to dynamic values

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/unary/not.md
+++ b/crates/ty_python_semantic/resources/mdtest/unary/not.md
@@ -34,6 +34,17 @@ reveal_type(not warnings)  # revealed: Literal[False]
 y = 1
 ```
 
+## Dynamic
+
+```py
+from typing import Any
+
+def _(value: Any) -> None:
+    result = not value
+    reveal_type(result)  # revealed: bool
+    result.nonexistent()  # error: [unresolved-attribute] "Object of type `bool` has no attribute `nonexistent`"
+```
+
 ## Union
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9487,7 +9487,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         match (op, operand_type) {
-            (_, Type::Dynamic(_) | Type::Divergent(_)) => operand_type,
+            (ast::UnaryOp::Invert | ast::UnaryOp::UAdd | ast::UnaryOp::USub, Type::Dynamic(_))
+            | (_, Type::Divergent(_)) => operand_type,
             (_, Type::Never) => Type::Never,
 
             (_, Type::TypeAlias(alias)) => {


### PR DESCRIPTION
## Summary

Prior to this change, we treated all unary operations applied to a dynamic value as producing the same dynamic type. This is appropriate for `+`, `-`, and `~`, whose dunder implementations may return arbitrary values, but not for `not`: Python always produces a `bool` after evaluating its operand's truthiness.

```python
from typing import Any, reveal_type

def check(value: Any) -> None:
    result = reveal_type(not value)  # bool
    result.nonexistent()  # error: `bool` has no attribute `nonexistent`
```

We now allow `not` on dynamic operands to use the existing truthiness-inference path, while retaining dynamic propagation for the other unary operators. This restores downstream checking of the resulting boolean value.

Closes https://github.com/astral-sh/ty/issues/3572.
