### PR TITLE
[ty] Compact retained definitions by node

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -59,8 +59,9 @@ use crate::use_def::{
 };
 use crate::{Db, Statement, StatementNodeKey};
 use crate::{
-    EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopToken, NarrowingAliasPredicate,
-    PossiblyNarrowedPlaces, SemanticIndex, VisibleAncestorsIter, get_loop_header,
+    DefinitionsByNode, EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopToken,
+    NarrowingAliasPredicate, PossiblyNarrowedPlaces, SemanticIndex, VisibleAncestorsIter,
+    get_loop_header,
 };
 
 use super::place::PlaceExprRef;
@@ -2239,7 +2240,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         SemanticIndex {
             place_tables: place_tables.into(),
             scopes: self.scopes.into(),
-            definitions_by_node: self.definitions_by_node,
+            definitions_by_node: DefinitionsByNode::from_map(self.definitions_by_node),
             expressions_by_node: self.expressions_by_node,
             statements_by_node: self.statements_by_node,
             scope_ids_by_scope: self.scope_ids_by_scope.into(),

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -201,8 +201,8 @@ impl<'db> Definitions<'db> {
         self.definitions.push(definition);
     }
 
-    pub(crate) fn into_vec(self) -> Vec<Definition<'db>> {
-        self.definitions.into_vec()
+    pub(crate) fn into_boxed_slice(self) -> Box<[Definition<'db>]> {
+        self.definitions.into_vec().into_boxed_slice()
     }
 }
 

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -200,6 +200,10 @@ impl<'db> Definitions<'db> {
     pub fn push(&mut self, definition: Definition<'db>) {
         self.definitions.push(definition);
     }
+
+    pub(crate) fn into_vec(self) -> Vec<Definition<'db>> {
+        self.definitions.into_vec()
+    }
 }
 
 impl<'db> Deref for Definitions<'db> {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -265,35 +265,34 @@ pub enum EnclosingSnapshotResult<'map, 'db> {
 #[derive(Debug, PartialEq, Eq, Update, get_size2::GetSize)]
 struct DefinitionsByNode<'db> {
     single: FxHashMap<DefinitionNodeKey, Definition<'db>>,
-    multiple: FxHashMap<DefinitionNodeKey, Box<[Definition<'db>]>>,
+    non_single: FxHashMap<DefinitionNodeKey, Box<[Definition<'db>]>>,
 }
 
 impl<'db> DefinitionsByNode<'db> {
     fn from_map(definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>) -> Self {
         let mut single = FxHashMap::default();
-        let mut multiple = FxHashMap::default();
+        let mut non_single = FxHashMap::default();
         single.reserve(definitions_by_node.len());
 
         for (key, definitions) in definitions_by_node {
-            let definitions = definitions.into_vec();
-            if let [definition] = definitions.as_slice() {
-                single.insert(key, *definition);
+            if definitions.len() == 1 {
+                single.insert(key, definitions[0]);
             } else {
-                multiple.insert(key, definitions.into_boxed_slice());
+                non_single.insert(key, definitions.into_boxed_slice());
             }
         }
 
         single.shrink_to_fit();
-        multiple.shrink_to_fit();
+        non_single.shrink_to_fit();
 
-        Self { single, multiple }
+        Self { single, non_single }
     }
 
     fn get(&self, key: DefinitionNodeKey) -> Option<&[Definition<'db>]> {
         self.single
             .get(&key)
             .map(std::slice::from_ref)
-            .or_else(|| self.multiple.get(&key).map(AsRef::as_ref))
+            .or_else(|| self.non_single.get(&key).map(AsRef::as_ref))
     }
 }
 
@@ -565,7 +564,8 @@ impl<'db> SemanticIndex<'db> {
     /// Returns the [`definition::Definition`] salsa ingredient(s) for `definition_key`.
     ///
     /// There will only ever be >1 `Definition` associated with a `definition_key`
-    /// if the definition is created by a wildcard (`*`) import.
+    /// if the definitions are created by a wildcard (`*`) import or synthesized
+    /// for a loop header.
     #[track_caller]
     pub fn definitions(&self, definition_key: impl Into<DefinitionNodeKey>) -> &[Definition<'db>] {
         self.definitions_by_node
@@ -590,9 +590,9 @@ impl<'db> SemanticIndex<'db> {
     /// the `debug_assertions` feature is enabled, this method will panic.
     ///
     /// It is generally safe to use this method for any AST node that does not
-    /// correspond to a `*` (wildcard) import, since `*` imports are the only
-    /// situations that can result in multiple definitions being associated with a
-    /// single AST node.
+    /// correspond to a `*` (wildcard) import or a loop statement, since those are
+    /// the only situations that can result in multiple definitions being
+    /// associated with a single AST node.
     #[track_caller]
     pub fn expect_single_definition(
         &self,

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -262,6 +262,41 @@ pub enum EnclosingSnapshotResult<'map, 'db> {
     NoLongerInEagerContext,
 }
 
+#[derive(Debug, PartialEq, Eq, Update, get_size2::GetSize)]
+struct DefinitionsByNode<'db> {
+    single: FxHashMap<DefinitionNodeKey, Definition<'db>>,
+    multiple: FxHashMap<DefinitionNodeKey, Box<[Definition<'db>]>>,
+}
+
+impl<'db> DefinitionsByNode<'db> {
+    fn from_map(definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>) -> Self {
+        let mut single = FxHashMap::default();
+        let mut multiple = FxHashMap::default();
+        single.reserve(definitions_by_node.len());
+
+        for (key, definitions) in definitions_by_node {
+            let definitions = definitions.into_vec();
+            if let [definition] = definitions.as_slice() {
+                single.insert(key, *definition);
+            } else {
+                multiple.insert(key, definitions.into_boxed_slice());
+            }
+        }
+
+        single.shrink_to_fit();
+        multiple.shrink_to_fit();
+
+        Self { single, multiple }
+    }
+
+    fn get(&self, key: DefinitionNodeKey) -> Option<&[Definition<'db>]> {
+        self.single
+            .get(&key)
+            .map(std::slice::from_ref)
+            .or_else(|| self.multiple.get(&key).map(AsRef::as_ref))
+    }
+}
+
 /// The place tables and use-def maps for all scopes in a file.
 #[derive(Debug, Update, get_size2::GetSize)]
 pub struct SemanticIndex<'db> {
@@ -275,7 +310,7 @@ pub struct SemanticIndex<'db> {
     scopes_by_expression: ExpressionsScopeMap,
 
     /// Map from a node creating a definition to its definition.
-    definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>,
+    definitions_by_node: DefinitionsByNode<'db>,
 
     /// Map from a standalone expression to its [`Expression`] ingredient.
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
@@ -532,17 +567,19 @@ impl<'db> SemanticIndex<'db> {
     /// There will only ever be >1 `Definition` associated with a `definition_key`
     /// if the definition is created by a wildcard (`*`) import.
     #[track_caller]
-    pub fn definitions(&self, definition_key: impl Into<DefinitionNodeKey>) -> &Definitions<'db> {
-        &self.definitions_by_node[&definition_key.into()]
+    pub fn definitions(&self, definition_key: impl Into<DefinitionNodeKey>) -> &[Definition<'db>] {
+        self.definitions_by_node
+            .get(definition_key.into())
+            .expect("definition should be present in the semantic index")
     }
 
     /// Returns the [`definition::Definition`] salsa ingredient(s) for `definition_node`, if any.
     pub fn try_definitions(
         &self,
         definition_node: ast::AnyNodeRef<'_>,
-    ) -> Option<&Definitions<'db>> {
+    ) -> Option<&[Definition<'db>]> {
         let definition_key = DefinitionNodeKey::from_node_ref(definition_node);
-        self.definitions_by_node.get(&definition_key)
+        self.definitions_by_node.get(definition_key)
     }
 
     /// Returns the [`definition::Definition`] salsa ingredient for `definition_key`.
@@ -576,7 +613,7 @@ impl<'db> SemanticIndex<'db> {
         definition_key: impl Into<DefinitionNodeKey>,
     ) -> Option<Definition<'db>> {
         self.definitions_by_node
-            .get(&definition_key.into())?
+            .get(definition_key.into())?
             .iter()
             .copied()
             .exactly_one()

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -6,7 +6,6 @@ use ruff_python_ast as ast;
 use std::iter::{FusedIterator, once};
 use std::sync::Arc;
 
-use itertools::Itertools;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_index::{FrozenIndexVec, IndexSlice};
@@ -613,11 +612,9 @@ impl<'db> SemanticIndex<'db> {
         definition_key: impl Into<DefinitionNodeKey>,
     ) -> Option<Definition<'db>> {
         self.definitions_by_node
-            .get(definition_key.into())?
-            .iter()
+            .single
+            .get(&definition_key.into())
             .copied()
-            .exactly_one()
-            .ok()
     }
 
     /// Returns the [`Expression`] ingredient for an expression node.


### PR DESCRIPTION
## Summary

When we build the semantic index, we retain a mapping from definition-producing AST nodes to their definitions. Most nodes have exactly one definition, but we currently store every entry in the append-friendly `Definitions` representation used while building the index.

This PR compacts the mapping when we freeze the semantic index. We store common single-definition entries directly and reserve exact-size boxed slices for uncommon entries with zero or multiple definitions (including wildcard imports and synthesized loop headers).

(The primary motivation here is reducing memory.)
