### PR TITLE
[ty] Discover uv workspace roots

### DIFF
--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -12,6 +12,7 @@ use ruff_python_ast::PySourceType;
 use std::error::Error;
 use std::fmt;
 use std::fmt::Debug;
+use std::process::Output;
 pub use test::{DbWithTestSystem, DbWithWritableSystem, InMemorySystem, TestSystem};
 use walk_directory::WalkDirectoryBuilder;
 
@@ -99,6 +100,20 @@ pub trait System: Debug + Sync + Send {
 
     /// Find an executable binary's path by name.
     fn which(&self, binary_name: &str) -> WhichResult;
+
+    /// Runs a command in the given working directory, returning its output.
+    fn run_command(
+        &self,
+        program: &str,
+        args: &[&str],
+        current_directory: &SystemPath,
+    ) -> Result<Output> {
+        let _ = (program, args, current_directory);
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "running commands is not supported by this system",
+        ))
+    }
 
     /// Reads the content of the file at `path` into a [`String`].
     fn read_to_string(&self, path: &SystemPath) -> Result<String>;

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -15,6 +15,7 @@ use crate::system::{
 use filetime::FileTime;
 use ruff_notebook::{Notebook, NotebookError};
 use std::num::NonZeroUsize;
+use std::process::{Command, Output};
 use std::sync::Arc;
 use std::{any::Any, path::PathBuf};
 
@@ -127,6 +128,18 @@ impl System for OsSystem {
             Ok(path) => Ok(path),
             Err(_) => Err(WhichError::NonUtf8Path),
         }
+    }
+
+    fn run_command(
+        &self,
+        program: &str,
+        args: &[&str],
+        current_directory: &SystemPath,
+    ) -> Result<Output> {
+        Command::new(program)
+            .args(args)
+            .current_dir(current_directory.as_std_path())
+            .output()
     }
 
     fn current_directory(&self) -> &SystemPath {

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -1,6 +1,7 @@
 use ruff_notebook::{Notebook, NotebookError};
 use rustc_hash::FxHashMap;
 use std::panic::RefUnwindSafe;
+use std::process::Output;
 use std::sync::{Arc, Mutex};
 
 use crate::Db;
@@ -138,6 +139,15 @@ impl System for TestSystem {
 
     fn which(&self, _name: &str) -> WhichResult {
         Err(WhichError::CannotFindBinaryPath)
+    }
+
+    fn run_command(
+        &self,
+        program: &str,
+        args: &[&str],
+        current_directory: &SystemPath,
+    ) -> Result<Output> {
+        self.system().run_command(program, args, current_directory)
     }
 
     fn read_directory<'a>(

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -106,6 +106,7 @@ impl std::fmt::Display for RuleResolutionError {
             ValueSource::File(path) => format_args!("`{}`", path.as_path()),
             ValueSource::Cli => format_args!("the CLI"),
             ValueSource::Editor => format_args!("the editor configuration"),
+            ValueSource::UvWorkspace => format_args!("uv workspace metadata"),
         };
         match kind {
             RuleResolutionErrorKind::Removed => {

--- a/crates/ruff_ranged_value/src/lib.rs
+++ b/crates/ruff_ranged_value/src/lib.rs
@@ -29,6 +29,9 @@ pub enum ValueSource {
     /// or if the value was auto-discovered by the editor
     /// (e.g., the Python environment)
     Editor,
+
+    /// The value was provided by `uv workspace metadata`.
+    UvWorkspace,
 }
 
 impl ValueSource {
@@ -37,6 +40,7 @@ impl ValueSource {
             ValueSource::File(path) => Some(&**path),
             ValueSource::Cli => None,
             ValueSource::Editor => None,
+            ValueSource::UvWorkspace => None,
         }
     }
 

--- a/crates/ty/Cargo.toml
+++ b/crates/ty/Cargo.toml
@@ -66,6 +66,7 @@ toml = { workspace = true }
 
 [features]
 default = []
+test-uv = []
 
 [lints]
 workspace = true

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -20,7 +20,7 @@ use ruff_db::diagnostic::{
     Diagnostic, DiagnosticId, DisplayDiagnosticConfig, DisplayDiagnostics, Severity,
 };
 use ruff_db::files::File;
-use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
+use ruff_db::system::{OsSystem, System, SystemPath, SystemPathBuf};
 use ruff_db::{STACK_SIZE, max_parallelism};
 use ruff_diagnostics::Applicability;
 use salsa::Database;
@@ -156,8 +156,19 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
         Some(config_file) => {
             ProjectMetadata::from_config_file(config_file.clone(), &project_path, &system)?
         }
+        None if check_paths.iter().any(|path| system.is_file(path)) => {
+            // `uv check --script` passes a file as its check path. Disable uv workspace metadata
+            // for scripts until script integration is implemented in a follow-up.
+            ProjectMetadata::discover_without_uv(&project_path, &system)?
+        }
         None => ProjectMetadata::discover(&project_path, &system)?,
     };
+
+    if watch && project_metadata.has_uv_workspace() {
+        return Err(anyhow!(
+            "`--watch` is not supported with uv workspace integration"
+        ));
+    }
 
     project_metadata.apply_configuration_files(&system)?;
 

--- a/crates/ty/tests/cli/main.rs
+++ b/crates/ty/tests/cli/main.rs
@@ -7,6 +7,7 @@ mod python_environment;
 mod rule;
 mod rule_selection;
 mod scripts;
+mod uv_workspace;
 
 use anyhow::Context as _;
 use insta::Settings;
@@ -878,6 +879,7 @@ impl CliTest {
 
         let mut settings = insta::Settings::clone_current();
         settings.add_filter(&tempdir_filter(&project_dir), "<temp_dir>/");
+        settings.add_filter(r"\bty\.exe\b", "ty");
         settings.add_filter(r#"\\(\w\w|\s|\.|")"#, "/$1");
         // 0.003s
         settings.add_filter(r"\d.\d\d\ds", "0.000s");

--- a/crates/ty/tests/cli/uv_workspace.rs
+++ b/crates/ty/tests/cli/uv_workspace.rs
@@ -1,3 +1,8 @@
+//! Integration tests for ty's side of `uv check`.
+//!
+//! Corresponding uv-side workspace tests live at
+//! <https://github.com/astral-sh/uv/blob/main/crates/uv/tests/project/check.rs>.
+
 #[cfg(feature = "test-uv")]
 use std::{path::Path, process::Command};
 
@@ -23,7 +28,10 @@ version = "0.1.0"
 requires-python = ">=3.8"
 "#,
         ),
-        ("packages/member/member.py", "value: int = 1"),
+        (
+            "packages/member/member.py",
+            "value: int = 'selected-member'",
+        ),
         (
             "packages/sibling/pyproject.toml",
             r#"
@@ -33,12 +41,15 @@ version = "0.1.0"
 requires-python = ">=3.8"
 "#,
         ),
-        ("packages/sibling/sibling.py", "value: int = 'wrong'"),
+        (
+            "packages/sibling/sibling.py",
+            "value: int = 'unselected-sibling'",
+        ),
     ])
 }
 
 #[cfg(feature = "test-uv")]
-fn command_with_uv(case: &CliTest, virtual_env: Option<&Path>) -> anyhow::Result<Option<Command>> {
+fn command_with_uv(case: &CliTest, virtual_env: Option<&Path>) -> anyhow::Result<Command> {
     let mut sync = Command::new("uv");
     sync.current_dir(case.root())
         .args(["workspace", "metadata", "--sync"])
@@ -53,28 +64,6 @@ fn command_with_uv(case: &CliTest, virtual_env: Option<&Path>) -> anyhow::Result
         "failed to prepare uv workspace"
     );
 
-    // TODO: Remove this capability check once CI's pinned uv includes environment metadata by
-    // default.
-    let mut metadata = Command::new("uv");
-    metadata
-        .current_dir(case.root())
-        .args(["workspace", "metadata", "--frozen", "--active"])
-        .env("UV_CACHE_DIR", case.root().join("cache"))
-        .env("UV_OFFLINE", "1")
-        .env("UV_PYTHON_DOWNLOADS", "never");
-    if let Some(virtual_env) = virtual_env {
-        metadata.env("VIRTUAL_ENV", virtual_env);
-    }
-    let metadata = metadata.output()?;
-    anyhow::ensure!(
-        metadata.status.success(),
-        "failed to query uv workspace metadata: {}",
-        String::from_utf8_lossy(&metadata.stderr)
-    );
-    if !String::from_utf8_lossy(&metadata.stdout).contains("\"environment\"") {
-        return Ok(None);
-    }
-
     let mut command = case.command();
     command
         .env("TY_UV", "1")
@@ -82,50 +71,28 @@ fn command_with_uv(case: &CliTest, virtual_env: Option<&Path>) -> anyhow::Result
         .env("UV_CACHE_DIR", case.root().join("cache"))
         .env("UV_OFFLINE", "1")
         .env("UV_PYTHON_DOWNLOADS", "never")
+        .env("TY_OUTPUT_FORMAT", "concise")
         .env("PATH", std::env::var_os("PATH").unwrap_or_default());
     if let Some(virtual_env) = virtual_env {
         command.env("VIRTUAL_ENV", virtual_env);
     }
 
-    Ok(Some(command))
+    Ok(command)
 }
 
-#[cfg(feature = "test-uv")]
-#[test]
-fn uv_check_uses_test_ty_binary() -> anyhow::Result<()> {
-    let case = workspace_case()?;
-    case.write_file("packages/member/member.py", "value: int = 'wrong'")?;
-
-    let output = Command::new("uv")
-        .current_dir(case.root().join("packages/member"))
-        .arg("check")
-        .env("TY", &case.ty_binary_path)
-        .env("UV_CACHE_DIR", case.root().join("cache"))
-        .env("UV_OFFLINE", "1")
-        .env("UV_PYTHON_DOWNLOADS", "never")
-        .output()?;
-    let stdout = String::from_utf8(output.stdout)?;
-
-    assert!(!output.status.success());
-    assert!(stdout.contains("invalid-assignment"));
-    assert!(stdout.contains("member.py"));
-
-    Ok(())
-}
-
+/// The workspace root provides first-party imports without expanding analysis to unselected
+/// sibling members.
 #[cfg(feature = "test-uv")]
 #[test]
 fn uses_uv_workspace_root_without_checking_siblings() -> anyhow::Result<()> {
     let case = workspace_case()?;
-    case.write_file("shared.py", "value: int = 1")?;
+    case.write_file("shared.py", "value: int = 'unselected-workspace-root'")?;
     case.write_file(
         "packages/member/member.py",
-        "import shared\nvalue: int = 'wrong'",
+        "import shared\nvalue: int = 'selected-member'",
     )?;
 
-    let Some(mut command) = command_with_uv(&case, None)? else {
-        return Ok(());
-    };
+    let mut command = command_with_uv(&case, None)?;
     command
         .current_dir(case.root().join("packages/member"))
         .arg(".");
@@ -134,15 +101,7 @@ fn uses_uv_workspace_root_without_checking_siblings() -> anyhow::Result<()> {
     success: false
     exit_code: 1
     ----- stdout -----
-    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
-     --> member.py:2:8
-      |
-    2 | value: int = 'wrong'
-      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
-      |        |
-      |        Declared type
-      |
-
+    member.py:2:14: error[invalid-assignment] Object of type `Literal["selected-member"]` is not assignable to `int`
     Found 1 diagnostic
 
     ----- stderr -----
@@ -152,55 +111,38 @@ fn uses_uv_workspace_root_without_checking_siblings() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// An explicit file is treated as a script, so workspace discovery stays disabled even when
+/// `TY_UV` is set.
 #[cfg(feature = "test-uv")]
 #[test]
 fn explicit_file_path_disables_uv_workspace_discovery() -> anyhow::Result<()> {
     let case = workspace_case()?;
-    case.write_file("shared.py", "value: int = 1")?;
-    case.write_file("packages/member/member.py", "import shared")?;
+    case.write_file("shared.py", "value: int = 'unselected-workspace-root'")?;
+    case.write_file(
+        "packages/member/member.py",
+        "import shared\nvalue: int = 'selected-script'",
+    )?;
 
-    let Some(mut command) = command_with_uv(&case, None)? else {
-        return Ok(());
-    };
+    let mut command = command_with_uv(&case, None)?;
     command
         .current_dir(case.root().join("packages/member"))
         .arg("member.py");
 
-    let output = command.output()?;
-    let stdout = String::from_utf8(output.stdout)?;
-    assert!(!output.status.success());
-    assert!(stdout.contains("Cannot resolve imported module `shared`"));
-
-    Ok(())
-}
-
-#[cfg(feature = "test-uv")]
-#[test]
-fn explicit_directory_path_uses_uv_workspace_discovery() -> anyhow::Result<()> {
-    let case = workspace_case()?;
-    case.write_file("shared.py", "value: int = 1")?;
-    case.write_file("packages/member/member.py", "import shared")?;
-
-    let Some(mut command) = command_with_uv(&case, None)? else {
-        return Ok(());
-    };
-    command
-        .current_dir(case.root().join("packages/member"))
-        .arg(".");
-
-    assert_cmd_snapshot!(command, @"
-    success: true
-    exit_code: 0
+    assert_cmd_snapshot!(command, @r#"
+    success: false
+    exit_code: 1
     ----- stdout -----
-    All checks passed!
+    member.py:1:8: error[unresolved-import] Cannot resolve imported module `shared`
+    member.py:2:14: error[invalid-assignment] Object of type `Literal["selected-script"]` is not assignable to `int`
+    Found 2 diagnostics
 
     ----- stderr -----
-    ");
-    assert!(case.root().join(".venv").is_dir());
+    "#);
 
     Ok(())
 }
 
+/// An explicitly selected member inherits ty rule configuration from the uv workspace root.
 #[cfg(feature = "test-uv")]
 #[test]
 fn explicit_workspace_member_directory_uses_workspace_configuration() -> anyhow::Result<()> {
@@ -215,11 +157,7 @@ members = ["packages/*"]
 invalid-assignment = "ignore"
 "#,
     )?;
-    case.write_file("packages/member/member.py", "value: int = 'wrong'")?;
-
-    let Some(mut command) = command_with_uv(&case, None)? else {
-        return Ok(());
-    };
+    let mut command = command_with_uv(&case, None)?;
     command.arg("packages/member");
 
     assert_cmd_snapshot!(command, @"
@@ -234,6 +172,8 @@ invalid-assignment = "ignore"
     Ok(())
 }
 
+/// Workspace configuration still applies when the selected member lives outside the workspace
+/// root's directory tree.
 #[cfg(feature = "test-uv")]
 #[test]
 fn external_workspace_member_uses_workspace_configuration() -> anyhow::Result<()> {
@@ -257,12 +197,13 @@ version = "0.1.0"
 requires-python = ">=3.8"
 "#,
         ),
-        ("../external-package/member.py", "value: int = 'wrong'"),
+        (
+            "../external-package/member.py",
+            "value: int = 'selected-external-member'",
+        ),
     ])?;
 
-    let Some(mut command) = command_with_uv(&case, None)? else {
-        return Ok(());
-    };
+    let mut command = command_with_uv(&case, None)?;
     command
         .args(["--project", "../external-package", "../external-package"])
         .env("UV_PROJECT", case.root());
@@ -279,6 +220,7 @@ requires-python = ">=3.8"
     Ok(())
 }
 
+/// Excludes passed by `uv check` prevent an unselected nested member from being analyzed.
 #[cfg(feature = "test-uv")]
 #[test]
 fn selected_workspace_member_excludes_nested_member() -> anyhow::Result<()> {
@@ -299,46 +241,59 @@ version = "0.1.0"
 requires-python = ">=3.8"
 "#,
     )?;
-    case.write_file("packages/member/nested/nested.py", "value: int = 'wrong'")?;
+    case.write_file(
+        "packages/member/nested/nested.py",
+        "value: int = 'unselected-nested-member'",
+    )?;
 
-    let Some(mut command) = command_with_uv(&case, None)? else {
-        return Ok(());
-    };
+    let mut command = command_with_uv(&case, None)?;
     command.args(["--exclude", "packages/member/nested", "packages/member"]);
 
-    assert_cmd_snapshot!(command, @"
-    success: true
-    exit_code: 0
+    assert_cmd_snapshot!(command, @r#"
+    success: false
+    exit_code: 1
     ----- stdout -----
-    All checks passed!
+    packages/member/member.py:1:14: error[invalid-assignment] Object of type `Literal["selected-member"]` is not assignable to `int`
+    Found 1 diagnostic
 
     ----- stderr -----
-    ");
+    "#);
 
     Ok(())
 }
 
+/// Metadata discovery preserves uv's active isolated environment instead of using an invalid
+/// Python environment configured in the workspace.
 #[cfg(feature = "test-uv")]
 #[test]
 fn forwards_active_environment_to_uv() -> anyhow::Result<()> {
     let case = workspace_case()?;
+    case.write_file(
+        "pyproject.toml",
+        r#"
+[tool.uv.workspace]
+members = ["packages/*"]
+
+[tool.ty.environment]
+python = "missing-configured-environment"
+"#,
+    )?;
     let environment = case.root().join("isolated");
-    let Some(mut command) = command_with_uv(&case, Some(&environment))? else {
-        return Ok(());
-    };
+    let mut command = command_with_uv(&case, Some(&environment))?;
     command
         .current_dir(case.root().join("packages/member"))
         .arg(".")
         .env_remove("UV_PROJECT_ENVIRONMENT");
 
-    assert_cmd_snapshot!(command, @"
-    success: true
-    exit_code: 0
+    assert_cmd_snapshot!(command, @r#"
+    success: false
+    exit_code: 1
     ----- stdout -----
-    All checks passed!
+    member.py:1:14: error[invalid-assignment] Object of type `Literal["selected-member"]` is not assignable to `int`
+    Found 1 diagnostic
 
     ----- stderr -----
-    ");
+    "#);
 
     assert!(environment.is_dir());
     assert!(!case.root().join(".venv").exists());
@@ -346,55 +301,51 @@ fn forwards_active_environment_to_uv() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Merely exposing the uv executable must not change ordinary ty project discovery without
+/// `TY_UV`.
 #[test]
 fn uv_workspace_discovery_is_opt_in() -> anyhow::Result<()> {
     let case = workspace_case()?;
-    case.write_file("shared.py", "value: int = 1")?;
-    case.write_file("packages/member/member.py", "import shared")?;
+    case.write_file("shared.py", "value: int = 'unselected-workspace-root'")?;
+    case.write_file(
+        "packages/member/member.py",
+        "import shared\nvalue: int = 'selected-member'",
+    )?;
 
     let mut command = case.command();
     command
         .current_dir(case.root().join("packages/member"))
         .env("UV", "uv")
+        .env("TY_OUTPUT_FORMAT", "concise")
         .env_remove("TY_UV");
 
-    assert_cmd_snapshot!(command, @"
+    assert_cmd_snapshot!(command, @r#"
     success: false
     exit_code: 1
     ----- stdout -----
-    error[unresolved-import]: Cannot resolve imported module `shared`
-     --> member.py:1:8
-      |
-    1 | import shared
-      |        ^^^^^^
-      |
-    info: Searched in the following paths during module resolution:
-    info:   1. <temp_dir>/packages/member (first-party code)
-    info:   2. vendored://stdlib (stdlib typeshed stubs vendored by ty)
-    info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment
-
-    Found 1 diagnostic
+    member.py:1:8: error[unresolved-import] Cannot resolve imported module `shared`
+    member.py:2:14: error[invalid-assignment] Object of type `Literal["selected-member"]` is not assignable to `int`
+    Found 2 diagnostics
 
     ----- stderr -----
-    ");
+    "#);
 
     Ok(())
 }
 
-#[cfg(feature = "test-uv")]
+/// Failures to invoke uv are visible by default instead of silently disabling integration.
 #[test]
-fn finds_uv_on_path_without_uv_environment_variable() -> anyhow::Result<()> {
+fn warns_when_uv_workspace_metadata_cannot_be_loaded() -> anyhow::Result<()> {
     let case = workspace_case()?;
-    case.write_file("shared.py", "value: int = 1")?;
-    case.write_file("packages/member/member.py", "import shared")?;
+    case.write_file("packages/member/member.py", "value: int = 1")?;
 
-    let Some(mut command) = command_with_uv(&case, None)? else {
-        return Ok(());
-    };
+    let mut command = case.command();
     command
         .current_dir(case.root().join("packages/member"))
         .arg(".")
-        .env_remove("UV");
+        .env("TY_UV", "1")
+        .env("UV", "missing-uv-executable")
+        .env("TY_OUTPUT_FORMAT", "concise");
 
     assert_cmd_snapshot!(command, @"
     success: true
@@ -403,11 +354,44 @@ fn finds_uv_on_path_without_uv_environment_variable() -> anyhow::Result<()> {
     All checks passed!
 
     ----- stderr -----
+    WARN Failed to invoke `uv workspace metadata`: No such file or directory (os error 2)
     ");
 
     Ok(())
 }
 
+/// Workspace discovery can find uv on `PATH` when the `UV` executable override is absent.
+#[cfg(feature = "test-uv")]
+#[test]
+fn finds_uv_on_path_without_uv_environment_variable() -> anyhow::Result<()> {
+    let case = workspace_case()?;
+    case.write_file("shared.py", "value: int = 'unselected-workspace-root'")?;
+    case.write_file(
+        "packages/member/member.py",
+        "import shared\nvalue: int = 'selected-member'",
+    )?;
+
+    let mut command = command_with_uv(&case, None)?;
+    command
+        .current_dir(case.root().join("packages/member"))
+        .arg(".")
+        .env_remove("UV");
+
+    assert_cmd_snapshot!(command, @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    member.py:2:14: error[invalid-assignment] Object of type `Literal["selected-member"]` is not assignable to `int`
+    Found 1 diagnostic
+
+    ----- stderr -----
+    "#);
+
+    Ok(())
+}
+
+/// Version-sensitive diagnostics attribute their assumed Python version to workspace metadata,
+/// not to a command-line override.
 #[cfg(feature = "test-uv")]
 #[test]
 fn reports_uv_workspace_python_version_source() -> anyhow::Result<()> {
@@ -415,9 +399,7 @@ fn reports_uv_workspace_python_version_source() -> anyhow::Result<()> {
     case.write_file("packages/member/member.py", "frozendict")?;
 
     for output_format in ["full", "concise"] {
-        let Some(mut command) = command_with_uv(&case, None)? else {
-            return Ok(());
-        };
+        let mut command = command_with_uv(&case, None)?;
         command
             .current_dir(case.root().join("packages/member"))
             .arg(".")

--- a/crates/ty/tests/cli/uv_workspace.rs
+++ b/crates/ty/tests/cli/uv_workspace.rs
@@ -336,7 +336,10 @@ fn uv_workspace_discovery_is_opt_in() -> anyhow::Result<()> {
 /// Failures to invoke uv are visible by default instead of silently disabling integration.
 #[test]
 fn warns_when_uv_workspace_metadata_cannot_be_loaded() -> anyhow::Result<()> {
-    let case = workspace_case()?;
+    let case = workspace_case()?.with_filter(
+        "program not found",
+        "No such file or directory (os error 2)",
+    );
     case.write_file("packages/member/member.py", "value: int = 1")?;
 
     let mut command = case.command();

--- a/crates/ty/tests/cli/uv_workspace.rs
+++ b/crates/ty/tests/cli/uv_workspace.rs
@@ -1,0 +1,392 @@
+#[cfg(feature = "test-uv")]
+use std::{path::Path, process::Command};
+
+use insta_cmd::assert_cmd_snapshot;
+
+use crate::CliTest;
+
+fn workspace_case() -> anyhow::Result<CliTest> {
+    CliTest::with_files([
+        (
+            "pyproject.toml",
+            r#"
+[tool.uv.workspace]
+members = ["packages/*"]
+"#,
+        ),
+        (
+            "packages/member/pyproject.toml",
+            r#"
+[project]
+name = "member"
+version = "0.1.0"
+requires-python = ">=3.8"
+"#,
+        ),
+        ("packages/member/member.py", "value: int = 1"),
+        (
+            "packages/sibling/pyproject.toml",
+            r#"
+[project]
+name = "sibling"
+version = "0.1.0"
+requires-python = ">=3.8"
+"#,
+        ),
+        ("packages/sibling/sibling.py", "value: int = 'wrong'"),
+    ])
+}
+
+#[cfg(feature = "test-uv")]
+fn command_with_uv(case: &CliTest, virtual_env: Option<&Path>) -> anyhow::Result<Option<Command>> {
+    let mut sync = Command::new("uv");
+    sync.current_dir(case.root())
+        .args(["workspace", "metadata", "--sync"])
+        .env("UV_CACHE_DIR", case.root().join("cache"))
+        .env("UV_OFFLINE", "1")
+        .env("UV_PYTHON_DOWNLOADS", "never");
+    if let Some(virtual_env) = virtual_env {
+        sync.arg("--active").env("VIRTUAL_ENV", virtual_env);
+    }
+    anyhow::ensure!(
+        sync.output()?.status.success(),
+        "failed to prepare uv workspace"
+    );
+
+    // TODO: Remove this capability check once CI's pinned uv includes environment metadata by
+    // default.
+    let mut metadata = Command::new("uv");
+    metadata
+        .current_dir(case.root())
+        .args(["workspace", "metadata", "--frozen", "--active"])
+        .env("UV_CACHE_DIR", case.root().join("cache"))
+        .env("UV_OFFLINE", "1")
+        .env("UV_PYTHON_DOWNLOADS", "never");
+    if let Some(virtual_env) = virtual_env {
+        metadata.env("VIRTUAL_ENV", virtual_env);
+    }
+    let metadata = metadata.output()?;
+    anyhow::ensure!(
+        metadata.status.success(),
+        "failed to query uv workspace metadata"
+    );
+    if !String::from_utf8_lossy(&metadata.stdout).contains("\"environment\"") {
+        return Ok(None);
+    }
+
+    let mut command = case.command();
+    command
+        .env("TY_UV", "1")
+        .env("UV", "uv")
+        .env("UV_CACHE_DIR", case.root().join("cache"))
+        .env("UV_OFFLINE", "1")
+        .env("UV_PYTHON_DOWNLOADS", "never")
+        .env("PATH", std::env::var_os("PATH").unwrap_or_default());
+    if let Some(virtual_env) = virtual_env {
+        command.env("VIRTUAL_ENV", virtual_env);
+    }
+
+    Ok(Some(command))
+}
+
+#[cfg(feature = "test-uv")]
+#[test]
+fn uv_check_uses_test_ty_binary() -> anyhow::Result<()> {
+    let case = workspace_case()?;
+    case.write_file("packages/member/member.py", "value: int = 'wrong'")?;
+
+    let output = Command::new("uv")
+        .current_dir(case.root().join("packages/member"))
+        .arg("check")
+        .env("TY", &case.ty_binary_path)
+        .env("UV_CACHE_DIR", case.root().join("cache"))
+        .env("UV_OFFLINE", "1")
+        .env("UV_PYTHON_DOWNLOADS", "never")
+        .output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+
+    assert!(!output.status.success());
+    assert!(stdout.contains("invalid-assignment"));
+    assert!(stdout.contains("member.py"));
+
+    Ok(())
+}
+
+#[cfg(feature = "test-uv")]
+#[test]
+fn uses_uv_workspace_root_without_checking_siblings() -> anyhow::Result<()> {
+    let case = workspace_case()?;
+    case.write_file("shared.py", "value: int = 1")?;
+    case.write_file(
+        "packages/member/member.py",
+        "import shared\nvalue: int = 'wrong'",
+    )?;
+
+    let Some(mut command) = command_with_uv(&case, None)? else {
+        return Ok(());
+    };
+    command
+        .current_dir(case.root().join("packages/member"))
+        .arg(".");
+
+    assert_cmd_snapshot!(command, @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[invalid-assignment]: Object of type `Literal["wrong"]` is not assignable to `int`
+     --> member.py:2:8
+      |
+    2 | value: int = 'wrong'
+      |        ---   ^^^^^^^ Incompatible value of type `Literal["wrong"]`
+      |        |
+      |        Declared type
+      |
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    "#);
+    assert!(case.root().join(".venv").is_dir());
+
+    Ok(())
+}
+
+#[cfg(feature = "test-uv")]
+#[test]
+fn explicit_file_path_disables_uv_workspace_discovery() -> anyhow::Result<()> {
+    let case = workspace_case()?;
+    case.write_file("shared.py", "value: int = 1")?;
+    case.write_file("packages/member/member.py", "import shared")?;
+
+    let Some(mut command) = command_with_uv(&case, None)? else {
+        return Ok(());
+    };
+    command
+        .current_dir(case.root().join("packages/member"))
+        .arg("member.py");
+
+    let output = command.output()?;
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(!output.status.success());
+    assert!(stdout.contains("Cannot resolve imported module `shared`"));
+
+    Ok(())
+}
+
+#[cfg(feature = "test-uv")]
+#[test]
+fn explicit_directory_path_uses_uv_workspace_discovery() -> anyhow::Result<()> {
+    let case = workspace_case()?;
+    case.write_file("shared.py", "value: int = 1")?;
+    case.write_file("packages/member/member.py", "import shared")?;
+
+    let Some(mut command) = command_with_uv(&case, None)? else {
+        return Ok(());
+    };
+    command
+        .current_dir(case.root().join("packages/member"))
+        .arg(".");
+
+    assert_cmd_snapshot!(command, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    ");
+    assert!(case.root().join(".venv").is_dir());
+
+    Ok(())
+}
+
+#[cfg(feature = "test-uv")]
+#[test]
+fn explicit_workspace_member_directory_uses_workspace_configuration() -> anyhow::Result<()> {
+    let case = workspace_case()?;
+    case.write_file(
+        "pyproject.toml",
+        r#"
+[tool.uv.workspace]
+members = ["packages/*"]
+
+[tool.ty.rules]
+invalid-assignment = "ignore"
+"#,
+    )?;
+    case.write_file("packages/member/member.py", "value: int = 'wrong'")?;
+
+    let Some(mut command) = command_with_uv(&case, None)? else {
+        return Ok(());
+    };
+    command.arg("packages/member");
+
+    assert_cmd_snapshot!(command, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[cfg(feature = "test-uv")]
+#[test]
+fn selected_workspace_member_excludes_nested_member() -> anyhow::Result<()> {
+    let case = workspace_case()?;
+    case.write_file(
+        "pyproject.toml",
+        r#"
+[tool.uv.workspace]
+members = ["packages/*", "packages/member/nested"]
+"#,
+    )?;
+    case.write_file(
+        "packages/member/nested/pyproject.toml",
+        r#"
+[project]
+name = "nested"
+version = "0.1.0"
+requires-python = ">=3.8"
+"#,
+    )?;
+    case.write_file("packages/member/nested/nested.py", "value: int = 'wrong'")?;
+
+    let Some(mut command) = command_with_uv(&case, None)? else {
+        return Ok(());
+    };
+    command.args(["--exclude", "packages/member/nested", "packages/member"]);
+
+    assert_cmd_snapshot!(command, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[cfg(feature = "test-uv")]
+#[test]
+fn forwards_active_environment_to_uv() -> anyhow::Result<()> {
+    let case = workspace_case()?;
+    let environment = case.root().join("isolated");
+    let Some(mut command) = command_with_uv(&case, Some(&environment))? else {
+        return Ok(());
+    };
+    command
+        .current_dir(case.root().join("packages/member"))
+        .arg(".")
+        .env_remove("UV_PROJECT_ENVIRONMENT");
+
+    assert_cmd_snapshot!(command, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    ");
+
+    assert!(environment.is_dir());
+    assert!(!case.root().join(".venv").exists());
+
+    Ok(())
+}
+
+#[test]
+fn uv_workspace_discovery_is_opt_in() -> anyhow::Result<()> {
+    let case = workspace_case()?;
+    case.write_file("shared.py", "value: int = 1")?;
+    case.write_file("packages/member/member.py", "import shared")?;
+
+    let mut command = case.command();
+    command
+        .current_dir(case.root().join("packages/member"))
+        .env("UV", "uv")
+        .env_remove("TY_UV");
+
+    assert_cmd_snapshot!(command, @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    error[unresolved-import]: Cannot resolve imported module `shared`
+     --> member.py:1:8
+      |
+    1 | import shared
+      |        ^^^^^^
+      |
+    info: Searched in the following paths during module resolution:
+    info:   1. <temp_dir>/packages/member (first-party code)
+    info:   2. vendored://stdlib (stdlib typeshed stubs vendored by ty)
+    info: make sure your Python environment is properly configured: https://docs.astral.sh/ty/modules/#python-environment
+
+    Found 1 diagnostic
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[cfg(feature = "test-uv")]
+#[test]
+fn finds_uv_on_path_without_uv_environment_variable() -> anyhow::Result<()> {
+    let case = workspace_case()?;
+    case.write_file("shared.py", "value: int = 1")?;
+    case.write_file("packages/member/member.py", "import shared")?;
+
+    let Some(mut command) = command_with_uv(&case, None)? else {
+        return Ok(());
+    };
+    command
+        .current_dir(case.root().join("packages/member"))
+        .arg(".")
+        .env_remove("UV");
+
+    assert_cmd_snapshot!(command, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[cfg(feature = "test-uv")]
+#[test]
+fn reports_uv_workspace_python_version_source() -> anyhow::Result<()> {
+    let case = workspace_case()?;
+    case.write_file(".python-version", "3.12")?;
+    case.write_file("packages/member/member.py", "PythonFinalizationError")?;
+
+    for output_format in ["full", "concise"] {
+        let Some(mut command) = command_with_uv(&case, None)? else {
+            return Ok(());
+        };
+        command
+            .current_dir(case.root().join("packages/member"))
+            .arg(".")
+            .arg("--output-format")
+            .arg(output_format);
+
+        let output = command.output()?;
+        let stdout = String::from_utf8(output.stdout)?;
+        assert!(!output.status.success());
+        assert!(!stdout.contains("specified on the command line"));
+        if output_format == "full" {
+            assert!(stdout.contains("provided by uv workspace metadata"));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/ty/tests/cli/uv_workspace.rs
+++ b/crates/ty/tests/cli/uv_workspace.rs
@@ -68,7 +68,8 @@ fn command_with_uv(case: &CliTest, virtual_env: Option<&Path>) -> anyhow::Result
     let metadata = metadata.output()?;
     anyhow::ensure!(
         metadata.status.success(),
-        "failed to query uv workspace metadata"
+        "failed to query uv workspace metadata: {}",
+        String::from_utf8_lossy(&metadata.stderr)
     );
     if !String::from_utf8_lossy(&metadata.stdout).contains("\"environment\"") {
         return Ok(None);
@@ -220,6 +221,51 @@ invalid-assignment = "ignore"
         return Ok(());
     };
     command.arg("packages/member");
+
+    assert_cmd_snapshot!(command, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    ");
+
+    Ok(())
+}
+
+#[cfg(feature = "test-uv")]
+#[test]
+fn external_workspace_member_uses_workspace_configuration() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "pyproject.toml",
+            r#"
+[tool.uv.workspace]
+members = ["../external-package"]
+
+[tool.ty.rules]
+invalid-assignment = "ignore"
+"#,
+        ),
+        (
+            "../external-package/pyproject.toml",
+            r#"
+[project]
+name = "external-package"
+version = "0.1.0"
+requires-python = ">=3.8"
+"#,
+        ),
+        ("../external-package/member.py", "value: int = 'wrong'"),
+    ])?;
+
+    let Some(mut command) = command_with_uv(&case, None)? else {
+        return Ok(());
+    };
+    command
+        .args(["--project", "../external-package", "../external-package"])
+        .env("UV_PROJECT", case.root());
 
     assert_cmd_snapshot!(command, @"
     success: true

--- a/crates/ty/tests/cli/uv_workspace.rs
+++ b/crates/ty/tests/cli/uv_workspace.rs
@@ -412,8 +412,7 @@ fn finds_uv_on_path_without_uv_environment_variable() -> anyhow::Result<()> {
 #[test]
 fn reports_uv_workspace_python_version_source() -> anyhow::Result<()> {
     let case = workspace_case()?;
-    case.write_file(".python-version", "3.12")?;
-    case.write_file("packages/member/member.py", "PythonFinalizationError")?;
+    case.write_file("packages/member/member.py", "frozendict")?;
 
     for output_format in ["full", "concise"] {
         let Some(mut command) = command_with_uv(&case, None)? else {

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -8,11 +8,15 @@ use std::sync::Arc;
 use thiserror::Error;
 use ty_combine::Combine;
 use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy, ProgramSettings};
+use ty_static::EnvVars;
 
 use crate::Db;
-use crate::metadata::options::{OptionDiagnostic, ProgramSettingsDiagnostic, ToSettingsError};
+use crate::metadata::options::{
+    EnvironmentOptions, OptionDiagnostic, ProgramSettingsDiagnostic, ToSettingsError,
+};
 use crate::metadata::pyproject::{Project, PyProject, PyProjectError, ResolveRequiresPythonError};
 use crate::metadata::settings::Settings;
+use crate::metadata::value::RelativePathBuf;
 pub use options::Options;
 use options::TyTomlError;
 
@@ -22,6 +26,7 @@ pub mod pyproject;
 pub mod python_version;
 mod script;
 pub mod settings;
+mod uv;
 pub mod value;
 
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
@@ -41,10 +46,15 @@ pub struct ProjectMetadata {
     /// the file specified by [`Self::config_file_override`] if it is `Some` (e.g. when using `--config-file <path>`).
     pub(super) options: Options,
 
+    /// Options derived from the uv workspace, with higher precedence than project and user-level
+    /// configuration.
+    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
+    uv_workspace_options: Option<Box<Options>>,
+
     /// The user-level configuration path and its options.
     ///
-    /// Its options have lower precedence than [`Self::override_options`] and [`Self::options`],
-    /// but higher precedence than [`Self::fallback_options`].
+    /// Its options have lower precedence than [`Self::override_options`], [`Self::options`], and
+    /// [`Self::uv_workspace_options`], but higher precedence than [`Self::fallback_options`].
     #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     user_configuration: Option<Box<(SystemPathBuf, Options)>>,
 
@@ -58,6 +68,9 @@ pub struct ProjectMetadata {
     /// instead of from the project's `pyproject.toml` or `ty.toml` file.
     #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     config_file_override: Option<SystemPathBuf>,
+
+    #[cfg_attr(test, serde(skip))]
+    uv_workspace: Option<uv::UvWorkspace>,
 }
 
 impl ProjectMetadata {
@@ -67,10 +80,12 @@ impl ProjectMetadata {
             name: ProjectName::new(name),
             root,
             options: Options::default(),
+            uv_workspace_options: None,
             override_options: None,
             user_configuration: None,
             fallback_options: None,
             config_file_override: None,
+            uv_workspace: None,
         }
     }
 
@@ -94,10 +109,12 @@ impl ProjectMetadata {
             name: ProjectName::new(root.file_name().unwrap_or("root")),
             root: root.to_path_buf(),
             options,
+            uv_workspace_options: None,
             override_options: None,
             user_configuration: None,
             fallback_options: None,
             config_file_override: Some(path),
+            uv_workspace: None,
         })
     }
 
@@ -152,24 +169,49 @@ impl ProjectMetadata {
             name,
             root,
             options,
+            uv_workspace_options: None,
             override_options: None,
             user_configuration: None,
             fallback_options: None,
             config_file_override: None,
+            uv_workspace: None,
         })
     }
 
     /// Discovers the closest project at `path` and returns its metadata.
     ///
     /// The algorithm traverses upwards in the `path`'s ancestor chain and uses the following precedence
-    /// the resolve the project's root.
+    /// to resolve the project's root.
     ///
     /// 1. The closest `pyproject.toml` with a `tool.ty` section or `ty.toml`.
+    /// 1. The uv workspace root, if uv integration is enabled.
     /// 1. The closest `pyproject.toml`.
     /// 1. Fallback to use `path` as the root and use the default settings.
     pub fn discover(
         path: &SystemPath,
         system: &dyn System,
+    ) -> Result<ProjectMetadata, ProjectMetadataError> {
+        let uv_workspace = if matches!(system.env_var(EnvVars::TY_UV).as_deref(), Ok("1" | "true"))
+        {
+            uv::UvWorkspace::discover(path, system)
+        } else {
+            None
+        };
+        Self::discover_with_uv_workspace(path, system, uv_workspace)
+    }
+
+    /// Discovers the closest project without considering uv workspace metadata.
+    pub fn discover_without_uv(
+        path: &SystemPath,
+        system: &dyn System,
+    ) -> Result<ProjectMetadata, ProjectMetadataError> {
+        Self::discover_with_uv_workspace(path, system, None)
+    }
+
+    fn discover_with_uv_workspace(
+        path: &SystemPath,
+        system: &dyn System,
+        uv_workspace: Option<uv::UvWorkspace>,
     ) -> Result<ProjectMetadata, ProjectMetadataError> {
         tracing::debug!("Searching for a project in '{path}'");
 
@@ -178,8 +220,11 @@ impl ProjectMetadata {
         }
 
         let mut closest_project: Option<ProjectMetadata> = None;
+        let mut uv_project: Option<ProjectMetadata> = None;
+        let uv_workspace_root = uv_workspace.as_ref().map(uv::UvWorkspace::root);
 
         for project_root in path.ancestors() {
+            let is_uv_workspace_root = uv_workspace_root == Some(project_root);
             let pyproject_path = project_root.join("pyproject.toml");
 
             let pyproject = if let Ok(pyproject_str) = system.read_to_string(&pyproject_path) {
@@ -242,7 +287,7 @@ impl ProjectMetadata {
                     }
                 })?;
 
-                return Ok(metadata);
+                return Ok(metadata.with_uv_workspace(uv_workspace));
             }
 
             if let Some(pyproject) = pyproject {
@@ -259,18 +304,30 @@ impl ProjectMetadata {
                 if has_ty_section {
                     tracing::debug!("Found project at '{}'", project_root);
 
-                    return Ok(metadata);
+                    return Ok(metadata.with_uv_workspace(uv_workspace));
                 }
 
-                // Not a project itself, keep looking for an enclosing project.
-                if closest_project.is_none() {
+                if is_uv_workspace_root {
+                    uv_project = Some(metadata);
+                } else if closest_project.is_none() {
+                    // Not a project itself, keep looking for an enclosing project.
                     closest_project = Some(metadata);
                 }
+            } else if is_uv_workspace_root {
+                uv_project = Some(Self::new(
+                    project_root.file_name().unwrap_or("root"),
+                    project_root.to_path_buf(),
+                ));
             }
         }
 
-        // No project found, but maybe a pyproject.toml was found.
-        let metadata = if let Some(closest_project) = closest_project {
+        // No explicitly configured project was found. Prefer the uv workspace over the closest
+        // plain `pyproject.toml`, if available.
+        let metadata = if let Some(uv_project) = uv_project {
+            tracing::debug!("Using uv workspace at '{}'", uv_project.root());
+
+            uv_project
+        } else if let Some(closest_project) = closest_project {
             tracing::debug!(
                 "Project without `tool.ty` section: '{}'",
                 closest_project.root()
@@ -286,7 +343,13 @@ impl ProjectMetadata {
             Self::new(path.file_name().unwrap_or("root"), path.to_path_buf())
         };
 
-        Ok(metadata)
+        Ok(metadata.with_uv_workspace(uv_workspace))
+    }
+
+    #[must_use]
+    fn with_uv_workspace(mut self, uv_workspace: Option<uv::UvWorkspace>) -> Self {
+        self.uv_workspace = uv_workspace;
+        self
     }
 
     /// Rediscovers the project, while preserving applied options.
@@ -357,10 +420,14 @@ impl ProjectMetadata {
         }
     }
 
+    pub fn has_uv_workspace(&self) -> bool {
+        self.uv_workspace.is_some()
+    }
+
     /// Applies lower-precedence options to this project.
     ///
     /// Options applied later take precedence over options applied earlier, but all fallback options
-    /// have lower precedence than the raw and user-level options.
+    /// have lower precedence than the raw, uv workspace, and user-level options.
     pub fn apply_fallback_options(&mut self, options: Options) {
         if let Some(existing) = self.fallback_options.as_mut() {
             let previous = std::mem::replace(existing.as_mut(), options);
@@ -372,7 +439,7 @@ impl ProjectMetadata {
 
     /// Returns the project's option layers from highest to lowest precedence.
     ///
-    /// `options` is used as the raw base layer between the override and user-level options.
+    /// `options` is used as the raw base layer between the uv workspace and user-level options.
     /// Layers can be merged by passing them to [`Options::combine_with`] in iterator order:
     ///
     /// ```ignore
@@ -388,6 +455,7 @@ impl ProjectMetadata {
         self.override_options
             .as_deref()
             .into_iter()
+            .chain(self.uv_workspace_options.as_deref())
             .chain(std::iter::once(options))
             .chain(
                 self.user_configuration
@@ -401,6 +469,7 @@ impl ProjectMetadata {
     ///
     /// This includes:
     ///
+    /// * The uv workspace configuration
     /// * The user-level configuration
     pub fn apply_configuration_files(
         &mut self,
@@ -415,6 +484,19 @@ impl ProjectMetadata {
             );
             self.user_configuration = Some(Box::new((user.path().to_owned(), user.into_options())));
         }
+
+        self.uv_workspace_options = self.uv_workspace.as_ref().map(|uv_workspace| {
+            Box::new(Options {
+                environment: Some(EnvironmentOptions {
+                    python_version: uv_workspace.python_version().cloned(),
+                    python: uv_workspace
+                        .environment()
+                        .map(|path| RelativePathBuf::new(path, ValueSource::UvWorkspace)),
+                    ..EnvironmentOptions::default()
+                }),
+                ..Options::default()
+            })
+        });
 
         Ok(())
     }
@@ -523,7 +605,10 @@ mod tests {
     use insta::assert_ron_snapshot;
     use ruff_db::system::{SystemPathBuf, TestSystem};
     use ruff_python_ast::PythonVersion;
+    use ruff_ranged_value::ValueSource;
+    use ty_static::EnvVars;
 
+    use crate::metadata::{Options, uv::UvWorkspace, value::RelativePathBuf};
     use crate::{ProjectMetadata, ProjectMetadataError};
 
     #[test]
@@ -774,6 +859,232 @@ unclosed table, expected `]`
             )
             "#);
         });
+
+        Ok(())
+    }
+
+    #[test]
+    fn uv_workspace_precedes_plain_member_pyproject() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        let root = SystemPathBuf::from("/app");
+        let member = root.join("packages/member");
+
+        system.memory_file_system().write_files_all([
+            (root.join("pyproject.toml"), "[tool.uv.workspace]"),
+            (
+                member.join("pyproject.toml"),
+                r#"
+                [project]
+                name = "member"
+                "#,
+            ),
+        ])?;
+
+        let uv_workspace = uv_workspace(&root, &member, &system)?;
+        let project =
+            ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
+
+        assert_eq!(project.root(), &*root);
+
+        Ok(())
+    }
+
+    #[test]
+    fn uv_workspace_discovery_is_system_independent() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        let root = SystemPathBuf::from("/app");
+        let member = root.join("packages/member");
+
+        system.set_env_var(EnvVars::TY_UV, "1");
+        system.set_env_var(EnvVars::UV, "uv");
+        system
+            .memory_file_system()
+            .write_file_all(member.join("pyproject.toml"), "[project]\nname = 'member'")?;
+
+        let project = ProjectMetadata::discover(&member, &system)?;
+
+        assert_eq!(project.root(), &*member);
+
+        Ok(())
+    }
+
+    #[test]
+    fn member_ty_configuration_selects_project_root() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        let root = SystemPathBuf::from("/app");
+        let member = root.join("packages/member");
+
+        system.memory_file_system().write_files_all([
+            (root.join("uv.toml"), ""),
+            (
+                member.join("pyproject.toml"),
+                r#"
+                [project]
+                name = "member"
+
+                [tool.ty.environment]
+                python-version = "3.10"
+                "#,
+            ),
+        ])?;
+
+        let uv_workspace = uv_workspace(&root, &member, &system)?;
+        let mut project =
+            ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
+        project.apply_configuration_files(&system)?;
+
+        assert_eq!(project.root(), &*member);
+        assert_eq!(
+            project
+                .to_merged_options()
+                .options()
+                .environment
+                .as_ref()
+                .and_then(|environment| environment.python_version.as_deref())
+                .copied()
+                .map(PythonVersion::from),
+            Some(PythonVersion::PY310)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn outer_ty_configuration_precedes_uv_workspace() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        let root = SystemPathBuf::from("/app");
+        let workspace = root.join("workspace");
+        let member = workspace.join("packages/member");
+
+        system.memory_file_system().write_files_all([
+            (
+                root.join("ty.toml"),
+                r#"
+                [environment]
+                python-version = "3.10"
+                "#,
+            ),
+            (workspace.join("pyproject.toml"), "[tool.uv.workspace]"),
+            (
+                member.join("pyproject.toml"),
+                r#"
+                [project]
+                name = "member"
+                "#,
+            ),
+        ])?;
+
+        let uv_workspace = uv_workspace(&workspace, &member, &system)?;
+        let project =
+            ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
+
+        assert_eq!(project.root(), &*root);
+
+        Ok(())
+    }
+
+    #[test]
+    fn applies_uv_workspace_environment() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        let root = SystemPathBuf::from("/app");
+        let member = root.join("packages/member");
+        let environment = root.join("uv-venv");
+
+        system.memory_file_system().write_files_all([
+            (
+                root.join("pyproject.toml"),
+                r#"
+                [tool.uv.workspace]
+
+                [tool.ty.environment]
+                python = "/project-venv"
+                python-version = "3.10"
+                "#,
+            ),
+            (member.join("pyproject.toml"), "[project]\nname = 'member'"),
+            (environment.join("marker"), ""),
+        ])?;
+
+        let metadata = serde_json::json!({
+            "workspace_root": root,
+            "environment": {
+                "root": environment,
+                "python": {
+                    "version": "3.13.5",
+                },
+            },
+        });
+        let uv_workspace =
+            UvWorkspace::from_metadata(&member, metadata.to_string().as_bytes(), &system)?;
+        let mut project =
+            ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
+        project.apply_fallback_options(Options::from_toml_str(
+            r#"
+            [environment]
+            python = "/editor-venv"
+            python-version = "3.10"
+            "#,
+            ValueSource::Editor,
+        )?);
+        project.apply_configuration_files(&system)?;
+
+        let merged_options = project.to_merged_options();
+        let project_environment = merged_options.options().environment.as_ref();
+        assert_eq!(
+            project_environment
+                .and_then(|environment| environment.python_version.as_deref())
+                .copied()
+                .map(PythonVersion::from),
+            Some(PythonVersion::PY313)
+        );
+        assert_eq!(
+            project_environment
+                .and_then(|environment| environment.python.as_ref())
+                .map(RelativePathBuf::path),
+            Some(environment.as_path())
+        );
+        assert!(matches!(
+            project_environment
+                .and_then(|environment| environment.python.as_ref())
+                .map(RelativePathBuf::source),
+            Some(ValueSource::UvWorkspace)
+        ));
+        assert!(matches!(
+            project_environment
+                .and_then(|environment| environment.python_version.as_ref())
+                .map(ruff_ranged_value::RangedValue::source),
+            Some(ValueSource::UvWorkspace)
+        ));
+
+        let user_config_directory = root.join("config");
+        system
+            .in_memory()
+            .set_user_configuration_directory(Some(user_config_directory.clone()));
+        system.memory_file_system().write_file_all(
+            user_config_directory.join("ty/ty.toml"),
+            r#"
+            [environment]
+            python = "/user-venv"
+            python-version = "3.12"
+            "#,
+        )?;
+        project.apply_configuration_files(&system)?;
+
+        let merged_options = project.to_merged_options();
+        let project_environment = merged_options.options().environment.as_ref();
+        assert_eq!(
+            project_environment
+                .and_then(|environment| environment.python_version.as_deref())
+                .copied()
+                .map(PythonVersion::from),
+            Some(PythonVersion::PY313)
+        );
+        assert_eq!(
+            project_environment
+                .and_then(|environment| environment.python.as_ref())
+                .map(|python| python.path().as_str()),
+            Some(environment.as_str())
+        );
 
         Ok(())
     }
@@ -1235,6 +1546,22 @@ unclosed table, expected `]`
     fn assert_error_chain_eq(error: ProjectMetadataError, message: &str) {
         let error = anyhow::Error::new(error);
         assert_eq!(format!("{error:#}").replace('\\', "/"), message);
+    }
+
+    fn uv_workspace(
+        root: &SystemPathBuf,
+        member: &SystemPathBuf,
+        system: &TestSystem,
+    ) -> anyhow::Result<UvWorkspace> {
+        let metadata = serde_json::json!({
+            "workspace_root": root,
+        });
+
+        Ok(UvWorkspace::from_metadata(
+            member,
+            metadata.to_string().as_bytes(),
+            system,
+        )?)
     }
 
     fn with_escaped_paths<R>(f: impl FnOnce() -> R) -> R {

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -46,8 +46,9 @@ pub struct ProjectMetadata {
     /// the file specified by [`Self::config_file_override`] if it is `Some` (e.g. when using `--config-file <path>`).
     pub(super) options: Options,
 
-    /// Options derived from the uv workspace, with higher precedence than project and user-level
-    /// configuration.
+    /// The Python version and interpreter path derived from uv workspace metadata.
+    ///
+    /// These options have higher precedence than project and user-level configuration.
     #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     uv_workspace_options: Option<Box<Options>>,
 
@@ -193,10 +194,17 @@ impl ProjectMetadata {
     ) -> Result<ProjectMetadata, ProjectMetadataError> {
         let uv_workspace = if matches!(system.env_var(EnvVars::TY_UV).as_deref(), Ok("1" | "true"))
         {
-            uv::UvWorkspace::discover(path, system)
+            match uv::UvWorkspace::discover(path, system) {
+                Ok(workspace) => Some(workspace),
+                Err(error) => {
+                    tracing::warn!("{error}");
+                    None
+                }
+            }
         } else {
             None
         };
+
         Self::discover_with_uv_workspace(path, system, uv_workspace)
     }
 
@@ -221,117 +229,49 @@ impl ProjectMetadata {
 
         let mut closest_project: Option<ProjectMetadata> = None;
         let mut uv_project: Option<ProjectMetadata> = None;
-        let uv_workspace_root = uv_workspace
-            .as_ref()
-            .map(|workspace| workspace.root().to_path_buf());
+        let uv_workspace_root = uv_workspace.as_ref().map(uv::UvWorkspace::root);
 
-        // Workspace members can live outside the workspace directory, for example when uv's
-        // members include `../external-package`. Include that root explicitly because walking
-        // the member's ancestors alone cannot discover its workspace configuration.
-        let external_uv_workspace_root = uv_workspace_root
-            .as_deref()
-            .filter(|root| !path.starts_with(root));
-
-        for project_root in path.ancestors().chain(external_uv_workspace_root) {
-            let is_uv_workspace_root = uv_workspace_root.as_deref() == Some(project_root);
-            let pyproject_path = project_root.join("pyproject.toml");
-
-            let pyproject = if let Ok(pyproject_str) = system.read_to_string(&pyproject_path) {
-                match PyProject::from_toml_str(
-                    &pyproject_str,
-                    ValueSource::File(Arc::new(pyproject_path.clone())),
-                ) {
-                    Ok(pyproject) => Some(pyproject),
-                    Err(error) => {
-                        return Err(ProjectMetadataError::InvalidPyProject {
-                            path: pyproject_path,
-                            source: Box::new(error),
-                        });
-                    }
+        for project_root in path.ancestors() {
+            let is_uv_workspace_root = uv_workspace_root == Some(project_root);
+            let Some((metadata, has_ty_configuration)) = Self::discover_in(project_root, system)?
+            else {
+                if is_uv_workspace_root {
+                    uv_project = Some(Self::new(
+                        project_root.file_name().unwrap_or("root"),
+                        project_root.to_path_buf(),
+                    ));
                 }
-            } else {
-                None
+                continue;
             };
 
-            // A `ty.toml` takes precedence over a `pyproject.toml`.
-            let ty_toml_path = project_root.join("ty.toml");
-            if let Ok(ty_str) = system.read_to_string(&ty_toml_path) {
-                let options = match Options::from_toml_str(
-                    &ty_str,
-                    ValueSource::File(Arc::new(ty_toml_path.clone())),
-                ) {
-                    Ok(options) => options,
-                    Err(error) => {
-                        return Err(ProjectMetadataError::InvalidTyToml {
-                            path: ty_toml_path,
-                            source: Box::new(error),
-                        });
-                    }
-                };
-
-                if pyproject
-                    .as_ref()
-                    .is_some_and(|project| project.ty().is_some())
-                {
-                    // TODO: Consider using a diagnostic here
-                    tracing::warn!(
-                        "Ignoring the `tool.ty` section in `{pyproject_path}` because `{ty_toml_path}` takes precedence."
-                    );
-                }
-
+            if has_ty_configuration {
                 tracing::debug!("Found project at '{}'", project_root);
-
-                let metadata = ProjectMetadata::from_options(
-                    options,
-                    project_root.to_path_buf(),
-                    pyproject
-                        .as_ref()
-                        .and_then(|pyproject| pyproject.project.as_ref()),
-                    &FallibleStrategy,
-                )
-                .map_err(|err| {
-                    ProjectMetadataError::InvalidRequiresPythonConstraint {
-                        source: err,
-                        path: pyproject_path,
-                    }
-                })?;
-
                 return Ok(metadata.with_uv_workspace(uv_workspace));
             }
 
-            if let Some(pyproject) = pyproject {
-                let has_ty_section = pyproject.ty().is_some();
-                let metadata =
-                    ProjectMetadata::from_pyproject(pyproject, project_root.to_path_buf())
-                        .map_err(
-                            |err| ProjectMetadataError::InvalidRequiresPythonConstraint {
-                                source: err,
-                                path: pyproject_path,
-                            },
-                        )?;
-
-                if has_ty_section {
-                    tracing::debug!("Found project at '{}'", project_root);
-
-                    return Ok(metadata.with_uv_workspace(uv_workspace));
-                }
-
-                if is_uv_workspace_root {
-                    uv_project = Some(metadata);
-                } else if closest_project.is_none() {
-                    // Not a project itself, keep looking for an enclosing project.
-                    closest_project = Some(metadata);
-                }
-            } else if is_uv_workspace_root {
-                uv_project = Some(Self::new(
-                    project_root.file_name().unwrap_or("root"),
-                    project_root.to_path_buf(),
-                ));
+            if is_uv_workspace_root {
+                uv_project = Some(metadata);
+            } else if closest_project.is_none() {
+                closest_project = Some(metadata);
             }
         }
 
-        // No explicitly configured project was found. Prefer the uv workspace over the closest
-        // plain `pyproject.toml`, if available.
+        // Workspace members can live outside the workspace directory, so their ancestor chain may
+        // never include the workspace root.
+        if let Some(workspace_root) = uv_workspace_root
+            && !path.starts_with(workspace_root)
+        {
+            let metadata = Self::discover_in(workspace_root, system)?
+                .map(|(metadata, _)| metadata)
+                .unwrap_or_else(|| {
+                    Self::new(
+                        workspace_root.file_name().unwrap_or("root"),
+                        workspace_root.to_path_buf(),
+                    )
+                });
+            uv_project = Some(metadata);
+        }
+
         let metadata = if let Some(uv_project) = uv_project {
             tracing::debug!("Using uv workspace at '{}'", uv_project.root());
 
@@ -353,6 +293,89 @@ impl ProjectMetadata {
         };
 
         Ok(metadata.with_uv_workspace(uv_workspace))
+    }
+
+    fn discover_in(
+        project_root: &SystemPath,
+        system: &dyn System,
+    ) -> Result<Option<(ProjectMetadata, bool)>, ProjectMetadataError> {
+        let pyproject_path = project_root.join("pyproject.toml");
+
+        let pyproject = if let Ok(pyproject_str) = system.read_to_string(&pyproject_path) {
+            match PyProject::from_toml_str(
+                &pyproject_str,
+                ValueSource::File(Arc::new(pyproject_path.clone())),
+            ) {
+                Ok(pyproject) => Some(pyproject),
+                Err(error) => {
+                    return Err(ProjectMetadataError::InvalidPyProject {
+                        path: pyproject_path,
+                        source: Box::new(error),
+                    });
+                }
+            }
+        } else {
+            None
+        };
+
+        // A `ty.toml` takes precedence over a `pyproject.toml`.
+        let ty_toml_path = project_root.join("ty.toml");
+        if let Ok(ty_str) = system.read_to_string(&ty_toml_path) {
+            let options = match Options::from_toml_str(
+                &ty_str,
+                ValueSource::File(Arc::new(ty_toml_path.clone())),
+            ) {
+                Ok(options) => options,
+                Err(error) => {
+                    return Err(ProjectMetadataError::InvalidTyToml {
+                        path: ty_toml_path,
+                        source: Box::new(error),
+                    });
+                }
+            };
+
+            if pyproject
+                .as_ref()
+                .is_some_and(|project| project.ty().is_some())
+            {
+                // TODO: Consider using a diagnostic here
+                tracing::warn!(
+                    "Ignoring the `tool.ty` section in `{pyproject_path}` because `{ty_toml_path}` takes precedence."
+                );
+            }
+
+            let metadata = ProjectMetadata::from_options(
+                options,
+                project_root.to_path_buf(),
+                pyproject
+                    .as_ref()
+                    .and_then(|pyproject| pyproject.project.as_ref()),
+                &FallibleStrategy,
+            )
+            .map_err(|source| {
+                ProjectMetadataError::InvalidRequiresPythonConstraint {
+                    source,
+                    path: pyproject_path,
+                }
+            })?;
+
+            return Ok(Some((metadata, true)));
+        }
+
+        let Some(pyproject) = pyproject else {
+            return Ok(None);
+        };
+
+        let has_ty_configuration = pyproject.ty().is_some();
+        let metadata = ProjectMetadata::from_pyproject(pyproject, project_root.to_path_buf())
+            .map_err(
+                |source| ProjectMetadataError::InvalidRequiresPythonConstraint {
+                    source,
+                    path: pyproject_path,
+                },
+            )?;
+
+        Ok(Some((metadata, has_ty_configuration)))
     }
 
     #[must_use]

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -221,10 +221,19 @@ impl ProjectMetadata {
 
         let mut closest_project: Option<ProjectMetadata> = None;
         let mut uv_project: Option<ProjectMetadata> = None;
-        let uv_workspace_root = uv_workspace.as_ref().map(uv::UvWorkspace::root);
+        let uv_workspace_root = uv_workspace
+            .as_ref()
+            .map(|workspace| workspace.root().to_path_buf());
 
-        for project_root in path.ancestors() {
-            let is_uv_workspace_root = uv_workspace_root == Some(project_root);
+        // Workspace members can live outside the workspace directory, for example when uv's
+        // members include `../external-package`. Include that root explicitly because walking
+        // the member's ancestors alone cannot discover its workspace configuration.
+        let external_uv_workspace_root = uv_workspace_root
+            .as_deref()
+            .filter(|root| !path.starts_with(root));
+
+        for project_root in path.ancestors().chain(external_uv_workspace_root) {
+            let is_uv_workspace_root = uv_workspace_root.as_deref() == Some(project_root);
             let pyproject_path = project_root.join("pyproject.toml");
 
             let pyproject = if let Ok(pyproject_str) = system.read_to_string(&pyproject_path) {
@@ -880,7 +889,42 @@ unclosed table, expected `]`
             ),
         ])?;
 
-        let uv_workspace = uv_workspace(&root, &member, &system)?;
+        let uv_workspace = uv_workspace(&root, &system)?;
+        let project =
+            ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
+
+        assert_eq!(project.root(), &*root);
+
+        Ok(())
+    }
+
+    #[test]
+    fn external_uv_workspace_precedes_plain_member_pyproject() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        let root = SystemPathBuf::from("/app/workspace");
+        let member = SystemPathBuf::from("/app/external-package");
+
+        system.memory_file_system().write_files_all([
+            (
+                root.join("pyproject.toml"),
+                r#"
+                [tool.uv.workspace]
+                members = ["../external-package"]
+
+                [tool.ty.rules]
+                invalid-assignment = "ignore"
+                "#,
+            ),
+            (
+                member.join("pyproject.toml"),
+                r#"
+                [project]
+                name = "external-package"
+                "#,
+            ),
+        ])?;
+
+        let uv_workspace = uv_workspace(&root, &system)?;
         let project =
             ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
 
@@ -928,7 +972,7 @@ unclosed table, expected `]`
             ),
         ])?;
 
-        let uv_workspace = uv_workspace(&root, &member, &system)?;
+        let uv_workspace = uv_workspace(&root, &system)?;
         let mut project =
             ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
         project.apply_configuration_files(&system)?;
@@ -974,7 +1018,7 @@ unclosed table, expected `]`
             ),
         ])?;
 
-        let uv_workspace = uv_workspace(&workspace, &member, &system)?;
+        let uv_workspace = uv_workspace(&workspace, &system)?;
         let project =
             ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
 
@@ -1014,8 +1058,7 @@ unclosed table, expected `]`
                 },
             },
         });
-        let uv_workspace =
-            UvWorkspace::from_metadata(&member, metadata.to_string().as_bytes(), &system)?;
+        let uv_workspace = UvWorkspace::from_metadata(metadata.to_string().as_bytes(), &system)?;
         let mut project =
             ProjectMetadata::discover_with_uv_workspace(&member, &system, Some(uv_workspace))?;
         project.apply_fallback_options(Options::from_toml_str(
@@ -1548,17 +1591,12 @@ unclosed table, expected `]`
         assert_eq!(format!("{error:#}").replace('\\', "/"), message);
     }
 
-    fn uv_workspace(
-        root: &SystemPathBuf,
-        member: &SystemPathBuf,
-        system: &TestSystem,
-    ) -> anyhow::Result<UvWorkspace> {
+    fn uv_workspace(root: &SystemPathBuf, system: &TestSystem) -> anyhow::Result<UvWorkspace> {
         let metadata = serde_json::json!({
             "workspace_root": root,
         });
 
         Ok(UvWorkspace::from_metadata(
-            member,
             metadata.to_string().as_bytes(),
             system,
         )?)

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -197,6 +197,7 @@ impl Options {
                     SysPrefixPathOrigin::ConfigFileSetting(path.clone(), python_path.range())
                 }
                 ValueSource::Editor => SysPrefixPathOrigin::Editor,
+                ValueSource::UvWorkspace => SysPrefixPathOrigin::UvWorkspace,
             };
 
             PythonEnvironment::new(python_path.absolute(project_root, system), origin, system)
@@ -565,6 +566,7 @@ fn python_version_from_config(
                 PythonVersionFileSource::new(path.clone(), ranged_version.range()),
             ),
             ValueSource::Editor => PythonVersionSource::Editor,
+            ValueSource::UvWorkspace => PythonVersionSource::UvWorkspace,
         },
     }
 }
@@ -685,6 +687,10 @@ fn unsupported_inferred_python_version_diagnostic(
         PythonVersionSource::Editor => diagnostic.sub(SubDiagnostic::new(
             SubDiagnosticSeverity::Info,
             "The version was inferred from your editor.",
+        )),
+        PythonVersionSource::UvWorkspace => diagnostic.sub(SubDiagnostic::new(
+            SubDiagnosticSeverity::Info,
+            "The version was provided by uv workspace metadata.",
         )),
         PythonVersionSource::Default => diagnostic.sub(SubDiagnostic::new(
             SubDiagnosticSeverity::Info,
@@ -1101,6 +1107,7 @@ impl Rules {
                 ValueSource::File(_) => LintSource::File,
                 ValueSource::Cli => LintSource::Cli,
                 ValueSource::Editor => LintSource::Editor,
+                ValueSource::UvWorkspace => LintSource::UvWorkspace,
             };
 
             let mut set_lint_level = |lint| {
@@ -2267,6 +2274,10 @@ impl OptionDiagnostic {
             ValueSource::Editor => self.sub(SubDiagnostic::new(
                 SubDiagnosticSeverity::Info,
                 "The {value_label} was specified in the editor settings.",
+            )),
+            ValueSource::UvWorkspace => self.sub(SubDiagnostic::new(
+                SubDiagnosticSeverity::Info,
+                format!("The {value_label} was provided by uv workspace metadata."),
             )),
         }
     }

--- a/crates/ty_project/src/metadata/uv.rs
+++ b/crates/ty_project/src/metadata/uv.rs
@@ -1,0 +1,272 @@
+use std::path::PathBuf;
+
+use pep440_rs::Version;
+use ruff_db::system::{System, SystemPath, SystemPathBuf};
+use ruff_python_ast::PythonVersion;
+use ruff_ranged_value::{RangedValue, ValueSource};
+use serde::Deserialize;
+use thiserror::Error;
+use ty_static::EnvVars;
+
+use super::python_version::SupportedPythonVersion;
+
+#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
+pub(super) struct UvWorkspace {
+    root: SystemPathBuf,
+    environment: Option<SystemPathBuf>,
+    python_version: Option<RangedValue<SupportedPythonVersion>>,
+}
+
+impl UvWorkspace {
+    pub(super) fn discover(path: &SystemPath, system: &dyn System) -> Option<Self> {
+        let uv = system
+            .env_var(EnvVars::UV)
+            .unwrap_or_else(|_| "uv".to_string());
+
+        // `uv check` has already selected and synchronized the environment. Keep this query
+        // read-only so package selection and `--isolated` aren't overwritten by a second sync.
+        let output = match system.run_command(
+            &uv,
+            &["workspace", "metadata", "--frozen", "--active"],
+            path,
+        ) {
+            Ok(output) => output,
+            Err(error) => {
+                tracing::debug!("Failed to invoke `uv workspace metadata`: {error}");
+                return None;
+            }
+        };
+
+        if !output.status.success() {
+            tracing::debug!(
+                "`uv workspace metadata` failed with status {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return None;
+        }
+
+        match Self::from_metadata(path, &output.stdout, system) {
+            Ok(workspace) => Some(workspace),
+            Err(error) => {
+                tracing::debug!("Failed to use `uv workspace metadata` output: {error}");
+                None
+            }
+        }
+    }
+
+    pub(super) fn from_metadata(
+        path: &SystemPath,
+        metadata: &[u8],
+        system: &dyn System,
+    ) -> Result<Self, UvWorkspaceError> {
+        let metadata = serde_json::from_slice::<WorkspaceMetadata>(metadata)
+            .map_err(UvWorkspaceError::InvalidMetadata)?;
+
+        let root = existing_directory(metadata.workspace_root, "workspace root", system)?;
+        if !path.starts_with(&root) {
+            return Err(UvWorkspaceError::WorkspaceRootNotAncestor {
+                root,
+                path: path.to_path_buf(),
+            });
+        }
+
+        let (environment, python_version) = match metadata.environment {
+            Some(environment) => (
+                Some(existing_directory(
+                    environment.root,
+                    "environment root",
+                    system,
+                )?),
+                Some(resolve_python_version(&environment.python.version)?),
+            ),
+            None => (None, None),
+        };
+
+        Ok(Self {
+            root,
+            environment,
+            python_version,
+        })
+    }
+
+    pub(super) fn root(&self) -> &SystemPath {
+        &self.root
+    }
+
+    pub(super) fn environment(&self) -> Option<&SystemPath> {
+        self.environment.as_deref()
+    }
+
+    pub(super) fn python_version(&self) -> Option<&RangedValue<SupportedPythonVersion>> {
+        self.python_version.as_ref()
+    }
+}
+
+fn resolve_python_version(
+    version: &Version,
+) -> Result<RangedValue<SupportedPythonVersion>, UvWorkspaceError> {
+    let mut release = version.release().iter().copied();
+    let Some(major) = release.next() else {
+        return Err(UvWorkspaceError::InvalidPythonVersion(version.clone()));
+    };
+    let Some(minor) = release.next() else {
+        return Err(UvWorkspaceError::InvalidPythonVersion(version.clone()));
+    };
+    let Ok(major) = u8::try_from(major) else {
+        return Err(UvWorkspaceError::InvalidPythonVersion(version.clone()));
+    };
+    let Ok(minor) = u8::try_from(minor) else {
+        return Err(UvWorkspaceError::InvalidPythonVersion(version.clone()));
+    };
+    let Ok(version) = SupportedPythonVersion::try_from(PythonVersion::from((major, minor))) else {
+        return Err(UvWorkspaceError::InvalidPythonVersion(version.clone()));
+    };
+
+    Ok(RangedValue::new(version, ValueSource::UvWorkspace))
+}
+
+fn existing_directory(
+    path: PathBuf,
+    description: &'static str,
+    system: &dyn System,
+) -> Result<SystemPathBuf, UvWorkspaceError> {
+    let path = match SystemPathBuf::from_path_buf(path) {
+        Ok(path) => path,
+        Err(path) => return Err(UvWorkspaceError::NonUnicodePath { description, path }),
+    };
+
+    if !system.is_directory(&path) {
+        return Err(UvWorkspaceError::MissingDirectory { description, path });
+    }
+
+    Ok(path)
+}
+
+#[derive(Debug, Error)]
+pub(super) enum UvWorkspaceError {
+    #[error("invalid `uv workspace metadata` JSON: {0}")]
+    InvalidMetadata(serde_json::Error),
+
+    #[error("unsupported Python version `{0}` returned by `uv workspace metadata`")]
+    InvalidPythonVersion(Version),
+
+    #[error("non-Unicode {description} returned by `uv workspace metadata`: `{path}`", path = path.display())]
+    NonUnicodePath {
+        description: &'static str,
+        path: PathBuf,
+    },
+
+    #[error("missing {description} returned by `uv workspace metadata`: `{path}`")]
+    MissingDirectory {
+        description: &'static str,
+        path: SystemPathBuf,
+    },
+
+    #[error("uv workspace root `{root}` is not an ancestor of `{path}`")]
+    WorkspaceRootNotAncestor {
+        root: SystemPathBuf,
+        path: SystemPathBuf,
+    },
+}
+
+#[derive(Deserialize)]
+struct WorkspaceMetadata {
+    workspace_root: PathBuf,
+    environment: Option<WorkspaceEnvironment>,
+}
+
+#[derive(Deserialize)]
+struct WorkspaceEnvironment {
+    root: PathBuf,
+    python: WorkspacePython,
+}
+
+#[derive(Deserialize)]
+struct WorkspacePython {
+    version: Version,
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::system::{SystemPath, TestSystem};
+
+    use super::{UvWorkspace, UvWorkspaceError};
+
+    #[test]
+    fn rejects_invalid_metadata() {
+        let system = TestSystem::default();
+
+        assert!(matches!(
+            UvWorkspace::from_metadata(SystemPath::new("/app"), b"{", &system),
+            Err(UvWorkspaceError::InvalidMetadata(_))
+        ));
+    }
+
+    #[test]
+    fn environment_can_be_omitted() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        system
+            .memory_file_system()
+            .write_file_all("/app/pyproject.toml", "[tool.uv.workspace]")?;
+        let metadata = br#"{
+            "workspace_root": "/app"
+        }"#;
+
+        let workspace = UvWorkspace::from_metadata(SystemPath::new("/app"), metadata, &system)?;
+
+        assert!(workspace.environment().is_none());
+        assert!(workspace.python_version().is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn uses_environment_python_version() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        system.memory_file_system().write_files_all([
+            ("/app/pyproject.toml", "[tool.uv.workspace]"),
+            ("/env/marker", ""),
+        ])?;
+        let metadata = br#"{
+            "workspace_root": "/app",
+            "environment": {
+                "root": "/env",
+                "python": { "version": "3.13.5" }
+            }
+        }"#;
+
+        let workspace = UvWorkspace::from_metadata(SystemPath::new("/app"), metadata, &system)?;
+
+        assert_eq!(workspace.environment(), Some(SystemPath::new("/env")));
+        assert_eq!(
+            workspace.python_version().map(ToString::to_string),
+            Some("3.13".to_string())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_unsupported_environment_python_version() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        system.memory_file_system().write_files_all([
+            ("/app/pyproject.toml", "[tool.uv.workspace]"),
+            ("/env/marker", ""),
+        ])?;
+        let metadata = br#"{
+            "workspace_root": "/app",
+            "environment": {
+                "root": "/env",
+                "python": { "version": "3.16.0" }
+            }
+        }"#;
+
+        assert!(matches!(
+            UvWorkspace::from_metadata(SystemPath::new("/app"), metadata, &system),
+            Err(UvWorkspaceError::InvalidPythonVersion(_))
+        ));
+
+        Ok(())
+    }
+}

--- a/crates/ty_project/src/metadata/uv.rs
+++ b/crates/ty_project/src/metadata/uv.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use pep440_rs::Version;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
-use ruff_python_ast::PythonVersion;
 use ruff_ranged_value::{RangedValue, ValueSource};
 use serde::Deserialize;
 use thiserror::Error;
@@ -18,41 +17,32 @@ pub(super) struct UvWorkspace {
 }
 
 impl UvWorkspace {
-    pub(super) fn discover(path: &SystemPath, system: &dyn System) -> Option<Self> {
+    pub(super) fn discover(
+        path: &SystemPath,
+        system: &dyn System,
+    ) -> Result<Self, UvWorkspaceError> {
         let uv = system
             .env_var(EnvVars::UV)
             .unwrap_or_else(|_| "uv".to_string());
 
         // `uv check` has already selected and synchronized the environment. Keep this query
         // read-only so package selection and `--isolated` aren't overwritten by a second sync.
-        let output = match system.run_command(
-            &uv,
-            &["workspace", "metadata", "--frozen", "--active"],
-            path,
-        ) {
-            Ok(output) => output,
-            Err(error) => {
-                tracing::debug!("Failed to invoke `uv workspace metadata`: {error}");
-                return None;
-            }
-        };
+        let output = system
+            .run_command(
+                &uv,
+                &["workspace", "metadata", "--frozen", "--active"],
+                path,
+            )
+            .map_err(UvWorkspaceError::Invocation)?;
 
         if !output.status.success() {
-            tracing::debug!(
-                "`uv workspace metadata` failed with status {}: {}",
-                output.status,
-                String::from_utf8_lossy(&output.stderr)
-            );
-            return None;
+            return Err(UvWorkspaceError::CommandFailed {
+                status: output.status,
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
         }
 
-        match Self::from_metadata(&output.stdout, system) {
-            Ok(workspace) => Some(workspace),
-            Err(error) => {
-                tracing::debug!("Failed to use `uv workspace metadata` output: {error}");
-                None
-            }
-        }
+        Self::from_metadata(&output.stdout, system)
     }
 
     pub(super) fn from_metadata(
@@ -99,22 +89,12 @@ impl UvWorkspace {
 fn resolve_python_version(
     version: &Version,
 ) -> Result<RangedValue<SupportedPythonVersion>, UvWorkspaceError> {
-    let mut release = version.release().iter().copied();
-    let Some(major) = release.next() else {
+    let [major, minor, ..] = version.release() else {
         return Err(UvWorkspaceError::InvalidPythonVersion(version.clone()));
     };
-    let Some(minor) = release.next() else {
-        return Err(UvWorkspaceError::InvalidPythonVersion(version.clone()));
-    };
-    let Ok(major) = u8::try_from(major) else {
-        return Err(UvWorkspaceError::InvalidPythonVersion(version.clone()));
-    };
-    let Ok(minor) = u8::try_from(minor) else {
-        return Err(UvWorkspaceError::InvalidPythonVersion(version.clone()));
-    };
-    let Ok(version) = SupportedPythonVersion::try_from(PythonVersion::from((major, minor))) else {
-        return Err(UvWorkspaceError::InvalidPythonVersion(version.clone()));
-    };
+    let version = format!("{major}.{minor}")
+        .parse::<SupportedPythonVersion>()
+        .map_err(|_| UvWorkspaceError::InvalidPythonVersion(version.clone()))?;
 
     Ok(RangedValue::new(version, ValueSource::UvWorkspace))
 }
@@ -138,6 +118,15 @@ fn existing_directory(
 
 #[derive(Debug, Error)]
 pub(super) enum UvWorkspaceError {
+    #[error("Failed to invoke `uv workspace metadata`: {0}")]
+    Invocation(#[source] std::io::Error),
+
+    #[error("`uv workspace metadata` failed with status {status}: {stderr}")]
+    CommandFailed {
+        status: std::process::ExitStatus,
+        stderr: String,
+    },
+
     #[error("invalid `uv workspace metadata` JSON: {0}")]
     InvalidMetadata(serde_json::Error),
 

--- a/crates/ty_project/src/metadata/uv.rs
+++ b/crates/ty_project/src/metadata/uv.rs
@@ -46,7 +46,7 @@ impl UvWorkspace {
             return None;
         }
 
-        match Self::from_metadata(path, &output.stdout, system) {
+        match Self::from_metadata(&output.stdout, system) {
             Ok(workspace) => Some(workspace),
             Err(error) => {
                 tracing::debug!("Failed to use `uv workspace metadata` output: {error}");
@@ -56,7 +56,6 @@ impl UvWorkspace {
     }
 
     pub(super) fn from_metadata(
-        path: &SystemPath,
         metadata: &[u8],
         system: &dyn System,
     ) -> Result<Self, UvWorkspaceError> {
@@ -64,12 +63,6 @@ impl UvWorkspace {
             .map_err(UvWorkspaceError::InvalidMetadata)?;
 
         let root = existing_directory(metadata.workspace_root, "workspace root", system)?;
-        if !path.starts_with(&root) {
-            return Err(UvWorkspaceError::WorkspaceRootNotAncestor {
-                root,
-                path: path.to_path_buf(),
-            });
-        }
 
         let (environment, python_version) = match metadata.environment {
             Some(environment) => (
@@ -162,12 +155,6 @@ pub(super) enum UvWorkspaceError {
         description: &'static str,
         path: SystemPathBuf,
     },
-
-    #[error("uv workspace root `{root}` is not an ancestor of `{path}`")]
-    WorkspaceRootNotAncestor {
-        root: SystemPathBuf,
-        path: SystemPathBuf,
-    },
 }
 
 #[derive(Deserialize)]
@@ -198,7 +185,7 @@ mod tests {
         let system = TestSystem::default();
 
         assert!(matches!(
-            UvWorkspace::from_metadata(SystemPath::new("/app"), b"{", &system),
+            UvWorkspace::from_metadata(b"{", &system),
             Err(UvWorkspaceError::InvalidMetadata(_))
         ));
     }
@@ -213,7 +200,7 @@ mod tests {
             "workspace_root": "/app"
         }"#;
 
-        let workspace = UvWorkspace::from_metadata(SystemPath::new("/app"), metadata, &system)?;
+        let workspace = UvWorkspace::from_metadata(metadata, &system)?;
 
         assert!(workspace.environment().is_none());
         assert!(workspace.python_version().is_none());
@@ -236,7 +223,7 @@ mod tests {
             }
         }"#;
 
-        let workspace = UvWorkspace::from_metadata(SystemPath::new("/app"), metadata, &system)?;
+        let workspace = UvWorkspace::from_metadata(metadata, &system)?;
 
         assert_eq!(workspace.environment(), Some(SystemPath::new("/env")));
         assert_eq!(
@@ -263,7 +250,7 @@ mod tests {
         }"#;
 
         assert!(matches!(
-            UvWorkspace::from_metadata(SystemPath::new("/app"), metadata, &system),
+            UvWorkspace::from_metadata(metadata, &system),
             Err(UvWorkspaceError::InvalidPythonVersion(_))
         ));
 

--- a/crates/ty_project/src/metadata/value.rs
+++ b/crates/ty_project/src/metadata/value.rs
@@ -76,7 +76,9 @@ impl RelativePathBuf {
     pub fn absolute(&self, project_root: &SystemPath, system: &dyn System) -> SystemPathBuf {
         let relative_to = match self.0.source() {
             ValueSource::File(_) => project_root,
-            ValueSource::Cli | ValueSource::Editor => system.current_directory(),
+            ValueSource::Cli | ValueSource::Editor | ValueSource::UvWorkspace => {
+                system.current_directory()
+            }
         };
 
         // Expand tildes and environment variables in the path (e.g. `~/.cache/foo`).
@@ -146,7 +148,9 @@ impl RelativeGlobPattern {
     ) -> Result<AbsolutePortableGlobPattern, PortableGlobError> {
         let relative_to = match self.0.source() {
             ValueSource::File(_) => project_root,
-            ValueSource::Cli | ValueSource::Editor => system.current_directory(),
+            ValueSource::Cli | ValueSource::Editor | ValueSource::UvWorkspace => {
+                system.current_directory()
+            }
         };
 
         let pattern = PortableGlobPattern::parse(&self.0, kind)?;

--- a/crates/ty_python_semantic/src/diagnostic/mod.rs
+++ b/crates/ty_python_semantic/src/diagnostic/mod.rs
@@ -33,9 +33,10 @@ pub fn inferred_python_version_source_annotation(
             .as_ref()
             .and_then(|source| source.span(db))
             .map(Annotation::primary),
-        PythonVersionSource::Cli | PythonVersionSource::Editor | PythonVersionSource::Default => {
-            None
-        }
+        PythonVersionSource::Cli
+        | PythonVersionSource::Editor
+        | PythonVersionSource::UvWorkspace
+        | PythonVersionSource::Default => None,
     }
 }
 
@@ -98,6 +99,11 @@ pub fn add_inferred_python_version_hint_to_diagnostic(
             diagnostic.info(format_args!(
                 "Python {version} was assumed when {action} \
                 because it's the version of the selected Python interpreter in your editor",
+            ));
+        }
+        crate::PythonVersionSource::UvWorkspace => {
+            diagnostic.info(format_args!(
+                "Python {version} was assumed when {action} because it was provided by uv workspace metadata",
             ));
         }
         crate::PythonVersionSource::InstallationDirectoryLayout {

--- a/crates/ty_python_semantic/src/lint.rs
+++ b/crates/ty_python_semantic/src/lint.rs
@@ -662,4 +662,7 @@ pub enum LintSource {
 
     /// The rule was enabled from the configuration in the editor.
     Editor,
+
+    /// The rule was enabled by uv workspace metadata.
+    UvWorkspace,
 }

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -379,6 +379,9 @@ impl Drop for LintDiagnosticGuard<'_, '_> {
                 LintSource::Editor => {
                     format!("rule `{rule}` was selected in the editor settings")
                 }
+                LintSource::UvWorkspace => {
+                    format!("rule `{rule}` was selected by uv workspace metadata")
+                }
             });
         }
 

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::fmt::Display;
 use std::hash::{DefaultHasher, Hash, Hasher as _};
 use std::panic::RefUnwindSafe;
+use std::process::Output;
 use std::sync::Arc;
 
 use crate::Db;
@@ -179,6 +180,16 @@ impl System for LSPSystem {
 
     fn is_same_file(&self, first: &SystemPath, second: &SystemPath) -> Result<bool> {
         self.native_system.is_same_file(first, second)
+    }
+
+    fn run_command(
+        &self,
+        program: &str,
+        args: &[&str],
+        current_directory: &SystemPath,
+    ) -> Result<Output> {
+        self.native_system
+            .run_command(program, args, current_directory)
     }
 
     fn source_type(&self, path: &SystemPath) -> Option<PySourceType> {

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -2107,6 +2107,8 @@ pub enum SysPrefixPathOrigin {
     PythonCliFlag,
     /// The selected interpreter in the user's editor.
     Editor,
+    /// The `sys.prefix` path was provided by `uv workspace metadata`.
+    UvWorkspace,
     /// The `sys.prefix` path came from the `VIRTUAL_ENV` environment variable
     VirtualEnvVar,
     /// The `sys.prefix` path came from the `CONDA_PREFIX` environment variable
@@ -2136,6 +2138,7 @@ impl SysPrefixPathOrigin {
             | Self::DerivedFromPyvenvCfg
             | Self::CondaPrefixVar
             | Self::PythonBinary
+            | Self::UvWorkspace
             | Self::SelfEnvironment => false,
         }
     }
@@ -2154,7 +2157,8 @@ impl SysPrefixPathOrigin {
             Self::VirtualEnvVar
             | Self::CondaPrefixVar
             | Self::DerivedFromPyvenvCfg
-            | Self::LocalVenv => true,
+            | Self::LocalVenv
+            | Self::UvWorkspace => true,
         }
     }
 
@@ -2169,7 +2173,8 @@ impl SysPrefixPathOrigin {
             | Self::DerivedFromPyvenvCfg
             | Self::ConfigFileSetting(..)
             | Self::PythonCliFlag
-            | Self::PythonBinary => false,
+            | Self::PythonBinary
+            | Self::UvWorkspace => false,
             Self::LocalVenv => true,
         }
     }
@@ -2185,6 +2190,7 @@ impl std::fmt::Display for SysPrefixPathOrigin {
             Self::DerivedFromPyvenvCfg => f.write_str("derived `sys.prefix` path"),
             Self::LocalVenv => f.write_str("local virtual environment"),
             Self::Editor => f.write_str("selected interpreter in your editor"),
+            Self::UvWorkspace => f.write_str("uv workspace environment"),
             Self::SelfEnvironment => f.write_str("ty environment"),
             Self::PythonBinary => f.write_str("Python binary discovered in $PATH"),
         }
@@ -2620,6 +2626,18 @@ mod tests {
             minor_version: 12,
             free_threaded: false,
             origin: SysPrefixPathOrigin::PythonCliFlag,
+            virtual_env: None,
+        };
+        test.run();
+    }
+
+    #[test]
+    fn can_find_site_packages_directory_no_virtual_env_at_origin_uv_workspace() {
+        let test = PythonEnvironmentTestCase {
+            system: TestSystem::default(),
+            minor_version: 12,
+            free_threaded: false,
+            origin: SysPrefixPathOrigin::UvWorkspace,
             virtual_env: None,
         };
         test.run();

--- a/crates/ty_site_packages/src/version.rs
+++ b/crates/ty_site_packages/src/version.rs
@@ -39,6 +39,9 @@ pub enum PythonVersionSource {
     /// (e.g., the Python environment)
     Editor,
 
+    /// The value was provided by `uv workspace metadata`.
+    UvWorkspace,
+
     /// We fell back to a default value because the value was not specified via the CLI or a config file.
     #[default]
     Default,

--- a/crates/ty_static/src/env_vars.rs
+++ b/crates/ty_static/src/env_vars.rs
@@ -61,6 +61,19 @@ impl EnvVars {
     /// Accepts the same values as the `--output-format` command-line argument.
     pub const TY_OUTPUT_FORMAT: &'static str = "TY_OUTPUT_FORMAT";
 
+    /// Enable uv integration.
+    ///
+    /// When set to `"1"` or `"true"`, ty invokes `uv workspace metadata` to discover the workspace
+    /// root.
+    #[attr_hidden]
+    pub const TY_UV: &'static str = "TY_UV";
+
+    /// The path to the uv executable to use for workspace discovery.
+    ///
+    /// ty uses this path when uv integration is enabled by `TY_UV`.
+    #[attr_hidden]
+    pub const UV: &'static str = "UV";
+
     /// Used to detect an activated virtual environment.
     pub const VIRTUAL_ENV: &'static str = "VIRTUAL_ENV";
 


### PR DESCRIPTION
This introduces minimal support for acquiring `uv workspace metadata` when, and only when, ty is invoked through `uv check`, and packages/workspaces are being requested (and not e.g. --script, see below). All other invocations of metadata are "future work". 

## `uv check` Recap

As a recap, `uv check` on current main will:

* Apply standard package selection (usually default to the package that owns cwd, with `--package` to select a different one, and `--all-packages` to select all of them)
* Run `uv sync` for the selected packages, and to fetch the appropriate version of ty
* Set `VIRTUAL_ENV=/path/to/.venv/`
* Set `UV=/path/to/uv.exe`
* Set `TY_UV=1`
* Set the working dir to either be the "right" one for the selected packages (generally the one package that will be worked on, or the workspace if there's multiple or the package lives outside the workspace)
* Run something like `ty check --exclude=packages/a/subpkg/ -- packages/a/ packages/b/` 
  * in this example invocation, `a` and `b` were selected and `subpkg` was not, and an explicit exclude was introduced to prevent it from being implicitly analyzed as part of `a`, under normal circumstances no exclude is needed, but any non-virtual workspace may need this kind of thing, and non-virtual workspaces are orthodox)

The consequences of this are that `uv check` already "just works" without this PR, however there are a few corner cases that are debatable.


## What This Changes

The following behaviours should *only* apply when TY_UV=1 mode is set, indicating we are being invoked through `uv check` (if you set env-var we simply assume you are `uv check` and GLHF if you're not; interactions with flags uv will never set are not guaranteed to make sense).

* We will run `uv workspace metadata --frozen --active` in the cwd that uv told us to run in
  * `--frozen` because we assume apriori that `uv check` already ran lock+sync
  * `--active` to ensure we continue to use the VIRTUAL_ENV that uv told us to use (notably important for `--isolated`)
  * Notably we *do not* pass `--sync` because the new default main uv behaviour for `uv workspace metadata` is to opportunistically emit environment metadata (python interpreter, package-to-module mappings) even if `--sync` isn't requested. We *should not* pass `--sync` in this case because uv has performed package/extra/group selection and we don't know what that was, and we are trying to avoid defining a protocol for forwarding that for the MVP.
  * Corner Case 1: If the user runs `uv check --isolated` and *there is no uv.lock* then this will fail as the rerun with --frozen will not find any lock to use. This is fine for an MVP.
  * Corner Case 2: If the workspace has `conflicts` the package versions reported may be subtly incorrect. In general "how does ty operate in a world with conflicts" is "that's the neat part, it doesn't" for the forseeable future (uv check can maybe be made to work but how the heck does the LSP?)
  * Corner Case 3: flags like `--no-project` and `--no-sync` are whacky nonsense I am refusing to put anymore thought into for an MVP.
* The relevant parts of the metadata will be stored on ProjectMetadata (currently only a few fields)
* ty will preferentially read config from the uv workspace root that metadata reports (notably quite important for the member-outside-the-workspace-dir case, where otherwise ty could get lost)
* ty will preferentially use the python version/interpreter the metadata reports, deferring to uv as "the authority" on these configs (and ignoring it's own).


## Future Work for `--watch`

If TY_UV=1 mode is enabled, `--watch` is forbidden (which is fine uv will never pass that). In the future it would be nice to have `uv check --watch`, but this will require us to have a proper system for ty actually telling uv to resync with the proper package selection, and for uv metadata to have some way to report what members to watch.


## Future Work for `ty check`

It would be nice if `ty check` could opportunistically detect that uv is available and auto-use TY_UV=1 mode. This is explicitly out of scope for the MVP as it causes endless UX arguments. I think under the current architecture it will probably "just" be ty instead opting to run `uv workspace metadata --sync` to sync the entire workspace (maybe with `--isolated` if we don't want to clobber the "real" venv... also it would then remember the venv location and pass `--active` for all subsequent invocations to keep reusing the same ephemeral venv).

Note to self: `uv workspace metadata --isolated` exists but is fake because of the accursed "global deprecated --isolated flag that is different from the --isolated flag other commands have, so need to add that in the future if we decide we need it.


## Future Work For Scripts

In the current implementation `TY_UV=1` mode is disabled if a path to a *file* is passed, as this should only happen if `uv check --script` is run. This is a temporary measure to keep scope tight for an MVP.

`uv check --script` already works better than `ty check path/to/script.py` because `uv check` will set VIRTUAL_ENV to the script's isolated venv -- the above just means we won't immediately have richer features TY_UV mode adds.

In "package mode" where TY_UV=1 applies, if a package contains random pep723 scripts, ty will attempt to analyze them with the workspace's venv, which is wrong in the same way ty is wrong already. In a followup we will make ty check if a file is a script, and if so, not analyze it unless the CLI was passed an explicit path to exactly that file (indicating --script).

In a followup we can teach ty to run `uv workspace metadata --script=...` when it finds a script and considers it in-scope to analyze it. Some fiddly corners around whether VIRTUAL_ENV should be cleared for such invocations, in general script venvs work kinda like ephemeral venvs but consistently resolved to the same path so you don't need to try super hard to be consistent, uv will figure it out.


## Future Work For LSP

LSP is out of scope for the MVP.

The rough idea for how it *should* work is that it will initially start up as it does now and opportunistically kick off `uv workspace metadata --sync (--isolated?)` in the background. If that returns successfully, it's answers will then be respected and integrated in much the same way they are when invoked with `uv check`. This may cause mass invalidations but ty is fast so it's fine right? :)

(The idea of this architecture is ty will give okish results early and fast and then as soon as uv is done "snap" into a richer form, in a similar way to how rust-analyzer can "snap to life" when `cargo check` completes.)

After the first run it can then setup proper watchers and opportunistically invoke things like `uv workspace metadata --script` or reinvoke `uv workspace metadata --sync` as needed. See the future work for scripts and watchers for details of that. 


## Future Work for meow

Meow lints will opportunistically be enabled when the UvMetadata is attached to the ProjectMetadata and contains package-to-module maps. Meow and attaching more metadata will be implemented in a followup PR.