### PR TITLE
[pylint] Fix `PLW0108` false positive on forward-referenced callables

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_lambda.py
@@ -61,3 +61,12 @@ _ = lambda *args: f(*args, y=x)
 # https://github.com/astral-sh/ruff/issues/18675
 _ = lambda x: (string := str)(x)
 _ = lambda x: ((x := 1) and str)(x)
+
+# https://github.com/astral-sh/ruff/issues/24704
+# the called function is bound later, so the lambda defers the lookup and is
+# necessary (inlining would raise `NameError`)
+_ = lambda y: forward_reference(y)
+
+
+def forward_reference(y):
+    pass

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
@@ -220,6 +220,24 @@ pub(crate) fn unnecessary_lambda(checker: &Checker, lambda: &ExprLambda) {
         }
     }
 
+    // A `lambda` defers evaluation of its body until it is called. If the called
+    // function references a symbol that is only bound *after* the lambda (a
+    // forward reference), inlining the call would move that reference before its
+    // binding and raise `NameError`. In that case the lambda is necessary.
+    // Ex) `x = lambda y: f(y)` followed by `def f(y): ...`
+    //
+    // We compare against the *end* of the lambda so that names bound within the
+    // lambda body itself (e.g. `lambda x: (string := str)(x)`) are not mistaken
+    // for forward references.
+    for name in &names {
+        if let Some(binding_id) = checker.semantic().lookup_symbol(name.id()) {
+            let binding = checker.semantic().binding(binding_id);
+            if binding.range().start() > lambda.range().end() {
+                return;
+            }
+        }
+    }
+
     let mut diagnostic = checker.report_diagnostic(UnnecessaryLambda, lambda.range());
     // Suppress the fix if the assignment expression target shadows one of the lambda's parameters.
     // This is necessary to avoid introducing a change in the behavior of the program.

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLW0108_unnecessary_lambda.py.snap
@@ -171,6 +171,8 @@ help: Inline function call
    - _ = lambda x: (string := str)(x)
 62 + _ = (string := str)
 63 | _ = lambda x: ((x := 1) and str)(x)
+64 |
+65 | # https://github.com/astral-sh/ruff/issues/24704
 note: This is an unsafe fix and may change runtime behavior
 
 PLW0108 Lambda may be unnecessary; consider inlining inner function
@@ -180,5 +182,7 @@ PLW0108 Lambda may be unnecessary; consider inlining inner function
 62 | _ = lambda x: (string := str)(x)
 63 | _ = lambda x: ((x := 1) and str)(x)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+64 |
+65 | # https://github.com/astral-sh/ruff/issues/24704
    |
 help: Inline function call


### PR DESCRIPTION
## Summary

Fixes #24704.

`unnecessary-lambda` (PLW0108) flagged `lambda y: f(y)` even when `f` is defined *later* in the scope:

```python
x = {"a": lambda y: f(y)}  # PLW0108 fired here


def f(y):
    pass
```

The offered fix inlines the lambda to `f`. But a `lambda` defers the name lookup until call time, whereas the inlined reference is evaluated immediately — so when the callable is bound *after* the lambda, the rewrite raises `NameError`. The lambda is therefore necessary, and the rule should not fire.

This adds a guard: skip the rule when a referenced name's binding starts after the **end** of the lambda (a forward reference). Comparing against the lambda's *end* (not its start) ensures names bound *within* the lambda body itself — e.g. `lambda x: (string := str)(x)` — are not mistaken for forward references and continue to be reported.

## Test Plan

- Added a forward-reference case to `unnecessary_lambda.py` and updated the snapshot. The new case produces no diagnostic; all existing cases (including the walrus cases and a `def`-defined-before case) are unchanged.
- `cargo test -p ruff_linter unnecessary_lambda` passes.
- Manually verified with the built binary: the forward-reference case is no longer flagged, while `lambda y: h(y)` (with `h` defined earlier) and `lambda x: str(x)` are still flagged.

---

*Disclosure: prepared with the assistance of Claude Code; reviewed and owned by me.*
