### PR TITLE
docs: fix typo `bin/active` → `bin/activate` in tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -58,7 +58,7 @@ Found 1 error.
 !!! note
 
     As an alternative to `uv run`, you can also run Ruff by activating the project's virtual
-    environment (`source .venv/bin/active` on Linux and macOS, or `.venv\Scripts\activate` on
+    environment (`source .venv/bin/activate` on Linux and macOS, or `.venv\Scripts\activate` on
     Windows) and running `ruff check` directly.
 
 Ruff identified an unused import, which is a common error in Python code. Ruff considers this a


### PR DESCRIPTION
## Summary

Fixes a one-character typo in  (line 61).

The Linux/macOS virtual environment activation command was written as:

```
source .venv/bin/active
```

but should be:

```
source .venv/bin/activate
```

The Windows command on the same line () was already correct, making the discrepancy easy to spot.

## How verified

The fix was verified by reading the file directly —  is not a valid shell script; the correct file installed by Python’s `venv` module is always .
