### PR TITLE
[pylint] Fix PLR1733/PLR1736 false positives in for-else and shadowed inner loops

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
@@ -62,3 +62,16 @@ def for_else_no_false_positive(result: dict[str, float]) -> dict[str, float]:
             if result[res_glob] <= 0:  # okay, res_glob from loop may be unbound
                 result.pop(res_glob)
     return result
+
+
+def inner_loop_shadowing(d: dict):
+    # `k` from the outer loop is shadowed by the inner `for k in ...`.
+    # Lookups inside the inner loop body refer to the inner `k`, not the outer
+    # one, so they must NOT be flagged.
+    for k, v in d.items():
+        for k in range(3):    # shadows outer `k`
+            print(d[k])       # OK - not the same `k`
+        for v in range(3):    # shadows outer `v`
+            print(d[k])       # OK - not the same `v`
+        # After the inner loops, the outer variable is still live; do flag.
+        print(d[k])           # PLR1733

--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py
@@ -73,5 +73,6 @@ def inner_loop_shadowing(d: dict):
             print(d[k])       # OK - not the same `k`
         for v in range(3):    # shadows outer `v`
             print(d[k])       # OK - not the same `v`
-        # After the inner loops, the outer variable is still live; do flag.
-        print(d[k])           # PLR1733
+        # After an inner loop rebinds `k`, the visitor conservatively stops
+        # flagging for the rest of the outer body (modified=true).
+        print(d[k])           # OK - conservative: outer `k` is gone

--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_list_index_lookup.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_list_index_lookup.py
@@ -83,3 +83,26 @@ def nested_index_lookup():
     column_names = ["a", "b"]
     for index, column_name in enumerate(column_names):
         _ = data[column_names[index]]  # PLR1736
+
+
+def for_else_no_false_positive(letters):
+    # The `else` branch runs even when the loop body never executes (empty
+    # iterable), so `index` and `letter` may be unbound there. No PLR1736.
+    for index, letter in enumerate(letters):
+        if letter == "z":
+            break
+    else:
+        print(letters[index])  # OK - index may be unbound
+
+
+def inner_loop_shadowing(letters):
+    # `index` from the outer loop is shadowed by the inner `for index in ...`.
+    # The lookup `letters[index]` inside the inner loop refers to the inner
+    # `index`, not the outer one, so it must NOT be flagged.
+    for index, letter in enumerate(letters):
+        for index in range(3):       # shadows outer `index`
+            print(letters[index])    # OK - not the same `index`
+        for letter in range(3):      # shadows outer `letter`
+            print(letters[index])    # OK - not the same `letter`
+        # After the inner loops, the outer variable is still live; do flag.
+        print(letters[index])        # PLR1736

--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_list_index_lookup.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_list_index_lookup.py
@@ -104,5 +104,6 @@ def inner_loop_shadowing(letters):
             print(letters[index])    # OK - not the same `index`
         for letter in range(3):      # shadows outer `letter`
             print(letters[index])    # OK - not the same `letter`
-        # After the inner loops, the outer variable is still live; do flag.
-        print(letters[index])        # PLR1736
+        # After an inner loop rebinds `index`, the visitor conservatively stops
+        # flagging for the rest of the outer body (modified=true).
+        print(letters[index])        # OK - conservative: outer `index` is gone

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -126,6 +126,7 @@ impl SequenceIndexVisitor<'_> {
             Expr::Tuple(ast::ExprTuple { elts, .. }) | Expr::List(ast::ExprList { elts, .. }) => {
                 elts.iter().any(|elt| self.rebinds_loop_var(elt))
             }
+            Expr::Starred(ast::ExprStarred { value, .. }) => self.rebinds_loop_var(value),
             _ => false,
         }
     }
@@ -154,26 +155,47 @@ impl Visitor<'_> for SequenceIndexVisitor<'_> {
             Stmt::Delete(ast::StmtDelete { targets, .. }) => {
                 self.modified = targets.iter().any(|target| self.is_assignment(target));
             }
-            // If an inner `for` loop rebinds `index_name` or `value_name`, any lookups
-            // inside its body refer to the *inner* binding, not the outer loop's variable.
-            // Skip the inner body entirely; the `else` clause is unaffected.
+            // If an inner `for` loop rebinds `index_name` or `value_name`, skip the body:
+            // any `sequence[index]` inside refers to the *inner* variable, not the outer
+            // one. Mark `modified` so the outer loop also stops flagging after this point
+            // (the rebinding is visible in the outer scope after the inner loop finishes).
+            // Always visit `iter` and `orelse` — those still use the outer binding.
             Stmt::For(ast::StmtFor {
                 target,
+                iter,
                 body,
                 orelse,
                 ..
             }) => {
+                self.visit_expr(iter);
                 if self.rebinds_loop_var(target) {
-                    for s in orelse {
-                        self.visit_stmt(s);
-                    }
+                    self.modified = true;
                 } else {
                     for s in body {
                         self.visit_stmt(s);
                     }
-                    for s in orelse {
+                }
+                for s in orelse {
+                    self.visit_stmt(s);
+                }
+            }
+            Stmt::AsyncFor(ast::StmtAsyncFor {
+                target,
+                iter,
+                body,
+                orelse,
+                ..
+            }) => {
+                self.visit_expr(iter);
+                if self.rebinds_loop_var(target) {
+                    self.modified = true;
+                } else {
+                    for s in body {
                         self.visit_stmt(s);
                     }
+                }
+                for s in orelse {
+                    self.visit_stmt(s);
                 }
             }
             _ => visitor::walk_stmt(self, stmt),

--- a/crates/ruff_linter/src/rules/pylint/helpers.rs
+++ b/crates/ruff_linter/src/rules/pylint/helpers.rs
@@ -112,6 +112,23 @@ impl SequenceIndexVisitor<'_> {
             _ => false,
         }
     }
+
+    /// Returns `true` if the given loop target rebinds `index_name` or `value_name`.
+    ///
+    /// When an inner `for` loop uses the same variable name as the outer loop's key or
+    /// value binding, any `sequence[index]` lookups inside the inner loop body refer to
+    /// the *inner* binding, not the outer one, so they must not be flagged.
+    fn rebinds_loop_var(&self, target: &Expr) -> bool {
+        match target {
+            Expr::Name(ast::ExprName { id, .. }) => {
+                id == self.index_name || id == self.value_name
+            }
+            Expr::Tuple(ast::ExprTuple { elts, .. }) | Expr::List(ast::ExprList { elts, .. }) => {
+                elts.iter().any(|elt| self.rebinds_loop_var(elt))
+            }
+            _ => false,
+        }
+    }
 }
 
 impl Visitor<'_> for SequenceIndexVisitor<'_> {
@@ -136,6 +153,28 @@ impl Visitor<'_> for SequenceIndexVisitor<'_> {
             }
             Stmt::Delete(ast::StmtDelete { targets, .. }) => {
                 self.modified = targets.iter().any(|target| self.is_assignment(target));
+            }
+            // If an inner `for` loop rebinds `index_name` or `value_name`, any lookups
+            // inside its body refer to the *inner* binding, not the outer loop's variable.
+            // Skip the inner body entirely; the `else` clause is unaffected.
+            Stmt::For(ast::StmtFor {
+                target,
+                body,
+                orelse,
+                ..
+            }) => {
+                if self.rebinds_loop_var(target) {
+                    for s in orelse {
+                        self.visit_stmt(s);
+                    }
+                } else {
+                    for s in body {
+                        self.visit_stmt(s);
+                    }
+                    for s in orelse {
+                        self.visit_stmt(s);
+                    }
+                }
             }
             _ => visitor::walk_stmt(self, stmt),
         }

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
@@ -57,7 +57,8 @@ pub(crate) fn unnecessary_list_index_lookup(checker: &Checker, stmt_for: &StmtFo
     let ranges = {
         let mut visitor = SequenceIndexVisitor::new(&sequence.id, &index_name.id, &value_name.id);
         visitor.visit_body(&stmt_for.body);
-        visitor.visit_body(&stmt_for.orelse);
+        // Do not visit `orelse`: the loop variable may be unbound there if the iterable
+        // is empty (the `else` branch runs even when the loop body never executes).
         visitor.into_accesses()
     };
 


### PR DESCRIPTION
Fixes #25182

## Summary

Three related false positives in `PLR1733` (`unnecessary-dict-index-lookup`) and `PLR1736` (`unnecessary-list-index-lookup`):

### 1. PLR1736: for-else false positive

The `else` clause of a `for` loop runs **even when the iterable is empty** (the loop body never executes), so the loop variable may be unbound in the `else` block. Flagging `sequence[index]` there is incorrect.

`PLR1733` already correctly skipped the `orelse`; this PR removes the `orelse` visit from `unnecessary_list_index_lookup` to match.

### 2. PLR1733/PLR1736: shadowed inner loop variable

When an inner `for` loop rebinds the same name as the outer loop's key or value variable, any `sequence[index]` lookups inside the inner body refer to the *inner* binding, not the outer one.

```python
# Before: PLR1736 falsely fired on seq[i] inside the inner loop
for i, val in enumerate(seq):
    for i in range(3):   # rebinds 
        print(seq[i])    # ← must NOT flag;  is the inner loop's 
```

Added a `rebinds_loop_var` helper and a `Stmt::For` arm in `SequenceIndexVisitor` (shared by both rules via `helpers.rs`): when the inner loop's target shadows `index_name` or `value_name`, the inner body is skipped entirely.

## Test plan

New test cases added to:
- `crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_list_index_lookup.py`
- `crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dict_index_lookup.py`

Run with:
```
cargo test -p ruff_linter --test rules -- PLR1733 PLR1736
```