### PR TITLE
Add missing primer projects to good.txt

### DIFF
--- a/crates/ty_python_semantic/resources/primer/good.txt
+++ b/crates/ty_python_semantic/resources/primer/good.txt
@@ -44,6 +44,7 @@ dacite
 dd-trace-py
 dedupe
 discord.py
+django-modern-rest
 django-stubs
 django-test-migrations
 docstring-adder
@@ -115,6 +116,7 @@ pyp
 pyppeteer
 pyproject-metadata
 pytest
+pytest-autoprofile
 pytest-robotframework
 python-chess
 python-htmlgen


### PR DESCRIPTION
## Summary
Add `django-modern-rest` and `pytest-autoprofile` to the ty primer `good.txt` list. These upstream projects completed `uvx ty check` without crashing, panicking, or timing out