### PR TITLE
[parser] Drop deep expression chains iteratively to avoid stack overflow

### DIFF
--- a/crates/ruff_python_ast/src/expr_drop.rs
+++ b/crates/ruff_python_ast/src/expr_drop.rs
@@ -1,0 +1,81 @@
+//! Iterative `Drop` for the expression nodes the parser builds with *iterative*
+//! loops: left-associative binary chains (`a + b + c + ...`) and postfix chains
+//! (`f()()...`, `a[0][0]...`, `a.b.c...`). Unlike recursive-descent constructs,
+//! these bypass the parser's recursion-depth guard, so their depth is bounded
+//! only by the input length. Such a tree parses fine, but the derived drop glue
+//! recurses once per level (~150 bytes of stack each) and overflows when it is
+//! dropped — a denial-of-service vector for consumers parsing untrusted source
+//! on a normally-sized stack.
+//!
+//! The fix gives the four node types forming these spines a manual `Drop` that
+//! walks the recursive edge (`left`/`func`/`value`), detaching each node and
+//! replacing the edge with a trivial placeholder *before* the node drops, so no
+//! drop ever recurses and a spine of any depth is torn down in O(1) stack. A
+//! single [`iter_expr_drop`] helper handles all four edges in one `match`, so
+//! a chain that mixes kinds (e.g. `f()[0].a()...`) is still torn down in one
+//! flat loop.
+
+use crate::{Expr, ExprAttribute, ExprBinOp, ExprCall, ExprNoneLiteral, ExprSubscript};
+
+/// Iteratively drop the chain of expressions reachable by following the spine
+/// edge starting at `head` — the field along which the parser builds unbounded
+/// left-associative and postfix chains.
+///
+/// `head` is left holding a [`placeholder`]; the caller's own field drop then
+/// disposes of that placeholder.
+fn iter_expr_drop(head: &mut Box<Expr>) {
+    // Fast path: if the node along the spine edge isn't itself one of the
+    // chainable kinds, there is no deep spine here, so the ordinary recursive
+    // drop is shallow. This keeps the common case (e.g. dropping a plain
+    // `a + b` or `f()`) free of any extra work.
+    if !matches!(
+        **head,
+        Expr::BinOp(_) | Expr::Call(_) | Expr::Subscript(_) | Expr::Attribute(_)
+    ) {
+        return;
+    }
+    let mut node = std::mem::replace(&mut **head, placeholder());
+    // Each iteration detaches the next node down the spine and then drops the
+    // current one. The current node's own spine edge has already been replaced
+    // with a placeholder, so its `Drop` runs without recursing.
+    loop {
+        let next = match &mut node {
+            Expr::BinOp(inner) => std::mem::replace(&mut *inner.left, placeholder()),
+            Expr::Call(inner) => std::mem::replace(&mut *inner.func, placeholder()),
+            Expr::Subscript(inner) => std::mem::replace(&mut *inner.value, placeholder()),
+            Expr::Attribute(inner) => std::mem::replace(&mut *inner.value, placeholder()),
+            _ => break,
+        };
+        node = next;
+    }
+}
+
+/// A trivial expression used to sever a recursive edge before the owning node
+/// is dropped. It owns no children, so dropping it is a no-op.
+fn placeholder() -> Expr {
+    Expr::NoneLiteral(ExprNoneLiteral::default())
+}
+
+impl Drop for ExprBinOp {
+    fn drop(&mut self) {
+        iter_expr_drop(&mut self.left);
+    }
+}
+
+impl Drop for ExprCall {
+    fn drop(&mut self) {
+        iter_expr_drop(&mut self.func);
+    }
+}
+
+impl Drop for ExprSubscript {
+    fn drop(&mut self) {
+        iter_expr_drop(&mut self.value);
+    }
+}
+
+impl Drop for ExprAttribute {
+    fn drop(&mut self) {
+        iter_expr_drop(&mut self.value);
+    }
+}

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -11,6 +11,7 @@ pub use python_version::*;
 
 pub mod comparable;
 pub mod docstrings;
+mod expr_drop;
 mod expression;
 pub mod find_node;
 mod generated;

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -404,3 +404,58 @@ fn recursion_limit_nested_lambda_chain() {
         err.error
     );
 }
+
+/// Depth for the drop-on-overflow regression tests below. The chains they build
+/// are formed by *iterative* parser loops, so they bypass the recursion-depth
+/// guard and produce a spine far deeper than a default thread stack can absorb
+/// with the derived (recursive) drop glue — i.e. deep enough that they overflow
+/// on drop without the manual `Drop` impls in `ruff_python_ast::expr_drop`.
+const DROP_CHAIN_DEPTH: usize = 100_000;
+
+#[test]
+fn deep_left_assoc_binop_chain_parses_and_drops() {
+    // `1 + 1 + ... + 1` — a left-associative `ExprBinOp` spine.
+    let src = format!("1{}", " + 1".repeat(DROP_CHAIN_DEPTH));
+    let parsed = parse_expression(&src).unwrap();
+    assert!(parsed.errors().is_empty());
+    // The drop at the end of this scope must not overflow the stack.
+    drop(parsed);
+}
+
+#[test]
+fn deep_call_chain_parses_and_drops() {
+    // `f()()()...` — a balanced postfix spine that keeps bracket nesting at
+    // zero, so the parser's `nesting()` guard never trips.
+    let src = format!("f{}", "()".repeat(DROP_CHAIN_DEPTH));
+    let parsed = parse_expression(&src).unwrap();
+    assert!(parsed.errors().is_empty());
+    drop(parsed);
+}
+
+#[test]
+fn deep_subscript_chain_parses_and_drops() {
+    // `x[0][0][0]...` — likewise balanced.
+    let src = format!("x{}", "[0]".repeat(DROP_CHAIN_DEPTH));
+    let parsed = parse_expression(&src).unwrap();
+    assert!(parsed.errors().is_empty());
+    drop(parsed);
+}
+
+#[test]
+fn deep_attribute_chain_parses_and_drops() {
+    // `x.a.a.a...` — attribute access has no brackets at all.
+    let src = format!("x{}", ".a".repeat(DROP_CHAIN_DEPTH));
+    let parsed = parse_expression(&src).unwrap();
+    assert!(parsed.errors().is_empty());
+    drop(parsed);
+}
+
+#[test]
+fn deep_mixed_postfix_chain_parses_and_drops() {
+    // `x[0].a()[0].a()...` mixes all three postfix node kinds, exercising the
+    // single shared `iter_expr_drop` loop across kinds within one spine.
+    let src = format!("x{}", "[0].a()".repeat(DROP_CHAIN_DEPTH / 3));
+    let parsed = parse_expression(&src).unwrap();
+    assert!(parsed.errors().is_empty());
+    drop(parsed);
+}


### PR DESCRIPTION
Alternative solution to #25462 using a custom drop implementation, and thereby doesn't limit left-associative binary chain limits.

## AI Summary

The parser builds left-associative binary chains (`a + b + c + ...`) and postfix chains (`f()()...`, `a[0][0]...`, `a.b.c...`) with iterative loops, so their depth is bounded only by the input length rather than by the recursion guard. Such a tree parses fine, but the compiler-derived drop glue recurses once per level (~150 bytes of stack each) and overflows the native stack when the tree is dropped — a denial-of-service vector for any consumer that parses untrusted source on a normally-sized stack.

Give the four node types that form these spines a manual `Drop` that walks the recursive edge (`left`/`func`/`value`), detaching each node and replacing the edge with a trivial placeholder before the node drops, so no drop ever recurses and a spine of any depth is torn down in O(1) stack. A single `iter_expr_drop` helper handles all four edges in one `match`, so a chain that mixes kinds is torn down in one flat loop.

Unlike a parse-time depth cap, this rejects no valid Python and keeps ty's support for large flat expressions intact.
