### PR TITLE
[ty] Add mdtest extension functions for constraint-set assignability

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -852,3 +852,27 @@ def same_typevar[T]():
     expected = ~ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 ```
+
+## Displaying constraints
+
+The `with_detailed_display` method can be used to print out the boolean formula that a constraint
+set represents. However, this method is only intended for debugging purposes, and we reserve the
+right to change the rendering at any time! We therefore do _not_ have a battery of mdtests printing
+out all of the different kinds of constraints described above. Here we just test that the method
+exists, and provides more detail than otherwise.
+
+```py
+from ty_extensions import ConstraintSet
+
+class Super: ...
+class Base(Super): ...
+class Sub(Base): ...
+
+def _[T]() -> None:
+    # revealed: ConstraintSet[bool]
+    reveal_type(ConstraintSet.range(Sub, T, Super))
+    # We are not asserting anything specific about what's displayed here, just that it's different
+    # from above. If our constraint set rendering changes, update this accordingly.
+    # revealed: ConstraintSet[(Sub ≤ T@_ ≤ Super)]
+    reveal_type(ConstraintSet.range(Sub, T, Super).with_detailed_display())
+```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/implies_subtype_of.md
@@ -50,20 +50,34 @@ question when considering a typevar, by translating the desired relationship int
 
 ```py
 from typing import Any
-from ty_extensions import ConstraintSet, is_assignable_to, is_subtype_of, static_assert
+from ty_extensions import ConstraintSet, is_assignable_to, is_constraint_set_assignable_to, is_subtype_of, static_assert
 
 def assignability[T]():
+    # TODO: is_assignable_to should eventually work the way is_constraint_set_assignable_to does
+    # below.
     constraints = is_assignable_to(T, bool)
-    # TODO: expected = ConstraintSet.range(Never, T, bool)
     expected = ConstraintSet.never()
     static_assert(constraints == expected)
 
+    constraints = is_constraint_set_assignable_to(T, bool)
+    expected = ConstraintSet.range(Never, T, bool)
+    static_assert(constraints == expected)
+
+    # TODO: is_assignable_to should eventually work the way is_constraint_set_assignable_to does
+    # below.
     constraints = is_assignable_to(T, int)
-    # TODO: expected = ConstraintSet.range(Never, T, int)
     expected = ConstraintSet.never()
+    static_assert(constraints == expected)
+
+    constraints = is_constraint_set_assignable_to(T, int)
+    expected = ConstraintSet.range(Never, T, int)
     static_assert(constraints == expected)
 
     constraints = is_assignable_to(T, object)
+    expected = ConstraintSet.always()
+    static_assert(constraints == expected)
+
+    constraints = is_constraint_set_assignable_to(T, object)
     expected = ConstraintSet.always()
     static_assert(constraints == expected)
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3396,6 +3396,14 @@ impl<'db> Type<'db> {
                 ))
                 .into()
             }
+            Type::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
+                if name == "with_detailed_display" =>
+            {
+                Place::bound(Type::KnownBoundMethod(
+                    KnownBoundMethodType::ConstraintSetWithDetailedDisplay(tracked),
+                ))
+                .into()
+            }
 
             Type::ClassLiteral(class)
                 if name == "__get__" && class.is_known(db, KnownClass::FunctionType) =>
@@ -6037,6 +6045,7 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
+                | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_)
             )
             | Type::DataclassDecorator(_)
             | Type::DataclassTransformer(_)
@@ -6284,7 +6293,8 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
-                | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_),
+                | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
+                | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
             )
             | Type::DataclassDecorator(_)
             | Type::DataclassTransformer(_)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2543,6 +2543,15 @@ impl<'db> Bindings<'db> {
                         overload.set_return_type(Type::bool_literal(result));
                     }
 
+                    Type::KnownBoundMethod(
+                        KnownBoundMethodType::ConstraintSetWithDetailedDisplay(tracked),
+                    ) => {
+                        let tracked = tracked.with_detailed_display(db);
+                        overload.set_return_type(Type::KnownInstance(
+                            KnownInstanceType::ConstraintSet(tracked),
+                        ));
+                    }
+
                     Type::ClassLiteral(class) => match class.known(db) {
                         Some(KnownClass::Bool) => match overload.parameter_types() {
                             [Some(arg)] => {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1835,6 +1835,21 @@ impl<'db> Bindings<'db> {
                             }
                         }
 
+                        Some(KnownFunction::IsConstraintSetAssignableTo) => {
+                            if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                let ty_a = type_form_argument(db, *ty_a);
+                                let ty_b = type_form_argument(db, *ty_b);
+                                let constraints = ConstraintSetBuilder::new();
+                                let result = constraints.into_owned(|constraints| {
+                                    ty_a.when_constraint_set_assignable_to(db, ty_b, constraints)
+                                });
+                                let tracked = InternedConstraintSet::new(db, result);
+                                overload.set_return_type(Type::KnownInstance(
+                                    KnownInstanceType::ConstraintSet(tracked),
+                                ));
+                            }
+                        }
+
                         Some(KnownFunction::IsDisjointFrom) => {
                             if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
                                 let ty_a = type_form_argument(db, *ty_a);

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -581,7 +581,6 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         self.node.solutions_with(db, builder, choose)
     }
 
-    #[expect(dead_code)] // Keep this around for debugging purposes
     pub(crate) fn display(self, db: &'db dyn Db) -> impl Display {
         self.node
             .simplify_for_display(db, self.builder)

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1121,6 +1121,9 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         return f
                             .write_str("bound method `ConstraintSet.satisfied_by_all_typevars`");
                     }
+                    KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_) => {
+                        return f.write_str("bound method `ConstraintSet.with_detailed_display`");
+                    }
                 };
 
                 let class_ty = cls.to_class_literal(self.db);
@@ -3087,7 +3090,9 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 f.with_type(ty).write_str("ConstraintSet")?;
                 let constraints = ConstraintSetBuilder::new();
                 let set = constraints.load(self.db, interned_set.constraints(self.db));
-                if set.is_always_satisfied(self.db) {
+                if interned_set.detailed_display(self.db) {
+                    write!(f, "[{}]", set.display(self.db))
+                } else if set.is_always_satisfied(self.db) {
                     f.write_str("[Literal[True]]")
                 } else if set.is_never_satisfied(self.db) {
                     f.write_str("[Literal[False]]")

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1927,6 +1927,8 @@ pub enum KnownFunction {
     IsSubtypeOf,
     /// `ty_extensions.is_assignable_to`
     IsAssignableTo,
+    /// `ty_extensions.is_constraint_set_assignable_to`
+    IsConstraintSetAssignableTo,
     /// `ty_extensions.is_disjoint_from`
     IsDisjointFrom,
     /// `ty_extensions.is_singleton`
@@ -2035,6 +2037,7 @@ impl KnownFunction {
             Self::TotalOrdering => module.is_functools(),
             Self::GetattrStatic => module.is_inspect(),
             Self::IsAssignableTo
+            | Self::IsConstraintSetAssignableTo
             | Self::IsDisjointFrom
             | Self::IsEquivalentTo
             | Self::IsSingleValued
@@ -2590,6 +2593,7 @@ pub(crate) mod tests {
                 | KnownFunction::IsDisjointFrom
                 | KnownFunction::IsSingleValued
                 | KnownFunction::IsAssignableTo
+                | KnownFunction::IsConstraintSetAssignableTo
                 | KnownFunction::IsEquivalentTo
                 | KnownFunction::HasMember
                 | KnownFunction::RevealProtocolInterface

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -24,14 +24,26 @@ use ty_python_core::{definition::Definition, scope::ScopeId};
 /// mdtests. In theory, that means there's no need for this to be interned; being tracked would be
 /// sufficient. However, we currently think that tracked structs are unsound w.r.t. salsa cycles,
 /// so out of an abundance of caution, we are interning the struct.
-#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::interned(debug, constructor=new_internal, heap_size=ruff_memory_usage::heap_size)]
 pub struct InternedConstraintSet<'db> {
     #[returns(ref)]
     pub(super) constraints: OwnedConstraintSet<'db>,
+
+    pub(super) detailed_display: bool,
 }
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for InternedConstraintSet<'_> {}
+
+impl<'db> InternedConstraintSet<'db> {
+    pub(super) fn new(db: &'db dyn Db, constraints: OwnedConstraintSet<'db>) -> Self {
+        Self::new_internal(db, constraints, false)
+    }
+
+    pub(super) fn with_detailed_display(self, db: &'db dyn Db) -> Self {
+        Self::new_internal(db, self.constraints(db), true)
+    }
+}
 
 /// A salsa-interned payload for `functools.partial(...)` instances.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -176,6 +176,7 @@ pub enum KnownBoundMethodType<'db> {
     ConstraintSetImpliesSubtypeOf(InternedConstraintSet<'db>),
     ConstraintSetSatisfies(InternedConstraintSet<'db>),
     ConstraintSetSatisfiedByAllTypeVars(InternedConstraintSet<'db>),
+    ConstraintSetWithDetailedDisplay(InternedConstraintSet<'db>),
 }
 
 pub(super) fn walk_method_wrapper_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
@@ -210,7 +211,8 @@ pub(super) fn walk_method_wrapper_type<'db, V: visitor::TypeVisitor<'db> + ?Size
         | KnownBoundMethodType::ConstraintSetNever
         | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
         | KnownBoundMethodType::ConstraintSetSatisfies(_)
-        | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_) => {}
+        | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
+        | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_) => {}
     }
 }
 
@@ -253,7 +255,8 @@ impl<'db> KnownBoundMethodType<'db> {
             | KnownBoundMethodType::ConstraintSetNever
             | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
             | KnownBoundMethodType::ConstraintSetSatisfies(_)
-            | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_) => Some(self),
+            | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
+            | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_) => Some(self),
         }
     }
 
@@ -271,7 +274,8 @@ impl<'db> KnownBoundMethodType<'db> {
             | KnownBoundMethodType::ConstraintSetNever
             | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
             | KnownBoundMethodType::ConstraintSetSatisfies(_)
-            | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_) => {
+            | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
+            | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_) => {
                 KnownClass::ConstraintSet
             }
         }
@@ -467,6 +471,13 @@ impl<'db> KnownBoundMethodType<'db> {
                     KnownClass::Bool.to_instance(db),
                 )))
             }
+
+            KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_) => {
+                Either::Right(std::iter::once(Signature::new(
+                    Parameters::empty(),
+                    KnownClass::ConstraintSet.to_instance(db),
+                )))
+            }
         }
     }
 }
@@ -529,6 +540,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             | (
                 KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_),
                 KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_),
+            )
+            | (
+                KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
+                KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
             ) => self.always(),
 
             (
@@ -543,7 +558,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
-                | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_),
+                | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
+                | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
                 KnownBoundMethodType::FunctionTypeDunderGet(_)
                 | KnownBoundMethodType::FunctionTypeDunderCall(_)
                 | KnownBoundMethodType::PropertyDunderGet(_)
@@ -555,7 +571,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
-                | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_),
+                | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
+                | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
             ) => self.never(),
         }
     }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -258,7 +258,8 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetNever
                 | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
                 | KnownBoundMethodType::ConstraintSetSatisfies(_)
-                | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_),
+                | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
+                | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
             )
             | Type::DataclassDecorator(_)
             | Type::DataclassTransformer(_)

--- a/crates/ty_vendored/ty_extensions/ty_extensions.pyi
+++ b/crates/ty_vendored/ty_extensions/ty_extensions.pyi
@@ -163,6 +163,16 @@ class ConstraintSet:
     def __and__(self, other: ConstraintSet) -> ConstraintSet: ...
     def __or__(self, other: ConstraintSet) -> ConstraintSet: ...
     def __invert__(self) -> ConstraintSet: ...
+    def with_detailed_display(self) -> ConstraintSet:
+        """
+        Returns a copy of this constraint set that will display the full
+        constraint formula when rendered as a string.
+
+        Typically we only display "bool" for a non-trivial constraint set, to
+        help ensure that we do not write test cases that depend on how
+        constraint sets are rendered. But it can be useful to see the full
+        detail for debugging purposes.
+        """
 
 class GenericContext:
     """

--- a/crates/ty_vendored/ty_extensions/ty_extensions.pyi
+++ b/crates/ty_vendored/ty_extensions/ty_extensions.pyi
@@ -205,6 +205,21 @@ def is_assignable_to(ty: TypeForm[object], to: TypeForm[object]) -> ConstraintSe
     .. _assignable: https://typing.python.org/en/latest/spec/concepts.html#the-assignable-to-or-consistent-subtyping-relation
     """
 
+def is_constraint_set_assignable_to(
+    ty: TypeForm[object],
+    to: TypeForm[object],
+) -> ConstraintSet:
+    """Returns a constraint set that is satisfied when `ty` is `assignable`_ to `to`.
+
+    This differs from `is_assignable_to` in how it treats typevars.
+    `is_assignable_to` will assume that all typevars are non-inferable, and will
+    require all possible specializations of a typevar to satisfy the relation.
+    This method will instead return a constraint set describing which
+    specializations (possibly not all of them) satisfy the relation.
+
+    .. _assignable: https://typing.python.org/en/latest/spec/concepts.html#the-assignable-to-or-consistent-subtyping-relation
+    """
+
 def is_disjoint_from(
     type_a: TypeForm[object], type_b: TypeForm[object]
 ) -> ConstraintSet:


### PR DESCRIPTION
This adds two new extension methods that were helpful while I was reviewing #25471:

- `ConstraintSet.with_detailed_display` causes us to print out the full boolean formula of a constraint set. I put this behind a method so that we aren't tempted to add mdtests that assert on the rendering of a constraint set, since this can change arbitrarily (even across different runs of ty).

- `is_constraint_set_assignable_to` lets us test the `ConstraintSetAssignability` typing relation, which differs from `Assignability` in how it handles comparisons against typevars.