### PR TITLE
[ty] Share semantic token encoding

### DIFF
--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -54,7 +54,8 @@ pub use references::ReferencesMode;
 pub use rename::{can_rename, rename};
 pub use selection_range::selection_range;
 pub use semantic_tokens::{
-    SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens, semantic_tokens,
+    EncodedSemanticToken, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
+    encoded_semantic_tokens, semantic_tokens,
 };
 pub use signature_help::{ParameterDetails, SignatureDetails, SignatureHelpInfo, signature_help};
 pub use symbols::{FlatSymbols, HierarchicalSymbols, SymbolId, SymbolInfo, SymbolKind};

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -196,6 +196,9 @@ pub fn semantic_tokens(db: &dyn Db, file: File, range: Option<TextRange>) -> Sem
 }
 
 /// An LSP-compatible semantic token encoded relative to the previous token.
+///
+/// Mirrors `lsp_types::SemanticToken` but in ty's domain types — the LSP-layer
+/// conversion happens in `ty_server`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EncodedSemanticToken {
     pub delta_line: u32,

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -30,6 +30,7 @@ use crate::Db;
 use bitflags::bitflags;
 use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
+use ruff_db::source::{line_index, source_text};
 use ruff_python_ast::visitor::source_order::{
     SourceOrderVisitor, TraversalSignal, walk_arguments, walk_expr,
     walk_interpolated_string_element, walk_stmt,
@@ -38,6 +39,7 @@ use ruff_python_ast::{
     self as ast, AnyNodeRef, ArgOrKeyword, BytesLiteral, Expr, InterpolatedStringElement, Stmt,
     StringLiteral, TypeParam,
 };
+use ruff_source_file::{OneIndexed, PositionEncoding, SourceLocation};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use std::ops::Deref;
 use ty_python_core::definition::{Definition, DefinitionKind, ParameterDefinitionNodeKind};
@@ -191,6 +193,190 @@ pub fn semantic_tokens(db: &dyn Db, file: File, range: Option<TextRange>) -> Sem
     visitor.visit_body(parsed.suite());
 
     SemanticTokens::new(visitor.tokens)
+}
+
+/// An LSP-compatible semantic token encoded relative to the previous token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncodedSemanticToken {
+    pub delta_line: u32,
+    pub delta_start: u32,
+    pub length: u32,
+    pub token_type: u32,
+    pub token_modifiers_bitset: u32,
+}
+
+impl EncodedSemanticToken {
+    pub const LEN: usize = 5;
+
+    pub const fn as_u32_array(self) -> [u32; Self::LEN] {
+        [
+            self.delta_line,
+            self.delta_start,
+            self.length,
+            self.token_type,
+            self.token_modifiers_bitset,
+        ]
+    }
+}
+
+/// Generates LSP-compatible semantic tokens for a Python file within the specified range.
+///
+/// The encoded tokens use zero-based line and character offsets relative to the start of the
+/// source text. For regular files, this directly corresponds to LSP positions.
+pub fn encoded_semantic_tokens(
+    db: &dyn Db,
+    file: File,
+    range: Option<TextRange>,
+    encoding: PositionEncoding,
+    multiline_token_support: bool,
+) -> Vec<EncodedSemanticToken> {
+    let source = source_text(db, file);
+    let line_index = line_index(db, file);
+    let semantic_token_data = semantic_tokens(db, file, range);
+
+    let mut encoder = Encoder {
+        tokens: Vec::with_capacity(semantic_token_data.len()),
+        prev_line: 0,
+        prev_start: 0,
+    };
+
+    for token in &*semantic_token_data {
+        let start = line_index.source_location(token.range().start(), source.as_str(), encoding);
+        let end = line_index.source_location(token.range().end(), source.as_str(), encoding);
+
+        let Some(start) = source_location_to_position(&start) else {
+            continue;
+        };
+        let Some(end) = source_location_to_position(&end) else {
+            continue;
+        };
+
+        if start.line == end.line {
+            let len = end.character - start.character;
+            encoder.push(start, len, token.token_type, token.modifiers);
+        } else if multiline_token_support {
+            let Some(len) = multiline_length(start, end, &line_index, source.as_str(), encoding)
+            else {
+                continue;
+            };
+            encoder.push(start, len, token.token_type, token.modifiers);
+        } else {
+            for line in start.line..=end.line {
+                let start_character = if line == start.line {
+                    start.character
+                } else {
+                    0
+                };
+
+                let end_character = if line == end.line {
+                    end.character
+                } else {
+                    let line_len = line_index.line_len(
+                        OneIndexed::from_zero_indexed(line as usize),
+                        source.as_str(),
+                        encoding,
+                    );
+                    let Ok(line_len) = u32::try_from(line_len) else {
+                        continue;
+                    };
+                    line_len
+                };
+
+                let Some(len) = end_character.checked_sub(start_character) else {
+                    continue;
+                };
+
+                if len == 0 {
+                    continue;
+                }
+
+                encoder.push(
+                    EncodedSemanticTokenPosition {
+                        line,
+                        character: start_character,
+                    },
+                    len,
+                    token.token_type,
+                    token.modifiers,
+                );
+            }
+        }
+    }
+
+    encoder.tokens
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EncodedSemanticTokenPosition {
+    line: u32,
+    character: u32,
+}
+
+fn source_location_to_position(location: &SourceLocation) -> Option<EncodedSemanticTokenPosition> {
+    Some(EncodedSemanticTokenPosition {
+        line: u32::try_from(location.line.to_zero_indexed()).ok()?,
+        character: u32::try_from(location.character_offset.to_zero_indexed()).ok()?,
+    })
+}
+
+fn multiline_length(
+    start: EncodedSemanticTokenPosition,
+    end: EncodedSemanticTokenPosition,
+    line_index: &ruff_source_file::LineIndex,
+    source: &str,
+    encoding: PositionEncoding,
+) -> Option<u32> {
+    let mut length = 0u32;
+
+    for line in start.line..end.line {
+        let line_len = line_index.line_len(
+            OneIndexed::from_zero_indexed(line as usize),
+            source,
+            encoding,
+        );
+        length = length.checked_add(u32::try_from(line_len).ok()?)?;
+    }
+
+    length = length.checked_sub(start.character)?;
+    length.checked_add(end.character)
+}
+
+struct Encoder {
+    tokens: Vec<EncodedSemanticToken>,
+    prev_line: u32,
+    prev_start: u32,
+}
+
+impl Encoder {
+    fn push(
+        &mut self,
+        start: EncodedSemanticTokenPosition,
+        length: u32,
+        ty: SemanticTokenType,
+        modifiers: SemanticTokenModifier,
+    ) {
+        let Some(delta_line) = start.line.checked_sub(self.prev_line) else {
+            return;
+        };
+        let Some(delta_start) = (if delta_line == 0 {
+            start.character.checked_sub(self.prev_start)
+        } else {
+            Some(start.character)
+        }) else {
+            return;
+        };
+
+        self.tokens.push(EncodedSemanticToken {
+            delta_line,
+            delta_start,
+            length,
+            token_type: ty as u32,
+            token_modifiers_bitset: modifiers.bits(),
+        });
+
+        self.prev_line = start.line;
+        self.prev_start = start.character;
+    }
 }
 
 /// AST visitor that collects semantic tokens.
@@ -4659,5 +4845,19 @@ from pathlib import Missing as Alias
 
             result
         }
+    }
+
+    #[test]
+    fn encoded_semantic_tokens_basic() {
+        let test = SemanticTokenTest::new("def foo():\n    foo()\n");
+
+        let tokens =
+            encoded_semantic_tokens(&test.db, test.file, None, PositionEncoding::Utf16, true);
+        let data = tokens
+            .iter()
+            .flat_map(|token| token.as_u32_array())
+            .collect::<Vec<_>>();
+
+        assert_eq!(data, vec![0, 4, 3, 7, 1, 1, 4, 3, 7, 0]);
     }
 }

--- a/crates/ty_server/src/server/api/semantic_tokens.rs
+++ b/crates/ty_server/src/server/api/semantic_tokens.rs
@@ -1,11 +1,9 @@
 use lsp_types::SemanticToken;
 use ruff_db::source::{line_index, source_text};
-use ruff_source_file::OneIndexed;
-use ruff_text_size::{Ranged, TextRange};
-use ty_ide::{SemanticTokenModifier, SemanticTokenType};
+use ruff_text_size::TextRange;
 use ty_project::ProjectDatabase;
 
-use crate::document::{PositionEncoding, ToRangeExt};
+use crate::document::PositionEncoding;
 
 /// Common logic for generating semantic tokens, either for full document or a specific range.
 /// If no range is provided, the entire file is processed.
@@ -18,28 +16,33 @@ pub(crate) fn generate_semantic_tokens(
 ) -> Vec<SemanticToken> {
     let source = source_text(db, file);
 
-    // Notebooks require cell-local coordinate conversion, which is an LSP-server concern.
-    // For regular files, we can use the shared encoder from ty_ide.
+    let mut tokens =
+        ty_ide::encoded_semantic_tokens(db, file, range, encoding.into(), multiline_token_support)
+            .into_iter()
+            .map(convert_semantic_token)
+            .collect::<Vec<_>>();
+
     if source.as_notebook().is_some() {
-        generate_semantic_tokens_notebook(
-            db,
-            file,
-            range,
-            encoding,
-            multiline_token_support,
-        )
-    } else {
-        ty_ide::encoded_semantic_tokens(
-            db,
-            file,
-            range,
-            encoding.into(),
-            multiline_token_support,
-        )
-        .into_iter()
-        .map(convert_semantic_token)
-        .collect()
+        if let (Some(range), Some(first)) = (range, tokens.first_mut()) {
+            let line_index = line_index(db, file);
+            let cell_start_global_line = u32::try_from(
+                line_index
+                    .source_location(range.start(), source.as_str(), encoding.into())
+                    .line
+                    .to_zero_indexed(),
+            )
+            .unwrap_or(0);
+
+            // [Note]:
+            // 1. `ty_server` constrains `range` to the current cell's global offset at the request level.
+            // 2. Notebook responses must use cell-local coordinates.
+            // 3. `SemanticToken` uses delta encoding, so only the first token's `delta_line` (relative to line 0)
+            //    needs adjustment. All subsequent relative deltas remain correct because every token shifts by the same offset.
+            first.delta_line -= cell_start_global_line;
+        }
     }
+
+    tokens
 }
 
 fn convert_semantic_token(token: ty_ide::EncodedSemanticToken) -> SemanticToken {
@@ -49,129 +52,5 @@ fn convert_semantic_token(token: ty_ide::EncodedSemanticToken) -> SemanticToken 
         length: token.length,
         token_type: token.token_type,
         token_modifiers_bitset: token.token_modifiers_bitset,
-    }
-}
-
-fn generate_semantic_tokens_notebook(
-    db: &ProjectDatabase,
-    file: ruff_db::files::File,
-    range: Option<TextRange>,
-    encoding: PositionEncoding,
-    multiline_token_support: bool,
-) -> Vec<SemanticToken> {
-    let source = source_text(db, file);
-    let line_index = line_index(db, file);
-    let semantic_token_data = ty_ide::semantic_tokens(db, file, range);
-
-    let mut encoder = Encoder {
-        tokens: Vec::with_capacity(semantic_token_data.len()),
-        prev_line: 0,
-        prev_start: 0,
-    };
-
-    for token in &*semantic_token_data {
-        let Some(lsp_range) = token
-            .range()
-            .to_lsp_range(db, file, encoding)
-            .map(|lsp_range| lsp_range.local_range())
-        else {
-            continue;
-        };
-
-        if lsp_range.start.line == lsp_range.end.line {
-            let len = lsp_range.end.character - lsp_range.start.character;
-            encoder.push_token_at(lsp_range.start, len, token.token_type, token.modifiers);
-        } else if multiline_token_support {
-            // If the client supports multiline-tokens,
-            // compute the length of the entire range.
-            let mut len = 0;
-
-            for line in lsp_range.start.line..lsp_range.end.line {
-                let line_len = line_index.line_len(
-                    OneIndexed::from_zero_indexed(line as usize),
-                    &source,
-                    encoding.into(),
-                );
-
-                len += u32::try_from(line_len).unwrap();
-            }
-
-            // Subtract the first line because we added the length from the beginning.
-            len -= lsp_range.start.character;
-            // We didn't compute the length of the last line, add it now.
-            len += lsp_range.end.character;
-
-            encoder.push_token_at(lsp_range.start, len, token.token_type, token.modifiers);
-        } else {
-            // Multiline token but the client only supports single line tokens
-            // Push a token for each line.
-            for line in lsp_range.start.line..=lsp_range.end.line {
-                let start_character = if line == lsp_range.start.line {
-                    lsp_range.start.character
-                } else {
-                    0
-                };
-
-                let start = lsp_types::Position {
-                    line,
-                    character: start_character,
-                };
-
-                let end = if line == lsp_range.end.line {
-                    lsp_range.end.character
-                } else {
-                    let line_len = line_index.line_len(
-                        OneIndexed::from_zero_indexed(line as usize),
-                        &source,
-                        encoding.into(),
-                    );
-                    u32::try_from(line_len).unwrap()
-                };
-
-                let len = end - start.character;
-
-                encoder.push_token_at(start, len, token.token_type, token.modifiers);
-            }
-        }
-    }
-
-    encoder.tokens
-}
-
-struct Encoder {
-    tokens: Vec<SemanticToken>,
-    prev_line: u32,
-    prev_start: u32,
-}
-
-impl Encoder {
-    fn push_token_at(
-        &mut self,
-        start: lsp_types::Position,
-        length: u32,
-        ty: SemanticTokenType,
-        modifiers: SemanticTokenModifier,
-    ) {
-        // LSP semantic tokens are encoded as deltas
-        let delta_line = start.line - self.prev_line;
-        let delta_start = if delta_line == 0 {
-            start.character - self.prev_start
-        } else {
-            start.character
-        };
-
-        let token_type = ty as u32;
-        let token_modifiers = modifiers.bits();
-
-        self.tokens.push(SemanticToken {
-            delta_line,
-            delta_start,
-            length,
-            token_type,
-            token_modifiers_bitset: token_modifiers,
-        });
-
-        self.prev_line = start.line;
-        self.prev_start = start.character;
     }
 }

--- a/crates/ty_server/src/server/api/semantic_tokens.rs
+++ b/crates/ty_server/src/server/api/semantic_tokens.rs
@@ -2,7 +2,7 @@ use lsp_types::SemanticToken;
 use ruff_db::source::{line_index, source_text};
 use ruff_source_file::OneIndexed;
 use ruff_text_size::{Ranged, TextRange};
-use ty_ide::{SemanticTokenModifier, SemanticTokenType, semantic_tokens};
+use ty_ide::{SemanticTokenModifier, SemanticTokenType};
 use ty_project::ProjectDatabase;
 
 use crate::document::{PositionEncoding, ToRangeExt};
@@ -17,8 +17,51 @@ pub(crate) fn generate_semantic_tokens(
     multiline_token_support: bool,
 ) -> Vec<SemanticToken> {
     let source = source_text(db, file);
+
+    // Notebooks require cell-local coordinate conversion, which is an LSP-server concern.
+    // For regular files, we can use the shared encoder from ty_ide.
+    if source.as_notebook().is_some() {
+        generate_semantic_tokens_notebook(
+            db,
+            file,
+            range,
+            encoding,
+            multiline_token_support,
+        )
+    } else {
+        ty_ide::encoded_semantic_tokens(
+            db,
+            file,
+            range,
+            encoding.into(),
+            multiline_token_support,
+        )
+        .into_iter()
+        .map(convert_semantic_token)
+        .collect()
+    }
+}
+
+fn convert_semantic_token(token: ty_ide::EncodedSemanticToken) -> SemanticToken {
+    SemanticToken {
+        delta_line: token.delta_line,
+        delta_start: token.delta_start,
+        length: token.length,
+        token_type: token.token_type,
+        token_modifiers_bitset: token.token_modifiers_bitset,
+    }
+}
+
+fn generate_semantic_tokens_notebook(
+    db: &ProjectDatabase,
+    file: ruff_db::files::File,
+    range: Option<TextRange>,
+    encoding: PositionEncoding,
+    multiline_token_support: bool,
+) -> Vec<SemanticToken> {
+    let source = source_text(db, file);
     let line_index = line_index(db, file);
-    let semantic_token_data = semantic_tokens(db, file, range);
+    let semantic_token_data = ty_ide::semantic_tokens(db, file, range);
 
     let mut encoder = Encoder {
         tokens: Vec::with_capacity(semantic_token_data.len()),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Move semantic-token delta encoding into ty_ide so all ty consumers use the same LSP-compatible representation. 
Adapt ty_server to wrap the shared encoded tokens as lsp_types::SemanticToken, and have ty_wasm expose the encoded token data directly.

## Test Plan

<!-- How was it tested? -->
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo fmt --all -- --check`
- `git diff --check`
- `npm run dev:build` from `playground/ty`
- `npm run lint` from `playground`
- `npm run dev:wasm --workspace ruff-playground` from `playground`
- `npm run tsc` from `playground`