### PR TITLE
[ty] Deduplicate retained use-def place states

### DIFF
--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -304,13 +304,21 @@ struct PlaceStateInterner {
 }
 
 impl PlaceStateInterner {
-    fn with_capacity(bindings: usize, declarations: usize) -> Self {
+    fn with_capacity(
+        interned_bindings: usize,
+        interned_ids_by_bindings: usize,
+        interned_declarations: usize,
+        interned_ids_by_declarations: usize,
+    ) -> Self {
         Self {
-            interned_bindings: IndexVec::with_capacity(bindings),
-            interned_ids_by_bindings: FxHashMap::with_capacity_and_hasher(bindings, FxBuildHasher),
-            interned_declarations: IndexVec::with_capacity(declarations),
+            interned_bindings: IndexVec::with_capacity(interned_bindings),
+            interned_ids_by_bindings: FxHashMap::with_capacity_and_hasher(
+                interned_ids_by_bindings,
+                FxBuildHasher,
+            ),
+            interned_declarations: IndexVec::with_capacity(interned_declarations),
             interned_ids_by_declarations: FxHashMap::with_capacity_and_hasher(
-                declarations,
+                interned_ids_by_declarations,
                 FxBuildHasher,
             ),
             always_unbound_bindings: None,
@@ -1803,9 +1811,13 @@ impl<'db> UseDefMapBuilder<'db> {
             + self.enclosing_snapshots.len()
             + place_state_count;
         let interned_declarations_capacity = self.declarations_by_binding.len() + place_state_count;
+        // Most place states are handled by the common-case fields, so don't size the lookup tables
+        // for every candidate entry.
         let mut place_state_interner = PlaceStateInterner::with_capacity(
             interned_bindings_capacity,
+            self.bindings_by_definition.len(),
             interned_declarations_capacity,
+            self.declarations_by_binding.len(),
         );
         // These fields are manually interned because they have a statistically high duplication rate (>50%).
         let bindings_by_definition = Self::intern_bindings_by_definition(

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1737,7 +1737,7 @@ impl<'db> UseDefMapBuilder<'db> {
         );
         let end_of_scope_symbols = Self::intern_place_states(
             self.symbol_states,
-            |state| (state.bindings(), state.declarations()),
+            PlaceState::into_parts,
             &mut interned_bindings,
             &mut interned_ids_by_bindings,
             &mut interned_declarations,
@@ -1745,7 +1745,7 @@ impl<'db> UseDefMapBuilder<'db> {
         );
         let end_of_scope_members = Self::intern_place_states(
             self.member_states,
-            |state| (state.bindings(), state.declarations()),
+            PlaceState::into_parts,
             &mut interned_bindings,
             &mut interned_ids_by_bindings,
             &mut interned_declarations,
@@ -1753,7 +1753,7 @@ impl<'db> UseDefMapBuilder<'db> {
         );
         let reachable_definitions_by_symbol = Self::intern_place_states(
             self.reachable_symbol_definitions,
-            |definitions| (&definitions.bindings, &definitions.declarations),
+            |definitions| (definitions.bindings, definitions.declarations),
             &mut interned_bindings,
             &mut interned_ids_by_bindings,
             &mut interned_declarations,
@@ -1761,7 +1761,7 @@ impl<'db> UseDefMapBuilder<'db> {
         );
         let reachable_definitions_by_member = Self::intern_place_states(
             self.reachable_member_definitions,
-            |definitions| (&definitions.bindings, &definitions.declarations),
+            |definitions| (definitions.bindings, definitions.declarations),
             &mut interned_bindings,
             &mut interned_ids_by_bindings,
             &mut interned_declarations,
@@ -1908,7 +1908,7 @@ impl<'db> UseDefMapBuilder<'db> {
 
     fn intern_place_states<I: Idx, T>(
         place_states: IndexVec<I, T>,
-        get_parts: impl for<'a> Fn(&'a T) -> (&'a Bindings, &'a Declarations),
+        get_parts: impl Fn(T) -> (Bindings, Declarations),
         interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
         interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
         interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
@@ -1917,7 +1917,7 @@ impl<'db> UseDefMapBuilder<'db> {
         let mut interned_ids_by_place = IndexVec::with_capacity(place_states.len());
 
         for place_state in place_states {
-            let (bindings, declarations) = get_parts(&place_state);
+            let (bindings, declarations) = get_parts(place_state);
             let interned_id = Self::intern_place_state(
                 bindings,
                 declarations,
@@ -1934,26 +1934,26 @@ impl<'db> UseDefMapBuilder<'db> {
     }
 
     fn intern_place_state(
-        bindings: &Bindings,
-        declarations: &Declarations,
+        bindings: Bindings,
+        declarations: Declarations,
         interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
         interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
         interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
         interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
     ) -> InternedPlaceStateId {
-        let bindings_id = if let Some(bindings_id) = interned_ids_by_bindings.get(bindings) {
+        let bindings_id = if let Some(bindings_id) = interned_ids_by_bindings.get(&bindings) {
             *bindings_id
         } else {
             let bindings_id = interned_bindings.push(bindings.clone());
-            interned_ids_by_bindings.insert(bindings.clone(), bindings_id);
+            interned_ids_by_bindings.insert(bindings, bindings_id);
             bindings_id
         };
         let declarations_id =
-            if let Some(declarations_id) = interned_ids_by_declarations.get(declarations) {
+            if let Some(declarations_id) = interned_ids_by_declarations.get(&declarations) {
                 *declarations_id
             } else {
                 let declarations_id = interned_declarations.push(declarations.clone());
-                interned_ids_by_declarations.insert(declarations.clone(), declarations_id);
+                interned_ids_by_declarations.insert(declarations, declarations_id);
                 declarations_id
             };
         InternedPlaceStateId(bindings_id, declarations_id)

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -304,21 +304,13 @@ struct PlaceStateInterner {
 }
 
 impl PlaceStateInterner {
-    fn with_capacity(
-        interned_bindings: usize,
-        interned_ids_by_bindings: usize,
-        interned_declarations: usize,
-        interned_ids_by_declarations: usize,
-    ) -> Self {
+    fn with_capacity(bindings: usize, declarations: usize) -> Self {
         Self {
-            interned_bindings: IndexVec::with_capacity(interned_bindings),
-            interned_ids_by_bindings: FxHashMap::with_capacity_and_hasher(
-                interned_ids_by_bindings,
-                FxBuildHasher,
-            ),
-            interned_declarations: IndexVec::with_capacity(interned_declarations),
+            interned_bindings: IndexVec::with_capacity(bindings),
+            interned_ids_by_bindings: FxHashMap::with_capacity_and_hasher(bindings, FxBuildHasher),
+            interned_declarations: IndexVec::with_capacity(declarations),
             interned_ids_by_declarations: FxHashMap::with_capacity_and_hasher(
-                interned_ids_by_declarations,
+                declarations,
                 FxBuildHasher,
             ),
             always_unbound_bindings: None,
@@ -1802,21 +1794,8 @@ impl<'db> UseDefMapBuilder<'db> {
         self.range_reachability.shrink_to_fit();
         self.enclosing_snapshots.shrink_to_fit();
 
-        let place_state_count = self.symbol_states.len()
-            + self.member_states.len()
-            + self.reachable_symbol_definitions.len()
-            + self.reachable_member_definitions.len();
-        let interned_bindings_capacity = self.bindings_by_definition.len()
-            + self.bindings_by_use.len()
-            + self.enclosing_snapshots.len()
-            + place_state_count;
-        let interned_declarations_capacity = self.declarations_by_binding.len() + place_state_count;
-        // Most place states are handled by the common-case fields, so don't size the lookup tables
-        // for every candidate entry.
         let mut place_state_interner = PlaceStateInterner::with_capacity(
-            interned_bindings_capacity,
             self.bindings_by_definition.len(),
-            interned_declarations_capacity,
             self.declarations_by_binding.len(),
         );
         // These fields are manually interned because they have a statistically high duplication rate (>50%).

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -294,7 +294,7 @@ impl InternedPlaceStateId {
 #[derive(Clone, Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 struct RetainedPlaceStates<T> {
     end_of_scope: T,
-    reachable: ReachableDefinitions,
+    reachable: T,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -361,7 +361,7 @@ pub struct UseDefMap<'db> {
     bindings_by_definition: FxHashMap<Definition<'db>, InternedBindingsId>,
 
     /// Retained [`PlaceState`] values for each symbol.
-    symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<PlaceState>>,
+    symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<InternedPlaceStateId>>,
 
     /// Retained [`PlaceState`] values for each member.
     member_states: FrozenIndexVec<ScopedMemberId, RetainedPlaceStates<InternedPlaceStateId>>,
@@ -543,8 +543,9 @@ impl<'db> UseDefMap<'db> {
         &self,
         symbol: ScopedSymbolId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
+        let place_state_id = self.symbol_states[symbol].end_of_scope;
         self.bindings_iterator(
-            self.symbol_states[symbol].end_of_scope.bindings(),
+            &self.interned_bindings[place_state_id.bindings_id()],
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -574,7 +575,8 @@ impl<'db> UseDefMap<'db> {
         &self,
         symbol: ScopedSymbolId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let bindings = &self.symbol_states[symbol].reachable.bindings;
+        let place_state_id = self.symbol_states[symbol].reachable;
+        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -582,7 +584,8 @@ impl<'db> UseDefMap<'db> {
         &self,
         member: ScopedMemberId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let bindings = &self.member_states[member].reachable.bindings;
+        let place_state_id = self.member_states[member].reachable;
+        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -650,7 +653,8 @@ impl<'db> UseDefMap<'db> {
         &'map self,
         symbol: ScopedSymbolId,
     ) -> DeclarationsIterator<'map, 'db> {
-        let declarations = self.symbol_states[symbol].end_of_scope.declarations();
+        let place_state_id = self.symbol_states[symbol].end_of_scope;
+        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
         self.declarations_iterator(declarations, BoundnessAnalysis::BasedOnUnboundVisibility)
     }
 
@@ -667,7 +671,8 @@ impl<'db> UseDefMap<'db> {
         &self,
         symbol: ScopedSymbolId,
     ) -> DeclarationsIterator<'_, 'db> {
-        let declarations = &self.symbol_states[symbol].reachable.declarations;
+        let place_state_id = self.symbol_states[symbol].reachable;
+        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
         self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
     }
 
@@ -675,7 +680,8 @@ impl<'db> UseDefMap<'db> {
         &self,
         member: ScopedMemberId,
     ) -> DeclarationsIterator<'_, 'db> {
-        let declarations = &self.member_states[member].reachable.declarations;
+        let place_state_id = self.member_states[member].reachable;
+        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
         self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
     }
 
@@ -714,10 +720,14 @@ impl<'db> UseDefMap<'db> {
     > + 'map {
         self.symbol_states.iter_enumerated().map(
             |(symbol_id, RetainedPlaceStates { reachable, .. })| {
-                let declarations = self
-                    .declarations_iterator(&reachable.declarations, BoundnessAnalysis::AssumeBound);
-                let bindings =
-                    self.bindings_iterator(&reachable.bindings, BoundnessAnalysis::AssumeBound);
+                let declarations = self.declarations_iterator(
+                    &self.interned_declarations[reachable.declarations_id()],
+                    BoundnessAnalysis::AssumeBound,
+                );
+                let bindings = self.bindings_iterator(
+                    &self.interned_bindings[reachable.bindings_id()],
+                    BoundnessAnalysis::AssumeBound,
+                );
                 (symbol_id, declarations, bindings)
             },
         )
@@ -1725,8 +1735,33 @@ impl<'db> UseDefMapBuilder<'db> {
             &mut interned_bindings,
             &mut interned_ids_by_bindings,
         );
-        let end_of_scope_members = Self::intern_end_of_scope_members(
+        let end_of_scope_symbols = Self::intern_place_states(
+            self.symbol_states,
+            |state| (state.bindings(), state.declarations()),
+            &mut interned_bindings,
+            &mut interned_ids_by_bindings,
+            &mut interned_declarations,
+            &mut interned_ids_by_declarations,
+        );
+        let end_of_scope_members = Self::intern_place_states(
             self.member_states,
+            |state| (state.bindings(), state.declarations()),
+            &mut interned_bindings,
+            &mut interned_ids_by_bindings,
+            &mut interned_declarations,
+            &mut interned_ids_by_declarations,
+        );
+        let reachable_definitions_by_symbol = Self::intern_place_states(
+            self.reachable_symbol_definitions,
+            |definitions| (&definitions.bindings, &definitions.declarations),
+            &mut interned_bindings,
+            &mut interned_ids_by_bindings,
+            &mut interned_declarations,
+            &mut interned_ids_by_declarations,
+        );
+        let reachable_definitions_by_member = Self::intern_place_states(
+            self.reachable_member_definitions,
+            |definitions| (&definitions.bindings, &definitions.declarations),
             &mut interned_bindings,
             &mut interned_ids_by_bindings,
             &mut interned_declarations,
@@ -1755,25 +1790,6 @@ impl<'db> UseDefMapBuilder<'db> {
         for &(_, RangeInfo { reachability, .. }) in &self.range_reachability {
             self.reachability_constraints.mark_used(reachability);
         }
-        for symbol_state in &mut self.symbol_states {
-            symbol_state.finish(&mut self.reachability_constraints);
-        }
-        for reachable_definition in &mut self.reachable_symbol_definitions {
-            reachable_definition
-                .bindings
-                .finish(&mut self.reachability_constraints);
-            reachable_definition
-                .declarations
-                .finish(&mut self.reachability_constraints);
-        }
-        for reachable_definition in &mut self.reachable_member_definitions {
-            reachable_definition
-                .bindings
-                .finish(&mut self.reachability_constraints);
-            reachable_definition
-                .declarations
-                .finish(&mut self.reachability_constraints);
-        }
         for enclosing_snapshot in &enclosing_snapshots {
             // Bindings are already marked above.
             if let InternedEnclosingSnapshotId::Constraint(constraint) = enclosing_snapshot {
@@ -1782,9 +1798,9 @@ impl<'db> UseDefMapBuilder<'db> {
         }
         self.reachability_constraints.mark_used(self.reachability);
         let symbol_states =
-            Self::zip_place_states(self.symbol_states, self.reachable_symbol_definitions);
+            Self::zip_place_states(end_of_scope_symbols, reachable_definitions_by_symbol);
         let member_states =
-            Self::zip_place_states(end_of_scope_members, self.reachable_member_definitions);
+            Self::zip_place_states(end_of_scope_members, reachable_definitions_by_member);
         let multi_bindings_by_use = MultiBindingsByUse::from_map(self.multi_bindings_by_use);
 
         UseDefMap {
@@ -1808,7 +1824,7 @@ impl<'db> UseDefMapBuilder<'db> {
 
     fn zip_place_states<I: Idx, T>(
         end_of_scope: IndexVec<I, T>,
-        reachable: IndexVec<I, ReachableDefinitions>,
+        reachable: IndexVec<I, T>,
     ) -> FrozenIndexVec<I, RetainedPlaceStates<T>> {
         assert_eq!(end_of_scope.len(), reachable.len());
 
@@ -1890,53 +1906,66 @@ impl<'db> UseDefMapBuilder<'db> {
         interned_ids_by_use
     }
 
-    fn intern_end_of_scope_members(
-        end_of_scope_members: IndexVec<ScopedMemberId, PlaceState>,
+    fn intern_place_states<I: Idx, T: Eq + std::hash::Hash>(
+        place_states: IndexVec<I, T>,
+        get_parts: impl for<'a> Fn(&'a T) -> (&'a Bindings, &'a Declarations),
         interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
         interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
         interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
         interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
-    ) -> IndexVec<ScopedMemberId, InternedPlaceStateId> {
-        let mut interned_ids_by_member: IndexVec<ScopedMemberId, InternedPlaceStateId> =
-            IndexVec::with_capacity(end_of_scope_members.len());
-        let mut interned_ids_by_place_state: FxHashMap<PlaceState, InternedPlaceStateId> =
-            FxHashMap::with_capacity_and_hasher(end_of_scope_members.len(), FxBuildHasher);
+    ) -> IndexVec<I, InternedPlaceStateId> {
+        let mut interned_ids_by_place = IndexVec::with_capacity(place_states.len());
+        let mut interned_ids_by_place_state =
+            FxHashMap::with_capacity_and_hasher(place_states.len(), FxBuildHasher);
 
-        for place_state in end_of_scope_members {
-            let interned_id = if let Some(interned_id) =
-                interned_ids_by_place_state.get(&place_state)
-            {
-                *interned_id
-            } else {
-                let bindings_id = if let Some(bindings_id) =
-                    interned_ids_by_bindings.get(place_state.bindings())
-                {
-                    *bindings_id
+        for place_state in place_states {
+            let interned_id =
+                if let Some(interned_id) = interned_ids_by_place_state.get(&place_state) {
+                    *interned_id
                 } else {
-                    let bindings_id = interned_bindings.push(place_state.bindings().clone());
-                    interned_ids_by_bindings.insert(place_state.bindings().clone(), bindings_id);
-                    bindings_id
+                    let (bindings, declarations) = get_parts(&place_state);
+                    let place_state_id = Self::intern_place_state(
+                        bindings,
+                        declarations,
+                        interned_bindings,
+                        interned_ids_by_bindings,
+                        interned_declarations,
+                        interned_ids_by_declarations,
+                    );
+                    interned_ids_by_place_state.insert(place_state, place_state_id);
+                    place_state_id
                 };
-                let declarations_id = if let Some(declarations_id) =
-                    interned_ids_by_declarations.get(place_state.declarations())
-                {
-                    *declarations_id
-                } else {
-                    let declarations_id =
-                        interned_declarations.push(place_state.declarations().clone());
-                    interned_ids_by_declarations
-                        .insert(place_state.declarations().clone(), declarations_id);
-                    declarations_id
-                };
-                let place_state_id = InternedPlaceStateId(bindings_id, declarations_id);
-                interned_ids_by_place_state.insert(place_state, place_state_id);
-                place_state_id
-            };
-            interned_ids_by_member.push(interned_id);
+            interned_ids_by_place.push(interned_id);
         }
 
-        interned_ids_by_member.shrink_to_fit();
-        interned_ids_by_member
+        interned_ids_by_place.shrink_to_fit();
+        interned_ids_by_place
+    }
+
+    fn intern_place_state(
+        bindings: &Bindings,
+        declarations: &Declarations,
+        interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
+        interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
+        interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
+        interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
+    ) -> InternedPlaceStateId {
+        let bindings_id = if let Some(bindings_id) = interned_ids_by_bindings.get(bindings) {
+            *bindings_id
+        } else {
+            let bindings_id = interned_bindings.push(bindings.clone());
+            interned_ids_by_bindings.insert(bindings.clone(), bindings_id);
+            bindings_id
+        };
+        let declarations_id =
+            if let Some(declarations_id) = interned_ids_by_declarations.get(declarations) {
+                *declarations_id
+            } else {
+                let declarations_id = interned_declarations.push(declarations.clone());
+                interned_ids_by_declarations.insert(declarations.clone(), declarations_id);
+                declarations_id
+            };
+        InternedPlaceStateId(bindings_id, declarations_id)
     }
 
     fn intern_enclosing_snapshots(

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -280,6 +280,15 @@ struct InternedBindingsId;
 #[derive(salsa::Update, get_size2::GetSize)]
 struct InternedDeclarationsId;
 
+/// Uniquely identifies a retained [`PlaceState`] entry in [`UseDefMap::retained_place_states`].
+#[newtype_index]
+#[derive(salsa::Update, get_size2::GetSize)]
+struct RetainedPlaceStateId;
+
+impl RetainedPlaceStateId {
+    const ALWAYS_UNDEFINED: Self = Self::from_u32(0);
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
 struct InternedPlaceStateId(InternedBindingsId, InternedDeclarationsId);
 
@@ -373,9 +382,9 @@ impl PlaceStateInterner {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
-struct RetainedPlaceStates<T> {
+struct RetainedPlaceStates<T, U = T> {
     end_of_scope: T,
-    reachable: T,
+    reachable: U,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -406,6 +415,9 @@ pub struct UseDefMap<'db> {
     interned_bindings: FrozenIndexVec<InternedBindingsId, Bindings>,
     /// Interned [`Declarations`] values.
     interned_declarations: FrozenIndexVec<InternedDeclarationsId, Declarations>,
+
+    /// Retained [`PlaceState`] values, with one shared entry for the common always-undefined state.
+    retained_place_states: FrozenIndexVec<RetainedPlaceStateId, PlaceState>,
 
     /// [`Bindings`] reaching a [`ScopedUseId`].
     bindings_by_use: FrozenIndexVec<ScopedUseId, InternedBindingsId>,
@@ -442,10 +454,13 @@ pub struct UseDefMap<'db> {
     bindings_by_definition: FxHashMap<Definition<'db>, InternedBindingsId>,
 
     /// Retained [`PlaceState`] values for each symbol.
-    symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<InternedPlaceStateId>>,
+    symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<RetainedPlaceStateId>>,
 
     /// Retained [`PlaceState`] values for each member.
-    member_states: FrozenIndexVec<ScopedMemberId, RetainedPlaceStates<InternedPlaceStateId>>,
+    member_states: FrozenIndexVec<
+        ScopedMemberId,
+        RetainedPlaceStates<InternedPlaceStateId, RetainedPlaceStateId>,
+    >,
 
     /// Snapshot of bindings in this scope that can be used to resolve a reference in a nested
     /// scope.
@@ -626,7 +641,7 @@ impl<'db> UseDefMap<'db> {
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.symbol_states[symbol].end_of_scope;
         self.bindings_iterator(
-            &self.interned_bindings[place_state_id.bindings_id()],
+            self.retained_place_states[place_state_id].bindings(),
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -657,7 +672,7 @@ impl<'db> UseDefMap<'db> {
         symbol: ScopedSymbolId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.symbol_states[symbol].reachable;
-        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
+        let bindings = self.retained_place_states[place_state_id].bindings();
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -666,7 +681,7 @@ impl<'db> UseDefMap<'db> {
         member: ScopedMemberId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.member_states[member].reachable;
-        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
+        let bindings = self.retained_place_states[place_state_id].bindings();
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -735,7 +750,7 @@ impl<'db> UseDefMap<'db> {
         symbol: ScopedSymbolId,
     ) -> DeclarationsIterator<'map, 'db> {
         let place_state_id = self.symbol_states[symbol].end_of_scope;
-        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
+        let declarations = self.retained_place_states[place_state_id].declarations();
         self.declarations_iterator(declarations, BoundnessAnalysis::BasedOnUnboundVisibility)
     }
 
@@ -753,7 +768,7 @@ impl<'db> UseDefMap<'db> {
         symbol: ScopedSymbolId,
     ) -> DeclarationsIterator<'_, 'db> {
         let place_state_id = self.symbol_states[symbol].reachable;
-        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
+        let declarations = self.retained_place_states[place_state_id].declarations();
         self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
     }
 
@@ -762,7 +777,7 @@ impl<'db> UseDefMap<'db> {
         member: ScopedMemberId,
     ) -> DeclarationsIterator<'_, 'db> {
         let place_state_id = self.member_states[member].reachable;
-        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
+        let declarations = self.retained_place_states[place_state_id].declarations();
         self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
     }
 
@@ -801,14 +816,13 @@ impl<'db> UseDefMap<'db> {
     > + 'map {
         self.symbol_states.iter_enumerated().map(
             |(symbol_id, RetainedPlaceStates { reachable, .. })| {
+                let place_state = &self.retained_place_states[*reachable];
                 let declarations = self.declarations_iterator(
-                    &self.interned_declarations[reachable.declarations_id()],
+                    place_state.declarations(),
                     BoundnessAnalysis::AssumeBound,
                 );
-                let bindings = self.bindings_iterator(
-                    &self.interned_bindings[reachable.bindings_id()],
-                    BoundnessAnalysis::AssumeBound,
-                );
+                let bindings =
+                    self.bindings_iterator(place_state.bindings(), BoundnessAnalysis::AssumeBound);
                 (symbol_id, declarations, bindings)
             },
         )
@@ -1809,22 +1823,26 @@ impl<'db> UseDefMapBuilder<'db> {
         );
         let bindings_by_use =
             Self::intern_bindings_by_use(self.bindings_by_use, &mut place_state_interner);
-        let end_of_scope_symbols = Self::intern_place_states(
+        let mut retained_place_states = IndexVec::new();
+        retained_place_states.push(PlaceState::undefined(
+            ScopedReachabilityConstraintId::ALWAYS_TRUE,
+        ));
+        let end_of_scope_symbols = Self::retain_place_states(
             self.symbol_states,
-            PlaceState::into_parts,
-            &mut place_state_interner,
+            |place_state| place_state,
+            &mut retained_place_states,
         );
         let end_of_scope_members =
             Self::intern_end_of_scope_members(self.member_states, &mut place_state_interner);
-        let reachable_definitions_by_symbol = Self::intern_place_states(
+        let reachable_definitions_by_symbol = Self::retain_place_states(
             self.reachable_symbol_definitions,
-            |definitions| (definitions.bindings, definitions.declarations),
-            &mut place_state_interner,
+            |definitions| PlaceState::from_parts(definitions.bindings, definitions.declarations),
+            &mut retained_place_states,
         );
-        let reachable_definitions_by_member = Self::intern_place_states(
+        let reachable_definitions_by_member = Self::retain_place_states(
             self.reachable_member_definitions,
-            |definitions| (definitions.bindings, definitions.declarations),
-            &mut place_state_interner,
+            |definitions| PlaceState::from_parts(definitions.bindings, definitions.declarations),
+            &mut retained_place_states,
         );
         let enclosing_snapshots =
             Self::intern_enclosing_snapshots(self.enclosing_snapshots, &mut place_state_interner);
@@ -1836,6 +1854,7 @@ impl<'db> UseDefMapBuilder<'db> {
 
         interned_bindings.shrink_to_fit();
         interned_declarations.shrink_to_fit();
+        retained_place_states.shrink_to_fit();
 
         // We only walk the fields that are copied through to the UseDefMap when we finish building
         // it.
@@ -1844,6 +1863,9 @@ impl<'db> UseDefMapBuilder<'db> {
         }
         for declarations in &mut interned_declarations {
             declarations.finish(&mut self.reachability_constraints);
+        }
+        for place_state in &mut retained_place_states {
+            place_state.finish(&mut self.reachability_constraints);
         }
         for bindings in self.multi_bindings_by_use.values_mut().flatten() {
             bindings.finish(&mut self.reachability_constraints);
@@ -1871,6 +1893,7 @@ impl<'db> UseDefMapBuilder<'db> {
             reachability_constraints: self.reachability_constraints.build(),
             interned_bindings: interned_bindings.into(),
             interned_declarations: interned_declarations.into(),
+            retained_place_states: retained_place_states.into(),
             bindings_by_use: bindings_by_use.into(),
             multi_bindings_by_use,
             range_reachability: self.range_reachability.into_boxed_slice(),
@@ -1883,10 +1906,10 @@ impl<'db> UseDefMapBuilder<'db> {
         }
     }
 
-    fn zip_place_states<I: Idx, T>(
+    fn zip_place_states<I: Idx, T, U>(
         end_of_scope: IndexVec<I, T>,
-        reachable: IndexVec<I, T>,
-    ) -> FrozenIndexVec<I, RetainedPlaceStates<T>> {
+        reachable: IndexVec<I, U>,
+    ) -> FrozenIndexVec<I, RetainedPlaceStates<T, U>> {
         assert_eq!(end_of_scope.len(), reachable.len());
 
         end_of_scope
@@ -1945,21 +1968,25 @@ impl<'db> UseDefMapBuilder<'db> {
         interned_ids_by_use
     }
 
-    fn intern_place_states<I: Idx, T>(
+    fn retain_place_states<I: Idx, T>(
         place_states: IndexVec<I, T>,
-        get_parts: impl Fn(T) -> (Bindings, Declarations),
-        place_state_interner: &mut PlaceStateInterner,
-    ) -> IndexVec<I, InternedPlaceStateId> {
-        let mut interned_ids_by_place = IndexVec::with_capacity(place_states.len());
+        get_place_state: impl Fn(T) -> PlaceState,
+        retained_place_states: &mut IndexVec<RetainedPlaceStateId, PlaceState>,
+    ) -> IndexVec<I, RetainedPlaceStateId> {
+        let mut retained_ids_by_place = IndexVec::with_capacity(place_states.len());
 
         for place_state in place_states {
-            let (bindings, declarations) = get_parts(place_state);
-            let interned_id = place_state_interner.intern_place_state(bindings, declarations);
-            interned_ids_by_place.push(interned_id);
+            let place_state = get_place_state(place_state);
+            let retained_id = if place_state.is_always_undefined() {
+                RetainedPlaceStateId::ALWAYS_UNDEFINED
+            } else {
+                retained_place_states.push(place_state)
+            };
+            retained_ids_by_place.push(retained_id);
         }
 
-        interned_ids_by_place.shrink_to_fit();
-        interned_ids_by_place
+        retained_ids_by_place.shrink_to_fit();
+        retained_ids_by_place
     }
 
     fn intern_end_of_scope_members(

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1906,7 +1906,7 @@ impl<'db> UseDefMapBuilder<'db> {
         interned_ids_by_use
     }
 
-    fn intern_place_states<I: Idx, T: Eq + std::hash::Hash>(
+    fn intern_place_states<I: Idx, T>(
         place_states: IndexVec<I, T>,
         get_parts: impl for<'a> Fn(&'a T) -> (&'a Bindings, &'a Declarations),
         interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
@@ -1915,26 +1915,17 @@ impl<'db> UseDefMapBuilder<'db> {
         interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
     ) -> IndexVec<I, InternedPlaceStateId> {
         let mut interned_ids_by_place = IndexVec::with_capacity(place_states.len());
-        let mut interned_ids_by_place_state =
-            FxHashMap::with_capacity_and_hasher(place_states.len(), FxBuildHasher);
 
         for place_state in place_states {
-            let interned_id =
-                if let Some(interned_id) = interned_ids_by_place_state.get(&place_state) {
-                    *interned_id
-                } else {
-                    let (bindings, declarations) = get_parts(&place_state);
-                    let place_state_id = Self::intern_place_state(
-                        bindings,
-                        declarations,
-                        interned_bindings,
-                        interned_ids_by_bindings,
-                        interned_declarations,
-                        interned_ids_by_declarations,
-                    );
-                    interned_ids_by_place_state.insert(place_state, place_state_id);
-                    place_state_id
-                };
+            let (bindings, declarations) = get_parts(&place_state);
+            let interned_id = Self::intern_place_state(
+                bindings,
+                declarations,
+                interned_bindings,
+                interned_ids_by_bindings,
+                interned_declarations,
+                interned_ids_by_declarations,
+            );
             interned_ids_by_place.push(interned_id);
         }
 

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -298,6 +298,9 @@ struct PlaceStateInterner {
     interned_ids_by_bindings: FxHashMap<Bindings, InternedBindingsId>,
     interned_declarations: IndexVec<InternedDeclarationsId, Declarations>,
     interned_ids_by_declarations: FxHashMap<Declarations, InternedDeclarationsId>,
+    // Undeclared states are common and can be interned by their dense constraint IDs.
+    undeclared_declarations_by_constraint:
+        IndexVec<ScopedReachabilityConstraintId, Option<InternedDeclarationsId>>,
     // These values are extremely common, so avoid repeatedly hashing their small vectors.
     always_unbound_bindings: Option<InternedBindingsId>,
     always_undeclared_declarations: Option<InternedDeclarationsId>,
@@ -313,6 +316,7 @@ impl PlaceStateInterner {
                 declaration_map,
                 FxBuildHasher,
             ),
+            undeclared_declarations_by_constraint: IndexVec::new(),
             always_unbound_bindings: None,
             always_undeclared_declarations: None,
         }
@@ -350,6 +354,25 @@ impl PlaceStateInterner {
             return interned_id;
         }
 
+        if let Some(reachability_constraint) = declarations.undeclared_reachability_constraint()
+            && !reachability_constraint.is_terminal()
+        {
+            let index = reachability_constraint.index();
+            let len = self.undeclared_declarations_by_constraint.len();
+            if index >= len {
+                self.undeclared_declarations_by_constraint
+                    .resize(index + 1, None);
+            } else if let Some(interned_id) =
+                self.undeclared_declarations_by_constraint[reachability_constraint]
+            {
+                return interned_id;
+            }
+
+            let interned_id = self.interned_declarations.push(declarations);
+            self.undeclared_declarations_by_constraint[reachability_constraint] = Some(interned_id);
+            return interned_id;
+        }
+
         match self.interned_ids_by_declarations.entry(declarations) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
@@ -376,9 +399,9 @@ impl PlaceStateInterner {
         bindings: Bindings,
         declarations: Declarations,
     ) -> InternedPlaceStateId {
-        // Apart from the always-undeclared state, retained declarations rarely repeat. Keep the
-        // compact IDs without hashing every declaration vector to find the occasional duplicate.
-        let declarations_id = if declarations.is_always_undeclared() {
+        // Other retained declarations rarely repeat. Keep the compact IDs without hashing every
+        // declaration vector to find the occasional duplicate.
+        let declarations_id = if declarations.undeclared_reachability_constraint().is_some() {
             self.intern_declarations(declarations)
         } else {
             self.interned_declarations.push(declarations)

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -280,15 +280,6 @@ struct InternedBindingsId;
 #[derive(salsa::Update, get_size2::GetSize)]
 struct InternedDeclarationsId;
 
-/// Uniquely identifies a retained [`PlaceState`] entry in [`UseDefMap::retained_place_states`].
-#[newtype_index]
-#[derive(salsa::Update, get_size2::GetSize)]
-struct RetainedPlaceStateId;
-
-impl RetainedPlaceStateId {
-    const ALWAYS_UNDEFINED: Self = Self::from_u32(0);
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
 struct InternedPlaceStateId(InternedBindingsId, InternedDeclarationsId);
 
@@ -382,9 +373,9 @@ impl PlaceStateInterner {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
-struct RetainedPlaceStates<T, U = T> {
+struct RetainedPlaceStates<T> {
     end_of_scope: T,
-    reachable: U,
+    reachable: T,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -415,9 +406,6 @@ pub struct UseDefMap<'db> {
     interned_bindings: FrozenIndexVec<InternedBindingsId, Bindings>,
     /// Interned [`Declarations`] values.
     interned_declarations: FrozenIndexVec<InternedDeclarationsId, Declarations>,
-
-    /// Retained [`PlaceState`] values, with one shared entry for the common always-undefined state.
-    retained_place_states: FrozenIndexVec<RetainedPlaceStateId, PlaceState>,
 
     /// [`Bindings`] reaching a [`ScopedUseId`].
     bindings_by_use: FrozenIndexVec<ScopedUseId, InternedBindingsId>,
@@ -454,13 +442,10 @@ pub struct UseDefMap<'db> {
     bindings_by_definition: FxHashMap<Definition<'db>, InternedBindingsId>,
 
     /// Retained [`PlaceState`] values for each symbol.
-    symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<RetainedPlaceStateId>>,
+    symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<InternedPlaceStateId>>,
 
     /// Retained [`PlaceState`] values for each member.
-    member_states: FrozenIndexVec<
-        ScopedMemberId,
-        RetainedPlaceStates<InternedPlaceStateId, RetainedPlaceStateId>,
-    >,
+    member_states: FrozenIndexVec<ScopedMemberId, RetainedPlaceStates<InternedPlaceStateId>>,
 
     /// Snapshot of bindings in this scope that can be used to resolve a reference in a nested
     /// scope.
@@ -641,7 +626,7 @@ impl<'db> UseDefMap<'db> {
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.symbol_states[symbol].end_of_scope;
         self.bindings_iterator(
-            self.retained_place_states[place_state_id].bindings(),
+            &self.interned_bindings[place_state_id.bindings_id()],
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -672,7 +657,7 @@ impl<'db> UseDefMap<'db> {
         symbol: ScopedSymbolId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.symbol_states[symbol].reachable;
-        let bindings = self.retained_place_states[place_state_id].bindings();
+        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -681,7 +666,7 @@ impl<'db> UseDefMap<'db> {
         member: ScopedMemberId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.member_states[member].reachable;
-        let bindings = self.retained_place_states[place_state_id].bindings();
+        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -750,7 +735,7 @@ impl<'db> UseDefMap<'db> {
         symbol: ScopedSymbolId,
     ) -> DeclarationsIterator<'map, 'db> {
         let place_state_id = self.symbol_states[symbol].end_of_scope;
-        let declarations = self.retained_place_states[place_state_id].declarations();
+        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
         self.declarations_iterator(declarations, BoundnessAnalysis::BasedOnUnboundVisibility)
     }
 
@@ -768,7 +753,7 @@ impl<'db> UseDefMap<'db> {
         symbol: ScopedSymbolId,
     ) -> DeclarationsIterator<'_, 'db> {
         let place_state_id = self.symbol_states[symbol].reachable;
-        let declarations = self.retained_place_states[place_state_id].declarations();
+        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
         self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
     }
 
@@ -777,7 +762,7 @@ impl<'db> UseDefMap<'db> {
         member: ScopedMemberId,
     ) -> DeclarationsIterator<'_, 'db> {
         let place_state_id = self.member_states[member].reachable;
-        let declarations = self.retained_place_states[place_state_id].declarations();
+        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
         self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
     }
 
@@ -816,13 +801,14 @@ impl<'db> UseDefMap<'db> {
     > + 'map {
         self.symbol_states.iter_enumerated().map(
             |(symbol_id, RetainedPlaceStates { reachable, .. })| {
-                let place_state = &self.retained_place_states[*reachable];
                 let declarations = self.declarations_iterator(
-                    place_state.declarations(),
+                    &self.interned_declarations[reachable.declarations_id()],
                     BoundnessAnalysis::AssumeBound,
                 );
-                let bindings =
-                    self.bindings_iterator(place_state.bindings(), BoundnessAnalysis::AssumeBound);
+                let bindings = self.bindings_iterator(
+                    &self.interned_bindings[reachable.bindings_id()],
+                    BoundnessAnalysis::AssumeBound,
+                );
                 (symbol_id, declarations, bindings)
             },
         )
@@ -1808,9 +1794,18 @@ impl<'db> UseDefMapBuilder<'db> {
         self.range_reachability.shrink_to_fit();
         self.enclosing_snapshots.shrink_to_fit();
 
+        let place_state_count = self.symbol_states.len()
+            + self.member_states.len()
+            + self.reachable_symbol_definitions.len()
+            + self.reachable_member_definitions.len();
+        let interned_bindings_capacity = self.bindings_by_definition.len()
+            + self.bindings_by_use.len()
+            + self.enclosing_snapshots.len()
+            + place_state_count;
+        let interned_declarations_capacity = self.declarations_by_binding.len() + place_state_count;
         let mut place_state_interner = PlaceStateInterner::with_capacity(
-            self.bindings_by_definition.len(),
-            self.declarations_by_binding.len(),
+            interned_bindings_capacity,
+            interned_declarations_capacity,
         );
         // These fields are manually interned because they have a statistically high duplication rate (>50%).
         let bindings_by_definition = Self::intern_bindings_by_definition(
@@ -1823,26 +1818,22 @@ impl<'db> UseDefMapBuilder<'db> {
         );
         let bindings_by_use =
             Self::intern_bindings_by_use(self.bindings_by_use, &mut place_state_interner);
-        let mut retained_place_states = IndexVec::new();
-        retained_place_states.push(PlaceState::undefined(
-            ScopedReachabilityConstraintId::ALWAYS_TRUE,
-        ));
-        let end_of_scope_symbols = Self::retain_place_states(
+        let end_of_scope_symbols = Self::intern_place_states(
             self.symbol_states,
-            |place_state| place_state,
-            &mut retained_place_states,
+            PlaceState::into_parts,
+            &mut place_state_interner,
         );
         let end_of_scope_members =
             Self::intern_end_of_scope_members(self.member_states, &mut place_state_interner);
-        let reachable_definitions_by_symbol = Self::retain_place_states(
+        let reachable_definitions_by_symbol = Self::intern_place_states(
             self.reachable_symbol_definitions,
-            |definitions| PlaceState::from_parts(definitions.bindings, definitions.declarations),
-            &mut retained_place_states,
+            |definitions| (definitions.bindings, definitions.declarations),
+            &mut place_state_interner,
         );
-        let reachable_definitions_by_member = Self::retain_place_states(
+        let reachable_definitions_by_member = Self::intern_place_states(
             self.reachable_member_definitions,
-            |definitions| PlaceState::from_parts(definitions.bindings, definitions.declarations),
-            &mut retained_place_states,
+            |definitions| (definitions.bindings, definitions.declarations),
+            &mut place_state_interner,
         );
         let enclosing_snapshots =
             Self::intern_enclosing_snapshots(self.enclosing_snapshots, &mut place_state_interner);
@@ -1854,7 +1845,6 @@ impl<'db> UseDefMapBuilder<'db> {
 
         interned_bindings.shrink_to_fit();
         interned_declarations.shrink_to_fit();
-        retained_place_states.shrink_to_fit();
 
         // We only walk the fields that are copied through to the UseDefMap when we finish building
         // it.
@@ -1863,9 +1853,6 @@ impl<'db> UseDefMapBuilder<'db> {
         }
         for declarations in &mut interned_declarations {
             declarations.finish(&mut self.reachability_constraints);
-        }
-        for place_state in &mut retained_place_states {
-            place_state.finish(&mut self.reachability_constraints);
         }
         for bindings in self.multi_bindings_by_use.values_mut().flatten() {
             bindings.finish(&mut self.reachability_constraints);
@@ -1893,7 +1880,6 @@ impl<'db> UseDefMapBuilder<'db> {
             reachability_constraints: self.reachability_constraints.build(),
             interned_bindings: interned_bindings.into(),
             interned_declarations: interned_declarations.into(),
-            retained_place_states: retained_place_states.into(),
             bindings_by_use: bindings_by_use.into(),
             multi_bindings_by_use,
             range_reachability: self.range_reachability.into_boxed_slice(),
@@ -1906,10 +1892,10 @@ impl<'db> UseDefMapBuilder<'db> {
         }
     }
 
-    fn zip_place_states<I: Idx, T, U>(
+    fn zip_place_states<I: Idx, T>(
         end_of_scope: IndexVec<I, T>,
-        reachable: IndexVec<I, U>,
-    ) -> FrozenIndexVec<I, RetainedPlaceStates<T, U>> {
+        reachable: IndexVec<I, T>,
+    ) -> FrozenIndexVec<I, RetainedPlaceStates<T>> {
         assert_eq!(end_of_scope.len(), reachable.len());
 
         end_of_scope
@@ -1968,25 +1954,21 @@ impl<'db> UseDefMapBuilder<'db> {
         interned_ids_by_use
     }
 
-    fn retain_place_states<I: Idx, T>(
+    fn intern_place_states<I: Idx, T>(
         place_states: IndexVec<I, T>,
-        get_place_state: impl Fn(T) -> PlaceState,
-        retained_place_states: &mut IndexVec<RetainedPlaceStateId, PlaceState>,
-    ) -> IndexVec<I, RetainedPlaceStateId> {
-        let mut retained_ids_by_place = IndexVec::with_capacity(place_states.len());
+        get_parts: impl Fn(T) -> (Bindings, Declarations),
+        place_state_interner: &mut PlaceStateInterner,
+    ) -> IndexVec<I, InternedPlaceStateId> {
+        let mut interned_ids_by_place = IndexVec::with_capacity(place_states.len());
 
         for place_state in place_states {
-            let place_state = get_place_state(place_state);
-            let retained_id = if place_state.is_always_undefined() {
-                RetainedPlaceStateId::ALWAYS_UNDEFINED
-            } else {
-                retained_place_states.push(place_state)
-            };
-            retained_ids_by_place.push(retained_id);
+            let (bindings, declarations) = get_parts(place_state);
+            let interned_id = place_state_interner.intern_place_state(bindings, declarations);
+            interned_ids_by_place.push(interned_id);
         }
 
-        retained_ids_by_place.shrink_to_fit();
-        retained_ids_by_place
+        interned_ids_by_place.shrink_to_fit();
+        interned_ids_by_place
     }
 
     fn intern_end_of_scope_members(

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -293,6 +293,85 @@ impl InternedPlaceStateId {
     }
 }
 
+struct PlaceStateInterner {
+    interned_bindings: IndexVec<InternedBindingsId, Bindings>,
+    interned_ids_by_bindings: FxHashMap<Bindings, InternedBindingsId>,
+    interned_declarations: IndexVec<InternedDeclarationsId, Declarations>,
+    interned_ids_by_declarations: FxHashMap<Declarations, InternedDeclarationsId>,
+    // These values are extremely common, so avoid repeatedly hashing their small vectors.
+    always_unbound_bindings: Option<InternedBindingsId>,
+    always_undeclared_declarations: Option<InternedDeclarationsId>,
+}
+
+impl PlaceStateInterner {
+    fn with_capacity(bindings: usize, declarations: usize) -> Self {
+        Self {
+            interned_bindings: IndexVec::with_capacity(bindings),
+            interned_ids_by_bindings: FxHashMap::with_capacity_and_hasher(bindings, FxBuildHasher),
+            interned_declarations: IndexVec::with_capacity(declarations),
+            interned_ids_by_declarations: FxHashMap::with_capacity_and_hasher(
+                declarations,
+                FxBuildHasher,
+            ),
+            always_unbound_bindings: None,
+            always_undeclared_declarations: None,
+        }
+    }
+
+    fn intern_bindings(&mut self, bindings: Bindings) -> InternedBindingsId {
+        if bindings.is_always_unbound() {
+            if let Some(interned_id) = self.always_unbound_bindings {
+                return interned_id;
+            }
+
+            let interned_id = self.interned_bindings.push(bindings);
+            self.always_unbound_bindings = Some(interned_id);
+            return interned_id;
+        }
+
+        match self.interned_ids_by_bindings.entry(bindings) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let interned_id = self.interned_bindings.push(entry.key().clone());
+                entry.insert(interned_id);
+                interned_id
+            }
+        }
+    }
+
+    fn intern_declarations(&mut self, declarations: Declarations) -> InternedDeclarationsId {
+        if declarations.is_always_undeclared() {
+            if let Some(interned_id) = self.always_undeclared_declarations {
+                return interned_id;
+            }
+
+            let interned_id = self.interned_declarations.push(declarations);
+            self.always_undeclared_declarations = Some(interned_id);
+            return interned_id;
+        }
+
+        match self.interned_ids_by_declarations.entry(declarations) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let interned_id = self.interned_declarations.push(entry.key().clone());
+                entry.insert(interned_id);
+                interned_id
+            }
+        }
+    }
+
+    fn intern_place_state(
+        &mut self,
+        bindings: Bindings,
+        declarations: Declarations,
+    ) -> InternedPlaceStateId {
+        InternedPlaceStateId(
+            self.intern_bindings(bindings),
+            self.intern_declarations(declarations),
+        )
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 struct RetainedPlaceStates<T> {
     end_of_scope: T,
@@ -1724,64 +1803,45 @@ impl<'db> UseDefMapBuilder<'db> {
             + self.enclosing_snapshots.len()
             + place_state_count;
         let interned_declarations_capacity = self.declarations_by_binding.len() + place_state_count;
-        let mut interned_bindings = IndexVec::with_capacity(interned_bindings_capacity);
-        let mut interned_ids_by_bindings =
-            FxHashMap::with_capacity_and_hasher(interned_bindings_capacity, FxBuildHasher);
-        let mut interned_declarations = IndexVec::with_capacity(interned_declarations_capacity);
-        let mut interned_ids_by_declarations =
-            FxHashMap::with_capacity_and_hasher(interned_declarations_capacity, FxBuildHasher);
+        let mut place_state_interner = PlaceStateInterner::with_capacity(
+            interned_bindings_capacity,
+            interned_declarations_capacity,
+        );
         // These fields are manually interned because they have a statistically high duplication rate (>50%).
         let bindings_by_definition = Self::intern_bindings_by_definition(
             self.bindings_by_definition,
-            &mut interned_bindings,
-            &mut interned_ids_by_bindings,
+            &mut place_state_interner,
         );
         let declarations_by_binding = Self::intern_declarations_by_binding(
             self.declarations_by_binding,
-            &mut interned_declarations,
-            &mut interned_ids_by_declarations,
+            &mut place_state_interner,
         );
-        let bindings_by_use = Self::intern_bindings_by_use(
-            self.bindings_by_use,
-            &mut interned_bindings,
-            &mut interned_ids_by_bindings,
-        );
+        let bindings_by_use =
+            Self::intern_bindings_by_use(self.bindings_by_use, &mut place_state_interner);
         let end_of_scope_symbols = Self::intern_place_states(
             self.symbol_states,
             PlaceState::into_parts,
-            &mut interned_bindings,
-            &mut interned_ids_by_bindings,
-            &mut interned_declarations,
-            &mut interned_ids_by_declarations,
+            &mut place_state_interner,
         );
-        let end_of_scope_members = Self::intern_end_of_scope_members(
-            self.member_states,
-            &mut interned_bindings,
-            &mut interned_ids_by_bindings,
-            &mut interned_declarations,
-            &mut interned_ids_by_declarations,
-        );
+        let end_of_scope_members =
+            Self::intern_end_of_scope_members(self.member_states, &mut place_state_interner);
         let reachable_definitions_by_symbol = Self::intern_place_states(
             self.reachable_symbol_definitions,
             |definitions| (definitions.bindings, definitions.declarations),
-            &mut interned_bindings,
-            &mut interned_ids_by_bindings,
-            &mut interned_declarations,
-            &mut interned_ids_by_declarations,
+            &mut place_state_interner,
         );
         let reachable_definitions_by_member = Self::intern_place_states(
             self.reachable_member_definitions,
             |definitions| (definitions.bindings, definitions.declarations),
-            &mut interned_bindings,
-            &mut interned_ids_by_bindings,
-            &mut interned_declarations,
-            &mut interned_ids_by_declarations,
+            &mut place_state_interner,
         );
-        let enclosing_snapshots = Self::intern_enclosing_snapshots(
-            self.enclosing_snapshots,
-            &mut interned_bindings,
-            &mut interned_ids_by_bindings,
-        );
+        let enclosing_snapshots =
+            Self::intern_enclosing_snapshots(self.enclosing_snapshots, &mut place_state_interner);
+        let PlaceStateInterner {
+            mut interned_bindings,
+            mut interned_declarations,
+            ..
+        } = place_state_interner;
 
         interned_bindings.shrink_to_fit();
         interned_declarations.shrink_to_fit();
@@ -1850,20 +1910,13 @@ impl<'db> UseDefMapBuilder<'db> {
 
     fn intern_bindings_by_definition(
         bindings_by_definition: FxHashMap<Definition<'db>, Bindings>,
-        interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
-        interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
+        place_state_interner: &mut PlaceStateInterner,
     ) -> FxHashMap<Definition<'db>, InternedBindingsId> {
         let mut interned_ids_by_definition: FxHashMap<Definition<'db>, InternedBindingsId> =
             FxHashMap::with_capacity_and_hasher(bindings_by_definition.len(), FxBuildHasher);
 
         for (definition, bindings) in bindings_by_definition {
-            let interned_id = if let Some(interned_id) = interned_ids_by_bindings.get(&bindings) {
-                *interned_id
-            } else {
-                let interned_id = interned_bindings.push(bindings.clone());
-                interned_ids_by_bindings.insert(bindings, interned_id);
-                interned_id
-            };
+            let interned_id = place_state_interner.intern_bindings(bindings);
             interned_ids_by_definition.insert(definition, interned_id);
         }
 
@@ -1872,21 +1925,13 @@ impl<'db> UseDefMapBuilder<'db> {
 
     fn intern_declarations_by_binding(
         declarations_by_binding: FxHashMap<Definition<'db>, Declarations>,
-        interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
-        interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
+        place_state_interner: &mut PlaceStateInterner,
     ) -> FxHashMap<Definition<'db>, InternedDeclarationsId> {
         let mut interned_ids_by_binding: FxHashMap<Definition<'db>, InternedDeclarationsId> =
             FxHashMap::with_capacity_and_hasher(declarations_by_binding.len(), FxBuildHasher);
 
         for (binding, declarations) in declarations_by_binding {
-            let interned_id =
-                if let Some(interned_id) = interned_ids_by_declarations.get(&declarations) {
-                    *interned_id
-                } else {
-                    let interned_id = interned_declarations.push(declarations.clone());
-                    interned_ids_by_declarations.insert(declarations, interned_id);
-                    interned_id
-                };
+            let interned_id = place_state_interner.intern_declarations(declarations);
             interned_ids_by_binding.insert(binding, interned_id);
         }
 
@@ -1895,20 +1940,13 @@ impl<'db> UseDefMapBuilder<'db> {
 
     fn intern_bindings_by_use(
         bindings_by_use: IndexVec<ScopedUseId, Bindings>,
-        interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
-        interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
+        place_state_interner: &mut PlaceStateInterner,
     ) -> IndexVec<ScopedUseId, InternedBindingsId> {
         let mut interned_ids_by_use: IndexVec<ScopedUseId, InternedBindingsId> =
             IndexVec::with_capacity(bindings_by_use.len());
 
         for bindings in bindings_by_use {
-            let interned_id = if let Some(interned_id) = interned_ids_by_bindings.get(&bindings) {
-                *interned_id
-            } else {
-                let interned_id = interned_bindings.push(bindings.clone());
-                interned_ids_by_bindings.insert(bindings, interned_id);
-                interned_id
-            };
+            let interned_id = place_state_interner.intern_bindings(bindings);
             interned_ids_by_use.push(interned_id);
         }
 
@@ -1919,23 +1957,13 @@ impl<'db> UseDefMapBuilder<'db> {
     fn intern_place_states<I: Idx, T>(
         place_states: IndexVec<I, T>,
         get_parts: impl Fn(T) -> (Bindings, Declarations),
-        interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
-        interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
-        interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
-        interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
+        place_state_interner: &mut PlaceStateInterner,
     ) -> IndexVec<I, InternedPlaceStateId> {
         let mut interned_ids_by_place = IndexVec::with_capacity(place_states.len());
 
         for place_state in place_states {
             let (bindings, declarations) = get_parts(place_state);
-            let interned_id = Self::intern_place_state(
-                bindings,
-                declarations,
-                interned_bindings,
-                interned_ids_by_bindings,
-                interned_declarations,
-                interned_ids_by_declarations,
-            );
+            let interned_id = place_state_interner.intern_place_state(bindings, declarations);
             interned_ids_by_place.push(interned_id);
         }
 
@@ -1945,10 +1973,7 @@ impl<'db> UseDefMapBuilder<'db> {
 
     fn intern_end_of_scope_members(
         end_of_scope_members: IndexVec<ScopedMemberId, PlaceState>,
-        interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
-        interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
-        interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
-        interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
+        place_state_interner: &mut PlaceStateInterner,
     ) -> IndexVec<ScopedMemberId, InternedPlaceStateId> {
         let mut interned_ids_by_member = IndexVec::with_capacity(end_of_scope_members.len());
         let mut interned_ids_by_place_state =
@@ -1959,13 +1984,9 @@ impl<'db> UseDefMapBuilder<'db> {
                 Entry::Occupied(entry) => *entry.get(),
                 Entry::Vacant(entry) => {
                     let place_state = entry.key();
-                    let interned_id = Self::intern_place_state(
+                    let interned_id = place_state_interner.intern_place_state(
                         place_state.bindings().clone(),
                         place_state.declarations().clone(),
-                        interned_bindings,
-                        interned_ids_by_bindings,
-                        interned_declarations,
-                        interned_ids_by_declarations,
                     );
                     entry.insert(interned_id);
                     interned_id
@@ -1978,37 +1999,9 @@ impl<'db> UseDefMapBuilder<'db> {
         interned_ids_by_member
     }
 
-    fn intern_place_state(
-        bindings: Bindings,
-        declarations: Declarations,
-        interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
-        interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
-        interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
-        interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
-    ) -> InternedPlaceStateId {
-        let bindings_id = match interned_ids_by_bindings.entry(bindings) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => {
-                let bindings_id = interned_bindings.push(entry.key().clone());
-                entry.insert(bindings_id);
-                bindings_id
-            }
-        };
-        let declarations_id = match interned_ids_by_declarations.entry(declarations) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => {
-                let declarations_id = interned_declarations.push(entry.key().clone());
-                entry.insert(declarations_id);
-                declarations_id
-            }
-        };
-        InternedPlaceStateId(bindings_id, declarations_id)
-    }
-
     fn intern_enclosing_snapshots(
         enclosing_snapshots: EnclosingSnapshots,
-        interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
-        interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
+        place_state_interner: &mut PlaceStateInterner,
     ) -> IndexVec<ScopedEnclosingSnapshotId, InternedEnclosingSnapshotId> {
         let mut interned_ids_by_snapshot: IndexVec<
             ScopedEnclosingSnapshotId,
@@ -2018,14 +2011,7 @@ impl<'db> UseDefMapBuilder<'db> {
         for snapshot in enclosing_snapshots {
             let interned_id = match snapshot {
                 EnclosingSnapshot::Bindings(bindings) => {
-                    let interned_bindings_id =
-                        if let Some(interned_id) = interned_ids_by_bindings.get(&bindings) {
-                            *interned_id
-                        } else {
-                            let interned_id = interned_bindings.push(bindings.clone());
-                            interned_ids_by_bindings.insert(bindings, interned_id);
-                            interned_id
-                        };
+                    let interned_bindings_id = place_state_interner.intern_bindings(bindings);
                     InternedEnclosingSnapshotId::Bindings(interned_bindings_id)
                 }
                 EnclosingSnapshot::Constraint(constraint) => {

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -283,9 +283,6 @@ struct InternedDeclarationsId;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
 struct InternedPlaceStateId(InternedBindingsId, InternedDeclarationsId);
 
-// Small scopes rarely contain duplicate constrained undeclared states.
-const MIN_PLACE_STATE_COUNT_TO_REUSE_RETAINED_UNDECLARED: usize = 16;
-
 impl InternedPlaceStateId {
     fn bindings_id(self) -> InternedBindingsId {
         self.0
@@ -301,20 +298,16 @@ struct PlaceStateInterner {
     interned_ids_by_bindings: FxHashMap<Bindings, InternedBindingsId>,
     interned_declarations: IndexVec<InternedDeclarationsId, Declarations>,
     interned_ids_by_declarations: FxHashMap<Declarations, InternedDeclarationsId>,
-    last_retained_undeclared: Option<(ScopedReachabilityConstraintId, InternedDeclarationsId)>,
-    reuse_retained_undeclared: bool,
+    // Undeclared states are common and can be interned by their dense constraint IDs.
+    undeclared_declarations_by_constraint:
+        IndexVec<ScopedReachabilityConstraintId, Option<InternedDeclarationsId>>,
     // These values are extremely common, so avoid repeatedly hashing their small vectors.
     always_unbound_bindings: Option<InternedBindingsId>,
     always_undeclared_declarations: Option<InternedDeclarationsId>,
 }
 
 impl PlaceStateInterner {
-    fn with_capacity(
-        bindings: usize,
-        declaration_map: usize,
-        declarations: usize,
-        reuse_retained_undeclared: bool,
-    ) -> Self {
+    fn with_capacity(bindings: usize, declaration_map: usize, declarations: usize) -> Self {
         Self {
             interned_bindings: IndexVec::with_capacity(bindings),
             interned_ids_by_bindings: FxHashMap::with_capacity_and_hasher(bindings, FxBuildHasher),
@@ -323,8 +316,7 @@ impl PlaceStateInterner {
                 declaration_map,
                 FxBuildHasher,
             ),
-            last_retained_undeclared: None,
-            reuse_retained_undeclared,
+            undeclared_declarations_by_constraint: IndexVec::new(),
             always_unbound_bindings: None,
             always_undeclared_declarations: None,
         }
@@ -362,6 +354,25 @@ impl PlaceStateInterner {
             return interned_id;
         }
 
+        if let Some(reachability_constraint) = declarations.undeclared_reachability_constraint()
+            && !reachability_constraint.is_terminal()
+        {
+            let index = reachability_constraint.index();
+            let len = self.undeclared_declarations_by_constraint.len();
+            if index >= len {
+                self.undeclared_declarations_by_constraint
+                    .resize(index + 1, None);
+            } else if let Some(interned_id) =
+                self.undeclared_declarations_by_constraint[reachability_constraint]
+            {
+                return interned_id;
+            }
+
+            let interned_id = self.interned_declarations.push(declarations);
+            self.undeclared_declarations_by_constraint[reachability_constraint] = Some(interned_id);
+            return interned_id;
+        }
+
         match self.interned_ids_by_declarations.entry(declarations) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
@@ -390,20 +401,8 @@ impl PlaceStateInterner {
     ) -> InternedPlaceStateId {
         // Other retained declarations rarely repeat. Keep the compact IDs without hashing every
         // declaration vector to find the occasional duplicate.
-        let declarations_id = if declarations.is_always_undeclared() {
+        let declarations_id = if declarations.undeclared_reachability_constraint().is_some() {
             self.intern_declarations(declarations)
-        } else if self.reuse_retained_undeclared
-            && let Some(reachability_constraint) = declarations.undeclared_reachability_constraint()
-        {
-            if let Some((last_constraint, interned_id)) = self.last_retained_undeclared
-                && last_constraint == reachability_constraint
-            {
-                interned_id
-            } else {
-                let interned_id = self.interned_declarations.push(declarations);
-                self.last_retained_undeclared = Some((reachability_constraint, interned_id));
-                interned_id
-            }
         } else {
             self.interned_declarations.push(declarations)
         };
@@ -1848,7 +1847,6 @@ impl<'db> UseDefMapBuilder<'db> {
             interned_bindings_capacity,
             interned_ids_by_declarations_capacity,
             interned_declarations_capacity,
-            place_state_count >= MIN_PLACE_STATE_COUNT_TO_REUSE_RETAINED_UNDECLARED,
         );
         // These fields are manually interned because they have a statistically high duplication rate (>50%).
         let bindings_by_definition = Self::intern_bindings_by_definition(

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -283,6 +283,9 @@ struct InternedDeclarationsId;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
 struct InternedPlaceStateId(InternedBindingsId, InternedDeclarationsId);
 
+// Small scopes rarely contain duplicate constrained undeclared states.
+const MIN_PLACE_STATE_COUNT_TO_REUSE_RETAINED_UNDECLARED: usize = 16;
+
 impl InternedPlaceStateId {
     fn bindings_id(self) -> InternedBindingsId {
         self.0
@@ -298,16 +301,20 @@ struct PlaceStateInterner {
     interned_ids_by_bindings: FxHashMap<Bindings, InternedBindingsId>,
     interned_declarations: IndexVec<InternedDeclarationsId, Declarations>,
     interned_ids_by_declarations: FxHashMap<Declarations, InternedDeclarationsId>,
-    // Undeclared states are common and can be interned by their dense constraint IDs.
-    undeclared_declarations_by_constraint:
-        IndexVec<ScopedReachabilityConstraintId, Option<InternedDeclarationsId>>,
+    last_retained_undeclared: Option<(ScopedReachabilityConstraintId, InternedDeclarationsId)>,
+    reuse_retained_undeclared: bool,
     // These values are extremely common, so avoid repeatedly hashing their small vectors.
     always_unbound_bindings: Option<InternedBindingsId>,
     always_undeclared_declarations: Option<InternedDeclarationsId>,
 }
 
 impl PlaceStateInterner {
-    fn with_capacity(bindings: usize, declaration_map: usize, declarations: usize) -> Self {
+    fn with_capacity(
+        bindings: usize,
+        declaration_map: usize,
+        declarations: usize,
+        reuse_retained_undeclared: bool,
+    ) -> Self {
         Self {
             interned_bindings: IndexVec::with_capacity(bindings),
             interned_ids_by_bindings: FxHashMap::with_capacity_and_hasher(bindings, FxBuildHasher),
@@ -316,7 +323,8 @@ impl PlaceStateInterner {
                 declaration_map,
                 FxBuildHasher,
             ),
-            undeclared_declarations_by_constraint: IndexVec::new(),
+            last_retained_undeclared: None,
+            reuse_retained_undeclared,
             always_unbound_bindings: None,
             always_undeclared_declarations: None,
         }
@@ -354,25 +362,6 @@ impl PlaceStateInterner {
             return interned_id;
         }
 
-        if let Some(reachability_constraint) = declarations.undeclared_reachability_constraint()
-            && !reachability_constraint.is_terminal()
-        {
-            let index = reachability_constraint.index();
-            let len = self.undeclared_declarations_by_constraint.len();
-            if index >= len {
-                self.undeclared_declarations_by_constraint
-                    .resize(index + 1, None);
-            } else if let Some(interned_id) =
-                self.undeclared_declarations_by_constraint[reachability_constraint]
-            {
-                return interned_id;
-            }
-
-            let interned_id = self.interned_declarations.push(declarations);
-            self.undeclared_declarations_by_constraint[reachability_constraint] = Some(interned_id);
-            return interned_id;
-        }
-
         match self.interned_ids_by_declarations.entry(declarations) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
@@ -401,8 +390,20 @@ impl PlaceStateInterner {
     ) -> InternedPlaceStateId {
         // Other retained declarations rarely repeat. Keep the compact IDs without hashing every
         // declaration vector to find the occasional duplicate.
-        let declarations_id = if declarations.undeclared_reachability_constraint().is_some() {
+        let declarations_id = if declarations.is_always_undeclared() {
             self.intern_declarations(declarations)
+        } else if self.reuse_retained_undeclared
+            && let Some(reachability_constraint) = declarations.undeclared_reachability_constraint()
+        {
+            if let Some((last_constraint, interned_id)) = self.last_retained_undeclared
+                && last_constraint == reachability_constraint
+            {
+                interned_id
+            } else {
+                let interned_id = self.interned_declarations.push(declarations);
+                self.last_retained_undeclared = Some((reachability_constraint, interned_id));
+                interned_id
+            }
         } else {
             self.interned_declarations.push(declarations)
         };
@@ -1847,6 +1848,7 @@ impl<'db> UseDefMapBuilder<'db> {
             interned_bindings_capacity,
             interned_ids_by_declarations_capacity,
             interned_declarations_capacity,
+            place_state_count >= MIN_PLACE_STATE_COUNT_TO_REUSE_RETAINED_UNDECLARED,
         );
         // These fields are manually interned because they have a statistically high duplication rate (>50%).
         let bindings_by_definition = Self::intern_bindings_by_definition(

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -304,13 +304,13 @@ struct PlaceStateInterner {
 }
 
 impl PlaceStateInterner {
-    fn with_capacity(bindings: usize, declarations: usize) -> Self {
+    fn with_capacity(bindings: usize, declaration_map: usize, declarations: usize) -> Self {
         Self {
             interned_bindings: IndexVec::with_capacity(bindings),
             interned_ids_by_bindings: FxHashMap::with_capacity_and_hasher(bindings, FxBuildHasher),
             interned_declarations: IndexVec::with_capacity(declarations),
             interned_ids_by_declarations: FxHashMap::with_capacity_and_hasher(
-                declarations,
+                declaration_map,
                 FxBuildHasher,
             ),
             always_unbound_bindings: None,
@@ -369,6 +369,21 @@ impl PlaceStateInterner {
             self.intern_bindings(bindings),
             self.intern_declarations(declarations),
         )
+    }
+
+    fn retain_place_state(
+        &mut self,
+        bindings: Bindings,
+        declarations: Declarations,
+    ) -> InternedPlaceStateId {
+        // Apart from the always-undeclared state, retained declarations rarely repeat. Keep the
+        // compact IDs without hashing every declaration vector to find the occasional duplicate.
+        let declarations_id = if declarations.is_always_undeclared() {
+            self.intern_declarations(declarations)
+        } else {
+            self.interned_declarations.push(declarations)
+        };
+        InternedPlaceStateId(self.intern_bindings(bindings), declarations_id)
     }
 }
 
@@ -1803,8 +1818,11 @@ impl<'db> UseDefMapBuilder<'db> {
             + self.enclosing_snapshots.len()
             + place_state_count;
         let interned_declarations_capacity = self.declarations_by_binding.len() + place_state_count;
+        let interned_ids_by_declarations_capacity =
+            self.declarations_by_binding.len() + self.member_states.len();
         let mut place_state_interner = PlaceStateInterner::with_capacity(
             interned_bindings_capacity,
+            interned_ids_by_declarations_capacity,
             interned_declarations_capacity,
         );
         // These fields are manually interned because they have a statistically high duplication rate (>50%).
@@ -1963,7 +1981,7 @@ impl<'db> UseDefMapBuilder<'db> {
 
         for place_state in place_states {
             let (bindings, declarations) = get_parts(place_state);
-            let interned_id = place_state_interner.intern_place_state(bindings, declarations);
+            let interned_id = place_state_interner.retain_place_state(bindings, declarations);
             interned_ids_by_place.push(interned_id);
         }
 

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -240,6 +240,8 @@
 //! [`SemanticIndexBuilder`](crate::builder::SemanticIndexBuilder), e.g. where it
 //! visits a `StmtIf` node.
 
+use std::collections::hash_map::Entry;
+
 use ruff_index::{FrozenIndexVec, Idx, IndexSlice, IndexVec, newtype_index};
 use ruff_text_size::TextRange;
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -1713,12 +1715,21 @@ impl<'db> UseDefMapBuilder<'db> {
         self.range_reachability.shrink_to_fit();
         self.enclosing_snapshots.shrink_to_fit();
 
-        let mut interned_bindings = IndexVec::with_capacity(self.bindings_by_definition.len());
+        let place_state_count = self.symbol_states.len()
+            + self.member_states.len()
+            + self.reachable_symbol_definitions.len()
+            + self.reachable_member_definitions.len();
+        let interned_bindings_capacity = self.bindings_by_definition.len()
+            + self.bindings_by_use.len()
+            + self.enclosing_snapshots.len()
+            + place_state_count;
+        let interned_declarations_capacity = self.declarations_by_binding.len() + place_state_count;
+        let mut interned_bindings = IndexVec::with_capacity(interned_bindings_capacity);
         let mut interned_ids_by_bindings =
-            FxHashMap::with_capacity_and_hasher(self.bindings_by_definition.len(), FxBuildHasher);
-        let mut interned_declarations = IndexVec::with_capacity(self.declarations_by_binding.len());
+            FxHashMap::with_capacity_and_hasher(interned_bindings_capacity, FxBuildHasher);
+        let mut interned_declarations = IndexVec::with_capacity(interned_declarations_capacity);
         let mut interned_ids_by_declarations =
-            FxHashMap::with_capacity_and_hasher(self.declarations_by_binding.len(), FxBuildHasher);
+            FxHashMap::with_capacity_and_hasher(interned_declarations_capacity, FxBuildHasher);
         // These fields are manually interned because they have a statistically high duplication rate (>50%).
         let bindings_by_definition = Self::intern_bindings_by_definition(
             self.bindings_by_definition,
@@ -1743,9 +1754,8 @@ impl<'db> UseDefMapBuilder<'db> {
             &mut interned_declarations,
             &mut interned_ids_by_declarations,
         );
-        let end_of_scope_members = Self::intern_place_states(
+        let end_of_scope_members = Self::intern_end_of_scope_members(
             self.member_states,
-            PlaceState::into_parts,
             &mut interned_bindings,
             &mut interned_ids_by_bindings,
             &mut interned_declarations,
@@ -1933,6 +1943,41 @@ impl<'db> UseDefMapBuilder<'db> {
         interned_ids_by_place
     }
 
+    fn intern_end_of_scope_members(
+        end_of_scope_members: IndexVec<ScopedMemberId, PlaceState>,
+        interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
+        interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
+        interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
+        interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
+    ) -> IndexVec<ScopedMemberId, InternedPlaceStateId> {
+        let mut interned_ids_by_member = IndexVec::with_capacity(end_of_scope_members.len());
+        let mut interned_ids_by_place_state =
+            FxHashMap::with_capacity_and_hasher(end_of_scope_members.len(), FxBuildHasher);
+
+        for place_state in end_of_scope_members {
+            let interned_id = match interned_ids_by_place_state.entry(place_state) {
+                Entry::Occupied(entry) => *entry.get(),
+                Entry::Vacant(entry) => {
+                    let place_state = entry.key();
+                    let interned_id = Self::intern_place_state(
+                        place_state.bindings().clone(),
+                        place_state.declarations().clone(),
+                        interned_bindings,
+                        interned_ids_by_bindings,
+                        interned_declarations,
+                        interned_ids_by_declarations,
+                    );
+                    entry.insert(interned_id);
+                    interned_id
+                }
+            };
+            interned_ids_by_member.push(interned_id);
+        }
+
+        interned_ids_by_member.shrink_to_fit();
+        interned_ids_by_member
+    }
+
     fn intern_place_state(
         bindings: Bindings,
         declarations: Declarations,
@@ -1941,21 +1986,22 @@ impl<'db> UseDefMapBuilder<'db> {
         interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
         interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
     ) -> InternedPlaceStateId {
-        let bindings_id = if let Some(bindings_id) = interned_ids_by_bindings.get(&bindings) {
-            *bindings_id
-        } else {
-            let bindings_id = interned_bindings.push(bindings.clone());
-            interned_ids_by_bindings.insert(bindings, bindings_id);
-            bindings_id
+        let bindings_id = match interned_ids_by_bindings.entry(bindings) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let bindings_id = interned_bindings.push(entry.key().clone());
+                entry.insert(bindings_id);
+                bindings_id
+            }
         };
-        let declarations_id =
-            if let Some(declarations_id) = interned_ids_by_declarations.get(&declarations) {
-                *declarations_id
-            } else {
-                let declarations_id = interned_declarations.push(declarations.clone());
-                interned_ids_by_declarations.insert(declarations, declarations_id);
+        let declarations_id = match interned_ids_by_declarations.entry(declarations) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                let declarations_id = interned_declarations.push(entry.key().clone());
+                entry.insert(declarations_id);
                 declarations_id
-            };
+            }
+        };
         InternedPlaceStateId(bindings_id, declarations_id)
     }
 

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -380,13 +380,20 @@ impl Bindings {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
 pub(crate) struct PlaceState {
     declarations: Declarations,
     bindings: Bindings,
 }
 
 impl PlaceState {
+    pub(super) fn from_parts(bindings: Bindings, declarations: Declarations) -> Self {
+        Self {
+            declarations,
+            bindings,
+        }
+    }
+
     /// Return a new [`PlaceState`] representing an unbound, undeclared place.
     pub(super) fn undefined(reachability: ScopedReachabilityConstraintId) -> Self {
         Self {
@@ -468,8 +475,13 @@ impl PlaceState {
         &self.declarations
     }
 
-    pub(super) fn into_parts(self) -> (Bindings, Declarations) {
-        (self.bindings, self.declarations)
+    pub(super) fn is_always_undefined(&self) -> bool {
+        self.bindings.is_always_unbound() && self.declarations.is_always_undeclared()
+    }
+
+    pub(super) fn finish(&mut self, reachability_constraints: &mut ReachabilityConstraintsBuilder) {
+        self.bindings.finish(reachability_constraints);
+        self.declarations.finish(reachability_constraints);
     }
 }
 

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -98,14 +98,24 @@ impl PreviousDefinitions {
 }
 
 impl Declarations {
-    pub(super) fn is_always_undeclared(&self) -> bool {
-        matches!(
-            self.live_declarations.as_slice(),
-            [LiveDeclaration {
+    pub(super) fn undeclared_reachability_constraint(
+        &self,
+    ) -> Option<ScopedReachabilityConstraintId> {
+        let [
+            LiveDeclaration {
                 declaration: ScopedDefinitionId::UNBOUND,
-                reachability_constraint: ScopedReachabilityConstraintId::ALWAYS_TRUE,
-            }]
-        )
+                reachability_constraint,
+            },
+        ] = self.live_declarations.as_slice()
+        else {
+            return None;
+        };
+        Some(*reachability_constraint)
+    }
+
+    pub(super) fn is_always_undeclared(&self) -> bool {
+        self.undeclared_reachability_constraint()
+            == Some(ScopedReachabilityConstraintId::ALWAYS_TRUE)
     }
 
     pub(super) fn undeclared(reachability_constraint: ScopedReachabilityConstraintId) -> Self {

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -445,6 +445,10 @@ impl PlaceState {
     pub(super) fn declarations(&self) -> &Declarations {
         &self.declarations
     }
+
+    pub(super) fn into_parts(self) -> (Bindings, Declarations) {
+        (self.bindings, self.declarations)
+    }
 }
 
 #[cfg(test)]

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -445,11 +445,6 @@ impl PlaceState {
     pub(super) fn declarations(&self) -> &Declarations {
         &self.declarations
     }
-
-    pub(super) fn finish(&mut self, reachability_constraints: &mut ReachabilityConstraintsBuilder) {
-        self.declarations.finish(reachability_constraints);
-        self.bindings.finish(reachability_constraints);
-    }
 }
 
 #[cfg(test)]

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -380,20 +380,13 @@ impl Bindings {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub(crate) struct PlaceState {
     declarations: Declarations,
     bindings: Bindings,
 }
 
 impl PlaceState {
-    pub(super) fn from_parts(bindings: Bindings, declarations: Declarations) -> Self {
-        Self {
-            declarations,
-            bindings,
-        }
-    }
-
     /// Return a new [`PlaceState`] representing an unbound, undeclared place.
     pub(super) fn undefined(reachability: ScopedReachabilityConstraintId) -> Self {
         Self {
@@ -475,13 +468,8 @@ impl PlaceState {
         &self.declarations
     }
 
-    pub(super) fn is_always_undefined(&self) -> bool {
-        self.bindings.is_always_unbound() && self.declarations.is_always_undeclared()
-    }
-
-    pub(super) fn finish(&mut self, reachability_constraints: &mut ReachabilityConstraintsBuilder) {
-        self.bindings.finish(reachability_constraints);
-        self.declarations.finish(reachability_constraints);
+    pub(super) fn into_parts(self) -> (Bindings, Declarations) {
+        (self.bindings, self.declarations)
     }
 }
 

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -98,6 +98,16 @@ impl PreviousDefinitions {
 }
 
 impl Declarations {
+    pub(super) fn is_always_undeclared(&self) -> bool {
+        matches!(
+            self.live_declarations.as_slice(),
+            [LiveDeclaration {
+                declaration: ScopedDefinitionId::UNBOUND,
+                reachability_constraint: ScopedReachabilityConstraintId::ALWAYS_TRUE,
+            }]
+        )
+    }
+
     pub(super) fn undeclared(reachability_constraint: ScopedReachabilityConstraintId) -> Self {
         let initial_declaration = LiveDeclaration {
             declaration: ScopedDefinitionId::UNBOUND,
@@ -203,6 +213,18 @@ pub(super) struct Bindings {
 }
 
 impl Bindings {
+    pub(super) fn is_always_unbound(&self) -> bool {
+        self.unbound_narrowing_constraint.is_none()
+            && matches!(
+                self.live_bindings.as_slice(),
+                [LiveBinding {
+                    binding: ScopedDefinitionId::UNBOUND,
+                    narrowing_constraint: ScopedNarrowingConstraint::ALWAYS_TRUE,
+                    reachability_constraint: ScopedReachabilityConstraintId::ALWAYS_TRUE,
+                }]
+            )
+    }
+
     pub(super) fn unbound_narrowing_constraint(&self) -> ScopedNarrowingConstraint {
         self.unbound_narrowing_constraint
             .unwrap_or(self.live_bindings[0].narrowing_constraint)


### PR DESCRIPTION
## Summary

When we finish building a semantic index, we retain the end-of-scope and reachable bindings and declarations for every symbol and member. We already interned some of these values, but retained symbol states and reachable states were still stored inline. Many of those states repeat, especially for undefined places. This PR stores retained use-def states as compact IDs into the existing bindings and declarations arenas.

I think the tradeoffs here are favorable: a 2.85% memory reduction on Prefect, a +1% walltime change on some real projects, a -1% a few others, and up to -3% on some of the micro-benchmarks. But it's a big memory win.
