### PR TITLE
[ty] nested class typevar subdiagnostic

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/scoping.md
@@ -402,11 +402,20 @@ class C[T]:
     ok1: list[T] = []
 
     class Bad:
-        # error: [unbound-type-variable]
-        bad: list[T] = []
+        bad: list[T] = []  # snapshot: unbound-type-variable
 
     class Inner[S]: ...
     ok2: Inner[T]
+```
+
+```snapshot
+error[unbound-type-variable]: Type variable `T` is not bound to any outer generic context
+ --> src/mdtest_snippet.py:5:19
+  |
+5 |         bad: list[T] = []  # snapshot: unbound-type-variable
+  |                   ^
+  |
+info: Type variables from outer generic class `C` are not valid in nested classes
 ```
 
 ## Type parameter defaults cannot reference outer-scope type parameters

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -15,6 +15,7 @@ use crate::types::signatures::{ConcatenateTail, Signature};
 use crate::types::special_form::{AliasSpec, LegacyStdlibAlias};
 use crate::types::string_annotation::parse_string_annotation;
 use crate::types::tuple::{TupleSpecBuilder, TupleType};
+use crate::types::typevar::TypeVarInstance;
 use ty_python_core::scope::ScopeKind;
 
 use crate::types::{
@@ -2869,14 +2870,37 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
         if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty {
             if let Some(builder) = self.context.report_lint(&UNBOUND_TYPE_VARIABLE, expression) {
-                builder.into_diagnostic(format_args!(
+                let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Type variable `{name}` is not bound to any outer generic context",
                     name = typevar.name(self.db())
                 ));
+                if let Some(class_name) = self.outer_class_name_for_unbound_typevar(typevar) {
+                    diagnostic.info(format_args!(
+                        "Type variables from outer generic class `{class_name}` are not valid in \
+                        nested classes"
+                    ));
+                }
             }
             Type::unknown()
         } else {
             ty
         }
+    }
+
+    fn outer_class_name_for_unbound_typevar(
+        &self,
+        typevar: TypeVarInstance<'db>,
+    ) -> Option<String> {
+        let db = self.db();
+        self.index
+            .ancestor_scopes(self.scope().file_scope_id(db))
+            .filter_map(|(_, scope)| scope.node().as_class().map(|class| (scope, class)))
+            // Skip the innermost class; only outer classes can explain a nested-class boundary.
+            .skip(1)
+            .find_map(|(scope, class)| {
+                let generic_context = GenericContext::of_node(db, scope.node(), self.index)?;
+                generic_context.binds_typevar(db, typevar)?;
+                self.index.expect_single_definition(class).name(db)
+            })
     }
 }


### PR DESCRIPTION
Closes https://github.com/astral-sh/ty/issues/3562

## Summary

Improve `unbound-type-variable` diagnostics for type variables from outer generic classes used in nested class bodies.

## Test Plan

md test
