### PR TITLE
[pyupgrade] Skip UP032 for format strings with no equivalent f-string

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md
+++ b/crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md
@@ -1,0 +1,54 @@
+# `f-string` (`UP032`)
+
+```toml
+lint.select = ["UP032"]
+```
+
+## Format strings with no equivalent f-string are skipped
+
+Some `str.format` calls parse fine but have no f-string that behaves the same, so UP032 leaves them
+alone.
+
+A signed index raises `KeyError` (Python reads `+0` as a name), but an f-string would read it as
+index `0`:
+
+```py
+"{+0}".format(0)
+"{-0}".format(0)
+```
+
+A non-identifier attribute is `getattr(x, " a")`, whereas `f"{x. a}"` reads `x.a`:
+
+```py
+"{. a}".format(x)
+```
+
+A string key that contains the quote the f-string would wrap it in:
+
+```py
+"{[']}".format(x)
+```
+
+A conversion other than `s`, `r`, or `a` raises `ValueError`:
+
+```py
+"{!?}".format(0)
+```
+
+## Valid conversions are unaffected
+
+```py
+"{!r}".format(x)  # snapshot: f-string
+```
+
+```snapshot
+error[UP032]: Use f-string instead of `format` call
+ --> src/mdtest_snippet.py:1:1
+  |
+1 | "{!r}".format(x)  # snapshot: f-string
+  | ^^^^^^^^^^^^^^^^
+  |
+help: Convert to f-string
+  - "{!r}".format(x)  # snapshot: f-string
+1 + f"{x!r}"  # snapshot: f-string
+```

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -11,6 +11,7 @@ use ruff_python_ast::{self as ast, Expr, Keyword, StringFlags};
 use ruff_python_literal::format::{
     FieldName, FieldNamePart, FieldType, FormatPart, FormatString, FromTemplate,
 };
+use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -303,6 +304,22 @@ impl FStringConversion {
 
                     let field = FieldName::parse(&field_name)?;
 
+                    // `usize::parse` accepts a leading `+`, so `"{+0}"` parses as index 0 here,
+                    // but Python reads `+0` as a name and raises `KeyError`.
+                    if matches!(field.field_type, FieldType::Index(_))
+                        && field_name.starts_with('+')
+                    {
+                        return Err(anyhow::anyhow!("signed index in field name"));
+                    }
+
+                    for part in &field.parts {
+                        if let FieldNamePart::Attribute(name) = part
+                            && !is_identifier(name)
+                        {
+                            return Err(anyhow::anyhow!("non-identifier attribute"));
+                        }
+                    }
+
                     // Map from field type to specifier.
                     let specifier = match field.field_type {
                         FieldType::Auto => IndexOrKeyword::Index(summary.arg_auto()),
@@ -360,6 +377,11 @@ impl FStringConversion {
                                     "\"" => '\'',
                                     _ => unreachable!("invalid trailing quote"),
                                 };
+                                if index.contains(quote) {
+                                    return Err(anyhow::anyhow!(
+                                        "string index contains the f-string quote"
+                                    ));
+                                }
                                 converted.push('[');
                                 converted.push(quote);
                                 converted.push_str(&index);
@@ -370,6 +392,9 @@ impl FStringConversion {
                     }
 
                     if let Some(conversion_spec) = conversion_spec {
+                        if !matches!(conversion_spec, 's' | 'r' | 'a') {
+                            return Err(anyhow::anyhow!("unknown conversion specifier"));
+                        }
                         converted.push('!');
                         converted.push(conversion_spec);
                     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Fixes part of #15874: UP032 emitted broken fixes for str.format calls that have no equivalent f-string. Signed indices, non-identifier attributes, quote-clashing string keys, and unknown conversions are now skipped instead.

## Test Plan

New mdtest at crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md.
