### PR TITLE
[pyupgrade] Parenthesize UP032 args that would misparse in an f-string

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md
+++ b/crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md
@@ -1,0 +1,66 @@
+# `f-string` (`UP032`)
+
+```toml
+lint.select = ["UP032"]
+```
+
+## Arguments that would misparse are parenthesized
+
+In an f-string a leading `{` reads as an escaped brace and a lambda's `:` reads as the format-spec
+separator, so we wrap either one in parentheses.
+
+```py
+"{}".format(lambda: 1)  # snapshot: f-string
+```
+
+```snapshot
+error[UP032]: Use f-string instead of `format` call
+ --> src/mdtest_snippet.py:1:1
+  |
+1 | "{}".format(lambda: 1)  # snapshot: f-string
+  | ^^^^^^^^^^^^^^^^^^^^^^
+  |
+help: Convert to f-string
+  - "{}".format(lambda: 1)  # snapshot: f-string
+1 + f"{(lambda: 1)}"  # snapshot: f-string
+2 | "{}".format({} | {})  # snapshot: f-string
+3 | "{.x}".format(lambda: 1)  # snapshot: f-string
+```
+
+```py
+"{}".format({} | {})  # snapshot: f-string
+```
+
+```snapshot
+error[UP032]: Use f-string instead of `format` call
+ --> src/mdtest_snippet.py:2:1
+  |
+2 | "{}".format({} | {})  # snapshot: f-string
+  | ^^^^^^^^^^^^^^^^^^^^
+  |
+help: Convert to f-string
+1 | "{}".format(lambda: 1)  # snapshot: f-string
+  - "{}".format({} | {})  # snapshot: f-string
+2 + f"{({} | {})}"  # snapshot: f-string
+3 | "{.x}".format(lambda: 1)  # snapshot: f-string
+```
+
+A lambda is wrapped even when the field has a trailing accessor:
+
+```py
+"{.x}".format(lambda: 1)  # snapshot: f-string
+```
+
+```snapshot
+error[UP032]: Use f-string instead of `format` call
+ --> src/mdtest_snippet.py:3:1
+  |
+3 | "{.x}".format(lambda: 1)  # snapshot: f-string
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+help: Convert to f-string
+1 | "{}".format(lambda: 1)  # snapshot: f-string
+2 | "{}".format({} | {})  # snapshot: f-string
+  - "{.x}".format(lambda: 1)  # snapshot: f-string
+3 + f"{(lambda: 1).x}"  # snapshot: f-string
+```

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/f_strings.rs
@@ -139,6 +139,9 @@ enum FormatContext {
 
 /// Returns `true` if the expression should be parenthesized when used in an f-string.
 fn parenthesize(expr: &Expr, text: &str, context: FormatContext) -> bool {
+    if text.starts_with('{') || matches!(expr, Expr::Lambda(_)) {
+        return true;
+    }
     match (context, expr) {
         // E.g., `x + y` should be parenthesized in `f"{(x + y)[0]}"`.
         (
@@ -148,7 +151,6 @@ fn parenthesize(expr: &Expr, text: &str, context: FormatContext) -> bool {
             | Expr::BoolOp(_)
             | Expr::Compare(_)
             | Expr::If(_)
-            | Expr::Lambda(_)
             | Expr::Await(_)
             | Expr::Yield(_)
             | Expr::YieldFrom(_)


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Fixes part of #15874: UP032 produced invalid f-strings for arguments that misparse bare in {...}. A lambda's : reads as the format-spec separator and a leading { as an escaped brace, so both are now parenthesized. The leading-{ check is textual since the misparse is lexer-level, covering shapes like {} | {} and {1: 2}.keys() too.

## Test Plan

New mdtest at crates/ruff_linter/resources/mdtest/pyupgrade/f-string.md.
