### PR TITLE
Fix potential index out of range in `LineIndex` computation

### DIFF
--- a/crates/ruff_source_file/src/line_index.rs
+++ b/crates/ruff_source_file/src/line_index.rs
@@ -294,7 +294,19 @@ impl LineIndex {
         if row_index.saturating_add(1) >= starts.len() {
             contents.text_len()
         } else {
-            starts[row_index + 1] - TextSize::new(1)
+            let next_line_start = starts[row_index + 1].to_usize();
+            let bytes = contents.as_bytes();
+
+            let line_ending_len = if bytes[next_line_start - 1] == b'\n'
+                && next_line_start >= 2
+                && bytes[next_line_start - 2] == b'\r'
+            {
+                2
+            } else {
+                1
+            };
+
+            starts[row_index + 1] - TextSize::new(line_ending_len)
         }
     }
 
@@ -809,6 +821,42 @@ mod tests {
                 line: OneIndexed::from_zero_indexed(1),
                 column: OneIndexed::from_zero_indexed(1)
             }
+        );
+    }
+
+    #[test]
+    fn line_end_exclusive_handles_different_line_endings() {
+        let lf_contents = "a\nb";
+        let lf_index = LineIndex::from_source_text(lf_contents);
+        assert_eq!(
+            lf_index.line_end_exclusive(OneIndexed::from_zero_indexed(0), lf_contents),
+            TextSize::from(1)
+        );
+        assert_eq!(
+            lf_index.line_end_exclusive(OneIndexed::from_zero_indexed(1), lf_contents),
+            TextSize::from(3)
+        );
+
+        let crlf_contents = "a\r\nb";
+        let crlf_index = LineIndex::from_source_text(crlf_contents);
+        assert_eq!(
+            crlf_index.line_end_exclusive(OneIndexed::from_zero_indexed(0), crlf_contents),
+            TextSize::from(1)
+        );
+        assert_eq!(
+            crlf_index.line_end_exclusive(OneIndexed::from_zero_indexed(1), crlf_contents),
+            TextSize::from(4)
+        );
+
+        let cr_contents = "a\rb";
+        let cr_index = LineIndex::from_source_text(cr_contents);
+        assert_eq!(
+            cr_index.line_end_exclusive(OneIndexed::from_zero_indexed(0), cr_contents),
+            TextSize::from(1)
+        );
+        assert_eq!(
+            cr_index.line_end_exclusive(OneIndexed::from_zero_indexed(1), cr_contents),
+            TextSize::from(3)
         );
     }
 

--- a/crates/ruff_source_file/src/line_index.rs
+++ b/crates/ruff_source_file/src/line_index.rs
@@ -297,15 +297,11 @@ impl LineIndex {
             let next_line_start = starts[row_index + 1].to_usize();
             let bytes = contents.as_bytes();
 
-            let line_ending_len = if bytes[next_line_start - 1] == b'\n'
-                && next_line_start >= 2
-                && bytes[next_line_start - 2] == b'\r'
-            {
+            let line_ending_len = if bytes[..next_line_start].ends_with(b"\r\n") {
                 2
             } else {
                 1
             };
-
             starts[row_index + 1] - TextSize::new(line_ending_len)
         }
     }


### PR DESCRIPTION
## Summary

`LineIndex::line_end_exclusive` always subtracts one byte from the start of the next line. That works for `\n` and `\r`, but it returns the wrong offset for `\r\n` line endings.

This updates the helper to subtract the full line-ending width and adds unit tests covering LF, CRLF, and CR inputs.

## Test Plan

- `cargo fmt -p ruff_source_file --check`
- `cargo test -p ruff_source_file`
