### PR TITLE
[ty] Normalize dynamic class literals in cycle recovery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -1175,6 +1175,19 @@ class Unrelated: ...
 Bad: type[Unrelated] = type("Bad", (Base,), {})
 ```
 
+## Dynamic class reassignment in a loop
+
+A dynamic class can capture the previous value of a loop-carried variable in its namespace. Type
+inference should reach a fixed point instead of repeatedly nesting the dynamic class's member type.
+
+```py
+def make_chain(depth: int) -> type[object]:
+    current: type[object] = type("Leaf", (object,), {})
+    for index in range(depth):
+        current = type(f"Level{index}", (object,), {"child": current})
+    return current
+```
+
 ## Special base classes
 
 Some special base classes work with dynamic class creation, but special semantics may not be fully

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -1188,6 +1188,26 @@ def make_chain(depth: int) -> type[object]:
     return current
 ```
 
+## Dynamic class base reassignment in a loop
+
+A dynamic class that is not the direct right-hand side of an assignment stores its inferred bases in
+its identity. Those bases should not prevent type inference from reaching a fixed point.
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def identity(value: T) -> T:
+    return value
+
+def make_chain(depth: int) -> type[object]:
+    current: type[object] = object
+    for _ in range(depth):
+        current = identity(type("Level", (current,), {}))  # error: [unsupported-dynamic-base]
+    return current
+```
+
 ## Special base classes
 
 Some special base classes work with dynamic class creation, but special semantics may not be fully

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -1208,6 +1208,35 @@ def make_chain(depth: int) -> type[object]:
     return current
 ```
 
+## Functional dynamic class reassignment in a loop
+
+Functional class literals can capture the previous value of a loop-carried variable when they are
+used in a dynamic class namespace. Their inferred field or member types should not prevent type
+inference from reaching a fixed point.
+
+```py
+from enum import Enum
+from typing import NamedTuple, TypedDict
+
+def make_named_tuple_chain(depth: int) -> type[object]:
+    current: type[object] = object
+    for _ in range(depth):
+        current = type("Level", (), {"child": NamedTuple("N", [("value", current)])})
+    return current
+
+def make_typed_dict_chain(depth: int) -> type[object]:
+    current: type[object] = object
+    for _ in range(depth):
+        current = type("Level", (), {"child": TypedDict("T", {"value": current})})
+    return current
+
+def make_enum_chain(depth: int) -> type[object]:
+    current: type[object] = object
+    for _ in range(depth):
+        current = type("Level", (), {"child": Enum("E", {"VALUE": current})})
+    return current
+```
+
 ## Special base classes
 
 Some special base classes work with dynamic class creation, but special semantics may not be fully

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -784,6 +784,24 @@ impl<'db> DataclassParams<'db> {
             params.field_specifiers(db),
         )
     }
+
+    pub(super) fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        let field_specifiers = self
+            .field_specifiers(db)
+            .iter()
+            .map(|ty| {
+                let ty = ty.recursive_type_normalized_impl(db, div, true);
+                if nested { ty } else { Some(ty.unwrap_or(div)) }
+            })
+            .collect::<Option<Box<_>>>()?;
+
+        Some(Self::new(db, self.flags(db), field_specifiers))
+    }
 }
 
 /// Representation of a type: a set of possible values at runtime.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2073,6 +2073,9 @@ impl<'db> Type<'db> {
             Type::GenericAlias(generic) => generic
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::GenericAlias),
+            Type::ClassLiteral(class) => class
+                .recursive_type_normalized_impl(db, div, nested)
+                .map(Type::ClassLiteral),
             Type::SubclassOf(subclass_of) => subclass_of
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::SubclassOf),
@@ -2107,7 +2110,6 @@ impl<'db> Type<'db> {
             | Type::DataclassDecorator(_)
             | Type::DataclassTransformer(_)
             | Type::ModuleLiteral(_)
-            | Type::ClassLiteral(_)
             | Type::SpecialForm(_)
             | Type::LiteralValue(_) => Some(self),
         }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -349,6 +349,23 @@ impl<'db> ClassLiteral<'db> {
             .expect("`object` should always be a non-generic class in typeshed")
     }
 
+    pub(super) fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        match self {
+            Self::Dynamic(dynamic) => Some(Self::Dynamic(
+                dynamic.recursive_type_normalized_impl(db, div, nested)?,
+            )),
+            Self::Static(_)
+            | Self::DynamicNamedTuple(_)
+            | Self::DynamicTypedDict(_)
+            | Self::DynamicEnum(_) => Some(self),
+        }
+    }
+
     /// Returns the name of the class.
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db ast::name::Name {
         match self {
@@ -854,7 +871,9 @@ impl<'db> ClassType<'db> {
         nested: bool,
     ) -> Option<Self> {
         match self {
-            Self::NonGeneric(_) => Some(self),
+            Self::NonGeneric(class) => Some(Self::NonGeneric(
+                class.recursive_type_normalized_impl(db, div, nested)?,
+            )),
             Self::Generic(generic) => Some(Self::Generic(
                 generic.recursive_type_normalized_impl(db, div, nested)?,
             )),

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -359,10 +359,16 @@ impl<'db> ClassLiteral<'db> {
             Self::Dynamic(dynamic) => Some(Self::Dynamic(
                 dynamic.recursive_type_normalized_impl(db, div, nested)?,
             )),
-            Self::Static(_)
-            | Self::DynamicNamedTuple(_)
-            | Self::DynamicTypedDict(_)
-            | Self::DynamicEnum(_) => Some(self),
+            Self::DynamicNamedTuple(named_tuple) => Some(Self::DynamicNamedTuple(
+                named_tuple.recursive_type_normalized_impl(db, div, nested)?,
+            )),
+            Self::DynamicTypedDict(typed_dict) => Some(Self::DynamicTypedDict(
+                typed_dict.recursive_type_normalized_impl(db, div, nested)?,
+            )),
+            Self::DynamicEnum(enum_literal) => Some(Self::DynamicEnum(
+                enum_literal.recursive_type_normalized_impl(db, div, nested)?,
+            )),
+            Self::Static(_) => Some(self),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -105,6 +105,42 @@ pub enum DynamicClassAnchor<'db> {
     },
 }
 
+impl<'db> DynamicClassAnchor<'db> {
+    fn recursive_type_normalized_impl(
+        &self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        match self {
+            Self::Definition(definition) => Some(Self::Definition(*definition)),
+            Self::ScopeOffset {
+                scope,
+                offset,
+                explicit_bases,
+            } => {
+                let explicit_bases = explicit_bases
+                    .iter()
+                    .map(|base| {
+                        let base = base.recursive_type_normalized_impl(db, div, true);
+                        if nested {
+                            base
+                        } else {
+                            Some(base.unwrap_or(div))
+                        }
+                    })
+                    .collect::<Option<Box<_>>>()?;
+
+                Some(Self::ScopeOffset {
+                    scope: *scope,
+                    offset: *offset,
+                    explicit_bases,
+                })
+            }
+        }
+    }
+}
+
 impl get_size2::GetSize for DynamicClassLiteral<'_> {}
 
 /// Returns the `bases` argument for a dynamic class constructor call.
@@ -498,13 +534,16 @@ impl<'db> DynamicClassLiteral<'db> {
 }
 
 impl<'db> DynamicClassLiteral<'db> {
-    /// Normalize member types because they are part of this dynamic class's interned identity.
+    /// Normalize types that are part of this dynamic class's interned identity.
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
+        let anchor = self
+            .anchor(db)
+            .recursive_type_normalized_impl(db, div, nested)?;
         let members = self
             .members(db)
             .iter()
@@ -514,14 +553,18 @@ impl<'db> DynamicClassLiteral<'db> {
                 Some((name.clone(), ty))
             })
             .collect::<Option<Box<_>>>()?;
+        let dataclass_params = match self.dataclass_params(db) {
+            Some(params) => Some(params.recursive_type_normalized_impl(db, div, nested)?),
+            None => None,
+        };
 
         Some(Self::new(
             db,
             self.name(db).clone(),
-            self.anchor(db).clone(),
+            anchor,
             members,
             self.has_dynamic_namespace(db),
-            self.dataclass_params(db),
+            dataclass_params,
         ))
     }
 }

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -497,6 +497,35 @@ impl<'db> DynamicClassLiteral<'db> {
     }
 }
 
+impl<'db> DynamicClassLiteral<'db> {
+    /// Normalize member types because they are part of this dynamic class's interned identity.
+    pub(super) fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        let members = self
+            .members(db)
+            .iter()
+            .map(|(name, ty)| {
+                let ty = ty.recursive_type_normalized_impl(db, div, true);
+                let ty = if nested { ty? } else { ty.unwrap_or(div) };
+                Some((name.clone(), ty))
+            })
+            .collect::<Option<Box<_>>>()?;
+
+        Some(Self::new(
+            db,
+            self.name(db).clone(),
+            self.anchor(db).clone(),
+            members,
+            self.has_dynamic_namespace(db),
+            self.dataclass_params(db),
+        ))
+    }
+}
+
 /// Error for metaclass conflicts in dynamic classes.
 ///
 /// This mirrors `MetaclassErrorKind::Conflict` for regular classes.

--- a/crates/ty_python_semantic/src/types/class/enum_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/enum_literal.rs
@@ -23,6 +23,27 @@ pub struct EnumSpec<'db> {
     pub(crate) has_known_members: bool,
 }
 
+impl<'db> EnumSpec<'db> {
+    fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        let members = self
+            .members(db)
+            .iter()
+            .map(|(name, ty)| {
+                let ty = ty.recursive_type_normalized_impl(db, div, true);
+                let ty = if nested { ty? } else { ty.unwrap_or(div) };
+                Some((name.clone(), ty))
+            })
+            .collect::<Option<Box<_>>>()?;
+
+        Some(Self::new(db, members, self.has_known_members(db)))
+    }
+}
+
 impl get_size2::GetSize for EnumSpec<'_> {}
 
 /// Anchor for identifying a functional enum class literal.
@@ -43,6 +64,31 @@ pub enum DynamicEnumAnchor<'db> {
     },
 }
 
+impl<'db> DynamicEnumAnchor<'db> {
+    fn recursive_type_normalized_impl(
+        &self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        match self {
+            Self::Definition { definition, spec } => Some(Self::Definition {
+                definition: *definition,
+                spec: spec.recursive_type_normalized_impl(db, div, nested)?,
+            }),
+            Self::ScopeOffset {
+                scope,
+                offset,
+                spec,
+            } => Some(Self::ScopeOffset {
+                scope: *scope,
+                offset: *offset,
+                spec: spec.recursive_type_normalized_impl(db, div, nested)?,
+            }),
+        }
+    }
+}
+
 /// A class created via the functional enum syntax, e.g. `Enum("Color", "RED GREEN BLUE")`.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct DynamicEnumLiteral<'db> {
@@ -55,6 +101,32 @@ pub struct DynamicEnumLiteral<'db> {
 }
 
 impl get_size2::GetSize for DynamicEnumLiteral<'_> {}
+
+impl<'db> DynamicEnumLiteral<'db> {
+    pub(super) fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        let mixin_type = match self.mixin_type(db) {
+            Some(mixin) => {
+                let mixin = mixin.recursive_type_normalized_impl(db, div, true);
+                Some(if nested { mixin? } else { mixin.unwrap_or(div) })
+            }
+            None => None,
+        };
+
+        Some(Self::new(
+            db,
+            self.name(db).clone(),
+            self.anchor(db)
+                .recursive_type_normalized_impl(db, div, nested)?,
+            self.base_class(db),
+            mixin_type,
+        ))
+    }
+}
 
 #[salsa::tracked]
 impl<'db> DynamicEnumLiteral<'db> {

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -152,6 +152,22 @@ pub struct DynamicNamedTupleLiteral<'db> {
 
 impl get_size2::GetSize for DynamicNamedTupleLiteral<'_> {}
 
+impl<'db> DynamicNamedTupleLiteral<'db> {
+    pub(super) fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        Some(Self::new(
+            db,
+            self.name(db).clone(),
+            self.anchor(db)
+                .recursive_type_normalized_impl(db, div, nested)?,
+        ))
+    }
+}
+
 #[salsa::tracked]
 impl<'db> DynamicNamedTupleLiteral<'db> {
     /// Returns the definition where this namedtuple is created, if it was assigned to a variable.
@@ -508,6 +524,32 @@ pub enum DynamicNamedTupleAnchor<'db> {
     },
 }
 
+impl<'db> DynamicNamedTupleAnchor<'db> {
+    fn recursive_type_normalized_impl(
+        &self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        match self {
+            Self::CollectionsDefinition { definition, spec } => Some(Self::CollectionsDefinition {
+                definition: *definition,
+                spec: spec.recursive_type_normalized_impl(db, div, nested)?,
+            }),
+            Self::TypingDefinition(definition) => Some(Self::TypingDefinition(*definition)),
+            Self::ScopeOffset {
+                scope,
+                offset,
+                spec,
+            } => Some(Self::ScopeOffset {
+                scope: *scope,
+                offset: *offset,
+                spec: spec.recursive_type_normalized_impl(db, div, nested)?,
+            }),
+        }
+    }
+}
+
 /// A specification describing the fields of a dynamic `namedtuple`
 /// or `NamedTuple` class.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
@@ -539,15 +581,24 @@ impl<'db> NamedTupleSpec<'db> {
             .fields(db)
             .iter()
             .map(|f| {
+                let ty = f.ty.recursive_type_normalized_impl(db, div, true);
+                let ty = if nested { ty? } else { ty.unwrap_or(div) };
+                let default = match f.default {
+                    Some(default) => {
+                        let default = default.recursive_type_normalized_impl(db, div, true);
+                        Some(if nested {
+                            default?
+                        } else {
+                            default.unwrap_or(div)
+                        })
+                    }
+                    None => None,
+                };
+
                 Some(NamedTupleField {
                     name: f.name.clone(),
-                    ty: if nested {
-                        f.ty.recursive_type_normalized_impl(db, div, nested)?
-                    } else {
-                        f.ty.recursive_type_normalized_impl(db, div, nested)
-                            .unwrap_or(div)
-                    },
-                    default: None,
+                    ty,
+                    default,
                     definition: f.definition,
                 })
             })

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -638,6 +638,28 @@ pub enum DynamicTypedDictAnchor<'db> {
     },
 }
 
+impl<'db> DynamicTypedDictAnchor<'db> {
+    fn recursive_type_normalized_impl(
+        &self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        match self {
+            Self::Definition(definition) => Some(Self::Definition(*definition)),
+            Self::ScopeOffset {
+                scope,
+                offset,
+                schema,
+            } => Some(Self::ScopeOffset {
+                scope: *scope,
+                offset: *offset,
+                schema: schema.recursive_type_normalized_impl(db, div, nested)?,
+            }),
+        }
+    }
+}
+
 #[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
 pub struct DynamicTypedDictLiteral<'db> {
     /// The name of the TypedDict (from the first argument).
@@ -656,6 +678,22 @@ pub struct DynamicTypedDictLiteral<'db> {
 }
 
 impl get_size2::GetSize for DynamicTypedDictLiteral<'_> {}
+
+impl<'db> DynamicTypedDictLiteral<'db> {
+    pub(super) fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        Some(Self::new(
+            db,
+            self.name(db).clone(),
+            self.anchor(db)
+                .recursive_type_normalized_impl(db, div, nested)?,
+        ))
+    }
+}
 
 #[salsa::tracked]
 impl<'db> DynamicTypedDictLiteral<'db> {

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1892,6 +1892,31 @@ impl<'db> SynthesizedTypedDictType<'db> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, get_size2::GetSize, salsa::Update)]
 pub struct TypedDictSchema<'db>(BTreeMap<Name, TypedDictField<'db>>);
 
+impl<'db> TypedDictSchema<'db> {
+    pub(super) fn recursive_type_normalized_impl(
+        &self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        self.iter()
+            .map(|(name, field)| {
+                let declared_ty = field
+                    .declared_ty
+                    .recursive_type_normalized_impl(db, div, true);
+                let declared_ty = if nested {
+                    declared_ty?
+                } else {
+                    declared_ty.unwrap_or(div)
+                };
+                let mut field = field.clone();
+                field.declared_ty = declared_ty;
+                Some((name.clone(), field))
+            })
+            .collect()
+    }
+}
+
 impl<'db> Deref for TypedDictSchema<'db> {
     type Target = BTreeMap<Name, TypedDictField<'db>>;
 


### PR DESCRIPTION
## Summary

A dynamically created class can capture the previous value of a loop-carried variable in its members or bases. Prior to this change, we treated class literals as atomic during recursive type normalization, so the class's interned identity kept growing on each inference cycle and Salsa eventually panicked after too many cycle iterations.

Closes https://github.com/astral-sh/ty/issues/3627.
