### PR TITLE
[ty] Compact retained definition maps

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -58,8 +58,9 @@ use crate::use_def::{
 };
 use crate::{Db, Statement, StatementNodeKey};
 use crate::{
-    EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopToken, NarrowingAliasPredicate,
-    PossiblyNarrowedPlaces, SemanticIndex, VisibleAncestorsIter, get_loop_header,
+    DefinitionsByNode, EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopToken,
+    NarrowingAliasPredicate, PossiblyNarrowedPlaces, SemanticIndex, VisibleAncestorsIter,
+    get_loop_header,
 };
 
 use super::place::PlaceExprRef;
@@ -2241,7 +2242,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         SemanticIndex {
             place_tables: place_tables.into(),
             scopes: self.scopes.into(),
-            definitions_by_node: self.definitions_by_node,
+            definitions_by_node: DefinitionsByNode::from_map(self.definitions_by_node),
             expressions_by_node: self.expressions_by_node,
             statements_by_node: self.statements_by_node,
             scope_ids_by_scope: self.scope_ids_by_scope.into(),

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -199,6 +199,10 @@ impl<'db> Definitions<'db> {
     pub fn push(&mut self, definition: Definition<'db>) {
         self.definitions.push(definition);
     }
+
+    pub(crate) fn into_vec(self) -> Vec<Definition<'db>> {
+        self.definitions.into_vec()
+    }
 }
 
 impl<'db> Deref for Definitions<'db> {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -256,6 +256,41 @@ pub enum EnclosingSnapshotResult<'map, 'db> {
     NoLongerInEagerContext,
 }
 
+#[derive(Debug, PartialEq, Eq, Update, get_size2::GetSize)]
+struct DefinitionsByNode<'db> {
+    single: FxHashMap<DefinitionNodeKey, Definition<'db>>,
+    multiple: FxHashMap<DefinitionNodeKey, Box<[Definition<'db>]>>,
+}
+
+impl<'db> DefinitionsByNode<'db> {
+    fn from_map(definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>) -> Self {
+        let mut single = FxHashMap::default();
+        let mut multiple = FxHashMap::default();
+        single.reserve(definitions_by_node.len());
+
+        for (key, definitions) in definitions_by_node {
+            let definitions = definitions.into_vec();
+            if let [definition] = definitions.as_slice() {
+                single.insert(key, *definition);
+            } else {
+                multiple.insert(key, definitions.into_boxed_slice());
+            }
+        }
+
+        single.shrink_to_fit();
+        multiple.shrink_to_fit();
+
+        Self { single, multiple }
+    }
+
+    fn get(&self, key: DefinitionNodeKey) -> Option<&[Definition<'db>]> {
+        self.single
+            .get(&key)
+            .map(std::slice::from_ref)
+            .or_else(|| self.multiple.get(&key).map(AsRef::as_ref))
+    }
+}
+
 /// The place tables and use-def maps for all scopes in a file.
 #[derive(Debug, Update, get_size2::GetSize)]
 pub struct SemanticIndex<'db> {
@@ -269,7 +304,7 @@ pub struct SemanticIndex<'db> {
     scopes_by_expression: ExpressionsScopeMap,
 
     /// Map from a node creating a definition to its definition.
-    definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>,
+    definitions_by_node: DefinitionsByNode<'db>,
 
     /// Map from a standalone expression to its [`Expression`] ingredient.
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
@@ -527,17 +562,19 @@ impl<'db> SemanticIndex<'db> {
     /// There will only ever be >1 `Definition` associated with a `definition_key`
     /// if the definition is created by a wildcard (`*`) import.
     #[track_caller]
-    pub fn definitions(&self, definition_key: impl Into<DefinitionNodeKey>) -> &Definitions<'db> {
-        &self.definitions_by_node[&definition_key.into()]
+    pub fn definitions(&self, definition_key: impl Into<DefinitionNodeKey>) -> &[Definition<'db>] {
+        self.definitions_by_node
+            .get(definition_key.into())
+            .expect("definition should be present in the semantic index")
     }
 
     /// Returns the [`definition::Definition`] salsa ingredient(s) for `definition_node`, if any.
     pub fn try_definitions(
         &self,
         definition_node: ast::AnyNodeRef<'_>,
-    ) -> Option<&Definitions<'db>> {
+    ) -> Option<&[Definition<'db>]> {
         let definition_key = DefinitionNodeKey::from_node_ref(definition_node);
-        self.definitions_by_node.get(&definition_key)
+        self.definitions_by_node.get(definition_key)
     }
 
     /// Returns the [`definition::Definition`] salsa ingredient for `definition_key`.
@@ -571,7 +608,7 @@ impl<'db> SemanticIndex<'db> {
         definition_key: impl Into<DefinitionNodeKey>,
     ) -> Option<Definition<'db>> {
         self.definitions_by_node
-            .get(&definition_key.into())?
+            .get(definition_key.into())?
             .iter()
             .copied()
             .exactly_one()

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -163,11 +163,10 @@
 //! The data structure we build to answer these questions is the `UseDefMap`. It has a
 //! `bindings_by_use` vector of [`InternedBindingsId`] indexed by [`ScopedUseId`]
 //! (plus an interned bindings table), a
-//! `declarations_by_binding` map of [`InternedDeclarationsId`], a `bindings_by_definition` map of
-//! [`InternedBindingsId`], and `symbol_states` and `member_states` vectors indexed by
-//! [`ScopedSymbolId`]/[`ScopedMemberId`]. The values are (in principle) a list of live bindings at
-//! that use/definition, or at the end of the scope for that place, with a list of the dominating
-//! constraints for each binding.
+//! `definitions_by_definition` map of [`DefinitionsAtDefinition`], and `symbol_states` and
+//! `member_states` vectors indexed by [`ScopedSymbolId`]/[`ScopedMemberId`]. The values are (in
+//! principle) a list of live bindings at that use/definition, or at the end of the scope for that
+//! place, with a list of the dominating constraints for each binding.
 //!
 //! In order to avoid vectors-of-vectors-of-vectors and all the allocations that would entail, we
 //! don't actually store these "list of visible definitions" as a vector of [`Definition`].
@@ -240,9 +239,12 @@
 //! [`SemanticIndexBuilder`](crate::builder::SemanticIndexBuilder), e.g. where it
 //! visits a `StmtIf` node.
 
+use std::hash::Hash;
+
 use ruff_index::{FrozenIndexVec, Idx, IndexSlice, IndexVec, newtype_index};
 use ruff_text_size::TextRange;
 use rustc_hash::{FxBuildHasher, FxHashMap};
+use salsa::plumbing::AsId;
 use thin_vec::ThinVec;
 
 use crate::ast_ids::ScopedUseId;
@@ -297,6 +299,62 @@ struct RetainedPlaceStates<T> {
     reachable: ReachableDefinitions,
 }
 
+#[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+struct DefinitionsAtDefinition<B, D> {
+    bindings: B,
+    declarations: Option<D>,
+}
+
+/// An immutable map optimized for the small per-scope definition maps that dominate in practice.
+#[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+enum RetainedDefinitionMap<K: Eq + Hash, V> {
+    Small(Box<[(K, V)]>),
+    Large(Box<FxHashMap<K, V>>),
+}
+
+impl<K, V> RetainedDefinitionMap<K, V>
+where
+    K: AsId + Eq + Hash,
+{
+    const SMALL_MAP_THRESHOLD: usize = 16;
+
+    fn from_entries(mut entries: Vec<(K, V)>) -> Self {
+        if entries.len() <= Self::SMALL_MAP_THRESHOLD {
+            entries.sort_unstable_by_key(|(key, _)| key.as_id());
+            Self::Small(entries.into_boxed_slice())
+        } else {
+            let mut map = FxHashMap::with_capacity_and_hasher(entries.len(), FxBuildHasher);
+            map.extend(entries);
+            Self::Large(Box::new(map))
+        }
+    }
+
+    fn get(&self, key: &K) -> Option<&V> {
+        match self {
+            Self::Small(entries) => {
+                let key_id = key.as_id();
+                entries
+                    .binary_search_by_key(&key_id, |(candidate, _)| candidate.as_id())
+                    .ok()
+                    .map(|index| &entries[index].1)
+            }
+            Self::Large(map) => map.get(key),
+        }
+    }
+}
+
+impl<K, V> std::ops::Index<&K> for RetainedDefinitionMap<K, V>
+where
+    K: AsId + Eq + Hash,
+{
+    type Output = V;
+
+    #[track_caller]
+    fn index(&self, index: &K) -> &Self::Output {
+        self.get(index).expect("key not found")
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
 enum InternedEnclosingSnapshotId {
     Constraint(ScopedNarrowingConstraint),
@@ -346,19 +404,17 @@ pub struct UseDefMap<'db> {
     /// If the definition is both a declaration and a binding -- `x: int = 1` for example -- then
     /// we don't actually need anything here, all we'll need to validate is that our own RHS is a
     /// valid assignment to our own annotation.
-    declarations_by_binding: FxHashMap<Definition<'db>, InternedDeclarationsId>,
-
+    ///
     /// If the definition is a declaration (only) -- `x: int` for example -- then we need
     /// [`Bindings`] to know whether this declaration is consistent with the previously
     /// inferred type.
     ///
-    /// If the definition is both a declaration and a binding -- `x: int = 1` for example -- then
-    /// we don't actually need anything here, all we'll need to validate is that our own RHS is a
-    /// valid assignment to our own annotation.
-    ///
-    /// If we see a binding to a `Final`-qualified symbol, we also need this map to find previous
-    /// bindings to that symbol. If there are any, the assignment is invalid.
-    bindings_by_definition: FxHashMap<Definition<'db>, InternedBindingsId>,
+    /// If we see a binding to a `Final`-qualified symbol, we also need the bindings to find
+    /// previous bindings to that symbol. If there are any, the assignment is invalid.
+    definitions_by_definition: RetainedDefinitionMap<
+        Definition<'db>,
+        DefinitionsAtDefinition<InternedBindingsId, InternedDeclarationsId>,
+    >,
 
     /// Retained [`PlaceState`] values for each symbol.
     symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<PlaceState>>,
@@ -618,7 +674,7 @@ impl<'db> UseDefMap<'db> {
         &self,
         definition: Definition<'db>,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let bindings_id = self.bindings_by_definition[&definition];
+        let bindings_id = self.definitions_by_definition[&definition].bindings;
         self.bindings_iterator(
             &self.interned_bindings[bindings_id],
             BoundnessAnalysis::BasedOnUnboundVisibility,
@@ -629,7 +685,9 @@ impl<'db> UseDefMap<'db> {
         &self,
         binding: Definition<'db>,
     ) -> DeclarationsIterator<'_, 'db> {
-        let declarations_id = self.declarations_by_binding[&binding];
+        let declarations_id = self.definitions_by_definition[&binding]
+            .declarations
+            .expect("binding definition should have retained declarations");
         self.declarations_iterator(
             &self.interned_declarations[declarations_id],
             BoundnessAnalysis::BasedOnUnboundVisibility,
@@ -967,11 +1025,10 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// keyed by their text range.
     range_reachability: Vec<(TextRange, RangeInfo)>,
 
-    /// Live declarations for each so-far-recorded binding.
-    declarations_by_binding: FxHashMap<Definition<'db>, Declarations>,
-
-    /// Live bindings for each so-far-recorded definition.
-    bindings_by_definition: FxHashMap<Definition<'db>, Bindings>,
+    /// Live bindings for each so-far-recorded definition and, for binding-only definitions, the
+    /// live declarations.
+    definitions_by_definition:
+        FxHashMap<Definition<'db>, DefinitionsAtDefinition<Bindings, Declarations>>,
 
     /// Currently live bindings and declarations for each place.
     symbol_states: IndexVec<ScopedSymbolId, PlaceState>,
@@ -1002,8 +1059,7 @@ impl<'db> UseDefMapBuilder<'db> {
             multi_bindings_by_use: FxHashMap::default(),
             reachability: ScopedReachabilityConstraintId::ALWAYS_TRUE,
             range_reachability: Vec::new(),
-            declarations_by_binding: FxHashMap::default(),
-            bindings_by_definition: FxHashMap::default(),
+            definitions_by_definition: FxHashMap::default(),
             symbol_states: IndexVec::new(),
             member_states: IndexVec::new(),
             reachable_member_definitions: IndexVec::new(),
@@ -1084,20 +1140,22 @@ impl<'db> UseDefMapBuilder<'db> {
         previous_definitions: PreviousDefinitions,
     ) {
         let bindings = match place {
-            ScopedPlaceId::Symbol(symbol) => self.symbol_states[symbol].bindings(),
-            ScopedPlaceId::Member(member) => self.member_states[member].bindings(),
+            ScopedPlaceId::Symbol(symbol) => self.symbol_states[symbol].bindings().clone(),
+            ScopedPlaceId::Member(member) => self.member_states[member].bindings().clone(),
         };
-
-        self.bindings_by_definition
-            .insert(binding, bindings.clone());
 
         let def_id = self.push_definition(DefinitionState::Defined(binding));
         let place_state = match place {
             ScopedPlaceId::Symbol(symbol) => &mut self.symbol_states[symbol],
             ScopedPlaceId::Member(member) => &mut self.member_states[member],
         };
-        self.declarations_by_binding
-            .insert(binding, place_state.declarations().clone());
+        self.definitions_by_definition.insert(
+            binding,
+            DefinitionsAtDefinition {
+                bindings,
+                declarations: Some(place_state.declarations().clone()),
+            },
+        );
 
         place_state.record_binding(
             def_id,
@@ -1353,8 +1411,13 @@ impl<'db> UseDefMapBuilder<'db> {
             ScopedPlaceId::Member(member) => &mut self.member_states[member],
         };
 
-        self.bindings_by_definition
-            .insert(declaration, place_state.bindings().clone());
+        self.definitions_by_definition.insert(
+            declaration,
+            DefinitionsAtDefinition {
+                bindings: place_state.bindings().clone(),
+                declarations: None,
+            },
+        );
         place_state.record_declaration(def_id, self.reachability);
 
         let definitions = match place {
@@ -1374,8 +1437,8 @@ impl<'db> UseDefMapBuilder<'db> {
         place: ScopedPlaceId,
         definition: Definition<'db>,
     ) {
-        // We don't need to store anything in self.bindings_by_declaration or
-        // self.declarations_by_binding.
+        // We don't need to store prior state for a definition that is both a declaration and a
+        // binding.
         let def_id = self.push_definition(DefinitionState::Defined(definition));
         let place_state = match place {
             ScopedPlaceId::Symbol(symbol) => &mut self.symbol_states[symbol],
@@ -1703,22 +1766,26 @@ impl<'db> UseDefMapBuilder<'db> {
         self.range_reachability.shrink_to_fit();
         self.enclosing_snapshots.shrink_to_fit();
 
-        let mut interned_bindings = IndexVec::with_capacity(self.bindings_by_definition.len());
-        let mut interned_ids_by_bindings =
-            FxHashMap::with_capacity_and_hasher(self.bindings_by_definition.len(), FxBuildHasher);
-        let mut interned_declarations = IndexVec::with_capacity(self.declarations_by_binding.len());
-        let mut interned_ids_by_declarations =
-            FxHashMap::with_capacity_and_hasher(self.declarations_by_binding.len(), FxBuildHasher);
-        // These fields are manually interned because they have a statistically high duplication rate (>50%).
-        let bindings_by_definition = Self::intern_bindings_by_definition(
-            self.bindings_by_definition,
-            &mut interned_bindings,
-            &mut interned_ids_by_bindings,
+        let mut interned_bindings = IndexVec::with_capacity(self.definitions_by_definition.len());
+        let mut interned_ids_by_bindings = FxHashMap::with_capacity_and_hasher(
+            self.definitions_by_definition.len(),
+            FxBuildHasher,
         );
-        let declarations_by_binding = Self::intern_declarations_by_binding(
-            self.declarations_by_binding,
+        let declarations_capacity = self
+            .definitions_by_definition
+            .values()
+            .filter(|definitions| definitions.declarations.is_some())
+            .count();
+        let mut interned_declarations = IndexVec::with_capacity(declarations_capacity);
+        let mut interned_ids_by_declarations =
+            FxHashMap::with_capacity_and_hasher(declarations_capacity, FxBuildHasher);
+        // These fields are manually interned because they have a statistically high duplication rate (>50%).
+        let definitions_by_definition = Self::intern_definitions_by_definition(
+            self.definitions_by_definition,
             &mut interned_declarations,
             &mut interned_ids_by_declarations,
+            &mut interned_bindings,
+            &mut interned_ids_by_bindings,
         );
         let bindings_by_use = Self::intern_bindings_by_use(
             self.bindings_by_use,
@@ -1799,8 +1866,7 @@ impl<'db> UseDefMapBuilder<'db> {
             range_reachability: self.range_reachability.into_boxed_slice(),
             symbol_states,
             member_states,
-            declarations_by_binding,
-            bindings_by_definition,
+            definitions_by_definition,
             enclosing_snapshots: enclosing_snapshots.into(),
             end_of_scope_reachability: self.reachability,
         }
@@ -1822,49 +1888,55 @@ impl<'db> UseDefMapBuilder<'db> {
             .collect()
     }
 
-    fn intern_bindings_by_definition(
-        bindings_by_definition: FxHashMap<Definition<'db>, Bindings>,
+    fn intern_definitions_by_definition(
+        definitions_by_definition: FxHashMap<
+            Definition<'db>,
+            DefinitionsAtDefinition<Bindings, Declarations>,
+        >,
+        interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
+        interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
         interned_bindings: &mut IndexVec<InternedBindingsId, Bindings>,
         interned_ids_by_bindings: &mut FxHashMap<Bindings, InternedBindingsId>,
-    ) -> FxHashMap<Definition<'db>, InternedBindingsId> {
-        let mut interned_ids_by_definition: FxHashMap<Definition<'db>, InternedBindingsId> =
-            FxHashMap::with_capacity_and_hasher(bindings_by_definition.len(), FxBuildHasher);
+    ) -> RetainedDefinitionMap<
+        Definition<'db>,
+        DefinitionsAtDefinition<InternedBindingsId, InternedDeclarationsId>,
+    > {
+        let mut interned_ids_by_definition = Vec::with_capacity(definitions_by_definition.len());
 
-        for (definition, bindings) in bindings_by_definition {
-            let interned_id = if let Some(interned_id) = interned_ids_by_bindings.get(&bindings) {
+        for (
+            definition,
+            DefinitionsAtDefinition {
+                bindings,
+                declarations,
+            },
+        ) in definitions_by_definition
+        {
+            let bindings = if let Some(interned_id) = interned_ids_by_bindings.get(&bindings) {
                 *interned_id
             } else {
                 let interned_id = interned_bindings.push(bindings.clone());
                 interned_ids_by_bindings.insert(bindings, interned_id);
                 interned_id
             };
-            interned_ids_by_definition.insert(definition, interned_id);
-        }
-
-        interned_ids_by_definition
-    }
-
-    fn intern_declarations_by_binding(
-        declarations_by_binding: FxHashMap<Definition<'db>, Declarations>,
-        interned_declarations: &mut IndexVec<InternedDeclarationsId, Declarations>,
-        interned_ids_by_declarations: &mut FxHashMap<Declarations, InternedDeclarationsId>,
-    ) -> FxHashMap<Definition<'db>, InternedDeclarationsId> {
-        let mut interned_ids_by_binding: FxHashMap<Definition<'db>, InternedDeclarationsId> =
-            FxHashMap::with_capacity_and_hasher(declarations_by_binding.len(), FxBuildHasher);
-
-        for (binding, declarations) in declarations_by_binding {
-            let interned_id =
+            let declarations = declarations.map(|declarations| {
                 if let Some(interned_id) = interned_ids_by_declarations.get(&declarations) {
                     *interned_id
                 } else {
                     let interned_id = interned_declarations.push(declarations.clone());
                     interned_ids_by_declarations.insert(declarations, interned_id);
                     interned_id
-                };
-            interned_ids_by_binding.insert(binding, interned_id);
+                }
+            });
+            interned_ids_by_definition.push((
+                definition,
+                DefinitionsAtDefinition {
+                    bindings,
+                    declarations,
+                },
+            ));
         }
 
-        interned_ids_by_binding
+        RetainedDefinitionMap::from_entries(interned_ids_by_definition)
     }
 
     fn intern_bindings_by_use(


### PR DESCRIPTION
## Summary

- consolidate retained binding and declaration state keyed by definition into one immutable map
- store small retained definition maps as sorted slices and preserve hashed lookup for larger maps
- store common single-definition AST node entries directly and reserve boxed slices for rare multi-definition entries

## Memory

On a bounded internal workload with `api` excluded:

- `main`: `17,187,916,248` retained bytes
- this PR: `16,961,951,904` retained bytes
- reduction: `225,964,344` bytes (`1.314670%`)

## Test Plan

- `cargo test -p ty_python_core -p ty_python_semantic`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `uvx prek run --files crates/ty_python_core/src/builder.rs crates/ty_python_core/src/definition.rs crates/ty_python_core/src/lib.rs crates/ty_python_core/src/use_def.rs`