### PR TITLE
[ty] Compare vector AST ID builder

### DIFF
--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -34,11 +34,11 @@ pub(crate) struct AstIds {
 
 impl AstIds {
     pub(super) fn from_builders(builders: IndexVec<FileScopeId, AstIdsBuilder>) -> Self {
-        let capacity = builders.iter().map(|builder| builder.uses_map.len()).sum();
+        let capacity = builders.iter().map(|builder| builder.uses.len()).sum();
         let mut uses_map = FxHashMap::with_capacity_and_hasher(capacity, FxBuildHasher);
 
         for builder in builders {
-            for (key, use_id) in builder.uses_map {
+            for (key, use_id) in builder.uses {
                 let previous = uses_map.insert(key, use_id);
                 debug_assert!(previous.is_none());
             }
@@ -112,19 +112,23 @@ impl HasScopedUseId for ast::ExprRef<'_> {
 
 #[derive(Debug, Default)]
 pub(super) struct AstIdsBuilder {
-    uses_map: FxHashMap<ExpressionNodeKey, ScopedUseId>,
+    uses: Vec<(ExpressionNodeKey, ScopedUseId)>,
 }
 
 impl AstIdsBuilder {
     /// Adds `expr` to the use ids map and returns its id.
     pub(super) fn record_use(&mut self, expr: impl Into<ExpressionNodeKey>) -> ScopedUseId {
-        let use_id = self.uses_map.len().into();
-        self.uses_map.insert(expr.into(), use_id);
+        let use_id = self.uses.len().into();
+        self.uses.push((expr.into(), use_id));
         use_id
     }
 
-    pub(super) fn try_use_id(&self, key: impl Into<ExpressionNodeKey>) -> Option<ScopedUseId> {
-        self.uses_map.get(&key.into()).copied()
+    pub(super) fn try_find_use_id(&self, key: impl Into<ExpressionNodeKey>) -> Option<ScopedUseId> {
+        let key = key.into();
+        self.uses
+            .iter()
+            .rev()
+            .find_map(|(use_key, use_id)| (*use_key == key).then_some(*use_id))
     }
 }
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -790,7 +790,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         collection_use: &ast::Expr,
     ) -> Option<Definition<'db>> {
         let use_def = self.current_use_def_map();
-        let use_id = self.current_ast_ids().try_use_id(collection_use)?;
+        let use_id = self.current_ast_ids().try_find_use_id(collection_use)?;
 
         use_def
             .bindings_at_use(use_id)


### PR DESCRIPTION
## Summary

Temporary stacked comparison PR for CodSpeed. Replaces the per-scope `FxHashMap` in `AstIdsBuilder` with an append-only `Vec` and a reverse-scanned builder-time lookup while leaving the retained file-level `FxHashMap` unchanged.

This is intended to answer the performance question in #25455 empirically.