### PR TITLE
Guarantee minimum stack size when parsing a module, standalone expression, and suites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,6 +2318,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,6 +2737,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -3522,6 +3550,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "stacker",
  "static_assertions",
  "thin-vec",
  "unicode-ident",
@@ -4061,6 +4090,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.0",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,7 +575,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.19",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -685,7 +694,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1035,7 +1044,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1115,7 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -2301,6 +2310,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +2748,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -3603,6 +3631,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "stacker",
  "static_assertions",
  "thin-vec",
  "unicode-ident",
@@ -3839,7 +3868,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4143,6 +4172,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stacker"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4249,7 +4291,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4259,7 +4301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5431,7 +5473,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,7 @@ snapbox = { version = "1.0.0", features = [
     "examples",
 ] }
 static_assertions = "1.1.0"
+stacker = "0.1.24"
 strum = { version = "0.28.0", features = ["strum_macros"] }
 strum_macros = { version = "0.28.0" }
 supports-hyperlinks = { version = "3.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ snapbox = { version = "1.0.0", features = [
     "examples",
 ] }
 static_assertions = "1.1.0"
+stacker = "0.1.24"
 strum = { version = "0.28.0", features = ["strum_macros"] }
 strum_macros = { version = "0.28.0" }
 supports-hyperlinks = { version = "3.1.0" }

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -24,6 +24,7 @@ get-size2 = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
 static_assertions = { workspace = true }
+stacker = { workspace = true }
 thin-vec = { workspace = true }
 unicode-ident = { workspace = true }
 unicode-normalization = { workspace = true }

--- a/crates/ruff_python_parser/src/error.rs
+++ b/crates/ruff_python_parser/src/error.rs
@@ -205,9 +205,6 @@ pub enum ParseErrorType {
     TStringError(InterpolatedStringErrorType),
     /// Parser encountered an error during lexing.
     Lexical(LexicalErrorType),
-
-    /// Parser aborted because [`crate::ParseOptions::max_recursion_depth`] was exceeded.
-    RecursionLimitExceeded,
 }
 
 impl ParseErrorType {
@@ -339,7 +336,6 @@ impl std::fmt::Display for ParseErrorType {
             ParseErrorType::UnexpectedExpressionToken => {
                 write!(f, "Unexpected token at the end of an expression")
             }
-            ParseErrorType::RecursionLimitExceeded => f.write_str("Source is too deeply nested"),
         }
     }
 }

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -123,12 +123,6 @@ impl<'src> Lexer<'src> {
         self.current_range
     }
 
-    /// Returns the current parenthesis, bracket, and brace nesting level.
-    #[inline]
-    pub(crate) const fn nesting(&self) -> u32 {
-        self.nesting
-    }
-
     /// Returns the flags for the current token.
     pub(crate) const fn current_flags(&self) -> TokenFlags {
         self.current_flags

--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -123,6 +123,12 @@ impl<'src> Lexer<'src> {
         self.current_range
     }
 
+    /// Returns the current parenthesis, bracket, and brace nesting level.
+    #[inline]
+    pub(crate) const fn nesting(&self) -> u32 {
+        self.nesting
+    }
+
     /// Returns the flags for the current token.
     pub(crate) const fn current_flags(&self) -> TokenFlags {
         self.current_flags

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -86,6 +86,13 @@ mod token_set;
 mod token_source;
 pub mod typing;
 
+// Windows test threads have a 1 MiB stack by default. Keep successfully parsed
+// recursive ASTs shallow enough for their unprotected drop glue in debug builds.
+#[cfg(all(test, target_os = "windows"))]
+const RECURSIVE_AST_TEST_DEPTH: usize = 1_000;
+#[cfg(all(test, not(target_os = "windows")))]
+const RECURSIVE_AST_TEST_DEPTH: usize = 5_000;
+
 /// Parse a full Python module usually consisting of multiple lines.
 ///
 /// This is a convenience function that can be used to parse a full Python program without having to

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -87,13 +87,6 @@ mod token_set;
 mod token_source;
 pub mod typing;
 
-// Windows test threads have a 1 MiB stack by default. Keep successfully parsed
-// recursive ASTs shallow enough for their unprotected drop glue in debug builds.
-#[cfg(all(test, target_os = "windows"))]
-const RECURSIVE_AST_TEST_DEPTH: usize = 1_000;
-#[cfg(all(test, not(target_os = "windows")))]
-const RECURSIVE_AST_TEST_DEPTH: usize = 5_000;
-
 /// Parse a full Python module usually consisting of multiple lines.
 ///
 /// This is a convenience function that can be used to parse a full Python program without having to

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -87,6 +87,13 @@ mod token_set;
 mod token_source;
 pub mod typing;
 
+// Windows test threads have a 1 MiB stack by default. Keep successfully parsed
+// recursive ASTs shallow enough for their unprotected drop glue in debug builds.
+#[cfg(all(test, target_os = "windows"))]
+const RECURSIVE_AST_TEST_DEPTH: usize = 1_000;
+#[cfg(all(test, not(target_os = "windows")))]
+const RECURSIVE_AST_TEST_DEPTH: usize = 5_000;
+
 /// Parse a full Python module usually consisting of multiple lines.
 ///
 /// This is a convenience function that can be used to parse a full Python program without having to

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -343,15 +343,6 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> ParsedExpr {
         let token = self.current_token_kind();
-        self.parse_lhs_expression_inner(left_precedence, context, token)
-    }
-
-    fn parse_lhs_expression_inner(
-        &mut self,
-        left_precedence: OperatorPrecedence,
-        context: ExpressionContext,
-        token: TokenKind,
-    ) -> ParsedExpr {
         let start = self.node_start();
 
         if let Some(unary_op) = token.as_unary_operator() {

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -27,10 +27,7 @@ use crate::{
     UnsupportedSyntaxErrorKind,
 };
 
-use super::{
-    InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind,
-    STACK_GROWTH_NESTING_THRESHOLD,
-};
+use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind};
 
 /// A token set consisting of a newline or end of file.
 const NEWLINE_EOF_SET: TokenSet = TokenSet::new([TokenKind::Newline, TokenKind::EndOfFile]);
@@ -305,17 +302,7 @@ impl<'src> Parser<'src> {
                 BinaryLikeOperator::Binary(bin_op) => {
                     self.bump(TokenKind::from(bin_op));
 
-                    let right = if new_precedence.is_right_associative() {
-                        // For right-associative operators (`**`), the right
-                        // operand recursion is unbounded in `a**a**a**...`,
-                        // and it bypasses stack growth in `parse_lhs_expression`
-                        // (that scope is exited once the atom is parsed).
-                        self.with_grown_stack(|parser| {
-                            parser.parse_binary_expression_or_higher(new_precedence, context)
-                        })
-                    } else {
-                        self.parse_binary_expression_or_higher(new_precedence, context)
-                    };
+                    let right = self.parse_binary_expression_or_higher(new_precedence, context);
 
                     Expr::BinOp(ast::ExprBinOp {
                         left: Box::new(left.expr),
@@ -346,31 +333,7 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> ParsedExpr {
         let token = self.current_token_kind();
-        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD
-            && !Self::token_starts_unnested_recursive_lhs(token)
-        {
-            return self.parse_lhs_expression_inner(left_precedence, context, token);
-        }
-
-        self.with_grown_stack(|parser| {
-            parser.parse_lhs_expression_inner(left_precedence, context, token)
-        })
-    }
-
-    /// Returns whether parsing an expression that starts with `token` can recurse without
-    /// first increasing delimiter nesting.
-    #[inline]
-    fn token_starts_unnested_recursive_lhs(token: TokenKind) -> bool {
-        token.as_unary_operator().is_some()
-            || matches!(
-                token,
-                TokenKind::Star
-                    | TokenKind::Await
-                    | TokenKind::Lambda
-                    | TokenKind::Yield
-                    | TokenKind::FStringStart
-                    | TokenKind::TStringStart
-            )
+        self.parse_lhs_expression_inner(left_precedence, context, token)
     }
 
     fn parse_lhs_expression_inner(
@@ -689,10 +652,10 @@ impl<'src> Parser<'src> {
                 self.parse_strings()
             }
             TokenKind::Lpar => {
-                return self.parse_parenthesized_expression();
+                return self.with_grown_stack(Self::parse_parenthesized_expression);
             }
-            TokenKind::Lsqb => self.parse_list_like_expression(),
-            TokenKind::Lbrace => self.parse_set_or_dict_like_expression(),
+            TokenKind::Lsqb => self.with_grown_stack(Self::parse_list_like_expression),
+            TokenKind::Lbrace => self.with_grown_stack(Self::parse_set_or_dict_like_expression),
 
             kind => {
                 if kind.is_keyword() {
@@ -722,6 +685,22 @@ impl<'src> Parser<'src> {
     ///
     /// This method does nothing if the current token is not a candidate for a postfix expression.
     pub(super) fn parse_postfix_expression(
+        &mut self,
+        lhs: Expr,
+        start: TextSize,
+        context: ExpressionContext,
+    ) -> Expr {
+        if !matches!(
+            self.current_token_kind(),
+            TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Dot
+        ) {
+            return lhs;
+        }
+
+        self.with_grown_stack(|parser| parser.parse_postfix_expression_inner(lhs, start, context))
+    }
+
+    fn parse_postfix_expression_inner(
         &mut self,
         mut lhs: Expr,
         start: TextSize,
@@ -2989,9 +2968,7 @@ impl<'src> Parser<'src> {
         // lambda x: yield y
         // lambda x: yield from y
 
-        // `lambda: lambda: lambda: ...` recurses through the lambda body at
-        // the conditional layer, bypassing stack growth in `parse_lhs_expression`.
-        let body = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
+        let body = self.parse_conditional_expression_or_higher();
 
         ast::ExprLambda {
             body: Box::new(body.expr),
@@ -3015,9 +2992,7 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Else);
 
-        // `a if b else a if b else ...` recurses through `orelse` at the
-        // conditional layer, which is not covered by stack growth in
-        // `parse_lhs_expression` (that scope is released once each atom is parsed).
+        // `a if b else a if b else ...` recurses through the `orelse` expression.
         let orelse = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
 
         ast::ExprIf {

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -303,6 +303,10 @@ impl<'src> Parser<'src> {
                     self.bump(TokenKind::from(bin_op));
 
                     let right = if new_precedence.is_right_associative() {
+                        // For right-associative operators (`**`), the right
+                        // operand recursion is unbounded in `a**a**a**...`,
+                        // and it bypasses stack growth in `parse_lhs_expression`
+                        // (that scope is exited once the atom is parsed).
                         self.with_grown_stack(|parser| {
                             parser.parse_binary_expression_or_higher(new_precedence, context)
                         })
@@ -2969,6 +2973,8 @@ impl<'src> Parser<'src> {
         // lambda x: yield y
         // lambda x: yield from y
 
+        // `lambda: lambda: lambda: ...` recurses through the lambda body at
+        // the conditional layer, bypassing stack growth in `parse_lhs_expression`.
         let body = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
 
         ast::ExprLambda {
@@ -2993,6 +2999,9 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Else);
 
+        // `a if b else a if b else ...` recurses through `orelse` at the
+        // conditional layer, which is not covered by stack growth in
+        // `parse_lhs_expression` (that scope is released once each atom is parsed).
         let orelse = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
 
         ast::ExprIf {

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -27,10 +27,7 @@ use crate::{
     UnsupportedSyntaxErrorKind,
 };
 
-use super::{
-    InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind,
-    STACK_GROWTH_NESTING_THRESHOLD,
-};
+use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind};
 
 /// A token set consisting of a newline or end of file.
 const NEWLINE_EOF_SET: TokenSet = TokenSet::new([TokenKind::Newline, TokenKind::EndOfFile]);
@@ -346,31 +343,7 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> ParsedExpr {
         let token = self.current_token_kind();
-        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD
-            && !Self::token_starts_unnested_recursive_lhs(token)
-        {
-            return self.parse_lhs_expression_inner(left_precedence, context, token);
-        }
-
-        self.with_grown_stack(|parser| {
-            parser.parse_lhs_expression_inner(left_precedence, context, token)
-        })
-    }
-
-    /// Returns whether parsing an expression that starts with `token` can recurse without
-    /// first increasing delimiter nesting.
-    #[inline]
-    fn token_starts_unnested_recursive_lhs(token: TokenKind) -> bool {
-        token.as_unary_operator().is_some()
-            || matches!(
-                token,
-                TokenKind::Star
-                    | TokenKind::Await
-                    | TokenKind::Lambda
-                    | TokenKind::Yield
-                    | TokenKind::FStringStart
-                    | TokenKind::TStringStart
-            )
+        self.parse_lhs_expression_inner(left_precedence, context, token)
     }
 
     fn parse_lhs_expression_inner(
@@ -689,10 +662,11 @@ impl<'src> Parser<'src> {
                 self.parse_strings()
             }
             TokenKind::Lpar => {
-                return self.parse_parenthesized_expression();
+                // Nested content re-enters expression parsing after the opening delimiter.
+                return self.with_grown_stack(Self::parse_parenthesized_expression);
             }
-            TokenKind::Lsqb => self.parse_list_like_expression(),
-            TokenKind::Lbrace => self.parse_set_or_dict_like_expression(),
+            TokenKind::Lsqb => self.with_grown_stack(Self::parse_list_like_expression),
+            TokenKind::Lbrace => self.with_grown_stack(Self::parse_set_or_dict_like_expression),
 
             kind => {
                 if kind.is_keyword() {
@@ -729,8 +703,12 @@ impl<'src> Parser<'src> {
     ) -> Expr {
         loop {
             lhs = match self.current_token_kind() {
-                TokenKind::Lpar => Expr::Call(self.parse_call_expression(lhs, start)),
-                TokenKind::Lsqb => Expr::Subscript(self.parse_subscript_expression(lhs, start)),
+                TokenKind::Lpar => Expr::Call(
+                    self.with_grown_stack(|parser| parser.parse_call_expression(lhs, start)),
+                ),
+                TokenKind::Lsqb => Expr::Subscript(
+                    self.with_grown_stack(|parser| parser.parse_subscript_expression(lhs, start)),
+                ),
                 TokenKind::Dot => {
                     Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
                 }
@@ -1161,7 +1139,9 @@ impl<'src> Parser<'src> {
             self.bump(TokenKind::from(nested_op));
         }
 
-        let operand = self.parse_binary_expression_or_higher(precedence, context);
+        let operand = self.with_grown_stack(|parser| {
+            parser.parse_binary_expression_or_higher(precedence, context)
+        });
         let operand =
             nested_operators
                 .into_iter()
@@ -1646,11 +1626,13 @@ impl<'src> Parser<'src> {
         let mut flags = self.tokens.current_flags().as_any_string_flags();
 
         self.bump(kind.start_token());
-        let elements = self.parse_interpolated_string_elements(
-            flags,
-            InterpolatedStringElementsKind::Regular(kind),
-            kind,
-        );
+        let elements = self.with_grown_stack(|parser| {
+            parser.parse_interpolated_string_elements(
+                flags,
+                InterpolatedStringElementsKind::Regular(kind),
+                kind,
+            )
+        });
 
         if !self.expect(kind.end_token()) {
             flags = flags.with_unclosed(true);
@@ -2775,19 +2757,21 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::Star);
 
-        let parsed_expr = match context.starred_expression_precedence() {
-            StarredExpressionPrecedence::Conditional => self
-                .parse_conditional_expression_or_higher_impl(
-                    // test_err starred_starred_expression
-                    // print(*
-                    // *[])
-                    // print(* *[])
-                    context.disallow_starred_expressions(),
-                ),
-            StarredExpressionPrecedence::BitwiseOr => {
-                self.parse_expression_with_bitwise_or_precedence()
+        let parsed_expr = self.with_grown_stack(|parser| {
+            match context.starred_expression_precedence() {
+                StarredExpressionPrecedence::Conditional => parser
+                    .parse_conditional_expression_or_higher_impl(
+                        // test_err starred_starred_expression
+                        // print(*
+                        // *[])
+                        // print(* *[])
+                        context.disallow_starred_expressions(),
+                    ),
+                StarredExpressionPrecedence::BitwiseOr => {
+                    parser.parse_expression_with_bitwise_or_precedence()
+                }
             }
-        };
+        });
 
         ast::ExprStarred {
             value: Box::new(parsed_expr.expr),
@@ -2808,10 +2792,12 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::Await);
 
-        let parsed_expr = self.parse_binary_expression_or_higher(
-            OperatorPrecedence::Await,
-            ExpressionContext::default(),
-        );
+        let parsed_expr = self.with_grown_stack(|parser| {
+            parser.parse_binary_expression_or_higher(
+                OperatorPrecedence::Await,
+                ExpressionContext::default(),
+            )
+        });
 
         ast::ExprAwait {
             value: Box::new(parsed_expr.expr),
@@ -2836,7 +2822,9 @@ impl<'src> Parser<'src> {
         }
 
         let value = self.at_expr().then(|| {
-            let parsed_expr = self.parse_expression_list(ExpressionContext::starred_bitwise_or());
+            let parsed_expr = self.with_grown_stack(|parser| {
+                parser.parse_expression_list(ExpressionContext::starred_bitwise_or())
+            });
 
             // test_ok iter_unpack_yield_py37
             // # parse_options: {"target-version": "3.7"}
@@ -2892,7 +2880,7 @@ impl<'src> Parser<'src> {
         // would have stopped at the comma. Then, the outer expression would
         // have been a tuple expression with two elements: `yield from x` and `y`.
         let expr = self
-            .parse_expression_list(ExpressionContext::default())
+            .with_grown_stack(|parser| parser.parse_expression_list(ExpressionContext::default()))
             .expr;
 
         match &expr {

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -303,18 +303,9 @@ impl<'src> Parser<'src> {
                     self.bump(TokenKind::from(bin_op));
 
                     let right = if new_precedence.is_right_associative() {
-                        // For right-associative operators (`**`), the right
-                        // operand recursion is unbounded in `a**a**a**...`,
-                        // and it bypasses the guard in `parse_lhs_expression`
-                        // (that scope is exited once the atom is parsed).
-                        if let Some(right) = self.with_recursion(|parser| {
+                        self.with_grown_stack(|parser| {
                             parser.parse_binary_expression_or_higher(new_precedence, context)
-                        }) {
-                            right
-                        } else {
-                            self.report_recursion_limit_exceeded(self.current_token_range());
-                            self.recursion_recovery_expr()
-                        }
+                        })
                     } else {
                         self.parse_binary_expression_or_higher(new_precedence, context)
                     };
@@ -352,14 +343,15 @@ impl<'src> Parser<'src> {
             return self.parse_lhs_expression_inner(left_precedence, context, token);
         }
 
-        if let Some(result) = self.with_recursion(|parser| {
-            parser.parse_lhs_expression_inner(left_precedence, context, token)
-        }) {
-            result
-        } else {
-            self.report_recursion_limit_exceeded(self.current_token_range());
-            self.recursion_recovery_expr()
+        if matches!(token, TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Lbrace) {
+            return self.with_grown_delimited_stack(|parser| {
+                parser.parse_lhs_expression_inner(left_precedence, context, token)
+            });
         }
+
+        self.with_grown_stack(|parser| {
+            parser.parse_lhs_expression_inner(left_precedence, context, token)
+        })
     }
 
     /// Returns whether parsing an expression that starts with `token` can
@@ -379,20 +371,6 @@ impl<'src> Parser<'src> {
                     | TokenKind::Lsqb
                     | TokenKind::Lbrace
             )
-    }
-
-    /// The standard expression-recovery node returned when the recursion
-    /// limit is exceeded: an empty `Name` with the `Invalid` context.
-    fn recursion_recovery_expr(&mut self) -> ParsedExpr {
-        ParsedExpr {
-            expr: Expr::Name(ast::ExprName {
-                range: self.missing_node_range(),
-                id: Name::empty(),
-                ctx: ExprContext::Invalid,
-                node_index: AtomicNodeIndex::NONE,
-            }),
-            is_parenthesized: false,
-        }
     }
 
     fn parse_lhs_expression_inner(
@@ -750,26 +728,19 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> Expr {
         loop {
-            lhs = match self.current_token_kind() {
-                TokenKind::Lpar => {
-                    if self.tokens.nesting() > self.max_nesting_depth {
-                        self.report_recursion_limit_exceeded(self.current_token_range());
-                        break lhs;
+            lhs =
+                match self.current_token_kind() {
+                    TokenKind::Lpar => Expr::Call(self.with_grown_delimited_stack(|parser| {
+                        parser.parse_call_expression(lhs, start)
+                    })),
+                    TokenKind::Lsqb => Expr::Subscript(self.with_grown_delimited_stack(|parser| {
+                        parser.parse_subscript_expression(lhs, start)
+                    })),
+                    TokenKind::Dot => {
+                        Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
                     }
-                    Expr::Call(self.parse_call_expression(lhs, start))
-                }
-                TokenKind::Lsqb => {
-                    if self.tokens.nesting() > self.max_nesting_depth {
-                        self.report_recursion_limit_exceeded(self.current_token_range());
-                        break lhs;
-                    }
-                    Expr::Subscript(self.parse_subscript_expression(lhs, start))
-                }
-                TokenKind::Dot => {
-                    Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
-                }
-                _ => break lhs,
-            };
+                    _ => break lhs,
+                };
         }
     }
 
@@ -1903,18 +1874,13 @@ impl<'src> Parser<'src> {
 
         let format_spec = if self.eat(TokenKind::Colon) {
             let spec_start = self.node_start();
-            let elements = if let Some(elements) = self.with_recursion(|parser| {
+            let elements = self.with_grown_stack(|parser| {
                 parser.parse_interpolated_string_elements(
                     flags,
                     InterpolatedStringElementsKind::FormatSpec(string_kind),
                     string_kind,
                 )
-            }) {
-                elements
-            } else {
-                self.report_recursion_limit_exceeded(self.current_token_range());
-                ast::InterpolatedStringElements::from(vec![])
-            };
+            });
             Some(Box::new(ast::InterpolatedStringFormatSpec {
                 range: self.node_range(spec_start),
                 elements,
@@ -3003,15 +2969,7 @@ impl<'src> Parser<'src> {
         // lambda x: yield y
         // lambda x: yield from y
 
-        // `lambda: lambda: lambda: ...` recurses through the lambda body at
-        // the conditional layer, bypassing the `parse_lhs_expression` guard.
-        let body =
-            if let Some(body) = self.with_recursion(Self::parse_conditional_expression_or_higher) {
-                body
-            } else {
-                self.report_recursion_limit_exceeded(self.current_token_range());
-                self.recursion_recovery_expr()
-            };
+        let body = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
 
         ast::ExprLambda {
             body: Box::new(body.expr),
@@ -3035,17 +2993,7 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Else);
 
-        // `a if b else a if b else ...` recurses through `orelse` at the
-        // conditional layer, which is not covered by the `parse_lhs_expression`
-        // guard (that scope is released once each atom is parsed). Guard here.
-        let orelse = if let Some(orelse) =
-            self.with_recursion(Self::parse_conditional_expression_or_higher)
-        {
-            orelse
-        } else {
-            self.report_recursion_limit_exceeded(self.current_token_range());
-            self.recursion_recovery_expr()
-        };
+        let orelse = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
 
         ast::ExprIf {
             body: Box::new(body),

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -27,7 +27,10 @@ use crate::{
     UnsupportedSyntaxErrorKind,
 };
 
-use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind};
+use super::{
+    InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind,
+    STACK_GROWTH_NESTING_THRESHOLD,
+};
 
 /// A token set consisting of a newline or end of file.
 const NEWLINE_EOF_SET: TokenSet = TokenSet::new([TokenKind::Newline, TokenKind::EndOfFile]);
@@ -343,14 +346,10 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> ParsedExpr {
         let token = self.current_token_kind();
-        if !Self::token_starts_recursive_lhs(token) {
+        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD
+            && !Self::token_starts_unnested_recursive_lhs(token)
+        {
             return self.parse_lhs_expression_inner(left_precedence, context, token);
-        }
-
-        if matches!(token, TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Lbrace) {
-            return self.with_grown_delimited_stack(|parser| {
-                parser.parse_lhs_expression_inner(left_precedence, context, token)
-            });
         }
 
         self.with_grown_stack(|parser| {
@@ -358,10 +357,10 @@ impl<'src> Parser<'src> {
         })
     }
 
-    /// Returns whether parsing an expression that starts with `token` can
-    /// immediately recurse through another expression parse.
+    /// Returns whether parsing an expression that starts with `token` can recurse without
+    /// first increasing delimiter nesting.
     #[inline]
-    fn token_starts_recursive_lhs(token: TokenKind) -> bool {
+    fn token_starts_unnested_recursive_lhs(token: TokenKind) -> bool {
         token.as_unary_operator().is_some()
             || matches!(
                 token,
@@ -371,9 +370,6 @@ impl<'src> Parser<'src> {
                     | TokenKind::Yield
                     | TokenKind::FStringStart
                     | TokenKind::TStringStart
-                    | TokenKind::Lpar
-                    | TokenKind::Lsqb
-                    | TokenKind::Lbrace
             )
     }
 
@@ -732,19 +728,14 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> Expr {
         loop {
-            lhs =
-                match self.current_token_kind() {
-                    TokenKind::Lpar => Expr::Call(self.with_grown_delimited_stack(|parser| {
-                        parser.parse_call_expression(lhs, start)
-                    })),
-                    TokenKind::Lsqb => Expr::Subscript(self.with_grown_delimited_stack(|parser| {
-                        parser.parse_subscript_expression(lhs, start)
-                    })),
-                    TokenKind::Dot => {
-                        Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
-                    }
-                    _ => break lhs,
-                };
+            lhs = match self.current_token_kind() {
+                TokenKind::Lpar => Expr::Call(self.parse_call_expression(lhs, start)),
+                TokenKind::Lsqb => Expr::Subscript(self.parse_subscript_expression(lhs, start)),
+                TokenKind::Dot => {
+                    Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
+                }
+                _ => break lhs,
+            };
         }
     }
 

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -27,7 +27,10 @@ use crate::{
     UnsupportedSyntaxErrorKind,
 };
 
-use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind};
+use super::{
+    InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind,
+    STACK_GROWTH_NESTING_THRESHOLD,
+};
 
 /// A token set consisting of a newline or end of file.
 const NEWLINE_EOF_SET: TokenSet = TokenSet::new([TokenKind::Newline, TokenKind::EndOfFile]);
@@ -343,6 +346,39 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> ParsedExpr {
         let token = self.current_token_kind();
+        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD
+            && !Self::token_starts_unnested_recursive_lhs(token)
+        {
+            return self.parse_lhs_expression_inner(left_precedence, context, token);
+        }
+
+        self.with_grown_stack(|parser| {
+            parser.parse_lhs_expression_inner(left_precedence, context, token)
+        })
+    }
+
+    /// Returns whether parsing an expression that starts with `token` can recurse without
+    /// first increasing delimiter nesting.
+    #[inline]
+    fn token_starts_unnested_recursive_lhs(token: TokenKind) -> bool {
+        token.as_unary_operator().is_some()
+            || matches!(
+                token,
+                TokenKind::Star
+                    | TokenKind::Await
+                    | TokenKind::Lambda
+                    | TokenKind::Yield
+                    | TokenKind::FStringStart
+                    | TokenKind::TStringStart
+            )
+    }
+
+    fn parse_lhs_expression_inner(
+        &mut self,
+        left_precedence: OperatorPrecedence,
+        context: ExpressionContext,
+        token: TokenKind,
+    ) -> ParsedExpr {
         let start = self.node_start();
 
         if let Some(unary_op) = token.as_unary_operator() {
@@ -653,11 +689,10 @@ impl<'src> Parser<'src> {
                 self.parse_strings()
             }
             TokenKind::Lpar => {
-                // Nested content re-enters expression parsing after the opening delimiter.
-                return self.with_grown_stack(Self::parse_parenthesized_expression);
+                return self.parse_parenthesized_expression();
             }
-            TokenKind::Lsqb => self.with_grown_stack(Self::parse_list_like_expression),
-            TokenKind::Lbrace => self.with_grown_stack(Self::parse_set_or_dict_like_expression),
+            TokenKind::Lsqb => self.parse_list_like_expression(),
+            TokenKind::Lbrace => self.parse_set_or_dict_like_expression(),
 
             kind => {
                 if kind.is_keyword() {
@@ -694,12 +729,8 @@ impl<'src> Parser<'src> {
     ) -> Expr {
         loop {
             lhs = match self.current_token_kind() {
-                TokenKind::Lpar => Expr::Call(
-                    self.with_grown_stack(|parser| parser.parse_call_expression(lhs, start)),
-                ),
-                TokenKind::Lsqb => Expr::Subscript(
-                    self.with_grown_stack(|parser| parser.parse_subscript_expression(lhs, start)),
-                ),
+                TokenKind::Lpar => Expr::Call(self.parse_call_expression(lhs, start)),
+                TokenKind::Lsqb => Expr::Subscript(self.parse_subscript_expression(lhs, start)),
                 TokenKind::Dot => {
                     Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
                 }
@@ -1130,9 +1161,7 @@ impl<'src> Parser<'src> {
             self.bump(TokenKind::from(nested_op));
         }
 
-        let operand = self.with_grown_stack(|parser| {
-            parser.parse_binary_expression_or_higher(precedence, context)
-        });
+        let operand = self.parse_binary_expression_or_higher(precedence, context);
         let operand =
             nested_operators
                 .into_iter()
@@ -1617,13 +1646,11 @@ impl<'src> Parser<'src> {
         let mut flags = self.tokens.current_flags().as_any_string_flags();
 
         self.bump(kind.start_token());
-        let elements = self.with_grown_stack(|parser| {
-            parser.parse_interpolated_string_elements(
-                flags,
-                InterpolatedStringElementsKind::Regular(kind),
-                kind,
-            )
-        });
+        let elements = self.parse_interpolated_string_elements(
+            flags,
+            InterpolatedStringElementsKind::Regular(kind),
+            kind,
+        );
 
         if !self.expect(kind.end_token()) {
             flags = flags.with_unclosed(true);
@@ -2748,21 +2775,19 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::Star);
 
-        let parsed_expr = self.with_grown_stack(|parser| {
-            match context.starred_expression_precedence() {
-                StarredExpressionPrecedence::Conditional => parser
-                    .parse_conditional_expression_or_higher_impl(
-                        // test_err starred_starred_expression
-                        // print(*
-                        // *[])
-                        // print(* *[])
-                        context.disallow_starred_expressions(),
-                    ),
-                StarredExpressionPrecedence::BitwiseOr => {
-                    parser.parse_expression_with_bitwise_or_precedence()
-                }
+        let parsed_expr = match context.starred_expression_precedence() {
+            StarredExpressionPrecedence::Conditional => self
+                .parse_conditional_expression_or_higher_impl(
+                    // test_err starred_starred_expression
+                    // print(*
+                    // *[])
+                    // print(* *[])
+                    context.disallow_starred_expressions(),
+                ),
+            StarredExpressionPrecedence::BitwiseOr => {
+                self.parse_expression_with_bitwise_or_precedence()
             }
-        });
+        };
 
         ast::ExprStarred {
             value: Box::new(parsed_expr.expr),
@@ -2783,12 +2808,10 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::Await);
 
-        let parsed_expr = self.with_grown_stack(|parser| {
-            parser.parse_binary_expression_or_higher(
-                OperatorPrecedence::Await,
-                ExpressionContext::default(),
-            )
-        });
+        let parsed_expr = self.parse_binary_expression_or_higher(
+            OperatorPrecedence::Await,
+            ExpressionContext::default(),
+        );
 
         ast::ExprAwait {
             value: Box::new(parsed_expr.expr),
@@ -2813,9 +2836,7 @@ impl<'src> Parser<'src> {
         }
 
         let value = self.at_expr().then(|| {
-            let parsed_expr = self.with_grown_stack(|parser| {
-                parser.parse_expression_list(ExpressionContext::starred_bitwise_or())
-            });
+            let parsed_expr = self.parse_expression_list(ExpressionContext::starred_bitwise_or());
 
             // test_ok iter_unpack_yield_py37
             // # parse_options: {"target-version": "3.7"}
@@ -2871,7 +2892,7 @@ impl<'src> Parser<'src> {
         // would have stopped at the comma. Then, the outer expression would
         // have been a tuple expression with two elements: `yield from x` and `y`.
         let expr = self
-            .with_grown_stack(|parser| parser.parse_expression_list(ExpressionContext::default()))
+            .parse_expression_list(ExpressionContext::default())
             .expr;
 
         match &expr {

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1157,11 +1157,36 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::from(op));
 
-        let operand = self.parse_binary_expression_or_higher(OperatorPrecedence::from(op), context);
+        // Consecutive unary operators at the same precedence can be consumed
+        // iteratively and rebuilt after parsing the operand. Operators at
+        // differing precedences must retain the recursive path so binary
+        // expression binding and its diagnostics remain unchanged.
+        let precedence = OperatorPrecedence::from(op);
+        let mut nested_operators = Vec::new();
+        while let Some(nested_op) = self.current_token_kind().as_unary_operator()
+            && OperatorPrecedence::from(nested_op) == precedence
+        {
+            nested_operators.push((nested_op, self.node_start()));
+            self.bump(TokenKind::from(nested_op));
+        }
+
+        let operand = self.parse_binary_expression_or_higher(precedence, context);
+        let operand =
+            nested_operators
+                .into_iter()
+                .rev()
+                .fold(operand.expr, |operand, (op, start)| {
+                    Expr::UnaryOp(ast::ExprUnaryOp {
+                        op,
+                        operand: Box::new(operand),
+                        range: self.node_range(start),
+                        node_index: AtomicNodeIndex::NONE,
+                    })
+                });
 
         ast::ExprUnaryOp {
             op,
-            operand: Box::new(operand.expr),
+            operand: Box::new(operand),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -248,9 +248,11 @@ impl<'src> Parser<'src> {
         left_precedence: OperatorPrecedence,
         context: ExpressionContext,
     ) -> ParsedExpr {
-        let start = self.node_start();
-        let lhs = self.parse_lhs_expression(left_precedence, context);
-        self.parse_binary_expression_or_higher_recursive(lhs, left_precedence, context, start)
+        self.with_recursion(|parser| {
+            let start = parser.node_start();
+            let lhs = parser.parse_lhs_expression(left_precedence, context);
+            parser.parse_binary_expression_or_higher_recursive(lhs, left_precedence, context, start)
+        })
     }
 
     fn parse_binary_expression_or_higher_recursive(
@@ -334,15 +336,6 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> ParsedExpr {
         let token = self.current_token_kind();
-        self.parse_lhs_expression_inner(left_precedence, context, token)
-    }
-
-    fn parse_lhs_expression_inner(
-        &mut self,
-        left_precedence: OperatorPrecedence,
-        context: ExpressionContext,
-        token: TokenKind,
-    ) -> ParsedExpr {
         let start = self.node_start();
 
         if let Some(unary_op) = token.as_unary_operator() {
@@ -1124,36 +1117,11 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::from(op));
 
-        // Consecutive unary operators at the same precedence can be consumed
-        // iteratively and rebuilt after parsing the operand. Operators at
-        // differing precedences must retain the recursive path so binary
-        // expression binding and its diagnostics remain unchanged.
-        let precedence = OperatorPrecedence::from(op);
-        let mut nested_operators = Vec::new();
-        while let Some(nested_op) = self.current_token_kind().as_unary_operator()
-            && OperatorPrecedence::from(nested_op) == precedence
-        {
-            nested_operators.push((nested_op, self.node_start()));
-            self.bump(TokenKind::from(nested_op));
-        }
-
-        let operand = self.parse_binary_expression_or_higher(precedence, context);
-        let operand =
-            nested_operators
-                .into_iter()
-                .rev()
-                .fold(operand.expr, |operand, (op, start)| {
-                    Expr::UnaryOp(ast::ExprUnaryOp {
-                        op,
-                        operand: Box::new(operand),
-                        range: self.node_range(start),
-                        node_index: AtomicNodeIndex::NONE,
-                    })
-                });
+        let operand = self.parse_binary_expression_or_higher(OperatorPrecedence::from(op), context);
 
         ast::ExprUnaryOp {
             op,
-            operand: Box::new(operand),
+            operand: Box::new(operand.expr),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }
@@ -1852,11 +1820,13 @@ impl<'src> Parser<'src> {
 
         let format_spec = if self.eat(TokenKind::Colon) {
             let spec_start = self.node_start();
-            let elements = self.parse_interpolated_string_elements(
-                flags,
-                InterpolatedStringElementsKind::FormatSpec(string_kind),
-                string_kind,
-            );
+            let elements = self.with_recursion(|parser| {
+                parser.parse_interpolated_string_elements(
+                    flags,
+                    InterpolatedStringElementsKind::FormatSpec(string_kind),
+                    string_kind,
+                )
+            });
             Some(Box::new(ast::InterpolatedStringFormatSpec {
                 range: self.node_range(spec_start),
                 elements,
@@ -2935,7 +2905,8 @@ impl<'src> Parser<'src> {
         // lambda x: yield y
         // lambda x: yield from y
 
-        let body = self.parse_conditional_expression_or_higher();
+        // Lambda bodies recurse through the conditional layer without entering the binary parser.
+        let body = self.with_recursion(Self::parse_conditional_expression_or_higher);
 
         ast::ExprLambda {
             body: Box::new(body.expr),
@@ -2959,7 +2930,8 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Else);
 
-        let orelse = self.parse_conditional_expression_or_higher();
+        // The binary-expression guard has already returned before parsing the `else` branch.
+        let orelse = self.with_recursion(Self::parse_conditional_expression_or_higher);
 
         ast::ExprIf {
             body: Box::new(body),

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -28,7 +28,10 @@ use crate::{
     UnsupportedSyntaxErrorKind,
 };
 
-use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind};
+use super::{
+    InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind,
+    STACK_GROWTH_NESTING_THRESHOLD,
+};
 
 /// A token set consisting of a newline or end of file.
 const NEWLINE_EOF_SET: TokenSet = TokenSet::new([TokenKind::Newline, TokenKind::EndOfFile]);
@@ -344,14 +347,10 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> ParsedExpr {
         let token = self.current_token_kind();
-        if !Self::token_starts_recursive_lhs(token) {
+        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD
+            && !Self::token_starts_unnested_recursive_lhs(token)
+        {
             return self.parse_lhs_expression_inner(left_precedence, context, token);
-        }
-
-        if matches!(token, TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Lbrace) {
-            return self.with_grown_delimited_stack(|parser| {
-                parser.parse_lhs_expression_inner(left_precedence, context, token)
-            });
         }
 
         self.with_grown_stack(|parser| {
@@ -359,10 +358,10 @@ impl<'src> Parser<'src> {
         })
     }
 
-    /// Returns whether parsing an expression that starts with `token` can
-    /// immediately recurse through another expression parse.
+    /// Returns whether parsing an expression that starts with `token` can recurse without
+    /// first increasing delimiter nesting.
     #[inline]
-    fn token_starts_recursive_lhs(token: TokenKind) -> bool {
+    fn token_starts_unnested_recursive_lhs(token: TokenKind) -> bool {
         token.as_unary_operator().is_some()
             || matches!(
                 token,
@@ -372,9 +371,6 @@ impl<'src> Parser<'src> {
                     | TokenKind::Yield
                     | TokenKind::FStringStart
                     | TokenKind::TStringStart
-                    | TokenKind::Lpar
-                    | TokenKind::Lsqb
-                    | TokenKind::Lbrace
             )
     }
 
@@ -735,19 +731,14 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> Expr {
         loop {
-            lhs =
-                match self.current_token_kind() {
-                    TokenKind::Lpar => Expr::Call(self.with_grown_delimited_stack(|parser| {
-                        parser.parse_call_expression(lhs, start)
-                    })),
-                    TokenKind::Lsqb => Expr::Subscript(self.with_grown_delimited_stack(|parser| {
-                        parser.parse_subscript_expression(lhs, start)
-                    })),
-                    TokenKind::Dot => {
-                        Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
-                    }
-                    _ => break lhs,
-                };
+            lhs = match self.current_token_kind() {
+                TokenKind::Lpar => Expr::Call(self.parse_call_expression(lhs, start)),
+                TokenKind::Lsqb => Expr::Subscript(self.parse_subscript_expression(lhs, start)),
+                TokenKind::Dot => {
+                    Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
+                }
+                _ => break lhs,
+            };
         }
     }
 

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -28,7 +28,10 @@ use crate::{
     UnsupportedSyntaxErrorKind,
 };
 
-use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind};
+use super::{
+    InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind,
+    STACK_GROWTH_NESTING_THRESHOLD,
+};
 
 /// A token set consisting of a newline or end of file.
 const NEWLINE_EOF_SET: TokenSet = TokenSet::new([TokenKind::Newline, TokenKind::EndOfFile]);
@@ -344,6 +347,39 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> ParsedExpr {
         let token = self.current_token_kind();
+        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD
+            && !Self::token_starts_unnested_recursive_lhs(token)
+        {
+            return self.parse_lhs_expression_inner(left_precedence, context, token);
+        }
+
+        self.with_grown_stack(|parser| {
+            parser.parse_lhs_expression_inner(left_precedence, context, token)
+        })
+    }
+
+    /// Returns whether parsing an expression that starts with `token` can recurse without
+    /// first increasing delimiter nesting.
+    #[inline]
+    fn token_starts_unnested_recursive_lhs(token: TokenKind) -> bool {
+        token.as_unary_operator().is_some()
+            || matches!(
+                token,
+                TokenKind::Star
+                    | TokenKind::Await
+                    | TokenKind::Lambda
+                    | TokenKind::Yield
+                    | TokenKind::FStringStart
+                    | TokenKind::TStringStart
+            )
+    }
+
+    fn parse_lhs_expression_inner(
+        &mut self,
+        left_precedence: OperatorPrecedence,
+        context: ExpressionContext,
+        token: TokenKind,
+    ) -> ParsedExpr {
         let start = self.node_start();
 
         if let Some(unary_op) = token.as_unary_operator() {
@@ -656,11 +692,10 @@ impl<'src> Parser<'src> {
                 self.parse_strings()
             }
             TokenKind::Lpar => {
-                // Nested content re-enters expression parsing after the opening delimiter.
-                return self.with_grown_stack(Self::parse_parenthesized_expression);
+                return self.parse_parenthesized_expression();
             }
-            TokenKind::Lsqb => self.with_grown_stack(Self::parse_list_like_expression),
-            TokenKind::Lbrace => self.with_grown_stack(Self::parse_set_or_dict_like_expression),
+            TokenKind::Lsqb => self.parse_list_like_expression(),
+            TokenKind::Lbrace => self.parse_set_or_dict_like_expression(),
 
             kind => {
                 if kind.is_keyword() {
@@ -697,12 +732,8 @@ impl<'src> Parser<'src> {
     ) -> Expr {
         loop {
             lhs = match self.current_token_kind() {
-                TokenKind::Lpar => Expr::Call(
-                    self.with_grown_stack(|parser| parser.parse_call_expression(lhs, start)),
-                ),
-                TokenKind::Lsqb => Expr::Subscript(
-                    self.with_grown_stack(|parser| parser.parse_subscript_expression(lhs, start)),
-                ),
+                TokenKind::Lpar => Expr::Call(self.parse_call_expression(lhs, start)),
+                TokenKind::Lsqb => Expr::Subscript(self.parse_subscript_expression(lhs, start)),
                 TokenKind::Dot => {
                     Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
                 }
@@ -1143,9 +1174,7 @@ impl<'src> Parser<'src> {
             self.bump(TokenKind::from(nested_op));
         }
 
-        let operand = self.with_grown_stack(|parser| {
-            parser.parse_binary_expression_or_higher(precedence, context)
-        });
+        let operand = self.parse_binary_expression_or_higher(precedence, context);
         let operand =
             nested_operators
                 .into_iter()
@@ -1612,13 +1641,11 @@ impl<'src> Parser<'src> {
         let mut flags = self.tokens.current_flags().as_any_string_flags();
 
         self.bump(kind.start_token());
-        let elements = self.with_grown_stack(|parser| {
-            parser.parse_interpolated_string_elements(
-                flags,
-                InterpolatedStringElementsKind::Regular(kind),
-                kind,
-            )
-        });
+        let elements = self.parse_interpolated_string_elements(
+            flags,
+            InterpolatedStringElementsKind::Regular(kind),
+            kind,
+        );
 
         if !self.expect(kind.end_token()) {
             flags = flags.with_unclosed(true);
@@ -2737,21 +2764,19 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::Star);
 
-        let parsed_expr = self.with_grown_stack(|parser| {
-            match context.starred_expression_precedence() {
-                StarredExpressionPrecedence::Conditional => parser
-                    .parse_conditional_expression_or_higher_impl(
-                        // test_err starred_starred_expression
-                        // print(*
-                        // *[])
-                        // print(* *[])
-                        context.disallow_starred_expressions(),
-                    ),
-                StarredExpressionPrecedence::BitwiseOr => {
-                    parser.parse_expression_with_bitwise_or_precedence()
-                }
+        let parsed_expr = match context.starred_expression_precedence() {
+            StarredExpressionPrecedence::Conditional => self
+                .parse_conditional_expression_or_higher_impl(
+                    // test_err starred_starred_expression
+                    // print(*
+                    // *[])
+                    // print(* *[])
+                    context.disallow_starred_expressions(),
+                ),
+            StarredExpressionPrecedence::BitwiseOr => {
+                self.parse_expression_with_bitwise_or_precedence()
             }
-        });
+        };
 
         ast::ExprStarred {
             value: Box::new(parsed_expr.expr),
@@ -2772,12 +2797,10 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::Await);
 
-        let parsed_expr = self.with_grown_stack(|parser| {
-            parser.parse_binary_expression_or_higher(
-                OperatorPrecedence::Await,
-                ExpressionContext::default(),
-            )
-        });
+        let parsed_expr = self.parse_binary_expression_or_higher(
+            OperatorPrecedence::Await,
+            ExpressionContext::default(),
+        );
 
         ast::ExprAwait {
             value: Box::new(parsed_expr.expr),
@@ -2802,9 +2825,7 @@ impl<'src> Parser<'src> {
         }
 
         let value = self.at_expr().then(|| {
-            let parsed_expr = self.with_grown_stack(|parser| {
-                parser.parse_expression_list(ExpressionContext::starred_bitwise_or())
-            });
+            let parsed_expr = self.parse_expression_list(ExpressionContext::starred_bitwise_or());
 
             // test_ok iter_unpack_yield_py37
             // # parse_options: {"target-version": "3.7"}
@@ -2860,7 +2881,7 @@ impl<'src> Parser<'src> {
         // would have stopped at the comma. Then, the outer expression would
         // have been a tuple expression with two elements: `yield from x` and `y`.
         let expr = self
-            .with_grown_stack(|parser| parser.parse_expression_list(ExpressionContext::default()))
+            .parse_expression_list(ExpressionContext::default())
             .expr;
 
         match &expr {

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1170,11 +1170,36 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::from(op));
 
-        let operand = self.parse_binary_expression_or_higher(OperatorPrecedence::from(op), context);
+        // Consecutive unary operators at the same precedence can be consumed
+        // iteratively and rebuilt after parsing the operand. Operators at
+        // differing precedences must retain the recursive path so binary
+        // expression binding and its diagnostics remain unchanged.
+        let precedence = OperatorPrecedence::from(op);
+        let mut nested_operators = Vec::new();
+        while let Some(nested_op) = self.current_token_kind().as_unary_operator()
+            && OperatorPrecedence::from(nested_op) == precedence
+        {
+            nested_operators.push((nested_op, self.node_start()));
+            self.bump(TokenKind::from(nested_op));
+        }
+
+        let operand = self.parse_binary_expression_or_higher(precedence, context);
+        let operand =
+            nested_operators
+                .into_iter()
+                .rev()
+                .fold(operand.expr, |operand, (op, start)| {
+                    Expr::UnaryOp(ast::ExprUnaryOp {
+                        op,
+                        operand: Box::new(operand),
+                        range: self.node_range(start),
+                        node_index: AtomicNodeIndex::NONE,
+                    })
+                });
 
         ast::ExprUnaryOp {
             op,
-            operand: Box::new(operand.expr),
+            operand: Box::new(operand),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -28,10 +28,7 @@ use crate::{
     UnsupportedSyntaxErrorKind,
 };
 
-use super::{
-    InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind,
-    STACK_GROWTH_NESTING_THRESHOLD,
-};
+use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind};
 
 /// A token set consisting of a newline or end of file.
 const NEWLINE_EOF_SET: TokenSet = TokenSet::new([TokenKind::Newline, TokenKind::EndOfFile]);
@@ -306,17 +303,7 @@ impl<'src> Parser<'src> {
                 BinaryLikeOperator::Binary(bin_op) => {
                     self.bump(TokenKind::from(bin_op));
 
-                    let right = if new_precedence.is_right_associative() {
-                        // For right-associative operators (`**`), the right
-                        // operand recursion is unbounded in `a**a**a**...`,
-                        // and it bypasses stack growth in `parse_lhs_expression`
-                        // (that scope is exited once the atom is parsed).
-                        self.with_grown_stack(|parser| {
-                            parser.parse_binary_expression_or_higher(new_precedence, context)
-                        })
-                    } else {
-                        self.parse_binary_expression_or_higher(new_precedence, context)
-                    };
+                    let right = self.parse_binary_expression_or_higher(new_precedence, context);
 
                     Expr::BinOp(ast::ExprBinOp {
                         left: Box::new(left.expr),
@@ -347,31 +334,7 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> ParsedExpr {
         let token = self.current_token_kind();
-        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD
-            && !Self::token_starts_unnested_recursive_lhs(token)
-        {
-            return self.parse_lhs_expression_inner(left_precedence, context, token);
-        }
-
-        self.with_grown_stack(|parser| {
-            parser.parse_lhs_expression_inner(left_precedence, context, token)
-        })
-    }
-
-    /// Returns whether parsing an expression that starts with `token` can recurse without
-    /// first increasing delimiter nesting.
-    #[inline]
-    fn token_starts_unnested_recursive_lhs(token: TokenKind) -> bool {
-        token.as_unary_operator().is_some()
-            || matches!(
-                token,
-                TokenKind::Star
-                    | TokenKind::Await
-                    | TokenKind::Lambda
-                    | TokenKind::Yield
-                    | TokenKind::FStringStart
-                    | TokenKind::TStringStart
-            )
+        self.parse_lhs_expression_inner(left_precedence, context, token)
     }
 
     fn parse_lhs_expression_inner(
@@ -692,10 +655,10 @@ impl<'src> Parser<'src> {
                 self.parse_strings()
             }
             TokenKind::Lpar => {
-                return self.parse_parenthesized_expression();
+                return self.with_grown_stack(Self::parse_parenthesized_expression);
             }
-            TokenKind::Lsqb => self.parse_list_like_expression(),
-            TokenKind::Lbrace => self.parse_set_or_dict_like_expression(),
+            TokenKind::Lsqb => self.with_grown_stack(Self::parse_list_like_expression),
+            TokenKind::Lbrace => self.with_grown_stack(Self::parse_set_or_dict_like_expression),
 
             kind => {
                 if kind.is_keyword() {
@@ -725,6 +688,22 @@ impl<'src> Parser<'src> {
     ///
     /// This method does nothing if the current token is not a candidate for a postfix expression.
     fn parse_postfix_expression(
+        &mut self,
+        lhs: Expr,
+        start: TextSize,
+        context: ExpressionContext,
+    ) -> Expr {
+        if !matches!(
+            self.current_token_kind(),
+            TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Dot
+        ) {
+            return lhs;
+        }
+
+        self.with_grown_stack(|parser| parser.parse_postfix_expression_inner(lhs, start, context))
+    }
+
+    fn parse_postfix_expression_inner(
         &mut self,
         mut lhs: Expr,
         start: TextSize,
@@ -2974,9 +2953,7 @@ impl<'src> Parser<'src> {
         // lambda x: yield y
         // lambda x: yield from y
 
-        // `lambda: lambda: lambda: ...` recurses through the lambda body at
-        // the conditional layer, bypassing stack growth in `parse_lhs_expression`.
-        let body = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
+        let body = self.parse_conditional_expression_or_higher();
 
         ast::ExprLambda {
             body: Box::new(body.expr),
@@ -3000,9 +2977,7 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Else);
 
-        // `a if b else a if b else ...` recurses through `orelse` at the
-        // conditional layer, which is not covered by stack growth in
-        // `parse_lhs_expression` (that scope is released once each atom is parsed).
+        // `a if b else a if b else ...` recurses through the `orelse` expression.
         let orelse = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
 
         ast::ExprIf {

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -304,6 +304,10 @@ impl<'src> Parser<'src> {
                     self.bump(TokenKind::from(bin_op));
 
                     let right = if new_precedence.is_right_associative() {
+                        // For right-associative operators (`**`), the right
+                        // operand recursion is unbounded in `a**a**a**...`,
+                        // and it bypasses stack growth in `parse_lhs_expression`
+                        // (that scope is exited once the atom is parsed).
                         self.with_grown_stack(|parser| {
                             parser.parse_binary_expression_or_higher(new_precedence, context)
                         })
@@ -2954,6 +2958,8 @@ impl<'src> Parser<'src> {
         // lambda x: yield y
         // lambda x: yield from y
 
+        // `lambda: lambda: lambda: ...` recurses through the lambda body at
+        // the conditional layer, bypassing stack growth in `parse_lhs_expression`.
         let body = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
 
         ast::ExprLambda {
@@ -2978,6 +2984,9 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Else);
 
+        // `a if b else a if b else ...` recurses through `orelse` at the
+        // conditional layer, which is not covered by stack growth in
+        // `parse_lhs_expression` (that scope is released once each atom is parsed).
         let orelse = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
 
         ast::ExprIf {

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -655,10 +655,10 @@ impl<'src> Parser<'src> {
                 self.parse_strings()
             }
             TokenKind::Lpar => {
-                return self.with_grown_stack(Self::parse_parenthesized_expression);
+                return self.parse_parenthesized_expression();
             }
-            TokenKind::Lsqb => self.with_grown_stack(Self::parse_list_like_expression),
-            TokenKind::Lbrace => self.with_grown_stack(Self::parse_set_or_dict_like_expression),
+            TokenKind::Lsqb => self.parse_list_like_expression(),
+            TokenKind::Lbrace => self.parse_set_or_dict_like_expression(),
 
             kind => {
                 if kind.is_keyword() {
@@ -688,22 +688,6 @@ impl<'src> Parser<'src> {
     ///
     /// This method does nothing if the current token is not a candidate for a postfix expression.
     fn parse_postfix_expression(
-        &mut self,
-        lhs: Expr,
-        start: TextSize,
-        context: ExpressionContext,
-    ) -> Expr {
-        if !matches!(
-            self.current_token_kind(),
-            TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Dot
-        ) {
-            return lhs;
-        }
-
-        self.with_grown_stack(|parser| parser.parse_postfix_expression_inner(lhs, start, context))
-    }
-
-    fn parse_postfix_expression_inner(
         &mut self,
         mut lhs: Expr,
         start: TextSize,
@@ -1868,13 +1852,11 @@ impl<'src> Parser<'src> {
 
         let format_spec = if self.eat(TokenKind::Colon) {
             let spec_start = self.node_start();
-            let elements = self.with_grown_stack(|parser| {
-                parser.parse_interpolated_string_elements(
-                    flags,
-                    InterpolatedStringElementsKind::FormatSpec(string_kind),
-                    string_kind,
-                )
-            });
+            let elements = self.parse_interpolated_string_elements(
+                flags,
+                InterpolatedStringElementsKind::FormatSpec(string_kind),
+                string_kind,
+            );
             Some(Box::new(ast::InterpolatedStringFormatSpec {
                 range: self.node_range(spec_start),
                 elements,
@@ -2977,8 +2959,7 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Else);
 
-        // `a if b else a if b else ...` recurses through the `orelse` expression.
-        let orelse = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
+        let orelse = self.parse_conditional_expression_or_higher();
 
         ast::ExprIf {
             body: Box::new(body),

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -344,15 +344,6 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> ParsedExpr {
         let token = self.current_token_kind();
-        self.parse_lhs_expression_inner(left_precedence, context, token)
-    }
-
-    fn parse_lhs_expression_inner(
-        &mut self,
-        left_precedence: OperatorPrecedence,
-        context: ExpressionContext,
-        token: TokenKind,
-    ) -> ParsedExpr {
         let start = self.node_start();
 
         if let Some(unary_op) = token.as_unary_operator() {

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -304,18 +304,9 @@ impl<'src> Parser<'src> {
                     self.bump(TokenKind::from(bin_op));
 
                     let right = if new_precedence.is_right_associative() {
-                        // For right-associative operators (`**`), the right
-                        // operand recursion is unbounded in `a**a**a**...`,
-                        // and it bypasses the guard in `parse_lhs_expression`
-                        // (that scope is exited once the atom is parsed).
-                        if let Some(right) = self.with_recursion(|parser| {
+                        self.with_grown_stack(|parser| {
                             parser.parse_binary_expression_or_higher(new_precedence, context)
-                        }) {
-                            right
-                        } else {
-                            self.report_recursion_limit_exceeded(self.current_token_range());
-                            self.recursion_recovery_expr()
-                        }
+                        })
                     } else {
                         self.parse_binary_expression_or_higher(new_precedence, context)
                     };
@@ -353,14 +344,15 @@ impl<'src> Parser<'src> {
             return self.parse_lhs_expression_inner(left_precedence, context, token);
         }
 
-        if let Some(result) = self.with_recursion(|parser| {
-            parser.parse_lhs_expression_inner(left_precedence, context, token)
-        }) {
-            result
-        } else {
-            self.report_recursion_limit_exceeded(self.current_token_range());
-            self.recursion_recovery_expr()
+        if matches!(token, TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Lbrace) {
+            return self.with_grown_delimited_stack(|parser| {
+                parser.parse_lhs_expression_inner(left_precedence, context, token)
+            });
         }
+
+        self.with_grown_stack(|parser| {
+            parser.parse_lhs_expression_inner(left_precedence, context, token)
+        })
     }
 
     /// Returns whether parsing an expression that starts with `token` can
@@ -380,20 +372,6 @@ impl<'src> Parser<'src> {
                     | TokenKind::Lsqb
                     | TokenKind::Lbrace
             )
-    }
-
-    /// The standard expression-recovery node returned when the recursion
-    /// limit is exceeded: an empty `Name` with the `Invalid` context.
-    fn recursion_recovery_expr(&mut self) -> ParsedExpr {
-        ParsedExpr {
-            expr: Expr::Name(ast::ExprName {
-                range: self.missing_node_range(),
-                id: Name::empty(),
-                ctx: ExprContext::Invalid,
-                node_index: AtomicNodeIndex::NONE,
-            }),
-            is_parenthesized: false,
-        }
     }
 
     fn parse_lhs_expression_inner(
@@ -753,26 +731,19 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> Expr {
         loop {
-            lhs = match self.current_token_kind() {
-                TokenKind::Lpar => {
-                    if self.tokens.nesting() > self.max_nesting_depth {
-                        self.report_recursion_limit_exceeded(self.current_token_range());
-                        break lhs;
+            lhs =
+                match self.current_token_kind() {
+                    TokenKind::Lpar => Expr::Call(self.with_grown_delimited_stack(|parser| {
+                        parser.parse_call_expression(lhs, start)
+                    })),
+                    TokenKind::Lsqb => Expr::Subscript(self.with_grown_delimited_stack(|parser| {
+                        parser.parse_subscript_expression(lhs, start)
+                    })),
+                    TokenKind::Dot => {
+                        Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
                     }
-                    Expr::Call(self.parse_call_expression(lhs, start))
-                }
-                TokenKind::Lsqb => {
-                    if self.tokens.nesting() > self.max_nesting_depth {
-                        self.report_recursion_limit_exceeded(self.current_token_range());
-                        break lhs;
-                    }
-                    Expr::Subscript(self.parse_subscript_expression(lhs, start))
-                }
-                TokenKind::Dot => {
-                    Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
-                }
-                _ => break lhs,
-            };
+                    _ => break lhs,
+                };
         }
     }
 
@@ -1898,18 +1869,13 @@ impl<'src> Parser<'src> {
 
         let format_spec = if self.eat(TokenKind::Colon) {
             let spec_start = self.node_start();
-            let elements = if let Some(elements) = self.with_recursion(|parser| {
+            let elements = self.with_grown_stack(|parser| {
                 parser.parse_interpolated_string_elements(
                     flags,
                     InterpolatedStringElementsKind::FormatSpec(string_kind),
                     string_kind,
                 )
-            }) {
-                elements
-            } else {
-                self.report_recursion_limit_exceeded(self.current_token_range());
-                ast::InterpolatedStringElements::from(vec![])
-            };
+            });
             Some(Box::new(ast::InterpolatedStringFormatSpec {
                 range: self.node_range(spec_start),
                 elements,
@@ -2988,15 +2954,7 @@ impl<'src> Parser<'src> {
         // lambda x: yield y
         // lambda x: yield from y
 
-        // `lambda: lambda: lambda: ...` recurses through the lambda body at
-        // the conditional layer, bypassing the `parse_lhs_expression` guard.
-        let body =
-            if let Some(body) = self.with_recursion(Self::parse_conditional_expression_or_higher) {
-                body
-            } else {
-                self.report_recursion_limit_exceeded(self.current_token_range());
-                self.recursion_recovery_expr()
-            };
+        let body = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
 
         ast::ExprLambda {
             body: Box::new(body.expr),
@@ -3020,17 +2978,7 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Else);
 
-        // `a if b else a if b else ...` recurses through `orelse` at the
-        // conditional layer, which is not covered by the `parse_lhs_expression`
-        // guard (that scope is released once each atom is parsed). Guard here.
-        let orelse = if let Some(orelse) =
-            self.with_recursion(Self::parse_conditional_expression_or_higher)
-        {
-            orelse
-        } else {
-            self.report_recursion_limit_exceeded(self.current_token_range());
-            self.recursion_recovery_expr()
-        };
+        let orelse = self.with_grown_stack(Self::parse_conditional_expression_or_higher);
 
         ast::ExprIf {
             body: Box::new(body),

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -28,10 +28,7 @@ use crate::{
     UnsupportedSyntaxErrorKind,
 };
 
-use super::{
-    InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind,
-    STACK_GROWTH_NESTING_THRESHOLD,
-};
+use super::{InterpolatedStringElementsKind, Parenthesized, RecoveryContextKind};
 
 /// A token set consisting of a newline or end of file.
 const NEWLINE_EOF_SET: TokenSet = TokenSet::new([TokenKind::Newline, TokenKind::EndOfFile]);
@@ -347,31 +344,7 @@ impl<'src> Parser<'src> {
         context: ExpressionContext,
     ) -> ParsedExpr {
         let token = self.current_token_kind();
-        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD
-            && !Self::token_starts_unnested_recursive_lhs(token)
-        {
-            return self.parse_lhs_expression_inner(left_precedence, context, token);
-        }
-
-        self.with_grown_stack(|parser| {
-            parser.parse_lhs_expression_inner(left_precedence, context, token)
-        })
-    }
-
-    /// Returns whether parsing an expression that starts with `token` can recurse without
-    /// first increasing delimiter nesting.
-    #[inline]
-    fn token_starts_unnested_recursive_lhs(token: TokenKind) -> bool {
-        token.as_unary_operator().is_some()
-            || matches!(
-                token,
-                TokenKind::Star
-                    | TokenKind::Await
-                    | TokenKind::Lambda
-                    | TokenKind::Yield
-                    | TokenKind::FStringStart
-                    | TokenKind::TStringStart
-            )
+        self.parse_lhs_expression_inner(left_precedence, context, token)
     }
 
     fn parse_lhs_expression_inner(
@@ -692,10 +665,11 @@ impl<'src> Parser<'src> {
                 self.parse_strings()
             }
             TokenKind::Lpar => {
-                return self.parse_parenthesized_expression();
+                // Nested content re-enters expression parsing after the opening delimiter.
+                return self.with_grown_stack(Self::parse_parenthesized_expression);
             }
-            TokenKind::Lsqb => self.parse_list_like_expression(),
-            TokenKind::Lbrace => self.parse_set_or_dict_like_expression(),
+            TokenKind::Lsqb => self.with_grown_stack(Self::parse_list_like_expression),
+            TokenKind::Lbrace => self.with_grown_stack(Self::parse_set_or_dict_like_expression),
 
             kind => {
                 if kind.is_keyword() {
@@ -732,8 +706,12 @@ impl<'src> Parser<'src> {
     ) -> Expr {
         loop {
             lhs = match self.current_token_kind() {
-                TokenKind::Lpar => Expr::Call(self.parse_call_expression(lhs, start)),
-                TokenKind::Lsqb => Expr::Subscript(self.parse_subscript_expression(lhs, start)),
+                TokenKind::Lpar => Expr::Call(
+                    self.with_grown_stack(|parser| parser.parse_call_expression(lhs, start)),
+                ),
+                TokenKind::Lsqb => Expr::Subscript(
+                    self.with_grown_stack(|parser| parser.parse_subscript_expression(lhs, start)),
+                ),
                 TokenKind::Dot => {
                     Expr::Attribute(self.parse_attribute_expression(lhs, start, context))
                 }
@@ -1174,7 +1152,9 @@ impl<'src> Parser<'src> {
             self.bump(TokenKind::from(nested_op));
         }
 
-        let operand = self.parse_binary_expression_or_higher(precedence, context);
+        let operand = self.with_grown_stack(|parser| {
+            parser.parse_binary_expression_or_higher(precedence, context)
+        });
         let operand =
             nested_operators
                 .into_iter()
@@ -1641,11 +1621,13 @@ impl<'src> Parser<'src> {
         let mut flags = self.tokens.current_flags().as_any_string_flags();
 
         self.bump(kind.start_token());
-        let elements = self.parse_interpolated_string_elements(
-            flags,
-            InterpolatedStringElementsKind::Regular(kind),
-            kind,
-        );
+        let elements = self.with_grown_stack(|parser| {
+            parser.parse_interpolated_string_elements(
+                flags,
+                InterpolatedStringElementsKind::Regular(kind),
+                kind,
+            )
+        });
 
         if !self.expect(kind.end_token()) {
             flags = flags.with_unclosed(true);
@@ -2764,19 +2746,21 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::Star);
 
-        let parsed_expr = match context.starred_expression_precedence() {
-            StarredExpressionPrecedence::Conditional => self
-                .parse_conditional_expression_or_higher_impl(
-                    // test_err starred_starred_expression
-                    // print(*
-                    // *[])
-                    // print(* *[])
-                    context.disallow_starred_expressions(),
-                ),
-            StarredExpressionPrecedence::BitwiseOr => {
-                self.parse_expression_with_bitwise_or_precedence()
+        let parsed_expr = self.with_grown_stack(|parser| {
+            match context.starred_expression_precedence() {
+                StarredExpressionPrecedence::Conditional => parser
+                    .parse_conditional_expression_or_higher_impl(
+                        // test_err starred_starred_expression
+                        // print(*
+                        // *[])
+                        // print(* *[])
+                        context.disallow_starred_expressions(),
+                    ),
+                StarredExpressionPrecedence::BitwiseOr => {
+                    parser.parse_expression_with_bitwise_or_precedence()
+                }
             }
-        };
+        });
 
         ast::ExprStarred {
             value: Box::new(parsed_expr.expr),
@@ -2797,10 +2781,12 @@ impl<'src> Parser<'src> {
         let start = self.node_start();
         self.bump(TokenKind::Await);
 
-        let parsed_expr = self.parse_binary_expression_or_higher(
-            OperatorPrecedence::Await,
-            ExpressionContext::default(),
-        );
+        let parsed_expr = self.with_grown_stack(|parser| {
+            parser.parse_binary_expression_or_higher(
+                OperatorPrecedence::Await,
+                ExpressionContext::default(),
+            )
+        });
 
         ast::ExprAwait {
             value: Box::new(parsed_expr.expr),
@@ -2825,7 +2811,9 @@ impl<'src> Parser<'src> {
         }
 
         let value = self.at_expr().then(|| {
-            let parsed_expr = self.parse_expression_list(ExpressionContext::starred_bitwise_or());
+            let parsed_expr = self.with_grown_stack(|parser| {
+                parser.parse_expression_list(ExpressionContext::starred_bitwise_or())
+            });
 
             // test_ok iter_unpack_yield_py37
             // # parse_options: {"target-version": "3.7"}
@@ -2881,7 +2869,7 @@ impl<'src> Parser<'src> {
         // would have stopped at the comma. Then, the outer expression would
         // have been a tuple expression with two elements: `yield from x` and `y`.
         let expr = self
-            .parse_expression_list(ExpressionContext::default())
+            .with_grown_stack(|parser| parser.parse_expression_list(ExpressionContext::default()))
             .expr;
 
         match &expr {

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -34,14 +34,11 @@ mod statement;
 #[cfg(test)]
 mod tests;
 
-// `STACK_RED_ZONE` reserves enough headroom to amortize stack checks across multiple guarded
-// recursion edges. `STACK_SIZE` is the stack segment allocated when that threshold is crossed.
+// This is the amount of bytes that need to be left on the stack before increasing the size.
+// It must be at least as large as the stack required by any code that does not call
+// `with_grown_stack`.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
-const STACK_CHECK_INTERVAL: u8 = 16;
-// Avoid stack checks on ordinary shallow expressions inside delimiters such as calls and
-// subscripts. Nested content re-enters `parse_lhs_expression` after the opening delimiter.
-const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
 
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {
@@ -71,10 +68,6 @@ pub(crate) struct Parser<'src> {
 
     /// The start offset in the source code from which to start parsing at.
     start_offset: TextSize,
-
-    /// Number of guarded recursive parser edges that can be traversed before checking
-    /// the remaining stack again.
-    stack_checks_remaining: u8,
 }
 
 impl<'src> Parser<'src> {
@@ -101,31 +94,13 @@ impl<'src> Parser<'src> {
             prev_token_end: TextSize::new(0),
             start_offset,
             current_token_id: TokenId::default(),
-            stack_checks_remaining: 0,
         }
     }
 
     /// Runs a recursive parser edge on a stack with sufficient remaining space.
     #[inline]
     fn with_grown_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
-        if self.stack_checks_remaining > 0 {
-            self.stack_checks_remaining -= 1;
-            return f(self);
-        }
-
-        if stacker::remaining_stack().is_some_and(|remaining| remaining >= STACK_RED_ZONE) {
-            self.stack_checks_remaining = STACK_CHECK_INTERVAL;
-            return f(self);
-        }
-
-        stacker::grow(STACK_SIZE, || {
-            self.stack_checks_remaining = STACK_CHECK_INTERVAL;
-            let result = f(self);
-            // The cached headroom belongs to the grown stack segment. The caller's
-            // stack still needs to be checked when parsing recurses again.
-            self.stack_checks_remaining = 0;
-            result
-        })
+        stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || f(self))
     }
 
     /// Consumes the [`Parser`] and returns the parsed [`Parsed`].

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -34,10 +34,13 @@ mod statement;
 #[cfg(test)]
 mod tests;
 
-// Keep enough stack for parser code between explicitly instrumented recursion edges.
+// `STACK_RED_ZONE` is the required headroom at an instrumented recursion edge; `STACK_SIZE`
+// is the stack segment allocated when that threshold is crossed. These values match rustc's
+// `ensure_sufficient_stack` helper.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
-// Avoid stack checks on normal, shallow delimiter use such as calls and subscripts.
+// Avoid stack checks on ordinary shallow expressions inside delimiters such as calls and
+// subscripts. Nested content re-enters `parse_lhs_expression` after the opening delimiter.
 const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
 
 #[derive(Debug)]
@@ -101,15 +104,6 @@ impl<'src> Parser<'src> {
     #[inline]
     fn with_grown_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
         stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || f(self))
-    }
-
-    #[inline]
-    fn with_grown_delimited_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
-        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD {
-            f(self)
-        } else {
-            self.with_grown_stack(f)
-        }
     }
 
     /// Consumes the [`Parser`] and returns the parsed [`Parsed`].

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -39,6 +39,9 @@ mod tests;
 // `ensure_sufficient_stack` helper.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
+// Avoid stack checks on ordinary shallow expressions inside delimiters such as calls and
+// subscripts. Nested content re-enters `parse_lhs_expression` after the opening delimiter.
+const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
 
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -34,6 +34,12 @@ mod statement;
 #[cfg(test)]
 mod tests;
 
+// Keep enough stack for parser code between explicitly instrumented recursion edges.
+const STACK_RED_ZONE: usize = 100 * 1024;
+const STACK_SIZE: usize = 1024 * 1024;
+// Avoid stack checks on normal, shallow delimiter use such as calls and subscripts.
+const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
+
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {
     source: &'src str,
@@ -62,12 +68,6 @@ pub(crate) struct Parser<'src> {
 
     /// The start offset in the source code from which to start parsing at.
     start_offset: TextSize,
-
-    /// Current parser recursion depth remaining before the depth limit is exceeded.
-    depth_remaining: u16,
-
-    /// Maximum lexer nesting depth before postfix calls and subscripts should stop recursing.
-    max_nesting_depth: u32,
 }
 
 impl<'src> Parser<'src> {
@@ -83,8 +83,6 @@ impl<'src> Parser<'src> {
         options: ParseOptions,
     ) -> Self {
         let tokens = TokenSource::from_source(source, options.mode, start_offset);
-        let depth_remaining = options.max_recursion_depth;
-        let max_nesting_depth = u32::from(options.max_recursion_depth.saturating_sub(2));
 
         Parser {
             options,
@@ -96,38 +94,21 @@ impl<'src> Parser<'src> {
             prev_token_end: TextSize::new(0),
             start_offset,
             current_token_id: TokenId::default(),
-            depth_remaining,
-            max_nesting_depth,
         }
     }
 
-    /// Runs `f` if the recursive parser depth limit has not been hit.
-    ///
-    /// # Note
-    ///
-    /// This recursion guard is a temporary fix for #22930.
-    #[must_use]
+    /// Runs a recursive parser edge on a stack with sufficient remaining space.
     #[inline]
-    fn with_recursion<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> Option<T> {
-        if self.depth_remaining == 0 {
-            return None;
-        }
-
-        self.depth_remaining -= 1;
-        let result = f(self);
-        self.depth_remaining += 1;
-        Some(result)
+    fn with_grown_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || f(self))
     }
 
-    #[cold]
-    #[inline(never)]
-    fn report_recursion_limit_exceeded<R: Ranged>(&mut self, ranged: R) {
-        self.add_error(ParseErrorType::RecursionLimitExceeded, ranged);
-        // Skip to end-of-file so outer parser frames unwind quickly and our
-        // `ParserProgress` infinite-loop guards don't fire when they see the
-        // same `(` / `[` etc. that this frame failed to consume.
-        while self.current_token_kind() != TokenKind::EndOfFile {
-            self.bump_any();
+    #[inline]
+    fn with_grown_delimited_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD {
+            f(self)
+        } else {
+            self.with_grown_stack(f)
         }
     }
 

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -34,11 +34,11 @@ mod statement;
 #[cfg(test)]
 mod tests;
 
-// `STACK_RED_ZONE` is the required headroom at an instrumented recursion edge; `STACK_SIZE`
-// is the stack segment allocated when that threshold is crossed. These values match rustc's
-// `ensure_sufficient_stack` helper.
+// `STACK_RED_ZONE` reserves enough headroom to amortize stack checks across multiple guarded
+// recursion edges. `STACK_SIZE` is the stack segment allocated when that threshold is crossed.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
+const STACK_CHECK_INTERVAL: u8 = 16;
 // Avoid stack checks on ordinary shallow expressions inside delimiters such as calls and
 // subscripts. Nested content re-enters `parse_lhs_expression` after the opening delimiter.
 const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
@@ -71,6 +71,10 @@ pub(crate) struct Parser<'src> {
 
     /// The start offset in the source code from which to start parsing at.
     start_offset: TextSize,
+
+    /// Number of guarded recursive parser edges that can be traversed before checking
+    /// the remaining stack again.
+    stack_checks_remaining: u8,
 }
 
 impl<'src> Parser<'src> {
@@ -97,13 +101,31 @@ impl<'src> Parser<'src> {
             prev_token_end: TextSize::new(0),
             start_offset,
             current_token_id: TokenId::default(),
+            stack_checks_remaining: 0,
         }
     }
 
     /// Runs a recursive parser edge on a stack with sufficient remaining space.
     #[inline]
     fn with_grown_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
-        stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || f(self))
+        if self.stack_checks_remaining > 0 {
+            self.stack_checks_remaining -= 1;
+            return f(self);
+        }
+
+        if stacker::remaining_stack().is_some_and(|remaining| remaining >= STACK_RED_ZONE) {
+            self.stack_checks_remaining = STACK_CHECK_INTERVAL;
+            return f(self);
+        }
+
+        stacker::grow(STACK_SIZE, || {
+            self.stack_checks_remaining = STACK_CHECK_INTERVAL;
+            let result = f(self);
+            // The cached headroom belongs to the grown stack segment. The caller's
+            // stack still needs to be checked when parsing recurses again.
+            self.stack_checks_remaining = 0;
+            result
+        })
     }
 
     /// Consumes the [`Parser`] and returns the parsed [`Parsed`].

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -39,9 +39,6 @@ mod tests;
 // `ensure_sufficient_stack` helper.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
-// Avoid stack checks on ordinary shallow expressions inside delimiters such as calls and
-// subscripts. Nested content re-enters `parse_lhs_expression` after the opening delimiter.
-const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
 
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -65,6 +65,9 @@ impl NameInterner {
 // `ensure_sufficient_stack` helper.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
+// Avoid stack checks on ordinary shallow expressions inside delimiters such as calls and
+// subscripts. Nested content re-enters `parse_lhs_expression` after the opening delimiter.
+const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
 
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -60,14 +60,11 @@ impl NameInterner {
     }
 }
 
-// `STACK_RED_ZONE` reserves enough headroom to amortize stack checks across multiple guarded
-// recursion edges. `STACK_SIZE` is the stack segment allocated when that threshold is crossed.
+// This is the amount of bytes that need to be left on the stack before increasing the size.
+// It must be at least as large as the stack required by any code that does not call
+// `with_grown_stack`.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
-const STACK_CHECK_INTERVAL: u8 = 16;
-// Avoid stack checks on ordinary shallow expressions inside delimiters such as calls and
-// subscripts. Nested content re-enters `parse_lhs_expression` after the opening delimiter.
-const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
 
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {
@@ -121,10 +118,6 @@ pub(crate) struct Parser<'src> {
 
     /// Reusable, nesting-safe scratch storage for `elif` and `else` clauses.
     elif_else_scratch: ScratchBuffer<ElifElseClause>,
-
-    /// Number of guarded recursive parser edges that can be traversed before checking
-    /// the remaining stack again.
-    stack_checks_remaining: u8,
 }
 
 impl<'src> Parser<'src> {
@@ -159,31 +152,13 @@ impl<'src> Parser<'src> {
             stmt_scratch: ScratchBuffer::with_capacity(32),
             alias_scratch: ScratchBuffer::new(),
             elif_else_scratch: ScratchBuffer::new(),
-            stack_checks_remaining: 0,
         }
     }
 
     /// Runs a recursive parser edge on a stack with sufficient remaining space.
     #[inline]
     fn with_grown_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
-        if self.stack_checks_remaining > 0 {
-            self.stack_checks_remaining -= 1;
-            return f(self);
-        }
-
-        if stacker::remaining_stack().is_some_and(|remaining| remaining >= STACK_RED_ZONE) {
-            self.stack_checks_remaining = STACK_CHECK_INTERVAL;
-            return f(self);
-        }
-
-        stacker::grow(STACK_SIZE, || {
-            self.stack_checks_remaining = STACK_CHECK_INTERVAL;
-            let result = f(self);
-            // The cached headroom belongs to the grown stack segment. The caller's
-            // stack still needs to be checked when parsing recurses again.
-            self.stack_checks_remaining = 0;
-            result
-        })
+        stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || f(self))
     }
 
     /// Consumes the [`Parser`] and returns the parsed [`Parsed`].

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -65,9 +65,6 @@ impl NameInterner {
 // `ensure_sufficient_stack` helper.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
-// Avoid stack checks on ordinary shallow expressions inside delimiters such as calls and
-// subscripts. Nested content re-enters `parse_lhs_expression` after the opening delimiter.
-const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
 
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -60,11 +60,11 @@ impl NameInterner {
     }
 }
 
-// Check the remaining stack at parser entry and for each nested suite. This covers standalone
-// expressions and recursive statement nesting without checking every expression node.
-// `STACK_RED_ZONE` must be at least as large as the stack required between those checks.
+// Stack probes access thread-local state, so avoid them while recursive parser calls remain
+// shallow. `STACK_RED_ZONE` must cover the stack used before the first deferred probe.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
+const MAX_UNCHECKED_RECURSION_DEPTH: usize = 20;
 
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {
@@ -100,6 +100,9 @@ pub(crate) struct Parser<'src> {
 
     /// The start offset in the source code from which to start parsing at.
     start_offset: TextSize,
+
+    /// Number of active recursive statement, expression, and pattern parsing operations.
+    recursion_depth: usize,
 
     /// Reusable, nesting-safe scratch storage for expression lists.
     expr_scratch: ScratchBuffer<Expr>,
@@ -145,6 +148,7 @@ impl<'src> Parser<'src> {
             recovery_context: RecoveryContext::empty(),
             prev_token_end: TextSize::new(0),
             start_offset,
+            recursion_depth: 0,
             current_token_id: TokenId::default(),
             expr_scratch: ScratchBuffer::with_capacity(16),
             keyword_scratch: ScratchBuffer::new(),
@@ -155,24 +159,36 @@ impl<'src> Parser<'src> {
         }
     }
 
-    /// Runs a recursive parser edge on a stack with sufficient remaining space.
+    /// Grows the stack for recursive parser calls only after shallow nesting is exceeded.
     #[inline]
-    fn with_grown_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+    fn with_recursion<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        self.recursion_depth += 1;
+
+        let result = if self.recursion_depth > MAX_UNCHECKED_RECURSION_DEPTH {
+            self.grow_stack(f)
+        } else {
+            f(self)
+        };
+
+        self.recursion_depth -= 1;
+        result
+    }
+
+    #[cold]
+    fn grow_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
         stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || f(self))
     }
 
     /// Consumes the [`Parser`] and returns the parsed [`Parsed`].
     pub(crate) fn parse(mut self) -> Parsed<Mod> {
-        stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || {
-            let syntax = match self.options.mode {
-                Mode::Expression | Mode::ParenthesizedExpression => {
-                    Mod::Expression(self.parse_single_expression())
-                }
-                Mode::Module | Mode::Ipython => Mod::Module(self.parse_module()),
-            };
+        let syntax = stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || match self.options.mode {
+            Mode::Expression | Mode::ParenthesizedExpression => {
+                Mod::Expression(self.parse_single_expression())
+            }
+            Mode::Module | Mode::Ipython => Mod::Module(self.parse_module()),
+        });
 
-            self.finish(syntax)
-        })
+        self.finish(syntax)
     }
 
     /// Parses a single expression.

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -60,9 +60,9 @@ impl NameInterner {
     }
 }
 
-// This is the amount of bytes that need to be left on the stack before increasing the size.
-// It must be at least as large as the stack required by any code that does not call
-// `with_grown_stack`.
+// Check the remaining stack at parser entry and for each nested suite. This covers standalone
+// expressions and recursive statement nesting without checking every expression node.
+// `STACK_RED_ZONE` must be at least as large as the stack required between those checks.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
 
@@ -163,14 +163,16 @@ impl<'src> Parser<'src> {
 
     /// Consumes the [`Parser`] and returns the parsed [`Parsed`].
     pub(crate) fn parse(mut self) -> Parsed<Mod> {
-        let syntax = match self.options.mode {
-            Mode::Expression | Mode::ParenthesizedExpression => {
-                Mod::Expression(self.parse_single_expression())
-            }
-            Mode::Module | Mode::Ipython => Mod::Module(self.parse_module()),
-        };
+        stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || {
+            let syntax = match self.options.mode {
+                Mode::Expression | Mode::ParenthesizedExpression => {
+                    Mod::Expression(self.parse_single_expression())
+                }
+                Mode::Module | Mode::Ipython => Mod::Module(self.parse_module()),
+            };
 
-        self.finish(syntax)
+            self.finish(syntax)
+        })
     }
 
     /// Parses a single expression.

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -60,11 +60,11 @@ impl NameInterner {
     }
 }
 
-// `STACK_RED_ZONE` is the required headroom at an instrumented recursion edge; `STACK_SIZE`
-// is the stack segment allocated when that threshold is crossed. These values match rustc's
-// `ensure_sufficient_stack` helper.
+// `STACK_RED_ZONE` reserves enough headroom to amortize stack checks across multiple guarded
+// recursion edges. `STACK_SIZE` is the stack segment allocated when that threshold is crossed.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
+const STACK_CHECK_INTERVAL: u8 = 16;
 // Avoid stack checks on ordinary shallow expressions inside delimiters such as calls and
 // subscripts. Nested content re-enters `parse_lhs_expression` after the opening delimiter.
 const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
@@ -121,6 +121,10 @@ pub(crate) struct Parser<'src> {
 
     /// Reusable, nesting-safe scratch storage for `elif` and `else` clauses.
     elif_else_scratch: ScratchBuffer<ElifElseClause>,
+
+    /// Number of guarded recursive parser edges that can be traversed before checking
+    /// the remaining stack again.
+    stack_checks_remaining: u8,
 }
 
 impl<'src> Parser<'src> {
@@ -155,13 +159,31 @@ impl<'src> Parser<'src> {
             stmt_scratch: ScratchBuffer::with_capacity(32),
             alias_scratch: ScratchBuffer::new(),
             elif_else_scratch: ScratchBuffer::new(),
+            stack_checks_remaining: 0,
         }
     }
 
     /// Runs a recursive parser edge on a stack with sufficient remaining space.
     #[inline]
     fn with_grown_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
-        stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || f(self))
+        if self.stack_checks_remaining > 0 {
+            self.stack_checks_remaining -= 1;
+            return f(self);
+        }
+
+        if stacker::remaining_stack().is_some_and(|remaining| remaining >= STACK_RED_ZONE) {
+            self.stack_checks_remaining = STACK_CHECK_INTERVAL;
+            return f(self);
+        }
+
+        stacker::grow(STACK_SIZE, || {
+            self.stack_checks_remaining = STACK_CHECK_INTERVAL;
+            let result = f(self);
+            // The cached headroom belongs to the grown stack segment. The caller's
+            // stack still needs to be checked when parsing recurses again.
+            self.stack_checks_remaining = 0;
+            result
+        })
     }
 
     /// Consumes the [`Parser`] and returns the parsed [`Parsed`].

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -60,10 +60,13 @@ impl NameInterner {
     }
 }
 
-// Keep enough stack for parser code between explicitly instrumented recursion edges.
+// `STACK_RED_ZONE` is the required headroom at an instrumented recursion edge; `STACK_SIZE`
+// is the stack segment allocated when that threshold is crossed. These values match rustc's
+// `ensure_sufficient_stack` helper.
 const STACK_RED_ZONE: usize = 100 * 1024;
 const STACK_SIZE: usize = 1024 * 1024;
-// Avoid stack checks on normal, shallow delimiter use such as calls and subscripts.
+// Avoid stack checks on ordinary shallow expressions inside delimiters such as calls and
+// subscripts. Nested content re-enters `parse_lhs_expression` after the opening delimiter.
 const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
 
 #[derive(Debug)]
@@ -159,15 +162,6 @@ impl<'src> Parser<'src> {
     #[inline]
     fn with_grown_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
         stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || f(self))
-    }
-
-    #[inline]
-    fn with_grown_delimited_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
-        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD {
-            f(self)
-        } else {
-            self.with_grown_stack(f)
-        }
     }
 
     /// Consumes the [`Parser`] and returns the parsed [`Parsed`].

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -60,6 +60,12 @@ impl NameInterner {
     }
 }
 
+// Keep enough stack for parser code between explicitly instrumented recursion edges.
+const STACK_RED_ZONE: usize = 100 * 1024;
+const STACK_SIZE: usize = 1024 * 1024;
+// Avoid stack checks on normal, shallow delimiter use such as calls and subscripts.
+const STACK_GROWTH_NESTING_THRESHOLD: u32 = 64;
+
 #[derive(Debug)]
 pub(crate) struct Parser<'src> {
     source: &'src str,
@@ -95,12 +101,6 @@ pub(crate) struct Parser<'src> {
     /// The start offset in the source code from which to start parsing at.
     start_offset: TextSize,
 
-    /// Current parser recursion depth remaining before the depth limit is exceeded.
-    depth_remaining: u16,
-
-    /// Maximum lexer nesting depth before postfix calls and subscripts should stop recursing.
-    max_nesting_depth: u32,
-
     /// Reusable, nesting-safe scratch storage for expression lists.
     expr_scratch: ScratchBuffer<Expr>,
 
@@ -133,8 +133,6 @@ impl<'src> Parser<'src> {
         options: ParseOptions,
     ) -> Self {
         let tokens = TokenSource::from_source(source, options.mode, start_offset);
-        let depth_remaining = options.max_recursion_depth;
-        let max_nesting_depth = u32::from(options.max_recursion_depth.saturating_sub(2));
 
         Parser {
             options,
@@ -148,8 +146,6 @@ impl<'src> Parser<'src> {
             prev_token_end: TextSize::new(0),
             start_offset,
             current_token_id: TokenId::default(),
-            depth_remaining,
-            max_nesting_depth,
             expr_scratch: ScratchBuffer::with_capacity(16),
             keyword_scratch: ScratchBuffer::new(),
             parameter_scratch: ScratchBuffer::new(),
@@ -159,33 +155,18 @@ impl<'src> Parser<'src> {
         }
     }
 
-    /// Runs `f` if the recursive parser depth limit has not been hit.
-    ///
-    /// # Note
-    ///
-    /// This recursion guard is a temporary fix for #22930.
-    #[must_use]
+    /// Runs a recursive parser edge on a stack with sufficient remaining space.
     #[inline]
-    fn with_recursion<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> Option<T> {
-        if self.depth_remaining == 0 {
-            return None;
-        }
-
-        self.depth_remaining -= 1;
-        let result = f(self);
-        self.depth_remaining += 1;
-        Some(result)
+    fn with_grown_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, || f(self))
     }
 
-    #[cold]
-    #[inline(never)]
-    fn report_recursion_limit_exceeded<R: Ranged>(&mut self, ranged: R) {
-        self.add_error(ParseErrorType::RecursionLimitExceeded, ranged);
-        // Skip to end-of-file so outer parser frames unwind quickly and our
-        // `ParserProgress` infinite-loop guards don't fire when they see the
-        // same `(` / `[` etc. that this frame failed to consume.
-        while self.current_token_kind() != TokenKind::EndOfFile {
-            self.bump_any();
+    #[inline]
+    fn with_grown_delimited_stack<T>(&mut self, f: impl FnOnce(&mut Self) -> T) -> T {
+        if self.tokens.nesting() < STACK_GROWTH_NESTING_THRESHOLD {
+            f(self)
+        } else {
+            self.with_grown_stack(f)
         }
     }
 

--- a/crates/ruff_python_parser/src/parser/options.rs
+++ b/crates/ruff_python_parser/src/parser/options.rs
@@ -2,20 +2,6 @@ use ruff_python_ast::{PySourceType, PythonVersion};
 
 use crate::{AsMode, Mode};
 
-/// The default maximum recursion depth used by the parser.
-///
-/// Real-world Python rarely nests more than a handful of levels deep; this cap
-/// exists to keep the parser from overflowing the stack on adversarial or
-/// machine-generated input.
-///
-/// The default value mirrors CPython's `MAXSTACK` of 200 nested parentheses
-/// (`Parser/parser.c`): a one-statement module of the form `((((1))))` at
-/// depth 200 must parse, and one at depth 201 must fail. Each nesting level
-/// costs one `with_recursion` call, plus two framing calls (one for the
-/// surrounding statement and one for the innermost atom), so the cap is set
-/// to `200 + 2`.
-const DEFAULT_MAX_RECURSION_DEPTH: u16 = 202;
-
 /// Options for controlling how a source file is parsed.
 ///
 /// You can construct a [`ParseOptions`] directly from a [`Mode`]:
@@ -40,11 +26,6 @@ pub struct ParseOptions {
     pub(crate) mode: Mode,
     /// Target version for detecting version-related syntax errors.
     pub(crate) target_version: PythonVersion,
-    /// Maximum recursion depth for the parser. The parser aborts with a
-    /// [`crate::ParseErrorType::RecursionLimitExceeded`] error once this many
-    /// nested expression / statement / pattern nodes are on the parser's call
-    /// stack. Defaults to [`DEFAULT_MAX_RECURSION_DEPTH`].
-    pub(crate) max_recursion_depth: u16,
 }
 
 impl ParseOptions {
@@ -57,17 +38,6 @@ impl ParseOptions {
     pub fn target_version(&self) -> PythonVersion {
         self.target_version
     }
-
-    /// Set the maximum recursion depth for the parser.
-    #[must_use]
-    pub fn with_max_recursion_depth(mut self, depth: u16) -> Self {
-        self.max_recursion_depth = depth;
-        self
-    }
-
-    pub fn max_recursion_depth(&self) -> u16 {
-        self.max_recursion_depth
-    }
 }
 
 impl From<Mode> for ParseOptions {
@@ -75,7 +45,6 @@ impl From<Mode> for ParseOptions {
         Self {
             mode,
             target_version: PythonVersion::default(),
-            max_recursion_depth: DEFAULT_MAX_RECURSION_DEPTH,
         }
     }
 }
@@ -85,7 +54,6 @@ impl From<PySourceType> for ParseOptions {
         Self {
             mode: source_type.as_mode(),
             target_version: PythonVersion::default(),
-            max_recursion_depth: DEFAULT_MAX_RECURSION_DEPTH,
         }
     }
 }

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -88,7 +88,7 @@ impl Parser<'_> {
     ///
     /// See: <https://docs.python.org/3/reference/compound_stmts.html#grammar-token-python-grammar-pattern>
     fn parse_match_pattern(&mut self, allow_star_pattern: AllowStarPattern) -> Pattern {
-        self.with_grown_stack(|parser| parser.parse_match_pattern_inner(allow_star_pattern))
+        self.parse_match_pattern_inner(allow_star_pattern)
     }
 
     fn parse_match_pattern_inner(&mut self, allow_star_pattern: AllowStarPattern) -> Pattern {

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -88,25 +88,7 @@ impl Parser<'_> {
     ///
     /// See: <https://docs.python.org/3/reference/compound_stmts.html#grammar-token-python-grammar-pattern>
     fn parse_match_pattern(&mut self, allow_star_pattern: AllowStarPattern) -> Pattern {
-        if let Some(result) =
-            self.with_recursion(|parser| parser.parse_match_pattern_inner(allow_star_pattern))
-        {
-            result
-        } else {
-            let range = self.missing_node_range();
-            self.report_recursion_limit_exceeded(self.current_token_range());
-            let invalid_node = Expr::Name(ast::ExprName {
-                range,
-                id: Name::empty(),
-                ctx: ExprContext::Invalid,
-                node_index: AtomicNodeIndex::NONE,
-            });
-            Pattern::MatchValue(ast::PatternMatchValue {
-                range: invalid_node.range(),
-                value: Box::new(invalid_node),
-                node_index: AtomicNodeIndex::NONE,
-            })
-        }
+        self.with_grown_stack(|parser| parser.parse_match_pattern_inner(allow_star_pattern))
     }
 
     fn parse_match_pattern_inner(&mut self, allow_star_pattern: AllowStarPattern) -> Pattern {

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -88,10 +88,6 @@ impl Parser<'_> {
     ///
     /// See: <https://docs.python.org/3/reference/compound_stmts.html#grammar-token-python-grammar-pattern>
     fn parse_match_pattern(&mut self, allow_star_pattern: AllowStarPattern) -> Pattern {
-        self.parse_match_pattern_inner(allow_star_pattern)
-    }
-
-    fn parse_match_pattern_inner(&mut self, allow_star_pattern: AllowStarPattern) -> Pattern {
         let start = self.node_start();
 
         // We don't yet know if it's an or pattern or an as pattern, so use whatever
@@ -144,33 +140,37 @@ impl Parser<'_> {
     ///
     /// See: <https://docs.python.org/3/reference/compound_stmts.html#grammar-token-python-grammar-closed_pattern>
     fn parse_match_pattern_lhs(&mut self, allow_star_pattern: AllowStarPattern) -> Pattern {
-        let start = self.node_start();
+        self.with_recursion(|parser| {
+            let start = parser.node_start();
 
-        let mut lhs = match self.current_token_kind() {
-            TokenKind::Lbrace => Pattern::MatchMapping(self.parse_match_pattern_mapping()),
-            TokenKind::Star => {
-                let star_pattern = self.parse_match_pattern_star();
-                if allow_star_pattern.is_no() {
-                    self.add_error(ParseErrorType::InvalidStarPatternUsage, &star_pattern);
+            let mut lhs = match parser.current_token_kind() {
+                TokenKind::Lbrace => Pattern::MatchMapping(parser.parse_match_pattern_mapping()),
+                TokenKind::Star => {
+                    let star_pattern = parser.parse_match_pattern_star();
+                    if allow_star_pattern.is_no() {
+                        parser.add_error(ParseErrorType::InvalidStarPatternUsage, &star_pattern);
+                    }
+                    Pattern::MatchStar(star_pattern)
                 }
-                Pattern::MatchStar(star_pattern)
+                TokenKind::Lpar | TokenKind::Lsqb => {
+                    parser.parse_parenthesized_or_sequence_pattern()
+                }
+                _ => parser.parse_match_pattern_literal(),
+            };
+
+            if parser.at(TokenKind::Lpar) {
+                lhs = Pattern::MatchClass(parser.parse_match_pattern_class(lhs, start));
             }
-            TokenKind::Lpar | TokenKind::Lsqb => self.parse_parenthesized_or_sequence_pattern(),
-            _ => self.parse_match_pattern_literal(),
-        };
 
-        if self.at(TokenKind::Lpar) {
-            lhs = Pattern::MatchClass(self.parse_match_pattern_class(lhs, start));
-        }
+            if matches!(
+                parser.current_token_kind(),
+                TokenKind::Plus | TokenKind::Minus
+            ) {
+                lhs = Pattern::MatchValue(parser.parse_complex_literal_pattern(lhs, start));
+            }
 
-        if matches!(
-            self.current_token_kind(),
-            TokenKind::Plus | TokenKind::Minus
-        ) {
-            lhs = Pattern::MatchValue(self.parse_complex_literal_pattern(lhs, start));
-        }
-
-        lhs
+            lhs
+        })
     }
 
     /// Parses a mapping pattern.

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -2829,8 +2829,19 @@ impl<'src> Parser<'src> {
     /// - <https://docs.python.org/3/reference/compound_stmts.html#the-async-for-statement>
     /// - <https://docs.python.org/3/reference/compound_stmts.html#coroutine-function-definition>
     fn parse_async_statement(&mut self) -> Stmt {
-        let async_start = self.node_start();
+        let mut async_start = self.node_start();
         self.bump(TokenKind::Async);
+
+        // Consume repeated invalid `async` prefixes iteratively. This is the only
+        // invalid-async recovery shape that can recurse without bound.
+        while self.at(TokenKind::Async) {
+            self.add_error(
+                ParseErrorType::UnexpectedTokenAfterAsync(TokenKind::Async),
+                self.current_token_range(),
+            );
+            async_start = self.node_start();
+            self.bump(TokenKind::Async);
+        }
 
         match self.current_token_kind() {
             // test_ok async_function_definition
@@ -2868,8 +2879,9 @@ impl<'src> Parser<'src> {
                 );
 
                 // Although this statement is not a valid `async` statement,
-                // we still parse it.
-                self.with_grown_stack(Self::parse_statement)
+                // we still parse it. Repeated `async` recovery was handled
+                // iteratively above so this path cannot recurse without bound.
+                self.parse_statement()
             }
         }
     }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3120,12 +3120,10 @@ impl<'src> Parser<'src> {
     fn parse_block(&mut self) -> Suite {
         self.bump(TokenKind::Indent);
 
-        let statements = self.with_grown_stack(|parser| {
-            parser.parse_list_into_thin_vec(
-                RecoveryContextKind::BlockStatements,
-                Parser::parse_statement,
-            )
-        });
+        let statements = self.parse_list_into_thin_vec(
+            RecoveryContextKind::BlockStatements,
+            Parser::parse_statement,
+        );
 
         self.expect(TokenKind::Dedent);
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -2868,24 +2868,8 @@ impl<'src> Parser<'src> {
                 );
 
                 // Although this statement is not a valid `async` statement,
-                // we still parse it. Guard the recursive recovery path so
-                // `async async async ...` cannot overflow the parser stack.
-                if let Some(stmt) = self.with_recursion(Self::parse_statement) {
-                    stmt
-                } else {
-                    let range = self.node_range(async_start);
-                    self.add_error(ParseErrorType::RecursionLimitExceeded, range);
-                    Stmt::Expr(ast::StmtExpr {
-                        range,
-                        value: Box::new(Expr::Name(ast::ExprName {
-                            range,
-                            id: Name::new_static("async"),
-                            ctx: ExprContext::Invalid,
-                            node_index: AtomicNodeIndex::NONE,
-                        })),
-                        node_index: AtomicNodeIndex::NONE,
-                    })
-                }
+                // we still parse it.
+                self.with_grown_stack(Self::parse_statement)
             }
         }
     }
@@ -3124,17 +3108,12 @@ impl<'src> Parser<'src> {
     fn parse_block(&mut self) -> Suite {
         self.bump(TokenKind::Indent);
 
-        let statements = if let Some(statements) = self.with_recursion(|parser| {
+        let statements = self.with_grown_stack(|parser| {
             parser.parse_list_into_thin_vec(
                 RecoveryContextKind::BlockStatements,
                 Parser::parse_statement,
             )
-        }) {
-            statements
-        } else {
-            self.report_recursion_limit_exceeded(self.current_token_range());
-            Suite::new()
-        };
+        });
 
         self.expect(TokenKind::Dedent);
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -2838,8 +2838,19 @@ impl<'src> Parser<'src> {
     /// - <https://docs.python.org/3/reference/compound_stmts.html#the-async-for-statement>
     /// - <https://docs.python.org/3/reference/compound_stmts.html#coroutine-function-definition>
     fn parse_async_statement(&mut self) -> Stmt {
-        let async_start = self.node_start();
+        let mut async_start = self.node_start();
         self.bump(TokenKind::Async);
+
+        // Consume repeated invalid `async` prefixes iteratively. This is the only
+        // invalid-async recovery shape that can recurse without bound.
+        while self.at(TokenKind::Async) {
+            self.add_error(
+                ParseErrorType::UnexpectedTokenAfterAsync(TokenKind::Async),
+                self.current_token_range(),
+            );
+            async_start = self.node_start();
+            self.bump(TokenKind::Async);
+        }
 
         match self.current_token_kind() {
             // test_ok async_function_definition
@@ -2877,8 +2888,9 @@ impl<'src> Parser<'src> {
                 );
 
                 // Although this statement is not a valid `async` statement,
-                // we still parse it.
-                self.with_grown_stack(Self::parse_statement)
+                // we still parse it. Repeated `async` recovery was handled
+                // iteratively above so this path cannot recurse without bound.
+                self.parse_statement()
             }
         }
     }

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -2877,24 +2877,8 @@ impl<'src> Parser<'src> {
                 );
 
                 // Although this statement is not a valid `async` statement,
-                // we still parse it. Guard the recursive recovery path so
-                // `async async async ...` cannot overflow the parser stack.
-                if let Some(stmt) = self.with_recursion(Self::parse_statement) {
-                    stmt
-                } else {
-                    let range = self.node_range(async_start);
-                    self.add_error(ParseErrorType::RecursionLimitExceeded, range);
-                    Stmt::Expr(ast::StmtExpr {
-                        range,
-                        value: Box::new(Expr::Name(ast::ExprName {
-                            range,
-                            id: Name::new_static("async"),
-                            ctx: ExprContext::Invalid,
-                            node_index: AtomicNodeIndex::NONE,
-                        })),
-                        node_index: AtomicNodeIndex::NONE,
-                    })
-                }
+                // we still parse it.
+                self.with_grown_stack(Self::parse_statement)
             }
         }
     }
@@ -3133,7 +3117,7 @@ impl<'src> Parser<'src> {
     fn parse_block(&mut self) -> Suite {
         self.bump(TokenKind::Indent);
 
-        let statements = if let Some(statements) = self.with_recursion(|parser| {
+        let statements = self.with_grown_stack(|parser| {
             let snapshot = parser.stmt_scratch.snapshot();
             parser.parse_list(RecoveryContextKind::BlockStatements, |parser| {
                 let statement = parser.parse_statement();
@@ -3141,12 +3125,7 @@ impl<'src> Parser<'src> {
             });
 
             parser.stmt_scratch.take_thin_vec(snapshot)
-        }) {
-            statements
-        } else {
-            self.report_recursion_limit_exceeded(self.current_token_range());
-            Suite::new()
-        };
+        });
 
         self.expect(TokenKind::Dedent);
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -2838,19 +2838,8 @@ impl<'src> Parser<'src> {
     /// - <https://docs.python.org/3/reference/compound_stmts.html#the-async-for-statement>
     /// - <https://docs.python.org/3/reference/compound_stmts.html#coroutine-function-definition>
     fn parse_async_statement(&mut self) -> Stmt {
-        let mut async_start = self.node_start();
+        let async_start = self.node_start();
         self.bump(TokenKind::Async);
-
-        // Consume repeated invalid `async` prefixes iteratively. This is the only
-        // invalid-async recovery shape that can recurse without bound.
-        while self.at(TokenKind::Async) {
-            self.add_error(
-                ParseErrorType::UnexpectedTokenAfterAsync(TokenKind::Async),
-                self.current_token_range(),
-            );
-            async_start = self.node_start();
-            self.bump(TokenKind::Async);
-        }
 
         match self.current_token_kind() {
             // test_ok async_function_definition
@@ -2888,9 +2877,9 @@ impl<'src> Parser<'src> {
                 );
 
                 // Although this statement is not a valid `async` statement,
-                // we still parse it. Repeated `async` recovery was handled
-                // iteratively above so this path cannot recurse without bound.
-                self.parse_statement()
+                // we still parse it. Guard the recursive recovery path so
+                // `async async async ...` cannot overflow the parser stack.
+                self.with_recursion(Self::parse_statement)
             }
         }
     }
@@ -3129,7 +3118,7 @@ impl<'src> Parser<'src> {
     fn parse_block(&mut self) -> Suite {
         self.bump(TokenKind::Indent);
 
-        let statements = self.with_grown_stack(|parser| {
+        let statements = self.with_recursion(|parser| {
             let snapshot = parser.stmt_scratch.snapshot();
             parser.parse_list(RecoveryContextKind::BlockStatements, |parser| {
                 let statement = parser.parse_statement();

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3129,15 +3129,12 @@ impl<'src> Parser<'src> {
     fn parse_block(&mut self) -> Suite {
         self.bump(TokenKind::Indent);
 
-        let statements = self.with_grown_stack(|parser| {
-            let snapshot = parser.stmt_scratch.snapshot();
-            parser.parse_list(RecoveryContextKind::BlockStatements, |parser| {
-                let statement = parser.parse_statement();
-                parser.stmt_scratch.push(statement);
-            });
-
-            parser.stmt_scratch.take_thin_vec(snapshot)
+        let snapshot = self.stmt_scratch.snapshot();
+        self.parse_list(RecoveryContextKind::BlockStatements, |parser| {
+            let statement = parser.parse_statement();
+            parser.stmt_scratch.push(statement);
         });
+        let statements = self.stmt_scratch.take_thin_vec(snapshot);
 
         self.expect(TokenKind::Dedent);
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -3129,12 +3129,15 @@ impl<'src> Parser<'src> {
     fn parse_block(&mut self) -> Suite {
         self.bump(TokenKind::Indent);
 
-        let snapshot = self.stmt_scratch.snapshot();
-        self.parse_list(RecoveryContextKind::BlockStatements, |parser| {
-            let statement = parser.parse_statement();
-            parser.stmt_scratch.push(statement);
+        let statements = self.with_grown_stack(|parser| {
+            let snapshot = parser.stmt_scratch.snapshot();
+            parser.parse_list(RecoveryContextKind::BlockStatements, |parser| {
+                let statement = parser.parse_statement();
+                parser.stmt_scratch.push(statement);
+            });
+
+            parser.stmt_scratch.take_thin_vec(snapshot)
         });
-        let statements = self.stmt_scratch.take_thin_vec(snapshot);
 
         self.expect(TokenKind::Dedent);
 

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -331,9 +331,18 @@ fn test_tstring_fstring_middle_fuzzer() {
 mod stack_growth {
     use super::*;
 
+    // Windows test threads have a 1 MiB stack by default. Keep successfully
+    // parsed ASTs shallow enough for their recursive drop glue in debug builds
+    // while still exercising parser stack growth.
+    const AST_STACK_GROWTH_DEPTH: usize = 1_000;
+
     #[test]
     fn nested_parens() {
-        let source = format!("{}1{}", "(".repeat(5_000), ")".repeat(5_000));
+        let source = format!(
+            "{}1{}",
+            "(".repeat(AST_STACK_GROWTH_DEPTH),
+            ")".repeat(AST_STACK_GROWTH_DEPTH)
+        );
         parse_module(&source).unwrap();
     }
 
@@ -342,7 +351,7 @@ mod stack_growth {
         // Nested function definitions exercise stack-growth instrumentation on
         // `parse_block` rather than `parse_lhs_expression`. Each level
         // needs one more leading tab to make indentation valid.
-        let depth = 1_000;
+        let depth = AST_STACK_GROWTH_DEPTH;
         let mut source = String::new();
         for i in 0..depth {
             source.push_str(&"\t".repeat(i));
@@ -355,7 +364,11 @@ mod stack_growth {
 
     #[test]
     fn nested_lists() {
-        let source = format!("{}1{}", "[".repeat(5_000), "]".repeat(5_000));
+        let source = format!(
+            "{}1{}",
+            "[".repeat(AST_STACK_GROWTH_DEPTH),
+            "]".repeat(AST_STACK_GROWTH_DEPTH)
+        );
         parse_module(&source).unwrap();
     }
 
@@ -367,13 +380,21 @@ mod stack_growth {
 
     #[test]
     fn nested_calls() {
-        let source = format!("x = {}1{}", "f(".repeat(5_000), ")".repeat(5_000));
+        let source = format!(
+            "x = {}1{}",
+            "f(".repeat(AST_STACK_GROWTH_DEPTH),
+            ")".repeat(AST_STACK_GROWTH_DEPTH)
+        );
         parse_module(&source).unwrap();
     }
 
     #[test]
     fn nested_subscripts() {
-        let source = format!("x = {}1{}", "a[".repeat(5_000), "]".repeat(5_000));
+        let source = format!(
+            "x = {}1{}",
+            "a[".repeat(AST_STACK_GROWTH_DEPTH),
+            "]".repeat(AST_STACK_GROWTH_DEPTH)
+        );
         parse_module(&source).unwrap();
     }
 
@@ -383,8 +404,8 @@ mod stack_growth {
         // stack-growth instrumentation in addition to statement / expression paths.
         let source = format!(
             "match x:\n case {}y{}: pass\n",
-            "(".repeat(5_000),
-            ")".repeat(5_000),
+            "(".repeat(AST_STACK_GROWTH_DEPTH),
+            ")".repeat(AST_STACK_GROWTH_DEPTH),
         );
         parse_module(&source).unwrap();
     }
@@ -394,7 +415,7 @@ mod stack_growth {
         // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
         // parenthesised sub-expression, exactly like the pattern described in
         // the tracking issue.
-        let depth = 5_000;
+        let depth = AST_STACK_GROWTH_DEPTH;
         let mut source = String::new();
         for _ in 0..depth {
             source.push_str("1+(");
@@ -414,7 +435,7 @@ mod stack_growth {
         // the binary-expression recursion path directly, unlike the
         // `1+(1+(...))` interplay test which recurses through parenthesised
         // atoms.
-        let depth = 5_000;
+        let depth = AST_STACK_GROWTH_DEPTH;
         let mut source = String::with_capacity(depth * 3 + 1);
         for _ in 0..depth {
             source.push_str("1**");
@@ -428,7 +449,7 @@ mod stack_growth {
         // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
         // conditional layer (`parse_if_expression` -> `orelse`), which is not
         // covered by stack growth in `parse_lhs_expression`.
-        let depth = 5_000;
+        let depth = AST_STACK_GROWTH_DEPTH;
         let mut source = String::with_capacity(depth * 12 + 1);
         for _ in 0..depth {
             source.push_str("1 if 1 else ");
@@ -443,7 +464,7 @@ mod stack_growth {
         // conditional layer (`parse_lambda_expr` -> body), bypassing stack
         // growth in `parse_lhs_expression` entirely.
         let mut source = String::from("x = ");
-        for _ in 0..5_000 {
+        for _ in 0..AST_STACK_GROWTH_DEPTH {
             source.push_str("lambda: ");
         }
         source.push('1');
@@ -462,9 +483,13 @@ fn invalid_async_chain_is_iterative() {
 #[test]
 fn nested_equal_precedence_unary_chains_are_iterative() {
     // Consecutive unary operators sharing precedence do not require stack growth.
-    let source = format!("{}1\n", "-~+".repeat(5_000));
+    // Keep the recursively owned output shallow enough to drop on Windows'
+    // default 1 MiB test-thread stack in debug builds.
+    const DEPTH: usize = 1_000;
+
+    let source = format!("{}1\n", "-~+".repeat(DEPTH));
     parse_module(&source).unwrap();
 
-    let source = format!("{}True\n", "not ".repeat(5_000));
+    let source = format!("{}True\n", "not ".repeat(DEPTH));
     parse_module(&source).unwrap();
 }

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -458,3 +458,13 @@ fn invalid_async_chain_is_iterative() {
     let parsed = crate::parse_unchecked(&source, ParseOptions::from(Mode::Module));
     assert!(!parsed.errors().is_empty());
 }
+
+#[test]
+fn nested_equal_precedence_unary_chains_are_iterative() {
+    // Consecutive unary operators sharing precedence do not require stack growth.
+    let source = format!("{}1\n", "-~+".repeat(5_000));
+    parse_module(&source).unwrap();
+
+    let source = format!("{}True\n", "not ".repeat(5_000));
+    parse_module(&source).unwrap();
+}

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -325,127 +325,134 @@ fn test_tstring_fstring_middle_fuzzer() {
     insta::assert_debug_snapshot!(error);
 }
 
-#[test]
-fn stack_growth_nested_parens() {
-    let source = format!("{}1{}", "(".repeat(5_000), ")".repeat(5_000));
-    parse_module(&source).unwrap();
-}
+// `stacker` is a no-op on unsupported platforms, so only require stack
+// growth where its native support is well established.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+mod stack_growth {
+    use super::*;
 
-#[test]
-fn stack_growth_nested_def_blocks() {
-    // Nested function definitions exercise stack-growth instrumentation on
-    // `parse_block` rather than `parse_lhs_expression`. Each level
-    // needs one more leading tab to make indentation valid.
-    let depth = 1_000;
-    let mut source = String::new();
-    for i in 0..depth {
-        source.push_str(&"\t".repeat(i));
-        source.push_str("def f():\n");
+    #[test]
+    fn nested_parens() {
+        let source = format!("{}1{}", "(".repeat(5_000), ")".repeat(5_000));
+        parse_module(&source).unwrap();
     }
-    source.push_str(&"\t".repeat(depth));
-    source.push_str("pass\n");
-    parse_module(&source).unwrap();
-}
 
-#[test]
-fn stack_growth_nested_lists() {
-    let source = format!("{}1{}", "[".repeat(5_000), "]".repeat(5_000));
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_unclosed_lists() {
-    let source = "[".repeat(5_000);
-    assert!(parse_module(&source).is_err());
-}
-
-#[test]
-fn stack_growth_nested_calls() {
-    let source = format!("x = {}1{}", "f(".repeat(5_000), ")".repeat(5_000));
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_nested_subscripts() {
-    let source = format!("x = {}1{}", "a[".repeat(5_000), "]".repeat(5_000));
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_nested_match_patterns() {
-    // Deeply parenthesised match patterns exercise pattern-parsing
-    // stack-growth instrumentation in addition to statement / expression paths.
-    let source = format!(
-        "match x:\n case {}y{}: pass\n",
-        "(".repeat(5_000),
-        ")".repeat(5_000),
-    );
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_binary_paren_interplay() {
-    // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
-    // parenthesised sub-expression, exactly like the pattern described in
-    // the tracking issue.
-    let depth = 5_000;
-    let mut source = String::new();
-    for _ in 0..depth {
-        source.push_str("1+(");
+    #[test]
+    fn nested_def_blocks() {
+        // Nested function definitions exercise stack-growth instrumentation on
+        // `parse_block` rather than `parse_lhs_expression`. Each level
+        // needs one more leading tab to make indentation valid.
+        let depth = 1_000;
+        let mut source = String::new();
+        for i in 0..depth {
+            source.push_str(&"\t".repeat(i));
+            source.push_str("def f():\n");
+        }
+        source.push_str(&"\t".repeat(depth));
+        source.push_str("pass\n");
+        parse_module(&source).unwrap();
     }
-    source.push('1');
-    for _ in 0..depth {
-        source.push(')');
+
+    #[test]
+    fn nested_lists() {
+        let source = format!("{}1{}", "[".repeat(5_000), "]".repeat(5_000));
+        parse_module(&source).unwrap();
     }
-    parse_module(&source).unwrap();
+
+    #[test]
+    fn unclosed_lists() {
+        let source = "[".repeat(5_000);
+        assert!(parse_module(&source).is_err());
+    }
+
+    #[test]
+    fn nested_calls() {
+        let source = format!("x = {}1{}", "f(".repeat(5_000), ")".repeat(5_000));
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn nested_subscripts() {
+        let source = format!("x = {}1{}", "a[".repeat(5_000), "]".repeat(5_000));
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn nested_match_patterns() {
+        // Deeply parenthesised match patterns exercise pattern-parsing
+        // stack-growth instrumentation in addition to statement / expression paths.
+        let source = format!(
+            "match x:\n case {}y{}: pass\n",
+            "(".repeat(5_000),
+            ")".repeat(5_000),
+        );
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn binary_paren_interplay() {
+        // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
+        // parenthesised sub-expression, exactly like the pattern described in
+        // the tracking issue.
+        let depth = 5_000;
+        let mut source = String::new();
+        for _ in 0..depth {
+            source.push_str("1+(");
+        }
+        source.push('1');
+        for _ in 0..depth {
+            source.push(')');
+        }
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn right_assoc_pow_chain() {
+        // `1**1**1**...**1` — `**` is right-associative, so the right operand
+        // is parsed by a recursive `parse_binary_expression_or_higher` call
+        // *without* any intervening parentheses or atom nesting. This exercises
+        // the binary-expression recursion path directly, unlike the
+        // `1+(1+(...))` interplay test which recurses through parenthesised
+        // atoms.
+        let depth = 5_000;
+        let mut source = String::with_capacity(depth * 3 + 1);
+        for _ in 0..depth {
+            source.push_str("1**");
+        }
+        source.push('1');
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn ternary_else_chain() {
+        // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
+        // conditional layer (`parse_if_expression` -> `orelse`), which is not
+        // covered by stack growth in `parse_lhs_expression`.
+        let depth = 5_000;
+        let mut source = String::with_capacity(depth * 12 + 1);
+        for _ in 0..depth {
+            source.push_str("1 if 1 else ");
+        }
+        source.push('1');
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn nested_lambda_chain() {
+        // `lambda: lambda: lambda: ...` — the lambda body recurses at the
+        // conditional layer (`parse_lambda_expr` -> body), bypassing stack
+        // growth in `parse_lhs_expression` entirely.
+        let mut source = String::from("x = ");
+        for _ in 0..5_000 {
+            source.push_str("lambda: ");
+        }
+        source.push('1');
+        parse_module(&source).unwrap();
+    }
 }
 
 #[test]
-fn stack_growth_right_assoc_pow_chain() {
-    // `1**1**1**...**1` — `**` is right-associative, so the right operand
-    // is parsed by a recursive `parse_binary_expression_or_higher` call
-    // *without* any intervening parentheses or atom nesting. This exercises
-    // the binary-expression recursion path directly, unlike the
-    // `1+(1+(...))` interplay test which recurses through parenthesised
-    // atoms.
-    let depth = 5_000;
-    let mut source = String::with_capacity(depth * 3 + 1);
-    for _ in 0..depth {
-        source.push_str("1**");
-    }
-    source.push('1');
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_ternary_else_chain() {
-    // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
-    // conditional layer (`parse_if_expression` -> `orelse`), which is not
-    // covered by stack growth in `parse_lhs_expression`.
-    let depth = 5_000;
-    let mut source = String::with_capacity(depth * 12 + 1);
-    for _ in 0..depth {
-        source.push_str("1 if 1 else ");
-    }
-    source.push('1');
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_nested_lambda_chain() {
-    // `lambda: lambda: lambda: ...` — the lambda body recurses at the
-    // conditional layer (`parse_lambda_expr` -> body), bypassing stack
-    // growth in `parse_lhs_expression` entirely.
-    let mut source = String::from("x = ");
-    for _ in 0..5_000 {
-        source.push_str("lambda: ");
-    }
-    source.push('1');
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_invalid_async_chain() {
+fn invalid_async_chain_is_iterative() {
     // Invalid repeated `async` prefixes are recovered iteratively.
     let source = format!("{}x = 1\n", "async ".repeat(5_000));
     let parsed = crate::parse_unchecked(&source, ParseOptions::from(Mode::Module));

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -342,27 +342,21 @@ mod stack_growth {
     }
 
     #[test]
-    fn nested_def_blocks() {
-        // Nested function definitions exercise stack-growth instrumentation on
-        // `parse_block` rather than `parse_lhs_expression`. Each level
-        // needs one more leading tab to make indentation valid.
-        let depth = RECURSIVE_AST_TEST_DEPTH;
-        let mut source = String::new();
-        for i in 0..depth {
-            source.push_str(&"\t".repeat(i));
-            source.push_str("def f():\n");
-        }
-        source.push_str(&"\t".repeat(depth));
-        source.push_str("pass\n");
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
     fn nested_lists() {
         let source = format!(
             "{}1{}",
             "[".repeat(RECURSIVE_AST_TEST_DEPTH),
             "]".repeat(RECURSIVE_AST_TEST_DEPTH)
+        );
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn nested_dictionaries() {
+        let source = format!(
+            "{}1{}",
+            "{'x':".repeat(RECURSIVE_AST_TEST_DEPTH),
+            "}".repeat(RECURSIVE_AST_TEST_DEPTH)
         );
         parse_module(&source).unwrap();
     }
@@ -396,18 +390,6 @@ mod stack_growth {
     }
 
     #[test]
-    fn nested_match_patterns() {
-        // Deeply parenthesised match patterns exercise pattern-parsing
-        // stack-growth instrumentation in addition to statement / expression paths.
-        let source = format!(
-            "match x:\n case {}y{}: pass\n",
-            "(".repeat(RECURSIVE_AST_TEST_DEPTH),
-            ")".repeat(RECURSIVE_AST_TEST_DEPTH),
-        );
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
     fn binary_paren_interplay() {
         // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
         // parenthesised sub-expression, exactly like the pattern described in
@@ -425,44 +407,13 @@ mod stack_growth {
     }
 
     #[test]
-    fn right_assoc_pow_chain() {
-        // `1**1**1**...**1` — `**` is right-associative, so the right operand
-        // is parsed by a recursive `parse_binary_expression_or_higher` call
-        // *without* any intervening parentheses or atom nesting. This exercises
-        // the binary-expression recursion path directly, unlike the
-        // `1+(1+(...))` interplay test which recurses through parenthesised
-        // atoms.
-        let depth = RECURSIVE_AST_TEST_DEPTH;
-        let mut source = String::with_capacity(depth * 3 + 1);
-        for _ in 0..depth {
-            source.push_str("1**");
-        }
-        source.push('1');
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
     fn ternary_else_chain() {
         // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
-        // conditional layer (`parse_if_expression` -> `orelse`), which is not
-        // covered by stack growth in `parse_lhs_expression`.
+        // conditional layer (`parse_if_expression` -> `orelse`).
         let depth = RECURSIVE_AST_TEST_DEPTH;
         let mut source = String::with_capacity(depth * 12 + 1);
         for _ in 0..depth {
             source.push_str("1 if 1 else ");
-        }
-        source.push('1');
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
-    fn nested_lambda_chain() {
-        // `lambda: lambda: lambda: ...` — the lambda body recurses at the
-        // conditional layer (`parse_lambda_expr` -> body), bypassing stack
-        // growth in `parse_lhs_expression` entirely.
-        let mut source = String::from("x = ");
-        for _ in 0..RECURSIVE_AST_TEST_DEPTH {
-            source.push_str("lambda: ");
         }
         source.push('1');
         parse_module(&source).unwrap();

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -325,13 +325,6 @@ fn test_tstring_fstring_middle_fuzzer() {
     insta::assert_debug_snapshot!(error);
 }
 
-fn parse_deep_ast(source: &str) {
-    let parsed = parse_module(source).unwrap();
-    // This regression suite isolates parser stack growth; walking or dropping
-    // a deeply nested returned AST is a separate consumer concern.
-    std::mem::forget(parsed);
-}
-
 #[test]
 fn stack_growth_nested_parens() {
     let source = format!("{}1{}", "(".repeat(5_000), ")".repeat(5_000));
@@ -340,6 +333,9 @@ fn stack_growth_nested_parens() {
 
 #[test]
 fn stack_growth_nested_def_blocks() {
+    // Nested function definitions exercise stack-growth instrumentation on
+    // `parse_block` rather than `parse_lhs_expression`. Each level
+    // needs one more leading tab to make indentation valid.
     let depth = 1_000;
     let mut source = String::new();
     for i in 0..depth {
@@ -348,13 +344,13 @@ fn stack_growth_nested_def_blocks() {
     }
     source.push_str(&"\t".repeat(depth));
     source.push_str("pass\n");
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_nested_lists() {
     let source = format!("{}1{}", "[".repeat(5_000), "]".repeat(5_000));
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
@@ -366,27 +362,32 @@ fn stack_growth_unclosed_lists() {
 #[test]
 fn stack_growth_nested_calls() {
     let source = format!("x = {}1{}", "f(".repeat(5_000), ")".repeat(5_000));
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_nested_subscripts() {
     let source = format!("x = {}1{}", "a[".repeat(5_000), "]".repeat(5_000));
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_nested_match_patterns() {
+    // Deeply parenthesised match patterns exercise pattern-parsing
+    // stack-growth instrumentation in addition to statement / expression paths.
     let source = format!(
         "match x:\n case {}y{}: pass\n",
         "(".repeat(5_000),
         ")".repeat(5_000),
     );
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_binary_paren_interplay() {
+    // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
+    // parenthesised sub-expression, exactly like the pattern described in
+    // the tracking issue.
     let depth = 5_000;
     let mut source = String::new();
     for _ in 0..depth {
@@ -396,43 +397,56 @@ fn stack_growth_binary_paren_interplay() {
     for _ in 0..depth {
         source.push(')');
     }
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_right_assoc_pow_chain() {
+    // `1**1**1**...**1` — `**` is right-associative, so the right operand
+    // is parsed by a recursive `parse_binary_expression_or_higher` call
+    // *without* any intervening parentheses or atom nesting. This exercises
+    // the binary-expression recursion path directly, unlike the
+    // `1+(1+(...))` interplay test which recurses through parenthesised
+    // atoms.
     let depth = 5_000;
     let mut source = String::with_capacity(depth * 3 + 1);
     for _ in 0..depth {
         source.push_str("1**");
     }
     source.push('1');
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_ternary_else_chain() {
+    // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
+    // conditional layer (`parse_if_expression` -> `orelse`), which is not
+    // covered by stack growth in `parse_lhs_expression`.
     let depth = 5_000;
     let mut source = String::with_capacity(depth * 12 + 1);
     for _ in 0..depth {
         source.push_str("1 if 1 else ");
     }
     source.push('1');
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_nested_lambda_chain() {
+    // `lambda: lambda: lambda: ...` — the lambda body recurses at the
+    // conditional layer (`parse_lambda_expr` -> body), bypassing stack
+    // growth in `parse_lhs_expression` entirely.
     let mut source = String::from("x = ");
     for _ in 0..5_000 {
         source.push_str("lambda: ");
     }
     source.push('1');
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_invalid_async_chain() {
+    // Invalid repeated `async` prefixes are recovered iteratively.
     let source = format!("{}x = 1\n", "async ".repeat(5_000));
     let parsed = crate::parse_unchecked(&source, ParseOptions::from(Mode::Module));
     assert!(!parsed.errors().is_empty());

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -325,225 +325,115 @@ fn test_tstring_fstring_middle_fuzzer() {
     insta::assert_debug_snapshot!(error);
 }
 
-#[test]
-fn recursion_limit_nested_parens() {
-    let src = format!("{}1{}", "(".repeat(1_000), ")".repeat(1_000));
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+fn parse_deep_ast(source: &str) {
+    let parsed = parse_module(source).unwrap();
+    // This regression suite isolates parser stack growth; walking or dropping
+    // a deeply nested returned AST is a separate consumer concern.
+    std::mem::forget(parsed);
 }
 
 #[test]
-fn recursion_limit_normal_python_unaffected() {
-    // 50 levels is well above what real-world Python ever produces and well
-    // below the default cap — the point is to confirm the default doesn't
-    // reject ordinary input.
-    let src = format!("x = {}1{}", "(".repeat(50), ")".repeat(50));
-    parse_module(&src).unwrap();
+fn stack_growth_nested_parens() {
+    let source = format!("{}1{}", "(".repeat(5_000), ")".repeat(5_000));
+    parse_module(&source).unwrap();
 }
 
 #[test]
-fn recursion_limit_preserves_prior_statements() {
-    // Recursion-limit recovery is limited for now: we drain the rest of the file but keep the
-    // statements parsed before the overflowing statement.
-    // TODO: Recover at the next newline so the trailing statement is preserved too.
-    let src = format!(
-        "before = 1\n{}1{}\nafter = 2\n",
-        "(".repeat(1_000),
-        ")".repeat(1_000),
-    );
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let parsed = crate::parse_unchecked(&src, opts)
-        .try_into_module()
-        .unwrap();
-
-    assert!(matches!(
-        parsed.errors().first().map(|error| &error.error),
-        Some(ParseErrorType::RecursionLimitExceeded)
-    ));
-    assert!(matches!(parsed.suite().first(), Some(Stmt::Assign(_))));
-}
-
-#[test]
-fn recursion_limit_nested_def_blocks() {
-    // Nested function definitions exercise instrumentation on
-    // `parse_statement` rather than `parse_lhs_expression`. Each level
-    // needs one more leading tab to make indentation valid.
-    let depth = 400;
-    let mut src = String::new();
+fn stack_growth_nested_def_blocks() {
+    let depth = 1_000;
+    let mut source = String::new();
     for i in 0..depth {
-        src.push_str(&"\t".repeat(i));
-        src.push_str("def f():\n");
+        source.push_str(&"\t".repeat(i));
+        source.push_str("def f():\n");
     }
-    src.push_str(&"\t".repeat(depth));
-    src.push_str("pass\n");
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+    source.push_str(&"\t".repeat(depth));
+    source.push_str("pass\n");
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_nested_lists() {
-    let src = format!("{}1{}", "[".repeat(1_000), "]".repeat(1_000));
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+fn stack_growth_nested_lists() {
+    let source = format!("{}1{}", "[".repeat(5_000), "]".repeat(5_000));
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_nested_calls() {
-    let src = format!("x = {}1{}", "f(".repeat(1_000), ")".repeat(1_000));
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+fn stack_growth_unclosed_lists() {
+    let source = "[".repeat(5_000);
+    assert!(parse_module(&source).is_err());
 }
 
 #[test]
-fn recursion_limit_nested_subscripts() {
-    let src = format!("x = {}1{}", "a[".repeat(1_000), "]".repeat(1_000));
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+fn stack_growth_nested_calls() {
+    let source = format!("x = {}1{}", "f(".repeat(5_000), ")".repeat(5_000));
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_nested_match_patterns() {
-    // Deeply parenthesised match patterns — exercises pattern-parsing
-    // instrumentation in addition to statement / expression paths.
-    let mut src = String::from("match x:\n case ");
-    for _ in 0..600 {
-        src.push('(');
-    }
-    src.push('y');
-    for _ in 0..600 {
-        src.push(')');
-    }
-    src.push_str(": pass\n");
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+fn stack_growth_nested_subscripts() {
+    let source = format!("x = {}1{}", "a[".repeat(5_000), "]".repeat(5_000));
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_binary_paren_interplay() {
-    // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
-    // parenthesised sub-expression, exactly like the pattern described in
-    // the tracking issue.
-    let depth = 2_000;
-    let mut src = String::new();
-    for _ in 0..depth {
-        src.push_str("1+(");
-    }
-    src.push('1');
-    for _ in 0..depth {
-        src.push(')');
-    }
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
-}
-
-#[test]
-fn recursion_limit_first_error_is_recursion_not_noise() {
-    // When the limit is hit the outer parser frames will emit secondary
-    // errors as they unwind. Callers read the first error via `into_result`
-    // / `Parsed::errors()`, so `RecursionLimitExceeded` must come first, and
-    // the drain-to-EOF after reporting the recursion limit should keep the total count
-    // small rather than producing one noisy error per unwound frame.
-    let src = format!("{}1{}", "(".repeat(2_000), ")".repeat(2_000));
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(50);
-    let parsed = crate::parse_unchecked(&src, opts);
-    let errors = parsed.errors();
-    let first = errors.first().expect("expected at least one error");
-    assert!(matches!(
-        first.error,
-        ParseErrorType::RecursionLimitExceeded
-    ));
-    // Exactly one `RecursionLimitExceeded` — guards against a regression
-    // where the unwind loops and re-triggers the limit check.
-    let recursion_errors = errors
-        .iter()
-        .filter(|e| matches!(e.error, ParseErrorType::RecursionLimitExceeded))
-        .count();
-    assert_eq!(recursion_errors, 1);
-    // Small, bounded tail of follow-up errors from the unwinding frames.
-    // Today this is 0; the generous cap is a regression gate, not a spec.
-    assert!(
-        errors.len() <= 8,
-        "expected a small number of errors, got {}: {errors:?}",
-        errors.len(),
+fn stack_growth_nested_match_patterns() {
+    let source = format!(
+        "match x:\n case {}y{}: pass\n",
+        "(".repeat(5_000),
+        ")".repeat(5_000),
     );
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_default_set() {
-    let opts = ParseOptions::from(Mode::Module);
-    // Guards against someone accidentally unsetting the default. Real-world
-    // Python never approaches this depth, and the value must stay within the
-    // threading stack's capacity — see the const's docs in `options.rs`.
-    assert!(opts.max_recursion_depth() >= 200);
-    assert!(opts.max_recursion_depth() <= 2000);
-}
-
-#[test]
-fn recursion_limit_right_assoc_pow_chain() {
-    // `1**1**1**...**1` — `**` is right-associative, so the right operand
-    // is parsed by a recursive `parse_binary_expression_or_higher` call
-    // *without* any intervening parentheses or atom nesting. This exercises
-    // the binary-expression recursion path directly, unlike the
-    // `1+(1+(...))` interplay test which recurses through parenthesised
-    // atoms.
-    let depth = 2_000;
-    let mut src = String::with_capacity(depth * 3 + 1);
+fn stack_growth_binary_paren_interplay() {
+    let depth = 5_000;
+    let mut source = String::new();
     for _ in 0..depth {
-        src.push_str("1**");
+        source.push_str("1+(");
     }
-    src.push('1');
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(
-        matches!(err.error, ParseErrorType::RecursionLimitExceeded),
-        "expected RecursionLimitExceeded, got {:?}",
-        err.error
-    );
+    source.push('1');
+    for _ in 0..depth {
+        source.push(')');
+    }
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_ternary_else_chain() {
-    // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
-    // conditional layer (`parse_if_expression` -> `orelse`), which is not
-    // covered by the `parse_lhs_expression` guard.
-    let depth = 2_000;
-    let mut src = String::with_capacity(depth * 12 + 1);
+fn stack_growth_right_assoc_pow_chain() {
+    let depth = 5_000;
+    let mut source = String::with_capacity(depth * 3 + 1);
     for _ in 0..depth {
-        src.push_str("1 if 1 else ");
+        source.push_str("1**");
     }
-    src.push('1');
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(
-        matches!(err.error, ParseErrorType::RecursionLimitExceeded),
-        "expected RecursionLimitExceeded, got {:?}",
-        err.error
-    );
+    source.push('1');
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_nested_lambda_chain() {
-    // `lambda: lambda: lambda: ...` — the lambda body recurses at the
-    // conditional layer (`parse_lambda_expr` -> body), bypassing the
-    // `parse_lhs_expression` guard entirely.
-    let depth = 2_000;
-    let mut src = String::from("x = ");
+fn stack_growth_ternary_else_chain() {
+    let depth = 5_000;
+    let mut source = String::with_capacity(depth * 12 + 1);
     for _ in 0..depth {
-        src.push_str("lambda: ");
+        source.push_str("1 if 1 else ");
     }
-    src.push('1');
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(
-        matches!(err.error, ParseErrorType::RecursionLimitExceeded),
-        "expected RecursionLimitExceeded, got {:?}",
-        err.error
-    );
+    source.push('1');
+    parse_deep_ast(&source);
+}
+
+#[test]
+fn stack_growth_nested_lambda_chain() {
+    let mut source = String::from("x = ");
+    for _ in 0..5_000 {
+        source.push_str("lambda: ");
+    }
+    source.push('1');
+    parse_deep_ast(&source);
+}
+
+#[test]
+fn stack_growth_invalid_async_chain() {
+    let source = format!("{}x = 1\n", "async ".repeat(5_000));
+    let parsed = crate::parse_unchecked(&source, ParseOptions::from(Mode::Module));
+    assert!(!parsed.errors().is_empty());
 }

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,6 +1,6 @@
 use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, Stmt};
 
-use crate::{Mode, ParseErrorType, ParseOptions, parse, parse_expression, parse_module};
+use crate::{Mode, ParseOptions, RECURSIVE_AST_TEST_DEPTH, parse, parse_expression, parse_module};
 
 #[test]
 fn test_modes() {
@@ -331,17 +331,12 @@ fn test_tstring_fstring_middle_fuzzer() {
 mod stack_growth {
     use super::*;
 
-    // Windows test threads have a 1 MiB stack by default. Keep successfully
-    // parsed ASTs shallow enough for their recursive drop glue in debug builds
-    // while still exercising parser stack growth.
-    const AST_STACK_GROWTH_DEPTH: usize = 1_000;
-
     #[test]
     fn nested_parens() {
         let source = format!(
             "{}1{}",
-            "(".repeat(AST_STACK_GROWTH_DEPTH),
-            ")".repeat(AST_STACK_GROWTH_DEPTH)
+            "(".repeat(RECURSIVE_AST_TEST_DEPTH),
+            ")".repeat(RECURSIVE_AST_TEST_DEPTH)
         );
         parse_module(&source).unwrap();
     }
@@ -351,7 +346,7 @@ mod stack_growth {
         // Nested function definitions exercise stack-growth instrumentation on
         // `parse_block` rather than `parse_lhs_expression`. Each level
         // needs one more leading tab to make indentation valid.
-        let depth = AST_STACK_GROWTH_DEPTH;
+        let depth = RECURSIVE_AST_TEST_DEPTH;
         let mut source = String::new();
         for i in 0..depth {
             source.push_str(&"\t".repeat(i));
@@ -366,14 +361,16 @@ mod stack_growth {
     fn nested_lists() {
         let source = format!(
             "{}1{}",
-            "[".repeat(AST_STACK_GROWTH_DEPTH),
-            "]".repeat(AST_STACK_GROWTH_DEPTH)
+            "[".repeat(RECURSIVE_AST_TEST_DEPTH),
+            "]".repeat(RECURSIVE_AST_TEST_DEPTH)
         );
         parse_module(&source).unwrap();
     }
 
     #[test]
     fn unclosed_lists() {
+        // Invalid input does not return a deeply nested AST that must be dropped
+        // on the test thread, so this does not need the lower Windows limit.
         let source = "[".repeat(5_000);
         assert!(parse_module(&source).is_err());
     }
@@ -382,8 +379,8 @@ mod stack_growth {
     fn nested_calls() {
         let source = format!(
             "x = {}1{}",
-            "f(".repeat(AST_STACK_GROWTH_DEPTH),
-            ")".repeat(AST_STACK_GROWTH_DEPTH)
+            "f(".repeat(RECURSIVE_AST_TEST_DEPTH),
+            ")".repeat(RECURSIVE_AST_TEST_DEPTH)
         );
         parse_module(&source).unwrap();
     }
@@ -392,8 +389,8 @@ mod stack_growth {
     fn nested_subscripts() {
         let source = format!(
             "x = {}1{}",
-            "a[".repeat(AST_STACK_GROWTH_DEPTH),
-            "]".repeat(AST_STACK_GROWTH_DEPTH)
+            "a[".repeat(RECURSIVE_AST_TEST_DEPTH),
+            "]".repeat(RECURSIVE_AST_TEST_DEPTH)
         );
         parse_module(&source).unwrap();
     }
@@ -404,8 +401,8 @@ mod stack_growth {
         // stack-growth instrumentation in addition to statement / expression paths.
         let source = format!(
             "match x:\n case {}y{}: pass\n",
-            "(".repeat(AST_STACK_GROWTH_DEPTH),
-            ")".repeat(AST_STACK_GROWTH_DEPTH),
+            "(".repeat(RECURSIVE_AST_TEST_DEPTH),
+            ")".repeat(RECURSIVE_AST_TEST_DEPTH),
         );
         parse_module(&source).unwrap();
     }
@@ -415,7 +412,7 @@ mod stack_growth {
         // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
         // parenthesised sub-expression, exactly like the pattern described in
         // the tracking issue.
-        let depth = AST_STACK_GROWTH_DEPTH;
+        let depth = RECURSIVE_AST_TEST_DEPTH;
         let mut source = String::new();
         for _ in 0..depth {
             source.push_str("1+(");
@@ -435,7 +432,7 @@ mod stack_growth {
         // the binary-expression recursion path directly, unlike the
         // `1+(1+(...))` interplay test which recurses through parenthesised
         // atoms.
-        let depth = AST_STACK_GROWTH_DEPTH;
+        let depth = RECURSIVE_AST_TEST_DEPTH;
         let mut source = String::with_capacity(depth * 3 + 1);
         for _ in 0..depth {
             source.push_str("1**");
@@ -449,7 +446,7 @@ mod stack_growth {
         // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
         // conditional layer (`parse_if_expression` -> `orelse`), which is not
         // covered by stack growth in `parse_lhs_expression`.
-        let depth = AST_STACK_GROWTH_DEPTH;
+        let depth = RECURSIVE_AST_TEST_DEPTH;
         let mut source = String::with_capacity(depth * 12 + 1);
         for _ in 0..depth {
             source.push_str("1 if 1 else ");
@@ -464,7 +461,7 @@ mod stack_growth {
         // conditional layer (`parse_lambda_expr` -> body), bypassing stack
         // growth in `parse_lhs_expression` entirely.
         let mut source = String::from("x = ");
-        for _ in 0..AST_STACK_GROWTH_DEPTH {
+        for _ in 0..RECURSIVE_AST_TEST_DEPTH {
             source.push_str("lambda: ");
         }
         source.push('1');
@@ -483,13 +480,9 @@ fn invalid_async_chain_is_iterative() {
 #[test]
 fn nested_equal_precedence_unary_chains_are_iterative() {
     // Consecutive unary operators sharing precedence do not require stack growth.
-    // Keep the recursively owned output shallow enough to drop on Windows'
-    // default 1 MiB test-thread stack in debug builds.
-    const DEPTH: usize = 1_000;
-
-    let source = format!("{}1\n", "-~+".repeat(DEPTH));
+    let source = format!("{}1\n", "-~+".repeat(RECURSIVE_AST_TEST_DEPTH));
     parse_module(&source).unwrap();
 
-    let source = format!("{}True\n", "not ".repeat(DEPTH));
+    let source = format!("{}True\n", "not ".repeat(RECURSIVE_AST_TEST_DEPTH));
     parse_module(&source).unwrap();
 }

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,6 +1,9 @@
 use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, Stmt};
 
-use crate::{Mode, ParseOptions, RECURSIVE_AST_TEST_DEPTH, parse, parse_expression, parse_module};
+use crate::{Mode, ParseOptions, parse, parse_expression, parse_module};
+
+// Keep recursive ASTs shallow enough for Windows's 1 MiB test-thread stacks.
+const RECURSIVE_AST_TEST_DEPTH: usize = 1_000;
 
 #[test]
 fn test_modes() {
@@ -338,50 +341,181 @@ fn test_tstring_fstring_middle_fuzzer() {
     insta::assert_debug_snapshot!(error);
 }
 
-// `stacker` is a no-op on unsupported platforms, so only require stack
-// growth where its native support is well established.
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-mod stack_growth {
-    use super::*;
-
-    #[test]
-    fn parser_entry() {
-        // A standalone expression starts on a stack smaller than the parser's red zone, so the
-        // entry check must grow the stack before parsing the nested expression.
-        let source = format!("{}1{}", "(".repeat(128), ")".repeat(128));
-        let parsed = stacker::grow(32 * 1024, || parse_expression(&source));
-        parsed.unwrap();
-    }
-
-    #[test]
-    fn nested_suites() {
-        // Each nested function crosses the suite boundary where the parser rechecks the stack.
-        let depth = RECURSIVE_AST_TEST_DEPTH;
-        let mut source = String::new();
-        for i in 0..depth {
-            source.push_str(&"\t".repeat(i));
-            source.push_str("def f():\n");
-        }
-        source.push_str(&"\t".repeat(depth));
-        source.push_str("pass\n");
-        parse_module(&source).unwrap();
-    }
+#[test]
+fn nested_parens_grow_stack() {
+    let src = format!("{}1{}", "(".repeat(1_000), ")".repeat(1_000));
+    let parsed = stacker::grow(32 * 1024, || parse_module(&src));
+    assert!(parsed.is_ok());
 }
 
 #[test]
-fn invalid_async_chain_is_iterative() {
-    // Invalid repeated `async` prefixes are recovered iteratively.
+fn normal_python_unaffected() {
+    let src = format!("x = {}1{}", "(".repeat(50), ")".repeat(50));
+    parse_module(&src).unwrap();
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn deep_nesting_preserves_surrounding_statements() {
+    let src = format!(
+        "before = 1\n{}1{}\nafter = 2\n",
+        "(".repeat(1_000),
+        ")".repeat(1_000),
+    );
+    let parsed = parse_module(&src).unwrap();
+
+    assert!(matches!(parsed.suite().first(), Some(Stmt::Assign(_))));
+    assert!(matches!(parsed.suite().last(), Some(Stmt::Assign(_))));
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn nested_def_blocks_grow_stack() {
+    // Each nested function crosses the suite boundary where the parser rechecks the stack.
+    let depth = RECURSIVE_AST_TEST_DEPTH;
+    let mut src = String::new();
+    for i in 0..depth {
+        src.push_str(&"\t".repeat(i));
+        src.push_str("def f():\n");
+    }
+    src.push_str(&"\t".repeat(depth));
+    src.push_str("pass\n");
+    parse_module(&src).unwrap();
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn nested_lists_grow_stack() {
+    let src = format!("{}1{}", "[".repeat(1_000), "]".repeat(1_000));
+    parse_module(&src).unwrap();
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn nested_calls_grow_stack() {
+    let src = format!("x = {}1{}", "f(".repeat(1_000), ")".repeat(1_000));
+    parse_module(&src).unwrap();
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn nested_subscripts_grow_stack() {
+    let src = format!("x = {}1{}", "a[".repeat(1_000), "]".repeat(1_000));
+    parse_module(&src).unwrap();
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn nested_match_patterns_grow_stack() {
+    // Deeply parenthesised match patterns — exercises pattern-parsing
+    // instrumentation in addition to statement / expression paths.
+    let mut src = String::from("match x:\n case ");
+    for _ in 0..600 {
+        src.push('(');
+    }
+    src.push('y');
+    for _ in 0..600 {
+        src.push(')');
+    }
+    src.push_str(": pass\n");
+    parse_module(&src).unwrap();
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn nested_invalid_mapping_pattern_keys_grow_stack() {
+    let depth = 512;
+    let src = format!(
+        "match value:\n    case {}0{}:\n        pass\n",
+        "{".repeat(depth),
+        ": 0}".repeat(depth)
+    );
+    let parsed = crate::parse_unchecked(&src, ParseOptions::from(Mode::Module));
+    assert!(!parsed.errors().is_empty());
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn binary_paren_interplay_grows_stack() {
+    // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
+    // parenthesised sub-expression, exactly like the pattern described in
+    // the tracking issue.
+    let depth = RECURSIVE_AST_TEST_DEPTH;
+    let mut src = String::new();
+    for _ in 0..depth {
+        src.push_str("1+(");
+    }
+    src.push('1');
+    for _ in 0..depth {
+        src.push(')');
+    }
+    parse_module(&src).unwrap();
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn right_assoc_pow_chain_grows_stack() {
+    // `1**1**1**...**1` — `**` is right-associative, so the right operand
+    // is parsed by a recursive `parse_binary_expression_or_higher` call
+    // *without* any intervening parentheses or atom nesting. This exercises
+    // the binary-expression recursion path directly, unlike the
+    // `1+(1+(...))` interplay test which recurses through parenthesised
+    // atoms.
+    let depth = RECURSIVE_AST_TEST_DEPTH;
+    let mut src = String::with_capacity(depth * 3 + 1);
+    for _ in 0..depth {
+        src.push_str("1**");
+    }
+    src.push('1');
+    parse_module(&src).unwrap();
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn ternary_else_chain_grows_stack() {
+    // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
+    // conditional layer (`parse_if_expression` -> `orelse`), which is not
+    // covered by the binary-expression guard.
+    let depth = RECURSIVE_AST_TEST_DEPTH;
+    let mut src = String::with_capacity(depth * 12 + 1);
+    for _ in 0..depth {
+        src.push_str("1 if 1 else ");
+    }
+    src.push('1');
+    parse_module(&src).unwrap();
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn nested_lambda_chain_grows_stack() {
+    // `lambda: lambda: lambda: ...` — the lambda body recurses at the
+    // conditional layer (`parse_lambda_expr` -> body), bypassing the
+    // binary-expression guard entirely.
+    let depth = RECURSIVE_AST_TEST_DEPTH;
+    let mut src = String::from("x = ");
+    for _ in 0..depth {
+        src.push_str("lambda: ");
+    }
+    src.push('1');
+    parse_module(&src).unwrap();
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[test]
+fn invalid_async_chain_grows_stack() {
     let source = format!("{}x = 1\n", "async ".repeat(5_000));
     let parsed = crate::parse_unchecked(&source, ParseOptions::from(Mode::Module));
     assert!(!parsed.errors().is_empty());
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 #[test]
-fn nested_equal_precedence_unary_chains_are_iterative() {
-    // Consecutive unary operators sharing precedence do not require stack growth.
-    let source = format!("{}1\n", "-~+".repeat(RECURSIVE_AST_TEST_DEPTH));
+fn nested_unary_chains_grow_stack() {
+    let depth = 300;
+    let source = format!("{}1\n", "-~+".repeat(depth));
     parse_module(&source).unwrap();
 
-    let source = format!("{}True\n", "not ".repeat(RECURSIVE_AST_TEST_DEPTH));
+    let source = format!("{}True\n", "not ".repeat(depth));
     parse_module(&source).unwrap();
 }

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -338,127 +338,134 @@ fn test_tstring_fstring_middle_fuzzer() {
     insta::assert_debug_snapshot!(error);
 }
 
-#[test]
-fn stack_growth_nested_parens() {
-    let source = format!("{}1{}", "(".repeat(5_000), ")".repeat(5_000));
-    parse_module(&source).unwrap();
-}
+// `stacker` is a no-op on unsupported platforms, so only require stack
+// growth where its native support is well established.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+mod stack_growth {
+    use super::*;
 
-#[test]
-fn stack_growth_nested_def_blocks() {
-    // Nested function definitions exercise stack-growth instrumentation on
-    // `parse_block` rather than `parse_lhs_expression`. Each level
-    // needs one more leading tab to make indentation valid.
-    let depth = 1_000;
-    let mut source = String::new();
-    for i in 0..depth {
-        source.push_str(&"\t".repeat(i));
-        source.push_str("def f():\n");
+    #[test]
+    fn nested_parens() {
+        let source = format!("{}1{}", "(".repeat(5_000), ")".repeat(5_000));
+        parse_module(&source).unwrap();
     }
-    source.push_str(&"\t".repeat(depth));
-    source.push_str("pass\n");
-    parse_module(&source).unwrap();
-}
 
-#[test]
-fn stack_growth_nested_lists() {
-    let source = format!("{}1{}", "[".repeat(5_000), "]".repeat(5_000));
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_unclosed_lists() {
-    let source = "[".repeat(5_000);
-    assert!(parse_module(&source).is_err());
-}
-
-#[test]
-fn stack_growth_nested_calls() {
-    let source = format!("x = {}1{}", "f(".repeat(5_000), ")".repeat(5_000));
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_nested_subscripts() {
-    let source = format!("x = {}1{}", "a[".repeat(5_000), "]".repeat(5_000));
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_nested_match_patterns() {
-    // Deeply parenthesised match patterns exercise pattern-parsing
-    // stack-growth instrumentation in addition to statement / expression paths.
-    let source = format!(
-        "match x:\n case {}y{}: pass\n",
-        "(".repeat(5_000),
-        ")".repeat(5_000),
-    );
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_binary_paren_interplay() {
-    // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
-    // parenthesised sub-expression, exactly like the pattern described in
-    // the tracking issue.
-    let depth = 5_000;
-    let mut source = String::new();
-    for _ in 0..depth {
-        source.push_str("1+(");
+    #[test]
+    fn nested_def_blocks() {
+        // Nested function definitions exercise stack-growth instrumentation on
+        // `parse_block` rather than `parse_lhs_expression`. Each level
+        // needs one more leading tab to make indentation valid.
+        let depth = 1_000;
+        let mut source = String::new();
+        for i in 0..depth {
+            source.push_str(&"\t".repeat(i));
+            source.push_str("def f():\n");
+        }
+        source.push_str(&"\t".repeat(depth));
+        source.push_str("pass\n");
+        parse_module(&source).unwrap();
     }
-    source.push('1');
-    for _ in 0..depth {
-        source.push(')');
+
+    #[test]
+    fn nested_lists() {
+        let source = format!("{}1{}", "[".repeat(5_000), "]".repeat(5_000));
+        parse_module(&source).unwrap();
     }
-    parse_module(&source).unwrap();
+
+    #[test]
+    fn unclosed_lists() {
+        let source = "[".repeat(5_000);
+        assert!(parse_module(&source).is_err());
+    }
+
+    #[test]
+    fn nested_calls() {
+        let source = format!("x = {}1{}", "f(".repeat(5_000), ")".repeat(5_000));
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn nested_subscripts() {
+        let source = format!("x = {}1{}", "a[".repeat(5_000), "]".repeat(5_000));
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn nested_match_patterns() {
+        // Deeply parenthesised match patterns exercise pattern-parsing
+        // stack-growth instrumentation in addition to statement / expression paths.
+        let source = format!(
+            "match x:\n case {}y{}: pass\n",
+            "(".repeat(5_000),
+            ")".repeat(5_000),
+        );
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn binary_paren_interplay() {
+        // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
+        // parenthesised sub-expression, exactly like the pattern described in
+        // the tracking issue.
+        let depth = 5_000;
+        let mut source = String::new();
+        for _ in 0..depth {
+            source.push_str("1+(");
+        }
+        source.push('1');
+        for _ in 0..depth {
+            source.push(')');
+        }
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn right_assoc_pow_chain() {
+        // `1**1**1**...**1` — `**` is right-associative, so the right operand
+        // is parsed by a recursive `parse_binary_expression_or_higher` call
+        // *without* any intervening parentheses or atom nesting. This exercises
+        // the binary-expression recursion path directly, unlike the
+        // `1+(1+(...))` interplay test which recurses through parenthesised
+        // atoms.
+        let depth = 5_000;
+        let mut source = String::with_capacity(depth * 3 + 1);
+        for _ in 0..depth {
+            source.push_str("1**");
+        }
+        source.push('1');
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn ternary_else_chain() {
+        // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
+        // conditional layer (`parse_if_expression` -> `orelse`), which is not
+        // covered by stack growth in `parse_lhs_expression`.
+        let depth = 5_000;
+        let mut source = String::with_capacity(depth * 12 + 1);
+        for _ in 0..depth {
+            source.push_str("1 if 1 else ");
+        }
+        source.push('1');
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn nested_lambda_chain() {
+        // `lambda: lambda: lambda: ...` — the lambda body recurses at the
+        // conditional layer (`parse_lambda_expr` -> body), bypassing stack
+        // growth in `parse_lhs_expression` entirely.
+        let mut source = String::from("x = ");
+        for _ in 0..5_000 {
+            source.push_str("lambda: ");
+        }
+        source.push('1');
+        parse_module(&source).unwrap();
+    }
 }
 
 #[test]
-fn stack_growth_right_assoc_pow_chain() {
-    // `1**1**1**...**1` — `**` is right-associative, so the right operand
-    // is parsed by a recursive `parse_binary_expression_or_higher` call
-    // *without* any intervening parentheses or atom nesting. This exercises
-    // the binary-expression recursion path directly, unlike the
-    // `1+(1+(...))` interplay test which recurses through parenthesised
-    // atoms.
-    let depth = 5_000;
-    let mut source = String::with_capacity(depth * 3 + 1);
-    for _ in 0..depth {
-        source.push_str("1**");
-    }
-    source.push('1');
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_ternary_else_chain() {
-    // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
-    // conditional layer (`parse_if_expression` -> `orelse`), which is not
-    // covered by stack growth in `parse_lhs_expression`.
-    let depth = 5_000;
-    let mut source = String::with_capacity(depth * 12 + 1);
-    for _ in 0..depth {
-        source.push_str("1 if 1 else ");
-    }
-    source.push('1');
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_nested_lambda_chain() {
-    // `lambda: lambda: lambda: ...` — the lambda body recurses at the
-    // conditional layer (`parse_lambda_expr` -> body), bypassing stack
-    // growth in `parse_lhs_expression` entirely.
-    let mut source = String::from("x = ");
-    for _ in 0..5_000 {
-        source.push_str("lambda: ");
-    }
-    source.push('1');
-    parse_module(&source).unwrap();
-}
-
-#[test]
-fn stack_growth_invalid_async_chain() {
+fn invalid_async_chain_is_iterative() {
     // Invalid repeated `async` prefixes are recovered iteratively.
     let source = format!("{}x = 1\n", "async ".repeat(5_000));
     let parsed = crate::parse_unchecked(&source, ParseOptions::from(Mode::Module));

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -338,225 +338,115 @@ fn test_tstring_fstring_middle_fuzzer() {
     insta::assert_debug_snapshot!(error);
 }
 
-#[test]
-fn recursion_limit_nested_parens() {
-    let src = format!("{}1{}", "(".repeat(1_000), ")".repeat(1_000));
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+fn parse_deep_ast(source: &str) {
+    let parsed = parse_module(source).unwrap();
+    // This regression suite isolates parser stack growth; walking or dropping
+    // a deeply nested returned AST is a separate consumer concern.
+    std::mem::forget(parsed);
 }
 
 #[test]
-fn recursion_limit_normal_python_unaffected() {
-    // 50 levels is well above what real-world Python ever produces and well
-    // below the default cap — the point is to confirm the default doesn't
-    // reject ordinary input.
-    let src = format!("x = {}1{}", "(".repeat(50), ")".repeat(50));
-    parse_module(&src).unwrap();
+fn stack_growth_nested_parens() {
+    let source = format!("{}1{}", "(".repeat(5_000), ")".repeat(5_000));
+    parse_module(&source).unwrap();
 }
 
 #[test]
-fn recursion_limit_preserves_prior_statements() {
-    // Recursion-limit recovery is limited for now: we drain the rest of the file but keep the
-    // statements parsed before the overflowing statement.
-    // TODO: Recover at the next newline so the trailing statement is preserved too.
-    let src = format!(
-        "before = 1\n{}1{}\nafter = 2\n",
-        "(".repeat(1_000),
-        ")".repeat(1_000),
-    );
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let parsed = crate::parse_unchecked(&src, opts)
-        .try_into_module()
-        .unwrap();
-
-    assert!(matches!(
-        parsed.errors().first().map(|error| &error.error),
-        Some(ParseErrorType::RecursionLimitExceeded)
-    ));
-    assert!(matches!(parsed.suite().first(), Some(Stmt::Assign(_))));
-}
-
-#[test]
-fn recursion_limit_nested_def_blocks() {
-    // Nested function definitions exercise instrumentation on
-    // `parse_statement` rather than `parse_lhs_expression`. Each level
-    // needs one more leading tab to make indentation valid.
-    let depth = 400;
-    let mut src = String::new();
+fn stack_growth_nested_def_blocks() {
+    let depth = 1_000;
+    let mut source = String::new();
     for i in 0..depth {
-        src.push_str(&"\t".repeat(i));
-        src.push_str("def f():\n");
+        source.push_str(&"\t".repeat(i));
+        source.push_str("def f():\n");
     }
-    src.push_str(&"\t".repeat(depth));
-    src.push_str("pass\n");
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+    source.push_str(&"\t".repeat(depth));
+    source.push_str("pass\n");
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_nested_lists() {
-    let src = format!("{}1{}", "[".repeat(1_000), "]".repeat(1_000));
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+fn stack_growth_nested_lists() {
+    let source = format!("{}1{}", "[".repeat(5_000), "]".repeat(5_000));
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_nested_calls() {
-    let src = format!("x = {}1{}", "f(".repeat(1_000), ")".repeat(1_000));
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+fn stack_growth_unclosed_lists() {
+    let source = "[".repeat(5_000);
+    assert!(parse_module(&source).is_err());
 }
 
 #[test]
-fn recursion_limit_nested_subscripts() {
-    let src = format!("x = {}1{}", "a[".repeat(1_000), "]".repeat(1_000));
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+fn stack_growth_nested_calls() {
+    let source = format!("x = {}1{}", "f(".repeat(5_000), ")".repeat(5_000));
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_nested_match_patterns() {
-    // Deeply parenthesised match patterns — exercises pattern-parsing
-    // instrumentation in addition to statement / expression paths.
-    let mut src = String::from("match x:\n case ");
-    for _ in 0..600 {
-        src.push('(');
-    }
-    src.push('y');
-    for _ in 0..600 {
-        src.push(')');
-    }
-    src.push_str(": pass\n");
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+fn stack_growth_nested_subscripts() {
+    let source = format!("x = {}1{}", "a[".repeat(5_000), "]".repeat(5_000));
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_binary_paren_interplay() {
-    // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
-    // parenthesised sub-expression, exactly like the pattern described in
-    // the tracking issue.
-    let depth = 2_000;
-    let mut src = String::new();
-    for _ in 0..depth {
-        src.push_str("1+(");
-    }
-    src.push('1');
-    for _ in 0..depth {
-        src.push(')');
-    }
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
-}
-
-#[test]
-fn recursion_limit_first_error_is_recursion_not_noise() {
-    // When the limit is hit the outer parser frames will emit secondary
-    // errors as they unwind. Callers read the first error via `into_result`
-    // / `Parsed::errors()`, so `RecursionLimitExceeded` must come first, and
-    // the drain-to-EOF after reporting the recursion limit should keep the total count
-    // small rather than producing one noisy error per unwound frame.
-    let src = format!("{}1{}", "(".repeat(2_000), ")".repeat(2_000));
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(50);
-    let parsed = crate::parse_unchecked(&src, opts);
-    let errors = parsed.errors();
-    let first = errors.first().expect("expected at least one error");
-    assert!(matches!(
-        first.error,
-        ParseErrorType::RecursionLimitExceeded
-    ));
-    // Exactly one `RecursionLimitExceeded` — guards against a regression
-    // where the unwind loops and re-triggers the limit check.
-    let recursion_errors = errors
-        .iter()
-        .filter(|e| matches!(e.error, ParseErrorType::RecursionLimitExceeded))
-        .count();
-    assert_eq!(recursion_errors, 1);
-    // Small, bounded tail of follow-up errors from the unwinding frames.
-    // Today this is 0; the generous cap is a regression gate, not a spec.
-    assert!(
-        errors.len() <= 8,
-        "expected a small number of errors, got {}: {errors:?}",
-        errors.len(),
+fn stack_growth_nested_match_patterns() {
+    let source = format!(
+        "match x:\n case {}y{}: pass\n",
+        "(".repeat(5_000),
+        ")".repeat(5_000),
     );
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_default_set() {
-    let opts = ParseOptions::from(Mode::Module);
-    // Guards against someone accidentally unsetting the default. Real-world
-    // Python never approaches this depth, and the value must stay within the
-    // threading stack's capacity — see the const's docs in `options.rs`.
-    assert!(opts.max_recursion_depth() >= 200);
-    assert!(opts.max_recursion_depth() <= 2000);
-}
-
-#[test]
-fn recursion_limit_right_assoc_pow_chain() {
-    // `1**1**1**...**1` — `**` is right-associative, so the right operand
-    // is parsed by a recursive `parse_binary_expression_or_higher` call
-    // *without* any intervening parentheses or atom nesting. This exercises
-    // the binary-expression recursion path directly, unlike the
-    // `1+(1+(...))` interplay test which recurses through parenthesised
-    // atoms.
-    let depth = 2_000;
-    let mut src = String::with_capacity(depth * 3 + 1);
+fn stack_growth_binary_paren_interplay() {
+    let depth = 5_000;
+    let mut source = String::new();
     for _ in 0..depth {
-        src.push_str("1**");
+        source.push_str("1+(");
     }
-    src.push('1');
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(
-        matches!(err.error, ParseErrorType::RecursionLimitExceeded),
-        "expected RecursionLimitExceeded, got {:?}",
-        err.error
-    );
+    source.push('1');
+    for _ in 0..depth {
+        source.push(')');
+    }
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_ternary_else_chain() {
-    // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
-    // conditional layer (`parse_if_expression` -> `orelse`), which is not
-    // covered by the `parse_lhs_expression` guard.
-    let depth = 2_000;
-    let mut src = String::with_capacity(depth * 12 + 1);
+fn stack_growth_right_assoc_pow_chain() {
+    let depth = 5_000;
+    let mut source = String::with_capacity(depth * 3 + 1);
     for _ in 0..depth {
-        src.push_str("1 if 1 else ");
+        source.push_str("1**");
     }
-    src.push('1');
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(
-        matches!(err.error, ParseErrorType::RecursionLimitExceeded),
-        "expected RecursionLimitExceeded, got {:?}",
-        err.error
-    );
+    source.push('1');
+    parse_deep_ast(&source);
 }
 
 #[test]
-fn recursion_limit_nested_lambda_chain() {
-    // `lambda: lambda: lambda: ...` — the lambda body recurses at the
-    // conditional layer (`parse_lambda_expr` -> body), bypassing the
-    // `parse_lhs_expression` guard entirely.
-    let depth = 2_000;
-    let mut src = String::from("x = ");
+fn stack_growth_ternary_else_chain() {
+    let depth = 5_000;
+    let mut source = String::with_capacity(depth * 12 + 1);
     for _ in 0..depth {
-        src.push_str("lambda: ");
+        source.push_str("1 if 1 else ");
     }
-    src.push('1');
-    let opts = ParseOptions::from(Mode::Module).with_max_recursion_depth(100);
-    let err = parse(&src, opts).unwrap_err();
-    assert!(
-        matches!(err.error, ParseErrorType::RecursionLimitExceeded),
-        "expected RecursionLimitExceeded, got {:?}",
-        err.error
-    );
+    source.push('1');
+    parse_deep_ast(&source);
+}
+
+#[test]
+fn stack_growth_nested_lambda_chain() {
+    let mut source = String::from("x = ");
+    for _ in 0..5_000 {
+        source.push_str("lambda: ");
+    }
+    source.push('1');
+    parse_deep_ast(&source);
+}
+
+#[test]
+fn stack_growth_invalid_async_chain() {
+    let source = format!("{}x = 1\n", "async ".repeat(5_000));
+    let parsed = crate::parse_unchecked(&source, ParseOptions::from(Mode::Module));
+    assert!(!parsed.errors().is_empty());
 }

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -355,27 +355,21 @@ mod stack_growth {
     }
 
     #[test]
-    fn nested_def_blocks() {
-        // Nested function definitions exercise stack-growth instrumentation on
-        // `parse_block` rather than `parse_lhs_expression`. Each level
-        // needs one more leading tab to make indentation valid.
-        let depth = RECURSIVE_AST_TEST_DEPTH;
-        let mut source = String::new();
-        for i in 0..depth {
-            source.push_str(&"\t".repeat(i));
-            source.push_str("def f():\n");
-        }
-        source.push_str(&"\t".repeat(depth));
-        source.push_str("pass\n");
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
     fn nested_lists() {
         let source = format!(
             "{}1{}",
             "[".repeat(RECURSIVE_AST_TEST_DEPTH),
             "]".repeat(RECURSIVE_AST_TEST_DEPTH)
+        );
+        parse_module(&source).unwrap();
+    }
+
+    #[test]
+    fn nested_dictionaries() {
+        let source = format!(
+            "{}1{}",
+            "{'x':".repeat(RECURSIVE_AST_TEST_DEPTH),
+            "}".repeat(RECURSIVE_AST_TEST_DEPTH)
         );
         parse_module(&source).unwrap();
     }
@@ -409,18 +403,6 @@ mod stack_growth {
     }
 
     #[test]
-    fn nested_match_patterns() {
-        // Deeply parenthesised match patterns exercise pattern-parsing
-        // stack-growth instrumentation in addition to statement / expression paths.
-        let source = format!(
-            "match x:\n case {}y{}: pass\n",
-            "(".repeat(RECURSIVE_AST_TEST_DEPTH),
-            ")".repeat(RECURSIVE_AST_TEST_DEPTH),
-        );
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
     fn binary_paren_interplay() {
         // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
         // parenthesised sub-expression, exactly like the pattern described in
@@ -438,44 +420,13 @@ mod stack_growth {
     }
 
     #[test]
-    fn right_assoc_pow_chain() {
-        // `1**1**1**...**1` — `**` is right-associative, so the right operand
-        // is parsed by a recursive `parse_binary_expression_or_higher` call
-        // *without* any intervening parentheses or atom nesting. This exercises
-        // the binary-expression recursion path directly, unlike the
-        // `1+(1+(...))` interplay test which recurses through parenthesised
-        // atoms.
-        let depth = RECURSIVE_AST_TEST_DEPTH;
-        let mut source = String::with_capacity(depth * 3 + 1);
-        for _ in 0..depth {
-            source.push_str("1**");
-        }
-        source.push('1');
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
     fn ternary_else_chain() {
         // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
-        // conditional layer (`parse_if_expression` -> `orelse`), which is not
-        // covered by stack growth in `parse_lhs_expression`.
+        // conditional layer (`parse_if_expression` -> `orelse`).
         let depth = RECURSIVE_AST_TEST_DEPTH;
         let mut source = String::with_capacity(depth * 12 + 1);
         for _ in 0..depth {
             source.push_str("1 if 1 else ");
-        }
-        source.push('1');
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
-    fn nested_lambda_chain() {
-        // `lambda: lambda: lambda: ...` — the lambda body recurses at the
-        // conditional layer (`parse_lambda_expr` -> body), bypassing stack
-        // growth in `parse_lhs_expression` entirely.
-        let mut source = String::from("x = ");
-        for _ in 0..RECURSIVE_AST_TEST_DEPTH {
-            source.push_str("lambda: ");
         }
         source.push('1');
         parse_module(&source).unwrap();

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -471,3 +471,13 @@ fn invalid_async_chain_is_iterative() {
     let parsed = crate::parse_unchecked(&source, ParseOptions::from(Mode::Module));
     assert!(!parsed.errors().is_empty());
 }
+
+#[test]
+fn nested_equal_precedence_unary_chains_are_iterative() {
+    // Consecutive unary operators sharing precedence do not require stack growth.
+    let source = format!("{}1\n", "-~+".repeat(5_000));
+    parse_module(&source).unwrap();
+
+    let source = format!("{}True\n", "not ".repeat(5_000));
+    parse_module(&source).unwrap();
+}

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -344,9 +344,18 @@ fn test_tstring_fstring_middle_fuzzer() {
 mod stack_growth {
     use super::*;
 
+    // Windows test threads have a 1 MiB stack by default. Keep successfully
+    // parsed ASTs shallow enough for their recursive drop glue in debug builds
+    // while still exercising parser stack growth.
+    const AST_STACK_GROWTH_DEPTH: usize = 1_000;
+
     #[test]
     fn nested_parens() {
-        let source = format!("{}1{}", "(".repeat(5_000), ")".repeat(5_000));
+        let source = format!(
+            "{}1{}",
+            "(".repeat(AST_STACK_GROWTH_DEPTH),
+            ")".repeat(AST_STACK_GROWTH_DEPTH)
+        );
         parse_module(&source).unwrap();
     }
 
@@ -355,7 +364,7 @@ mod stack_growth {
         // Nested function definitions exercise stack-growth instrumentation on
         // `parse_block` rather than `parse_lhs_expression`. Each level
         // needs one more leading tab to make indentation valid.
-        let depth = 1_000;
+        let depth = AST_STACK_GROWTH_DEPTH;
         let mut source = String::new();
         for i in 0..depth {
             source.push_str(&"\t".repeat(i));
@@ -368,7 +377,11 @@ mod stack_growth {
 
     #[test]
     fn nested_lists() {
-        let source = format!("{}1{}", "[".repeat(5_000), "]".repeat(5_000));
+        let source = format!(
+            "{}1{}",
+            "[".repeat(AST_STACK_GROWTH_DEPTH),
+            "]".repeat(AST_STACK_GROWTH_DEPTH)
+        );
         parse_module(&source).unwrap();
     }
 
@@ -380,13 +393,21 @@ mod stack_growth {
 
     #[test]
     fn nested_calls() {
-        let source = format!("x = {}1{}", "f(".repeat(5_000), ")".repeat(5_000));
+        let source = format!(
+            "x = {}1{}",
+            "f(".repeat(AST_STACK_GROWTH_DEPTH),
+            ")".repeat(AST_STACK_GROWTH_DEPTH)
+        );
         parse_module(&source).unwrap();
     }
 
     #[test]
     fn nested_subscripts() {
-        let source = format!("x = {}1{}", "a[".repeat(5_000), "]".repeat(5_000));
+        let source = format!(
+            "x = {}1{}",
+            "a[".repeat(AST_STACK_GROWTH_DEPTH),
+            "]".repeat(AST_STACK_GROWTH_DEPTH)
+        );
         parse_module(&source).unwrap();
     }
 
@@ -396,8 +417,8 @@ mod stack_growth {
         // stack-growth instrumentation in addition to statement / expression paths.
         let source = format!(
             "match x:\n case {}y{}: pass\n",
-            "(".repeat(5_000),
-            ")".repeat(5_000),
+            "(".repeat(AST_STACK_GROWTH_DEPTH),
+            ")".repeat(AST_STACK_GROWTH_DEPTH),
         );
         parse_module(&source).unwrap();
     }
@@ -407,7 +428,7 @@ mod stack_growth {
         // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
         // parenthesised sub-expression, exactly like the pattern described in
         // the tracking issue.
-        let depth = 5_000;
+        let depth = AST_STACK_GROWTH_DEPTH;
         let mut source = String::new();
         for _ in 0..depth {
             source.push_str("1+(");
@@ -427,7 +448,7 @@ mod stack_growth {
         // the binary-expression recursion path directly, unlike the
         // `1+(1+(...))` interplay test which recurses through parenthesised
         // atoms.
-        let depth = 5_000;
+        let depth = AST_STACK_GROWTH_DEPTH;
         let mut source = String::with_capacity(depth * 3 + 1);
         for _ in 0..depth {
             source.push_str("1**");
@@ -441,7 +462,7 @@ mod stack_growth {
         // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
         // conditional layer (`parse_if_expression` -> `orelse`), which is not
         // covered by stack growth in `parse_lhs_expression`.
-        let depth = 5_000;
+        let depth = AST_STACK_GROWTH_DEPTH;
         let mut source = String::with_capacity(depth * 12 + 1);
         for _ in 0..depth {
             source.push_str("1 if 1 else ");
@@ -456,7 +477,7 @@ mod stack_growth {
         // conditional layer (`parse_lambda_expr` -> body), bypassing stack
         // growth in `parse_lhs_expression` entirely.
         let mut source = String::from("x = ");
-        for _ in 0..5_000 {
+        for _ in 0..AST_STACK_GROWTH_DEPTH {
             source.push_str("lambda: ");
         }
         source.push('1');
@@ -475,9 +496,13 @@ fn invalid_async_chain_is_iterative() {
 #[test]
 fn nested_equal_precedence_unary_chains_are_iterative() {
     // Consecutive unary operators sharing precedence do not require stack growth.
-    let source = format!("{}1\n", "-~+".repeat(5_000));
+    // Keep the recursively owned output shallow enough to drop on Windows'
+    // default 1 MiB test-thread stack in debug builds.
+    const DEPTH: usize = 1_000;
+
+    let source = format!("{}1\n", "-~+".repeat(DEPTH));
     parse_module(&source).unwrap();
 
-    let source = format!("{}True\n", "not ".repeat(5_000));
+    let source = format!("{}True\n", "not ".repeat(DEPTH));
     parse_module(&source).unwrap();
 }

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -338,13 +338,6 @@ fn test_tstring_fstring_middle_fuzzer() {
     insta::assert_debug_snapshot!(error);
 }
 
-fn parse_deep_ast(source: &str) {
-    let parsed = parse_module(source).unwrap();
-    // This regression suite isolates parser stack growth; walking or dropping
-    // a deeply nested returned AST is a separate consumer concern.
-    std::mem::forget(parsed);
-}
-
 #[test]
 fn stack_growth_nested_parens() {
     let source = format!("{}1{}", "(".repeat(5_000), ")".repeat(5_000));
@@ -353,6 +346,9 @@ fn stack_growth_nested_parens() {
 
 #[test]
 fn stack_growth_nested_def_blocks() {
+    // Nested function definitions exercise stack-growth instrumentation on
+    // `parse_block` rather than `parse_lhs_expression`. Each level
+    // needs one more leading tab to make indentation valid.
     let depth = 1_000;
     let mut source = String::new();
     for i in 0..depth {
@@ -361,13 +357,13 @@ fn stack_growth_nested_def_blocks() {
     }
     source.push_str(&"\t".repeat(depth));
     source.push_str("pass\n");
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_nested_lists() {
     let source = format!("{}1{}", "[".repeat(5_000), "]".repeat(5_000));
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
@@ -379,27 +375,32 @@ fn stack_growth_unclosed_lists() {
 #[test]
 fn stack_growth_nested_calls() {
     let source = format!("x = {}1{}", "f(".repeat(5_000), ")".repeat(5_000));
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_nested_subscripts() {
     let source = format!("x = {}1{}", "a[".repeat(5_000), "]".repeat(5_000));
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_nested_match_patterns() {
+    // Deeply parenthesised match patterns exercise pattern-parsing
+    // stack-growth instrumentation in addition to statement / expression paths.
     let source = format!(
         "match x:\n case {}y{}: pass\n",
         "(".repeat(5_000),
         ")".repeat(5_000),
     );
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_binary_paren_interplay() {
+    // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
+    // parenthesised sub-expression, exactly like the pattern described in
+    // the tracking issue.
     let depth = 5_000;
     let mut source = String::new();
     for _ in 0..depth {
@@ -409,43 +410,56 @@ fn stack_growth_binary_paren_interplay() {
     for _ in 0..depth {
         source.push(')');
     }
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_right_assoc_pow_chain() {
+    // `1**1**1**...**1` — `**` is right-associative, so the right operand
+    // is parsed by a recursive `parse_binary_expression_or_higher` call
+    // *without* any intervening parentheses or atom nesting. This exercises
+    // the binary-expression recursion path directly, unlike the
+    // `1+(1+(...))` interplay test which recurses through parenthesised
+    // atoms.
     let depth = 5_000;
     let mut source = String::with_capacity(depth * 3 + 1);
     for _ in 0..depth {
         source.push_str("1**");
     }
     source.push('1');
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_ternary_else_chain() {
+    // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
+    // conditional layer (`parse_if_expression` -> `orelse`), which is not
+    // covered by stack growth in `parse_lhs_expression`.
     let depth = 5_000;
     let mut source = String::with_capacity(depth * 12 + 1);
     for _ in 0..depth {
         source.push_str("1 if 1 else ");
     }
     source.push('1');
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_nested_lambda_chain() {
+    // `lambda: lambda: lambda: ...` — the lambda body recurses at the
+    // conditional layer (`parse_lambda_expr` -> body), bypassing stack
+    // growth in `parse_lhs_expression` entirely.
     let mut source = String::from("x = ");
     for _ in 0..5_000 {
         source.push_str("lambda: ");
     }
     source.push('1');
-    parse_deep_ast(&source);
+    parse_module(&source).unwrap();
 }
 
 #[test]
 fn stack_growth_invalid_async_chain() {
+    // Invalid repeated `async` prefixes are recovered iteratively.
     let source = format!("{}x = 1\n", "async ".repeat(5_000));
     let parsed = crate::parse_unchecked(&source, ParseOptions::from(Mode::Module));
     assert!(!parsed.errors().is_empty());

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -345,90 +345,25 @@ mod stack_growth {
     use super::*;
 
     #[test]
-    fn nested_parens() {
-        let source = format!(
-            "{}1{}",
-            "(".repeat(RECURSIVE_AST_TEST_DEPTH),
-            ")".repeat(RECURSIVE_AST_TEST_DEPTH)
-        );
-        parse_module(&source).unwrap();
+    fn parser_entry() {
+        // A standalone expression starts on a stack smaller than the parser's red zone, so the
+        // entry check must grow the stack before parsing the nested expression.
+        let source = format!("{}1{}", "(".repeat(128), ")".repeat(128));
+        let parsed = stacker::grow(32 * 1024, || parse_expression(&source));
+        parsed.unwrap();
     }
 
     #[test]
-    fn nested_lists() {
-        let source = format!(
-            "{}1{}",
-            "[".repeat(RECURSIVE_AST_TEST_DEPTH),
-            "]".repeat(RECURSIVE_AST_TEST_DEPTH)
-        );
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
-    fn nested_dictionaries() {
-        let source = format!(
-            "{}1{}",
-            "{'x':".repeat(RECURSIVE_AST_TEST_DEPTH),
-            "}".repeat(RECURSIVE_AST_TEST_DEPTH)
-        );
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
-    fn unclosed_lists() {
-        // Invalid input does not return a deeply nested AST that must be dropped
-        // on the test thread, so this does not need the lower Windows limit.
-        let source = "[".repeat(5_000);
-        assert!(parse_module(&source).is_err());
-    }
-
-    #[test]
-    fn nested_calls() {
-        let source = format!(
-            "x = {}1{}",
-            "f(".repeat(RECURSIVE_AST_TEST_DEPTH),
-            ")".repeat(RECURSIVE_AST_TEST_DEPTH)
-        );
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
-    fn nested_subscripts() {
-        let source = format!(
-            "x = {}1{}",
-            "a[".repeat(RECURSIVE_AST_TEST_DEPTH),
-            "]".repeat(RECURSIVE_AST_TEST_DEPTH)
-        );
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
-    fn binary_paren_interplay() {
-        // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
-        // parenthesised sub-expression, exactly like the pattern described in
-        // the tracking issue.
+    fn nested_suites() {
+        // Each nested function crosses the suite boundary where the parser rechecks the stack.
         let depth = RECURSIVE_AST_TEST_DEPTH;
         let mut source = String::new();
-        for _ in 0..depth {
-            source.push_str("1+(");
+        for i in 0..depth {
+            source.push_str(&"\t".repeat(i));
+            source.push_str("def f():\n");
         }
-        source.push('1');
-        for _ in 0..depth {
-            source.push(')');
-        }
-        parse_module(&source).unwrap();
-    }
-
-    #[test]
-    fn ternary_else_chain() {
-        // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
-        // conditional layer (`parse_if_expression` -> `orelse`).
-        let depth = RECURSIVE_AST_TEST_DEPTH;
-        let mut source = String::with_capacity(depth * 12 + 1);
-        for _ in 0..depth {
-            source.push_str("1 if 1 else ");
-        }
-        source.push('1');
+        source.push_str(&"\t".repeat(depth));
+        source.push_str("pass\n");
         parse_module(&source).unwrap();
     }
 }

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,6 +1,6 @@
 use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, Stmt};
 
-use crate::{Mode, ParseErrorType, ParseOptions, parse, parse_expression, parse_module};
+use crate::{Mode, ParseOptions, RECURSIVE_AST_TEST_DEPTH, parse, parse_expression, parse_module};
 
 #[test]
 fn test_modes() {
@@ -344,17 +344,12 @@ fn test_tstring_fstring_middle_fuzzer() {
 mod stack_growth {
     use super::*;
 
-    // Windows test threads have a 1 MiB stack by default. Keep successfully
-    // parsed ASTs shallow enough for their recursive drop glue in debug builds
-    // while still exercising parser stack growth.
-    const AST_STACK_GROWTH_DEPTH: usize = 1_000;
-
     #[test]
     fn nested_parens() {
         let source = format!(
             "{}1{}",
-            "(".repeat(AST_STACK_GROWTH_DEPTH),
-            ")".repeat(AST_STACK_GROWTH_DEPTH)
+            "(".repeat(RECURSIVE_AST_TEST_DEPTH),
+            ")".repeat(RECURSIVE_AST_TEST_DEPTH)
         );
         parse_module(&source).unwrap();
     }
@@ -364,7 +359,7 @@ mod stack_growth {
         // Nested function definitions exercise stack-growth instrumentation on
         // `parse_block` rather than `parse_lhs_expression`. Each level
         // needs one more leading tab to make indentation valid.
-        let depth = AST_STACK_GROWTH_DEPTH;
+        let depth = RECURSIVE_AST_TEST_DEPTH;
         let mut source = String::new();
         for i in 0..depth {
             source.push_str(&"\t".repeat(i));
@@ -379,14 +374,16 @@ mod stack_growth {
     fn nested_lists() {
         let source = format!(
             "{}1{}",
-            "[".repeat(AST_STACK_GROWTH_DEPTH),
-            "]".repeat(AST_STACK_GROWTH_DEPTH)
+            "[".repeat(RECURSIVE_AST_TEST_DEPTH),
+            "]".repeat(RECURSIVE_AST_TEST_DEPTH)
         );
         parse_module(&source).unwrap();
     }
 
     #[test]
     fn unclosed_lists() {
+        // Invalid input does not return a deeply nested AST that must be dropped
+        // on the test thread, so this does not need the lower Windows limit.
         let source = "[".repeat(5_000);
         assert!(parse_module(&source).is_err());
     }
@@ -395,8 +392,8 @@ mod stack_growth {
     fn nested_calls() {
         let source = format!(
             "x = {}1{}",
-            "f(".repeat(AST_STACK_GROWTH_DEPTH),
-            ")".repeat(AST_STACK_GROWTH_DEPTH)
+            "f(".repeat(RECURSIVE_AST_TEST_DEPTH),
+            ")".repeat(RECURSIVE_AST_TEST_DEPTH)
         );
         parse_module(&source).unwrap();
     }
@@ -405,8 +402,8 @@ mod stack_growth {
     fn nested_subscripts() {
         let source = format!(
             "x = {}1{}",
-            "a[".repeat(AST_STACK_GROWTH_DEPTH),
-            "]".repeat(AST_STACK_GROWTH_DEPTH)
+            "a[".repeat(RECURSIVE_AST_TEST_DEPTH),
+            "]".repeat(RECURSIVE_AST_TEST_DEPTH)
         );
         parse_module(&source).unwrap();
     }
@@ -417,8 +414,8 @@ mod stack_growth {
         // stack-growth instrumentation in addition to statement / expression paths.
         let source = format!(
             "match x:\n case {}y{}: pass\n",
-            "(".repeat(AST_STACK_GROWTH_DEPTH),
-            ")".repeat(AST_STACK_GROWTH_DEPTH),
+            "(".repeat(RECURSIVE_AST_TEST_DEPTH),
+            ")".repeat(RECURSIVE_AST_TEST_DEPTH),
         );
         parse_module(&source).unwrap();
     }
@@ -428,7 +425,7 @@ mod stack_growth {
         // `1+(1+(1+(1+...)))` — each level alternates a binary operator and a
         // parenthesised sub-expression, exactly like the pattern described in
         // the tracking issue.
-        let depth = AST_STACK_GROWTH_DEPTH;
+        let depth = RECURSIVE_AST_TEST_DEPTH;
         let mut source = String::new();
         for _ in 0..depth {
             source.push_str("1+(");
@@ -448,7 +445,7 @@ mod stack_growth {
         // the binary-expression recursion path directly, unlike the
         // `1+(1+(...))` interplay test which recurses through parenthesised
         // atoms.
-        let depth = AST_STACK_GROWTH_DEPTH;
+        let depth = RECURSIVE_AST_TEST_DEPTH;
         let mut source = String::with_capacity(depth * 3 + 1);
         for _ in 0..depth {
             source.push_str("1**");
@@ -462,7 +459,7 @@ mod stack_growth {
         // `1 if 1 else 1 if 1 else ...` — the `else` operand recurses at the
         // conditional layer (`parse_if_expression` -> `orelse`), which is not
         // covered by stack growth in `parse_lhs_expression`.
-        let depth = AST_STACK_GROWTH_DEPTH;
+        let depth = RECURSIVE_AST_TEST_DEPTH;
         let mut source = String::with_capacity(depth * 12 + 1);
         for _ in 0..depth {
             source.push_str("1 if 1 else ");
@@ -477,7 +474,7 @@ mod stack_growth {
         // conditional layer (`parse_lambda_expr` -> body), bypassing stack
         // growth in `parse_lhs_expression` entirely.
         let mut source = String::from("x = ");
-        for _ in 0..AST_STACK_GROWTH_DEPTH {
+        for _ in 0..RECURSIVE_AST_TEST_DEPTH {
             source.push_str("lambda: ");
         }
         source.push('1');
@@ -496,13 +493,9 @@ fn invalid_async_chain_is_iterative() {
 #[test]
 fn nested_equal_precedence_unary_chains_are_iterative() {
     // Consecutive unary operators sharing precedence do not require stack growth.
-    // Keep the recursively owned output shallow enough to drop on Windows'
-    // default 1 MiB test-thread stack in debug builds.
-    const DEPTH: usize = 1_000;
-
-    let source = format!("{}1\n", "-~+".repeat(DEPTH));
+    let source = format!("{}1\n", "-~+".repeat(RECURSIVE_AST_TEST_DEPTH));
     parse_module(&source).unwrap();
 
-    let source = format!("{}True\n", "not ".repeat(DEPTH));
+    let source = format!("{}True\n", "not ".repeat(RECURSIVE_AST_TEST_DEPTH));
     parse_module(&source).unwrap();
 }

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -532,16 +532,14 @@ mod tests {
     use ruff_python_ast::Suite;
 
     use crate::error::LexicalErrorType;
-    use crate::{InterpolatedStringErrorType, ParseError, ParseErrorType, Parsed, parse_module};
+    use crate::{
+        InterpolatedStringErrorType, ParseError, ParseErrorType, Parsed, RECURSIVE_AST_TEST_DEPTH,
+        parse_module,
+    };
 
     const WINDOWS_EOL: &str = "\r\n";
     const MAC_EOL: &str = "\r";
     const UNIX_EOL: &str = "\n";
-    // Windows test threads have a 1 MiB stack by default. Keep successfully
-    // parsed ASTs shallow enough for their recursive drop glue in debug builds
-    // while still exercising parser stack growth.
-    const FORMAT_SPEC_STACK_GROWTH_DEPTH: usize = 1_000;
-
     fn parse_suite(source: &str) -> Result<Suite, ParseError> {
         parse_module(source).map(Parsed::into_suite)
     }
@@ -597,7 +595,7 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn fstring_nested_spec_stack_growth() {
-        parse_suite(&nested_format_spec('f', FORMAT_SPEC_STACK_GROWTH_DEPTH)).unwrap();
+        parse_suite(&nested_format_spec('f', RECURSIVE_AST_TEST_DEPTH)).unwrap();
     }
 
     #[test]
@@ -715,7 +713,7 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn tstring_nested_spec_stack_growth() {
-        parse_suite(&nested_format_spec('t', FORMAT_SPEC_STACK_GROWTH_DEPTH)).unwrap();
+        parse_suite(&nested_format_spec('t', RECURSIVE_AST_TEST_DEPTH)).unwrap();
     }
 
     #[test]

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -589,8 +589,7 @@ mod tests {
 
     #[test]
     fn fstring_nested_spec_stack_growth() {
-        let suite = parse_suite(&nested_format_spec('f', 5_000)).unwrap();
-        std::mem::forget(suite);
+        parse_suite(&nested_format_spec('f', 5_000)).unwrap();
     }
 
     #[test]
@@ -707,8 +706,7 @@ mod tests {
 
     #[test]
     fn tstring_nested_spec_stack_growth() {
-        let suite = parse_suite(&nested_format_spec('t', 5_000)).unwrap();
-        std::mem::forget(suite);
+        parse_suite(&nested_format_spec('t', 5_000)).unwrap();
     }
 
     #[test]

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -537,6 +537,10 @@ mod tests {
     const WINDOWS_EOL: &str = "\r\n";
     const MAC_EOL: &str = "\r";
     const UNIX_EOL: &str = "\n";
+    // Windows test threads have a 1 MiB stack by default. Keep successfully
+    // parsed ASTs shallow enough for their recursive drop glue in debug builds
+    // while still exercising parser stack growth.
+    const FORMAT_SPEC_STACK_GROWTH_DEPTH: usize = 1_000;
 
     fn parse_suite(source: &str) -> Result<Suite, ParseError> {
         parse_module(source).map(Parsed::into_suite)
@@ -593,7 +597,7 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn fstring_nested_spec_stack_growth() {
-        parse_suite(&nested_format_spec('f', 5_000)).unwrap();
+        parse_suite(&nested_format_spec('f', FORMAT_SPEC_STACK_GROWTH_DEPTH)).unwrap();
     }
 
     #[test]
@@ -711,7 +715,7 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn tstring_nested_spec_stack_growth() {
-        parse_suite(&nested_format_spec('t', 5_000)).unwrap();
+        parse_suite(&nested_format_spec('t', FORMAT_SPEC_STACK_GROWTH_DEPTH)).unwrap();
     }
 
     #[test]

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -542,6 +542,9 @@ mod tests {
         parse_module(source).map(Parsed::into_suite)
     }
 
+    // `stacker` is a no-op on unsupported platforms, so only require stack
+    // growth where its native support is well established.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     fn nested_format_spec(prefix: char, depth: usize) -> String {
         let mut replacement_field = String::from("{spec}");
         for _ in 0..depth {
@@ -587,6 +590,7 @@ mod tests {
         insta::assert_debug_snapshot!(suite);
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn fstring_nested_spec_stack_growth() {
         parse_suite(&nested_format_spec('f', 5_000)).unwrap();
@@ -704,6 +708,7 @@ mod tests {
         insta::assert_debug_snapshot!(suite);
     }
 
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn tstring_nested_spec_stack_growth() {
         parse_suite(&nested_format_spec('t', 5_000)).unwrap();

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -532,10 +532,7 @@ mod tests {
     use ruff_python_ast::Suite;
 
     use crate::error::LexicalErrorType;
-    use crate::{
-        InterpolatedStringErrorType, Mode, ParseError, ParseErrorType, ParseOptions, Parsed, parse,
-        parse_module,
-    };
+    use crate::{InterpolatedStringErrorType, ParseError, ParseErrorType, Parsed, parse_module};
 
     const WINDOWS_EOL: &str = "\r\n";
     const MAC_EOL: &str = "\r";
@@ -543,17 +540,6 @@ mod tests {
 
     fn parse_suite(source: &str) -> Result<Suite, ParseError> {
         parse_module(source).map(Parsed::into_suite)
-    }
-
-    fn parse_suite_with_recursion_limit(
-        source: &str,
-        max_recursion_depth: u16,
-    ) -> Result<Suite, ParseError> {
-        parse(
-            source,
-            ParseOptions::from(Mode::Module).with_max_recursion_depth(max_recursion_depth),
-        )
-        .map(|parsed| parsed.try_into_module().unwrap().into_suite())
     }
 
     fn nested_format_spec(prefix: char, depth: usize) -> String {
@@ -602,11 +588,9 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_fstring_nested_spec_recursion_limit() {
-        assert!(parse_suite_with_recursion_limit(r#"f"{foo:{spec}}""#, 8).is_ok());
-
-        let err = parse_suite_with_recursion_limit(&nested_format_spec('f', 200), 8).unwrap_err();
-        assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+    fn fstring_nested_spec_stack_growth() {
+        let suite = parse_suite(&nested_format_spec('f', 5_000)).unwrap();
+        std::mem::forget(suite);
     }
 
     #[test]
@@ -722,11 +706,9 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_tstring_nested_spec_recursion_limit() {
-        assert!(parse_suite_with_recursion_limit(r#"t"{foo:{spec}}""#, 8).is_ok());
-
-        let err = parse_suite_with_recursion_limit(&nested_format_spec('t', 200), 8).unwrap_err();
-        assert!(matches!(err.error, ParseErrorType::RecursionLimitExceeded));
+    fn tstring_nested_spec_stack_growth() {
+        let suite = parse_suite(&nested_format_spec('t', 5_000)).unwrap();
+        std::mem::forget(suite);
     }
 
     #[test]

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -532,27 +532,13 @@ mod tests {
     use ruff_python_ast::Suite;
 
     use crate::error::LexicalErrorType;
-    use crate::{
-        InterpolatedStringErrorType, ParseError, ParseErrorType, Parsed, RECURSIVE_AST_TEST_DEPTH,
-        parse_module,
-    };
+    use crate::{InterpolatedStringErrorType, ParseError, ParseErrorType, Parsed, parse_module};
 
     const WINDOWS_EOL: &str = "\r\n";
     const MAC_EOL: &str = "\r";
     const UNIX_EOL: &str = "\n";
     fn parse_suite(source: &str) -> Result<Suite, ParseError> {
         parse_module(source).map(Parsed::into_suite)
-    }
-
-    // `stacker` is a no-op on unsupported platforms, so only require stack
-    // growth where its native support is well established.
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    fn nested_format_spec(prefix: char, depth: usize) -> String {
-        let mut replacement_field = String::from("{spec}");
-        for _ in 0..depth {
-            replacement_field = format!("{{foo:{replacement_field}}}");
-        }
-        format!(r#"{prefix}"{replacement_field}""#)
     }
 
     fn string_parser_escaped_eol(eol: &str) -> Suite {
@@ -590,12 +576,6 @@ mod tests {
         let source = r#"f"{foo:{spec}}""#;
         let suite = parse_suite(source).unwrap();
         insta::assert_debug_snapshot!(suite);
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    #[test]
-    fn fstring_nested_spec_stack_growth() {
-        parse_suite(&nested_format_spec('f', RECURSIVE_AST_TEST_DEPTH)).unwrap();
     }
 
     #[test]
@@ -708,12 +688,6 @@ mod tests {
         let source = r#"t"{foo:{spec}}""#;
         let suite = parse_suite(source).unwrap();
         insta::assert_debug_snapshot!(suite);
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-    #[test]
-    fn tstring_nested_spec_stack_growth() {
-        parse_suite(&nested_format_spec('t', RECURSIVE_AST_TEST_DEPTH)).unwrap();
     }
 
     #[test]

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -537,8 +537,17 @@ mod tests {
     const WINDOWS_EOL: &str = "\r\n";
     const MAC_EOL: &str = "\r";
     const UNIX_EOL: &str = "\n";
+
     fn parse_suite(source: &str) -> Result<Suite, ParseError> {
         parse_module(source).map(Parsed::into_suite)
+    }
+
+    fn nested_format_spec(prefix: char, depth: usize) -> String {
+        let mut replacement_field = String::from("{spec}");
+        for _ in 0..depth {
+            replacement_field = format!("{{foo:{replacement_field}}}");
+        }
+        format!(r#"{prefix}"{replacement_field}""#)
     }
 
     fn string_parser_escaped_eol(eol: &str) -> Suite {
@@ -576,6 +585,11 @@ mod tests {
         let source = r#"f"{foo:{spec}}""#;
         let suite = parse_suite(source).unwrap();
         insta::assert_debug_snapshot!(suite);
+    }
+
+    #[test]
+    fn parse_fstring_nested_spec_grows_stack() {
+        assert!(parse_suite(&nested_format_spec('f', 200)).is_ok());
     }
 
     #[test]
@@ -688,6 +702,11 @@ mod tests {
         let source = r#"t"{foo:{spec}}""#;
         let suite = parse_suite(source).unwrap();
         insta::assert_debug_snapshot!(suite);
+    }
+
+    #[test]
+    fn parse_tstring_nested_spec_grows_stack() {
+        assert!(parse_suite(&nested_format_spec('t', 200)).is_ok());
     }
 
     #[test]

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -47,12 +47,6 @@ impl<'src> TokenSource<'src> {
         self.lexer.current_range()
     }
 
-    /// Returns the current parenthesis, bracket, and brace nesting level.
-    #[inline]
-    pub(crate) const fn nesting(&self) -> u32 {
-        self.lexer.nesting()
-    }
-
     /// Returns the flags for the current token.
     pub(crate) const fn current_flags(&self) -> TokenFlags {
         self.lexer.current_flags()

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -47,12 +47,6 @@ impl<'src> TokenSource<'src> {
         self.lexer.current_range()
     }
 
-    /// Returns the current parenthesis, bracket, and brace nesting level.
-    #[inline]
-    pub(crate) fn nesting(&self) -> u32 {
-        self.lexer.nesting()
-    }
-
     /// Returns the flags for the current token.
     pub(crate) const fn current_flags(&self) -> TokenFlags {
         self.lexer.current_flags()

--- a/crates/ruff_python_parser/src/token_source.rs
+++ b/crates/ruff_python_parser/src/token_source.rs
@@ -47,6 +47,12 @@ impl<'src> TokenSource<'src> {
         self.lexer.current_range()
     }
 
+    /// Returns the current parenthesis, bracket, and brace nesting level.
+    #[inline]
+    pub(crate) fn nesting(&self) -> u32 {
+        self.lexer.nesting()
+    }
+
     /// Returns the flags for the current token.
     pub(crate) const fn current_flags(&self) -> TokenFlags {
         self.lexer.current_flags()


### PR DESCRIPTION
## Summary

This PR removes the hard nesting limits in the parser and instead spills the stack to the heap when it approaches the stack limit, using [`stacker`](https://docs.rs/stacker/latest/stacker/). This is limited to supported platforms.


Why? 

The primary goal of Ruff's parser is to accept every valid (C)Python program. This is currently no longer the case because Ruff's recursion limits are stricter than CPython's. CPython uses multiple limits:

* 200: For nested parentheses
* 6000: Increased whenever CPython's PEG parser enters a new rule. The limit is lower for WASM release and even lower for WASM debug builds.
* When reaching CPython's stack limit

I don't see a way for Ruff to approximate the latter two limits other than by finding limits that are at least as large as CPython's. However, this is not enough to protect against all stack overflows: 

* Different platforms use different (default) stack sizes
* Applications can change the default stack size
* The stack frames are different between compilation profiles (debug > release)
* The stack frame depends on user code. How much stack space does the program use before it calls the parser? There's less stack size remaining if the call happens very deep in a call tree

We'd have to pick platform and compilation-target-specific limits. But even this won't be enough, because we don't control the stack size, or when the parser is called and how much stack size is remaining at this point. 


The idea of this PR is to remove the stack limitation from Ruff's parser and enable upstream applications to enforce relevant restriction if they want to (only applies to stack overflows, allocation failures are out of scope). This makes Ruff's parser again conformant with the Python standard and CPython. 

In general, I advise upstream tools from using a uniform stack size on platforms supporting changing the default thread stack size. In general, using a larger than default stack size should be more than enough to support all reasonable Python programs and stacker gives them the tool to increase the stack size on demand.

Upstream tools can restore the previous behavior by:

* Writing a custom visitor. 
* Make sure you use the same stack size on all platforms or use stacker
* If you only care about giving the user an idea what went wrong: abort with a custom message when reaching a too deeply nested node. It's important that you abort and don't panic, because `panic` still runs drop handler unless you use `panic=abort`. 
* If you want nice diagnostics: Use the node's range and build your own `Diagnostic`. Now, dropping the subtree is a bit tricky because the `Drop` implementation can stack overflow also. That's why you need to
  * Replace the subtree with a placeholder node (invalid expr name)
  * Queue the subtree for drop but repeat the cut-subtree replacement whenever the sub-tree exceeds the limit again, then requeue the sub-sub-tree, and so on... 


Writing this in user code not only removes the complexity from Ruff. It also has the advantage that you get perfect error recovery. The AST has the exact range of the problematic expression. It's not the range of whatever comes after the too-deeply nested parentheses.

As said before, this only protects against stack overflows. As the previous implementation, it doesn't protect against allocation errors. An attacker could construct a program that requires the parser to allocate more memory than is available (e.g. WASM32 has a 4GB limit). Examples are very long statement or expression lists, or binary expressions with the same precedence, etc. I'm sure there are ways to protect against this too, but this feels way beyond something the parser should be concerned about and not something that hard limits could solve. 



I think it would be interesting to have some semantic lint rule to detect nesting that is known to be unsupported by Python. Although, again, this has never come up, so maybe the need for this is low.



Follow-up to #24810.

## Performance

Neutral



## Considered alternatives

### Keep limits

Fix the non CPython conform limits but otherwise keep the limits in place. The main benefit of this approach is that upstream applications are less likely to run into stack overflow issues, but it also doesn't protect them against it.

* Some limits can only be approximations because they're CPython specific and not mentioned anywhere in the specification
* Error recovery and the diagnostic ranges are worse than when handled post-parsing
* Can still stack overflow on systems with smaller stack sizes, or depending on when or where the parser is called. 
* Makes assumptions what the right limit is for upstream tools
* Even CPython's ast module aborts when there's not enough remaining stack size
* Limits are also required when the parser unrolls recursions into a loop or when the Rust compiler applies the tail call recursion optimization


### Configurable limits

Don't set any limits by default. Very similar to the former with the same downsides except that Ruff makes no assumptions about what the right defaults are for downstream tools. 

I think that's a reasonable approach but it requires users to pick limits, which seems non-trivial and the error recovery is worse than if Ruff parses out the full program. But more importantly, I don't see a strong benefit over moving the entire complexity to programs for which increasing the thread's stack size itself isn't a sufficient mitigation. A post-parse visitor gives them the same flexibility, and it even allows them to customize what to do when the limit is exceeded (diagnostic vs abort vs something else). This approach also gives them a more accurate parse tree if they decide not to abort. 

## What do other parsers do

* Rustc uses stacker to support common cases where recursion stack overflows. But there are cases where rustc can overlfow
* CPython's AST module throws if there isn't enough stack frame remaining. 


## Note

This PR is no guarantee that we'll maintain the invariant that Ruff's parser never stack overflows on any input. We'll give our best, but we may decide that the risk of stack overflowing is rare enough and mitigating against it is to expensive (in terms of performance) so that the trade offs don't feel right.
