### PR TITLE
[`pyupgrade`] Avoid converting `format` calls with more kinds of side effects (`UP032`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md
+++ b/crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md
@@ -1,0 +1,49 @@
+# `f-string` (`UP032`)
+
+```toml
+lint.select = ["UP032"]
+```
+
+## Repeated arguments with side effects
+
+A `str.format` argument is evaluated once, but an f-string re-evaluates it on every interpolation. So
+when an argument is used more than once and can have a side effect, the call is left unconverted to
+avoid running that side effect twice. This used to cover only call expressions; it now covers any
+side-effecting expression, such as a subscript or a walrus binding.
+
+```py
+def foo(): ...
+
+
+d = {}
+
+"{x} {x}".format(x=foo())
+"{x} {x}".format(x=d["k"])
+"{x} {x}".format(x=(y := 1))
+```
+
+## A single use is still converted
+
+When the argument is interpolated once, the side effect runs once either way, so the fix is safe.
+
+```py
+def foo(): ...
+
+
+"{x}".format(x=foo())  # snapshot: f-string
+```
+
+```snapshot
+error[UP032]: Use f-string instead of `format` call
+ --> src/mdtest_snippet.py:4:1
+  |
+4 | "{x}".format(x=foo())  # snapshot: f-string
+  | ^^^^^^^^^^^^^^^^^^^^^
+  |
+help: Convert to f-string
+1 | def foo(): ...
+2 |
+3 |
+  - "{x}".format(x=foo())  # snapshot: f-string
+4 + f"{foo()}"  # snapshot: f-string
+```

--- a/crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md
+++ b/crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md
@@ -9,7 +9,8 @@ lint.select = ["UP032"]
 A `str.format` argument is evaluated once, but an f-string re-evaluates it on every interpolation. So
 when an argument is used more than once and can have a side effect, the call is left unconverted to
 avoid running that side effect twice. This used to cover only call expressions; it now covers any
-side-effecting expression, such as a subscript or a walrus binding.
+side-effecting expression, such as a subscript or a walrus binding. Even a builtin call like `list()`
+counts, since the f-string would construct a new object on each interpolation.
 
 ```py
 def foo(): ...
@@ -20,6 +21,7 @@ d = {}
 "{x} {x}".format(x=foo())
 "{x} {x}".format(x=d["k"])
 "{x} {x}".format(x=(y := 1))
+"{x.append} {x.append}".format(x=list())
 ```
 
 ## A single use is still converted

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::helpers::any_over_expr;
+use ruff_python_ast::helpers::contains_effect;
 use ruff_python_ast::str::{leading_quote, trailing_quote};
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{self as ast, Expr, Keyword, StringFlags};
@@ -247,6 +247,7 @@ impl FStringConversion {
         range: TextRange,
         summary: &mut FormatSummaryValues,
         locator: &Locator,
+        is_builtin: impl Fn(&str) -> bool,
     ) -> Result<Self> {
         let contents = locator.slice(range);
 
@@ -327,10 +328,8 @@ impl FStringConversion {
                     // string, we can't convert the format string to an f-string. For example,
                     // converting `"{x} {x}".format(x=foo())` would result in `f"{foo()} {foo()}"`,
                     // which would call `foo()` twice.
-                    if !seen.insert(specifier) {
-                        if any_over_expr(arg, &Expr::is_call_expr) {
-                            return Ok(Self::SideEffects);
-                        }
+                    if !seen.insert(specifier) && contains_effect(arg, &is_builtin) {
+                        return Ok(Self::SideEffects);
                     }
 
                     converted.push_str(&formatted_expr(
@@ -440,8 +439,12 @@ pub(crate) fn f_strings(checker: &Checker, call: &ast::ExprCall, summary: &Forma
                 break token.start();
             }
             TokenKind::String if !token.unwrap_string_flags().is_unclosed() => {
-                match FStringConversion::try_convert(token.range(), &mut summary, checker.locator())
-                {
+                match FStringConversion::try_convert(
+                    token.range(),
+                    &mut summary,
+                    checker.locator(),
+                    |id| checker.semantic().has_builtin_binding(id),
+                ) {
                     // If the format string contains side effects that would need to be repeated,
                     // we can't convert it to an f-string.
                     Ok(FStringConversion::SideEffects) => return,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -246,11 +246,8 @@ impl FStringConversion {
     fn try_convert(
         range: TextRange,
         summary: &mut FormatSummaryValues,
-        checker: &Checker,
+        locator: &Locator,
     ) -> Result<Self> {
-        let locator = checker.locator();
-        // Repeating a builtin initializer like `list()` is unsound, so treat every call as effectful.
-        let is_builtin = |_: &str| false;
         let contents = locator.slice(range);
 
         // Strip the unicode prefix. It's redundant in Python 3, and invalid when used
@@ -330,7 +327,10 @@ impl FStringConversion {
                     // string, we can't convert the format string to an f-string. For example,
                     // converting `"{x} {x}".format(x=foo())` would result in `f"{foo()} {foo()}"`,
                     // which would call `foo()` twice.
-                    if !seen.insert(specifier) && contains_effect(arg, is_builtin) {
+                    //
+                    // This is also true for builtins, so we don't treat them as special when
+                    // checking for effects here.
+                    if !seen.insert(specifier) && contains_effect(arg, |_| false) {
                         return Ok(Self::SideEffects);
                     }
 
@@ -441,7 +441,8 @@ pub(crate) fn f_strings(checker: &Checker, call: &ast::ExprCall, summary: &Forma
                 break token.start();
             }
             TokenKind::String if !token.unwrap_string_flags().is_unclosed() => {
-                match FStringConversion::try_convert(token.range(), &mut summary, checker) {
+                match FStringConversion::try_convert(token.range(), &mut summary, checker.locator())
+                {
                     // If the format string contains side effects that would need to be repeated,
                     // we can't convert it to an f-string.
                     Ok(FStringConversion::SideEffects) => return,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -246,9 +246,11 @@ impl FStringConversion {
     fn try_convert(
         range: TextRange,
         summary: &mut FormatSummaryValues,
-        locator: &Locator,
-        is_builtin: impl Fn(&str) -> bool,
+        checker: &Checker,
     ) -> Result<Self> {
+        let locator = checker.locator();
+        // Repeating a builtin initializer like `list()` is unsound, so treat every call as effectful.
+        let is_builtin = |_: &str| false;
         let contents = locator.slice(range);
 
         // Strip the unicode prefix. It's redundant in Python 3, and invalid when used
@@ -328,7 +330,7 @@ impl FStringConversion {
                     // string, we can't convert the format string to an f-string. For example,
                     // converting `"{x} {x}".format(x=foo())` would result in `f"{foo()} {foo()}"`,
                     // which would call `foo()` twice.
-                    if !seen.insert(specifier) && contains_effect(arg, &is_builtin) {
+                    if !seen.insert(specifier) && contains_effect(arg, is_builtin) {
                         return Ok(Self::SideEffects);
                     }
 
@@ -439,12 +441,7 @@ pub(crate) fn f_strings(checker: &Checker, call: &ast::ExprCall, summary: &Forma
                 break token.start();
             }
             TokenKind::String if !token.unwrap_string_flags().is_unclosed() => {
-                match FStringConversion::try_convert(
-                    token.range(),
-                    &mut summary,
-                    checker.locator(),
-                    |id| checker.semantic().has_builtin_binding(id),
-                ) {
+                match FStringConversion::try_convert(token.range(), &mut summary, checker) {
                     // If the format string contains side effects that would need to be repeated,
                     // we can't convert it to an f-string.
                     Ok(FStringConversion::SideEffects) => return,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Fixes part of #15874: UP032 unsoundly converted str.format calls that repeat a side-effecting argument. The check only
caught calls, so a repeated d[k] or walrus slipped through. Switch it to contains_effect.

## Test Plan

New mdtest at crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md.
