### PR TITLE
[ty] Support `Callable()` in match statement class patterns

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1908,19 +1908,26 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ast::Pattern::MatchClass(pattern) => {
                 let cls = self.add_standalone_expression(&pattern.cls);
 
+                // A class pattern is only irrefutable if:
+                // - It has no pattern arguments
+                // - The pattern arguments map to attributes that can be guaranteed
+                // to be extracted at runtime
+                // - It is a match-self pattern (like `int(_)` or `str(x)`) that matches
+                // the whole object rather than extracting an attribute
+                //
+                // For example: `case Point():` is exhaustive among Point instances,
+                // however case `Point(x, y):` and `case Point(x=_, y=_):`` can fail because attribute extraction can fail,
+                // even though x and y themselves are irrefutable capture/wildcard subpatterns.
+                //
+                // TODO: More precise evaluation of whether the class pattern is refutable, based
+                // on statically analyzing attributes and `__match_args__`, as well as handling
+                // builtin classes.
+                let is_irrefutable =
+                    pattern.arguments.patterns.is_empty() && pattern.arguments.keywords.is_empty();
+
                 PatternPredicateKind::Class(
                     cls,
-                    if pattern
-                        .arguments
-                        .patterns
-                        .iter()
-                        .all(ast::Pattern::is_irrefutable)
-                        && pattern
-                            .arguments
-                            .keywords
-                            .iter()
-                            .all(|kw| kw.pattern.is_irrefutable())
-                    {
+                    if is_irrefutable {
                         ClassPatternKind::Irrefutable
                     } else {
                         ClassPatternKind::Refutable

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1908,26 +1908,19 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ast::Pattern::MatchClass(pattern) => {
                 let cls = self.add_standalone_expression(&pattern.cls);
 
-                // A class pattern is only irrefutable if:
-                // - It has no pattern arguments
-                // - The pattern arguments map to attributes that can be guaranteed
-                // to be extracted at runtime
-                // - It is a match-self pattern (like `int(_)` or `str(x)`) that matches
-                // the whole object rather than extracting an attribute
-                //
-                // For example: `case Point():` is exhaustive among Point instances,
-                // however case `Point(x, y):` and `case Point(x=_, y=_):`` can fail because attribute extraction can fail,
-                // even though x and y themselves are irrefutable capture/wildcard subpatterns.
-                //
-                // TODO: More precise evaluation of whether the class pattern is refutable, based
-                // on statically analyzing attributes and `__match_args__`, as well as handling
-                // builtin classes.
-                let is_irrefutable =
-                    pattern.arguments.patterns.is_empty() && pattern.arguments.keywords.is_empty();
-
                 PatternPredicateKind::Class(
                     cls,
-                    if is_irrefutable {
+                    if pattern
+                        .arguments
+                        .patterns
+                        .iter()
+                        .all(ast::Pattern::is_irrefutable)
+                        && pattern
+                            .arguments
+                            .keywords
+                            .iter()
+                            .all(|kw| kw.pattern.is_irrefutable())
+                    {
                         ClassPatternKind::Irrefutable
                     } else {
                         ClassPatternKind::Refutable

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1908,6 +1908,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ast::Pattern::MatchClass(pattern) => {
                 let cls = self.add_standalone_expression(&pattern.cls);
 
+                // TODO: A class pattern with only irrefutable subpatterns can still fail if
+                // extracting an attribute named by `__match_args__` or a keyword fails. We retain
+                // this existing approximation because treating all class patterns with arguments
+                // as refutable caused a large ecosystem change. Follow-up work should determine
+                // irrefutability by analyzing the class's attributes and `__match_args__`.
                 PatternPredicateKind::Class(
                     cls,
                     if pattern

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -233,22 +233,12 @@ def _(subj: int | abc.Callable[..., str]) -> None:
             y = 3
 
     reveal_type(y)  # revealed: Literal[2, 3]
-
-def _(subj: abc.Callable[..., str]) -> None:
-    y = 1
-
-    match subj:
-        case abc.Callable(foo=_):
-            y = 2
-        case _:
-            y = 3
-
-    reveal_type(y)  # revealed: Literal[2, 3]
 ```
 
 ### With arguments
 
 ```py
+from typing_extensions import assert_never
 from dataclasses import dataclass
 
 @dataclass
@@ -257,7 +247,6 @@ class Point:
     y: int
 
 class Other: ...
-class C: ...
 
 def _(target: Point):
     y = 1
@@ -274,21 +263,10 @@ def _(target: Point):
 
 def _(target: Point):
     match target:
-        case Point(x, y):  # irrefutable sub-patterns, but refutable attribute extraction
+        case Point(x, y):  # irrefutable sub-patterns
             pass
         case _:
-            reveal_type(target)  # revealed: Point
-
-def _(target: C):
-    y = 1
-
-    match target:
-        case C(foo=_):
-            y = 2
-        case _:
-            y = 3
-
-    reveal_type(y)  # revealed: Literal[2, 3]
+            assert_never(target)
 
 def _(target: Point | Other):
     match target:

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -196,9 +196,11 @@ def _(target: FooSub | str):
             y = 4
 
     reveal_type(y)  # revealed: Literal[1, 3, 4]
+```
 
-# Also handle special case for `collections.abc.Callable`
+### `collections.abc.Callable`
 
+```py
 from collections import abc
 
 def _(subj: abc.Callable[..., str]) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -231,12 +231,22 @@ def _(subj: int | abc.Callable[..., str]) -> None:
             y = 3
 
     reveal_type(y)  # revealed: Literal[2, 3]
+
+def _(subj: abc.Callable[..., str]) -> None:
+    y = 1
+
+    match subj:
+        case abc.Callable(foo=_):
+            y = 2
+        case _:
+            y = 3
+
+    reveal_type(y)  # revealed: Literal[2, 3]
 ```
 
 ### With arguments
 
 ```py
-from typing_extensions import assert_never
 from dataclasses import dataclass
 
 @dataclass
@@ -245,6 +255,7 @@ class Point:
     y: int
 
 class Other: ...
+class C: ...
 
 def _(target: Point):
     y = 1
@@ -261,10 +272,21 @@ def _(target: Point):
 
 def _(target: Point):
     match target:
-        case Point(x, y):  # irrefutable sub-patterns
+        case Point(x, y):  # irrefutable sub-patterns, but refutable attribute extraction
             pass
         case _:
-            assert_never(target)
+            reveal_type(target)  # revealed: Point
+
+def _(target: C):
+    y = 1
+
+    match target:
+        case C(foo=_):
+            y = 2
+        case _:
+            y = 3
+
+    reveal_type(y)  # revealed: Literal[2, 3]
 
 def _(target: Point | Other):
     match target:

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -212,7 +212,7 @@ def _(subj: abc.Callable[..., str]) -> None:
         case _:
             y = 3
 
-    reveal_type(y)  # revealed: Literal[2]
+    reveal_type(y)  # revealed: Literal[2, 3]
 
 def _(subj: None) -> None:
     y = 1
@@ -221,7 +221,7 @@ def _(subj: None) -> None:
         case abc.Callable():
             y = 2
 
-    reveal_type(y)  # revealed: Literal[1]
+    reveal_type(y)  # revealed: Literal[1, 2]
 
 def _(subj: int | abc.Callable[..., str]) -> None:
     y = 1

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -196,6 +196,41 @@ def _(target: FooSub | str):
             y = 4
 
     reveal_type(y)  # revealed: Literal[1, 3, 4]
+
+# Also handle special case for `collections.abc.Callable`
+
+from collections import abc
+
+def _(subj: abc.Callable[..., str]) -> None:
+    y = 1
+
+    match subj:
+        case abc.Callable():
+            y = 2
+        case _:
+            y = 3
+
+    reveal_type(y)  # revealed: Literal[2]
+
+def _(subj: None) -> None:
+    y = 1
+
+    match subj:
+        case abc.Callable():
+            y = 2
+
+    reveal_type(y)  # revealed: Literal[1]
+
+def _(subj: int | abc.Callable[..., str]) -> None:
+    y = 1
+
+    match subj:
+        case abc.Callable():
+            y = 2
+        case _:
+            y = 3
+
+    reveal_type(y)  # revealed: Literal[2, 3]
 ```
 
 ### With arguments

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -212,7 +212,7 @@ def _(subj: abc.Callable[..., str]) -> None:
         case _:
             y = 3
 
-    reveal_type(y)  # revealed: Literal[2, 3]
+    reveal_type(y)  # revealed: Literal[2]
 
 def _(subj: None) -> None:
     y = 1
@@ -221,7 +221,7 @@ def _(subj: None) -> None:
         case abc.Callable():
             y = 2
 
-    reveal_type(y)  # revealed: Literal[1, 2]
+    reveal_type(y)  # revealed: Literal[1]
 
 def _(subj: int | abc.Callable[..., str]) -> None:
     y = 1

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -198,6 +198,28 @@ def _(target: FooSub | str):
     reveal_type(y)  # revealed: Literal[1, 3, 4]
 ```
 
+### Dynamic class
+
+A dynamically typed class pattern is not known to match every subject, so later cases remain
+reachable.
+
+```py
+from typing import Any
+
+DynamicClass: Any = int
+
+def _(target: int | str):
+    match target:
+        case DynamicClass():
+            reveal_type(target)  # revealed: (int & Any) | (str & Any)
+            y = 1
+        case _:
+            reveal_type(target)  # revealed: (int & Any) | (str & Any)
+            y = 2
+
+    reveal_type(y)  # revealed: Literal[1, 2]
+```
+
 ### `collections.abc.Callable`
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -220,6 +220,31 @@ def _(target: int | str):
     reveal_type(y)  # revealed: Literal[1, 2]
 ```
 
+### Subclass-of type
+
+A class pattern whose class expression has type `type[Base]` is not guaranteed to match a `Base`
+subject. `PatternClass` can evaluate to any subclass of `Base`, and a `Base` instance need not be an
+instance of that subclass. The `PatternClass` arm must therefore not be considered guaranteed to
+match, and the fallback arm remains reachable.
+
+```py
+class Base: ...
+class Derived(Base): ...
+
+PatternClass: type[Base] = Derived
+
+def _(target: Base):
+    match target:
+        case PatternClass():
+            reveal_type(target)  # revealed: Base
+            y = 1
+        case _:
+            reveal_type(target)  # revealed: Base
+            y = 2
+
+    reveal_type(y)  # revealed: Literal[1, 2]
+```
+
 ### `collections.abc.Callable`
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -342,7 +342,10 @@ def match_non_exhaustive(x: A | B | C):
             # this diagnostic is correct: the inferred type of `x` is `B & ~A & ~C`
             assert_never(x)  # error: [type-assertion-failure]
 
-# Note: no invalid-return-type diagnostic; the `match` is exhaustive
+# Class patterns with arguments are not exhaustive because attribute extraction can fail.
+# TODO: This should be exhaustive - will require analyzing `x` as an attribute on `GenericClass` to
+# guarantee it can be extracted at runtime
+# error: [invalid-return-type]
 def match_exhaustive_generic[T](obj: GenericClass[T]) -> GenericClass[T]:
     match obj:
         case GenericClass(x=42):

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -342,10 +342,7 @@ def match_non_exhaustive(x: A | B | C):
             # this diagnostic is correct: the inferred type of `x` is `B & ~A & ~C`
             assert_never(x)  # error: [type-assertion-failure]
 
-# Class patterns with arguments are not exhaustive because attribute extraction can fail.
-# TODO: This should be exhaustive - will require analyzing `x` as an attribute on `GenericClass` to
-# guarantee it can be extracted at runtime
-# error: [invalid-return-type]
+# Note: no invalid-return-type diagnostic; the `match` is exhaustive
 def match_exhaustive_generic[T](obj: GenericClass[T]) -> GenericClass[T]:
     match obj:
         case GenericClass(x=42):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
@@ -198,14 +198,14 @@ At runtime, `collections.abc.Callable` is supported in `match` statement class p
 ### `collections.abc.Callable`
 
 ```py
-import collections.abc
+from collections import abc
 
-def _(subj: int | collections.abc.Callable[..., str]) -> None:
+def _(subj: None | abc.Callable[..., str]) -> None:
     match subj:
-        # TODO: Should be valid.
-        # error: [invalid-match-pattern] "`<special-form 'collections.abc.Callable'>` cannot be used in a class pattern because it is not a type"
-        case collections.abc.Callable(): ...
-        case _: ...
+        case abc.Callable():
+            reveal_type(subj)  # revealed: (...) -> str
+        case _:
+            reveal_type(subj)  # revealed: None
 ```
 
 ### `typing.Callable`
@@ -213,7 +213,7 @@ def _(subj: int | collections.abc.Callable[..., str]) -> None:
 ```py
 import typing
 
-def _(subj: int | typing.Callable[..., str]) -> None:
+def _(subj: None | typing.Callable[..., str]) -> None:
     match subj:
         # error: [invalid-match-pattern] "`<special-form 'typing.Callable'>` cannot be used in a class pattern because it is not a type"
         case typing.Callable(): ...

--- a/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
@@ -208,6 +208,17 @@ def _(subj: None | abc.Callable[..., str]) -> None:
             reveal_type(subj)  # revealed: None
 ```
 
+`collections.abc.Callable` has no `__match_args__`, so it does not accept positional subpatterns:
+
+```py
+from collections import abc
+
+def _(subj: abc.Callable[..., str]) -> None:
+    match subj:
+        # error: [invalid-match-pattern] "Too many positional subpatterns for `collections.abc.Callable`: expected 0, got 1"
+        case abc.Callable(x): ...
+```
+
 ### `typing.Callable`
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/callable.md
@@ -206,6 +206,11 @@ def _(subj: None | abc.Callable[..., str]) -> None:
             reveal_type(subj)  # revealed: (...) -> str
         case _:
             reveal_type(subj)  # revealed: None
+
+def _(subj: tuple[abc.Callable[..., int]] | tuple[None]) -> None:
+    match subj:
+        case [abc.Callable()]:
+            reveal_type(subj[0])  # revealed: (...) -> int
 ```
 
 `collections.abc.Callable` has no `__match_args__`, so it does not accept positional subpatterns:

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -198,10 +198,10 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, Type, TypeContext,
-        UnionType, definite_match_pattern_type, enum_metadata, infer_narrowing_constraints,
-        infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
-        singleton_pattern_type,
+        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, SpecialFormType,
+        Type, TypeContext, UnionType, callable_pattern_type, definite_match_pattern_type,
+        enum_metadata, infer_narrowing_constraints, infer_same_file_expression_type,
+        mapping_pattern_type, sequence_pattern_type_builder, singleton_pattern_type,
     },
 };
 use ruff_index::IndexSlice;
@@ -994,9 +994,16 @@ fn analyze_single_pattern_predicate_kind<'db>(
             truthiness
         }
         PatternPredicateKind::Class(class_expr, kind) => {
-            let class_ty = infer_same_file_expression_type(db, *class_expr, TypeContext::default())
-                .as_class_literal()
-                .map(|class| Type::instance(db, class.top_materialization(db)));
+            let class_ty =
+                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
+                    Type::ClassLiteral(class) => {
+                        Some(Type::instance(db, class.top_materialization(db)))
+                    }
+                    Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
+                        Some(callable_pattern_type(db))
+                    }
+                    _ => None,
+                };
 
             class_ty.map_or(Truthiness::Ambiguous, |class_ty| {
                 if subject_ty.is_subtype_of(db, class_ty) {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -34,9 +34,9 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    definite_match_pattern_type, definite_sequence_pattern_type, exact_sequence_pattern_type,
-    mapping_pattern_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type,
+    callable_pattern_type, definite_match_pattern_type, definite_sequence_pattern_type,
+    exact_sequence_pattern_type, mapping_pattern_type, sequence_pattern_type_builder,
+    singleton_pattern_type, starred_sequence_pattern_type,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4838,6 +4838,20 @@ pub(crate) fn report_invalid_class_match_pattern<T: Ranged>(
     diagnostic.set_primary_message("This will raise `TypeError` at runtime");
 }
 
+pub(crate) fn report_too_many_positional_patterns_for_callable_class_pattern<T: Ranged>(
+    context: &InferContext,
+    first_excess_pattern: T,
+    positional_count: usize,
+) {
+    let Some(builder) = context.report_lint(&INVALID_MATCH_PATTERN, first_excess_pattern) else {
+        return;
+    };
+    let mut diagnostic = builder.into_diagnostic(format_args!(
+        "Too many positional subpatterns for `collections.abc.Callable`: expected 0, got {positional_count}"
+    ));
+    diagnostic.set_primary_message("This will raise `TypeError` at runtime");
+}
+
 pub(crate) fn add_type_expression_reference_link<'db, 'ctx>(
     mut diag: LintDiagnosticGuard<'db, 'ctx>,
 ) -> LintDiagnosticGuard<'db, 'ctx> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -63,6 +63,7 @@ use crate::types::diagnostic::{
     report_match_pattern_against_non_runtime_checkable_protocol,
     report_match_pattern_against_typed_dict, report_mismatched_type_name,
     report_possibly_missing_attribute, report_possibly_unresolved_reference,
+    report_too_many_positional_patterns_for_callable_class_pattern,
     report_unsupported_augmented_assignment, report_unsupported_comparison,
 };
 use crate::types::enums::{enum_ignored_names, is_enum_class_by_inheritance};
@@ -2268,19 +2269,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn validate_class_pattern(&mut self, pattern: &ast::PatternMatchClass, cls_ty: Type<'db>) {
-        let is_valid_class_pattern_target = |db: &dyn Db, cls_ty: Type| -> bool {
-            if matches!(
-                cls_ty,
-                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
-            ) {
-                // Special-case for the `collections.abc.Callable` special form
-                //
-                // This is not a type object, but is valid as a class pattern
-                return true;
+        if let Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) = cls_ty {
+            if let Some(first_excess_pattern) = pattern.arguments.patterns.first() {
+                report_too_many_positional_patterns_for_callable_class_pattern(
+                    &self.context,
+                    first_excess_pattern,
+                    pattern.arguments.patterns.len(),
+                );
             }
-
-            cls_ty.is_assignable_to(db, KnownClass::Type.to_instance(db))
-        };
+            return;
+        }
 
         if let Type::ClassLiteral(class) = cls_ty {
             if class.is_typed_dict(self.db()) {
@@ -2294,7 +2292,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     protocol_class,
                 );
             }
-        } else if !is_valid_class_pattern_target(self.db(), cls_ty) {
+        } else if !cls_ty.is_assignable_to(self.db(), KnownClass::Type.to_instance(self.db())) {
             report_invalid_class_match_pattern(&self.context, &*pattern.cls, cls_ty);
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2268,6 +2268,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn validate_class_pattern(&mut self, pattern: &ast::PatternMatchClass, cls_ty: Type<'db>) {
+        let is_valid_class_pattern_target = |db: &dyn Db, cls_ty: Type| -> bool {
+            if matches!(
+                cls_ty,
+                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
+            ) {
+                // Special-case for the `collections.abc.Callable` special form
+                //
+                // This is not a type object, but is valid as a class pattern
+                return true;
+            }
+
+            cls_ty.is_assignable_to(db, KnownClass::Type.to_instance(db))
+        };
+
         if let Type::ClassLiteral(class) = cls_ty {
             if class.is_typed_dict(self.db()) {
                 report_match_pattern_against_typed_dict(&self.context, &*pattern.cls, class);
@@ -2280,7 +2294,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     protocol_class,
                 );
             }
-        } else if !cls_ty.is_assignable_to(self.db(), KnownClass::Type.to_instance(self.db())) {
+        } else if !is_valid_class_pattern_target(self.db(), cls_ty) {
             report_invalid_class_match_pattern(&self.context, &*pattern.cls, cls_ty);
         }
     }

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -6,8 +6,8 @@ use crate::Db;
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::signatures::CallableSignature;
 use crate::types::{
-    CallableType, IntersectionBuilder, KnownClass, Parameter, Parameters, Signature, Type,
-    TypeContext, UnionType, infer_same_file_expression_type,
+    CallableType, IntersectionBuilder, KnownClass, Parameter, Parameters, Signature,
+    SpecialFormType, Type, TypeContext, UnionType, infer_same_file_expression_type,
 };
 
 pub(crate) fn singleton_pattern_type(db: &dyn Db, singleton: ast::Singleton) -> Type<'_> {
@@ -22,6 +22,10 @@ pub(crate) fn singleton_pattern_type(db: &dyn Db, singleton: ast::Singleton) -> 
 
 pub(crate) fn mapping_pattern_type(db: &dyn Db) -> Type<'_> {
     KnownClass::Mapping.to_instance(db).top_materialization(db)
+}
+
+pub(crate) fn callable_pattern_type(db: &dyn Db) -> Type<'_> {
+    Type::Callable(CallableType::unknown(db)).top_materialization(db)
 }
 
 pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<'_> {
@@ -179,10 +183,13 @@ pub(crate) fn definite_match_pattern_type<'db>(
         }
         PatternPredicateKind::Class(class_expr, kind) => {
             if kind.is_irrefutable() {
-                infer_same_file_expression_type(db, *class_expr, TypeContext::default())
-                    .to_instance(db)
-                    .unwrap_or(Type::Never)
-                    .top_materialization(db)
+                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
+                    Type::ClassLiteral(class) => Type::instance(db, class.top_materialization(db)),
+                    Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
+                        callable_pattern_type(db)
+                    }
+                    _ => Type::Never,
+                }
             } else {
                 Type::Never
             }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1989,6 +1989,11 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 Type::instance(self.db, class.top_materialization(self.db))
                     .negate_if(self.db, !is_positive)
             }
+            Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
+                Type::Callable(CallableType::unknown(self.db))
+                    .top_materialization(self.db)
+                    .negate_if(self.db, !is_positive)
+            }
             dynamic @ Type::Dynamic(_) => dynamic,
             _ => return None,
         };

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -11,9 +11,9 @@ use crate::types::{
     CallableType, ClassLiteral, ClassType, IntersectionBuilder, IntersectionType, KnownClass,
     KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature, SpecialFormType,
     SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionBuilder, definite_sequence_pattern_type, exact_sequence_pattern_type,
-    infer_expression_types, mapping_pattern_type, sequence_pattern_type_builder,
-    singleton_pattern_type, starred_sequence_pattern_type,
+    UnionBuilder, callable_pattern_type, definite_sequence_pattern_type,
+    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
+    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
 };
 use ty_python_core::expression::Expression;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
@@ -1990,9 +1990,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     .negate_if(self.db, !is_positive)
             }
             Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                Type::Callable(CallableType::unknown(self.db))
-                    .top_materialization(self.db)
-                    .negate_if(self.db, !is_positive)
+                callable_pattern_type(self.db).negate_if(self.db, !is_positive)
             }
             dynamic @ Type::Dynamic(_) => dynamic,
             _ => return None,
@@ -2059,7 +2057,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                         Type::instance(self.db, class.top_materialization(self.db))
                     }
                     Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                        Type::Callable(CallableType::unknown(self.db)).top_materialization(self.db)
+                        callable_pattern_type(self.db)
                     }
                     _ => Type::object(),
                 }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2058,6 +2058,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     Type::ClassLiteral(class) => {
                         Type::instance(self.db, class.top_materialization(self.db))
                     }
+                    Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
+                        Type::Callable(CallableType::unknown(self.db)).top_materialization(self.db)
+                    }
                     _ => Type::object(),
                 }
             }


### PR DESCRIPTION
## Summary
https://github.com/astral-sh/ty/issues/887

As titled. Covers:
- Validating proper use in the class pattern, including disallowing positional sub-patterns
- Reachability analysis
- Narrowing

## Test Plan

New mdtests
