### PR TITLE
fix(docs): SIM107 'Use instead' example always returns -1

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -30,12 +30,21 @@ use crate::checkers::ast::Checker;
 /// ```python
 /// def squared(n):
 ///     try:
-///         return_value = n**2
+///         return n**2
 ///     except Exception:
-///         return_value = "An exception occurred"
+///         return "An exception occurred"
+/// ```
+///
+/// Or, if cleanup is needed, use a `finally` block for cleanup only
+/// (without modifying the return value):
+/// ```python
+/// def squared(n):
+///     try:
+///         return n**2
+///     except Exception:
+///         return "An exception occurred"
 ///     finally:
-///         return_value = -1
-///     return return_value
+///         cleanup()  # Cleanup without affecting the return value
 /// ```
 ///
 /// ## References


### PR DESCRIPTION
Closes #22325.

The current "Use instead" example for SIM107 is misleading:

```python
def squared(n):
    try:
        return_value = n**2
    except Exception:
        return_value = "An exception occurred"
    finally:
        return_value = -1
    return return_value
```

This always returns `-1` because the `finally` block always executes and overwrites `return_value`, regardless of whether an exception occurred.

The fix replaces the example with two correct patterns:
1. Simply return from `try`/`except` without a `finally` block
2. Use `finally` only for cleanup that doesn't affect the return value