### PR TITLE
[ty] Track unused-binding captures across nested scopes

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -131,9 +131,41 @@ struct ScopeInfo<'ast> {
     /// Text ranges for `global` and `nonlocal` declarations in this scope, which we use to
     /// populate `nested_global_or_nonlocal_declarations` when we reach end of scope.
     this_scope_global_or_nonlocal_declarations: FxHashMap<Name, TextRange>,
+    /// Free symbol uses from nested scopes that may resolve to this scope.
+    pending_captures: PendingCaptures,
 }
 
 type NestedGlobalOrNonlocalDeclarations = FxHashMap<Name, SmallVec<[NestedDeclaration; 1]>>;
+
+/// Captures cannot be resolved until the enclosing scope is complete because a later binding can
+/// make the name local. Each pending capture remembers the bindings visible when the nested scope
+/// was created and, for lazy scopes, any bindings added afterward.
+type PendingCaptures = FxHashMap<Name, SmallVec<[PendingCapture; 1]>>;
+
+#[derive(Debug)]
+struct PendingCapture {
+    nested_scope: FileScopeId,
+    laziness: ScopeLaziness,
+    binding_definition_ids: SmallVec<[ScopedDefinitionId; 2]>,
+}
+
+#[derive(Debug)]
+struct UnresolvedCapture {
+    /// The scope containing the free symbol use. Retaining this lets final resolution apply class
+    /// scope visibility rules correctly as the capture is propagated outward.
+    nested_scope: FileScopeId,
+    name: Name,
+    laziness: ScopeLaziness,
+}
+
+impl UnresolvedCapture {
+    fn through_scope(mut self, scope_laziness: ScopeLaziness) -> Self {
+        if scope_laziness.is_lazy() {
+            self.laziness = ScopeLaziness::Lazy;
+        }
+        self
+    }
+}
 
 #[derive(Copy, Clone, Debug, get_size2::GetSize)]
 pub struct NestedDeclaration {
@@ -247,8 +279,6 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     generator_functions: FxHashSet<FileScopeId>,
     /// Snapshots of enclosing-scope place states visible from nested scopes.
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, ScopedEnclosingSnapshotId>,
-    /// Symbols in lazy enclosing scopes that are actually referenced by a nested scope.
-    used_lazy_captures: FxHashSet<(FileScopeId, ScopedSymbolId)>,
     /// Errors collected by the `semantic_checker`.
     semantic_syntax_errors: RefCell<Vec<SemanticSyntaxError>>,
 
@@ -298,7 +328,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             generator_functions: FxHashSet::default(),
 
             enclosing_snapshots: FxHashMap::default(),
-            used_lazy_captures: FxHashSet::default(),
 
             python_version: Program::get(db).python_version(db),
             source_text: OnceCell::new(),
@@ -481,6 +510,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             narrowing_aliases: saved_aliases,
             nested_global_or_nonlocal_declarations: FxHashMap::default(),
             this_scope_global_or_nonlocal_declarations: FxHashMap::default(),
+            pending_captures: FxHashMap::default(),
         });
     }
 
@@ -544,7 +574,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         }
     }
 
-    fn bound_scope(&self, enclosing_scope: FileScopeId, name: &str) -> Option<FileScopeId> {
+    fn bound_scope(&self, enclosing_scope: FileScopeId, symbol: &Symbol) -> Option<FileScopeId> {
         self.scope_stack
             .iter()
             .rev()
@@ -552,20 +582,115 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             .find_map(|scope_info| {
                 let scope_id = scope_info.file_scope_id;
                 let place_table = &self.place_tables[scope_id];
-                let place_id = place_table.symbol_id(name)?;
+                let place_id = place_table.symbol_id(symbol.name())?;
                 place_table.place(place_id).is_bound().then_some(scope_id)
             })
     }
 
-    fn scope_and_descendant_ids(
-        &self,
-        scope_id: FileScopeId,
-    ) -> impl Iterator<Item = FileScopeId> + '_ {
-        let descendants = self.scopes[scope_id].descendants();
+    fn register_pending_capture(&mut self, capture: UnresolvedCapture) {
+        let current_scope = self.current_scope();
+        let binding_definition_ids = self.place_tables[current_scope]
+            .symbol_id(&capture.name)
+            .into_iter()
+            .flat_map(|symbol| {
+                self.use_def_maps[current_scope].symbol_binding_definition_ids(symbol)
+            })
+            .collect();
 
-        std::iter::once(scope_id).chain(
-            (descendants.start.as_u32()..descendants.end.as_u32()).map(FileScopeId::from_u32),
-        )
+        let captures = self
+            .current_scope_info_mut()
+            .pending_captures
+            .entry(capture.name)
+            .or_default();
+
+        if let Some(pending) = captures
+            .iter_mut()
+            .find(|pending| pending.nested_scope == capture.nested_scope)
+        {
+            pending
+                .binding_definition_ids
+                .extend(binding_definition_ids);
+            if capture.laziness.is_lazy() {
+                pending.laziness = ScopeLaziness::Lazy;
+            }
+        } else {
+            captures.push(PendingCapture {
+                nested_scope: capture.nested_scope,
+                laziness: capture.laziness,
+                binding_definition_ids,
+            });
+        }
+    }
+
+    fn record_pending_capture_binding(
+        &mut self,
+        symbol: ScopedSymbolId,
+        definition_id: ScopedDefinitionId,
+    ) {
+        let current_scope = self.current_scope();
+        let name = self.place_tables[current_scope]
+            .symbol(symbol)
+            .name()
+            .clone();
+
+        let Some(captures) = self
+            .current_scope_info_mut()
+            .pending_captures
+            .get_mut(&name)
+        else {
+            return;
+        };
+
+        for capture in captures {
+            if capture.laziness.is_lazy() {
+                capture.binding_definition_ids.push(definition_id);
+            }
+        }
+    }
+
+    fn finish_pending_captures(
+        &mut self,
+        popped_scope_id: FileScopeId,
+        popped_scope_laziness: ScopeLaziness,
+        pending_captures: PendingCaptures,
+    ) -> Vec<UnresolvedCapture> {
+        let mut unresolved = Vec::new();
+
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "capture resolution and usage marking are order-independent"
+        )]
+        for (name, captures) in pending_captures {
+            for capture in captures {
+                if self.resolve_nested_reference_scope(capture.nested_scope, &name)
+                    == Some(popped_scope_id)
+                {
+                    self.use_def_maps[popped_scope_id]
+                        .mark_binding_definitions_used(capture.binding_definition_ids);
+                } else {
+                    unresolved.push(
+                        UnresolvedCapture {
+                            nested_scope: capture.nested_scope,
+                            name: name.clone(),
+                            laziness: capture.laziness,
+                        }
+                        .through_scope(popped_scope_laziness),
+                    );
+                }
+            }
+        }
+
+        for symbol in self.place_tables[popped_scope_id].symbols() {
+            if symbol.is_used() && !symbol.is_local() && !symbol.is_global() {
+                unresolved.push(UnresolvedCapture {
+                    nested_scope: popped_scope_id,
+                    name: symbol.name().clone(),
+                    laziness: popped_scope_laziness,
+                });
+            }
+        }
+
+        unresolved
     }
 
     // Records snapshots of the place states visible from the current lazy scope.
@@ -577,8 +702,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
             // We don't record lazy snapshots of attributes or subscripts, because these are difficult to track as they modify.
             for nested_symbol in self.place_tables[popped_scope_id].symbols() {
-                let nested_symbol_name = nested_symbol.name();
-
                 // For the same reason, we don't snapshot bindings owned by `global`/`nonlocal`
                 // forwarding declarations here; `snapshot_enclosing_state` stores only a
                 // constraint for those symbols. Also, if the enclosing scope allows its members to
@@ -593,7 +716,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // Note that even if this place is bound in the popped scope,
                 // it may refer to the enclosing scope bindings
                 // so we also need to snapshot the bindings of the enclosing scope.
-                let Some(enclosed_symbol_id) = enclosing_place_table.symbol_id(nested_symbol_name)
+                let Some(enclosed_symbol_id) =
+                    enclosing_place_table.symbol_id(nested_symbol.name())
                 else {
                     continue;
                 };
@@ -601,7 +725,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 if !enclosing_place.is_bound() {
                     // If the bound scope of a place can be modified from elsewhere, the snapshot will not be recorded.
                     if self
-                        .bound_scope(enclosing_scope_id, nested_symbol_name.as_str())
+                        .bound_scope(enclosing_scope_id, nested_symbol)
                         .is_none_or(|scope| self.scopes[scope].visibility().is_public())
                     {
                         continue;
@@ -694,14 +818,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 {
                     self.use_def_maps[key.enclosing_scope]
                         .update_enclosing_snapshot(*snapshot_id, enclosing_symbol);
-
-                    if self
-                        .used_lazy_captures
-                        .contains(&(key.enclosing_scope, enclosing_symbol))
-                    {
-                        self.use_def_maps[key.enclosing_scope]
-                            .mark_symbol_bindings_used(enclosing_symbol);
-                    }
                 }
             }
         }
@@ -754,52 +870,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             })
     }
 
-    /// Marks outer bindings captured by the popped scope or any descendant scope as used.
-    ///
-    /// For lazy popped scopes, later reassignments can still reach the captured reference, so we
-    /// remember the captured symbol and mark future live bindings in `update_lazy_snapshots`.
-    fn mark_captured_bindings_used(
-        &mut self,
-        popped_scope_id: FileScopeId,
-        popped_scope_laziness: ScopeLaziness,
-    ) {
-        let mut used_captures = Vec::new();
-
-        for free_symbol_scope in self.scope_and_descendant_ids(popped_scope_id) {
-            for free_symbol in self.place_tables[free_symbol_scope].symbols() {
-                if !free_symbol.is_used() || free_symbol.is_local() || free_symbol.is_global() {
-                    continue;
-                }
-
-                let name = free_symbol.name();
-                let Some(enclosing_scope_id) =
-                    self.resolve_nested_reference_scope(free_symbol_scope, name.as_str())
-                else {
-                    continue;
-                };
-                let Some(enclosing_symbol_id) =
-                    self.place_tables[enclosing_scope_id].symbol_id(name)
-                else {
-                    continue;
-                };
-
-                used_captures.push((enclosing_scope_id, enclosing_symbol_id));
-            }
-        }
-
-        used_captures.sort_unstable();
-        used_captures.dedup();
-
-        for (enclosing_scope_id, enclosing_symbol_id) in used_captures {
-            self.use_def_maps[enclosing_scope_id].mark_symbol_bindings_used(enclosing_symbol_id);
-
-            if popped_scope_laziness.is_lazy() {
-                self.used_lazy_captures
-                    .insert((enclosing_scope_id, enclosing_symbol_id));
-            }
-        }
-    }
-
     /// Returns the `NestedGlobalOrNonlocalDeclarations` that are still visible to the enclosing
     /// scope, including those contributed by `global` and `nonlocal` keywords in the popped scope,
     /// but excluding nested `nonlocal`s that resolved to the popped scope.
@@ -811,6 +881,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             narrowing_aliases,
             mut nested_global_or_nonlocal_declarations,
             this_scope_global_or_nonlocal_declarations,
+            pending_captures,
             ..
         } = self
             .scope_stack
@@ -831,7 +902,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         } else {
             self.record_lazy_snapshots(popped_scope_id);
         }
-        self.mark_captured_bindings_used(popped_scope_id, popped_scope_laziness);
+
+        let unresolved_captures =
+            self.finish_pending_captures(popped_scope_id, popped_scope_laziness, pending_captures);
+        if !self.scope_stack.is_empty() {
+            for capture in unresolved_captures {
+                self.register_pending_capture(capture);
+            }
+        }
 
         // If we've popped the module scope, there is no enclosing scope that needs our nested
         // bindings. Short-circuit here and return an empty map.
@@ -1447,6 +1525,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             self.mark_place_declared(place);
         }
 
+        let definition_id = self.current_use_def_map().next_definition_id();
         let use_def = self.current_use_def_map_mut();
         match category {
             DefinitionCategory::DeclarationAndBinding => {
@@ -1473,10 +1552,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
         }
 
-        if category.is_binding() {
-            if let Some(id) = place.as_symbol() {
-                self.update_lazy_snapshots(id);
-            }
+        if category.is_binding()
+            && let Some(id) = place.as_symbol()
+        {
+            self.record_pending_capture_binding(id, definition_id);
+            self.update_lazy_snapshots(id);
         }
 
         let mut try_node_stack_manager = std::mem::take(&mut self.try_node_context_stack_manager);

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -598,9 +598,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
     // Records snapshots of the place states visible from the current lazy scope.
     fn record_lazy_snapshots(&mut self, popped_scope_id: FileScopeId) {
-        // A lazy scope can capture an outer binding through a nested eager scope. For example,
+        // A lazy scope can capture an outer binding via a nested scope. For example,
         // in `def inner(): return [a for _ in xs]`, `a` is free in the comprehension scope,
-        // not directly in `inner`, so include free symbols from descendants.
+        // not directly in `inner`, so include descendant free symbols when recording snapshots.
         let mut nested_symbol_names = self.free_symbol_names_in_scope_tree(popped_scope_id);
         nested_symbol_names.extend(
             self.place_tables[popped_scope_id]

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -627,48 +627,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         }
     }
 
-    fn mark_captures_used_by_scope_tree(
-        &mut self,
-        popped_scope_id: FileScopeId,
-        popped_scope_laziness: ScopeLaziness,
-    ) {
-        let mut used_captures = Vec::new();
-
-        for free_symbol_scope in self.scope_and_descendant_ids(popped_scope_id) {
-            for free_symbol in self.place_tables[free_symbol_scope].symbols() {
-                if !free_symbol.is_used() || free_symbol.is_local() || free_symbol.is_global() {
-                    continue;
-                }
-
-                let name = free_symbol.name();
-                let Some(enclosing_scope_id) =
-                    self.resolve_nested_reference_scope(free_symbol_scope, name.as_str())
-                else {
-                    continue;
-                };
-                let Some(enclosing_symbol_id) =
-                    self.place_tables[enclosing_scope_id].symbol_id(name)
-                else {
-                    continue;
-                };
-
-                used_captures.push((enclosing_scope_id, enclosing_symbol_id));
-            }
-        }
-
-        used_captures.sort_unstable();
-        used_captures.dedup();
-
-        for (enclosing_scope_id, enclosing_symbol_id) in used_captures {
-            self.use_def_maps[enclosing_scope_id].mark_symbol_bindings_used(enclosing_symbol_id);
-
-            if popped_scope_laziness.is_lazy() {
-                self.used_lazy_captures
-                    .insert((enclosing_scope_id, enclosing_symbol_id));
-            }
-        }
-    }
-
     /// Any lazy snapshots of the place that have been reassigned are obsolete, so update them.
     /// ```py
     /// def outer() -> None:
@@ -796,6 +754,48 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             })
     }
 
+    fn mark_captured_bindings_used(
+        &mut self,
+        popped_scope_id: FileScopeId,
+        popped_scope_laziness: ScopeLaziness,
+    ) {
+        let mut used_captures = Vec::new();
+
+        for free_symbol_scope in self.scope_and_descendant_ids(popped_scope_id) {
+            for free_symbol in self.place_tables[free_symbol_scope].symbols() {
+                if !free_symbol.is_used() || free_symbol.is_local() || free_symbol.is_global() {
+                    continue;
+                }
+
+                let name = free_symbol.name();
+                let Some(enclosing_scope_id) =
+                    self.resolve_nested_reference_scope(free_symbol_scope, name.as_str())
+                else {
+                    continue;
+                };
+                let Some(enclosing_symbol_id) =
+                    self.place_tables[enclosing_scope_id].symbol_id(name)
+                else {
+                    continue;
+                };
+
+                used_captures.push((enclosing_scope_id, enclosing_symbol_id));
+            }
+        }
+
+        used_captures.sort_unstable();
+        used_captures.dedup();
+
+        for (enclosing_scope_id, enclosing_symbol_id) in used_captures {
+            self.use_def_maps[enclosing_scope_id].mark_symbol_bindings_used(enclosing_symbol_id);
+
+            if popped_scope_laziness.is_lazy() {
+                self.used_lazy_captures
+                    .insert((enclosing_scope_id, enclosing_symbol_id));
+            }
+        }
+    }
+
     /// Returns the `NestedGlobalOrNonlocalDeclarations` that are still visible to the enclosing
     /// scope, including those contributed by `global` and `nonlocal` keywords in the popped scope,
     /// but excluding nested `nonlocal`s that resolved to the popped scope.
@@ -827,7 +827,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         } else {
             self.record_lazy_snapshots(popped_scope_id);
         }
-        self.mark_captures_used_by_scope_tree(popped_scope_id, popped_scope_laziness);
+        self.mark_captured_bindings_used(popped_scope_id, popped_scope_laziness);
 
         // If we've popped the module scope, there is no enclosing scope that needs our nested
         // bindings. Short-circuit here and return an empty map.

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -541,7 +541,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         }
     }
 
-    fn bound_scope(&self, enclosing_scope: FileScopeId, symbol: &Symbol) -> Option<FileScopeId> {
+    fn bound_scope(&self, enclosing_scope: FileScopeId, name: &str) -> Option<FileScopeId> {
         self.scope_stack
             .iter()
             .rev()
@@ -549,20 +549,72 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             .find_map(|scope_info| {
                 let scope_id = scope_info.file_scope_id;
                 let place_table = &self.place_tables[scope_id];
-                let place_id = place_table.symbol_id(symbol.name())?;
+                let place_id = place_table.symbol_id(name)?;
                 place_table.place(place_id).is_bound().then_some(scope_id)
             })
     }
 
+    fn scope_and_descendant_ids(
+        &self,
+        scope_id: FileScopeId,
+    ) -> impl Iterator<Item = FileScopeId> + '_ {
+        let descendants = self.scopes[scope_id].descendants();
+
+        std::iter::once(scope_id).chain(
+            (descendants.start.as_u32()..descendants.end.as_u32()).map(FileScopeId::from_u32),
+        )
+    }
+
+    fn free_symbol_uses_in_scope_tree(
+        &self,
+        scope_id: FileScopeId,
+        name: &str,
+    ) -> Vec<(FileScopeId, ScopedSymbolId)> {
+        self.scope_and_descendant_ids(scope_id)
+            .filter_map(|candidate_scope_id| {
+                let place_table = &self.place_tables[candidate_scope_id];
+                let symbol_id = place_table.symbol_id(name)?;
+                let symbol = place_table.symbol(symbol_id);
+
+                (symbol.is_used() && !symbol.is_local() && !symbol.is_global())
+                    .then_some((candidate_scope_id, symbol_id))
+            })
+            .collect()
+    }
+
+    fn free_symbol_names_in_scope_tree(&self, scope_id: FileScopeId) -> FxHashSet<Name> {
+        let mut names = FxHashSet::default();
+
+        for candidate_scope_id in self.scope_and_descendant_ids(scope_id) {
+            for symbol in self.place_tables[candidate_scope_id].symbols() {
+                if symbol.is_used() && !symbol.is_local() && !symbol.is_global() {
+                    names.insert(symbol.name().clone());
+                }
+            }
+        }
+
+        names
+    }
+
     // Records snapshots of the place states visible from the current lazy scope.
     fn record_lazy_snapshots(&mut self, popped_scope_id: FileScopeId) {
+        // A lazy scope can capture an outer binding through a nested eager scope. For example,
+        // in `def inner(): return [a for _ in xs]`, `a` is free in the comprehension scope,
+        // not directly in `inner`, so include free symbols from descendants.
+        let mut nested_symbol_names = self.free_symbol_names_in_scope_tree(popped_scope_id);
+        nested_symbol_names.extend(
+            self.place_tables[popped_scope_id]
+                .symbols()
+                .map(|symbol| symbol.name().clone()),
+        );
+
         for enclosing_scope_info in self.scope_stack.iter().rev() {
             let enclosing_scope_id = enclosing_scope_info.file_scope_id;
             let enclosing_scope_kind = self.scopes[enclosing_scope_id].kind();
             let enclosing_place_table = &self.place_tables[enclosing_scope_id];
 
             // We don't record lazy snapshots of attributes or subscripts, because these are difficult to track as they modify.
-            for nested_symbol in self.place_tables[popped_scope_id].symbols() {
+            for nested_symbol_name in &nested_symbol_names {
                 // For the same reason, we don't snapshot bindings owned by `global`/`nonlocal`
                 // forwarding declarations here; `snapshot_enclosing_state` stores only a
                 // constraint for those symbols. Also, if the enclosing scope allows its members to
@@ -577,8 +629,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // Note that even if this place is bound in the popped scope,
                 // it may refer to the enclosing scope bindings
                 // so we also need to snapshot the bindings of the enclosing scope.
-                let Some(enclosed_symbol_id) =
-                    enclosing_place_table.symbol_id(nested_symbol.name())
+                let Some(enclosed_symbol_id) = enclosing_place_table.symbol_id(nested_symbol_name)
                 else {
                     continue;
                 };
@@ -586,7 +637,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 if !enclosing_place.is_bound() {
                     // If the bound scope of a place can be modified from elsewhere, the snapshot will not be recorded.
                     if self
-                        .bound_scope(enclosing_scope_id, nested_symbol)
+                        .bound_scope(enclosing_scope_id, nested_symbol_name.as_str())
                         .is_none_or(|scope| self.scopes[scope].visibility().is_public())
                     {
                         continue;
@@ -752,29 +803,19 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
             let enclosing_symbol =
                 self.place_tables[key.enclosing_scope].symbol(enclosing_symbol_id);
-            let nested_place_table = &self.place_tables[key.nested_scope];
+            let name = enclosing_symbol.name().as_str();
+            let resolves_to_enclosing_scope = self
+                .free_symbol_uses_in_scope_tree(key.nested_scope, name)
+                .into_iter()
+                .any(|(nested_scope, nested_symbol_id)| {
+                    let resolved_scope = *resolved_scopes_by_nested_symbol
+                        .entry((nested_scope, nested_symbol_id))
+                        .or_insert_with(|| self.resolve_nested_reference_scope(nested_scope, name));
 
-            let Some(nested_symbol_id) =
-                nested_place_table.symbol_id(enclosing_symbol.name().as_str())
-            else {
-                continue;
-            };
-
-            let nested_symbol = nested_place_table.symbol(nested_symbol_id);
-            if !nested_symbol.is_used() || nested_symbol.is_local() || nested_symbol.is_global() {
-                continue;
-            }
-
-            let resolved_scope = *resolved_scopes_by_nested_symbol
-                .entry((key.nested_scope, nested_symbol_id))
-                .or_insert_with(|| {
-                    self.resolve_nested_reference_scope(
-                        key.nested_scope,
-                        enclosing_symbol.name().as_str(),
-                    )
+                    resolved_scope == Some(key.enclosing_scope)
                 });
 
-            if resolved_scope == Some(key.enclosing_scope) {
+            if resolves_to_enclosing_scope {
                 snapshots_to_mark.push((key.enclosing_scope, snapshot_id));
             }
         }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -247,6 +247,8 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     generator_functions: FxHashSet<FileScopeId>,
     /// Snapshots of enclosing-scope place states visible from nested scopes.
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, ScopedEnclosingSnapshotId>,
+    /// Symbols in lazy enclosing scopes that are actually referenced by a nested scope.
+    used_lazy_captures: FxHashSet<(FileScopeId, ScopedSymbolId)>,
     /// Errors collected by the `semantic_checker`.
     semantic_syntax_errors: RefCell<Vec<SemanticSyntaxError>>,
 
@@ -296,6 +298,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             generator_functions: FxHashSet::default(),
 
             enclosing_snapshots: FxHashMap::default(),
+            used_lazy_captures: FxHashSet::default(),
 
             python_version: Program::get(db).python_version(db),
             source_text: OnceCell::new(),
@@ -565,56 +568,17 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         )
     }
 
-    fn free_symbol_uses_in_scope_tree(
-        &self,
-        scope_id: FileScopeId,
-        name: &str,
-    ) -> Vec<(FileScopeId, ScopedSymbolId)> {
-        self.scope_and_descendant_ids(scope_id)
-            .filter_map(|candidate_scope_id| {
-                let place_table = &self.place_tables[candidate_scope_id];
-                let symbol_id = place_table.symbol_id(name)?;
-                let symbol = place_table.symbol(symbol_id);
-
-                (symbol.is_used() && !symbol.is_local() && !symbol.is_global())
-                    .then_some((candidate_scope_id, symbol_id))
-            })
-            .collect()
-    }
-
-    fn free_symbol_names_in_scope_tree(&self, scope_id: FileScopeId) -> FxHashSet<Name> {
-        let mut names = FxHashSet::default();
-
-        for candidate_scope_id in self.scope_and_descendant_ids(scope_id) {
-            for symbol in self.place_tables[candidate_scope_id].symbols() {
-                if symbol.is_used() && !symbol.is_local() && !symbol.is_global() {
-                    names.insert(symbol.name().clone());
-                }
-            }
-        }
-
-        names
-    }
-
     // Records snapshots of the place states visible from the current lazy scope.
     fn record_lazy_snapshots(&mut self, popped_scope_id: FileScopeId) {
-        // A lazy scope can capture an outer binding via a nested scope. For example,
-        // in `def inner(): return [a for _ in xs]`, `a` is free in the comprehension scope,
-        // not directly in `inner`, so include descendant free symbols when recording snapshots.
-        let mut nested_symbol_names = self.free_symbol_names_in_scope_tree(popped_scope_id);
-        nested_symbol_names.extend(
-            self.place_tables[popped_scope_id]
-                .symbols()
-                .map(|symbol| symbol.name().clone()),
-        );
-
         for enclosing_scope_info in self.scope_stack.iter().rev() {
             let enclosing_scope_id = enclosing_scope_info.file_scope_id;
             let enclosing_scope_kind = self.scopes[enclosing_scope_id].kind();
             let enclosing_place_table = &self.place_tables[enclosing_scope_id];
 
             // We don't record lazy snapshots of attributes or subscripts, because these are difficult to track as they modify.
-            for nested_symbol_name in &nested_symbol_names {
+            for nested_symbol in self.place_tables[popped_scope_id].symbols() {
+                let nested_symbol_name = nested_symbol.name();
+
                 // For the same reason, we don't snapshot bindings owned by `global`/`nonlocal`
                 // forwarding declarations here; `snapshot_enclosing_state` stores only a
                 // constraint for those symbols. Also, if the enclosing scope allows its members to
@@ -659,6 +623,48 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     false,
                 );
                 self.enclosing_snapshots.insert(key, lazy_snapshot);
+            }
+        }
+    }
+
+    fn mark_captures_used_by_scope_tree(
+        &mut self,
+        popped_scope_id: FileScopeId,
+        popped_scope_laziness: ScopeLaziness,
+    ) {
+        let mut used_captures = Vec::new();
+
+        for free_symbol_scope in self.scope_and_descendant_ids(popped_scope_id) {
+            for free_symbol in self.place_tables[free_symbol_scope].symbols() {
+                if !free_symbol.is_used() || free_symbol.is_local() || free_symbol.is_global() {
+                    continue;
+                }
+
+                let name = free_symbol.name();
+                let Some(enclosing_scope_id) =
+                    self.resolve_nested_reference_scope(free_symbol_scope, name.as_str())
+                else {
+                    continue;
+                };
+                let Some(enclosing_symbol_id) =
+                    self.place_tables[enclosing_scope_id].symbol_id(name)
+                else {
+                    continue;
+                };
+
+                used_captures.push((enclosing_scope_id, enclosing_symbol_id));
+            }
+        }
+
+        used_captures.sort_unstable();
+        used_captures.dedup();
+
+        for (enclosing_scope_id, enclosing_symbol_id) in used_captures {
+            self.use_def_maps[enclosing_scope_id].mark_symbol_bindings_used(enclosing_symbol_id);
+
+            if popped_scope_laziness.is_lazy() {
+                self.used_lazy_captures
+                    .insert((enclosing_scope_id, enclosing_symbol_id));
             }
         }
     }
@@ -730,6 +736,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 {
                     self.use_def_maps[key.enclosing_scope]
                         .update_enclosing_snapshot(*snapshot_id, enclosing_symbol);
+
+                    if self
+                        .used_lazy_captures
+                        .contains(&(key.enclosing_scope, enclosing_symbol))
+                    {
+                        self.use_def_maps[key.enclosing_scope]
+                            .mark_symbol_bindings_used(enclosing_symbol);
+                    }
                 }
             }
         }
@@ -782,49 +796,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             })
     }
 
-    /// Marks bindings in enclosing scopes as used when a nested scope resolves a reference to them.
-    ///
-    /// This reuses enclosing-snapshot data so lazy scopes account for later reassignments that can
-    /// also reach the nested reference.
-    fn mark_captured_bindings_used(&mut self) {
-        let mut resolved_scopes_by_nested_symbol =
-            FxHashMap::<(FileScopeId, ScopedSymbolId), Option<FileScopeId>>::default();
-
-        let mut snapshots_to_mark = Vec::new();
-
-        #[expect(
-            clippy::iter_over_hash_type,
-            reason = "snapshot resolution is independent and marking bindings is idempotent"
-        )]
-        for (&key, &snapshot_id) in &self.enclosing_snapshots {
-            let ScopedPlaceId::Symbol(enclosing_symbol_id) = key.enclosing_place else {
-                continue;
-            };
-
-            let enclosing_symbol =
-                self.place_tables[key.enclosing_scope].symbol(enclosing_symbol_id);
-            let name = enclosing_symbol.name().as_str();
-            let resolves_to_enclosing_scope = self
-                .free_symbol_uses_in_scope_tree(key.nested_scope, name)
-                .into_iter()
-                .any(|(nested_scope, nested_symbol_id)| {
-                    let resolved_scope = *resolved_scopes_by_nested_symbol
-                        .entry((nested_scope, nested_symbol_id))
-                        .or_insert_with(|| self.resolve_nested_reference_scope(nested_scope, name));
-
-                    resolved_scope == Some(key.enclosing_scope)
-                });
-
-            if resolves_to_enclosing_scope {
-                snapshots_to_mark.push((key.enclosing_scope, snapshot_id));
-            }
-        }
-
-        for (scope_id, snapshot_id) in snapshots_to_mark {
-            self.use_def_maps[scope_id].mark_enclosing_snapshot_bindings_used(snapshot_id);
-        }
-    }
-
     /// Returns the `NestedGlobalOrNonlocalDeclarations` that are still visible to the enclosing
     /// scope, including those contributed by `global` and `nonlocal` keywords in the popped scope,
     /// but excluding nested `nonlocal`s that resolved to the popped scope.
@@ -849,11 +820,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         popped_scope.extend_descendants(children_end);
         let popped_scope_kind = popped_scope.kind();
 
-        if popped_scope.is_eager() {
+        let popped_scope_laziness = popped_scope.kind().laziness();
+
+        if popped_scope_laziness.is_eager() {
             self.record_eager_snapshots(popped_scope_id);
         } else {
             self.record_lazy_snapshots(popped_scope_id);
         }
+        self.mark_captures_used_by_scope_tree(popped_scope_id, popped_scope_laziness);
 
         // If we've popped the module scope, there is no enclosing scope that needs our nested
         // bindings. Short-circuit here and return an empty map.
@@ -2527,7 +2501,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         // Pop the root scope
         self.pop_scope();
-        self.mark_captured_bindings_used();
         self.sweep_nonlocal_lazy_snapshots();
         assert!(self.scope_stack.is_empty());
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -754,6 +754,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             })
     }
 
+    /// Marks outer bindings captured by the popped scope or any descendant scope as used.
+    ///
+    /// For lazy popped scopes, later reassignments can still reach the captured reference, so we
+    /// remember the captured symbol and mark future live bindings in `update_lazy_snapshots`.
     fn mark_captured_bindings_used(
         &mut self,
         popped_scope_id: FileScopeId,

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1794,17 +1794,12 @@ impl<'db> UseDefMapBuilder<'db> {
         debug_assert_eq!(use_id, new_use);
     }
 
-    pub(super) fn mark_enclosing_snapshot_bindings_used(
-        &mut self,
-        snapshot_id: ScopedEnclosingSnapshotId,
-    ) {
-        let Some(EnclosingSnapshot::Bindings(bindings)) = self.enclosing_snapshots.get(snapshot_id)
-        else {
-            return;
-        };
-
-        let binding_definition_ids: Vec<ScopedDefinitionId> =
-            bindings.iter().map(LiveBinding::binding).collect();
+    pub(super) fn mark_symbol_bindings_used(&mut self, symbol: ScopedSymbolId) {
+        let binding_definition_ids: Vec<ScopedDefinitionId> = self.symbol_states[symbol]
+            .bindings()
+            .iter()
+            .map(LiveBinding::binding)
+            .collect();
         self.mark_definition_ids_used(binding_definition_ids);
     }
 

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1794,12 +1794,20 @@ impl<'db> UseDefMapBuilder<'db> {
         debug_assert_eq!(use_id, new_use);
     }
 
-    pub(super) fn mark_symbol_bindings_used(&mut self, symbol: ScopedSymbolId) {
-        let binding_definition_ids: Vec<ScopedDefinitionId> = self.symbol_states[symbol]
+    pub(super) fn symbol_binding_definition_ids(
+        &self,
+        symbol: ScopedSymbolId,
+    ) -> impl Iterator<Item = ScopedDefinitionId> + '_ {
+        self.symbol_states[symbol]
             .bindings()
             .iter()
             .map(LiveBinding::binding)
-            .collect();
+    }
+
+    pub(super) fn mark_binding_definitions_used(
+        &mut self,
+        binding_definition_ids: impl IntoIterator<Item = ScopedDefinitionId>,
+    ) {
         self.mark_definition_ids_used(binding_definition_ids);
     }
 

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -653,6 +653,58 @@ mod tests {
     }
 
     #[test]
+    fn closure_uses_later_shadowing_binding() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def outer():
+                x = 0
+
+                def mid():
+                    def inner():
+                        return x
+
+                    x = 1
+                    return inner
+
+                return mid
+            ",
+        );
+
+        let bindings = collect_unused_bindings(&source)?;
+        let outer_x_start = TextSize::try_from(source.find("x = 0").unwrap()).unwrap();
+        assert_eq!(
+            bindings,
+            vec![UnusedBinding {
+                range: TextRange::new(outer_x_start, outer_x_start + TextSize::new(1)),
+                name: Name::new("x"),
+            }]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn nested_comprehension_capture_uses_intermediate_rebindings() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def outer():
+                a = 1
+
+                def inner():
+                    return [a for _ in range(1)]
+
+                a = 2
+                inner()
+                a = 3
+                return inner
+            ",
+        );
+
+        let names = collect_unused_names(&source)?;
+        assert_eq!(names, Vec::<String>::new());
+        Ok(())
+    }
+
+    #[test]
     fn nonlocal_proxy_scope_still_marks_outer_binding_used() -> anyhow::Result<()> {
         let source = dedent(
             "

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -559,6 +559,42 @@ mod tests {
     }
 
     #[test]
+    fn skips_binding_captured_by_comprehension_in_nested_function() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def outer() -> None:
+                a = 1
+
+                def inner() -> list[int]:
+                    return [a + x for x in [1, 2, 3]]
+
+                return inner
+            ",
+        );
+
+        let names = collect_unused_names(&source)?;
+        assert_eq!(names, Vec::<String>::new());
+        Ok(())
+    }
+
+    #[test]
+    fn skips_parameter_captured_by_nested_comprehension() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def foo(i: int):
+                def bar():
+                    return [[k for k in range(i)] for _ in range(2)]
+
+                return bar
+            ",
+        );
+
+        let names = collect_unused_names(&source)?;
+        assert_eq!(names, Vec::<String>::new());
+        Ok(())
+    }
+
+    #[test]
     fn closure_uses_nearest_shadowed_binding() -> anyhow::Result<()> {
         let source = dedent(
             "

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -559,6 +559,33 @@ mod tests {
     }
 
     #[test]
+    fn closure_use_does_not_mark_shadowed_binding_used() -> anyhow::Result<()> {
+        let source = dedent(
+            "
+            def outer():
+                x = 1
+                x = 2
+
+                def inner():
+                    return x
+
+                return inner
+            ",
+        );
+
+        let bindings = collect_unused_bindings(&source)?;
+        let first_x_start = TextSize::try_from(source.find("x = 1").unwrap()).unwrap();
+        assert_eq!(
+            bindings,
+            vec![UnusedBinding {
+                range: TextRange::new(first_x_start, first_x_start + TextSize::new(1)),
+                name: Name::new("x"),
+            }]
+        );
+        Ok(())
+    }
+
+    #[test]
     fn skips_binding_captured_by_comprehension_in_nested_function() -> anyhow::Result<()> {
         let source = dedent(
             "


### PR DESCRIPTION
## Summary

We previously determined whether an enclosing binding was used by reusing the snapshots created for type inference. This misses captures that originate in a descendant scope across a lazy function boundary:

```python
def outer(i: int):
    def inner():
        return [[k for k in range(i)] for _ in range(2)]

    return inner
```

The read of `i` belongs to a comprehension scope nested under `inner`. Snapshot traversal stops at the lazy `inner` scope, so the final unused-binding pass could not connect that descendant read to `outer`'s parameter and incorrectly reported `i` as unused.

This tracks capture usage independently from type-resolution snapshots. When a scope completes, unresolved free-name uses are propagated to its parent until the completed scope that owns the name can claim them.

We defer that resolution until each candidate enclosing scope is complete because a later binding can change which scope owns the name:

```python
def outer():
    x = 0

    def middle():
        def inner():
            return x

        x = 1
        return inner

    return middle
```

Here, Python treats `x` as local to `middle` even though its binding follows `inner`, so `inner` captures `x = 1` and `outer`'s `x = 0` remains unused. Pending captures retain the bindings visible when the nested scope was created and, for lazy scopes, later bindings and reassignments that can reach the capture.

Regression coverage includes nested comprehensions, captured parameters, shadowed outer bindings, bindings introduced after nested functions, intermediate reassignments, and `nonlocal` proxy scopes.

Closes https://github.com/astral-sh/ty/issues/3442.
