### PR TITLE
[ty] Omit redundant definitions-by-node entries

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1215,7 +1215,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             is_reexported,
         );
 
-        let num_definitions = {
+        let num_definitions = if is_loop_header {
+            // Loop headers are internal use-def definitions. They are retrieved through the loop
+            // token rather than by their AST node.
+            0
+        } else {
             let definitions = self.add_entry_for_definition_key(definition_node.key());
             definitions.push(definition);
             definitions.len()
@@ -2038,7 +2042,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     fn declare_parameter(&mut self, parameter: &'ast ast::ParameterWithDefault) {
         let symbol = self.add_symbol(parameter.name().id().clone());
 
-        let definition = self.add_definition(
+        self.add_definition(
             symbol.into(),
             ParameterDefinitionNodeRef::Parameter(parameter),
         );
@@ -2046,15 +2050,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.current_place_table_mut()
             .symbol_mut(symbol)
             .mark_parameter();
-
-        // Insert a mapping from the inner Parameter node to the same definition. This
-        // ensures that calling `HasType::inferred_type` on the inner parameter returns
-        // a valid type (and doesn't panic)
-        let existing_definition = self.definitions_by_node.insert(
-            (&parameter.parameter).into(),
-            Definitions::single(definition),
-        );
-        debug_assert_eq!(existing_definition, None);
     }
 
     fn declare_lambda_parameters(
@@ -2114,7 +2109,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     ) {
         let symbol = self.add_symbol(parameter.name().id().clone());
 
-        let definition = self.add_definition(
+        self.add_definition(
             symbol.into(),
             LambdaParameterDefinitionNodeRef {
                 index,
@@ -2126,15 +2121,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.current_place_table_mut()
             .symbol_mut(symbol)
             .mark_parameter();
-
-        // Insert a mapping from the inner Parameter node to the same definition. This
-        // ensures that calling `HasType::inferred_type` on the inner parameter returns
-        // a valid type (and doesn't panic)
-        let existing_definition = self.definitions_by_node.insert(
-            (&parameter.parameter).into(),
-            Definitions::single(definition),
-        );
-        debug_assert_eq!(existing_definition, None);
     }
 
     /// Add an unpackable assignment for the given [`Unpackable`].

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -534,7 +534,7 @@ impl ParameterDefinitionNodeRef<'_> {
         match self {
             Self::VariadicPositionalParameter(node) => node.into(),
             Self::VariadicKeywordParameter(node) => node.into(),
-            Self::Parameter(node) => node.into(),
+            Self::Parameter(node) => (&node.parameter).into(),
         }
     }
 }
@@ -1505,7 +1505,10 @@ pub struct DefinitionNodeKey(NodeKey);
 
 impl DefinitionNodeKey {
     pub(crate) fn from_node_ref(node: ast::AnyNodeRef<'_>) -> Self {
-        Self(NodeKey::from_node(node))
+        match node {
+            ast::AnyNodeRef::ParameterWithDefault(parameter) => parameter.into(),
+            _ => Self(NodeKey::from_node(node)),
+        }
     }
 
     pub fn from_assignment(node: &ast::StmtAssign) -> impl Iterator<Item = DefinitionNodeKey> {
@@ -1601,7 +1604,7 @@ impl From<&ast::Parameter> for DefinitionNodeKey {
 
 impl From<&ast::ParameterWithDefault> for DefinitionNodeKey {
     fn from(node: &ast::ParameterWithDefault) -> Self {
-        Self(NodeKey::from_node(node))
+        Self(NodeKey::from_node(&node.parameter))
     }
 }
 
@@ -1609,7 +1612,7 @@ impl From<ast::AnyParameterRef<'_>> for DefinitionNodeKey {
     fn from(value: ast::AnyParameterRef) -> Self {
         Self(match value {
             ast::AnyParameterRef::Variadic(node) => NodeKey::from_node(node),
-            ast::AnyParameterRef::NonVariadic(node) => NodeKey::from_node(node),
+            ast::AnyParameterRef::NonVariadic(node) => NodeKey::from_node(&node.parameter),
         })
     }
 }

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -563,8 +563,7 @@ impl<'db> SemanticIndex<'db> {
     /// Returns the [`definition::Definition`] salsa ingredient(s) for `definition_key`.
     ///
     /// There will only ever be >1 `Definition` associated with a `definition_key`
-    /// if the definitions are created by a wildcard (`*`) import or synthesized
-    /// for a loop header.
+    /// if the definitions are created by a wildcard (`*`) import.
     #[track_caller]
     pub fn definitions(&self, definition_key: impl Into<DefinitionNodeKey>) -> &[Definition<'db>] {
         self.definitions_by_node
@@ -589,9 +588,9 @@ impl<'db> SemanticIndex<'db> {
     /// the `debug_assertions` feature is enabled, this method will panic.
     ///
     /// It is generally safe to use this method for any AST node that does not
-    /// correspond to a `*` (wildcard) import or a loop statement, since those are
-    /// the only situations that can result in multiple definitions being
-    /// associated with a single AST node.
+    /// correspond to a `*` (wildcard) import, since those are the only situations
+    /// that can result in multiple definitions being associated with a single AST
+    /// node.
     #[track_caller]
     pub fn expect_single_definition(
         &self,


### PR DESCRIPTION
## Summary

This is a follow-up to #25498 to omit redundant entries from the retained mapping between AST nodes and definitions.

Loop-header definitions are internal use-def bindings retrieved through their `LoopToken`, so we no longer retain mappings from their enclosing `while` or `for` statements.

For non-variadic parameters, we previously retained duplicate mappings from both the outer `ParameterWithDefault` node and the inner Parameter node to the same definition. This PR consistently uses the inner node as the key and normalizes lookups from the outer node accordingly.
