### PR TITLE
[ty] Consolidate AST ID reverse lookup

### DIFF
--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -1,11 +1,13 @@
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
+use ruff_db::files::File;
 use ruff_index::{IndexVec, newtype_index};
 use ruff_python_ast as ast;
 use ruff_python_ast::ExprRef;
 
 use crate::Db;
-use crate::scope::{FileScopeId, ScopeId};
+use crate::frozen::FrozenMap;
+use crate::scope::FileScopeId;
 use crate::semantic_index;
 
 pub use node_key::ExpressionNodeKey;
@@ -27,7 +29,7 @@ pub use node_key::ExpressionNodeKey;
 #[derive(Debug, salsa::Update, get_size2::GetSize)]
 pub(crate) struct AstIds {
     /// Maps expressions which "use" a place (that is, [`ast::ExprName`], [`ast::ExprAttribute`] or [`ast::ExprSubscript`]) to a use id.
-    uses_map: FxHashMap<ExpressionNodeKey, ScopedUseId>,
+    uses_map: FrozenMap<ExpressionNodeKey, ScopedUseId>,
 }
 
 impl AstIds {
@@ -42,9 +44,9 @@ impl AstIds {
             }
         }
 
-        uses_map.shrink_to_fit();
-
-        Self { uses_map }
+        Self {
+            uses_map: FrozenMap::from(uses_map),
+        }
     }
 
     fn use_id(&self, key: impl Into<ExpressionNodeKey>) -> ScopedUseId {
@@ -52,8 +54,8 @@ impl AstIds {
     }
 }
 
-fn ast_ids<'db>(db: &'db dyn Db, scope: ScopeId) -> &'db AstIds {
-    semantic_index(db, scope.file(db)).ast_ids()
+fn ast_ids(db: &dyn Db, file: File) -> &AstIds {
+    semantic_index(db, file).ast_ids()
 }
 
 /// Uniquely identifies a use of a name in a [`crate::FileScopeId`].
@@ -62,48 +64,48 @@ fn ast_ids<'db>(db: &'db dyn Db, scope: ScopeId) -> &'db AstIds {
 pub struct ScopedUseId;
 
 pub trait HasScopedUseId {
-    /// Returns the ID that uniquely identifies the use in `scope`.
-    fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId;
+    /// Returns the ID that uniquely identifies the use in its scope.
+    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId;
 }
 
 impl HasScopedUseId for ast::Identifier {
-    fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId {
-        let ast_ids = ast_ids(db, scope);
+    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
+        let ast_ids = ast_ids(db, file);
         ast_ids.use_id(self)
     }
 }
 
 impl HasScopedUseId for ast::ExprName {
-    fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
         let expression_ref = ExprRef::from(self);
-        expression_ref.scoped_use_id(db, scope)
+        expression_ref.scoped_use_id(db, file)
     }
 }
 
 impl HasScopedUseId for ast::ExprAttribute {
-    fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
         let expression_ref = ExprRef::from(self);
-        expression_ref.scoped_use_id(db, scope)
+        expression_ref.scoped_use_id(db, file)
     }
 }
 
 impl HasScopedUseId for ast::ExprSubscript {
-    fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
         let expression_ref = ExprRef::from(self);
-        expression_ref.scoped_use_id(db, scope)
+        expression_ref.scoped_use_id(db, file)
     }
 }
 
 impl HasScopedUseId for ast::Keyword {
-    fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId {
-        let ast_ids = ast_ids(db, scope);
+    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
+        let ast_ids = ast_ids(db, file);
         ast_ids.use_id(self)
     }
 }
 
 impl HasScopedUseId for ast::ExprRef<'_> {
-    fn scoped_use_id(&self, db: &dyn Db, scope: ScopeId) -> ScopedUseId {
-        let ast_ids = ast_ids(db, scope);
+    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
+        let ast_ids = ast_ids(db, file);
         ast_ids.use_id(*self)
     }
 }

--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -1,21 +1,20 @@
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
-use ruff_index::newtype_index;
+use ruff_index::{IndexVec, newtype_index};
 use ruff_python_ast as ast;
 use ruff_python_ast::ExprRef;
 
 use crate::Db;
-use crate::scope::ScopeId;
+use crate::scope::{FileScopeId, ScopeId};
 use crate::semantic_index;
 
 pub use node_key::ExpressionNodeKey;
 
-/// AST ids for a single scope.
+/// AST ids for a file.
 ///
-/// The motivation for building the AST ids per scope isn't about reducing invalidation because
-/// the struct changes whenever the parsed AST changes. Instead, it's mainly that we can
-/// build the AST ids struct when building the place table and also keep the property that
-/// IDs of outer scopes are unaffected by changes in inner scopes.
+/// Use IDs are assigned per scope while building the semantic index. This keeps the property that
+/// IDs of outer scopes are unaffected by changes in inner scopes. Node IDs are unique within a
+/// file, so the final reverse lookup can merge the per-scope maps into a single map.
 ///
 /// For example, we don't want that adding new statements to `foo` changes the statement id of `x = foo()` in:
 ///
@@ -32,13 +31,29 @@ pub(crate) struct AstIds {
 }
 
 impl AstIds {
+    pub(super) fn from_builders(builders: IndexVec<FileScopeId, AstIdsBuilder>) -> Self {
+        let capacity = builders.iter().map(|builder| builder.uses_map.len()).sum();
+        let mut uses_map = FxHashMap::with_capacity_and_hasher(capacity, FxBuildHasher);
+
+        for builder in builders {
+            for (key, use_id) in builder.uses_map {
+                let previous = uses_map.insert(key, use_id);
+                debug_assert!(previous.is_none());
+            }
+        }
+
+        uses_map.shrink_to_fit();
+
+        Self { uses_map }
+    }
+
     fn use_id(&self, key: impl Into<ExpressionNodeKey>) -> ScopedUseId {
         self.uses_map[&key.into()]
     }
 }
 
 fn ast_ids<'db>(db: &'db dyn Db, scope: ScopeId) -> &'db AstIds {
-    semantic_index(db, scope.file(db)).ast_ids(scope.file_scope_id(db))
+    semantic_index(db, scope.file(db)).ast_ids()
 }
 
 /// Uniquely identifies a use of a name in a [`crate::FileScopeId`].
@@ -108,12 +123,6 @@ impl AstIdsBuilder {
 
     pub(super) fn try_use_id(&self, key: impl Into<ExpressionNodeKey>) -> Option<ScopedUseId> {
         self.uses_map.get(&key.into()).copied()
-    }
-
-    pub(super) fn finish(self) -> AstIds {
-        AstIds {
-            uses_map: self.uses_map,
-        }
     }
 }
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2221,16 +2221,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             .map(|builder| Arc::new(builder.finish()))
             .collect();
 
-        let mut ast_ids: IndexVec<_, _> = self
-            .ast_ids
-            .into_iter()
-            .map(super::ast_ids::AstIdsBuilder::finish)
-            .collect();
+        let ast_ids = super::ast_ids::AstIds::from_builders(self.ast_ids);
 
         self.scopes.shrink_to_fit();
         place_tables.shrink_to_fit();
         use_def_maps.shrink_to_fit();
-        ast_ids.shrink_to_fit();
         self.scope_ids_by_scope.shrink_to_fit();
         let mut semantic_syntax_errors = self.semantic_syntax_errors.into_inner();
         semantic_syntax_errors.shrink_to_fit();

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
-use ruff_index::{FrozenIndexVec, IndexSlice, IndexVec};
+use ruff_index::{FrozenIndexVec, IndexSlice};
 use ruff_python_ast::NodeIndex;
 use ruff_python_parser::semantic_errors::SemanticSyntaxError;
 use ruff_text_size::TextRange;
@@ -1456,8 +1456,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             .elt
             .as_name_expr()
             .unwrap();
-        let element_use_id =
-            element.scoped_use_id(&db, comprehension_scope_id.to_scope_id(&db, file));
+        let element_use_id = element.scoped_use_id(&db, file);
 
         let binding = use_def.first_binding_at_use(element_use_id).unwrap();
         let DefinitionKind::Comprehension(comprehension) = binding.kind(&db) else {
@@ -1727,7 +1726,7 @@ class C[T]:
         let ast::Expr::Name(x_use_expr_name) = x_use_expr.as_ref() else {
             panic!("expected a Name");
         };
-        let x_use_id = x_use_expr_name.scoped_use_id(&db, scope);
+        let x_use_id = x_use_expr_name.scoped_use_id(&db, file);
         let use_def = use_def_map(&db, scope);
         let binding = use_def.first_binding_at_use(x_use_id).unwrap();
         let DefinitionKind::Assignment(assignment) = binding.kind(&db) else {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -305,7 +305,7 @@ pub struct SemanticIndex<'db> {
     ///
     /// Note: We should not depend on this map when analysing other files or
     /// changing a file invalidates all dependents.
-    ast_ids: IndexVec<FileScopeId, AstIds>,
+    ast_ids: AstIds,
 
     /// The set of modules that are imported anywhere within this file.
     imported_modules: Arc<FrozenSet<ModuleName>>,
@@ -371,8 +371,8 @@ impl<'db> SemanticIndex<'db> {
     }
 
     #[track_caller]
-    pub(crate) fn ast_ids(&self, scope_id: FileScopeId) -> &AstIds {
-        &self.ast_ids[scope_id]
+    pub(crate) fn ast_ids(&self) -> &AstIds {
+        &self.ast_ids
     }
 
     /// Returns the ID of the `expression`'s enclosing scope.

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -428,7 +428,7 @@ impl<'db> OverloadLiteral<'db> {
             .expect_function()
             .node(&module)
             .name
-            .scoped_use_id(db, scope);
+            .scoped_use_id(db, self.file(db));
 
         let Place::Defined(DefinedPlace {
             ty: Type::FunctionLiteral(previous_type),

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7542,7 +7542,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Collect the types of each distinct key.
         let mut elements: Vec<(&str, Type<'db>)> = Vec::new();
 
-        for bindings in use_def.multi_bindings_at_use(keyword.scoped_use_id(db, self.scope())) {
+        for bindings in use_def.multi_bindings_at_use(keyword.scoped_use_id(db, self.file())) {
             let place = place_from_bindings(db, bindings.clone());
             let Some(key) = place.first_definition.and_then(definition_key) else {
                 continue;
@@ -8613,7 +8613,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return (place, None);
             }
 
-            let use_id = expr_ref.scoped_use_id(db, scope);
+            let use_id = expr_ref.scoped_use_id(db, self.file());
             let place = place_from_bindings(db, use_def.bindings_at_use(use_id)).place;
 
             (place, Some(use_id))


### PR DESCRIPTION
## Summary

Consolidates the per-scope AST ID reverse lookup maps into a single file-level map. IDs are still assigned per scope, preserving stable outer-scope IDs while reducing retained map overhead.