### PR TITLE
[ty] don't inject Unknown from non-callable elements of intersection call

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -1082,7 +1082,7 @@ def _(
     # `NotCallable` would fail with call-non-callable
     # We only show the call-top-callable error (it's more specific)
     # error: [call-top-callable]
-    x()
+    reveal_type(x())  # revealed: object
 ```
 
 ### Keyword arguments

--- a/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
@@ -69,6 +69,17 @@ def call_with_args(y: object, a: int, b: str) -> object:
     return None
 ```
 
+If a top-callable is part of an intersection, it should still contribute its return type even when
+the other intersection elements are not callable:
+
+```py
+def resolve(value: str):
+    if callable(value):
+        reveal_type(value)  # revealed: str & Top[(...) -> object]
+        # error: [call-top-callable]
+        reveal_type(value())  # revealed: object
+```
+
 ## Narrowing with named expressions (walrus operator)
 
 When `callable()` is used with a named expression, the target of the named expression should be

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -283,7 +283,17 @@ impl<'db> BindingsElement<'db> {
     }
 
     fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
-        IntersectionType::from_elements(db, self.items.iter().map(|item| item.return_type(db)))
+        if self.is_callable() {
+            IntersectionType::from_elements(
+                db,
+                self.items
+                    .iter()
+                    .filter(|item| item.is_callable())
+                    .map(|item| item.return_type(db)),
+            )
+        } else {
+            Type::unknown()
+        }
     }
 
     /// Check types for all bindings in this element.


### PR DESCRIPTION
## Summary

Avoid inserting `Unknown` into the return type of calling an intersection from non-callable intersection elements.

Closes https://github.com/astral-sh/ty/issues/3617

## Testing

Added/updated mdtests.

The ecosystem shows the expected results -- lots more cases where we now actually enforce top callables in an intersection returning `object`.