### PR TITLE
[ty] Temporary fix for `PropagatedPanic` crashes

### DIFF
--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -13,7 +13,7 @@ use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{File, Files};
 use ruff_db::system::System;
 use ruff_db::vendored::VendoredFileSystem;
-use salsa::{Database, Event, Setter};
+use salsa::{Database, Durability, Event, Setter};
 use ty_module_resolver::SearchPaths;
 use ty_python_core::program::{
     FallibleStrategy, MisconfigurationStrategy, Program, UseDefaultStrategy,
@@ -167,10 +167,10 @@ impl ProjectDatabase {
     ///
     /// WARNING: Triggers a new revision, canceling other database handles. This can lead to deadlock.
     pub fn system_mut(&mut self) -> &mut dyn System {
-        self.trigger_cancellation();
+        self.synthetic_write(Durability::LOW);
 
         Arc::get_mut(&mut self.system).expect(
-            "ref count should be 1 because `trigger_cancellation` drops all other DB references.",
+            "ref count should be 1 because `synthetic_write` drops all other DB references.",
         )
     }
 
@@ -775,4 +775,105 @@ pub(crate) mod tests {
 
     #[salsa::db]
     impl salsa::Database for TestDb {}
+}
+
+#[cfg(test)]
+pub(crate) mod cancellation_tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::{Duration, Instant};
+
+    use ruff_db::system::{SystemPathBuf, TestSystem};
+    use ruff_python_ast::name::Name;
+    use salsa::Cancelled;
+
+    use crate::db::Db;
+    use crate::{ProjectDatabase, ProjectMetadata};
+
+    #[derive(Debug, Default)]
+    struct CancellationGate {
+        started: AtomicBool,
+        resume: AtomicBool,
+    }
+
+    impl CancellationGate {
+        fn wait_until_started(&self) {
+            let start = Instant::now();
+            while !self.started.load(Ordering::Acquire) {
+                assert!(
+                    start.elapsed() < Duration::from_secs(10),
+                    "timed out waiting for fixpoint query"
+                );
+                std::thread::yield_now();
+            }
+        }
+    }
+
+    #[salsa::input]
+    struct FixpointInput {
+        #[returns(ref)]
+        gate: Arc<CancellationGate>,
+    }
+
+    #[salsa::tracked(cycle_initial=fixpoint_initial)]
+    fn interruptible_fixpoint_query(db: &dyn Db, input: FixpointInput) -> u32 {
+        let gate = input.gate(db);
+        gate.started.store(true, Ordering::Release);
+        while !gate.resume.load(Ordering::Acquire) {
+            db.unwind_if_revision_cancelled();
+            std::thread::yield_now();
+        }
+        42
+    }
+
+    fn fixpoint_initial(_db: &dyn Db, _id: salsa::Id, _input: FixpointInput) -> u32 {
+        0
+    }
+
+    pub(crate) fn assert_cancelled_fixpoint_recomputes<D, F>(mut db: D, mutate: F)
+    where
+        D: Db + Clone + Send + 'static,
+        F: FnOnce(&mut D),
+    {
+        let input = FixpointInput::new(&db, Arc::new(CancellationGate::default()));
+        let gate = Arc::clone(input.gate(&db));
+        let db_worker = db.clone();
+        let worker = std::thread::spawn(move || {
+            catch_unwind(AssertUnwindSafe(|| {
+                interruptible_fixpoint_query(&db_worker, input)
+            }))
+        });
+
+        gate.wait_until_started();
+        mutate(&mut db);
+
+        let cancelled = worker.join().unwrap().unwrap_err();
+        assert!(matches!(
+            cancelled.downcast_ref::<Cancelled>(),
+            Some(Cancelled::PendingWrite)
+        ));
+
+        gate.resume.store(true, Ordering::Release);
+        let recomputed = catch_unwind(AssertUnwindSafe(|| {
+            interruptible_fixpoint_query(&db, input)
+        }))
+        .unwrap_or_else(|error| {
+            panic!(
+                "fixpoint query failed after cancellation: {:?}",
+                error.downcast_ref::<Cancelled>()
+            )
+        });
+        assert_eq!(recomputed, 42);
+    }
+
+    #[test]
+    fn cancelling_fixpoint_while_mutably_accessing_system_allows_recomputation() {
+        let metadata = ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/test"));
+        let db = ProjectDatabase::use_defaults(metadata, TestSystem::default());
+
+        assert_cancelled_fixpoint_recomputes(db, |db| {
+            db.system_mut();
+        });
+    }
 }

--- a/crates/ty_project/src/files.rs
+++ b/crates/ty_project/src/files.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use rustc_hash::FxHashSet;
-use salsa::Setter;
+use salsa::{Durability, Setter};
 
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::File;
@@ -20,7 +20,9 @@ use crate::db::Db;
 /// without triggering a new salsa revision. This is safe because the initial indexing happens on first access,
 /// so no query can be depending on the contents of the indexed files before that. All subsequent mutations to
 /// the indexed files must go through `IndexedMut`, which uses the Salsa setter `project.set_file_set` to
-/// ensure that Salsa always knows when the set of indexed files have changed.
+/// ensure that Salsa always knows when the set of indexed files have changed. Mutations that
+/// do not set a new file set use a synthetic write because acquiring mutable access cancels
+/// pending queries.
 #[derive(Debug, get_size2::GetSize)]
 pub struct IndexedFiles {
     state: std::sync::Mutex<State>,
@@ -83,8 +85,11 @@ impl IndexedFiles {
 
         let indexed = match state {
             // If it's already lazy, just return. We also don't need to restore anything because the
-            // replace above was a no-op.
-            State::Lazy => return None,
+            // replace above was a no-op. The preceding cancellation still requires a new revision.
+            State::Lazy => {
+                db.synthetic_write(Durability::LOW);
+                return None;
+            }
             State::Indexed(indexed) => indexed,
         };
 
@@ -241,6 +246,7 @@ impl IndexedMut<'_> {
         } else {
             // The `indexed_mut` replaced the `state` with Lazy. Restore it back to the indexed state.
             *self.project.file_set(db).state.lock().unwrap() = State::Indexed(indexed);
+            db.synthetic_write(Durability::LOW);
         }
     }
 }
@@ -257,11 +263,41 @@ mod tests {
 
     use crate::ProjectMetadata;
     use crate::db::Db;
+    use crate::db::cancellation_tests::assert_cancelled_fixpoint_recomputes;
     use crate::db::tests::TestDb;
     use crate::files::Index;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{DbWithWritableSystem as _, SystemPathBuf};
     use ruff_python_ast::name::Name;
+
+    #[test]
+    fn cancelling_fixpoint_while_files_are_lazy_allows_recomputation() {
+        let metadata = ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/test"));
+        let db = TestDb::new(metadata);
+        let project = db.project();
+
+        assert_cancelled_fixpoint_recomputes(db, |db| {
+            project.replace_index_diagnostics(db, Vec::new());
+        });
+    }
+
+    #[test]
+    fn cancelling_fixpoint_while_restoring_unchanged_files_allows_recomputation() {
+        let metadata = ProjectMetadata::new(Name::new_static("test"), SystemPathBuf::from("/test"));
+        let db = TestDb::new(metadata);
+        let project = db.project();
+
+        match project.file_set(&db).get() {
+            Index::Lazy(lazy) => {
+                lazy.set(FxHashSet::default(), Vec::new());
+            }
+            Index::Indexed(_) => panic!("expected lazy file set"),
+        }
+
+        assert_cancelled_fixpoint_recomputes(db, |db| {
+            project.replace_index_diagnostics(db, Vec::new());
+        });
+    }
 
     #[test]
     fn re_entrance() -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

This is a workaround for #3339 to give me some more time to implement a proper fix in Salsa. 

The issue is that the fixpoint computation incorrectly assumes that the only reason a fixpoint query can panic is a bug in the implementation. In which case it doesn't make sense to re-run the query within the same revision because it is only going to panic again (we don't re-run the query in the same revision because there are stale values from the previous revision that Salsa might end up picking up as fresh values). However, that's not the case. The query can also panic if the execution gets cancelled because another thread tries to write (tries to acquire a mut db). 

This PR works around this limitation by changing all code paths in ty where we acquire a &mut Db without bumping the revision so that we bump the revision instead. This has the downside that Salsa has to do a little more work to verify that it's okay to reuse all cached queries (because nothing changed). But this seems clearly better than just crashing (and many users seem to be running into this).