### PR TITLE
[ty] Disallow file-system access in `ty_python_core`

### DIFF
--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -1,3 +1,7 @@
+#![warn(
+    clippy::disallowed_methods,
+    reason = "Prefer System trait methods over std methods in ty crates"
+)]
 use ruff_python_ast as ast;
 use std::iter::{FusedIterator, once};
 use std::sync::Arc;


### PR DESCRIPTION
## Summary

All other ty crates have this in their `lib.rs` to enforce that filesystem access goes via the `System` abstraction (ensuring that it is tracked by Salsa). This was missed in https://github.com/astral-sh/ruff/commit/461994073e2f6cac13a28e60b06038ba50214ffc.
