### PR TITLE
[ty] Compare BTreeMap AST ID builder

### DIFF
--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use ruff_db::files::File;
@@ -112,7 +114,7 @@ impl HasScopedUseId for ast::ExprRef<'_> {
 
 #[derive(Debug, Default)]
 pub(super) struct AstIdsBuilder {
-    uses_map: FxHashMap<ExpressionNodeKey, ScopedUseId>,
+    uses_map: BTreeMap<ExpressionNodeKey, ScopedUseId>,
 }
 
 impl AstIdsBuilder {


### PR DESCRIPTION
## Summary

Temporary stacked comparison PR for CodSpeed. Replaces the reverse-scanned `Vec` in `AstIdsBuilder` with a `BTreeMap` while leaving the retained file-level `FxHashMap` unchanged.

This is intended to answer the performance question in #25455 empirically.