### PR TITLE
Shrink additional parser AST collections

### DIFF
--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1245,8 +1245,7 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprBoolOp {
         self.bump(TokenKind::from(op));
 
-        let mut values = Vec::with_capacity(2);
-        values.push(lhs);
+        let mut values = vec![lhs];
         let mut progress = ParserProgress::default();
 
         // Keep adding the expression to `values` until we see a different
@@ -2626,7 +2625,7 @@ impl<'src> Parser<'src> {
     fn parse_generators(&mut self) -> Vec<ast::Comprehension> {
         const GENERATOR_SET: TokenSet = TokenSet::new([TokenKind::For, TokenKind::Async]);
 
-        let mut generators = Vec::with_capacity(1);
+        let mut generators = vec![];
         let mut progress = ParserProgress::default();
 
         while self.at_ts(GENERATOR_SET) {
@@ -2669,7 +2668,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::In);
         let iter = self.parse_simple_expression(ExpressionContext::default());
 
-        let mut ifs = Vec::new();
+        let mut ifs = vec![];
         let mut progress = ParserProgress::default();
 
         while self.eat(TokenKind::If) {
@@ -2677,9 +2676,6 @@ impl<'src> Parser<'src> {
 
             let parsed_expr = self.parse_simple_expression(ExpressionContext::default());
 
-            if ifs.is_empty() {
-                ifs.reserve_exact(1);
-            }
             ifs.push(parsed_expr.expr);
         }
 

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1245,7 +1245,8 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprBoolOp {
         self.bump(TokenKind::from(op));
 
-        let mut values = vec![lhs];
+        let mut values = Vec::with_capacity(2);
+        values.push(lhs);
         let mut progress = ParserProgress::default();
 
         // Keep adding the expression to `values` until we see a different
@@ -2625,7 +2626,7 @@ impl<'src> Parser<'src> {
     fn parse_generators(&mut self) -> Vec<ast::Comprehension> {
         const GENERATOR_SET: TokenSet = TokenSet::new([TokenKind::For, TokenKind::Async]);
 
-        let mut generators = vec![];
+        let mut generators = Vec::with_capacity(1);
         let mut progress = ParserProgress::default();
 
         while self.at_ts(GENERATOR_SET) {
@@ -2668,7 +2669,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::In);
         let iter = self.parse_simple_expression(ExpressionContext::default());
 
-        let mut ifs = vec![];
+        let mut ifs = Vec::new();
         let mut progress = ParserProgress::default();
 
         while self.eat(TokenKind::If) {
@@ -2676,6 +2677,9 @@ impl<'src> Parser<'src> {
 
             let parsed_expr = self.parse_simple_expression(ExpressionContext::default());
 
+            if ifs.is_empty() {
+                ifs.reserve_exact(1);
+            }
             ifs.push(parsed_expr.expr);
         }
 

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1004,6 +1004,8 @@ impl<'src> Parser<'src> {
                 slices.push(parser.parse_slice());
             });
 
+            slices.shrink_to_fit();
+
             slice = Expr::Tuple(ast::ExprTuple {
                 elts: slices,
                 ctx: ExprContext::Load,
@@ -1259,6 +1261,8 @@ impl<'src> Parser<'src> {
                 break;
             }
         }
+
+        values.shrink_to_fit();
 
         ast::ExprBoolOp {
             values,
@@ -2476,6 +2480,8 @@ impl<'src> Parser<'src> {
             self.expect(TokenKind::Rpar);
         }
 
+        elts.shrink_to_fit();
+
         ast::ExprTuple {
             elts,
             ctx: ExprContext::Load,
@@ -2504,6 +2510,8 @@ impl<'src> Parser<'src> {
         });
 
         self.expect(TokenKind::Rsqb);
+
+        elts.shrink_to_fit();
 
         ast::ExprList {
             elts,
@@ -2599,6 +2607,8 @@ impl<'src> Parser<'src> {
 
         self.expect(TokenKind::Rbrace);
 
+        items.shrink_to_fit();
+
         ast::ExprDict {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
@@ -2622,6 +2632,8 @@ impl<'src> Parser<'src> {
             progress.assert_progressing(self);
             generators.push(self.parse_comprehension());
         }
+
+        generators.shrink_to_fit();
 
         generators
     }
@@ -2666,6 +2678,8 @@ impl<'src> Parser<'src> {
 
             ifs.push(parsed_expr.expr);
         }
+
+        ifs.shrink_to_fit();
 
         ast::Comprehension {
             range: self.node_range(start),

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -572,7 +572,21 @@ impl<'src> Parser<'src> {
         recovery_context_kind: RecoveryContextKind,
         parse_element: impl Fn(&mut Parser<'src>) -> T,
     ) -> Vec<T> {
-        let mut elements = Vec::new();
+        self.parse_comma_separated_list_into_vec_with_capacity(
+            recovery_context_kind,
+            parse_element,
+            0,
+        )
+    }
+
+    /// Parses a comma separated list of elements into a vector with an initial capacity.
+    fn parse_comma_separated_list_into_vec_with_capacity<T>(
+        &mut self,
+        recovery_context_kind: RecoveryContextKind,
+        parse_element: impl Fn(&mut Parser<'src>) -> T,
+        capacity: usize,
+    ) -> Vec<T> {
+        let mut elements = Vec::with_capacity(capacity);
         self.parse_comma_separated_list(recovery_context_kind, |p| elements.push(parse_element(p)));
         elements
     }

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -572,21 +572,7 @@ impl<'src> Parser<'src> {
         recovery_context_kind: RecoveryContextKind,
         parse_element: impl Fn(&mut Parser<'src>) -> T,
     ) -> Vec<T> {
-        self.parse_comma_separated_list_into_vec_with_capacity(
-            recovery_context_kind,
-            parse_element,
-            0,
-        )
-    }
-
-    /// Parses a comma separated list of elements into a vector with an initial capacity.
-    fn parse_comma_separated_list_into_vec_with_capacity<T>(
-        &mut self,
-        recovery_context_kind: RecoveryContextKind,
-        parse_element: impl Fn(&mut Parser<'src>) -> T,
-        capacity: usize,
-    ) -> Vec<T> {
-        let mut elements = Vec::with_capacity(capacity);
+        let mut elements = Vec::new();
         self.parse_comma_separated_list(recovery_context_kind, |p| elements.push(parse_element(p)));
         elements
     }

--- a/crates/ruff_python_parser/src/parser/recovery.rs
+++ b/crates/ruff_python_parser/src/parser/recovery.rs
@@ -80,6 +80,8 @@ pub(super) fn pattern_to_expr(pattern: Pattern) -> Expr {
                 });
                 items.push(ast::DictItem { key: None, value });
             }
+            items.shrink_to_fit();
+
             Expr::Dict(ast::ExprDict {
                 range,
                 node_index,

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -614,7 +614,7 @@ impl<'src> Parser<'src> {
         // import ,
         // import x, y,
 
-        let names = self
+        let mut names = self
             .parse_comma_separated_list_into_vec(RecoveryContextKind::ImportNames, |p| {
                 p.parse_alias(ImportStyle::Import)
             });
@@ -624,6 +624,8 @@ impl<'src> Parser<'src> {
             // import
             self.add_error(ParseErrorType::EmptyImportNames, self.current_token_range());
         }
+
+        names.shrink_to_fit();
 
         ast::StmtImport {
             names,
@@ -739,6 +741,8 @@ impl<'src> Parser<'src> {
             // 2 + 2
             self.expect(TokenKind::Rpar);
         }
+
+        names.shrink_to_fit();
 
         ast::StmtImportFrom {
             module,
@@ -1444,6 +1448,8 @@ impl<'src> Parser<'src> {
             elif_else_clauses.push(self.parse_elif_or_else_clause(ElifOrElse::Else));
         }
 
+        elif_else_clauses.shrink_to_fit();
+
         ast::StmtIf {
             test: Box::new(test.expr),
             body,
@@ -1539,7 +1545,7 @@ impl<'src> Parser<'src> {
         // except* ExceptionGroup:
         //     pass
         let mut mixed_except_ranges = Vec::new();
-        let handlers = self.parse_clauses(Clause::Except, |p| {
+        let mut handlers = self.parse_clauses(Clause::Except, |p| {
             let (handler, kind) = p.parse_except_clause();
             if let ExceptClauseKind::Star(range) = kind {
                 p.add_unsupported_syntax_error(UnsupportedSyntaxErrorKind::ExceptStar, range);
@@ -1551,6 +1557,8 @@ impl<'src> Parser<'src> {
             }
             handler
         });
+        handlers.shrink_to_fit();
+
         // Empty handler has `is_star` false.
         let is_star = is_star.unwrap_or_default();
         for handler_err_range in mixed_except_ranges {
@@ -2170,7 +2178,9 @@ impl<'src> Parser<'src> {
     fn parse_with_statement(&mut self, start: TextSize) -> ast::StmtWith {
         self.bump(TokenKind::With);
 
-        let items = self.parse_with_items();
+        let mut items = self.parse_with_items();
+        items.shrink_to_fit();
+
         self.expect(TokenKind::Colon);
 
         let body = self.parse_body(Clause::With);
@@ -2985,6 +2995,8 @@ impl<'src> Parser<'src> {
             self.expect(TokenKind::Newline);
         }
 
+        decorators.shrink_to_fit();
+
         match self.current_token_kind() {
             TokenKind::Def => Stmt::FunctionDef(self.parse_function_definition(decorators, start)),
             TokenKind::Class => Stmt::ClassDef(self.parse_class_definition(decorators, start)),
@@ -3527,6 +3539,10 @@ impl<'src> Parser<'src> {
         if matches!(function_kind, FunctionKind::FunctionDef) {
             self.expect(TokenKind::Rpar);
         }
+
+        parameters.args.shrink_to_fit();
+        parameters.kwonlyargs.shrink_to_fit();
+        parameters.posonlyargs.shrink_to_fit();
 
         parameters.range = self.node_range(start);
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -614,11 +614,10 @@ impl<'src> Parser<'src> {
         // import ,
         // import x, y,
 
-        let mut names = self.parse_comma_separated_list_into_vec_with_capacity(
-            RecoveryContextKind::ImportNames,
-            |p| p.parse_alias(ImportStyle::Import),
-            1,
-        );
+        let mut names = self
+            .parse_comma_separated_list_into_vec(RecoveryContextKind::ImportNames, |p| {
+                p.parse_alias(ImportStyle::Import)
+            });
 
         if names.is_empty() {
             // test_err import_stmt_empty
@@ -692,7 +691,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::Import);
 
         let names_start = self.node_start();
-        let mut names = Vec::new();
+        let mut names = vec![];
         let mut seen_star_import = false;
 
         let parenthesized = Parenthesized::from(self.eat(TokenKind::Lpar));
@@ -1446,9 +1445,6 @@ impl<'src> Parser<'src> {
         });
 
         if self.at(TokenKind::Else) {
-            if elif_else_clauses.is_empty() {
-                elif_else_clauses.reserve_exact(1);
-            }
             elif_else_clauses.push(self.parse_elif_or_else_clause(ElifOrElse::Else));
         }
 
@@ -2282,17 +2278,15 @@ impl<'src> Parser<'src> {
                 // with (a | b) << c | d: ...
                 // # Postfix should still be parsed first
                 // with (a)[0] + b * c: ...
-                self.parse_comma_separated_list_into_vec_with_capacity(
+                self.parse_comma_separated_list_into_vec(
                     RecoveryContextKind::WithItems(WithItemKind::ParenthesizedExpression),
                     |p| p.parse_with_item(WithItemParsingState::Regular).item,
-                    1,
                 )
             }
         } else {
-            self.parse_comma_separated_list_into_vec_with_capacity(
+            self.parse_comma_separated_list_into_vec(
                 RecoveryContextKind::WithItems(WithItemKind::Unparenthesized),
                 |p| p.parse_with_item(WithItemParsingState::Regular).item,
-                1,
             )
         }
     }
@@ -2330,7 +2324,7 @@ impl<'src> Parser<'src> {
 
         self.bump(TokenKind::Lpar);
 
-        let mut parsed_with_items = Vec::with_capacity(1);
+        let mut parsed_with_items = vec![];
         let mut has_optional_vars = false;
 
         // test_err with_items_parenthesized_missing_comma
@@ -4006,9 +4000,6 @@ impl<'src> Parser<'src> {
         while recovery_kind.is_list_element(self) {
             progress.assert_progressing(self);
 
-            if clauses.is_empty() {
-                clauses.reserve_exact(1);
-            }
             clauses.push(parse_clause(self));
         }
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -614,10 +614,11 @@ impl<'src> Parser<'src> {
         // import ,
         // import x, y,
 
-        let mut names = self
-            .parse_comma_separated_list_into_vec(RecoveryContextKind::ImportNames, |p| {
-                p.parse_alias(ImportStyle::Import)
-            });
+        let mut names = self.parse_comma_separated_list_into_vec_with_capacity(
+            RecoveryContextKind::ImportNames,
+            |p| p.parse_alias(ImportStyle::Import),
+            1,
+        );
 
         if names.is_empty() {
             // test_err import_stmt_empty
@@ -691,7 +692,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::Import);
 
         let names_start = self.node_start();
-        let mut names = vec![];
+        let mut names = Vec::with_capacity(1);
         let mut seen_star_import = false;
 
         let parenthesized = Parenthesized::from(self.eat(TokenKind::Lpar));
@@ -1445,6 +1446,9 @@ impl<'src> Parser<'src> {
         });
 
         if self.at(TokenKind::Else) {
+            if elif_else_clauses.is_empty() {
+                elif_else_clauses.reserve_exact(1);
+            }
             elif_else_clauses.push(self.parse_elif_or_else_clause(ElifOrElse::Else));
         }
 
@@ -2278,15 +2282,17 @@ impl<'src> Parser<'src> {
                 // with (a | b) << c | d: ...
                 // # Postfix should still be parsed first
                 // with (a)[0] + b * c: ...
-                self.parse_comma_separated_list_into_vec(
+                self.parse_comma_separated_list_into_vec_with_capacity(
                     RecoveryContextKind::WithItems(WithItemKind::ParenthesizedExpression),
                     |p| p.parse_with_item(WithItemParsingState::Regular).item,
+                    1,
                 )
             }
         } else {
-            self.parse_comma_separated_list_into_vec(
+            self.parse_comma_separated_list_into_vec_with_capacity(
                 RecoveryContextKind::WithItems(WithItemKind::Unparenthesized),
                 |p| p.parse_with_item(WithItemParsingState::Regular).item,
+                1,
             )
         }
     }
@@ -2324,7 +2330,7 @@ impl<'src> Parser<'src> {
 
         self.bump(TokenKind::Lpar);
 
-        let mut parsed_with_items = vec![];
+        let mut parsed_with_items = Vec::with_capacity(1);
         let mut has_optional_vars = false;
 
         // test_err with_items_parenthesized_missing_comma
@@ -4000,6 +4006,9 @@ impl<'src> Parser<'src> {
         while recovery_kind.is_list_element(self) {
             progress.assert_progressing(self);
 
+            if clauses.is_empty() {
+                clauses.reserve_exact(1);
+            }
             clauses.push(parse_clause(self));
         }
 

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -692,7 +692,7 @@ impl<'src> Parser<'src> {
         self.expect(TokenKind::Import);
 
         let names_start = self.node_start();
-        let mut names = Vec::with_capacity(1);
+        let mut names = Vec::new();
         let mut seen_star_import = false;
 
         let parenthesized = Parenthesized::from(self.eat(TokenKind::Lpar));


### PR DESCRIPTION
## Summary

Shrink the containers for more AST node fields during parser to reduce AST memory consumption.

This PR adds more `shrink_to_fit` calls to the parser. It's still not all nodes, I focused on nodes for which we see the biggest memory improvements. 

| AST node field | Retained slack removed |
|---|---:|
| `Parameters.args` | 49.68 MiB |
| `StmtImportFrom.names` | 44.15 MiB |
| `ExprTuple.elts` | 25.39 MiB |
| `StmtFunctionDef.decorator_list` | 22.51 MiB |
| `ExprDict.items` | 22.42 MiB |
| `ExprList.elts` | 13.15 MiB |
| `StmtWith.items` | 11.96 MiB |
| `StmtImport.names` | 8.65 MiB |
| `StmtIf.elif_else_clauses` | 5.66 MiB |
| `ExprListComp.generators` | 5.26 MiB |
| `ExprBoolOp.values` | 4.29 MiB |
| `ExprGenerator.generators` | 3.37 MiB |
| `StmtTry.handlers` | 2.09 MiB |
| `Parameters.kwonlyargs` | 1.76 MiB |
| `Parameters.posonlyargs` | 1.69 MiB |
| `StmtClassDef.decorator_list` | 1.60 MiB |
| `ExprDictComp.generators` | 1.41 MiB |
| `Comprehension.ifs` | 1.12 MiB |
| `ExprSetComp.generators` | 753.1 KiB |
| **Total** | **226.92 MiB** |

I focused on nodes where the saving was at least one MiB, with the exception of `ExprSetComp` which shares its parsing with `ExprListComp`. 

These numbers are from parsing all Python files in pytest, typeshed, home-assistant-core, anyio, mypy, fastapi, pandas, flake8, trio, sphinx, and prefect.

## Performance

This PR introduces a small performance regression because the `shrink_to_fit` calls often require reallocating the collection nodes. The ty project walltime performance benchmarks range and the formatter and linter benchmarks from neutral to -1%. The parser benchmarks range from -1 to -4%, which is roughly what I'd expect