### PR TITLE
[ty] Fix narrowing enum literal unions by member identity

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -94,6 +94,15 @@ def _(x: Single | int):
     else:
         reveal_type(x)  # revealed: int
 
+def _(x: list[int] | Literal[Answer.NO]):
+    if x != Answer.NO:
+        reveal_type(x)  # revealed: list[int]
+
+def _(x: list[int] | Literal[Answer.NO]):
+    if x == Answer.NO:
+        return
+    reveal_type(x)  # revealed: list[int]
+
 class Color(Enum):
     RED = "red"
     GREEN = "green"

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -60,6 +60,7 @@ def _(x: None | Literal[1, True]):
 
 ```py
 from enum import Enum
+from typing import Literal
 
 class Answer(Enum):
     NO = 0
@@ -79,6 +80,11 @@ def _(x: Single | int):
         reveal_type(x)  # revealed: Single
     else:
         reveal_type(x)  # revealed: int
+
+def _(x: list[int] | Literal[Answer.NO]):
+    if x is Answer.NO:
+        return
+    reveal_type(x)  # revealed: list[int]
 ```
 
 ## `is` for `EllipsisType`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is_not.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is_not.md
@@ -59,6 +59,7 @@ Enum literals:
 
 ```py
 from enum import Enum
+from typing import Literal
 
 class Answer(Enum):
     NO = 0
@@ -80,6 +81,10 @@ def _(x: Single | int):
         reveal_type(x)  # revealed: int
     else:
         reveal_type(x)  # revealed: Single
+
+def _(x: list[int] | Literal[Answer.NO]):
+    if x is not Answer.NO:
+        reveal_type(x)  # revealed: list[int]
 ```
 
 ## `is not` for non-singleton types

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1608,7 +1608,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                                 existing_enum.enum_class(db) == new_enum.enum_class(db)
                             })
                     {
-                        if existing_negative == &new_negative {
+                        if existing_negative.as_enum_literal() == Some(new_enum) {
                             return;
                         }
                         continue;
@@ -1632,7 +1632,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                         if let Some(existing_enum) = existing_positive.as_enum_literal()
                             && existing_enum.enum_class(db) == new_enum.enum_class(db)
                         {
-                            if existing_positive == &new_negative {
+                            if existing_enum == new_enum {
                                 *self = Self::default();
                                 self.positive.insert(Type::Never);
                             }


### PR DESCRIPTION
## Summary

Prior to this change, we failed to narrow a union containing an explicitly annotated enum literal (e.g., `x: list[int] | Literal[Answer.NO]`) when comparing it against the corresponding enum member:

```python
from enum import Enum
from typing import Literal

class Answer(Enum):
    NO = 0
    YES = 1

def f(x: list[int] | Literal[Answer.NO]):
    if x is Answer.NO:
        return
    # Before: list[int] | Literal[Answer.NO]
    # After: list[int]
    reveal_type(x)
```

We were comparing the outer literal types, so the intersection builder failed to recognize that both types represented the
same enum member.

Now, we compare the underlying enum-literal identities instead, restoring narrowing for `is`, `is not`, `==`, and `!=`.

Closes https://github.com/astral-sh/ty/issues/3606.
