### PR TITLE
[ty] Preserve receiver constraints when binding overloaded methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -3173,13 +3173,13 @@ dynamic construction of enums using the functional syntax:
 from enum import Enum, IntEnum, StrEnum
 from ty_extensions import into_regular_callable
 
-# revealed: Overload[[_EnumMemberT](value: Any, names: None = None) -> _EnumMemberT, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
+# revealed: Overload[(value: Any, names: None = None) -> Enum, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
 reveal_type(into_regular_callable(Enum))
 
-# revealed: Overload[[_EnumMemberT](value: Any, names: None = None) -> _EnumMemberT, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
+# revealed: Overload[(value: Any, names: None = None) -> IntEnum, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
 reveal_type(into_regular_callable(IntEnum))
 
-# revealed: Overload[[_EnumMemberT](value: Any, names: None = None) -> _EnumMemberT, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
+# revealed: Overload[(value: Any, names: None = None) -> StrEnum, (value: str, names: Iterable[Iterable[str | Any]], *, module: str | None = None, qualname: str | None = None, type: type | None = None, start: int = 1, boundary: FlagBoundary | None = None) -> type[Enum]]
 reveal_type(into_regular_callable(StrEnum))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -275,9 +275,7 @@ def union_receiver(reader: Reader[int | str]):
 ## Method type variables inferred from `self`
 
 Binding an overload whose explicit receiver introduces a method type variable should infer that
-variable from the concrete receiver and apply it to the remainder of the signature. At present,
-receiver matching retains the overload, but does not yet apply the inferred `S = str`
-specialization.
+variable from the concrete receiver and apply it to the remainder of the signature.
 
 ```toml
 [environment]
@@ -285,9 +283,11 @@ python-version = "3.12"
 ```
 
 ```py
-from typing import overload
+from typing import Any, Callable, overload
 
 class ReceiverGeneric[T]:
+    value: T
+
     @overload
     def method[S](self: "ReceiverGeneric[S]", value: S) -> S: ...
     @overload
@@ -295,19 +295,46 @@ class ReceiverGeneric[T]:
     def method(self, value: object) -> object:
         return value
 
-# TODO: `Signature::can_bind_self_to` currently reduces receiver matching to a boolean. Instead,
-# each retained overload should preserve its receiver constraints so later specialization can apply
-# them.
-# TODO: revealed: Overload[(value: str) -> str, (value: bytes) -> bytes]
-reveal_type(ReceiverGeneric[str]().method)  # revealed: Overload[[S](value: S) -> S, (value: bytes) -> bytes]
+reveal_type(ReceiverGeneric[str]().method)  # revealed: Overload[(value: str) -> str, (value: bytes) -> bytes]
+
+def takes_callable(fn: Callable[..., Any]) -> None: ...
+def use_generic_receiver[T](value: ReceiverGeneric[T]) -> None:
+    # revealed: Overload[(value: T@use_generic_receiver) -> T@use_generic_receiver, (value: bytes) -> bytes]
+    reveal_type(value.method)
+    takes_callable(value.method)
+```
+
+## Callable objects with generic explicit receivers
+
+An overloaded `__call__` method with a generic explicit receiver should still make an unspecialized
+instance callable.
+
+```py
+from typing import Any, Callable, Generic, TypeVar, overload
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+def takes_callable(fn: Callable[..., Any]) -> None: ...
+
+class GenericCallable(Generic[T]):
+    @overload
+    def __call__(self: "GenericCallable[U]", value: U) -> U: ...
+    @overload
+    def __call__(self: "GenericCallable[bytes]", value: bytes) -> bytes: ...
+    def __call__(self, value: object) -> object:
+        return value
+
+    def method(self) -> None:
+        reveal_type(self.__call__)  # revealed: bound method Self@method.__call__[U](value: U) -> U
+        takes_callable(self)
 ```
 
 ## Structural protocol receivers
 
 Checking a generic protocol receiver requires solving all uses of its type variable together. Here
 `get()` would require `int` to be assignable to `T`, while `put()` would require `T` to be
-assignable to `str`, so no `T` can satisfy `ProtocolSelf[T]`. At present, the incompatible overload
-is retained because structural receiver specialization is not yet supported.
+assignable to `str`, so no `T` can satisfy `ProtocolSelf[T]`.
 
 ```py
 from typing import Callable, Protocol, TypeVar, overload
@@ -332,13 +359,93 @@ class ProtocolSelfImplementation(BaseWithProtocolSelf):
 
     def put(self, x: str) -> None: ...
 
-# TODO: The first overload should be eliminated, leaving `bound method
-# BaseWithProtocolSelf.method() -> bytes`.
-reveal_type(ProtocolSelfImplementation().method)  # revealed: Overload[[ProtocolSelfT]() -> ProtocolSelfT, () -> bytes]
+reveal_type(ProtocolSelfImplementation().method)  # revealed: bound method ProtocolSelfImplementation.method() -> bytes
 
 good_protocol_receiver: Callable[[], bytes] = ProtocolSelfImplementation().method
+bad_protocol_receiver: Callable[[], int] = ProtocolSelfImplementation().method  # error: [invalid-assignment]
+```
+
+## One-sided constraints from protocol receivers
+
+An explicit protocol receiver can constrain a method type variable without determining an exact
+specialization. The type variable should remain generic so that the bound method is assignable to
+compatible callbacks.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, Protocol, overload
+
+class Producer[T](Protocol):
+    def get(self) -> T: ...
+
+class BaseWithProducer:
+    @overload
+    def method[S](self: Producer[S], value: S) -> S: ...
+    @overload
+    def method(self, value: bytes) -> bytes: ...
+    def method(self, value: object) -> object:
+        return value
+
+class ProducerImplementation(BaseWithProducer):
+    def get(self) -> str:
+        return ""
+
+reveal_type(ProducerImplementation().method)  # revealed: Overload[[S](value: S) -> S, (value: bytes) -> bytes]
+producer_callback: Callable[[object], object] = ProducerImplementation().method
+# TODO: Retain the receiver constraint when converting the bound method to another callable.
 # TODO: error: [invalid-assignment]
-bad_protocol_receiver: Callable[[], int] = ProtocolSelfImplementation().method
+bad_producer_callback: Callable[[int], int] = ProducerImplementation().method
+reveal_type(ProducerImplementation().method(1))  # revealed: str | Literal[1]
+
+class Consumer[T](Protocol):
+    def put(self, value: T) -> None: ...
+
+class BaseWithConsumer:
+    @overload
+    def method[S](self: Consumer[S], value: S) -> S: ...
+    @overload
+    def method(self, value: bytes) -> bytes: ...
+    def method(self, value: object) -> object:
+        return value
+
+class ConsumerImplementation(BaseWithConsumer):
+    def put(self, value: object) -> None:
+        pass
+
+reveal_type(ConsumerImplementation().method)  # revealed: Overload[[S](value: S) -> S, (value: bytes) -> bytes]
+consumer_callback: Callable[[str], str] = ConsumerImplementation().method
+```
+
+## Class-object receivers
+
+A generic alias receiver should determine a method type variable that only flows out of an
+overloaded metaclass method, just like a class literal.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import overload
+from ty_extensions import into_regular_callable
+
+class Meta(type):
+    @overload
+    def __call__[T](cls: type[T], value: int) -> T: ...
+    @overload
+    def __call__(cls, value: str) -> str: ...
+    def __call__(cls, value: int | str) -> object:
+        return super().__call__()
+
+class GenericTarget[T](metaclass=Meta): ...
+
+# revealed: Overload[(value: int) -> GenericTarget[int], (value: str) -> str]
+reveal_type(into_regular_callable(GenericTarget[int]))
 ```
 
 ## Constructor

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2245,6 +2245,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         self.intersect_pending_typevar_constraint(bound_typevar, bounds);
     }
 
+    /// Adds a constraint set to the specialization that this builder is building up.
+    pub(crate) fn add_constraint_set(&mut self, set: ConstraintSet<'db, 'c>) {
+        self.pending.intersect(self.db, self.constraints, set);
+    }
+
     /// Finds all of the valid specializations of a constraint set, and adds their type mappings to
     /// the specialization that this builder is building up.
     ///

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -101,11 +101,9 @@ impl<'db> BoundMethodType<'db> {
 
             let self_instance = self.self_instance(db);
             return CallableSignature::from_overloads(
-                function_signature
-                    .overloads
-                    .iter()
-                    .filter(|signature| signature.can_bind_self_to(db, self_instance))
-                    .map(|signature| signature.bind_self(db, Some(typing_self_type))),
+                function_signature.overloads.iter().filter_map(|signature| {
+                    signature.bind_self_if_compatible(db, self_instance, typing_self_type)
+                }),
             );
         };
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -20,11 +20,12 @@ use smallvec::{SmallVec, smallvec_inline};
 use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::{
-    ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
+    ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, PathBounds,
 };
 use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::generics::{
-    ApplySpecialization, GenericContext, InferableTypeVars, Specialization, walk_generic_context,
+    ApplySpecialization, GenericContext, InferableTypeVars, Specialization, SpecializationBuilder,
+    walk_generic_context,
 };
 use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
 use crate::types::relation::{
@@ -1011,30 +1012,35 @@ impl<'db> Signature<'db> {
         }
     }
 
-    /// Returns `true` if this signature's first parameter can accept the bound `self` type.
+    /// Returns the conditions under which this signature's first parameter can accept the bound
+    /// `self` type.
     ///
     /// This is used to prune impossible overloads when a method is bound to a concrete receiver.
     /// If a signature has no positional first parameter, we conservatively keep it.
-    pub(crate) fn can_bind_self_to(&self, db: &'db dyn Db, self_type: Type<'db>) -> bool {
+    ///
+    /// For example, binding `Base().method` removes an overload whose first parameter is explicitly
+    /// annotated as `self: Child`, while binding `Child().method` keeps it.
+    fn when_can_bind_self_to<'c>(
+        &self,
+        db: &'db dyn Db,
+        self_type: Type<'db>,
+        constraints: &'c ConstraintSetBuilder<'db>,
+    ) -> ConstraintSet<'db, 'c> {
         // A dynamic receiver might be compatible with any explicit receiver annotation.
         if self_type.is_dynamic() {
-            return true;
+            return ConstraintSet::from_bool(constraints, true);
         }
 
         // Without a first parameter, there is no receiver annotation to check.
         let Some(first_parameter) = self.parameters.get(0) else {
-            return true;
+            return ConstraintSet::from_bool(constraints, true);
         };
 
-        // If there is no positional receiver, this signature cannot be pruned based on `self`.
-        if !first_parameter.is_positional() {
-            return true;
-        }
-
-        // Inferred receiver annotations describe the method owner, rather than constraining which
-        // overload is exposed for a bound receiver. Only explicit receiver annotations can prune.
-        if first_parameter.inferred_annotation {
-            return true;
+        // Without an explicit positional receiver, this signature cannot be pruned based on
+        // `self`. Inferred receiver annotations describe the method owner, rather than
+        // constraining which overload is exposed for a bound receiver.
+        if !first_parameter.is_positional() || first_parameter.inferred_annotation {
+            return ConstraintSet::from_bool(constraints, true);
         }
 
         let mut expected_self_ty = first_parameter.annotated_type();
@@ -1044,7 +1050,7 @@ impl<'db> Signature<'db> {
         // Avoid the more expensive normalization below for receiver annotations that already
         // accept all values, or already exactly match the bound receiver.
         if accepts_any_or_exact_self(expected_self_ty) {
-            return true;
+            return ConstraintSet::from_bool(constraints, true);
         }
 
         // TODO: Expand type aliases here so `type Alias = Self` in a class body
@@ -1053,7 +1059,7 @@ impl<'db> Signature<'db> {
 
         // `Self` binding can make the receiver annotation trivially compatible.
         if accepts_any_or_exact_self(expected_self_ty) {
-            return true;
+            return ConstraintSet::from_bool(constraints, true);
         }
 
         // A specialized receiver can make generic receiver annotations concrete enough to compare.
@@ -1063,19 +1069,91 @@ impl<'db> Signature<'db> {
 
             // Specialization can also make the receiver annotation trivially compatible.
             if accepts_any_or_exact_self(expected_self_ty) {
-                return true;
+                return ConstraintSet::from_bool(constraints, true);
             }
         }
 
+        self_type.when_constraint_set_assignable_to(db, expected_self_ty, constraints)
+    }
+
+    /// Returns this signature bound to `self_type` if its explicit receiver annotation is
+    /// compatible with the bound receiver.
+    ///
+    /// Matching the receiver can also constrain type variables that occur elsewhere in the
+    /// signature. For example, binding this overload to `Box[str]().method` should produce
+    /// `(value: str) -> str`, rather than `(value: S) -> S`:
+    ///
+    /// ```py
+    /// class Box[T]:
+    ///     @overload
+    ///     def method[S](self: "Box[S]", value: S) -> S: ...
+    /// ```
+    ///
+    /// A protocol receiver can impose a one-sided constraint instead of determining one exact
+    /// specialization. In that case, keep the type variable generic instead of choosing an
+    /// arbitrary compatible type.
+    pub(crate) fn bind_self_if_compatible(
+        &self,
+        db: &'db dyn Db,
+        self_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) -> Option<Self> {
         let constraints = ConstraintSetBuilder::new();
-        self_type
-            .when_assignable_to(
-                db,
-                expected_self_ty,
-                &constraints,
-                self.inferable_typevars(db),
-            )
+        let when = self.when_can_bind_self_to(db, self_type, &constraints);
+        let inferable = self.inferable_typevars(db);
+        // Prune the overload only if its own type variables cannot make the receiver compatible.
+        if !when
+            .reduce_inferable(db, &constraints, inferable.iter(db))
             .is_always_satisfied(db)
+        {
+            return None;
+        }
+
+        if when.is_always_satisfied(db) {
+            return Some(self.bind_self(db, Some(typing_self_type)));
+        }
+
+        let Some(generic_context) = self.generic_context else {
+            return Some(self.bind_self(db, Some(typing_self_type)));
+        };
+
+        let mut builder = SpecializationBuilder::new(db, &constraints, inferable);
+        builder.add_constraint_set(when);
+        let concrete_class_receiver =
+            matches!(self_type, Type::ClassLiteral(_) | Type::GenericAlias(_));
+        let bound_signature = self.bind_self(db, Some(typing_self_type));
+        let specialization = builder.build_with(generic_context, |typevar, bounds| {
+            // Exact bounds determine an unambiguous specialization, as in the `Box[str]`
+            // example above.
+            if let Some(bounds) = bounds
+                && let (Some(lower), Some(upper)) = (bounds.lower, bounds.upper)
+                && lower.is_equivalent_to(db, upper)
+            {
+                return Some(lower);
+            }
+
+            // A concrete class receiver should determine typevars that only flow out of the
+            // bound callable, as in `EnumMeta.__call__`. Keep underdetermined input typevars
+            // generic.
+            if let Some(bounds) = bounds
+                && concrete_class_receiver
+                && bound_signature.variance_of(db, typevar).is_covariant()
+                && let Some(lower) = bounds.lower
+                && !lower.is_never()
+                && let Ok(Some(solution)) =
+                    PathBounds::default_solve(db, &constraints, typevar, bounds)
+            {
+                return Some(solution);
+            }
+
+            // Preserve a generic signature when the receiver only narrows the possible values.
+            Some(Type::TypeVar(typevar))
+        });
+
+        Some(
+            self.apply_specialization(db, specialization)
+                .bind_self(db, Some(typing_self_type)),
+        )
     }
 
     pub(crate) fn has_explicit_positional_receiver_annotation(&self) -> bool {


### PR DESCRIPTION
## Summary

See: https://github.com/astral-sh/ruff/pull/24707#discussion_r3326577303.