### PR TITLE
[ty] expand type aliases inside type context unions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -516,13 +516,22 @@ python-version = "3.13"
 A function's arguments are also inferred using the type context:
 
 ```py
-from typing import TypedDict
+from typing import Callable, TypedDict
 
 class TD(TypedDict):
     x: int
 
 def first[T](x: list[T]) -> T:
     return x[0]
+
+type ObjectCallback = Callable[[object], None]
+type IntCallback = Callable[[int], None]
+
+def make_callback[T](callback: Callable[[T], None]) -> Callable[[T], None]:
+    return callback
+
+def consume(value: int) -> None:
+    pass
 
 x1: TD = first([{"x": 0}, {"x": 1}])
 reveal_type(x1)  # revealed: TD
@@ -539,6 +548,10 @@ x3: TD = first([{"y": 0}, {"x": 1}])
 # error: [invalid-key] "Unknown key "y" for TypedDict `TD`"
 # error: [invalid-assignment] "Object of type `TD | None | dict[str, int]` is not assignable to `TD | None`"
 x4: TD | None = first([{"y": 0}, {"x": 1}])
+
+# `ObjectCallback` is redundant in this union, so expanding the aliases collapses the narrowing
+# target to `IntCallback`.
+x5: ObjectCallback | IntCallback = make_callback(lambda value: consume(value.bit_length()))
 ```
 
 But not in a way that leads to assignability errors:

--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -496,6 +496,14 @@ reveal_type(x16)  # revealed: list[int | None]
 
 x17: EitherList = ["1", "2", "3"]
 reveal_type(x17)  # revealed: list[int | str]
+
+type SelfOp[T] = Mapping[Literal["$eq", "$ne"], T]
+type ListOp[T] = Mapping[Literal["$in", "$nin"], Sequence[T]]
+type Ops[T] = SelfOp[T] | ListOp[T]
+type NestedOp[T] = T | Ops[T]
+
+x18: NestedOp[str] = {"$in": ["a", "b"]}
+reveal_type(x18)  # revealed: dict[Literal["$in", "$nin"], list[str]]
 ```
 
 ## Annotations influence generic call argument inference

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -57,6 +57,7 @@ use crate::types::generics::Specialization;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
     ClassLiteral, KnownClass, StaticClassLiteral, Type, TypeAndQualifiers, TypeQualifiers,
+    UnionType,
 };
 use crate::{Db, FxIndexSet};
 
@@ -593,12 +594,24 @@ impl<'db> TypeContext<'db> {
 
     /// If the type annotation is a union, returns the target elements that it can be narrowed to.
     pub(crate) fn narrow_targets(&self, db: &'db dyn Db) -> Option<&[Type<'db>]> {
-        self.annotation
-            .and_then(|ty| ty.as_union_like(db))
-            // TODO: We could theoretically attempt to narrow to every element of
-            // the power set of this union. However, this leads to an exponential
-            // explosion of inference attempts, and is rarely needed in practice.
-            .map(|union| union.elements(db))
+        let union = self.annotation.and_then(|ty| ty.as_union_like(db))?;
+
+        let union = if union
+            .elements(db)
+            .iter()
+            .any(|element| matches!(element, Type::TypeAlias(_)))
+        {
+            UnionType::from_elements(db, union.elements(db).iter().copied())
+                .as_union_like(db)
+                .unwrap_or(union)
+        } else {
+            union
+        };
+
+        // TODO: We could theoretically attempt to narrow to every element of
+        // the power set of this union. However, this leads to an exponential
+        // explosion of inference attempts, and is rarely needed in practice.
+        Some(union.elements(db))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -601,6 +601,7 @@ impl<'db> TypeContext<'db> {
             .iter()
             .any(|element| matches!(element, Type::TypeAlias(_)))
         {
+            // Rebuild the union to expand alias elements and simplify any redundancies exposed.
             UnionType::from_elements(db, union.elements(db).iter().copied())
                 .as_union_like(db)
                 .unwrap_or(union)

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -594,7 +594,7 @@ impl<'db> TypeContext<'db> {
 
     /// If the type annotation is a union, returns the target elements that it can be narrowed to.
     pub(crate) fn narrow_targets(&self, db: &'db dyn Db) -> Option<Cow<'db, [Type<'db>]>> {
-        let union = self.annotation.and_then(|ty| ty.as_union_like(db))?;
+        let union = self.annotation?.as_union_like(db)?;
 
         let targets = if union.has_aliases(db) {
             let expanded = union.expand_aliases(db);

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -49,6 +49,7 @@ use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashMap;
 use salsa;
 use salsa::plumbing::AsId;
+use std::borrow::Cow;
 pub(super) use ty_python_core::frozen::{FrozenMap, FrozenSet};
 
 use crate::types::diagnostic::TypeCheckDiagnostics;
@@ -57,7 +58,6 @@ use crate::types::generics::Specialization;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
     ClassLiteral, KnownClass, StaticClassLiteral, Type, TypeAndQualifiers, TypeQualifiers,
-    UnionType,
 };
 use crate::{Db, FxIndexSet};
 
@@ -593,26 +593,24 @@ impl<'db> TypeContext<'db> {
     }
 
     /// If the type annotation is a union, returns the target elements that it can be narrowed to.
-    pub(crate) fn narrow_targets(&self, db: &'db dyn Db) -> Option<&[Type<'db>]> {
+    pub(crate) fn narrow_targets(&self, db: &'db dyn Db) -> Option<Cow<'db, [Type<'db>]>> {
         let union = self.annotation.and_then(|ty| ty.as_union_like(db))?;
 
-        let union = if union
-            .elements(db)
-            .iter()
-            .any(|element| matches!(element, Type::TypeAlias(_)))
-        {
-            // Rebuild the union to expand alias elements and simplify any redundancies exposed.
-            UnionType::from_elements(db, union.elements(db).iter().copied())
-                .as_union_like(db)
-                .unwrap_or(union)
+        let targets = if union.has_aliases(db) {
+            let expanded = union.expand_aliases(db);
+            if let Some(union) = expanded.as_union_like(db) {
+                Cow::Borrowed(union.elements(db))
+            } else {
+                Cow::Owned(vec![expanded])
+            }
         } else {
-            union
+            Cow::Borrowed(union.elements(db))
         };
 
         // TODO: We could theoretically attempt to narrow to every element of
         // the power set of this union. However, this leads to an exponential
         // explosion of inference attempts, and is rarely needed in practice.
-        Some(union.elements(db))
+        Some(targets)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6623,6 +6623,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // If the type context is a union, attempt to narrow to a specific element.
         for narrowed_ty in tcx
             .narrow_targets(db)
+            .as_deref()
             .into_iter()
             .flatten()
             .filter(|ty| ty.class_specialization(db).is_some())

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1007,18 +1007,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // Annotation unions retain type aliases so recursive aliases can be represented.
             // Normalize direct alias elements together before checking the union so reductions
             // that depend on multiple elements, such as all members of an enum, are visible.
-            (_, Type::Union(union))
-                if union
-                    .elements(db)
-                    .iter()
-                    .any(|element| matches!(element, Type::TypeAlias(_))) =>
-            {
+            (_, Type::Union(union)) if union.has_aliases(db) => {
                 self.with_recursion_guard(source, target, || {
-                    self.check_type_pair(
-                        db,
-                        source,
-                        UnionType::from_elements(db, union.elements(db).iter().copied()),
-                    )
+                    self.check_type_pair(db, source, union.expand_aliases(db))
                 })
             }
 

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -93,6 +93,19 @@ impl<'db> UnionType<'db> {
             .build()
     }
 
+    /// Returns `true` if any direct element of this union is a type alias.
+    pub(crate) fn has_aliases(self, db: &'db dyn Db) -> bool {
+        self.elements(db)
+            .iter()
+            .any(|element| matches!(element, Type::TypeAlias(_)))
+    }
+
+    /// Expands direct type alias elements of this union.
+    pub(crate) fn expand_aliases(self, db: &'db dyn Db) -> Type<'db> {
+        // Rebuild the union so that `UnionBuilder` simplifies any redundancies exposed.
+        Self::from_elements(db, self.elements(db).iter().copied())
+    }
+
     pub(crate) fn from_elements_cycle_recovery<I, T>(db: &'db dyn Db, elements: I) -> Type<'db>
     where
         I: IntoIterator<Item = T>,

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -100,7 +100,9 @@ impl<'db> UnionType<'db> {
             .any(|element| matches!(element, Type::TypeAlias(_)))
     }
 
-    /// Expands direct type alias elements of this union.
+    /// Recursively expands aliases that expose top-level union elements.
+    ///
+    /// Aliases nested inside non-union elements remain part of those elements.
     pub(crate) fn expand_aliases(self, db: &'db dyn Db) -> Type<'db> {
         // Rebuild the union so that `UnionBuilder` simplifies any redundancies exposed.
         Self::from_elements(db, self.elements(db).iter().copied())


### PR DESCRIPTION
## Summary

Normalize direct `TypeAlias` members before returning union narrowing targets.

Closes https://github.com/astral-sh/ty/issues/3567

## Testing

Added mdtests.