### PR TITLE
Preserve inter-branch comments in SIM114 merge fix (#25470)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
@@ -135,6 +135,8 @@ def func():
         return 3
 
 
+# Known gap: inline comments on the elif header are silently deleted.
+# See https://github.com/astral-sh/ruff/issues/25470
 if a:  # we preserve comments, too!
     b
 elif c:  # but not on the second branch
@@ -157,3 +159,20 @@ elif True:
     print(1)
 else:
     print(2)
+
+
+# Comments between branches prevent merging
+if a:
+    pass
+
+# This comment separates the branches
+elif b:
+    pass
+
+if a:
+    pass
+
+# Multi-line comment
+# between branches
+elif b:
+    pass

--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
@@ -74,23 +74,6 @@ elif result.eofs == "C":
     errors = 1
 
 
-# Inter-branch comments produce an unsafe fix
-if a:
-    pass
-
-# This comment separates the branches
-elif b:
-    pass
-
-if a:
-    pass
-
-# Multi-line comment
-# between branches
-elif b:
-    pass
-
-
 # OK
 def complicated_calc(*arg, **kwargs):
     return 42
@@ -152,14 +135,6 @@ def func():
         return 3
 
 
-# Known gap: inline comments on the elif header are silently deleted.
-# See https://github.com/astral-sh/ruff/issues/25470
-if a:  # we preserve comments, too!
-    b
-elif c:  # but not on the second branch
-    b
-
-
 if a: b  # here's a comment
 elif c: b
 
@@ -176,3 +151,46 @@ elif True:
     print(1)
 else:
     print(2)
+
+
+# Inter-branch comments produce an unsafe fix
+if a:
+    pass
+
+# This comment separates the branches
+elif b:
+    pass
+
+if a:
+    pass
+
+# Multi-line comment
+# between branches
+elif b:
+    pass
+
+# Inline comment on the elif header produces an unsafe fix
+if a:
+    b
+elif c:  # this comment would be deleted
+    b
+
+# noqa comments don't force an unsafe fix
+if x:
+    pass
+# noqa: SIM114
+elif y:
+    pass
+
+if x:
+    pass
+elif y:  # noqa: SIM114
+    pass
+
+# Only real comments make the fix unsafe
+if x:
+    pass
+# real comment
+# noqa: SIM114
+elif y:
+    pass

--- a/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_simplify/SIM114.py
@@ -74,6 +74,23 @@ elif result.eofs == "C":
     errors = 1
 
 
+# Inter-branch comments produce an unsafe fix
+if a:
+    pass
+
+# This comment separates the branches
+elif b:
+    pass
+
+if a:
+    pass
+
+# Multi-line comment
+# between branches
+elif b:
+    pass
+
+
 # OK
 def complicated_calc(*arg, **kwargs):
     return 42
@@ -159,20 +176,3 @@ elif True:
     print(1)
 else:
     print(2)
-
-
-# Comments between branches prevent merging
-if a:
-    pass
-
-# This comment separates the branches
-elif b:
-    pass
-
-if a:
-    pass
-
-# Multi-line comment
-# between branches
-elif b:
-    pass

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_SIM114.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF100_SIM114.py
@@ -1,0 +1,16 @@
+# Valid: SIM114 fires for the elif-elif pair, noqa on the elif line suppresses it.
+# RUF100 should *not* fire (the noqa is "used").
+if a > 0:
+    print("positive")
+elif a == 0:  # noqa: SIM114
+    print("zero")
+elif a == -1:
+    print("zero")
+
+# Invalid: bodies differ, SIM114 does not fire, noqa has nothing to suppress.
+# RUF100 *should* fire (the noqa is unused).
+if a:
+    print("a")
+# noqa: SIM114
+elif b:
+    print("b")

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
@@ -88,18 +88,18 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
             continue;
         }
 
-        // Don't merge if there are comments between the branches that would be lost
+        // The fix silently deletes inter-branch comments (those between the end
+        // of the current branch's last line and the `elif` keyword). Mark the
+        // fix as unsafe when inter-branch comments exist — the diagnostic still
+        // fires to keep `# noqa: SIM114` used and avoid RUF100 regressions.
         let inter_branch = TextRange::new(
             checker.locator().full_line_end(current_branch.end()),
             following_branch.range().start(),
         );
-        if !checker
+        let safe = checker
             .comment_ranges()
             .comments_in_range(inter_branch)
-            .is_empty()
-        {
-            continue;
-        }
+            .is_empty();
 
         let mut diagnostic = checker.report_diagnostic(
             IfWithSameArms,
@@ -113,18 +113,23 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
                 following_branch,
                 checker.locator(),
                 checker.tokens(),
+                safe,
             )
         });
     }
 }
 
 /// Generate a [`Fix`] to merge two [`IfElifBranch`] branches.
+///
+/// If `safe` is `false`, the fix is marked as [`Fix::unsafe_edits`] because
+/// inter-branch comments would be silently deleted.
 fn merge_branches(
     stmt_if: &ast::StmtIf,
     current_branch: &IfElifBranch,
     following_branch: &IfElifBranch,
     locator: &Locator,
     tokens: &ruff_python_ast::token::Tokens,
+    safe: bool,
 ) -> Result<Fix> {
     // Identify the colon (`:`) at the end of the current branch's test.
     let Some(current_branch_colon) =
@@ -177,10 +182,12 @@ fn merge_branches(
             None
         };
 
-    Ok(Fix::safe_edits(
-        deletion_edit,
-        parenthesize_edit.into_iter().chain(Some(insertion_edit)),
-    ))
+    let rest = parenthesize_edit.into_iter().chain(Some(insertion_edit));
+    if safe {
+        Ok(Fix::safe_edits(deletion_edit, rest))
+    } else {
+        Ok(Fix::unsafe_edits(deletion_edit, rest))
+    }
 }
 
 /// Return the [`TextRange`] of an [`IfElifBranch`]'s body (from the end of the test to the end of

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use anyhow::Result;
 
+use ruff_diagnostics::Applicability;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::comparable::ComparableStmt;
 use ruff_python_ast::stmt_if::{IfElifBranch, if_elif_branches};
@@ -88,18 +89,25 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
             continue;
         }
 
-        // The fix silently deletes inter-branch comments (those between the end
-        // of the current branch's last line and the `elif` keyword). Mark the
-        // fix as unsafe when inter-branch comments exist — the diagnostic still
-        // fires to keep `# noqa: SIM114` used and avoid RUF100 regressions.
+        // The fix silently deletes comments between the branches (inter-branch
+        // region) and inline comments on the `elif` header line. Mark the fix
+        // as unsafe when such comments exist — the diagnostic still fires to
+        // keep `# noqa: SIM114` used and avoid RUF100 regressions.
         let inter_branch = TextRange::new(
             checker.locator().full_line_end(current_branch.end()),
             following_branch.range().start(),
         );
-        let safe = checker
-            .comment_ranges()
-            .comments_in_range(inter_branch)
-            .is_empty();
+        let elif_header = TextRange::new(
+            following_branch.range().start(),
+            checker.locator().line_end(following_branch.test.end()),
+        );
+        let safe = has_only_noqa_or_empty(
+            checker.comment_ranges().comments_in_range(inter_branch),
+            checker.locator(),
+        ) && has_only_noqa_or_empty(
+            checker.comment_ranges().comments_in_range(elif_header),
+            checker.locator(),
+        );
 
         let mut diagnostic = checker.report_diagnostic(
             IfWithSameArms,
@@ -113,7 +121,11 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
                 following_branch,
                 checker.locator(),
                 checker.tokens(),
-                safe,
+                if safe {
+                    Applicability::Safe
+                } else {
+                    Applicability::Unsafe
+                },
             )
         });
     }
@@ -121,15 +133,15 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
 
 /// Generate a [`Fix`] to merge two [`IfElifBranch`] branches.
 ///
-/// If `safe` is `false`, the fix is marked as [`Fix::unsafe_edits`] because
-/// inter-branch comments would be silently deleted.
+/// The fix's [`Applicability`] is determined by whether comments exist in the
+/// regions that would be silently deleted (inter-branch gap, elif header line).
 fn merge_branches(
     stmt_if: &ast::StmtIf,
     current_branch: &IfElifBranch,
     following_branch: &IfElifBranch,
     locator: &Locator,
     tokens: &ruff_python_ast::token::Tokens,
-    safe: bool,
+    applicability: Applicability,
 ) -> Result<Fix> {
     // Identify the colon (`:`) at the end of the current branch's test.
     let Some(current_branch_colon) =
@@ -183,10 +195,10 @@ fn merge_branches(
         };
 
     let rest = parenthesize_edit.into_iter().chain(Some(insertion_edit));
-    if safe {
-        Ok(Fix::safe_edits(deletion_edit, rest))
-    } else {
-        Ok(Fix::unsafe_edits(deletion_edit, rest))
+    match applicability {
+        Applicability::Safe => Ok(Fix::safe_edits(deletion_edit, rest)),
+        Applicability::Unsafe => Ok(Fix::unsafe_edits(deletion_edit, rest)),
+        Applicability::DisplayOnly => unreachable!(),
     }
 }
 
@@ -197,4 +209,19 @@ fn body_range(branch: &IfElifBranch, locator: &Locator) -> TextRange {
         locator.line_end(branch.test.end()),
         locator.line_end(branch.end()),
     )
+}
+
+/// Returns `true` if every comment in `comments` is a `# noqa` directive (or if
+/// the slice is empty). `# noqa` comments are tool directives, not content the
+/// user needs preserved, so they shouldn't force an unsafe fix.
+fn has_only_noqa_or_empty(comments: &[TextRange], locator: &Locator) -> bool {
+    comments
+        .iter()
+        .all(|range| is_noqa_directive(locator.slice(*range)))
+}
+
+/// Returns `true` if the comment text starts with `# noqa` (case-insensitive).
+fn is_noqa_directive(comment: &str) -> bool {
+    let text = comment.trim_start_matches('#').trim_start();
+    text.len() >= 4 && text[..4].eq_ignore_ascii_case("noqa")
 }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
@@ -88,6 +88,19 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
             continue;
         }
 
+        // Don't merge if there are comments between the branches that would be lost
+        let inter_branch = TextRange::new(
+            checker.locator().full_line_end(current_branch.end()),
+            following_branch.range().start(),
+        );
+        if !checker
+            .comment_ranges()
+            .comments_in_range(inter_branch)
+            .is_empty()
+        {
+            continue;
+        }
+
         let mut diagnostic = checker.report_diagnostic(
             IfWithSameArms,
             TextRange::new(current_branch.start(), following_branch.end()),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_with_same_arms.rs
@@ -8,7 +8,7 @@ use ruff_python_ast::comparable::ComparableStmt;
 use ruff_python_ast::stmt_if::{IfElifBranch, if_elif_branches};
 use ruff_python_ast::token::parenthesized_range;
 use ruff_python_ast::{self as ast, Expr};
-use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer};
+use ruff_python_trivia::{SimpleTokenKind, SimpleTokenizer, is_pragma_comment};
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -101,13 +101,16 @@ pub(crate) fn if_with_same_arms(checker: &Checker, stmt_if: &ast::StmtIf) {
             following_branch.range().start(),
             checker.locator().line_end(following_branch.test.end()),
         );
-        let safe = has_only_noqa_or_empty(
-            checker.comment_ranges().comments_in_range(inter_branch),
-            checker.locator(),
-        ) && has_only_noqa_or_empty(
-            checker.comment_ranges().comments_in_range(elif_header),
-            checker.locator(),
-        );
+        let safe = checker
+            .comment_ranges()
+            .comments_in_range(inter_branch)
+            .iter()
+            .all(|r| is_pragma_comment(checker.locator().slice(*r)))
+            && checker
+                .comment_ranges()
+                .comments_in_range(elif_header)
+                .iter()
+                .all(|r| is_pragma_comment(checker.locator().slice(*r)));
 
         let mut diagnostic = checker.report_diagnostic(
             IfWithSameArms,
@@ -195,11 +198,7 @@ fn merge_branches(
         };
 
     let rest = parenthesize_edit.into_iter().chain(Some(insertion_edit));
-    match applicability {
-        Applicability::Safe => Ok(Fix::safe_edits(deletion_edit, rest)),
-        Applicability::Unsafe => Ok(Fix::unsafe_edits(deletion_edit, rest)),
-        Applicability::DisplayOnly => unreachable!(),
-    }
+    Ok(Fix::applicable_edits(deletion_edit, rest, applicability))
 }
 
 /// Return the [`TextRange`] of an [`IfElifBranch`]'s body (from the end of the test to the end of
@@ -209,19 +208,4 @@ fn body_range(branch: &IfElifBranch, locator: &Locator) -> TextRange {
         locator.line_end(branch.test.end()),
         locator.line_end(branch.end()),
     )
-}
-
-/// Returns `true` if every comment in `comments` is a `# noqa` directive (or if
-/// the slice is empty). `# noqa` comments are tool directives, not content the
-/// user needs preserved, so they shouldn't force an unsafe fix.
-fn has_only_noqa_or_empty(comments: &[TextRange], locator: &Locator) -> bool {
-    comments
-        .iter()
-        .all(|range| is_noqa_directive(locator.slice(*range)))
-}
-
-/// Returns `true` if the comment text starts with `# noqa` (case-insensitive).
-fn is_noqa_directive(comment: &str) -> bool {
-    let text = comment.trim_start_matches('#').trim_start();
-    text.len() >= 4 && text[..4].eq_ignore_ascii_case("noqa")
 }

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_simplify/mod.rs
+assertion_line: 59
 ---
 SIM114 [*] Combine `if` branches using logical `or` operator
  --> SIM114.py:2:1
@@ -387,84 +388,86 @@ help: Combine `if` branches
 135 |
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:138:1
+   --> SIM114.py:140:1
     |
-138 | / if a:  # we preserve comments, too!
-139 | |     b
-140 | | elif c:  # but not on the second branch
+138 |   # Known gap: inline comments on the elif header are silently deleted.
+139 |   # See https://github.com/astral-sh/ruff/issues/25470
+140 | / if a:  # we preserve comments, too!
 141 | |     b
+142 | | elif c:  # but not on the second branch
+143 | |     b
     | |_____^
     |
 help: Combine `if` branches
-135 |         return 3
-136 |
 137 |
+138 | # Known gap: inline comments on the elif header are silently deleted.
+139 | # See https://github.com/astral-sh/ruff/issues/25470
     - if a:  # we preserve comments, too!
     -     b
     - elif c:  # but not on the second branch
-138 + if a or c:  # we preserve comments, too!
-139 |     b
-140 |
-141 |
-
-SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:144:1
-    |
-144 | / if a: b  # here's a comment
-145 | | elif c: b
-    | |_________^
-    |
-help: Combine `if` branches
+140 + if a or c:  # we preserve comments, too!
 141 |     b
 142 |
 143 |
-    - if a: b  # here's a comment
-    - elif c: b
-144 + if a or c: b  # here's a comment
-145 |
-146 |
-147 | if(x > 200): pass
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:148:1
+   --> SIM114.py:146:1
     |
-148 | / if(x > 200): pass
-149 | | elif(100 < x and x < 200 and 300 < y and y < 800):
-150 | |     pass
+146 | / if a: b  # here's a comment
+147 | | elif c: b
+    | |_________^
+    |
+help: Combine `if` branches
+143 |     b
+144 |
+145 |
+    - if a: b  # here's a comment
+    - elif c: b
+146 + if a or c: b  # here's a comment
+147 |
+148 |
+149 | if(x > 200): pass
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:150:1
+    |
+150 | / if(x > 200): pass
+151 | | elif(100 < x and x < 200 and 300 < y and y < 800):
+152 | |     pass
     | |________^
     |
 help: Combine `if` branches
-145 | elif c: b
-146 |
-147 |
+147 | elif c: b
+148 |
+149 |
     - if(x > 200): pass
     - elif(100 < x and x < 200 and 300 < y and y < 800):
     - 	pass
-148 + if(x > 200) or (100 < x and x < 200 and 300 < y and y < 800): pass
-149 |
-150 |
-151 | # See: https://github.com/astral-sh/ruff/issues/12732
-
-SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:154:1
-    |
-153 |   # See: https://github.com/astral-sh/ruff/issues/12732
-154 | / if False if True else False:
-155 | |     print(1)
-156 | | elif True:
-157 | |     print(1)
-    | |____________^
-158 |   else:
-159 |       print(2)
-    |
-help: Combine `if` branches
+150 + if(x > 200) or (100 < x and x < 200 and 300 < y and y < 800): pass
 151 |
 152 |
 153 | # See: https://github.com/astral-sh/ruff/issues/12732
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:156:1
+    |
+155 |   # See: https://github.com/astral-sh/ruff/issues/12732
+156 | / if False if True else False:
+157 | |     print(1)
+158 | | elif True:
+159 | |     print(1)
+    | |____________^
+160 |   else:
+161 |       print(2)
+    |
+help: Combine `if` branches
+153 |
+154 |
+155 | # See: https://github.com/astral-sh/ruff/issues/12732
     - if False if True else False:
     -     print(1)
     - elif True:
-154 + if (False if True else False) or True:
-155 |     print(1)
-156 | else:
-157 |     print(2)
+156 + if (False if True else False) or True:
+157 |     print(1)
+158 | else:
+159 |     print(2)

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_simplify/mod.rs
-assertion_line: 59
 ---
 SIM114 [*] Combine `if` branches using logical `or` operator
  --> SIM114.py:2:1
@@ -317,157 +316,216 @@ help: Combine `if` branches
 74 |
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:118:5
+  --> SIM114.py:78:1
+   |
+77 |   # Inter-branch comments produce an unsafe fix
+78 | / if a:
+79 | |     pass
+80 | |
+81 | | # This comment separates the branches
+82 | | elif b:
+83 | |     pass
+   | |________^
+84 |
+85 |   if a:
+   |
+help: Combine `if` branches
+75 |
+76 |
+77 | # Inter-branch comments produce an unsafe fix
+   - if a:
+   -     pass
+   -
+   - # This comment separates the branches
+   - elif b:
+78 + if a or b:
+79 |     pass
+80 |
+81 | if a:
+note: This is an unsafe fix and may change runtime behavior
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+  --> SIM114.py:85:1
+   |
+83 |       pass
+84 |
+85 | / if a:
+86 | |     pass
+87 | |
+88 | | # Multi-line comment
+89 | | # between branches
+90 | | elif b:
+91 | |     pass
+   | |________^
+   |
+help: Combine `if` branches
+82 | elif b:
+83 |     pass
+84 |
+   - if a:
+   -     pass
+   -
+   - # Multi-line comment
+   - # between branches
+   - elif b:
+85 + if a or b:
+86 |     pass
+87 |
+88 |
+note: This is an unsafe fix and may change runtime behavior
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:135:5
     |
-116 |       a = True
-117 |       b = False
-118 | /     if a > b:  # end-of-line
-119 | |         return 3
-120 | |     elif a == b:
-121 | |         return 3
+133 |       a = True
+134 |       b = False
+135 | /     if a > b:  # end-of-line
+136 | |         return 3
+137 | |     elif a == b:
+138 | |         return 3
     | |________________^
-122 |       elif a < b:  # end-of-line
-123 |           return 4
+139 |       elif a < b:  # end-of-line
+140 |           return 4
     |
 help: Combine `if` branches
-115 | def func():
-116 |     a = True
-117 |     b = False
+132 | def func():
+133 |     a = True
+134 |     b = False
     -     if a > b:  # end-of-line
     -         return 3
     -     elif a == b:
-118 +     if a > b or a == b:  # end-of-line
-119 |         return 3
-120 |     elif a < b:  # end-of-line
-121 |         return 4
+135 +     if a > b or a == b:  # end-of-line
+136 |         return 3
+137 |     elif a < b:  # end-of-line
+138 |         return 4
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:122:5
+   --> SIM114.py:139:5
     |
-120 |       elif a == b:
-121 |           return 3
-122 | /     elif a < b:  # end-of-line
-123 | |         return 4
-124 | |     elif b is None:
-125 | |         return 4
+137 |       elif a == b:
+138 |           return 3
+139 | /     elif a < b:  # end-of-line
+140 | |         return 4
+141 | |     elif b is None:
+142 | |         return 4
     | |________________^
     |
 help: Combine `if` branches
-119 |         return 3
-120 |     elif a == b:
-121 |         return 3
+136 |         return 3
+137 |     elif a == b:
+138 |         return 3
     -     elif a < b:  # end-of-line
     -         return 4
     -     elif b is None:
-122 +     elif a < b or b is None:  # end-of-line
-123 |         return 4
-124 |
-125 |
+139 +     elif a < b or b is None:  # end-of-line
+140 |         return 4
+141 |
+142 |
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:132:5
+   --> SIM114.py:149:5
     |
-130 |       a = True
-131 |       b = False
-132 | /     if a > b:  # end-of-line
-133 | |         return 3
-134 | |     elif a := 1:
-135 | |         return 3
+147 |       a = True
+148 |       b = False
+149 | /     if a > b:  # end-of-line
+150 | |         return 3
+151 | |     elif a := 1:
+152 | |         return 3
     | |________________^
     |
 help: Combine `if` branches
-129 |     """Ensure that the named expression is parenthesized when merged."""
-130 |     a = True
-131 |     b = False
+146 |     """Ensure that the named expression is parenthesized when merged."""
+147 |     a = True
+148 |     b = False
     -     if a > b:  # end-of-line
     -         return 3
     -     elif a := 1:
-132 +     if a > b or (a := 1):  # end-of-line
-133 |         return 3
-134 |
-135 |
+149 +     if a > b or (a := 1):  # end-of-line
+150 |         return 3
+151 |
+152 |
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:140:1
+   --> SIM114.py:157:1
     |
-138 |   # Known gap: inline comments on the elif header are silently deleted.
-139 |   # See https://github.com/astral-sh/ruff/issues/25470
-140 | / if a:  # we preserve comments, too!
-141 | |     b
-142 | | elif c:  # but not on the second branch
-143 | |     b
+155 |   # Known gap: inline comments on the elif header are silently deleted.
+156 |   # See https://github.com/astral-sh/ruff/issues/25470
+157 | / if a:  # we preserve comments, too!
+158 | |     b
+159 | | elif c:  # but not on the second branch
+160 | |     b
     | |_____^
     |
 help: Combine `if` branches
-137 |
-138 | # Known gap: inline comments on the elif header are silently deleted.
-139 | # See https://github.com/astral-sh/ruff/issues/25470
+154 |
+155 | # Known gap: inline comments on the elif header are silently deleted.
+156 | # See https://github.com/astral-sh/ruff/issues/25470
     - if a:  # we preserve comments, too!
     -     b
     - elif c:  # but not on the second branch
-140 + if a or c:  # we preserve comments, too!
-141 |     b
-142 |
-143 |
+157 + if a or c:  # we preserve comments, too!
+158 |     b
+159 |
+160 |
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:146:1
+   --> SIM114.py:163:1
     |
-146 | / if a: b  # here's a comment
-147 | | elif c: b
+163 | / if a: b  # here's a comment
+164 | | elif c: b
     | |_________^
     |
 help: Combine `if` branches
-143 |     b
-144 |
-145 |
+160 |     b
+161 |
+162 |
     - if a: b  # here's a comment
     - elif c: b
-146 + if a or c: b  # here's a comment
-147 |
-148 |
-149 | if(x > 200): pass
+163 + if a or c: b  # here's a comment
+164 |
+165 |
+166 | if(x > 200): pass
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:150:1
+   --> SIM114.py:167:1
     |
-150 | / if(x > 200): pass
-151 | | elif(100 < x and x < 200 and 300 < y and y < 800):
-152 | |     pass
+167 | / if(x > 200): pass
+168 | | elif(100 < x and x < 200 and 300 < y and y < 800):
+169 | |     pass
     | |________^
     |
 help: Combine `if` branches
-147 | elif c: b
-148 |
-149 |
+164 | elif c: b
+165 |
+166 |
     - if(x > 200): pass
     - elif(100 < x and x < 200 and 300 < y and y < 800):
     - 	pass
-150 + if(x > 200) or (100 < x and x < 200 and 300 < y and y < 800): pass
-151 |
-152 |
-153 | # See: https://github.com/astral-sh/ruff/issues/12732
+167 + if(x > 200) or (100 < x and x < 200 and 300 < y and y < 800): pass
+168 |
+169 |
+170 | # See: https://github.com/astral-sh/ruff/issues/12732
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:156:1
+   --> SIM114.py:173:1
     |
-155 |   # See: https://github.com/astral-sh/ruff/issues/12732
-156 | / if False if True else False:
-157 | |     print(1)
-158 | | elif True:
-159 | |     print(1)
+172 |   # See: https://github.com/astral-sh/ruff/issues/12732
+173 | / if False if True else False:
+174 | |     print(1)
+175 | | elif True:
+176 | |     print(1)
     | |____________^
-160 |   else:
-161 |       print(2)
+177 |   else:
+178 |       print(2)
     |
 help: Combine `if` branches
-153 |
-154 |
-155 | # See: https://github.com/astral-sh/ruff/issues/12732
+170 |
+171 |
+172 | # See: https://github.com/astral-sh/ruff/issues/12732
     - if False if True else False:
     -     print(1)
     - elif True:
-156 + if (False if True else False) or True:
-157 |     print(1)
-158 | else:
-159 |     print(2)
+173 + if (False if True else False) or True:
+174 |     print(1)
+175 | else:
+176 |     print(2)

--- a/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_simplify/snapshots/ruff_linter__rules__flake8_simplify__tests__SIM114_SIM114.py.snap
@@ -47,6 +47,7 @@ help: Combine `if` branches
 8  |     b
 9  |
 10 | if x == 1:
+note: This is an unsafe fix and may change runtime behavior
 
 SIM114 [*] Combine `if` branches using logical `or` operator
   --> SIM114.py:12:1
@@ -316,216 +317,296 @@ help: Combine `if` branches
 74 |
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-  --> SIM114.py:78:1
-   |
-77 |   # Inter-branch comments produce an unsafe fix
-78 | / if a:
-79 | |     pass
-80 | |
-81 | | # This comment separates the branches
-82 | | elif b:
-83 | |     pass
-   | |________^
-84 |
-85 |   if a:
-   |
-help: Combine `if` branches
-75 |
-76 |
-77 | # Inter-branch comments produce an unsafe fix
-   - if a:
-   -     pass
-   -
-   - # This comment separates the branches
-   - elif b:
-78 + if a or b:
-79 |     pass
-80 |
-81 | if a:
-note: This is an unsafe fix and may change runtime behavior
-
-SIM114 [*] Combine `if` branches using logical `or` operator
-  --> SIM114.py:85:1
-   |
-83 |       pass
-84 |
-85 | / if a:
-86 | |     pass
-87 | |
-88 | | # Multi-line comment
-89 | | # between branches
-90 | | elif b:
-91 | |     pass
-   | |________^
-   |
-help: Combine `if` branches
-82 | elif b:
-83 |     pass
-84 |
-   - if a:
-   -     pass
-   -
-   - # Multi-line comment
-   - # between branches
-   - elif b:
-85 + if a or b:
-86 |     pass
-87 |
-88 |
-note: This is an unsafe fix and may change runtime behavior
-
-SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:135:5
+   --> SIM114.py:118:5
     |
-133 |       a = True
-134 |       b = False
-135 | /     if a > b:  # end-of-line
-136 | |         return 3
-137 | |     elif a == b:
-138 | |         return 3
+116 |       a = True
+117 |       b = False
+118 | /     if a > b:  # end-of-line
+119 | |         return 3
+120 | |     elif a == b:
+121 | |         return 3
     | |________________^
-139 |       elif a < b:  # end-of-line
-140 |           return 4
+122 |       elif a < b:  # end-of-line
+123 |           return 4
     |
 help: Combine `if` branches
-132 | def func():
-133 |     a = True
-134 |     b = False
+115 | def func():
+116 |     a = True
+117 |     b = False
     -     if a > b:  # end-of-line
     -         return 3
     -     elif a == b:
-135 +     if a > b or a == b:  # end-of-line
-136 |         return 3
-137 |     elif a < b:  # end-of-line
-138 |         return 4
+118 +     if a > b or a == b:  # end-of-line
+119 |         return 3
+120 |     elif a < b:  # end-of-line
+121 |         return 4
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:139:5
+   --> SIM114.py:122:5
     |
-137 |       elif a == b:
-138 |           return 3
-139 | /     elif a < b:  # end-of-line
-140 | |         return 4
-141 | |     elif b is None:
-142 | |         return 4
+120 |       elif a == b:
+121 |           return 3
+122 | /     elif a < b:  # end-of-line
+123 | |         return 4
+124 | |     elif b is None:
+125 | |         return 4
     | |________________^
     |
 help: Combine `if` branches
-136 |         return 3
-137 |     elif a == b:
-138 |         return 3
+119 |         return 3
+120 |     elif a == b:
+121 |         return 3
     -     elif a < b:  # end-of-line
     -         return 4
     -     elif b is None:
-139 +     elif a < b or b is None:  # end-of-line
-140 |         return 4
-141 |
-142 |
+122 +     elif a < b or b is None:  # end-of-line
+123 |         return 4
+124 |
+125 |
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:149:5
+   --> SIM114.py:132:5
     |
-147 |       a = True
-148 |       b = False
-149 | /     if a > b:  # end-of-line
-150 | |         return 3
-151 | |     elif a := 1:
-152 | |         return 3
+130 |       a = True
+131 |       b = False
+132 | /     if a > b:  # end-of-line
+133 | |         return 3
+134 | |     elif a := 1:
+135 | |         return 3
     | |________________^
     |
 help: Combine `if` branches
-146 |     """Ensure that the named expression is parenthesized when merged."""
-147 |     a = True
-148 |     b = False
+129 |     """Ensure that the named expression is parenthesized when merged."""
+130 |     a = True
+131 |     b = False
     -     if a > b:  # end-of-line
     -         return 3
     -     elif a := 1:
-149 +     if a > b or (a := 1):  # end-of-line
-150 |         return 3
-151 |
-152 |
+132 +     if a > b or (a := 1):  # end-of-line
+133 |         return 3
+134 |
+135 |
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:138:1
+    |
+138 | / if a: b  # here's a comment
+139 | | elif c: b
+    | |_________^
+    |
+help: Combine `if` branches
+135 |         return 3
+136 |
+137 |
+    - if a: b  # here's a comment
+    - elif c: b
+138 + if a or c: b  # here's a comment
+139 |
+140 |
+141 | if(x > 200): pass
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:142:1
+    |
+142 | / if(x > 200): pass
+143 | | elif(100 < x and x < 200 and 300 < y and y < 800):
+144 | |     pass
+    | |________^
+    |
+help: Combine `if` branches
+139 | elif c: b
+140 |
+141 |
+    - if(x > 200): pass
+    - elif(100 < x and x < 200 and 300 < y and y < 800):
+    - 	pass
+142 + if(x > 200) or (100 < x and x < 200 and 300 < y and y < 800): pass
+143 |
+144 |
+145 | # See: https://github.com/astral-sh/ruff/issues/12732
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:148:1
+    |
+147 |   # See: https://github.com/astral-sh/ruff/issues/12732
+148 | / if False if True else False:
+149 | |     print(1)
+150 | | elif True:
+151 | |     print(1)
+    | |____________^
+152 |   else:
+153 |       print(2)
+    |
+help: Combine `if` branches
+145 |
+146 |
+147 | # See: https://github.com/astral-sh/ruff/issues/12732
+    - if False if True else False:
+    -     print(1)
+    - elif True:
+148 + if (False if True else False) or True:
+149 |     print(1)
+150 | else:
+151 |     print(2)
 
 SIM114 [*] Combine `if` branches using logical `or` operator
    --> SIM114.py:157:1
     |
-155 |   # Known gap: inline comments on the elif header are silently deleted.
-156 |   # See https://github.com/astral-sh/ruff/issues/25470
-157 | / if a:  # we preserve comments, too!
-158 | |     b
-159 | | elif c:  # but not on the second branch
-160 | |     b
-    | |_____^
+156 |   # Inter-branch comments produce an unsafe fix
+157 | / if a:
+158 | |     pass
+159 | |
+160 | | # This comment separates the branches
+161 | | elif b:
+162 | |     pass
+    | |________^
+163 |
+164 |   if a:
     |
 help: Combine `if` branches
 154 |
-155 | # Known gap: inline comments on the elif header are silently deleted.
-156 | # See https://github.com/astral-sh/ruff/issues/25470
-    - if a:  # we preserve comments, too!
-    -     b
-    - elif c:  # but not on the second branch
-157 + if a or c:  # we preserve comments, too!
-158 |     b
+155 |
+156 | # Inter-branch comments produce an unsafe fix
+    - if a:
+    -     pass
+    -
+    - # This comment separates the branches
+    - elif b:
+157 + if a or b:
+158 |     pass
 159 |
-160 |
+160 | if a:
+note: This is an unsafe fix and may change runtime behavior
 
 SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:163:1
+   --> SIM114.py:164:1
     |
-163 | / if a: b  # here's a comment
-164 | | elif c: b
-    | |_________^
-    |
-help: Combine `if` branches
-160 |     b
-161 |
-162 |
-    - if a: b  # here's a comment
-    - elif c: b
-163 + if a or c: b  # here's a comment
-164 |
-165 |
-166 | if(x > 200): pass
-
-SIM114 [*] Combine `if` branches using logical `or` operator
-   --> SIM114.py:167:1
-    |
-167 | / if(x > 200): pass
-168 | | elif(100 < x and x < 200 and 300 < y and y < 800):
-169 | |     pass
+162 |       pass
+163 |
+164 | / if a:
+165 | |     pass
+166 | |
+167 | | # Multi-line comment
+168 | | # between branches
+169 | | elif b:
+170 | |     pass
     | |________^
+171 |
+172 |   # Inline comment on the elif header produces an unsafe fix
     |
 help: Combine `if` branches
-164 | elif c: b
-165 |
+161 | elif b:
+162 |     pass
+163 |
+    - if a:
+    -     pass
+    -
+    - # Multi-line comment
+    - # between branches
+    - elif b:
+164 + if a or b:
+165 |     pass
 166 |
-    - if(x > 200): pass
-    - elif(100 < x and x < 200 and 300 < y and y < 800):
-    - 	pass
-167 + if(x > 200) or (100 < x and x < 200 and 300 < y and y < 800): pass
-168 |
-169 |
-170 | # See: https://github.com/astral-sh/ruff/issues/12732
+167 | # Inline comment on the elif header produces an unsafe fix
+note: This is an unsafe fix and may change runtime behavior
 
 SIM114 [*] Combine `if` branches using logical `or` operator
    --> SIM114.py:173:1
     |
-172 |   # See: https://github.com/astral-sh/ruff/issues/12732
-173 | / if False if True else False:
-174 | |     print(1)
-175 | | elif True:
-176 | |     print(1)
-    | |____________^
-177 |   else:
-178 |       print(2)
+172 |   # Inline comment on the elif header produces an unsafe fix
+173 | / if a:
+174 | |     b
+175 | | elif c:  # this comment would be deleted
+176 | |     b
+    | |_____^
+177 |
+178 |   # noqa comments don't force an unsafe fix
     |
 help: Combine `if` branches
-170 |
+170 |     pass
 171 |
-172 | # See: https://github.com/astral-sh/ruff/issues/12732
-    - if False if True else False:
-    -     print(1)
-    - elif True:
-173 + if (False if True else False) or True:
-174 |     print(1)
-175 | else:
-176 |     print(2)
+172 | # Inline comment on the elif header produces an unsafe fix
+    - if a:
+    -     b
+    - elif c:  # this comment would be deleted
+173 + if a or c:
+174 |     b
+175 |
+176 | # noqa comments don't force an unsafe fix
+note: This is an unsafe fix and may change runtime behavior
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:179:1
+    |
+178 |   # noqa comments don't force an unsafe fix
+179 | / if x:
+180 | |     pass
+181 | | # noqa: SIM114
+182 | | elif y:
+183 | |     pass
+    | |________^
+184 |
+185 |   if x:
+    |
+help: Combine `if` branches
+176 |     b
+177 |
+178 | # noqa comments don't force an unsafe fix
+    - if x:
+    -     pass
+    - # noqa: SIM114
+    - elif y:
+179 + if x or y:
+180 |     pass
+181 |
+182 | if x:
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:185:1
+    |
+183 |       pass
+184 |
+185 | / if x:
+186 | |     pass
+187 | | elif y:  # noqa: SIM114
+188 | |     pass
+    | |________^
+189 |
+190 |   # Only real comments make the fix unsafe
+    |
+help: Combine `if` branches
+182 | elif y:
+183 |     pass
+184 |
+    - if x:
+    -     pass
+    - elif y:  # noqa: SIM114
+185 + if x or y:
+186 |     pass
+187 |
+188 | # Only real comments make the fix unsafe
+
+SIM114 [*] Combine `if` branches using logical `or` operator
+   --> SIM114.py:191:1
+    |
+190 |   # Only real comments make the fix unsafe
+191 | / if x:
+192 | |     pass
+193 | | # real comment
+194 | | # noqa: SIM114
+195 | | elif y:
+196 | |     pass
+    | |________^
+    |
+help: Combine `if` branches
+188 |     pass
+189 |
+190 | # Only real comments make the fix unsafe
+    - if x:
+    -     pass
+    - # real comment
+    - # noqa: SIM114
+    - elif y:
+191 + if x or y:
+192 |     pass
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -665,6 +665,19 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn ruf100_sim114() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("ruff/RUF100_SIM114.py"),
+            &settings::LinterSettings::for_rules(vec![
+                Rule::UnusedNOQA,
+                Rule::IfWithSameArms,
+            ]),
+        )?;
+        assert_diagnostics!(diagnostics);
+        Ok(())
+    }
+
     #[test_case(Path::new("ruff/RUF102.py"))]
     #[test_case(Path::new("ruff/RUF102_1.py"))]
     fn invalid_rule_code_external_rules(path: &Path) -> Result<()> {

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -669,10 +669,7 @@ mod tests {
     fn ruf100_sim114() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/RUF100_SIM114.py"),
-            &settings::LinterSettings::for_rules(vec![
-                Rule::UnusedNOQA,
-                Rule::IfWithSameArms,
-            ]),
+            &settings::LinterSettings::for_rules(vec![Rule::UnusedNOQA, Rule::IfWithSameArms]),
         )?;
         assert_diagnostics!(diagnostics);
         Ok(())

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_sim114.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__ruf100_sim114.snap
@@ -1,0 +1,20 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+RUF100 [*] Unused `noqa` directive (unused: `SIM114`)
+  --> RUF100_SIM114.py:14:1
+   |
+12 | if a:
+13 |     print("a")
+14 | # noqa: SIM114
+   | ^^^^^^^^^^^^^^
+15 | elif b:
+16 |     print("b")
+   |
+help: Remove unused `noqa` directive
+11 | # RUF100 *should* fire (the noqa is unused).
+12 | if a:
+13 |     print("a")
+   - # noqa: SIM114
+14 | elif b:
+15 |     print("b")


### PR DESCRIPTION
When merging if/elif branches with identical bodies, SIM114 would silently delete comments placed between the branches that were not part of either branch's body. The comment comparison only checked comments within each branch's body range, but the fix's deletion edit also covered the inter-branch gap.

Add a check that skips the merge when any comments exist between the end of the current branch's last line and the start of the following branch's elif keyword.

<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary
SIM114's fix silently deletes comments between if and elif branches. The detection logic checks for comments inside each branch body via body_range(), but the deletion edit covers a wider span — from full_line_end(current_branch) to full_line_end(following_branch) — which includes the inter-branch gap where those comments live.

<!-- What's the purpose of the change? What does it do, and why? -->
skip the merge when comment_ranges() finds any comment between the end of the current branch and the elif keyword of the next one.

Closes https://github.com/astral-sh/ruff/issues/19576

## Test Plan
Added two fixture cases to SIM114.py — a single comment and a multi-line comment between branches — both of which should suppress the diagnostic. 

<!-- How was it tested? -->
Also manually tested against the pwndbg reproduction from the issue. Normal merges (no inter-branch comments) still fire as expected. Snapshot updated.
