### PR TITLE
[ty] Register file roots for first-party search paths

### DIFF
--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -196,8 +196,21 @@ impl Files {
     }
 
     /// The same as [`Self::root`] but panics if no root is found.
+    ///
+    /// First-party search paths (e.g., roots configured in `ty.toml`) may not have
+    /// been registered as file roots during static initialization. This function
+    /// attempts to lazily register the path as a [`FileRootKind::LibrarySearchPath`]
+    /// before panicking.
     #[track_caller]
     pub fn expect_root(&self, db: &dyn Db, path: &SystemPath) -> FileRoot {
+        if let Some(root) = self.root(db, path) {
+            return root;
+        }
+
+        // A configured first-party search path may not have been registered
+        // as a file root. Try to add one lazily.
+        self.try_add_root(db, path, FileRootKind::LibrarySearchPath);
+
         if let Some(root) = self.root(db, path) {
             return root;
         }

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -196,21 +196,8 @@ impl Files {
     }
 
     /// The same as [`Self::root`] but panics if no root is found.
-    ///
-    /// First-party search paths (e.g., roots configured in `ty.toml`) may not have
-    /// been registered as file roots during static initialization. This function
-    /// attempts to lazily register the path as a [`FileRootKind::LibrarySearchPath`]
-    /// before panicking.
     #[track_caller]
     pub fn expect_root(&self, db: &dyn Db, path: &SystemPath) -> FileRoot {
-        if let Some(root) = self.root(db, path) {
-            return root;
-        }
-
-        // A configured first-party search path may not have been registered
-        // as a file root. Try to add one lazily.
-        self.try_add_root(db, path, FileRootKind::LibrarySearchPath);
-
         if let Some(root) = self.root(db, path) {
             return root;
         }

--- a/crates/ruff_db/src/files/file_root.rs
+++ b/crates/ruff_db/src/files/file_root.rs
@@ -43,14 +43,14 @@ pub enum FileRootKind {
     Project,
 
     /// A non-project module resolution search path.
-    LibrarySearchPath,
+    SearchPath,
 }
 
 impl FileRootKind {
     const fn durability(self) -> Durability {
         match self {
             FileRootKind::Project => Durability::LOW,
-            FileRootKind::LibrarySearchPath => Durability::HIGH,
+            FileRootKind::SearchPath => Durability::HIGH,
         }
     }
 }

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -515,8 +515,7 @@ mod tests {
                 if let Some(top) = top {
                     let top = SystemPath::new(top);
                     if db.system().is_directory(top) {
-                        db.files()
-                            .try_add_root(&db, top, FileRootKind::LibrarySearchPath);
+                        db.files().try_add_root(&db, top, FileRootKind::SearchPath);
                     }
                 }
 
@@ -656,7 +655,7 @@ mod tests {
             db.files()
                 .try_add_root(&db, &project_root, FileRootKind::Project);
             db.files()
-                .try_add_root(&db, &site_packages_path, FileRootKind::LibrarySearchPath);
+                .try_add_root(&db, &site_packages_path, FileRootKind::SearchPath);
 
             let mut cursor: Option<Cursor> = None;
             for &Source {

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -2979,8 +2979,7 @@ class C: ...
                 if let Some(top) = top {
                     let top = SystemPath::new(top);
                     if db.system().is_directory(top) {
-                        db.files()
-                            .try_add_root(&db, top, FileRootKind::LibrarySearchPath);
+                        db.files().try_add_root(&db, top, FileRootKind::SearchPath);
                     }
                 }
             }

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -692,7 +692,7 @@ impl SearchPaths {
         }
     }
 
-    /// Registers the file roots for all non-dynamically discovered search paths that aren't first-party.
+    /// Registers file roots for all non-dynamically discovered search paths.
     pub fn try_register_static_roots(&self, db: &dyn Db) {
         let files = db.files();
         for path in self
@@ -702,8 +702,10 @@ impl SearchPaths {
             .chain(&self.stdlib_path)
         {
             if let Some(system_path) = path.as_system_path() {
-                if !path.is_first_party() {
-                    files.try_add_root(db, system_path, FileRootKind::LibrarySearchPath);
+                // Nested first-party paths reuse the project root. Other nested paths, such as
+                // site-packages inside `.venv`, need their own search-path root.
+                if !path.is_first_party() || files.root(db, system_path).is_none() {
+                    files.try_add_root(db, system_path, FileRootKind::SearchPath);
                 }
             }
         }
@@ -892,11 +894,7 @@ pub(crate) fn dynamic_resolution_paths<'db>(
                         // than they would otherwise.
                         if let Some(dynamic_path) = search_path.as_system_path() {
                             if files.root(db, dynamic_path).is_none() {
-                                files.try_add_root(
-                                    db,
-                                    dynamic_path,
-                                    FileRootKind::LibrarySearchPath,
-                                );
+                                files.try_add_root(db, dynamic_path, FileRootKind::SearchPath);
                             }
                         }
 

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -692,7 +692,7 @@ impl SearchPaths {
         }
     }
 
-    /// Registers the file roots for all non-dynamically discovered search paths that aren't first-party.
+    /// Registers the file roots for all non-dynamically discovered search paths.
     pub fn try_register_static_roots(&self, db: &dyn Db) {
         let files = db.files();
         for path in self
@@ -704,6 +704,10 @@ impl SearchPaths {
             if let Some(system_path) = path.as_system_path() {
                 if !path.is_first_party() {
                     files.try_add_root(db, system_path, FileRootKind::LibrarySearchPath);
+                } else {
+                    if files.root(db, system_path).is_none() {
+                        files.try_add_root(db, system_path, FileRootKind::LibrarySearchPath);
+                    }
                 }
             }
         }

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -692,7 +692,7 @@ impl SearchPaths {
         }
     }
 
-    /// Registers the file roots for all non-dynamically discovered search paths.
+    /// Registers the file roots for all non-dynamically discovered search paths that aren't first-party.
     pub fn try_register_static_roots(&self, db: &dyn Db) {
         let files = db.files();
         for path in self
@@ -704,10 +704,6 @@ impl SearchPaths {
             if let Some(system_path) = path.as_system_path() {
                 if !path.is_first_party() {
                     files.try_add_root(db, system_path, FileRootKind::LibrarySearchPath);
-                } else {
-                    if files.root(db, system_path).is_none() {
-                        files.try_add_root(db, system_path, FileRootKind::LibrarySearchPath);
-                    }
                 }
             }
         }

--- a/crates/ty_module_resolver/src/testing.rs
+++ b/crates/ty_module_resolver/src/testing.rs
@@ -273,11 +273,10 @@ impl TestCaseBuilder<MockedTypeshed> {
             .try_add_root(&db, SystemPath::new("/src"), FileRootKind::Project);
 
         db.files()
-            .try_add_root(&db, &stdlib, FileRootKind::LibrarySearchPath);
+            .try_add_root(&db, &stdlib, FileRootKind::SearchPath);
 
         for root in &roots {
-            db.files()
-                .try_add_root(&db, root, FileRootKind::LibrarySearchPath);
+            db.files().try_add_root(&db, root, FileRootKind::SearchPath);
         }
 
         TestCase {
@@ -336,8 +335,7 @@ impl TestCaseBuilder<VendoredTypeshed> {
         db.files()
             .try_add_root(&db, SystemPath::new("/src"), FileRootKind::Project);
         for root in &roots {
-            db.files()
-                .try_add_root(&db, root, FileRootKind::LibrarySearchPath);
+            db.files().try_add_root(&db, root, FileRootKind::SearchPath);
         }
 
         TestCase {

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -600,6 +600,7 @@ mod format {
 }
 
 #[cfg(any(test, feature = "testing"))]
+#[cfg_attr(not(feature = "testing"), expect(unreachable_pub))]
 pub(crate) mod testing {
     use std::sync::{Arc, Mutex};
 

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -105,11 +105,20 @@ impl ProjectDatabase {
         // TODO: Use the `program_settings` to compute the key for the database's persistent
         //   cache and load the cache if it exists.
         //   we may want to have a dedicated method for this?
+        // Important: For persistent caching it's essential that we can compute the
+        // cache key before loading the DB. Because of that, access to the `db` (other than system and vendored) is
+        // strictly forbidden before resolving the `program_settings`.
 
         // Initialize the `Program` singleton
         let (program_settings, program_settings_diagnostics) = strategy.to_anyhow(
             project_metadata.to_program_settings(db.system(), db.vendored(), strategy),
         )?;
+
+        // This must be called before `from_settings`, or the `SearchPath` root
+        // will take precedence over the `Project` root, resulting in
+        // all project files having HIGH durability.
+        project_metadata.try_add_project_root(&db);
+
         Program::from_settings(&db, program_settings);
 
         let (settings, settings_diagnostics) = strategy.map_err(
@@ -591,7 +600,7 @@ mod format {
 }
 
 #[cfg(any(test, feature = "testing"))]
-pub(crate) mod tests {
+pub(crate) mod testing {
     use std::sync::{Arc, Mutex};
 
     use ruff_db::Db as SourceDb;
@@ -775,4 +784,76 @@ pub(crate) mod tests {
 
     #[salsa::db]
     impl salsa::Database for TestDb {}
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::Db as _;
+    use ruff_db::files::FileRootKind;
+    use ruff_db::system::{SystemPathBuf, TestSystem};
+    use ty_module_resolver::list_modules;
+
+    use crate::{ProjectDatabase, ProjectMetadata};
+
+    #[test]
+    fn search_root_registration() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        let project = SystemPathBuf::from("/project");
+        let project_src = project.join("src");
+        let external = SystemPathBuf::from("/external");
+        let venv = project.join(".venv");
+
+        system.memory_file_system().write_files_all([
+            (
+                project.join("ty.toml"),
+                r#"
+                [environment]
+                root = ["src", "../external"]
+                extra-paths = [".venv"]
+                "#,
+            ),
+            (project_src.join("foo.py"), ""),
+            (external.join("bar.py"), ""),
+            (venv.join("baz.py"), ""),
+        ])?;
+
+        let metadata = ProjectMetadata::discover(&project, &system)?;
+        let db = ProjectDatabase::fallible(metadata, system)?;
+
+        let modules = list_modules(&db);
+        assert!(
+            modules
+                .iter()
+                .any(|module| module.name(&db).as_str() == "bar")
+        );
+
+        let project_src_root = db
+            .files()
+            .root(&db, &project_src)
+            .expect("project source file root");
+        assert_eq!(project_src_root.path(&db), &*project);
+        assert_eq!(
+            project_src_root.kind_at_time_of_creation(&db),
+            FileRootKind::Project
+        );
+
+        let external_root = db
+            .files()
+            .root(&db, &external)
+            .expect("external first-party file root");
+        assert_eq!(external_root.path(&db), &*external);
+        assert_eq!(
+            external_root.kind_at_time_of_creation(&db),
+            FileRootKind::SearchPath
+        );
+
+        let venv_root = db.files().root(&db, &venv).expect("virtualenv file root");
+        assert_eq!(venv_root.path(&db), &*venv);
+        assert_eq!(
+            venv_root.kind_at_time_of_creation(&db),
+            FileRootKind::SearchPath
+        );
+
+        Ok(())
+    }
 }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -673,6 +673,8 @@ pub(crate) mod testing {
                 .to_search_paths(self.system(), self.vendored(), &FallibleStrategy)
                 .expect("Valid search path settings");
 
+            self.files().try_add_root(self, root, FileRootKind::Project);
+
             Program::from_settings(
                 self,
                 ProgramSettings {
@@ -684,8 +686,6 @@ pub(crate) mod testing {
                     search_paths,
                 },
             );
-
-            self.files().try_add_root(self, root, FileRootKind::Project);
 
             Ok(())
         }

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -162,7 +162,7 @@ impl ProjectDatabase {
                                 // and then keying the submodule cache
                                 // off of that instead. ---AG
                                 FileRootKind::Project => {}
-                                FileRootKind::LibrarySearchPath => {
+                                FileRootKind::SearchPath => {
                                     root.set_revision(self).to(FileRevision::now());
                                 }
                             }
@@ -303,6 +303,8 @@ impl ProjectDatabase {
                     if let Some(overrides) = project_options_overrides {
                         metadata.apply_overrides(overrides);
                     }
+
+                    metadata.try_add_project_root(self);
 
                     let program_settings_diagnostics = match metadata.to_program_settings(
                         self.system(),

--- a/crates/ty_project/src/files.rs
+++ b/crates/ty_project/src/files.rs
@@ -257,7 +257,7 @@ mod tests {
 
     use crate::ProjectMetadata;
     use crate::db::Db;
-    use crate::db::tests::TestDb;
+    use crate::db::testing::TestDb;
     use crate::files::Index;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::{DbWithWritableSystem as _, SystemPathBuf};

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -182,13 +182,12 @@ impl Project {
             settings_diagnostics,
             program_settings_diagnostics,
         );
-        let project = Project::builder(Box::new(metadata), Box::new(settings), diagnostics)
+
+        Project::builder(Box::new(metadata), Box::new(settings), diagnostics)
             .durability(Durability::MEDIUM)
             .open_fileset_durability(Durability::LOW)
             .file_set_durability(Durability::LOW)
-            .new(db);
-
-        project
+            .new(db)
     }
 
     pub fn root(self, db: &dyn Db) -> &SystemPath {

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -6,7 +6,7 @@ use crate::glob::{GlobFilterCheckMode, IncludeResult};
 use crate::metadata::options::{OptionDiagnostic, ProgramSettingsDiagnostic};
 use crate::walk::{ProjectFilesFilter, ProjectFilesWalker};
 #[cfg(feature = "testing")]
-pub use db::tests::TestDb;
+pub use db::testing::TestDb;
 pub use db::{ChangeResult, CheckMode, Db, ProjectDatabase, SalsaMemoryDump};
 use files::{Index, Indexed, IndexedFiles};
 
@@ -15,7 +15,7 @@ pub use metadata::{ProjectMetadata, ProjectMetadataError};
 use ruff_db::diagnostic::{
     Diagnostic, DiagnosticId, Severity, SubDiagnostic, SubDiagnosticSeverity,
 };
-use ruff_db::files::{File, FileRootKind};
+use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
 use rustc_hash::FxHashSet;
@@ -188,18 +188,7 @@ impl Project {
             .file_set_durability(Durability::LOW)
             .new(db);
 
-        project.try_add_file_root(db);
-
         project
-    }
-
-    fn try_add_file_root(self, db: &dyn Db) {
-        // This adds a file root for the project itself. This enables
-        // tracking of when changes are made to the files in a project
-        // at the directory level. At time of writing (2025-07-17),
-        // this is used for caching completions for submodules.
-        db.files()
-            .try_add_root(db, self.root(db), FileRootKind::Project);
     }
 
     pub fn root(self, db: &dyn Db) -> &SystemPath {
@@ -284,7 +273,6 @@ impl Project {
 
         if metadata_changed {
             self.set_metadata(db).to(Box::new(metadata));
-            self.try_add_file_root(db);
         }
 
         if metadata_changed || settings_changed {
@@ -867,7 +855,7 @@ where
 mod tests {
     use crate::check_file_impl;
     use crate::db::Db as _;
-    use crate::db::tests::TestDb;
+    use crate::db::testing::TestDb;
     use crate::{IncludeResult, ProjectMetadata};
     use ruff_db::files::system_path_to_file;
     use ruff_db::source::source_text;

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -1,4 +1,5 @@
 use configuration_file::{ConfigurationFile, ConfigurationFileError};
+use ruff_db::files::FileRootKind;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_python_ast::name::Name;
@@ -280,6 +281,15 @@ impl ProjectMetadata {
 
     pub fn extra_configuration_paths(&self) -> &[SystemPathBuf] {
         &self.extra_configuration_paths
+    }
+
+    pub(crate) fn try_add_project_root(&self, db: &dyn Db) {
+        // This adds a file root for the project itself. This enables
+        // tracking of when changes are made to the files in a project
+        // at the directory level. At time of writing (2025-07-17),
+        // this is used for caching completions for submodules.
+        db.files()
+            .try_add_root(db, self.root(), FileRootKind::Project);
     }
 
     pub fn to_program_settings<Strategy: MisconfigurationStrategy>(

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -220,7 +220,7 @@ fn run_test(
     // Create a custom typeshed `VERSIONS` file if none was provided.
     if let Some(typeshed_path) = custom_typeshed_path {
         db.files()
-            .try_add_root(db, typeshed_path, FileRootKind::LibrarySearchPath);
+            .try_add_root(db, typeshed_path, FileRootKind::SearchPath);
         if !has_custom_versions_file {
             let versions_file = typeshed_path.join("stdlib/VERSIONS");
             let contents = typeshed_files


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes astral-sh/ty#3594.

`try_register_static_roots` previously skipped first-party search paths
(from `ty.toml` `root`) when registering file roots.
When queries like `list_modules_in` later called `expect_root()` on one
of these paths, ty panicked `No root found for path '/path/in/the/ty/config'`.


## Test Plan

<!-- How was it tested? -->

### `cargo test` Result

`FileRoot` count increases by 1. I think it is reasonable, because it reflects the newly registered first-party search path root.

```shell

failures:

---- commands::debug_command stdout ----
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Snapshot file: crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
Snapshot: debug_command
Source: crates/ty_server/tests/e2e/commands.rs:60
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
Expression: response
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────
  173   173 │ Memory report:
  174   174 │ =======SALSA STRUCTS=======
  175   175 │ `Program`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
  176   176 │ `Project`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
  177       │-`FileRoot`                                         metadata=[X.XXMB]   fields=[X.XXMB]   count=1
        177 │+`FileRoot`                                         metadata=[X.XXMB]   fields=[X.XXMB]   count=2
  178   178 │ `ModuleResolveModeIngredient`                      metadata=[X.XXMB]   fields=[X.XXMB]   count=1
  179   179 │ =======SALSA QUERIES=======
  180   180 │ `dynamic_resolution_paths -> alloc::vec::Vec<ty_module_resolver::path::SearchPath>`
  181   181 │     metadata=[X.XXMB]   fields=[X.XXMB]   count=1
────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────
To update snapshots run `cargo insta review`
Stopped on the first failure. Run `cargo insta test` to run all snapshots.


failures:
    commands::debug_command

test result: FAILED. 127 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out; finished in 22.90s

error: test failed, to rerun pass `-p ty_server --test e2e`

```



### Screen Recording

Before:

https://github.com/user-attachments/assets/9d84184d-ae37-415f-bb13-faf543b6a60f


After fix:

https://github.com/user-attachments/assets/15457c93-df1e-42eb-9ba3-94b0d1db0e93

