### PR TITLE
Render subdiagnostics in the Ruff/ty playgrounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3581,6 +3581,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "log",
+ "ruff_db",
  "ruff_formatter",
  "ruff_linter",
  "ruff_python_ast",

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -693,6 +693,13 @@ impl SubDiagnostic {
         self.primary_annotation().map(Annotation::get_span)
     }
 
+    /// Returns the primary message for this sub-diagnostic.
+    ///
+    /// A sub-diagnostic always has a message, but it may be empty.
+    pub fn primary_message(&self) -> &str {
+        self.inner.message.as_str()
+    }
+
     /// Introspects this diagnostic and returns what kind of "primary" message
     /// it contains for concise formatting.
     ///
@@ -706,7 +713,7 @@ impl SubDiagnostic {
     /// cases, just converting it to a string (or printing it) will do what
     /// you want.
     pub fn concise_message(&self) -> ConciseMessage<'_> {
-        let main = self.inner.message.as_str();
+        let main = self.primary_message();
         let annotation = self
             .primary_annotation()
             .and_then(|ann| ann.get_message())

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -1,5 +1,5 @@
-use std::fmt::Display;
-use std::{borrow::Cow, fmt::Formatter, path::Path, sync::Arc};
+use std::fmt::{Display, Formatter};
+use std::{borrow::Cow, path::Path, sync::Arc};
 
 use ruff_diagnostics::{Applicability, Fix};
 use ruff_source_file::{LineColumn, SourceCode, SourceFile};
@@ -688,6 +688,11 @@ impl SubDiagnostic {
         self.inner.annotations.iter().find(|ann| ann.is_primary)
     }
 
+    /// Returns a reference to the primary span of this sub-diagnostic.
+    pub fn primary_span_ref(&self) -> Option<&Span> {
+        self.primary_annotation().map(Annotation::get_span)
+    }
+
     /// Introspects this diagnostic and returns what kind of "primary" message
     /// it contains for concise formatting.
     ///
@@ -715,6 +720,12 @@ impl SubDiagnostic {
 
     pub fn severity(&self) -> SubDiagnosticSeverity {
         self.inner.severity
+    }
+}
+
+impl Display for SubDiagnostic {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.severity(), self.concise_message())
     }
 }
 

--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -723,12 +723,6 @@ impl SubDiagnostic {
     }
 }
 
-impl Display for SubDiagnostic {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: {}", self.severity(), self.concise_message())
-    }
-}
-
 #[derive(Debug, Clone, Eq, PartialEq, Hash, get_size2::GetSize)]
 struct SubDiagnosticInner {
     severity: SubDiagnosticSeverity,

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 test = false
 
 [dependencies]
+ruff_db = { workspace = true }
 ruff_formatter = { workspace = true }
 ruff_linter = { workspace = true }
 ruff_python_ast = { workspace = true }

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -31,7 +31,7 @@ const TYPES: &'static str = r#"
 export interface Diagnostic {
     code: string | null;
     message: string;
-    details: DiagnosticDetail[];
+    sub_diagnostics: SubDiagnostic[];
     start_location: {
         row: number;
         column: number;
@@ -56,16 +56,22 @@ export interface Diagnostic {
     } | null;
 }
 
-export interface DiagnosticDetail {
+export interface SubDiagnostic {
+    severity: string;
     message: string;
+    location: SubDiagnosticLocation | null;
+}
+
+export interface SubDiagnosticLocation {
+    path: string;
     start_location: {
         row: number;
         column: number;
-    } | null;
+    };
     end_location: {
         row: number;
         column: number;
-    } | null;
+    };
 }
 "#;
 
@@ -73,17 +79,24 @@ export interface DiagnosticDetail {
 pub struct ExpandedMessage {
     pub code: String,
     pub message: String,
-    pub details: Vec<ExpandedDiagnosticDetail>,
+    pub sub_diagnostics: Vec<ExpandedSubDiagnostic>,
     pub start_location: Location,
     pub end_location: Location,
     pub fix: Option<ExpandedFix>,
 }
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
-pub struct ExpandedDiagnosticDetail {
+pub struct ExpandedSubDiagnostic {
+    pub severity: String,
     pub message: String,
-    pub start_location: Option<Location>,
-    pub end_location: Option<Location>,
+    pub location: Option<ExpandedSubDiagnosticLocation>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+pub struct ExpandedSubDiagnosticLocation {
+    pub path: String,
+    pub start_location: Location,
+    pub end_location: Location,
 }
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
@@ -295,32 +308,30 @@ impl Workspace {
             .into_iter()
             .map(|msg| {
                 let range = msg.range().unwrap_or_default();
-                let details = msg
+                let sub_diagnostics = msg
                     .sub_diagnostics()
                     .iter()
                     .map(|sub_diagnostic| {
-                        let (start_location, end_location) = sub_diagnostic
-                            .primary_span_ref()
-                            .and_then(|span| {
-                                let source_code = span.as_ruff_file()?.to_source_code();
-                                let range = span.range()?;
+                        let location = sub_diagnostic.primary_span_ref().and_then(|span| {
+                            let source_file = span.as_ruff_file()?;
+                            let source_code = source_file.to_source_code();
+                            let range = span.range()?;
 
-                                Some((
-                                    source_code
-                                        .source_location(range.start(), self.position_encoding)
-                                        .into(),
-                                    source_code
-                                        .source_location(range.end(), self.position_encoding)
-                                        .into(),
-                                ))
+                            Some(ExpandedSubDiagnosticLocation {
+                                path: source_file.name().to_string(),
+                                start_location: source_code
+                                    .source_location(range.start(), self.position_encoding)
+                                    .into(),
+                                end_location: source_code
+                                    .source_location(range.end(), self.position_encoding)
+                                    .into(),
                             })
-                            .map(|(start, end)| (Some(start), Some(end)))
-                            .unwrap_or_default();
+                        });
 
-                        ExpandedDiagnosticDetail {
-                            message: sub_diagnostic.to_string(),
-                            start_location,
-                            end_location,
+                        ExpandedSubDiagnostic {
+                            severity: sub_diagnostic.severity().to_string(),
+                            message: sub_diagnostic.concise_message().to_string(),
+                            location,
                         }
                     })
                     .collect();
@@ -328,7 +339,7 @@ impl Workspace {
                 ExpandedMessage {
                     code: msg.secondary_code_or_id().to_string(),
                     message: msg.concise_message().to_string(),
-                    details,
+                    sub_diagnostics,
                     start_location: source_code
                         .source_location(range.start(), self.position_encoding)
                         .into(),

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -31,6 +31,7 @@ const TYPES: &'static str = r#"
 export interface Diagnostic {
     code: string | null;
     message: string;
+    details: DiagnosticDetail[];
     start_location: {
         row: number;
         column: number;
@@ -54,15 +55,35 @@ export interface Diagnostic {
         }[];
     } | null;
 }
+
+export interface DiagnosticDetail {
+    message: string;
+    start_location: {
+        row: number;
+        column: number;
+    } | null;
+    end_location: {
+        row: number;
+        column: number;
+    } | null;
+}
 "#;
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct ExpandedMessage {
     pub code: String,
     pub message: String,
+    pub details: Vec<ExpandedDiagnosticDetail>,
     pub start_location: Location,
     pub end_location: Location,
     pub fix: Option<ExpandedFix>,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+pub struct ExpandedDiagnosticDetail {
+    pub message: String,
+    pub start_location: Option<Location>,
+    pub end_location: Option<Location>,
 }
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
@@ -274,9 +295,40 @@ impl Workspace {
             .into_iter()
             .map(|msg| {
                 let range = msg.range().unwrap_or_default();
+                let details = msg
+                    .sub_diagnostics()
+                    .iter()
+                    .map(|sub_diagnostic| {
+                        let (start_location, end_location) = sub_diagnostic
+                            .primary_span_ref()
+                            .and_then(|span| {
+                                let source_code = span.as_ruff_file()?.to_source_code();
+                                let range = span.range()?;
+
+                                Some((
+                                    source_code
+                                        .source_location(range.start(), self.position_encoding)
+                                        .into(),
+                                    source_code
+                                        .source_location(range.end(), self.position_encoding)
+                                        .into(),
+                                ))
+                            })
+                            .map(|(start, end)| (Some(start), Some(end)))
+                            .unwrap_or_default();
+
+                        ExpandedDiagnosticDetail {
+                            message: sub_diagnostic.to_string(),
+                            start_location,
+                            end_location,
+                        }
+                    })
+                    .collect();
+
                 ExpandedMessage {
                     code: msg.secondary_code_or_id().to_string(),
                     message: msg.concise_message().to_string(),
+                    details,
                     start_location: source_code
                         .source_location(range.start(), self.position_encoding)
                         .into(),

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use js_sys::Error;
+use ruff_db::diagnostic;
 use ruff_linter::settings::types::PythonVersion;
 use ruff_linter::suppression::Suppressions;
 use serde::{Deserialize, Serialize};
@@ -31,7 +32,7 @@ const TYPES: &'static str = r#"
 export interface Diagnostic {
     code: string | null;
     message: string;
-    sub_diagnostics: SubDiagnostic[];
+    subDiagnostics: SubDiagnostic[];
     start_location: {
         row: number;
         column: number;
@@ -57,9 +58,17 @@ export interface Diagnostic {
 }
 
 export interface SubDiagnostic {
-    severity: string;
+    severity: SubDiagnosticSeverity;
     message: string;
     location: SubDiagnosticLocation | null;
+}
+
+export enum SubDiagnosticSeverity {
+    Help = "help",
+    Info = "info",
+    Warning = "warning",
+    Error = "error",
+    Fatal = "fatal",
 }
 
 export interface SubDiagnosticLocation {
@@ -79,6 +88,7 @@ export interface SubDiagnosticLocation {
 pub struct ExpandedMessage {
     pub code: String,
     pub message: String,
+    #[serde(rename = "subDiagnostics")]
     pub sub_diagnostics: Vec<ExpandedSubDiagnostic>,
     pub start_location: Location,
     pub end_location: Location,
@@ -87,9 +97,31 @@ pub struct ExpandedMessage {
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
 pub struct ExpandedSubDiagnostic {
-    pub severity: String,
+    pub severity: SubDiagnosticSeverity,
     pub message: String,
     pub location: Option<ExpandedSubDiagnosticLocation>,
+}
+
+#[derive(Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum SubDiagnosticSeverity {
+    Help,
+    Info,
+    Warning,
+    Error,
+    Fatal,
+}
+
+impl From<diagnostic::SubDiagnosticSeverity> for SubDiagnosticSeverity {
+    fn from(value: diagnostic::SubDiagnosticSeverity) -> Self {
+        match value {
+            diagnostic::SubDiagnosticSeverity::Help => Self::Help,
+            diagnostic::SubDiagnosticSeverity::Info => Self::Info,
+            diagnostic::SubDiagnosticSeverity::Warning => Self::Warning,
+            diagnostic::SubDiagnosticSeverity::Error => Self::Error,
+            diagnostic::SubDiagnosticSeverity::Fatal => Self::Fatal,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
@@ -329,7 +361,7 @@ impl Workspace {
                         });
 
                         ExpandedSubDiagnostic {
-                            severity: sub_diagnostic.severity().to_string(),
+                            severity: sub_diagnostic.severity().into(),
                             message: sub_diagnostic.concise_message().to_string(),
                             location,
                         }

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -4,7 +4,7 @@ use wasm_bindgen_test::wasm_bindgen_test;
 
 use ruff_linter::registry::Rule;
 use ruff_source_file::OneIndexed;
-use ruff_wasm::{ExpandedMessage, Location, PositionEncoding, Workspace};
+use ruff_wasm::{ExpandedDiagnosticDetail, ExpandedMessage, Location, PositionEncoding, Workspace};
 
 macro_rules! check {
     ($source:expr, $config:expr, $expected:expr) => {{
@@ -32,6 +32,7 @@ fn empty_config() {
         [ExpandedMessage {
             code: Rule::IfTuple.noqa_code().to_string(),
             message: "If test is a tuple, which is always `True`".to_string(),
+            details: vec![],
             start_location: Location {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(3)
@@ -55,6 +56,7 @@ fn syntax_error() {
         [ExpandedMessage {
             code: "invalid-syntax".to_string(),
             message: "Expected an expression".to_string(),
+            details: vec![],
             start_location: Location {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(3)
@@ -79,6 +81,7 @@ fn unsupported_syntax_error() {
             code: "invalid-syntax".to_string(),
             message: "Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)"
                 .to_string(),
+            details: vec![],
             start_location: Location {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(0)
@@ -88,6 +91,28 @@ fn unsupported_syntax_error() {
                 column: OneIndexed::from_zero_indexed(5)
             },
             fix: None,
+        }]
+    );
+}
+
+#[wasm_bindgen_test]
+fn sub_diagnostics() {
+    ruff_wasm::before_main();
+
+    let config = js_sys::JSON::parse(r#"{}"#).unwrap();
+    let output = Workspace::new(config, PositionEncoding::Utf8)
+        .unwrap()
+        .check("import os\n")
+        .unwrap();
+    let result: Vec<ExpandedMessage> = serde_wasm_bindgen::from_value(output).unwrap();
+
+    assert_eq!(result[0].message, "`os` imported but unused".to_string());
+    assert_eq!(
+        result[0].details,
+        [ExpandedDiagnosticDetail {
+            message: "help: Remove unused import: `os`".to_string(),
+            start_location: None,
+            end_location: None,
         }]
     );
 }

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -4,7 +4,7 @@ use wasm_bindgen_test::wasm_bindgen_test;
 
 use ruff_linter::registry::Rule;
 use ruff_source_file::OneIndexed;
-use ruff_wasm::{ExpandedDiagnosticDetail, ExpandedMessage, Location, PositionEncoding, Workspace};
+use ruff_wasm::{ExpandedMessage, ExpandedSubDiagnostic, Location, PositionEncoding, Workspace};
 
 macro_rules! check {
     ($source:expr, $config:expr, $expected:expr) => {{
@@ -32,7 +32,7 @@ fn empty_config() {
         [ExpandedMessage {
             code: Rule::IfTuple.noqa_code().to_string(),
             message: "If test is a tuple, which is always `True`".to_string(),
-            details: vec![],
+            sub_diagnostics: vec![],
             start_location: Location {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(3)
@@ -56,7 +56,7 @@ fn syntax_error() {
         [ExpandedMessage {
             code: "invalid-syntax".to_string(),
             message: "Expected an expression".to_string(),
-            details: vec![],
+            sub_diagnostics: vec![],
             start_location: Location {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(3)
@@ -81,7 +81,7 @@ fn unsupported_syntax_error() {
             code: "invalid-syntax".to_string(),
             message: "Cannot use `match` statement on Python 3.9 (syntax was added in Python 3.10)"
                 .to_string(),
-            details: vec![],
+            sub_diagnostics: vec![],
             start_location: Location {
                 row: OneIndexed::from_zero_indexed(0),
                 column: OneIndexed::from_zero_indexed(0)
@@ -108,11 +108,11 @@ fn sub_diagnostics() {
 
     assert_eq!(result[0].message, "`os` imported but unused".to_string());
     assert_eq!(
-        result[0].details,
-        [ExpandedDiagnosticDetail {
-            message: "help: Remove unused import: `os`".to_string(),
-            start_location: None,
-            end_location: None,
+        result[0].sub_diagnostics,
+        [ExpandedSubDiagnostic {
+            severity: "help".to_string(),
+            message: "Remove unused import: `os`".to_string(),
+            location: None,
         }]
     );
 }

--- a/crates/ruff_wasm/tests/api.rs
+++ b/crates/ruff_wasm/tests/api.rs
@@ -4,7 +4,10 @@ use wasm_bindgen_test::wasm_bindgen_test;
 
 use ruff_linter::registry::Rule;
 use ruff_source_file::OneIndexed;
-use ruff_wasm::{ExpandedMessage, ExpandedSubDiagnostic, Location, PositionEncoding, Workspace};
+use ruff_wasm::{
+    ExpandedMessage, ExpandedSubDiagnostic, Location, PositionEncoding, SubDiagnosticSeverity,
+    Workspace,
+};
 
 macro_rules! check {
     ($source:expr, $config:expr, $expected:expr) => {{
@@ -110,7 +113,7 @@ fn sub_diagnostics() {
     assert_eq!(
         result[0].sub_diagnostics,
         [ExpandedSubDiagnostic {
-            severity: "help".to_string(),
+            severity: SubDiagnosticSeverity::Help,
             message: "Remove unused import: `os`".to_string(),
             location: None,
         }]

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -493,16 +493,22 @@ pub(super) fn to_lsp_diagnostic(
         diagnostic.concise_message().to_string()
     };
 
-    // Append sub-diagnostics that have no location and thus can't be shown as
-    // related information.
+    // Append info sub-diagnostics that have no location (and thus
+    // can't be shown as "related information") to the message.
     let mut first = true;
     for sub_diagnostic in diagnostic.sub_diagnostics() {
-        if sub_diagnostic.primary_span_ref().is_none() {
+        if sub_diagnostic.primary_annotation().is_none() {
             if first {
                 message.push('\n');
                 first = false;
             }
-            write!(message, "\n{sub_diagnostic}").ok();
+            write!(
+                message,
+                "\n{severity}: {hint}",
+                hint = sub_diagnostic.concise_message(),
+                severity = sub_diagnostic.severity()
+            )
+            .ok();
         }
     }
 
@@ -546,7 +552,9 @@ fn sub_diagnostic_to_related_information(
     diagnostic: &SubDiagnostic,
     encoding: PositionEncoding,
 ) -> Option<DiagnosticRelatedInformation> {
-    let span = diagnostic.primary_span_ref()?;
+    let primary_annotation = diagnostic.primary_annotation()?;
+
+    let span = primary_annotation.get_span();
     let range = FileRange::try_from(span).ok()?;
     let location = range.to_lsp_range(db, encoding)?.into_location()?;
 

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -493,22 +493,16 @@ pub(super) fn to_lsp_diagnostic(
         diagnostic.concise_message().to_string()
     };
 
-    // Append info sub-diagnostics that have no location (and thus
-    // can't be shown as "related information") to the message.
+    // Append sub-diagnostics that have no location and thus can't be shown as
+    // related information.
     let mut first = true;
     for sub_diagnostic in diagnostic.sub_diagnostics() {
-        if sub_diagnostic.primary_annotation().is_none() {
+        if sub_diagnostic.primary_span_ref().is_none() {
             if first {
                 message.push('\n');
                 first = false;
             }
-            write!(
-                message,
-                "\n{severity}: {hint}",
-                hint = sub_diagnostic.concise_message(),
-                severity = sub_diagnostic.severity()
-            )
-            .ok();
+            write!(message, "\n{sub_diagnostic}").ok();
         }
     }
 
@@ -552,9 +546,7 @@ fn sub_diagnostic_to_related_information(
     diagnostic: &SubDiagnostic,
     encoding: PositionEncoding,
 ) -> Option<DiagnosticRelatedInformation> {
-    let primary_annotation = diagnostic.primary_annotation()?;
-
-    let span = primary_annotation.get_span();
+    let span = diagnostic.primary_span_ref()?;
     let range = FileRange::try_from(span).ok()?;
     let location = range.to_lsp_range(db, encoding)?.into_location()?;
 

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -905,22 +905,40 @@ impl Diagnostic {
             .sub_diagnostics()
             .iter()
             .map(|sub_diagnostic| {
-                let location = sub_diagnostic.primary_span_ref().and_then(|span| {
-                    let file_range = FileRange::try_from(span).ok()?;
-                    Some(Location {
-                        path: file_range.file().path(&workspace.db).to_string(),
-                        range: Range::from_file_range(
-                            &workspace.db,
-                            file_range,
-                            workspace.position_encoding,
-                        ),
+                let primary_annotation_index = sub_diagnostic
+                    .annotations()
+                    .iter()
+                    .position(ruff_db::diagnostic::Annotation::is_primary)
+                    .and_then(|index| u32::try_from(index).ok());
+                let annotations = sub_diagnostic
+                    .annotations()
+                    .iter()
+                    .map(|annotation| {
+                        let location =
+                            FileRange::try_from(annotation.get_span())
+                                .ok()
+                                .map(|file_range| Location {
+                                    path: file_range.file().path(&workspace.db).to_string(),
+                                    range: Range::from_file_range(
+                                        &workspace.db,
+                                        file_range,
+                                        workspace.position_encoding,
+                                    ),
+                                });
+
+                        SubDiagnosticAnnotation {
+                            primary: annotation.is_primary(),
+                            message: annotation.get_message().map(ToOwned::to_owned),
+                            location,
+                        }
                     })
-                });
+                    .collect();
 
                 SubDiagnostic {
                     severity: sub_diagnostic.severity().to_string(),
-                    message: sub_diagnostic.concise_message().to_string(),
-                    location,
+                    message: sub_diagnostic.primary_message().to_string(),
+                    primary_annotation_index,
+                    annotations,
                 }
             })
             .collect()
@@ -1001,6 +1019,17 @@ pub struct SubDiagnostic {
     pub severity: String,
     #[wasm_bindgen(getter_with_clone)]
     pub message: String,
+    pub primary_annotation_index: Option<u32>,
+    #[wasm_bindgen(getter_with_clone)]
+    pub annotations: Vec<SubDiagnosticAnnotation>,
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubDiagnosticAnnotation {
+    pub primary: bool,
+    #[wasm_bindgen(getter_with_clone)]
+    pub message: Option<String>,
     #[wasm_bindgen(getter_with_clone)]
     pub location: Option<Location>,
 }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -899,32 +899,28 @@ impl Diagnostic {
         JsString::from(self.inner.concise_message().to_string())
     }
 
-    #[wasm_bindgen]
-    pub fn details(&self, workspace: &Workspace) -> Vec<DiagnosticDetail> {
+    #[wasm_bindgen(js_name = "subDiagnostics")]
+    pub fn sub_diagnostics(&self, workspace: &Workspace) -> Vec<SubDiagnostic> {
         self.inner
             .sub_diagnostics()
             .iter()
             .map(|sub_diagnostic| {
-                let (path, range) = sub_diagnostic
-                    .primary_span_ref()
-                    .and_then(|span| {
-                        let file_range = FileRange::try_from(span).ok()?;
-                        Some((
-                            file_range.file().path(&workspace.db).to_string(),
-                            Range::from_file_range(
-                                &workspace.db,
-                                file_range,
-                                workspace.position_encoding,
-                            ),
-                        ))
+                let location = sub_diagnostic.primary_span_ref().and_then(|span| {
+                    let file_range = FileRange::try_from(span).ok()?;
+                    Some(Location {
+                        path: file_range.file().path(&workspace.db).to_string(),
+                        range: Range::from_file_range(
+                            &workspace.db,
+                            file_range,
+                            workspace.position_encoding,
+                        ),
                     })
-                    .map(|(path, range)| (Some(path), Some(range)))
-                    .unwrap_or_default();
+                });
 
-                DiagnosticDetail {
-                    message: sub_diagnostic.to_string(),
-                    path,
-                    range,
+                SubDiagnostic {
+                    severity: sub_diagnostic.severity().to_string(),
+                    message: sub_diagnostic.concise_message().to_string(),
+                    location,
                 }
             })
             .collect()
@@ -1000,12 +996,21 @@ impl Diagnostic {
 
 #[wasm_bindgen]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DiagnosticDetail {
+pub struct SubDiagnostic {
+    #[wasm_bindgen(getter_with_clone)]
+    pub severity: String,
     #[wasm_bindgen(getter_with_clone)]
     pub message: String,
     #[wasm_bindgen(getter_with_clone)]
-    pub path: Option<String>,
-    pub range: Option<Range>,
+    pub location: Option<Location>,
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Location {
+    #[wasm_bindgen(getter_with_clone)]
+    pub path: String,
+    pub range: Range,
 }
 
 fn edit_to_text_edit(workspace: &Workspace, file: File, edit: &Edit) -> TextEdit {

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -905,11 +905,6 @@ impl Diagnostic {
             .sub_diagnostics()
             .iter()
             .map(|sub_diagnostic| {
-                let primary_annotation_index = sub_diagnostic
-                    .annotations()
-                    .iter()
-                    .position(ruff_db::diagnostic::Annotation::is_primary)
-                    .and_then(|index| u32::try_from(index).ok());
                 let annotations = sub_diagnostic
                     .annotations()
                     .iter()
@@ -935,9 +930,8 @@ impl Diagnostic {
                     .collect();
 
                 SubDiagnostic {
-                    severity: sub_diagnostic.severity().to_string(),
+                    severity: sub_diagnostic.severity().into(),
                     message: sub_diagnostic.primary_message().to_string(),
-                    primary_annotation_index,
                     annotations,
                 }
             })
@@ -1015,11 +1009,9 @@ impl Diagnostic {
 #[wasm_bindgen]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubDiagnostic {
-    #[wasm_bindgen(getter_with_clone)]
-    pub severity: String,
+    pub severity: SubDiagnosticSeverity,
     #[wasm_bindgen(getter_with_clone)]
     pub message: String,
-    pub primary_annotation_index: Option<u32>,
     #[wasm_bindgen(getter_with_clone)]
     pub annotations: Vec<SubDiagnosticAnnotation>,
 }
@@ -1199,6 +1191,28 @@ impl From<diagnostic::Severity> for Severity {
             diagnostic::Severity::Warning => Self::Warning,
             diagnostic::Severity::Error => Self::Error,
             diagnostic::Severity::Fatal => Self::Fatal,
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum SubDiagnosticSeverity {
+    Help,
+    Info,
+    Warning,
+    Error,
+    Fatal,
+}
+
+impl From<diagnostic::SubDiagnosticSeverity> for SubDiagnosticSeverity {
+    fn from(value: diagnostic::SubDiagnosticSeverity) -> Self {
+        match value {
+            diagnostic::SubDiagnosticSeverity::Help => Self::Help,
+            diagnostic::SubDiagnosticSeverity::Info => Self::Info,
+            diagnostic::SubDiagnosticSeverity::Warning => Self::Warning,
+            diagnostic::SubDiagnosticSeverity::Error => Self::Error,
+            diagnostic::SubDiagnosticSeverity::Fatal => Self::Fatal,
         }
     }
 }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -900,6 +900,37 @@ impl Diagnostic {
     }
 
     #[wasm_bindgen]
+    pub fn details(&self, workspace: &Workspace) -> Vec<DiagnosticDetail> {
+        self.inner
+            .sub_diagnostics()
+            .iter()
+            .map(|sub_diagnostic| {
+                let (path, range) = sub_diagnostic
+                    .primary_span_ref()
+                    .and_then(|span| {
+                        let file_range = FileRange::try_from(span).ok()?;
+                        Some((
+                            file_range.file().path(&workspace.db).to_string(),
+                            Range::from_file_range(
+                                &workspace.db,
+                                file_range,
+                                workspace.position_encoding,
+                            ),
+                        ))
+                    })
+                    .map(|(path, range)| (Some(path), Some(range)))
+                    .unwrap_or_default();
+
+                DiagnosticDetail {
+                    message: sub_diagnostic.to_string(),
+                    path,
+                    range,
+                }
+            })
+            .collect()
+    }
+
+    #[wasm_bindgen]
     pub fn id(&self) -> JsString {
         JsString::from(self.inner.id().to_string())
     }
@@ -965,6 +996,16 @@ impl Diagnostic {
             preferred: true,
         })
     }
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticDetail {
+    #[wasm_bindgen(getter_with_clone)]
+    pub message: String,
+    #[wasm_bindgen(getter_with_clone)]
+    pub path: Option<String>,
+    pub range: Option<Range>,
 }
 
 fn edit_to_text_edit(workspace: &Workspace, file: File, edit: &Edit) -> TextEdit {

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -1,6 +1,6 @@
 #![cfg(target_arch = "wasm32")]
 
-use ty_wasm::{Position, PositionEncoding, Workspace};
+use ty_wasm::{Position, PositionEncoding, SubDiagnosticSeverity, Workspace};
 use wasm_bindgen_test::wasm_bindgen_test;
 
 #[wasm_bindgen_test]
@@ -37,30 +37,29 @@ fn check() {
     assert_eq!(
         sub_diagnostics
             .iter()
-            .map(|sub_diagnostic| (
-                sub_diagnostic.severity.as_str(),
-                sub_diagnostic.message.as_str()
-            ))
+            .map(|sub_diagnostic| (sub_diagnostic.severity, sub_diagnostic.message.as_str()))
             .collect::<Vec<_>>(),
         [
             (
-                "info",
+                SubDiagnosticSeverity::Info,
                 "Searched in the following paths during module resolution:"
             ),
-            ("info", "  1. / (first-party code)"),
+            (SubDiagnosticSeverity::Info, "  1. / (first-party code)"),
             (
-                "info",
+                SubDiagnosticSeverity::Info,
                 "  2. vendored://stdlib (stdlib typeshed stubs vendored by ty)"
             ),
             (
-                "info",
+                SubDiagnosticSeverity::Info,
                 "make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment"
             ),
         ]
     );
-    assert!(sub_diagnostics.iter().all(|sub_diagnostic| {
-        sub_diagnostic.primary_annotation_index.is_none() && sub_diagnostic.annotations.is_empty()
-    }));
+    assert!(
+        sub_diagnostics
+            .iter()
+            .all(|sub_diagnostic| sub_diagnostic.annotations.is_empty())
+    );
 }
 
 #[wasm_bindgen_test]
@@ -91,8 +90,7 @@ f(x=\"foo\")\n",
         .find(|sub_diagnostic| sub_diagnostic.message == "Function defined here")
         .expect("Expected a function definition sub-diagnostic");
 
-    assert_eq!(function_detail.severity, "info");
-    assert_eq!(function_detail.primary_annotation_index, Some(0));
+    assert_eq!(function_detail.severity, SubDiagnosticSeverity::Info);
     assert_eq!(function_detail.annotations.len(), 2);
 
     let function_annotation = &function_detail.annotations[0];
@@ -165,7 +163,6 @@ class VeryEggyOmelette(
         .expect("Expected a class definition sub-diagnostic");
 
     assert_eq!(definition_detail.annotations.len(), 3);
-    assert_eq!(definition_detail.primary_annotation_index, Some(1));
     assert_eq!(
         definition_detail
             .annotations
@@ -236,8 +233,7 @@ del movie['name']
         .find(|sub_diagnostic| sub_diagnostic.message == "Field defined here")
         .expect("Expected a field definition sub-diagnostic");
 
-    assert_eq!(field_detail.severity, "info");
-    assert_eq!(field_detail.primary_annotation_index, None);
+    assert_eq!(field_detail.severity, SubDiagnosticSeverity::Info);
     assert_eq!(field_detail.annotations.len(), 3);
     assert!(
         field_detail

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -58,15 +58,13 @@ fn check() {
             ),
         ]
     );
-    assert!(
-        sub_diagnostics
-            .iter()
-            .all(|sub_diagnostic| sub_diagnostic.location.is_none())
-    );
+    assert!(sub_diagnostics.iter().all(|sub_diagnostic| {
+        sub_diagnostic.primary_annotation_index.is_none() && sub_diagnostic.annotations.is_empty()
+    }));
 }
 
 #[wasm_bindgen_test]
-fn annotated_sub_diagnostics_have_ranges() {
+fn annotated_sub_diagnostics_include_all_annotations() {
     ty_wasm::before_main();
 
     let mut workspace = Workspace::new(
@@ -92,15 +90,195 @@ f(x=\"foo\")\n",
         .iter()
         .find(|sub_diagnostic| sub_diagnostic.message == "Function defined here")
         .expect("Expected a function definition sub-diagnostic");
-    let function_location = function_detail
+
+    assert_eq!(function_detail.severity, "info");
+    assert_eq!(function_detail.primary_annotation_index, Some(0));
+    assert_eq!(function_detail.annotations.len(), 2);
+
+    let function_annotation = &function_detail.annotations[0];
+    assert!(function_annotation.primary);
+    assert_eq!(function_annotation.message, None);
+    let function_location = function_annotation
         .location
         .as_ref()
         .expect("Expected a function definition location");
-
-    assert_eq!(function_detail.severity, "info");
     assert_eq!(function_location.path, "/test.py");
     assert_eq!(
         function_location.range.start,
         Position { line: 3, column: 5 }
+    );
+
+    let parameter_annotation = &function_detail.annotations[1];
+    assert!(!parameter_annotation.primary);
+    assert_eq!(
+        parameter_annotation.message.as_deref(),
+        Some("Parameter declared here")
+    );
+    assert_eq!(
+        parameter_annotation
+            .location
+            .as_ref()
+            .expect("Expected a parameter location")
+            .path,
+        "/test.py"
+    );
+}
+
+#[wasm_bindgen_test]
+fn sub_diagnostics_include_multiple_primary_annotations() {
+    ty_wasm::before_main();
+
+    let mut workspace = Workspace::new(
+        "/",
+        PositionEncoding::Utf32,
+        js_sys::JSON::parse("{}").unwrap(),
+    )
+    .expect("Workspace to be created");
+
+    workspace
+        .open_file(
+            "test.py",
+            "\
+class Eggs: ...
+
+class VeryEggyOmelette(
+    Eggs,
+    Eggs,
+    Eggs
+): ...
+",
+        )
+        .expect("File to be opened");
+
+    let result = workspace.check().expect("Check to succeed");
+    let diagnostic = result
+        .iter()
+        .find(|diagnostic| diagnostic.id() == "duplicate-base")
+        .expect("Expected a duplicate-base diagnostic");
+    let sub_diagnostics = diagnostic.sub_diagnostics(&workspace);
+    let definition_detail = sub_diagnostics
+        .iter()
+        .find(|sub_diagnostic| {
+            sub_diagnostic.message
+                == "The definition of class `VeryEggyOmelette` will raise `TypeError` at runtime"
+        })
+        .expect("Expected a class definition sub-diagnostic");
+
+    assert_eq!(definition_detail.annotations.len(), 3);
+    assert_eq!(definition_detail.primary_annotation_index, Some(1));
+    assert_eq!(
+        definition_detail
+            .annotations
+            .iter()
+            .map(|annotation| annotation.primary)
+            .collect::<Vec<_>>(),
+        [false, true, true]
+    );
+    assert_eq!(
+        definition_detail
+            .annotations
+            .iter()
+            .map(|annotation| annotation.message.as_deref())
+            .collect::<Vec<_>>(),
+        [
+            Some("Class `Eggs` first included in bases list here"),
+            Some("Class `Eggs` later repeated here"),
+            Some("Class `Eggs` later repeated here"),
+        ]
+    );
+}
+
+#[wasm_bindgen_test]
+fn secondary_only_sub_diagnostic_annotations_have_messages_and_locations() {
+    ty_wasm::before_main();
+
+    let mut workspace = Workspace::new(
+        "/",
+        PositionEncoding::Utf32,
+        js_sys::JSON::parse("{}").unwrap(),
+    )
+    .expect("Workspace to be created");
+
+    workspace
+        .open_file(
+            "test.py",
+            r"\
+from typing_extensions import TypedDict
+
+class Movie(TypedDict):
+    name: str
+
+movie: Movie = {'name': 'Blade Runner'}
+del movie['name']
+",
+        )
+        .expect("File to be opened");
+
+    let result = workspace.check().expect("Check to succeed");
+    let diagnostic = result
+        .iter()
+        .find(|diagnostic| {
+            diagnostic.message().as_string().as_deref()
+                == Some("Cannot delete required key \"name\" from TypedDict `Movie`")
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "Expected an invalid TypedDict deletion diagnostic, got: {:?}",
+                result
+                    .iter()
+                    .map(|diagnostic| diagnostic.message().as_string())
+                    .collect::<Vec<_>>()
+            )
+        });
+    let sub_diagnostics = diagnostic.sub_diagnostics(&workspace);
+    let field_detail = sub_diagnostics
+        .iter()
+        .find(|sub_diagnostic| sub_diagnostic.message == "Field defined here")
+        .expect("Expected a field definition sub-diagnostic");
+
+    assert_eq!(field_detail.severity, "info");
+    assert_eq!(field_detail.primary_annotation_index, None);
+    assert_eq!(field_detail.annotations.len(), 3);
+    assert!(
+        field_detail
+            .annotations
+            .iter()
+            .all(|annotation| !annotation.primary)
+    );
+    assert_eq!(
+        field_detail
+            .annotations
+            .iter()
+            .map(|annotation| annotation.message.as_deref())
+            .collect::<Vec<_>>(),
+        [
+            Some("`name` declared as required here"),
+            Some("Consider making it `NotRequired`"),
+            Some("`Movie` defined here"),
+        ]
+    );
+    assert!(
+        field_detail
+            .annotations
+            .iter()
+            .all(|annotation| annotation.location.is_some())
+    );
+    assert_eq!(
+        field_detail.annotations[0]
+            .location
+            .as_ref()
+            .expect("Expected a field declaration location")
+            .range
+            .start,
+        Position { line: 5, column: 5 }
+    );
+    assert_eq!(
+        field_detail.annotations[2]
+            .location
+            .as_ref()
+            .expect("Expected a class definition location")
+            .range
+            .start,
+        Position { line: 4, column: 7 }
     );
 }

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -33,24 +33,40 @@ fn check() {
         diagnostic.message(),
         "Cannot resolve imported module `random22`"
     );
-    let details = diagnostic.details(&workspace);
+    let sub_diagnostics = diagnostic.sub_diagnostics(&workspace);
     assert_eq!(
-        details
+        sub_diagnostics
             .iter()
-            .map(|detail| detail.message.as_str())
+            .map(|sub_diagnostic| (
+                sub_diagnostic.severity.as_str(),
+                sub_diagnostic.message.as_str()
+            ))
             .collect::<Vec<_>>(),
         [
-            "info: Searched in the following paths during module resolution:",
-            "info:   1. / (first-party code)",
-            "info:   2. vendored://stdlib (stdlib typeshed stubs vendored by ty)",
-            "info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment",
+            (
+                "info",
+                "Searched in the following paths during module resolution:"
+            ),
+            ("info", "  1. / (first-party code)"),
+            (
+                "info",
+                "  2. vendored://stdlib (stdlib typeshed stubs vendored by ty)"
+            ),
+            (
+                "info",
+                "make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment"
+            ),
         ]
     );
-    assert!(details.iter().all(|detail| detail.range.is_none()));
+    assert!(
+        sub_diagnostics
+            .iter()
+            .all(|sub_diagnostic| sub_diagnostic.location.is_none())
+    );
 }
 
 #[wasm_bindgen_test]
-fn annotated_sub_diagnostic_details_have_ranges() {
+fn annotated_sub_diagnostics_have_ranges() {
     ty_wasm::before_main();
 
     let mut workspace = Workspace::new(
@@ -71,15 +87,20 @@ f(x=\"foo\")\n",
 
     let result = workspace.check().expect("Check to succeed");
     let diagnostic = &result[0];
-    let details = diagnostic.details(&workspace);
-    let function_detail = details
+    let sub_diagnostics = diagnostic.sub_diagnostics(&workspace);
+    let function_detail = sub_diagnostics
         .iter()
-        .find(|detail| detail.message == "info: Function defined here")
+        .find(|sub_diagnostic| sub_diagnostic.message == "Function defined here")
         .expect("Expected a function definition sub-diagnostic");
+    let function_location = function_detail
+        .location
+        .as_ref()
+        .expect("Expected a function definition location");
 
-    assert_eq!(function_detail.path.as_deref(), Some("/test.py"));
+    assert_eq!(function_detail.severity, "info");
+    assert_eq!(function_location.path, "/test.py");
     assert_eq!(
-        function_detail.range.unwrap().start,
+        function_location.range.start,
         Position { line: 3, column: 5 }
     );
 }

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -33,4 +33,53 @@ fn check() {
         diagnostic.message(),
         "Cannot resolve imported module `random22`"
     );
+    let details = diagnostic.details(&workspace);
+    assert_eq!(
+        details
+            .iter()
+            .map(|detail| detail.message.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "info: Searched in the following paths during module resolution:",
+            "info:   1. / (first-party code)",
+            "info:   2. vendored://stdlib (stdlib typeshed stubs vendored by ty)",
+            "info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment",
+        ]
+    );
+    assert!(details.iter().all(|detail| detail.range.is_none()));
+}
+
+#[wasm_bindgen_test]
+fn annotated_sub_diagnostic_details_have_ranges() {
+    ty_wasm::before_main();
+
+    let mut workspace = Workspace::new(
+        "/",
+        PositionEncoding::Utf32,
+        js_sys::JSON::parse("{}").unwrap(),
+    )
+    .expect("Workspace to be created");
+
+    workspace
+        .open_file(
+            "test.py",
+            "from collections.abc import Buffer\n\n\
+def f(x: Buffer | list[str] | int): ...\n\n\
+f(x=\"foo\")\n",
+        )
+        .expect("File to be opened");
+
+    let result = workspace.check().expect("Check to succeed");
+    let diagnostic = &result[0];
+    let details = diagnostic.details(&workspace);
+    let function_detail = details
+        .iter()
+        .find(|detail| detail.message == "info: Function defined here")
+        .expect("Expected a function definition sub-diagnostic");
+
+    assert_eq!(function_detail.path.as_deref(), Some("/test.py"));
+    assert_eq!(
+        function_detail.range.unwrap().start,
+        Position { line: 3, column: 5 }
+    );
 }

--- a/playground/ruff/src/Editor/Diagnostics.tsx
+++ b/playground/ruff/src/Editor/Diagnostics.tsx
@@ -2,6 +2,7 @@ import type { Diagnostic, SubDiagnostic } from "ruff_wasm";
 import classNames from "classnames";
 import { Theme } from "shared";
 import { useMemo } from "react";
+import { PLAYGROUND_FILE_PATH } from "./SourceEditor";
 
 interface Props {
   diagnostics: Diagnostic[];
@@ -90,9 +91,9 @@ function Items({
                 Col {column}]
               </span>
             </button>
-            {diagnostic.sub_diagnostics.length > 0 ? (
+            {diagnostic.subDiagnostics.length > 0 ? (
               <ul className="pl-3 font-mono text-gray-500 whitespace-pre-wrap">
-                {diagnostic.sub_diagnostics.map((subDiagnostic, index) => (
+                {diagnostic.subDiagnostics.map((subDiagnostic, index) => (
                   <li key={index}>
                     <SubDiagnosticItem
                       subDiagnostic={subDiagnostic}
@@ -124,14 +125,14 @@ function SubDiagnosticItem({
 
   const start = location.start_location;
   const locationLabel =
-    location.path === "<filename>"
+    location.path === PLAYGROUND_FILE_PATH
       ? `[Ln ${start.row}, Col ${start.column}]`
       : `[${location.path}: Ln ${start.row}, Col ${start.column}]`;
 
   return (
     <>
       {subDiagnostic.severity}:{" "}
-      {location.path === "<filename>" ? (
+      {location.path === PLAYGROUND_FILE_PATH ? (
         <button
           onClick={() => onGoTo(start.row, start.column)}
           className="text-start cursor-pointer text-current underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-400 dark:hover:text-gray-400"

--- a/playground/ruff/src/Editor/Diagnostics.tsx
+++ b/playground/ruff/src/Editor/Diagnostics.tsx
@@ -90,9 +90,61 @@ function Items({
                 Col {column}]
               </span>
             </button>
+            {diagnostic.details.length > 0 ? (
+              <ul className="pl-3 font-mono text-gray-500 whitespace-pre-wrap">
+                {diagnostic.details.map((detail, index) => (
+                  <li key={index}>
+                    <Detail detail={detail} onGoTo={onGoTo} />
+                  </li>
+                ))}
+              </ul>
+            ) : null}
           </li>
         );
       })}
     </ul>
   );
+}
+
+function Detail({
+  detail,
+  onGoTo,
+}: {
+  detail: Diagnostic["details"][number];
+  onGoTo(line: number, column: number): void;
+}) {
+  const start = detail.start_location;
+  const [prefix, message] = splitSubdiagnosticMessage(detail.message);
+
+  if (start == null) {
+    return <span>{detail.message}</span>;
+  }
+
+  return (
+    <>
+      {prefix}
+      <button
+        onClick={() => onGoTo(start.row, start.column)}
+        className="text-start cursor-pointer text-current underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-400 dark:hover:text-gray-400"
+      >
+        {message}
+        <span className="text-gray-500">
+          {" "}
+          [Ln {start.row}, Col {start.column}]
+        </span>
+      </button>
+    </>
+  );
+}
+
+function splitSubdiagnosticMessage(message: string): [string, string] {
+  const separator = ": ";
+  const separatorIndex = message.indexOf(separator);
+
+  if (separatorIndex === -1) {
+    return ["", message];
+  }
+
+  const prefixEnd = separatorIndex + separator.length;
+  return [message.slice(0, prefixEnd), message.slice(prefixEnd)];
 }

--- a/playground/ruff/src/Editor/Diagnostics.tsx
+++ b/playground/ruff/src/Editor/Diagnostics.tsx
@@ -1,4 +1,4 @@
-import { Diagnostic } from "ruff_wasm";
+import type { Diagnostic, SubDiagnostic } from "ruff_wasm";
 import classNames from "classnames";
 import { Theme } from "shared";
 import { useMemo } from "react";
@@ -90,11 +90,14 @@ function Items({
                 Col {column}]
               </span>
             </button>
-            {diagnostic.details.length > 0 ? (
+            {diagnostic.sub_diagnostics.length > 0 ? (
               <ul className="pl-3 font-mono text-gray-500 whitespace-pre-wrap">
-                {diagnostic.details.map((detail, index) => (
+                {diagnostic.sub_diagnostics.map((subDiagnostic, index) => (
                   <li key={index}>
-                    <Detail detail={detail} onGoTo={onGoTo} />
+                    <SubDiagnosticItem
+                      subDiagnostic={subDiagnostic}
+                      onGoTo={onGoTo}
+                    />
                   </li>
                 ))}
               </ul>
@@ -106,45 +109,46 @@ function Items({
   );
 }
 
-function Detail({
-  detail,
+function SubDiagnosticItem({
+  subDiagnostic,
   onGoTo,
 }: {
-  detail: Diagnostic["details"][number];
+  subDiagnostic: SubDiagnostic;
   onGoTo(line: number, column: number): void;
 }) {
-  const start = detail.start_location;
-  const [prefix, message] = splitSubdiagnosticMessage(detail.message);
+  const location = subDiagnostic.location;
 
-  if (start == null) {
-    return <span>{detail.message}</span>;
+  if (location == null) {
+    return <span>{formatSubDiagnostic(subDiagnostic)}</span>;
   }
+
+  const start = location.start_location;
+  const locationLabel =
+    location.path === "<filename>"
+      ? `[Ln ${start.row}, Col ${start.column}]`
+      : `[${location.path}: Ln ${start.row}, Col ${start.column}]`;
 
   return (
     <>
-      {prefix}
-      <button
-        onClick={() => onGoTo(start.row, start.column)}
-        className="text-start cursor-pointer text-current underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-400 dark:hover:text-gray-400"
-      >
-        {message}
-        <span className="text-gray-500">
-          {" "}
-          [Ln {start.row}, Col {start.column}]
+      {subDiagnostic.severity}:{" "}
+      {location.path === "<filename>" ? (
+        <button
+          onClick={() => onGoTo(start.row, start.column)}
+          className="text-start cursor-pointer text-current underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-400 dark:hover:text-gray-400"
+        >
+          {subDiagnostic.message}
+          <span className="text-gray-500"> {locationLabel}</span>
+        </button>
+      ) : (
+        <span>
+          {subDiagnostic.message}
+          <span className="text-gray-500"> {locationLabel}</span>
         </span>
-      </button>
+      )}
     </>
   );
 }
 
-function splitSubdiagnosticMessage(message: string): [string, string] {
-  const separator = ": ";
-  const separatorIndex = message.indexOf(separator);
-
-  if (separatorIndex === -1) {
-    return ["", message];
-  }
-
-  const prefixEnd = separatorIndex + separator.length;
-  return [message.slice(0, prefixEnd), message.slice(prefixEnd)];
+function formatSubDiagnostic(subDiagnostic: SubDiagnostic): string {
+  return `${subDiagnostic.severity}: ${subDiagnostic.message}`;
 }

--- a/playground/ruff/src/Editor/SourceEditor.tsx
+++ b/playground/ruff/src/Editor/SourceEditor.tsx
@@ -182,20 +182,61 @@ function updateMarkers(monaco: Monaco, diagnostics: Array<Diagnostic>) {
   editor.setModelMarkers(
     model,
     "owner",
-    diagnostics.map((diagnostic) => ({
-      code: diagnostic.code ?? undefined,
-      startLineNumber: diagnostic.start_location.row,
-      startColumn: diagnostic.start_location.column,
-      endLineNumber: diagnostic.end_location.row,
-      endColumn: diagnostic.end_location.column,
-      message: diagnostic.code
-        ? `${diagnostic.code}: ${diagnostic.message}`
-        : diagnostic.message,
-      severity: MarkerSeverity.Error,
-      tags:
-        diagnostic.code === "F401" || diagnostic.code === "F841"
-          ? [MarkerTag.Unnecessary]
-          : [],
-    })),
+    diagnostics.map((diagnostic) => {
+      const message = diagnosticDisplayMessage(diagnostic);
+
+      return {
+        code: diagnostic.code ?? undefined,
+        startLineNumber: diagnostic.start_location.row,
+        startColumn: diagnostic.start_location.column,
+        endLineNumber: diagnostic.end_location.row,
+        endColumn: diagnostic.end_location.column,
+        message: diagnostic.code ? `${diagnostic.code}: ${message}` : message,
+        relatedInformation: diagnosticRelatedInformation(diagnostic, model.uri),
+        severity: MarkerSeverity.Error,
+        tags:
+          diagnostic.code === "F401" || diagnostic.code === "F841"
+            ? [MarkerTag.Unnecessary]
+            : [],
+      };
+    }),
   );
+}
+
+function diagnosticDisplayMessage(diagnostic: Diagnostic): string {
+  const details = diagnostic.details.filter(
+    (detail) => detail.start_location == null,
+  );
+
+  if (details.length === 0) {
+    return diagnostic.message;
+  }
+
+  return `${diagnostic.message}\n\n${details.map((detail) => detail.message).join("\n")}`;
+}
+
+function diagnosticRelatedInformation(
+  diagnostic: Diagnostic,
+  resource: editor.ITextModel["uri"],
+): editor.IRelatedInformation[] {
+  return diagnostic.details.flatMap((detail) => {
+    const start = detail.start_location;
+
+    if (start == null) {
+      return [];
+    }
+
+    const end = detail.end_location ?? start;
+
+    return [
+      {
+        resource,
+        message: detail.message,
+        startLineNumber: start.row,
+        startColumn: start.column,
+        endLineNumber: end.row,
+        endColumn: end.column,
+      },
+    ];
+  });
 }

--- a/playground/ruff/src/Editor/SourceEditor.tsx
+++ b/playground/ruff/src/Editor/SourceEditor.tsx
@@ -17,6 +17,8 @@ import { Theme } from "shared";
 import CodeActionProvider = languages.CodeActionProvider;
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 
+const PLAYGROUND_FILE_PATH = "<filename>";
+
 type MonacoEditorState = {
   monaco: Monaco;
   codeActionProvider: RuffCodeActionProvider;
@@ -204,39 +206,52 @@ function updateMarkers(monaco: Monaco, diagnostics: Array<Diagnostic>) {
 }
 
 function diagnosticDisplayMessage(diagnostic: Diagnostic): string {
-  const details = diagnostic.details.filter(
-    (detail) => detail.start_location == null,
+  const subDiagnostics = diagnostic.sub_diagnostics.filter(
+    (subDiagnostic) =>
+      subDiagnostic.location == null ||
+      subDiagnostic.location.path !== PLAYGROUND_FILE_PATH,
   );
 
-  if (details.length === 0) {
+  if (subDiagnostics.length === 0) {
     return diagnostic.message;
   }
 
-  return `${diagnostic.message}\n\n${details.map((detail) => detail.message).join("\n")}`;
+  return `${diagnostic.message}\n\n${subDiagnostics.map(formatSubDiagnostic).join("\n")}`;
 }
 
 function diagnosticRelatedInformation(
   diagnostic: Diagnostic,
   resource: editor.ITextModel["uri"],
 ): editor.IRelatedInformation[] {
-  return diagnostic.details.flatMap((detail) => {
-    const start = detail.start_location;
+  return diagnostic.sub_diagnostics.flatMap((subDiagnostic) => {
+    const location = subDiagnostic.location;
 
-    if (start == null) {
+    if (location == null || location.path !== PLAYGROUND_FILE_PATH) {
       return [];
     }
-
-    const end = detail.end_location ?? start;
 
     return [
       {
         resource,
-        message: detail.message,
-        startLineNumber: start.row,
-        startColumn: start.column,
-        endLineNumber: end.row,
-        endColumn: end.column,
+        message: formatSubDiagnostic(subDiagnostic),
+        startLineNumber: location.start_location.row,
+        startColumn: location.start_location.column,
+        endLineNumber: location.end_location.row,
+        endColumn: location.end_location.column,
       },
     ];
   });
+}
+
+function formatSubDiagnostic(
+  subDiagnostic: Diagnostic["sub_diagnostics"][number],
+): string {
+  const message = `${subDiagnostic.severity}: ${subDiagnostic.message}`;
+  const location = subDiagnostic.location;
+
+  if (location == null || location.path === PLAYGROUND_FILE_PATH) {
+    return message;
+  }
+
+  return `${message} (${location.path}:${location.start_location.row}:${location.start_location.column})`;
 }

--- a/playground/ruff/src/Editor/SourceEditor.tsx
+++ b/playground/ruff/src/Editor/SourceEditor.tsx
@@ -17,7 +17,7 @@ import { Theme } from "shared";
 import CodeActionProvider = languages.CodeActionProvider;
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 
-const PLAYGROUND_FILE_PATH = "<filename>";
+export const PLAYGROUND_FILE_PATH = "<filename>";
 
 type MonacoEditorState = {
   monaco: Monaco;
@@ -185,7 +185,7 @@ function updateMarkers(monaco: Monaco, diagnostics: Array<Diagnostic>) {
     model,
     "owner",
     diagnostics.map((diagnostic) => {
-      const message = diagnosticDisplayMessage(diagnostic);
+      const message = diagnosticMarkerMessage(diagnostic);
 
       return {
         code: diagnostic.code ?? undefined,
@@ -205,28 +205,28 @@ function updateMarkers(monaco: Monaco, diagnostics: Array<Diagnostic>) {
   );
 }
 
-function diagnosticDisplayMessage(diagnostic: Diagnostic): string {
-  const subDiagnostics = diagnostic.sub_diagnostics.filter(
-    (subDiagnostic) =>
-      subDiagnostic.location == null ||
-      subDiagnostic.location.path !== PLAYGROUND_FILE_PATH,
+function diagnosticMarkerMessage(diagnostic: Diagnostic): string {
+  // Monaco renders same-file subdiagnostics as related information. Keep
+  // unlocated and other-file subdiagnostics in the marker message instead.
+  const markerMessageSubDiagnostics = diagnostic.subDiagnostics.filter(
+    (subDiagnostic) => subDiagnostic.location?.path !== PLAYGROUND_FILE_PATH,
   );
 
-  if (subDiagnostics.length === 0) {
+  if (markerMessageSubDiagnostics.length === 0) {
     return diagnostic.message;
   }
 
-  return `${diagnostic.message}\n\n${subDiagnostics.map(formatSubDiagnostic).join("\n")}`;
+  return `${diagnostic.message}\n\n${markerMessageSubDiagnostics.map(formatSubDiagnostic).join("\n")}`;
 }
 
 function diagnosticRelatedInformation(
   diagnostic: Diagnostic,
   resource: editor.ITextModel["uri"],
 ): editor.IRelatedInformation[] {
-  return diagnostic.sub_diagnostics.flatMap((subDiagnostic) => {
+  return diagnostic.subDiagnostics.flatMap((subDiagnostic) => {
     const location = subDiagnostic.location;
 
-    if (location == null || location.path !== PLAYGROUND_FILE_PATH) {
+    if (location?.path !== PLAYGROUND_FILE_PATH) {
       return [];
     }
 
@@ -244,7 +244,7 @@ function diagnosticRelatedInformation(
 }
 
 function formatSubDiagnostic(
-  subDiagnostic: Diagnostic["sub_diagnostics"][number],
+  subDiagnostic: Diagnostic["subDiagnostics"][number],
 ): string {
   const message = `${subDiagnostic.severity}: ${subDiagnostic.message}`;
   const location = subDiagnostic.location;

--- a/playground/ty/src/Editor/Chrome.tsx
+++ b/playground/ty/src/Editor/Chrome.tsx
@@ -25,11 +25,13 @@ import SecondaryPanel, {
   SecondaryPanelResult,
   SecondaryTool,
 } from "./SecondaryPanel";
-import Diagnostics, { Diagnostic } from "./Diagnostics";
+import Diagnostics, {
+  type Diagnostic,
+  type DiagnosticLocation,
+} from "./Diagnostics";
 import VendoredFileBanner from "./VendoredFileBanner";
 import type { FileId, PlaygroundSession, ReadonlyFiles } from "../Playground";
-import { Uri, type editor } from "monaco-editor";
-import type { Monaco } from "@monaco-editor/react";
+import type { EditorHandle } from "./Editor";
 
 const Editor = lazy(() => import("./Editor"));
 
@@ -80,10 +82,7 @@ export default function Chrome({
     null,
   );
 
-  const editorRef = useRef<{
-    editor: editor.IStandaloneCodeEditor;
-    monaco: Monaco;
-  } | null>(null);
+  const editorRef = useRef<EditorHandle | null>(null);
 
   const handleFileRenamed = (file: FileId, newName: string) => {
     onRenameFile(session, file, newName);
@@ -125,80 +124,30 @@ export default function Chrome({
     [],
   );
 
-  const handleEditorMount = useCallback(
-    (editor: editor.IStandaloneCodeEditor, monaco: Monaco) => {
-      editorRef.current = { editor, monaco };
-    },
-    [],
-  );
+  const handleEditorMount = useCallback((handle: EditorHandle) => {
+    editorRef.current = handle;
+  }, []);
 
-  const handleGoTo = useCallback(
-    (line: number, column: number, path?: string | null) => {
-      const editorRefValue = editorRef.current;
+  const handleGoTo = useCallback((line: number, column: number) => {
+    const editorRefValue = editorRef.current;
 
-      if (editorRefValue == null) {
-        return;
-      }
+    if (editorRefValue == null) {
+      return;
+    }
 
-      const { editor, monaco } = editorRefValue;
+    const range = {
+      startLineNumber: line,
+      startColumn: column,
+      endLineNumber: line,
+      endColumn: column,
+    };
+    editorRefValue.editor.revealRange(range);
+    editorRefValue.editor.setSelection(range);
+  }, []);
 
-      if (path != null) {
-        const uri = path.startsWith("vendored:")
-          ? Uri.parse(path)
-          : Uri.file(path);
-        let model = monaco.editor.getModel(uri);
-
-        if (uri.scheme === "vendored") {
-          const vendoredPath = uri.authority
-            ? `${uri.authority}${uri.path}`
-            : uri.path;
-          const fileHandle = workspace.getVendoredFile(vendoredPath);
-          onSelectVendoredFile(fileHandle);
-
-          if (model == null) {
-            model = monaco.editor.createModel(
-              workspace.sourceText(fileHandle),
-              "python",
-              uri,
-            );
-          }
-        } else {
-          const file = Object.values(files.metadata).find((file) => {
-            return (
-              file.handle?.path() === path ||
-              file.uri.toString() === uri.toString()
-            );
-          });
-
-          if (file != null) {
-            onClearVendoredFile();
-            onSelectFile(file.id);
-            model = monaco.editor.getModel(file.uri) ?? model;
-          }
-        }
-
-        if (model != null) {
-          editor.setModel(model);
-        }
-      }
-
-      const range = {
-        startLineNumber: line,
-        startColumn: column,
-        endLineNumber: line,
-        endColumn: column,
-      };
-      editor.revealRange(range);
-      editor.setSelection(range);
-    },
-    [
-      files.metadata,
-      onClearVendoredFile,
-      onSelectFile,
-      onSelectVendoredFile,
-      workspace,
-    ],
-  );
+  const handleGoToLocation = useCallback((location: DiagnosticLocation) => {
+    editorRef.current?.goToLocation(location);
+  }, []);
 
   const handleRemoved = useCallback(
     (id: FileId) => {
@@ -219,6 +168,10 @@ export default function Chrome({
     files.currentVendoredFile ?? null,
     files.revision,
   );
+  const currentFilePath =
+    files.selected == null
+      ? null
+      : (files.metadata[files.selected].handle?.path() ?? null);
 
   return (
     <>
@@ -289,7 +242,9 @@ export default function Chrome({
                 <Panel id="diagnostics" minSize={150} className="my-2">
                   <Diagnostics
                     diagnostics={checkResult.diagnostics}
+                    currentFilePath={currentFilePath}
                     onGoTo={handleGoTo}
+                    onGoToLocation={handleGoToLocation}
                     theme={theme}
                   />
                 </Panel>
@@ -395,11 +350,7 @@ function useCheckResult(
       const serializedDiagnostics = diagnostics.map((diagnostic) => ({
         id: diagnostic.id(),
         message: diagnostic.message(),
-        details: diagnostic.details(workspace).map((detail) => ({
-          message: detail.message,
-          path: detail.path ?? null,
-          range: detail.range ?? null,
-        })),
+        subDiagnostics: diagnostic.subDiagnostics(workspace),
         severity: diagnostic.severity(),
         range: diagnostic.toRange(workspace) ?? null,
         textRange: diagnostic.textRange() ?? null,

--- a/playground/ty/src/Editor/Chrome.tsx
+++ b/playground/ty/src/Editor/Chrome.tsx
@@ -128,24 +128,7 @@ export default function Chrome({
     editorRef.current = handle;
   }, []);
 
-  const handleGoTo = useCallback((line: number, column: number) => {
-    const editorRefValue = editorRef.current;
-
-    if (editorRefValue == null) {
-      return;
-    }
-
-    const range = {
-      startLineNumber: line,
-      startColumn: column,
-      endLineNumber: line,
-      endColumn: column,
-    };
-    editorRefValue.editor.revealRange(range);
-    editorRefValue.editor.setSelection(range);
-  }, []);
-
-  const handleGoToLocation = useCallback((location: DiagnosticLocation) => {
+  const handleGoTo = useCallback((location: DiagnosticLocation) => {
     editorRef.current?.goToLocation(location);
   }, []);
 
@@ -244,7 +227,6 @@ export default function Chrome({
                     diagnostics={checkResult.diagnostics}
                     currentFilePath={currentFilePath}
                     onGoTo={handleGoTo}
-                    onGoToLocation={handleGoToLocation}
                     theme={theme}
                   />
                 </Panel>

--- a/playground/ty/src/Editor/Chrome.tsx
+++ b/playground/ty/src/Editor/Chrome.tsx
@@ -28,7 +28,7 @@ import SecondaryPanel, {
 import Diagnostics, { Diagnostic } from "./Diagnostics";
 import VendoredFileBanner from "./VendoredFileBanner";
 import type { FileId, PlaygroundSession, ReadonlyFiles } from "../Playground";
-import type { editor } from "monaco-editor";
+import { Uri, type editor } from "monaco-editor";
 import type { Monaco } from "@monaco-editor/react";
 
 const Editor = lazy(() => import("./Editor"));
@@ -132,22 +132,73 @@ export default function Chrome({
     [],
   );
 
-  const handleGoTo = useCallback((line: number, column: number) => {
-    const editor = editorRef.current?.editor;
+  const handleGoTo = useCallback(
+    (line: number, column: number, path?: string | null) => {
+      const editorRefValue = editorRef.current;
 
-    if (editor == null) {
-      return;
-    }
+      if (editorRefValue == null) {
+        return;
+      }
 
-    const range = {
-      startLineNumber: line,
-      startColumn: column,
-      endLineNumber: line,
-      endColumn: column,
-    };
-    editor.revealRange(range);
-    editor.setSelection(range);
-  }, []);
+      const { editor, monaco } = editorRefValue;
+
+      if (path != null) {
+        const uri = path.startsWith("vendored:")
+          ? Uri.parse(path)
+          : Uri.file(path);
+        let model = monaco.editor.getModel(uri);
+
+        if (uri.scheme === "vendored") {
+          const vendoredPath = uri.authority
+            ? `${uri.authority}${uri.path}`
+            : uri.path;
+          const fileHandle = workspace.getVendoredFile(vendoredPath);
+          onSelectVendoredFile(fileHandle);
+
+          if (model == null) {
+            model = monaco.editor.createModel(
+              workspace.sourceText(fileHandle),
+              "python",
+              uri,
+            );
+          }
+        } else {
+          const file = Object.values(files.metadata).find((file) => {
+            return (
+              file.handle?.path() === path ||
+              file.uri.toString() === uri.toString()
+            );
+          });
+
+          if (file != null) {
+            onClearVendoredFile();
+            onSelectFile(file.id);
+            model = monaco.editor.getModel(file.uri) ?? model;
+          }
+        }
+
+        if (model != null) {
+          editor.setModel(model);
+        }
+      }
+
+      const range = {
+        startLineNumber: line,
+        startColumn: column,
+        endLineNumber: line,
+        endColumn: column,
+      };
+      editor.revealRange(range);
+      editor.setSelection(range);
+    },
+    [
+      files.metadata,
+      onClearVendoredFile,
+      onSelectFile,
+      onSelectVendoredFile,
+      workspace,
+    ],
+  );
 
   const handleRemoved = useCallback(
     (id: FileId) => {
@@ -344,6 +395,11 @@ function useCheckResult(
       const serializedDiagnostics = diagnostics.map((diagnostic) => ({
         id: diagnostic.id(),
         message: diagnostic.message(),
+        details: diagnostic.details(workspace).map((detail) => ({
+          message: detail.message,
+          path: detail.path ?? null,
+          range: detail.range ?? null,
+        })),
         severity: diagnostic.severity(),
         range: diagnostic.toRange(workspace) ?? null,
         textRange: diagnostic.textRange() ?? null,

--- a/playground/ty/src/Editor/Diagnostics.tsx
+++ b/playground/ty/src/Editor/Diagnostics.tsx
@@ -1,6 +1,8 @@
 import type {
   Severity,
+  Location as TyLocation,
   Range,
+  SubDiagnostic,
   TextRange,
   Diagnostic as TyDiagnostic,
 } from "ty_wasm";
@@ -10,15 +12,19 @@ import { useMemo } from "react";
 
 interface Props {
   diagnostics: Diagnostic[];
+  currentFilePath: string | null;
   theme: Theme;
 
-  onGoTo(line: number, column: number, path?: string | null): void;
+  onGoTo(line: number, column: number): void;
+  onGoToLocation(location: DiagnosticLocation): void;
 }
 
 export default function Diagnostics({
   diagnostics: unsorted,
+  currentFilePath,
   theme,
   onGoTo,
+  onGoToLocation,
 }: Props) {
   const diagnostics = useMemo(() => {
     const sorted = [...unsorted];
@@ -46,7 +52,12 @@ export default function Diagnostics({
       </div>
 
       <div className="flex min-h-0 grow overflow-hidden p-2">
-        <Items diagnostics={diagnostics} onGoTo={onGoTo} />
+        <Items
+          diagnostics={diagnostics}
+          currentFilePath={currentFilePath}
+          onGoTo={onGoTo}
+          onGoToLocation={onGoToLocation}
+        />
       </div>
     </div>
   );
@@ -54,10 +65,14 @@ export default function Diagnostics({
 
 function Items({
   diagnostics,
+  currentFilePath,
   onGoTo,
+  onGoToLocation,
 }: {
   diagnostics: Array<Diagnostic>;
-  onGoTo(line: number, column: number, path?: string | null): void;
+  currentFilePath: string | null;
+  onGoTo(line: number, column: number): void;
+  onGoToLocation(location: DiagnosticLocation): void;
 }) {
   if (diagnostics.length === 0) {
     return (
@@ -95,11 +110,15 @@ function Items({
                 {id != null && ` (${id})`} [Ln {startLine}, Col {startColumn}]
               </span>
             </button>
-            {diagnostic.details.length > 0 ? (
+            {diagnostic.subDiagnostics.length > 0 ? (
               <ul className="pl-3 font-mono text-gray-500 whitespace-pre-wrap">
-                {diagnostic.details.map((detail, index) => (
+                {diagnostic.subDiagnostics.map((subDiagnostic, index) => (
                   <li key={index}>
-                    <Detail detail={detail} onGoTo={onGoTo} />
+                    <SubDiagnosticItem
+                      subDiagnostic={subDiagnostic}
+                      currentFilePath={currentFilePath}
+                      onGoToLocation={onGoToLocation}
+                    />
                   </li>
                 ))}
               </ul>
@@ -114,58 +133,50 @@ function Items({
 export interface Diagnostic {
   id: string;
   message: string;
-  details: DiagnosticDetail[];
+  subDiagnostics: SubDiagnostic[];
   severity: Severity;
   range: Range | null;
   textRange: TextRange | null;
   raw: TyDiagnostic;
 }
 
-interface DiagnosticDetail {
-  message: string;
-  path: string | null;
-  range: Range | null;
-}
+export type DiagnosticLocation = Pick<TyLocation, "path" | "range">;
 
-function Detail({
-  detail,
-  onGoTo,
+function SubDiagnosticItem({
+  subDiagnostic,
+  currentFilePath,
+  onGoToLocation,
 }: {
-  detail: DiagnosticDetail;
-  onGoTo(line: number, column: number, path?: string | null): void;
+  subDiagnostic: SubDiagnostic;
+  currentFilePath: string | null;
+  onGoToLocation(location: DiagnosticLocation): void;
 }) {
-  const start = detail.range?.start;
-  const [prefix, message] = splitSubdiagnosticMessage(detail.message);
+  const location = subDiagnostic.location;
 
-  if (start == null) {
-    return <span>{detail.message}</span>;
+  if (location == null) {
+    return <span>{formatSubDiagnostic(subDiagnostic)}</span>;
   }
+
+  const start = location.range.start;
+  const locationLabel =
+    location.path === currentFilePath
+      ? `[Ln ${start.line}, Col ${start.column}]`
+      : `[${location.path}: Ln ${start.line}, Col ${start.column}]`;
 
   return (
     <>
-      {prefix}
+      {subDiagnostic.severity}:{" "}
       <button
-        onClick={() => onGoTo(start.line, start.column, detail.path)}
+        onClick={() => onGoToLocation(location)}
         className="text-start cursor-pointer text-current underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-400 dark:hover:text-gray-400"
       >
-        {message}
-        <span className="text-gray-500">
-          {" "}
-          [Ln {start.line}, Col {start.column}]
-        </span>
+        {subDiagnostic.message}
+        <span className="text-gray-500"> {locationLabel}</span>
       </button>
     </>
   );
 }
 
-function splitSubdiagnosticMessage(message: string): [string, string] {
-  const separator = ": ";
-  const separatorIndex = message.indexOf(separator);
-
-  if (separatorIndex === -1) {
-    return ["", message];
-  }
-
-  const prefixEnd = separatorIndex + separator.length;
-  return [message.slice(0, prefixEnd), message.slice(prefixEnd)];
+function formatSubDiagnostic(subDiagnostic: SubDiagnostic): string {
+  return `${subDiagnostic.severity}: ${subDiagnostic.message}`;
 }

--- a/playground/ty/src/Editor/Diagnostics.tsx
+++ b/playground/ty/src/Editor/Diagnostics.tsx
@@ -3,6 +3,7 @@ import type {
   Location as TyLocation,
   Range,
   SubDiagnostic,
+  SubDiagnosticAnnotation,
   TextRange,
   Diagnostic as TyDiagnostic,
 } from "ty_wasm";
@@ -151,10 +152,68 @@ function SubDiagnosticItem({
   currentFilePath: string | null;
   onGoToLocation(location: DiagnosticLocation): void;
 }) {
-  const location = subDiagnostic.location;
+  const annotations = subDiagnostic.annotations;
+  const primaryAnnotationIndex = subDiagnostic.primary_annotation_index;
+  const primaryAnnotation =
+    primaryAnnotationIndex == null
+      ? undefined
+      : annotations[primaryAnnotationIndex];
+  const additionalAnnotations = annotations.filter(
+    (_, index) => index !== primaryAnnotationIndex,
+  );
 
+  return (
+    <>
+      {primaryAnnotation == null ? (
+        <span>{formatSubDiagnostic(subDiagnostic)}</span>
+      ) : (
+        <SubDiagnosticAnnotationItem
+          prefix={`${subDiagnostic.severity}: `}
+          message={formatPrimaryAnnotation(subDiagnostic, primaryAnnotation)}
+          annotation={primaryAnnotation}
+          currentFilePath={currentFilePath}
+          onGoToLocation={onGoToLocation}
+        />
+      )}
+      {additionalAnnotations.length > 0 ? (
+        <ul className="pl-3">
+          {additionalAnnotations.map((annotation, index) => (
+            <li key={index}>
+              <SubDiagnosticAnnotationItem
+                message={annotation.message ?? subDiagnostic.message}
+                annotation={annotation}
+                currentFilePath={currentFilePath}
+                onGoToLocation={onGoToLocation}
+              />
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </>
+  );
+}
+
+function SubDiagnosticAnnotationItem({
+  prefix,
+  message,
+  annotation,
+  currentFilePath,
+  onGoToLocation,
+}: {
+  prefix?: string;
+  message: string;
+  annotation: SubDiagnosticAnnotation;
+  currentFilePath: string | null;
+  onGoToLocation(location: DiagnosticLocation): void;
+}) {
+  const location = annotation.location;
   if (location == null) {
-    return <span>{formatSubDiagnostic(subDiagnostic)}</span>;
+    return (
+      <span>
+        {prefix}
+        {message}
+      </span>
+    );
   }
 
   const start = location.range.start;
@@ -165,12 +224,12 @@ function SubDiagnosticItem({
 
   return (
     <>
-      {subDiagnostic.severity}:{" "}
+      {prefix}
       <button
         onClick={() => onGoToLocation(location)}
         className="text-start cursor-pointer text-current underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-400 dark:hover:text-gray-400"
       >
-        {subDiagnostic.message}
+        {message}
         <span className="text-gray-500"> {locationLabel}</span>
       </button>
     </>
@@ -179,4 +238,13 @@ function SubDiagnosticItem({
 
 function formatSubDiagnostic(subDiagnostic: SubDiagnostic): string {
   return `${subDiagnostic.severity}: ${subDiagnostic.message}`;
+}
+
+function formatPrimaryAnnotation(
+  subDiagnostic: SubDiagnostic,
+  annotation: SubDiagnosticAnnotation,
+): string {
+  return annotation.message == null
+    ? subDiagnostic.message
+    : `${subDiagnostic.message}: ${annotation.message}`;
 }

--- a/playground/ty/src/Editor/Diagnostics.tsx
+++ b/playground/ty/src/Editor/Diagnostics.tsx
@@ -244,12 +244,12 @@ function SubDiagnosticAnnotationItem({
   return (
     <>
       {prefix}
+      {message}{" "}
       <button
         onClick={() => onGoTo(location)}
-        className="text-start cursor-pointer text-current underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-400 dark:hover:text-gray-400"
+        className="cursor-pointer text-gray-500 underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-400 dark:hover:text-gray-400"
       >
-        {message}
-        <span className="text-gray-500"> {locationLabel}</span>
+        {locationLabel}
       </button>
     </>
   );

--- a/playground/ty/src/Editor/Diagnostics.tsx
+++ b/playground/ty/src/Editor/Diagnostics.tsx
@@ -1,6 +1,6 @@
+import { SubDiagnosticSeverity } from "ty_wasm";
 import type {
   Severity,
-  Location as TyLocation,
   Range,
   SubDiagnostic,
   SubDiagnosticAnnotation,
@@ -16,8 +16,7 @@ interface Props {
   currentFilePath: string | null;
   theme: Theme;
 
-  onGoTo(line: number, column: number): void;
-  onGoToLocation(location: DiagnosticLocation): void;
+  onGoTo(location: DiagnosticLocation): void;
 }
 
 export default function Diagnostics({
@@ -25,7 +24,6 @@ export default function Diagnostics({
   currentFilePath,
   theme,
   onGoTo,
-  onGoToLocation,
 }: Props) {
   const diagnostics = useMemo(() => {
     const sorted = [...unsorted];
@@ -57,7 +55,6 @@ export default function Diagnostics({
           diagnostics={diagnostics}
           currentFilePath={currentFilePath}
           onGoTo={onGoTo}
-          onGoToLocation={onGoToLocation}
         />
       </div>
     </div>
@@ -68,12 +65,10 @@ function Items({
   diagnostics,
   currentFilePath,
   onGoTo,
-  onGoToLocation,
 }: {
   diagnostics: Array<Diagnostic>;
   currentFilePath: string | null;
-  onGoTo(line: number, column: number): void;
-  onGoToLocation(location: DiagnosticLocation): void;
+  onGoTo(location: DiagnosticLocation): void;
 }) {
   if (diagnostics.length === 0) {
     return (
@@ -94,6 +89,10 @@ function Items({
 
         const startLine = start?.line ?? 1;
         const startColumn = start?.column ?? 1;
+        const location =
+          currentFilePath == null || position == null
+            ? null
+            : { path: currentFilePath, range: position };
 
         const mostlyUniqueId = `${startLine}:${startColumn}-${id}`;
 
@@ -102,15 +101,24 @@ function Items({
 
         return (
           <li key={`${mostlyUniqueId}-${disambiguator}`}>
-            <button
-              onClick={() => onGoTo(startLine, startColumn)}
-              className="w-full text-start cursor-pointer select-text"
-            >
-              {diagnostic.message}
-              <span className="text-gray-500">
-                {id != null && ` (${id})`} [Ln {startLine}, Col {startColumn}]
+            {location == null ? (
+              <span className="w-full text-start select-text">
+                {diagnostic.message}
+                <span className="text-gray-500">
+                  {id != null && ` (${id})`} [Ln {startLine}, Col {startColumn}]
+                </span>
               </span>
-            </button>
+            ) : (
+              <button
+                onClick={() => onGoTo(location)}
+                className="w-full text-start cursor-pointer select-text"
+              >
+                {diagnostic.message}
+                <span className="text-gray-500">
+                  {id != null && ` (${id})`} [Ln {startLine}, Col {startColumn}]
+                </span>
+              </button>
+            )}
             {diagnostic.subDiagnostics.length > 0 ? (
               <ul className="pl-3 font-mono text-gray-500 whitespace-pre-wrap">
                 {diagnostic.subDiagnostics.map((subDiagnostic, index) => (
@@ -118,7 +126,7 @@ function Items({
                     <SubDiagnosticItem
                       subDiagnostic={subDiagnostic}
                       currentFilePath={currentFilePath}
-                      onGoToLocation={onGoToLocation}
+                      onGoTo={onGoTo}
                     />
                   </li>
                 ))}
@@ -141,26 +149,30 @@ export interface Diagnostic {
   raw: TyDiagnostic;
 }
 
-export type DiagnosticLocation = Pick<TyLocation, "path" | "range">;
+export type DiagnosticLocation = {
+  path: string;
+  range: Range;
+};
 
 function SubDiagnosticItem({
   subDiagnostic,
   currentFilePath,
-  onGoToLocation,
+  onGoTo,
 }: {
   subDiagnostic: SubDiagnostic;
   currentFilePath: string | null;
-  onGoToLocation(location: DiagnosticLocation): void;
+  onGoTo(location: DiagnosticLocation): void;
 }) {
-  const annotations = subDiagnostic.annotations;
-  const primaryAnnotationIndex = subDiagnostic.primary_annotation_index;
-  const primaryAnnotation =
-    primaryAnnotationIndex == null
-      ? undefined
-      : annotations[primaryAnnotationIndex];
-  const additionalAnnotations = annotations.filter(
-    (_, index) => index !== primaryAnnotationIndex,
-  );
+  let primaryAnnotation: SubDiagnosticAnnotation | undefined;
+  const additionalAnnotations: SubDiagnosticAnnotation[] = [];
+
+  for (const annotation of subDiagnostic.annotations) {
+    if (annotation.primary && primaryAnnotation == null) {
+      primaryAnnotation = annotation;
+    } else {
+      additionalAnnotations.push(annotation);
+    }
+  }
 
   return (
     <>
@@ -168,11 +180,14 @@ function SubDiagnosticItem({
         <span>{formatSubDiagnostic(subDiagnostic)}</span>
       ) : (
         <SubDiagnosticAnnotationItem
-          prefix={`${subDiagnostic.severity}: `}
-          message={formatPrimaryAnnotation(subDiagnostic, primaryAnnotation)}
+          prefix={`${formatSubDiagnosticSeverity(subDiagnostic.severity)}: `}
+          message={formatSubDiagnosticAnnotation(
+            subDiagnostic,
+            primaryAnnotation,
+          )}
           annotation={primaryAnnotation}
           currentFilePath={currentFilePath}
-          onGoToLocation={onGoToLocation}
+          onGoTo={onGoTo}
         />
       )}
       {additionalAnnotations.length > 0 ? (
@@ -180,10 +195,14 @@ function SubDiagnosticItem({
           {additionalAnnotations.map((annotation, index) => (
             <li key={index}>
               <SubDiagnosticAnnotationItem
-                message={annotation.message ?? subDiagnostic.message}
+                message={formatSubDiagnosticAnnotation(
+                  subDiagnostic,
+                  annotation,
+                  false,
+                )}
                 annotation={annotation}
                 currentFilePath={currentFilePath}
-                onGoToLocation={onGoToLocation}
+                onGoTo={onGoTo}
               />
             </li>
           ))}
@@ -198,13 +217,13 @@ function SubDiagnosticAnnotationItem({
   message,
   annotation,
   currentFilePath,
-  onGoToLocation,
+  onGoTo,
 }: {
   prefix?: string;
   message: string;
   annotation: SubDiagnosticAnnotation;
   currentFilePath: string | null;
-  onGoToLocation(location: DiagnosticLocation): void;
+  onGoTo(location: DiagnosticLocation): void;
 }) {
   const location = annotation.location;
   if (location == null) {
@@ -226,7 +245,7 @@ function SubDiagnosticAnnotationItem({
     <>
       {prefix}
       <button
-        onClick={() => onGoToLocation(location)}
+        onClick={() => onGoTo(location)}
         className="text-start cursor-pointer text-current underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-400 dark:hover:text-gray-400"
       >
         {message}
@@ -236,15 +255,35 @@ function SubDiagnosticAnnotationItem({
   );
 }
 
-function formatSubDiagnostic(subDiagnostic: SubDiagnostic): string {
-  return `${subDiagnostic.severity}: ${subDiagnostic.message}`;
+export function formatSubDiagnostic(subDiagnostic: SubDiagnostic): string {
+  return `${formatSubDiagnosticSeverity(subDiagnostic.severity)}: ${subDiagnostic.message}`;
 }
 
-function formatPrimaryAnnotation(
+export function formatSubDiagnosticAnnotation(
   subDiagnostic: SubDiagnostic,
   annotation: SubDiagnosticAnnotation,
+  includeSubDiagnosticMessage = annotation.primary,
 ): string {
-  return annotation.message == null
-    ? subDiagnostic.message
-    : `${subDiagnostic.message}: ${annotation.message}`;
+  if (annotation.message == null) {
+    return subDiagnostic.message;
+  }
+
+  return includeSubDiagnosticMessage
+    ? `${subDiagnostic.message}: ${annotation.message}`
+    : annotation.message;
+}
+
+function formatSubDiagnosticSeverity(severity: SubDiagnosticSeverity): string {
+  switch (severity) {
+    case SubDiagnosticSeverity.Help:
+      return "help";
+    case SubDiagnosticSeverity.Info:
+      return "info";
+    case SubDiagnosticSeverity.Warning:
+      return "warning";
+    case SubDiagnosticSeverity.Error:
+      return "error";
+    case SubDiagnosticSeverity.Fatal:
+      return "fatal";
+  }
 }

--- a/playground/ty/src/Editor/Diagnostics.tsx
+++ b/playground/ty/src/Editor/Diagnostics.tsx
@@ -12,7 +12,7 @@ interface Props {
   diagnostics: Diagnostic[];
   theme: Theme;
 
-  onGoTo(line: number, column: number): void;
+  onGoTo(line: number, column: number, path?: string | null): void;
 }
 
 export default function Diagnostics({
@@ -57,7 +57,7 @@ function Items({
   onGoTo,
 }: {
   diagnostics: Array<Diagnostic>;
-  onGoTo(line: number, column: number): void;
+  onGoTo(line: number, column: number, path?: string | null): void;
 }) {
   if (diagnostics.length === 0) {
     return (
@@ -95,6 +95,15 @@ function Items({
                 {id != null && ` (${id})`} [Ln {startLine}, Col {startColumn}]
               </span>
             </button>
+            {diagnostic.details.length > 0 ? (
+              <ul className="pl-3 font-mono text-gray-500 whitespace-pre-wrap">
+                {diagnostic.details.map((detail, index) => (
+                  <li key={index}>
+                    <Detail detail={detail} onGoTo={onGoTo} />
+                  </li>
+                ))}
+              </ul>
+            ) : null}
           </li>
         );
       })}
@@ -105,8 +114,58 @@ function Items({
 export interface Diagnostic {
   id: string;
   message: string;
+  details: DiagnosticDetail[];
   severity: Severity;
   range: Range | null;
   textRange: TextRange | null;
   raw: TyDiagnostic;
+}
+
+interface DiagnosticDetail {
+  message: string;
+  path: string | null;
+  range: Range | null;
+}
+
+function Detail({
+  detail,
+  onGoTo,
+}: {
+  detail: DiagnosticDetail;
+  onGoTo(line: number, column: number, path?: string | null): void;
+}) {
+  const start = detail.range?.start;
+  const [prefix, message] = splitSubdiagnosticMessage(detail.message);
+
+  if (start == null) {
+    return <span>{detail.message}</span>;
+  }
+
+  return (
+    <>
+      {prefix}
+      <button
+        onClick={() => onGoTo(start.line, start.column, detail.path)}
+        className="text-start cursor-pointer text-current underline decoration-dotted underline-offset-2 transition-colors hover:text-gray-400 dark:hover:text-gray-400"
+      >
+        {message}
+        <span className="text-gray-500">
+          {" "}
+          [Ln {start.line}, Col {start.column}]
+        </span>
+      </button>
+    </>
+  );
+}
+
+function splitSubdiagnosticMessage(message: string): [string, string] {
+  const separator = ": ";
+  const separatorIndex = message.indexOf(separator);
+
+  if (separatorIndex === -1) {
+    return ["", message];
+  }
+
+  const prefixEnd = separatorIndex + separator.length;
+  return [message.slice(0, prefixEnd), message.slice(prefixEnd)];
 }

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -463,9 +463,52 @@ class PlaygroundServer
   private getPlaygroundFileForUri(uri: Uri): PlaygroundFile | null {
     return (
       Object.values(this.props.files.metadata).find((file) => {
-        return file.uri.toString() === uri.toString();
+        return (
+          file.uri.toString() === uri.toString() ||
+          (uri.scheme === "file" && file.handle?.path() === uri.fsPath)
+        );
       }) ?? null
     );
+  }
+
+  private getDiagnosticDetailResource(
+    detail: Diagnostic["details"][number],
+  ): Uri | null {
+    const path = detail.path;
+
+    if (path == null) {
+      return null;
+    }
+
+    const uri = path.startsWith("vendored:") ? Uri.parse(path) : Uri.file(path);
+
+    return uri.scheme === "vendored"
+      ? uri
+      : (this.getPlaygroundFileForUri(uri)?.uri ?? uri);
+  }
+
+  private diagnosticRelatedInformation(
+    diagnostic: Diagnostic,
+  ): editor.IRelatedInformation[] {
+    return diagnostic.details.flatMap((detail) => {
+      const range = detail.range;
+      const resource = this.getDiagnosticDetailResource(detail);
+
+      if (range == null || resource == null) {
+        return [];
+      }
+
+      return [
+        {
+          resource,
+          message: detail.message,
+          startLineNumber: range.start.line,
+          startColumn: range.start.column,
+          endLineNumber: range.end.line,
+          endColumn: range.end.column,
+        },
+      ];
+    });
   }
 
   private getOrCreateVendoredFileHandle(vendoredPath: string): FileHandle {
@@ -569,7 +612,8 @@ class PlaygroundServer
           startColumn: range?.start?.column ?? 0,
           endLineNumber: range?.end?.line ?? 0,
           endColumn: range?.end?.column ?? 0,
-          message: diagnostic.message,
+          message: diagnosticDisplayMessage(diagnostic),
+          relatedInformation: this.diagnosticRelatedInformation(diagnostic),
           severity: mapSeverity(diagnostic.severity),
           tags: [],
         };
@@ -761,10 +805,16 @@ class PlaygroundServer
   ): boolean {
     const files = this.props.files;
 
-    // Model should already exist from mapNavigationTargets for both vendored and regular files
-    const model = this.monaco.editor.getModel(resource);
+    let model = this.monaco.editor.getModel(resource);
+
+    if (model == null && resource.scheme === "vendored") {
+      const vendoredPath = this.getVendoredPath(resource);
+      const fileHandle = this.getOrCreateVendoredFileHandle(vendoredPath);
+      const content = this.props.workspace.sourceText(fileHandle);
+      model = this.monaco.editor.createModel(content, "python", resource);
+    }
+
     if (model == null) {
-      // Model should have been created by mapNavigationTargets
       return false;
     }
 
@@ -965,6 +1015,18 @@ function tyRangeToMonacoRange(range: TyRange): IRange {
     endLineNumber: range.end.line,
     endColumn: range.end.column,
   };
+}
+
+function diagnosticDisplayMessage(diagnostic: Diagnostic): string {
+  const details = diagnostic.details.filter(
+    (detail) => detail.range == null || detail.path == null,
+  );
+
+  if (details.length === 0) {
+    return diagnostic.message;
+  }
+
+  return `${diagnostic.message}\n\n${details.map((detail) => detail.message).join("\n")}`;
 }
 
 function monacoRangeToTyRange(range: IRange): TyRange {

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -1003,18 +1003,20 @@ class PlaygroundServer
     diagnostic: Diagnostic,
   ): editor.IRelatedInformation[] {
     return diagnostic.subDiagnostics.flatMap((subDiagnostic) => {
-      const location = subDiagnostic.location;
+      return subDiagnostic.annotations.flatMap((annotation) => {
+        const location = annotation.location;
 
-      if (location == null) {
-        return [];
-      }
+        if (location == null) {
+          return [];
+        }
 
-      return [
-        {
-          message: formatSubDiagnostic(subDiagnostic),
-          ...this.mapLocation(location),
-        },
-      ];
+        return [
+          {
+            message: formatSubDiagnosticAnnotation(subDiagnostic, annotation),
+            ...this.mapLocation(location),
+          },
+        ];
+      });
     });
   }
 
@@ -1043,7 +1045,10 @@ function tyRangeToMonacoRange(range: TyRange): IRange {
 
 function diagnosticDisplayMessage(diagnostic: Diagnostic): string {
   const subDiagnostics = diagnostic.subDiagnostics.filter(
-    (subDiagnostic) => subDiagnostic.location == null,
+    (subDiagnostic) =>
+      !subDiagnostic.annotations.some(
+        (annotation) => annotation.primary && annotation.location != null,
+      ),
   );
 
   if (subDiagnostics.length === 0) {
@@ -1055,6 +1060,19 @@ function diagnosticDisplayMessage(diagnostic: Diagnostic): string {
 
 function formatSubDiagnostic(subDiagnostic: SubDiagnostic): string {
   return `${subDiagnostic.severity}: ${subDiagnostic.message}`;
+}
+
+function formatSubDiagnosticAnnotation(
+  subDiagnostic: SubDiagnostic,
+  annotation: SubDiagnostic["annotations"][number],
+): string {
+  if (annotation.message == null) {
+    return formatSubDiagnostic(subDiagnostic);
+  }
+
+  return annotation.primary
+    ? `${formatSubDiagnostic(subDiagnostic)}: ${annotation.message}`
+    : annotation.message;
 }
 
 function monacoRangeToTyRange(range: IRange): TyRange {

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -32,11 +32,14 @@ import {
   InlayHintKind,
   LocationLink,
   TextEdit,
-  type Location as TyLocation,
-  type SubDiagnostic,
 } from "ty_wasm";
 import { FileId, PlaygroundFile, ReadonlyFiles } from "../Playground";
-import { Diagnostic } from "./Diagnostics";
+import {
+  Diagnostic,
+  type DiagnosticLocation,
+  formatSubDiagnostic,
+  formatSubDiagnosticAnnotation,
+} from "./Diagnostics";
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 import CompletionItemKind = languages.CompletionItemKind;
 
@@ -58,7 +61,7 @@ type Props = {
 export type EditorHandle = {
   editor: IStandaloneCodeEditor;
   monaco: Monaco;
-  goToLocation(location: Pick<TyLocation, "path" | "range">): void;
+  goToLocation(location: DiagnosticLocation): void;
 };
 
 export default function Editor({
@@ -475,10 +478,7 @@ class PlaygroundServer
   private getPlaygroundFileForUri(uri: Uri): PlaygroundFile | null {
     return (
       Object.values(this.props.files.metadata).find((file) => {
-        return (
-          file.uri.toString() === uri.toString() ||
-          (uri.scheme === "file" && file.handle?.path() === uri.fsPath)
-        );
+        return file.uri.toString() === uri.toString();
       }) ?? null
     );
   }
@@ -788,32 +788,24 @@ class PlaygroundServer
   ): boolean {
     const files = this.props.files;
 
-    let model = this.monaco.editor.getModel(resource);
-    let resolvedResource = resource;
-
-    if (model == null && resource.scheme === "vendored") {
-      model = this.getOrCreateVendoredModel(resource);
-    } else if (model == null) {
-      const file = this.getPlaygroundFileForUri(resource);
-      if (file != null) {
-        resolvedResource = file.uri;
-        model = this.monaco.editor.getModel(file.uri);
-      }
-    }
+    const model =
+      resource.scheme === "vendored"
+        ? this.getOrCreateVendoredModel(resource)
+        : this.monaco.editor.getModel(resource);
 
     if (model == null) {
       return false;
     }
 
     // Handle file-specific logic
-    if (resolvedResource.scheme === "vendored") {
+    if (resource.scheme === "vendored") {
       // Get the file handle to track that we're viewing a vendored file
-      const vendoredPath = this.getVendoredPath(resolvedResource);
+      const vendoredPath = this.getVendoredPath(resource);
       const fileHandle = this.getOrCreateVendoredFileHandle(vendoredPath);
       this.props.onVendoredFileChange(fileHandle);
     } else {
       // Handle regular files
-      const file = this.getPlaygroundFileForUri(resolvedResource);
+      const file = this.getPlaygroundFileForUri(resource);
 
       if (file == null) {
         return false;
@@ -933,9 +925,12 @@ class PlaygroundServer
     return { edits };
   }
 
-  goToLocation(location: Pick<TyLocation, "path" | "range">): void {
-    const { resource, ...range } = this.mapLocation(location);
-    this.openCodeEditor(this.editor, resource, range);
+  goToLocation(location: DiagnosticLocation): void {
+    this.openCodeEditor(
+      this.editor,
+      this.uriForPath(location.path),
+      tyRangeToMonacoRange(location.range),
+    );
   }
 
   private mapNavigationTarget(link: LocationLink): languages.LocationLink {
@@ -971,30 +966,16 @@ class PlaygroundServer
     return path.startsWith("vendored:") ? Uri.parse(path) : Uri.file(path);
   }
 
-  private resolveLocationUri(path: string): Uri {
-    const uri = this.uriForPath(path);
-
-    if (this.monaco.editor.getModel(uri) != null) {
-      return uri;
-    }
-
-    if (uri.scheme === "vendored") {
-      return this.getOrCreateVendoredModel(uri).uri;
-    }
-
-    const file = this.getPlaygroundFileForUri(uri);
-    if (file == null) {
-      return uri;
-    }
-
-    return this.monaco.editor.getModel(file.uri)?.uri ?? file.uri;
-  }
-
   private mapLocation(
-    location: Pick<TyLocation, "path" | "range">,
+    location: DiagnosticLocation,
   ): { resource: Uri } & IRange {
+    const uri = this.uriForPath(location.path);
+
     return {
-      resource: this.resolveLocationUri(location.path),
+      resource:
+        uri.scheme === "vendored"
+          ? this.getOrCreateVendoredModel(uri).uri
+          : uri,
       ...tyRangeToMonacoRange(location.range),
     };
   }
@@ -1056,23 +1037,6 @@ function diagnosticDisplayMessage(diagnostic: Diagnostic): string {
   }
 
   return `${diagnostic.message}\n\n${subDiagnostics.map(formatSubDiagnostic).join("\n")}`;
-}
-
-function formatSubDiagnostic(subDiagnostic: SubDiagnostic): string {
-  return `${subDiagnostic.severity}: ${subDiagnostic.message}`;
-}
-
-function formatSubDiagnosticAnnotation(
-  subDiagnostic: SubDiagnostic,
-  annotation: SubDiagnostic["annotations"][number],
-): string {
-  if (annotation.message == null) {
-    return formatSubDiagnostic(subDiagnostic);
-  }
-
-  return annotation.primary
-    ? `${formatSubDiagnostic(subDiagnostic)}: ${annotation.message}`
-    : annotation.message;
 }
 
 function monacoRangeToTyRange(range: IRange): TyRange {

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -32,6 +32,8 @@ import {
   InlayHintKind,
   LocationLink,
   TextEdit,
+  type Location as TyLocation,
+  type SubDiagnostic,
 } from "ty_wasm";
 import { FileId, PlaygroundFile, ReadonlyFiles } from "../Playground";
 import { Diagnostic } from "./Diagnostics";
@@ -46,11 +48,17 @@ type Props = {
   hints: Hint[];
   theme: Theme;
   workspace: Workspace;
-  onMount(editor: IStandaloneCodeEditor, monaco: Monaco): void;
+  onMount(handle: EditorHandle): void;
   onOpenFile(file: FileId): void;
   onVendoredFileChange: (vendoredFileHandle: FileHandle) => void;
   onBackToUserFile: () => void;
   isViewingVendoredFile: boolean;
+};
+
+export type EditorHandle = {
+  editor: IStandaloneCodeEditor;
+  monaco: Monaco;
+  goToLocation(location: Pick<TyLocation, "path" | "range">): void;
 };
 
 export default function Editor({
@@ -121,7 +129,11 @@ export default function Editor({
       server.updateMarkers(diagnostics, hints);
       serverRef.current = server;
 
-      onMount(editor, instance);
+      onMount({
+        editor,
+        monaco: instance,
+        goToLocation: (location) => server.goToLocation(location),
+      });
     },
 
     [
@@ -471,46 +483,6 @@ class PlaygroundServer
     );
   }
 
-  private getDiagnosticDetailResource(
-    detail: Diagnostic["details"][number],
-  ): Uri | null {
-    const path = detail.path;
-
-    if (path == null) {
-      return null;
-    }
-
-    const uri = path.startsWith("vendored:") ? Uri.parse(path) : Uri.file(path);
-
-    return uri.scheme === "vendored"
-      ? uri
-      : (this.getPlaygroundFileForUri(uri)?.uri ?? uri);
-  }
-
-  private diagnosticRelatedInformation(
-    diagnostic: Diagnostic,
-  ): editor.IRelatedInformation[] {
-    return diagnostic.details.flatMap((detail) => {
-      const range = detail.range;
-      const resource = this.getDiagnosticDetailResource(detail);
-
-      if (range == null || resource == null) {
-        return [];
-      }
-
-      return [
-        {
-          resource,
-          message: detail.message,
-          startLineNumber: range.start.line,
-          startColumn: range.start.column,
-          endLineNumber: range.end.line,
-          endColumn: range.end.column,
-        },
-      ];
-    });
-  }
-
   private getOrCreateVendoredFileHandle(vendoredPath: string): FileHandle {
     const cachedHandle = this.vendoredFileHandles.get(vendoredPath);
     // Check if we already have a handle for this vendored file
@@ -522,6 +494,17 @@ class PlaygroundServer
     const handle = this.props.workspace.getVendoredFile(vendoredPath);
     this.vendoredFileHandles.set(vendoredPath, handle);
     return handle;
+  }
+
+  private createVendoredModel(uri: Uri): editor.ITextModel {
+    const vendoredPath = this.getVendoredPath(uri);
+    const fileHandle = this.getOrCreateVendoredFileHandle(vendoredPath);
+    const content = this.props.workspace.sourceText(fileHandle);
+    return this.monaco.editor.createModel(content, "python", uri);
+  }
+
+  private getOrCreateVendoredModel(uri: Uri): editor.ITextModel {
+    return this.monaco.editor.getModel(uri) ?? this.createVendoredModel(uri);
   }
 
   private getFileHandleForModel(model: editor.ITextModel) {
@@ -806,12 +789,16 @@ class PlaygroundServer
     const files = this.props.files;
 
     let model = this.monaco.editor.getModel(resource);
+    let resolvedResource = resource;
 
     if (model == null && resource.scheme === "vendored") {
-      const vendoredPath = this.getVendoredPath(resource);
-      const fileHandle = this.getOrCreateVendoredFileHandle(vendoredPath);
-      const content = this.props.workspace.sourceText(fileHandle);
-      model = this.monaco.editor.createModel(content, "python", resource);
+      model = this.getOrCreateVendoredModel(resource);
+    } else if (model == null) {
+      const file = this.getPlaygroundFileForUri(resource);
+      if (file != null) {
+        resolvedResource = file.uri;
+        model = this.monaco.editor.getModel(file.uri);
+      }
     }
 
     if (model == null) {
@@ -819,14 +806,14 @@ class PlaygroundServer
     }
 
     // Handle file-specific logic
-    if (resource.scheme === "vendored") {
+    if (resolvedResource.scheme === "vendored") {
       // Get the file handle to track that we're viewing a vendored file
-      const vendoredPath = this.getVendoredPath(resource);
+      const vendoredPath = this.getVendoredPath(resolvedResource);
       const fileHandle = this.getOrCreateVendoredFileHandle(vendoredPath);
       this.props.onVendoredFileChange(fileHandle);
     } else {
       // Handle regular files
-      const file = this.getPlaygroundFileForUri(resource);
+      const file = this.getPlaygroundFileForUri(resolvedResource);
 
       if (file == null) {
         return false;
@@ -946,35 +933,16 @@ class PlaygroundServer
     return { edits };
   }
 
+  goToLocation(location: Pick<TyLocation, "path" | "range">): void {
+    const { resource, ...range } = this.mapLocation(location);
+    this.openCodeEditor(this.editor, resource, range);
+  }
+
   private mapNavigationTarget(link: LocationLink): languages.LocationLink {
-    let uri = link.path.startsWith("vendored:")
-      ? Uri.parse(link.path)
-      : Uri.file(link.path);
-
-    // Pre-create models to ensure peek definition works
-    if (this.monaco.editor.getModel(uri) == null) {
-      if (uri.scheme === "vendored") {
-        // Handle vendored files
-        const vendoredPath = this.getVendoredPath(uri);
-        const fileHandle = this.getOrCreateVendoredFileHandle(vendoredPath);
-        const content = this.props.workspace.sourceText(fileHandle);
-        this.monaco.editor.createModel(content, "python", uri);
-      } else {
-        // Regular file models are owned by Monaco and created by the playground.
-        const file = this.getPlaygroundFileForUri(uri);
-        if (file == null) {
-          return {
-            uri,
-            range: tyRangeToMonacoRange(link.full_range),
-          } as languages.LocationLink;
-        }
-
-        const model = this.monaco.editor.getModel(file.uri);
-        if (model != null) {
-          uri = model.uri;
-        }
-      }
-    }
+    const location = this.mapLocation({
+      path: link.path,
+      range: link.full_range,
+    });
 
     const targetSelection =
       link.selection_range == null
@@ -987,11 +955,67 @@ class PlaygroundServer
         : tyRangeToMonacoRange(link.origin_selection_range);
 
     return {
-      uri: uri,
-      range: tyRangeToMonacoRange(link.full_range),
+      uri: location.resource,
+      range: {
+        startLineNumber: location.startLineNumber,
+        startColumn: location.startColumn,
+        endLineNumber: location.endLineNumber,
+        endColumn: location.endColumn,
+      },
       targetSelectionRange: targetSelection,
       originSelectionRange: originSelection,
     } as languages.LocationLink;
+  }
+
+  private uriForPath(path: string): Uri {
+    return path.startsWith("vendored:") ? Uri.parse(path) : Uri.file(path);
+  }
+
+  private resolveLocationUri(path: string): Uri {
+    const uri = this.uriForPath(path);
+
+    if (this.monaco.editor.getModel(uri) != null) {
+      return uri;
+    }
+
+    if (uri.scheme === "vendored") {
+      return this.getOrCreateVendoredModel(uri).uri;
+    }
+
+    const file = this.getPlaygroundFileForUri(uri);
+    if (file == null) {
+      return uri;
+    }
+
+    return this.monaco.editor.getModel(file.uri)?.uri ?? file.uri;
+  }
+
+  private mapLocation(
+    location: Pick<TyLocation, "path" | "range">,
+  ): { resource: Uri } & IRange {
+    return {
+      resource: this.resolveLocationUri(location.path),
+      ...tyRangeToMonacoRange(location.range),
+    };
+  }
+
+  private diagnosticRelatedInformation(
+    diagnostic: Diagnostic,
+  ): editor.IRelatedInformation[] {
+    return diagnostic.subDiagnostics.flatMap((subDiagnostic) => {
+      const location = subDiagnostic.location;
+
+      if (location == null) {
+        return [];
+      }
+
+      return [
+        {
+          message: formatSubDiagnostic(subDiagnostic),
+          ...this.mapLocation(location),
+        },
+      ];
+    });
   }
 
   private mapNavigationTargets(
@@ -1018,15 +1042,19 @@ function tyRangeToMonacoRange(range: TyRange): IRange {
 }
 
 function diagnosticDisplayMessage(diagnostic: Diagnostic): string {
-  const details = diagnostic.details.filter(
-    (detail) => detail.range == null || detail.path == null,
+  const subDiagnostics = diagnostic.subDiagnostics.filter(
+    (subDiagnostic) => subDiagnostic.location == null,
   );
 
-  if (details.length === 0) {
+  if (subDiagnostics.length === 0) {
     return diagnostic.message;
   }
 
-  return `${diagnostic.message}\n\n${details.map((detail) => detail.message).join("\n")}`;
+  return `${diagnostic.message}\n\n${subDiagnostics.map(formatSubDiagnostic).join("\n")}`;
+}
+
+function formatSubDiagnostic(subDiagnostic: SubDiagnostic): string {
+  return `${subDiagnostic.severity}: ${subDiagnostic.message}`;
 }
 
 function monacoRangeToTyRange(range: IRange): TyRange {


### PR DESCRIPTION
## Summary

@decorator-factory [said](https://discord.com/channels/267624335836053506/891788761371906108/1510258224719204352) on the Python community Discord that

>  Maybe better error messages are a good reason to recommend pyright over other things.

It turns out they'd been evaluating ty's diagnostics purely on the diagnostics they could see in the ty playground. That seems a bit of a shame, since we've improved our diagnostics a lot recently thanks to @sharkdp's excellent work -- but none of those improvements are visible in the playground right now, as the playground doesn't render any subdiagnostics currently!

This PR adds subdiagnostics to the Ruff and ty playgrounds: both in the "diagnostics" panel at the bottom of the playground, and in the tooltip rendering when you hover over a line with a diagnostic. In both cases, subdiagnostics with annotations are clickable, allowing you to jump straight to the line of code being annotated (even if it's in another file, even if that file is a vendored typeshed stub).

Obviously I'm very much not a frontend developer; this patch was very much Codex-driven. I manually tested it, however, and did several `/review` and `$simplify` rounds with Codex before submitting this.

## Test Plan


https://github.com/user-attachments/assets/3418d337-0f34-4e9f-8203-3da2f2008b86

