### PR TITLE
Reserve AST Vec's with correct capacity for common cases

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1245,8 +1245,7 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprBoolOp {
         self.bump(TokenKind::from(op));
 
-        let mut values = Vec::with_capacity(2);
-        values.push(lhs);
+        let mut values = vec![lhs];
         let mut progress = ParserProgress::default();
 
         // Keep adding the expression to `values` until we see a different
@@ -2626,7 +2625,7 @@ impl<'src> Parser<'src> {
     fn parse_generators(&mut self) -> Vec<ast::Comprehension> {
         const GENERATOR_SET: TokenSet = TokenSet::new([TokenKind::For, TokenKind::Async]);
 
-        let mut generators = Vec::with_capacity(1);
+        let mut generators = vec![];
         let mut progress = ParserProgress::default();
 
         while self.at_ts(GENERATOR_SET) {
@@ -2669,7 +2668,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::In);
         let iter = self.parse_simple_expression(ExpressionContext::default());
 
-        let mut ifs = Vec::new();
+        let mut ifs = vec![];
         let mut progress = ParserProgress::default();
 
         while self.eat(TokenKind::If) {
@@ -2677,9 +2676,6 @@ impl<'src> Parser<'src> {
 
             let parsed_expr = self.parse_simple_expression(ExpressionContext::default());
 
-            if ifs.is_empty() {
-                ifs.reserve_exact(1);
-            }
             ifs.push(parsed_expr.expr);
         }
 

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1245,7 +1245,8 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprBoolOp {
         self.bump(TokenKind::from(op));
 
-        let mut values = vec![lhs];
+        let mut values = Vec::with_capacity(2);
+        values.push(lhs);
         let mut progress = ParserProgress::default();
 
         // Keep adding the expression to `values` until we see a different
@@ -2625,7 +2626,7 @@ impl<'src> Parser<'src> {
     fn parse_generators(&mut self) -> Vec<ast::Comprehension> {
         const GENERATOR_SET: TokenSet = TokenSet::new([TokenKind::For, TokenKind::Async]);
 
-        let mut generators = vec![];
+        let mut generators = Vec::with_capacity(1);
         let mut progress = ParserProgress::default();
 
         while self.at_ts(GENERATOR_SET) {
@@ -2668,7 +2669,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::In);
         let iter = self.parse_simple_expression(ExpressionContext::default());
 
-        let mut ifs = vec![];
+        let mut ifs = Vec::new();
         let mut progress = ParserProgress::default();
 
         while self.eat(TokenKind::If) {
@@ -2676,6 +2677,9 @@ impl<'src> Parser<'src> {
 
             let parsed_expr = self.parse_simple_expression(ExpressionContext::default());
 
+            if ifs.is_empty() {
+                ifs.reserve_exact(1);
+            }
             ifs.push(parsed_expr.expr);
         }
 

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -572,7 +572,21 @@ impl<'src> Parser<'src> {
         recovery_context_kind: RecoveryContextKind,
         parse_element: impl Fn(&mut Parser<'src>) -> T,
     ) -> Vec<T> {
-        let mut elements = Vec::new();
+        self.parse_comma_separated_list_into_vec_with_capacity(
+            recovery_context_kind,
+            parse_element,
+            0,
+        )
+    }
+
+    /// Parses a comma separated list of elements into a vector with an initial capacity.
+    fn parse_comma_separated_list_into_vec_with_capacity<T>(
+        &mut self,
+        recovery_context_kind: RecoveryContextKind,
+        parse_element: impl Fn(&mut Parser<'src>) -> T,
+        capacity: usize,
+    ) -> Vec<T> {
+        let mut elements = Vec::with_capacity(capacity);
         self.parse_comma_separated_list(recovery_context_kind, |p| elements.push(parse_element(p)));
         elements
     }

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -572,21 +572,7 @@ impl<'src> Parser<'src> {
         recovery_context_kind: RecoveryContextKind,
         parse_element: impl Fn(&mut Parser<'src>) -> T,
     ) -> Vec<T> {
-        self.parse_comma_separated_list_into_vec_with_capacity(
-            recovery_context_kind,
-            parse_element,
-            0,
-        )
-    }
-
-    /// Parses a comma separated list of elements into a vector with an initial capacity.
-    fn parse_comma_separated_list_into_vec_with_capacity<T>(
-        &mut self,
-        recovery_context_kind: RecoveryContextKind,
-        parse_element: impl Fn(&mut Parser<'src>) -> T,
-        capacity: usize,
-    ) -> Vec<T> {
-        let mut elements = Vec::with_capacity(capacity);
+        let mut elements = Vec::new();
         self.parse_comma_separated_list(recovery_context_kind, |p| elements.push(parse_element(p)));
         elements
     }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -614,11 +614,10 @@ impl<'src> Parser<'src> {
         // import ,
         // import x, y,
 
-        let mut names = self.parse_comma_separated_list_into_vec_with_capacity(
-            RecoveryContextKind::ImportNames,
-            |p| p.parse_alias(ImportStyle::Import),
-            1,
-        );
+        let mut names = self
+            .parse_comma_separated_list_into_vec(RecoveryContextKind::ImportNames, |p| {
+                p.parse_alias(ImportStyle::Import)
+            });
 
         if names.is_empty() {
             // test_err import_stmt_empty
@@ -692,7 +691,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::Import);
 
         let names_start = self.node_start();
-        let mut names = Vec::new();
+        let mut names = vec![];
         let mut seen_star_import = false;
 
         let parenthesized = Parenthesized::from(self.eat(TokenKind::Lpar));
@@ -1446,9 +1445,6 @@ impl<'src> Parser<'src> {
         });
 
         if self.at(TokenKind::Else) {
-            if elif_else_clauses.is_empty() {
-                elif_else_clauses.reserve_exact(1);
-            }
             elif_else_clauses.push(self.parse_elif_or_else_clause(ElifOrElse::Else));
         }
 
@@ -2282,17 +2278,15 @@ impl<'src> Parser<'src> {
                 // with (a | b) << c | d: ...
                 // # Postfix should still be parsed first
                 // with (a)[0] + b * c: ...
-                self.parse_comma_separated_list_into_vec_with_capacity(
+                self.parse_comma_separated_list_into_vec(
                     RecoveryContextKind::WithItems(WithItemKind::ParenthesizedExpression),
                     |p| p.parse_with_item(WithItemParsingState::Regular).item,
-                    1,
                 )
             }
         } else {
-            self.parse_comma_separated_list_into_vec_with_capacity(
+            self.parse_comma_separated_list_into_vec(
                 RecoveryContextKind::WithItems(WithItemKind::Unparenthesized),
                 |p| p.parse_with_item(WithItemParsingState::Regular).item,
-                1,
             )
         }
     }
@@ -2330,7 +2324,7 @@ impl<'src> Parser<'src> {
 
         self.bump(TokenKind::Lpar);
 
-        let mut parsed_with_items = Vec::with_capacity(1);
+        let mut parsed_with_items = vec![];
         let mut has_optional_vars = false;
 
         // test_err with_items_parenthesized_missing_comma
@@ -4006,9 +4000,6 @@ impl<'src> Parser<'src> {
         while recovery_kind.is_list_element(self) {
             progress.assert_progressing(self);
 
-            if clauses.is_empty() {
-                clauses.reserve_exact(1);
-            }
             clauses.push(parse_clause(self));
         }
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -614,10 +614,11 @@ impl<'src> Parser<'src> {
         // import ,
         // import x, y,
 
-        let mut names = self
-            .parse_comma_separated_list_into_vec(RecoveryContextKind::ImportNames, |p| {
-                p.parse_alias(ImportStyle::Import)
-            });
+        let mut names = self.parse_comma_separated_list_into_vec_with_capacity(
+            RecoveryContextKind::ImportNames,
+            |p| p.parse_alias(ImportStyle::Import),
+            1,
+        );
 
         if names.is_empty() {
             // test_err import_stmt_empty
@@ -691,7 +692,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::Import);
 
         let names_start = self.node_start();
-        let mut names = vec![];
+        let mut names = Vec::new();
         let mut seen_star_import = false;
 
         let parenthesized = Parenthesized::from(self.eat(TokenKind::Lpar));
@@ -1445,6 +1446,9 @@ impl<'src> Parser<'src> {
         });
 
         if self.at(TokenKind::Else) {
+            if elif_else_clauses.is_empty() {
+                elif_else_clauses.reserve_exact(1);
+            }
             elif_else_clauses.push(self.parse_elif_or_else_clause(ElifOrElse::Else));
         }
 
@@ -2278,15 +2282,17 @@ impl<'src> Parser<'src> {
                 // with (a | b) << c | d: ...
                 // # Postfix should still be parsed first
                 // with (a)[0] + b * c: ...
-                self.parse_comma_separated_list_into_vec(
+                self.parse_comma_separated_list_into_vec_with_capacity(
                     RecoveryContextKind::WithItems(WithItemKind::ParenthesizedExpression),
                     |p| p.parse_with_item(WithItemParsingState::Regular).item,
+                    1,
                 )
             }
         } else {
-            self.parse_comma_separated_list_into_vec(
+            self.parse_comma_separated_list_into_vec_with_capacity(
                 RecoveryContextKind::WithItems(WithItemKind::Unparenthesized),
                 |p| p.parse_with_item(WithItemParsingState::Regular).item,
+                1,
             )
         }
     }
@@ -2324,7 +2330,7 @@ impl<'src> Parser<'src> {
 
         self.bump(TokenKind::Lpar);
 
-        let mut parsed_with_items = vec![];
+        let mut parsed_with_items = Vec::with_capacity(1);
         let mut has_optional_vars = false;
 
         // test_err with_items_parenthesized_missing_comma
@@ -4000,6 +4006,9 @@ impl<'src> Parser<'src> {
         while recovery_kind.is_list_element(self) {
             progress.assert_progressing(self);
 
+            if clauses.is_empty() {
+                clauses.reserve_exact(1);
+            }
             clauses.push(parse_clause(self));
         }
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -614,10 +614,11 @@ impl<'src> Parser<'src> {
         // import ,
         // import x, y,
 
-        let mut names = self
-            .parse_comma_separated_list_into_vec(RecoveryContextKind::ImportNames, |p| {
-                p.parse_alias(ImportStyle::Import)
-            });
+        let mut names = self.parse_comma_separated_list_into_vec_with_capacity(
+            RecoveryContextKind::ImportNames,
+            |p| p.parse_alias(ImportStyle::Import),
+            1,
+        );
 
         if names.is_empty() {
             // test_err import_stmt_empty
@@ -691,7 +692,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::Import);
 
         let names_start = self.node_start();
-        let mut names = vec![];
+        let mut names = Vec::with_capacity(1);
         let mut seen_star_import = false;
 
         let parenthesized = Parenthesized::from(self.eat(TokenKind::Lpar));
@@ -1445,6 +1446,9 @@ impl<'src> Parser<'src> {
         });
 
         if self.at(TokenKind::Else) {
+            if elif_else_clauses.is_empty() {
+                elif_else_clauses.reserve_exact(1);
+            }
             elif_else_clauses.push(self.parse_elif_or_else_clause(ElifOrElse::Else));
         }
 
@@ -2278,15 +2282,17 @@ impl<'src> Parser<'src> {
                 // with (a | b) << c | d: ...
                 // # Postfix should still be parsed first
                 // with (a)[0] + b * c: ...
-                self.parse_comma_separated_list_into_vec(
+                self.parse_comma_separated_list_into_vec_with_capacity(
                     RecoveryContextKind::WithItems(WithItemKind::ParenthesizedExpression),
                     |p| p.parse_with_item(WithItemParsingState::Regular).item,
+                    1,
                 )
             }
         } else {
-            self.parse_comma_separated_list_into_vec(
+            self.parse_comma_separated_list_into_vec_with_capacity(
                 RecoveryContextKind::WithItems(WithItemKind::Unparenthesized),
                 |p| p.parse_with_item(WithItemParsingState::Regular).item,
+                1,
             )
         }
     }
@@ -2324,7 +2330,7 @@ impl<'src> Parser<'src> {
 
         self.bump(TokenKind::Lpar);
 
-        let mut parsed_with_items = vec![];
+        let mut parsed_with_items = Vec::with_capacity(1);
         let mut has_optional_vars = false;
 
         // test_err with_items_parenthesized_missing_comma
@@ -4000,6 +4006,9 @@ impl<'src> Parser<'src> {
         while recovery_kind.is_list_element(self) {
             progress.assert_progressing(self);
 
+            if clauses.is_empty() {
+                clauses.reserve_exact(1);
+            }
             clauses.push(parse_clause(self));
         }
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -692,7 +692,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::Import);
 
         let names_start = self.node_start();
-        let mut names = Vec::with_capacity(1);
+        let mut names = Vec::new();
         let mut seen_star_import = false;
 
         let parenthesized = Parenthesized::from(self.eat(TokenKind::Lpar));


### PR DESCRIPTION
## Summary

There are some AST fields for which the most common case is that they contain exactly one element or two elements. This PR makes use of this knowledge by reserving the expected capacity. Reserving the exact capacity over using Vec's default capacity of 4 has the advantage that `shrink_to_fit` does not need to reallocate if we guessed the number of items correctly. 

There is a downside to this and this is that Vec will now grow more slowly from 1 to 2, to 4 where before it was 0 -> 4 with a single allocation. The benchmarks suggest that we get the number right in most cases and this outweights the few instances where we have to do extra re-salloc when going from 1 to 2, and then from 2 to 4 elements.


| Area | Handling added | Reason | Correct capacity |
|---|---|---|---:|
| `StmtImport.names` | capacity `1` | imports are nonempty and often singleton | 100.00% |
| `StmtImportFrom.names` | capacity `1` | from-import names are nonempty and singleton-biased | 70.50% |
| `StmtWith.items` | capacity `1` | with statements require at least one item and are usually singleton | 87.68% |
| `ExprBoolOp.values` | capacity `2` | bool ops have known minimum lhs + rhs | 89.07% |
| comprehension `generators` | capacity `1` | comprehensions require at least one generator | 94.13% |
| `Comprehension.ifs` | allocate only on first `if` | most comprehensions have no `if` | 99.90% |
| `StmtIf.elif_else_clauses` | allocate only on first clause | many `if`s have no clauses; first clause is common | 96.56% |
| `StmtTry.handlers` | allocate only on first handler | `try/finally` can have no handlers; first handler is common | 79.22% |
| **Total** |  |  | **83.65%** |

`7.44 MB` appeared to be an accidental extra value, so I removed it.


These numbers are from running ruff's parser over all Python files in pytest, typeshed, home-assistant-core, anyio, mypy, fastapi, pandas, flake8, trio, sphinx, and prefect.

