### PR TITLE
[`eradicate`] Avoid flagging `ruff:ignore` comments as code (`ERA001`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
+++ b/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
@@ -97,6 +97,7 @@ print(1)
 
 # ty: ignore
 # ruff: ignore[ARG001]
+# ruff: file-ignore[ARG001]
 
 # mypy: ignore-errors
 # pyright: ignore-errors

--- a/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
+++ b/crates/ruff_linter/resources/test/fixtures/eradicate/ERA001.py
@@ -92,9 +92,11 @@ print(1)
 
 
 # Regression tests for https://github.com/astral-sh/ruff/issues/19713,
-# https://github.com/astral-sh/ruff/issues/24186
+# https://github.com/astral-sh/ruff/issues/24186,
+# https://github.com/astral-sh/ruff/issues/25535
 
 # ty: ignore
+# ruff: ignore[ARG001]
 
 # mypy: ignore-errors
 # pyright: ignore-errors

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -22,7 +22,7 @@ static ALLOWLIST_REGEX: LazyLock<Regex> = LazyLock::new(|| {
             # Case-sensitive
             pyright
         |   pyrefly
-        |   ruff\s*:\s*(disable|enable|ignore)
+        |   ruff\s*:\s*(disable|enable|ignore|file-ignore)
         |   mypy:
         |   type:\s*ignore
         |   ty:\s*ignore
@@ -157,6 +157,7 @@ mod tests {
         assert!(!comment_contains_code("#ruff:enable[E501, F84]", &[]));
         assert!(!comment_contains_code("# ruff: ignore[ARG001]", &[]));
         assert!(!comment_contains_code("#ruff:ignore[ARG001]", &[]));
+        assert!(!comment_contains_code("#ruff:file-ignore[ARG001]", &[]));
         assert!(!comment_contains_code(
             "# pylint: disable=redefined-outer-name",
             &[]

--- a/crates/ruff_linter/src/rules/eradicate/detection.rs
+++ b/crates/ruff_linter/src/rules/eradicate/detection.rs
@@ -22,7 +22,7 @@ static ALLOWLIST_REGEX: LazyLock<Regex> = LazyLock::new(|| {
             # Case-sensitive
             pyright
         |   pyrefly
-        |   ruff\s*:\s*(disable|enable)
+        |   ruff\s*:\s*(disable|enable|ignore)
         |   mypy:
         |   type:\s*ignore
         |   ty:\s*ignore
@@ -155,6 +155,8 @@ mod tests {
         assert!(!comment_contains_code("\t# testing: Foo Bar Baz", &[]));
         assert!(!comment_contains_code("# ruff: disable[E501]", &[]));
         assert!(!comment_contains_code("#ruff:enable[E501, F84]", &[]));
+        assert!(!comment_contains_code("# ruff: ignore[ARG001]", &[]));
+        assert!(!comment_contains_code("#ruff:ignore[ARG001]", &[]));
         assert!(!comment_contains_code(
             "# pylint: disable=redefined-outer-name",
             &[]


### PR DESCRIPTION
Summary
--

Fixes #25535 by treating `ruff:ignore` and `ruff:file-ignore` comments in the same way as `ruff:enable` and `ruff:disable` comments.

Test Plan
--

New tests based on the issue
