### PR TITLE
[parser] Bound iterative expression chains to avoid stack overflow

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -261,6 +261,16 @@ impl<'src> Parser<'src> {
     ) -> ParsedExpr {
         let mut progress = ParserProgress::default();
 
+        // Each iteration of this loop deepens the left-associative spine of the
+        // resulting tree by one level (`((a op b) op c) op ...`). Because the
+        // loop is iterative it bypasses the `with_recursion` guard, so without
+        // an explicit bound a chain such as `1 + 1 + ... + 1` builds a tree of
+        // unbounded depth. That tree parses fine but overflows the native stack
+        // when it is later traversed or dropped (the derived drop glue recurses
+        // once per level). Counting the spine against `depth_remaining` keeps
+        // the total tree depth within `max_recursion_depth`.
+        let mut chain_depth: u16 = 0;
+
         loop {
             progress.assert_progressing(self);
 
@@ -289,6 +299,12 @@ impl<'src> Parser<'src> {
             };
 
             if stop_at_current_operator {
+                break;
+            }
+
+            chain_depth += 1;
+            if chain_depth >= self.depth_remaining {
+                self.report_recursion_limit_exceeded(self.current_token_range());
                 break;
             }
 
@@ -757,7 +773,18 @@ impl<'src> Parser<'src> {
         start: TextSize,
         context: ExpressionContext,
     ) -> Expr {
+        // Chained postfix (`f()()...`, `a[0][0]...`, `a.b.c...`) keeps bracket
+        // nesting balanced (and `.` has none), so it slips past the `nesting()`
+        // guards below and builds a left spine deep enough to overflow the
+        // stack on drop. Bound the chain length against the recursion budget.
+        let mut chain_depth: u16 = 0;
         loop {
+            chain_depth += 1;
+            if chain_depth >= self.depth_remaining {
+                self.report_recursion_limit_exceeded(self.current_token_range());
+                break lhs;
+            }
+
             lhs = match self.current_token_kind() {
                 TokenKind::Lpar => {
                     if self.tokens.nesting() > self.max_nesting_depth {

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -404,3 +404,113 @@ fn recursion_limit_nested_lambda_chain() {
         err.error
     );
 }
+
+#[test]
+fn recursion_limit_left_assoc_binary_chain() {
+    // `1+1+1+...+1` — left-associative binary operators are parsed iteratively
+    // (precedence climbing), so the left spine grows one level per operator
+    // *without* recursing into `parse_binary_expression_or_higher`. The tree
+    // builds fine but its depth equals the operator count, which overflows the
+    // native stack when the tree is later traversed or dropped. The chain
+    // length must be bounded by `max_recursion_depth`.
+    let depth = 5_000;
+    let mut src = String::with_capacity(depth * 2 + 1);
+    for _ in 0..depth {
+        src.push_str("1+");
+    }
+    src.push('1');
+    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
+    let err = parse(&src, opts).unwrap_err();
+    assert!(
+        matches!(err.error, ParseErrorType::RecursionLimitExceeded),
+        "expected RecursionLimitExceeded, got {:?}",
+        err.error
+    );
+}
+
+#[test]
+fn recursion_limit_attribute_chain() {
+    // `a.b.b.b...` — attribute access is a postfix operator parsed in a loop
+    // and introduces no bracket nesting, so it bypasses the postfix
+    // `nesting()` guard entirely. Each `.b` adds one level to the left spine.
+    let depth = 5_000;
+    let mut src = String::from("a");
+    for _ in 0..depth {
+        src.push_str(".b");
+    }
+    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
+    let err = parse(&src, opts).unwrap_err();
+    assert!(
+        matches!(err.error, ParseErrorType::RecursionLimitExceeded),
+        "expected RecursionLimitExceeded, got {:?}",
+        err.error
+    );
+}
+
+#[test]
+fn recursion_limit_call_chain() {
+    // `f()()()...` — chained calls return the lexer bracket nesting to zero
+    // between each `()`, so the postfix `nesting()` guard never fires; the
+    // chain length must instead be bounded directly.
+    let depth = 5_000;
+    let mut src = String::from("f");
+    for _ in 0..depth {
+        src.push_str("()");
+    }
+    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
+    let err = parse(&src, opts).unwrap_err();
+    assert!(
+        matches!(err.error, ParseErrorType::RecursionLimitExceeded),
+        "expected RecursionLimitExceeded, got {:?}",
+        err.error
+    );
+}
+
+#[test]
+fn recursion_limit_subscript_chain() {
+    // `a[0][0][0]...` — like chained calls, the brackets are balanced between
+    // each subscript, so `nesting()` returns to zero and the chain length must
+    // be bounded directly.
+    let depth = 5_000;
+    let mut src = String::from("a");
+    for _ in 0..depth {
+        src.push_str("[0]");
+    }
+    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
+    let err = parse(&src, opts).unwrap_err();
+    assert!(
+        matches!(err.error, ParseErrorType::RecursionLimitExceeded),
+        "expected RecursionLimitExceeded, got {:?}",
+        err.error
+    );
+}
+
+#[test]
+fn recursion_limit_flat_chains_not_rejected() {
+    // Boolean and comparison chains flatten into a single `BoolOp` / `Compare`
+    // node with a flat operand list rather than a deep tree, so they are safe
+    // to drop at any length and must NOT count against the recursion limit,
+    // even far beyond `max_recursion_depth`. Guards against a regression where
+    // the chain guard is applied to these flattened operators too.
+    let depth = 5_000;
+
+    let mut bool_chain = String::from("x = 1");
+    for _ in 0..depth {
+        bool_chain.push_str(" and 1");
+    }
+    parse(
+        &bool_chain,
+        ParseOptions::from(Mode::Module).with_max_recursion_depth(100),
+    )
+    .expect("flat boolean chain should parse regardless of length");
+
+    let mut cmp_chain = String::from("x = 1");
+    for _ in 0..depth {
+        cmp_chain.push_str(" < 1");
+    }
+    parse(
+        &cmp_chain,
+        ParseOptions::from(Mode::Module).with_max_recursion_depth(100),
+    )
+    .expect("flat comparison chain should parse regardless of length");
+}

--- a/crates/ty/tests/cli/main.rs
+++ b/crates/ty/tests/cli/main.rs
@@ -815,8 +815,13 @@ fn concise_revealed_type() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Very large flat expressions such as `1 + 1 + ... + 1` build a deeply nested
+/// AST (one `BinOp` per operator). The parser bounds the chain length against
+/// `max_recursion_depth` so the tree can never grow deep enough to overflow the
+/// stack when it is later traversed or dropped, reporting a syntax error
+/// instead. See the `recursion_limit_*` tests in `ruff_python_parser`.
 #[test]
-fn can_handle_large_binop_expressions() -> anyhow::Result<()> {
+fn large_binop_expressions_are_bounded() -> anyhow::Result<()> {
     let mut content = String::new();
     writeln!(
         &mut content,
@@ -831,14 +836,14 @@ fn can_handle_large_binop_expressions() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", &ruff_python_trivia::textwrap::dedent(&content))?;
 
     assert_cmd_snapshot!(case.command(), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
-    info[revealed-type]: Revealed type
-     --> test.py:4:13
+    error[invalid-syntax]: Source is too deeply nested
+     --> test.py:3:815
       |
-    4 | reveal_type(total)
-      |             ^^^^^ `Literal[2000]`
+    3 | …1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 …
+      |                                                                    ^
       |
 
     Found 1 diagnostic

--- a/crates/ty_server/tests/e2e/pull_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/pull_diagnostics.rs
@@ -353,7 +353,12 @@ def foo(
     Ok(())
 }
 
-/// Regression test for <https://github.com/astral-sh/ty/issues/2310>
+/// Regression test for <https://github.com/astral-sh/ty/issues/2310>.
+///
+/// A very large flat expression (`1 + 1 + ... + 1`) builds a deeply nested AST
+/// that could overflow the stack when traversed or dropped. The parser now
+/// bounds the chain length against `max_recursion_depth` and reports a syntax
+/// error, so the server returns a diagnostic instead of crashing.
 #[test]
 fn stack_size() -> Result<()> {
     use std::fmt::Write;

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__stack_size.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__stack_size.snap
@@ -9,18 +9,18 @@ expression: diagnostics
     {
       "range": {
         "start": {
-          "line": 3,
-          "character": 12
+          "line": 2,
+          "character": 814
         },
         "end": {
-          "line": 3,
-          "character": 17
+          "line": 2,
+          "character": 815
         }
       },
-      "severity": 3,
-      "code": "revealed-type",
+      "severity": 1,
+      "code": "invalid-syntax",
       "source": "ty",
-      "message": "Revealed type: `Literal[2000]`"
+      "message": "Source is too deeply nested"
     }
   ]
 }


### PR DESCRIPTION
I'm not convinced you'll merge this, but without it #24810 isn't that useful - code can build extremely deep ast nodes which stackoverflow when the panic.

Happy to discuss a better approach, I wanted to get feedback before going further.

---

## Summary

Left-associative binary chains (`1+1+...`) and postfix chains (`f()()...`, `a[0][0]...`, `a.b.c...`) are parsed in iterative loops (precedence climbing / postfix dispatch) rather than via recursion, so they bypass the `with_recursion` depth guard. The lexer `nesting()` guard only catches *accumulating* brackets like `f(f(...))`; chained postfix keeps nesting balanced (and `.` has no bracket at all), so it slips through entirely.

The result is a tree whose depth equals the operator/postfix count. It parses fine, but the derived drop glue recurses once per level, so dropping (or otherwise traversing) a sufficiently deep tree overflows the native stack -- a limit-independent DoS for consumers that parse untrusted source.

Count each chain level against `depth_remaining` in both loops so the total tree depth stays within `max_recursion_depth`, yielding a clean `RecursionLimitExceeded` instead of an abort. Flat `and`/comparison chains are unaffected: they flatten into a single `BoolOp`/`Compare` node and are safe to drop at any length.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
