### PR TITLE
[ty] Preserve slice-bound types in subscript inference

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -4640,7 +4640,7 @@ quux.<CURSOR>
         __format__ :: bound method Quux.__format__(format_spec: str, /) -> str
         __ge__ :: bound method Quux.__ge__(value: tuple[int | str, ...], /) -> bool
         __getattribute__ :: bound method Quux.__getattribute__(name: str, /) -> Any
-        __getitem__ :: Overload[(index: Literal[-2, 0], /) -> int, (index: Literal[-1, 1], /) -> str, (index: SupportsIndex, /) -> int | str, (index: slice[Any, Any, Any], /) -> tuple[int | str, ...]]
+        __getitem__ :: Overload[(index: Literal[-2, 0], /) -> int, (index: Literal[-1, 1], /) -> str, (index: SupportsIndex, /) -> int | str, (index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[int | str, ...]]
         __getstate__ :: bound method Quux.__getstate__() -> object
         __gt__ :: bound method Quux.__gt__(value: tuple[int | str, ...], /) -> bool
         __hash__ :: bound method Quux.__hash__() -> int

--- a/crates/ty_python_semantic/resources/mdtest/subscript/alias.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/alias.md
@@ -25,19 +25,23 @@ def f(
     implicit_zero: ImplicitZero,
     pep_613_zero: PEP613Zero,
     pep_695_zero: PEP695Zero,
+    invalid_bound: float,
 ):
     reveal_type(implicit_tuple[:2])  # revealed: tuple[str, int]
     reveal_type(implicit_tuple[implicit_zero])  # revealed: str
     reveal_type(implicit_tuple[pep_613_zero])  # revealed: str
     reveal_type(implicit_tuple[pep_695_zero])  # revealed: str
+    implicit_tuple[invalid_bound:]  # error: [invalid-argument-type]
 
     reveal_type(pep_613_tuple[:2])  # revealed: tuple[str, int]
     reveal_type(pep_613_tuple[implicit_zero])  # revealed: str
     reveal_type(pep_613_tuple[pep_613_zero])  # revealed: str
     reveal_type(pep_613_tuple[pep_695_zero])  # revealed: str
+    pep_613_tuple[invalid_bound:]  # error: [invalid-argument-type]
 
     reveal_type(pep_695_tuple[:2])  # revealed: tuple[str, int]
     reveal_type(pep_695_tuple[implicit_zero])  # revealed: str
     reveal_type(pep_695_tuple[pep_613_zero])  # revealed: str
     reveal_type(pep_695_tuple[pep_695_zero])  # revealed: str
+    pep_695_tuple[invalid_bound:]  # error: [invalid-argument-type]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/subscript/bytes.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/bytes.md
@@ -47,4 +47,14 @@ def _(m: int, n: int):
 def _(s: bytes) -> bytes:
     byte_slice2 = s[0:5]
     return reveal_type(byte_slice2)  # revealed: bytes
+
+def invalid_slice_bound(value: bytes, start: float) -> bytes:
+    return value[start:]  # error: [invalid-argument-type]
+```
+
+## Bytearray slices
+
+```py
+def invalid_slice_bound(value: bytearray, start: float) -> bytearray:
+    return value[start:]  # error: [invalid-argument-type]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/subscript/instance.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/instance.md
@@ -42,6 +42,27 @@ class Identity:
 reveal_type(Identity()[0])  # revealed: int
 ```
 
+## Slice bounds for user-defined `__getitem__`
+
+```py
+class IntegerSlices:
+    def __getitem__(self, key: slice[int | None, int | None, int | None]) -> str:
+        return ""
+
+class ArbitrarySlices:
+    def __getitem__(self, key: slice) -> str:
+        return ""
+
+def _(
+    integer_slices: IntegerSlices,
+    arbitrary_slices: ArbitrarySlices,
+    bound: object,
+    invalid_bound: float,
+) -> None:
+    integer_slices[invalid_bound:]  # error: [invalid-argument-type]
+    arbitrary_slices[bound:bound:bound]
+```
+
 ## `__getitem__` union
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/subscript/lists.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/lists.md
@@ -8,6 +8,8 @@ A list can be indexed into with:
 - slices
 
 ```py
+from typing import Any
+
 x = [1, 2, 3]
 reveal_type(x)  # revealed: list[int]
 
@@ -17,6 +19,12 @@ reveal_type(x[0:1])  # revealed: list[int]
 
 # error: [invalid-argument-type]
 reveal_type(x["a"])  # revealed: Unknown
+
+def invalid_slice_bound(xs: list[int], start: float) -> list[int]:
+    return xs[start:]  # error: [invalid-argument-type]
+
+def gradual_slice_bound(xs: list[int], start: Any) -> list[int]:
+    return xs[start:]
 ```
 
 ## Assignments within list assignment
@@ -32,6 +40,10 @@ x["a" if (y := 2) else 1] = 6
 
 # error: [invalid-assignment]
 x["a" if (y := 2) else "b"] = 6
+
+def invalid_slice_bound(xs: list[int], start: float) -> None:
+    xs[start:] = []  # error: [invalid-assignment]
+    del xs[start:]  # error: [invalid-argument-type]
 ```
 
 ## Walrus subscript access

--- a/crates/ty_python_semantic/resources/mdtest/subscript/string.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/string.md
@@ -94,10 +94,8 @@ def f(x: LiteralString):
 ## Unsupported slice types
 
 ```py
-# TODO: It would be great if we raised an error here. This can be done once
-# we have support for overloads and generics, and once typeshed has a more
-# precise annotation for `str.__getitem__`, that makes use of the generic
-# `slice[..]` type. We could then infer `slice[str, str]` here and see that
-# it doesn't match the signature of `str.__getitem__`.
-"foo"["bar":"baz"]
+def invalid_slice_bounds(s: str, start: float, end: float) -> str:
+    return s[start:end]  # error: [invalid-argument-type]
+
+"foo"["bar":"baz"]  # error: [invalid-argument-type]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -35,7 +35,7 @@ class I3: ...
 class I5: ...
 class HeterogeneousSubclass0(tuple[()]): ...
 
-# revealed: Overload[(self, index: SupportsIndex, /) -> Never, (self, index: slice[Any, Any, Any], /) -> tuple[()]]
+# revealed: Overload[(self, index: SupportsIndex, /) -> Never, (self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[()]]
 reveal_type(HeterogeneousSubclass0.__getitem__)
 
 def f0(h0: HeterogeneousSubclass0, i: int):
@@ -50,7 +50,7 @@ def f0(h0: HeterogeneousSubclass0, i: int):
 
 class HeterogeneousSubclass1(tuple[I0]): ...
 
-# revealed: Overload[(self, index: SupportsIndex, /) -> I0, (self, index: slice[Any, Any, Any], /) -> tuple[I0, ...]]
+# revealed: Overload[(self, index: SupportsIndex, /) -> I0, (self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[I0, ...]]
 reveal_type(HeterogeneousSubclass1.__getitem__)
 
 def f0(h1: HeterogeneousSubclass1, i: int):
@@ -64,7 +64,7 @@ def f0(h1: HeterogeneousSubclass1, i: int):
 # to illustrate that the `__getitem__` overloads for these two indices are combined
 class HeterogeneousSubclass4(tuple[I0, I1, I0, I3]): ...
 
-# revealed: Overload[(self, index: Literal[-4, -2, 0, 2], /) -> I0, (self, index: Literal[-3, 1], /) -> I1, (self, index: Literal[-1, 3], /) -> I3, (self, index: SupportsIndex, /) -> I0 | I1 | I3, (self, index: slice[Any, Any, Any], /) -> tuple[I0 | I1 | I3, ...]]
+# revealed: Overload[(self, index: Literal[-4, -2, 0, 2], /) -> I0, (self, index: Literal[-3, 1], /) -> I1, (self, index: Literal[-1, 3], /) -> I3, (self, index: SupportsIndex, /) -> I0 | I1 | I3, (self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[I0 | I1 | I3, ...]]
 reveal_type(HeterogeneousSubclass4.__getitem__)
 
 def f(h4: HeterogeneousSubclass4, i: int):
@@ -80,7 +80,7 @@ def f(h4: HeterogeneousSubclass4, i: int):
 
 class MixedSubclass(tuple[I0, *tuple[I1, ...], I2, I3, I2, I5]): ...
 
-# revealed: Overload[(self, index: Literal[0], /) -> I0, (self, index: Literal[-5], /) -> I1 | I0, (self, index: Literal[-1], /) -> I5, (self, index: Literal[1], /) -> I1 | I2, (self, index: Literal[-4, -2], /) -> I2, (self, index: Literal[2, 3], /) -> I1 | I2 | I3, (self, index: Literal[-3], /) -> I3, (self, index: Literal[4], /) -> I1 | I2 | I3 | I5, (self, index: SupportsIndex, /) -> I0 | I1 | I2 | I3 | I5, (self, index: slice[Any, Any, Any], /) -> tuple[I0 | I1 | I2 | I3 | I5, ...]]
+# revealed: Overload[(self, index: Literal[0], /) -> I0, (self, index: Literal[-5], /) -> I1 | I0, (self, index: Literal[-1], /) -> I5, (self, index: Literal[1], /) -> I1 | I2, (self, index: Literal[-4, -2], /) -> I2, (self, index: Literal[2, 3], /) -> I1 | I2 | I3, (self, index: Literal[-3], /) -> I3, (self, index: Literal[4], /) -> I1 | I2 | I3 | I5, (self, index: SupportsIndex, /) -> I0 | I1 | I2 | I3 | I5, (self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[I0 | I1 | I2 | I3 | I5, ...]]
 reveal_type(MixedSubclass.__getitem__)
 
 def g(m: MixedSubclass, i: int):
@@ -104,7 +104,7 @@ def g(m: MixedSubclass, i: int):
 
 class MixedSubclass2(tuple[I0, I1, *tuple[I2, ...], I3]): ...
 
-# revealed: Overload[(self, index: Literal[0], /) -> I0, (self, index: Literal[-2], /) -> I2 | I1, (self, index: Literal[1], /) -> I1, (self, index: Literal[-3], /) -> I2 | I1 | I0, (self, index: Literal[-1], /) -> I3, (self, index: Literal[2], /) -> I2 | I3, (self, index: SupportsIndex, /) -> I0 | I1 | I2 | I3, (self, index: slice[Any, Any, Any], /) -> tuple[I0 | I1 | I2 | I3, ...]]
+# revealed: Overload[(self, index: Literal[0], /) -> I0, (self, index: Literal[-2], /) -> I2 | I1, (self, index: Literal[1], /) -> I1, (self, index: Literal[-3], /) -> I2 | I1 | I0, (self, index: Literal[-1], /) -> I3, (self, index: Literal[2], /) -> I2 | I3, (self, index: SupportsIndex, /) -> I0 | I1 | I2 | I3, (self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[I0 | I1 | I2 | I3, ...]]
 reveal_type(MixedSubclass2.__getitem__)
 
 def g(m: MixedSubclass2, i: int):
@@ -139,7 +139,7 @@ reveal_mro(os.stat_result)
 # gives the right result for those elements in the tuple, and we aim to synthesize
 # the minimum number of overloads for any given tuple
 #
-# revealed: Overload[(self, index: Literal[-10, -9, -8, -7, -6, -5, -4, 0, 1, 2, 3, 4, 5, 6], /) -> int, (self, index: SupportsIndex, /) -> int | float, (self, index: slice[Any, Any, Any], /) -> tuple[int | float, ...]]
+# revealed: Overload[(self, index: Literal[-10, -9, -8, -7, -6, -5, -4, 0, 1, 2, 3, 4, 5, 6], /) -> int, (self, index: SupportsIndex, /) -> int | float, (self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[int | float, ...]]
 reveal_type(os.stat_result.__getitem__)
 ```
 
@@ -148,7 +148,7 @@ But perhaps the most commonly used tuple subclass instance is the singleton `sys
 ```py
 import sys
 
-# revealed: Overload[(self, index: Literal[-5, 0], /) -> Literal[3], (self, index: Literal[-4, 1], /) -> Literal[11], (self, index: Literal[-3, -1, 2, 4], /) -> int, (self, index: Literal[-2, 3], /) -> Literal["alpha", "beta", "candidate", "final"], (self, index: SupportsIndex, /) -> int | Literal["alpha", "beta", "candidate", "final"], (self, index: slice[Any, Any, Any], /) -> tuple[int | Literal["alpha", "beta", "candidate", "final"], ...]]
+# revealed: Overload[(self, index: Literal[-5, 0], /) -> Literal[3], (self, index: Literal[-4, 1], /) -> Literal[11], (self, index: Literal[-3, -1, 2, 4], /) -> int, (self, index: Literal[-2, 3], /) -> Literal["alpha", "beta", "candidate", "final"], (self, index: SupportsIndex, /) -> int | Literal["alpha", "beta", "candidate", "final"], (self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[int | Literal["alpha", "beta", "candidate", "final"], ...]]
 reveal_type(type(sys.version_info).__getitem__)
 ```
 
@@ -220,6 +220,9 @@ def _(m: int, n: int):
 
     tuple_slice = t[m:n]
     reveal_type(tuple_slice)  # revealed: tuple[Literal[1, "a", b"b"] | None, ...]
+
+def invalid_slice_bound(t: tuple[int, ...], start: float) -> tuple[int, ...]:
+    return t[start:]  # error: [invalid-argument-type]
 
 class I0: ...
 class I1: ...

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1564,12 +1564,12 @@ impl<'db> ClassType<'db> {
                         // Fallback overloads: for `tuple[int, str]`, we will generate the following overloads:
                         //
                         //    __getitem__(self, index: int, /) -> int | str
-                        //    __getitem__(self, index: slice[Any, Any, Any], /) -> tuple[int | str, ...]
+                        //    __getitem__(self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[int | str, ...]
                         //
                         // and for `tuple[str, *tuple[float, ...], bytes]`, we will generate the following overloads:
                         //
                         //    __getitem__(self, index: int, /) -> str | float | bytes
-                        //    __getitem__(self, index: slice[Any, Any, Any], /) -> tuple[str | float | bytes, ...]
+                        //    __getitem__(self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[str | float | bytes, ...]
                         //
                         overload_signatures.push(synthesize_getitem_overload_signature(
                             db,
@@ -1577,9 +1577,16 @@ impl<'db> ClassType<'db> {
                             all_elements_unioned,
                         ));
 
+                        let slice_bound = UnionType::from_elements(
+                            db,
+                            [KnownClass::SupportsIndex.to_instance(db), Type::none(db)],
+                        );
                         overload_signatures.push(synthesize_getitem_overload_signature(
                             db,
-                            KnownClass::Slice.to_instance(db),
+                            KnownClass::Slice.to_specialized_instance(
+                                db,
+                                &[slice_bound, slice_bound, slice_bound],
+                            ),
                             Type::homogeneous_tuple(db, all_elements_unioned),
                         ));
 

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1172,11 +1172,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     pub(super) fn infer_slice_expression(&mut self, slice: &ast::ExprSlice) -> Type<'db> {
-        enum SliceArg<'db> {
-            Arg(Type<'db>),
-            Unsupported,
-        }
-
         let db = self.db();
 
         let ast::ExprSlice {
@@ -1191,29 +1186,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let ty_upper = self.infer_optional_expression(upper.as_deref(), TypeContext::default());
         let ty_step = self.infer_optional_expression(step.as_deref(), TypeContext::default());
 
-        let type_to_slice_argument = |ty: Option<Type<'db>>| match ty {
-            Some(ty @ Type::LiteralValue(literal)) if literal.is_int() || literal.is_bool() => {
-                SliceArg::Arg(ty)
-            }
-            Some(ty @ Type::NominalInstance(instance))
-                if instance.has_known_class(db, KnownClass::NoneType) =>
-            {
-                SliceArg::Arg(ty)
-            }
-            None => SliceArg::Arg(Type::none(db)),
-            _ => SliceArg::Unsupported,
-        };
-
-        match (
-            type_to_slice_argument(ty_lower),
-            type_to_slice_argument(ty_upper),
-            type_to_slice_argument(ty_step),
-        ) {
-            (SliceArg::Arg(lower), SliceArg::Arg(upper), SliceArg::Arg(step)) => {
-                KnownClass::Slice.to_specialized_instance(db, &[lower, upper, step])
-            }
-            _ => KnownClass::Slice.to_instance(db),
-        }
+        KnownClass::Slice.to_specialized_instance(
+            db,
+            &[
+                ty_lower.unwrap_or_else(|| Type::none(db)),
+                ty_upper.unwrap_or_else(|| Type::none(db)),
+                ty_step.unwrap_or_else(|| Type::none(db)),
+            ],
+        )
     }
 
     /// Validate a subscript assignment of the form `object[key] = rhs_value`.


### PR DESCRIPTION
## Summary

Prior to this change, when a slice bound was not an integer literal, boolean literal, or `None`, we inferred a bare `slice[Any, Any, Any]`. This erased enough information that subscription checking accepted invalid slices even when `__getitem__` requires `SupportsIndex | None` bounds:

```python
def get(values: list[int], start: float) -> list[int]:
    return values[start:]  # error: [invalid-argument-type]
```

(This may have been waiting on https://github.com/astral-sh/ruff/commit/cb58704e085fe7e70d72842294575de47e47bead?)

We now preserve the inferred type of each provided slice bound in `slice[...]`, so ordinary argument checking diagnoses invalid bounds for built-in sequences and user-defined `__getitem__` methods with typed slice parameters.

Closes https://github.com/astral-sh/ty/issues/3547.
