### PR TITLE
[ty] resolve decorated overloaded signatures

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -678,8 +678,7 @@ def f2(y: int) -> int: ...
 def f2(y: str | int) -> str | int:
     return y
 
-# TODO: Should this reveal `Overloaded[(int, /, y: str) -> str, (int, /, y: int) -> int]` ?
-reveal_type(f2)  # revealed: Overload[(int, /, y: str) -> str | int, (int, /, y: int) -> str | int]
+reveal_type(f2)  # revealed: Overload[(int, /, y: str) -> str, (int, /, y: int) -> int]
 ```
 
 But, it's possible to add the additional parameter just to the overload signatures and not the
@@ -694,8 +693,7 @@ def f3(x: int, /, y: int) -> int: ...
 def f3(y: str | int) -> str | int:
     return y
 
-# TODO: Should reveal `Overloaded[(int, /, y: str) -> str, (int, /, y: int) -> int]`
-reveal_type(f3)  # revealed: Overload[(int, x: int, /, y: str) -> str | int, (int, x: int, /, y: int) -> str | int]
+reveal_type(f3)  # revealed: Overload[(int, x: int, /, y: str) -> str, (int, x: int, /, y: int) -> int]
 ```
 
 ## `Concatenate` with protocol classes

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1040,22 +1040,13 @@ class ClassWithOverloadedInit[T]:
     def __init__(self: "ClassWithOverloadedInit[str]", x: str) -> None: ...
     def __init__(self, x: int | str) -> None: ...
 
-# TODO: The old solver cannot handle this overloaded constructor. The ideal solution is that we
-# would solve **P once, and map it to the entire overloaded signature of the constructor. This
-# mapping would have to include the return types, since there are different return types for each
-# overload. We would then also have to determine that R must be equal to the return type of **P's
-# solution.
-
 # revealed: Overload[[T](x: int) -> ClassWithOverloadedInit[int], [T](x: str) -> ClassWithOverloadedInit[str]]
 reveal_type(into_regular_callable(ClassWithOverloadedInit))
-# TODO: revealed: Overload[(x: int) -> ClassWithOverloadedInit[int], (x: str) -> ClassWithOverloadedInit[str]]
-# revealed: Overload[[T](x: int) -> ClassWithOverloadedInit[int] | ClassWithOverloadedInit[str], [T](x: str) -> ClassWithOverloadedInit[int] | ClassWithOverloadedInit[str]]
+# revealed: Overload[[T](x: int) -> ClassWithOverloadedInit[int], [T](x: str) -> ClassWithOverloadedInit[str]]
 reveal_type(accepts_callable(ClassWithOverloadedInit))
-# TODO: revealed: ClassWithOverloadedInit[int]
-# revealed: ClassWithOverloadedInit[int] | ClassWithOverloadedInit[str]
+# revealed: ClassWithOverloadedInit[int]
 reveal_type(accepts_callable(ClassWithOverloadedInit)(0))
-# TODO: revealed: ClassWithOverloadedInit[str]
-# revealed: ClassWithOverloadedInit[int] | ClassWithOverloadedInit[str]
+# revealed: ClassWithOverloadedInit[str]
 reveal_type(accepts_callable(ClassWithOverloadedInit)(""))
 
 class GenericClass[T]:

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -520,6 +520,38 @@ reveal_type(func(1))  # revealed: Literal[1]
 reveal_type(func(""))  # revealed: Literal[""]
 ```
 
+## Identity Decorator
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+For an overloaded function, identity decorators preserve the overloads
+
+```py
+from typing import Callable, overload
+
+def identity[**P, T](f: Callable[P, T]) -> Callable[P, T]:
+    return f
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+@overload
+def f[T](x: list[T]) -> T: ...
+def f(x): ...
+
+g = identity(f)
+
+reveal_type(f)  # revealed: Overload[(x: int) -> int, (x: str) -> str, [T](x: list[T]) -> T]
+reveal_type(g)  # revealed: Overload[(x: int) -> int, (x: str) -> str, [T](x: list[T]) -> T]
+reveal_type(g(1))  # revealed: int
+reveal_type(g("a"))  # revealed: str
+reveal_type(g(["a"]))  # revealed: str
+```
+
 ## Invalid
 
 ### At least two overloads

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -314,8 +314,11 @@ impl<'db> CallableSignature<'db> {
                 Type::Callable(callable)
                     if matches!(callable.kind(db), CallableTypeKind::ParamSpecValue) =>
                 {
-                    Some(CallableSignature::from_overloads(
-                        callable.signatures(db).iter().map(|signature| Signature {
+                    let signatures = callable.signatures(db);
+                    let preserve_overloads = signatures.overloads.len() >= 2
+                        && matches!(self_signature.return_ty, Type::TypeVar(_));
+                    Some(CallableSignature::from_overloads(signatures.iter().map(
+                        |signature| Signature {
                             generic_context: GenericContext::merge_optional(
                                 db,
                                 signature.generic_context,
@@ -342,14 +345,18 @@ impl<'db> CallableSignature<'db> {
                                         .chain(signature.parameters().iter().cloned()),
                                 )
                             },
-                            return_ty: self_signature.return_ty.apply_type_mapping_impl(
-                                db,
-                                type_mapping,
-                                tcx,
-                                visitor,
-                            ),
-                        }),
-                    ))
+                            return_ty: if preserve_overloads {
+                                signature.return_ty
+                            } else {
+                                self_signature.return_ty.apply_type_mapping_impl(
+                                    db,
+                                    type_mapping,
+                                    tcx,
+                                    visitor,
+                                )
+                            },
+                        },
+                    )))
                 }
                 _ => None,
             }
@@ -1604,7 +1611,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                     Signature::new_generic(
                                         signature.generic_context,
                                         signature.parameters().clone(),
-                                        Type::unknown(),
+                                        signature.return_ty,
                                     )
                                 }),
                         ),


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

Fixes https://github.com/astral-sh/ty/issues/2278

## Summary

Hey astral team, great work with ty, it is a delight to use.

This PR solves an outstanding TODO regarding decorated overloaded functions.

Overload type information was merged to unions with decorators in the form of `[**P, T](f: Callable[P, T]) -> Callable[P, T]`, now the overloads propagate.

I hit this while trying to adopt `ty` and hit an error with a 3rd party package because they used a decorator of the above structure over an overloaded function.

This is my first contribution to ty, I'm very open for feedback.

## Test Plan

An mdtest covering this case is added as part of the PR.
Older tests were fixed to match new (and more accurate output)

## AI Disclosure

I have used AI (Claude Opus 4.8 with the Claude Code harness) to explore the codebase and bootstrap the development environment as well as for finding the right places in signature.rs where the fix should live.
The fix and the contents of the new test were written by me.