### PR TITLE
[ty] allow PEP 695 class type parameters in nested classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -392,21 +392,42 @@ def foo():
         ): ...
 ```
 
-## Class scopes do not cover inner scopes
+## Legacy class scopes do not cover inner scopes
 
-Just like regular symbols, the typevars of a generic class are only available in that class's scope,
-and are not available in nested scopes.
+Legacy typevars of a generic class are only available in that class's scope, and are not available
+in nested scopes.
 
 ```py
-class C[T]:
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+class C(Generic[T]):
     ok1: list[T] = []
 
     class Bad:
         # error: [unbound-type-variable]
         bad: list[T] = []
 
-    class Inner[S]: ...
+    class Inner(Generic[S]): ...
     ok2: Inner[T]
+```
+
+## PEP 695 class scopes cover inner scopes
+
+Unlike legacy typevars, PEP 695 class type parameters are valid in inner scopes contained within the
+class body.
+
+```py
+from typing import Optional
+
+class C[T]:
+    class Inner:
+        data: Optional[T] = None
+
+        def method(self, value: T) -> T:
+            return value
 ```
 
 ## Type parameter defaults cannot reference outer-scope type parameters

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -103,7 +103,8 @@ pub(crate) fn bind_typevar<'db>(
         }
     }
     // Walk ancestor scopes, tracking whether we've crossed a class scope boundary.
-    // Class-scoped type variables are not visible from inner class scopes.
+    // Legacy class-scoped type variables are not visible from inner class scopes, but
+    // PEP 695 class type parameter scopes do cover inner scopes.
     let mut crossed_class_scope = false;
     for (_, ancestor_scope) in index.ancestor_scopes(containing_scope) {
         let is_class_scope = ancestor_scope.kind().is_class();
@@ -120,9 +121,14 @@ pub(crate) fn bind_typevar<'db>(
             }
             node => GenericContext::of_node(db, node, index),
         };
-        // If we've already crossed a class boundary, skip class-scoped generic contexts.
-        // This prevents inner classes from accessing type parameters of outer classes.
-        if (!is_class_scope || !crossed_class_scope)
+        let class_typevars_visible = !is_class_scope
+            || !crossed_class_scope
+            || ancestor_scope.node().as_class().is_some_and(|class| {
+                let definition = index.expect_single_definition(class);
+                original_class_type(db, definition)
+                    .is_some_and(|class| class.has_pep_695_type_params(db))
+            });
+        if class_typevars_visible
             && let Some(generic_context) = generic_context
             && let Some(bound) = generic_context.binds_typevar(db, typevar)
         {


### PR DESCRIPTION
Fixes https://github.com/astral-sh/ty/issues/3562

## Summary

Allow PEP 695 class type parameters in nested classes.

## Test Plan

md tests