### PR TITLE
[ty] Handle cycles in function decorator inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/3593_function_known_decorators_cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3593_function_known_decorators_cycle.md
@@ -1,0 +1,25 @@
+# Function decorator inference cycle
+
+Regression test for <https://github.com/astral-sh/ty/issues/3593>.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from typing import Self, overload, reveal_type
+
+class C:
+    a: D
+
+C.a
+reveal_type(C().a)  # revealed: Unknown | D
+
+class D:
+    @overload
+    # error: [invalid-overload]
+    # error: [invalid-overload]
+    def __get__() -> Self:
+        pass
+```

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -219,7 +219,11 @@ pub(crate) fn infer_definition_types<'db>(
 /// `infer_definition_types` when we need to check decorators while
 /// already inside definition inference (e.g. checking `Self` in a
 /// `@staticmethod`).
-#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    returns(ref),
+    cycle_initial=|_, _, _| FunctionDecoratorInference::cycle_initial(),
+    heap_size=ruff_memory_usage::heap_size
+)]
 pub(crate) fn function_known_decorators<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
@@ -259,6 +263,16 @@ pub(crate) struct FunctionDecoratorInference<'db> {
 }
 
 impl<'db> FunctionDecoratorInference<'db> {
+    fn cycle_initial() -> Self {
+        Self {
+            expression_types: FrozenMap::default(),
+            bindings: Box::default(),
+            called_functions: Box::default(),
+            known_decorators: FunctionDecorators::empty(),
+            diagnostics: TypeCheckDiagnostics::default(),
+        }
+    }
+
     pub(crate) fn expression_type(
         &self,
         expression: impl Into<ExpressionNodeKey>,


### PR DESCRIPTION
## Summary

Handle recursive `function_known_decorators` queries by falling back to an empty decorator inference result while Salsa resolves the cycle. This prevents a Python 3.14 descriptor annotation with an overloaded `__get__` method from panicking and preserves conservative `Unknown` behavior during cycle recovery.

Closes https://github.com/astral-sh/ty/issues/3593.