### PR TITLE
[ty] fix variance inference for nested type aliases

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6852,6 +6852,7 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
             Type::TypeGuard(type_guard_type) => type_guard_type.variance_of(db, typevar),
             Type::TypeForm(typeform_type) => typeform_type.variance_of(db, typevar),
             Type::KnownInstance(known_instance) => known_instance.variance_of(db, typevar),
+            Type::TypeAlias(alias) => alias.variance_of(db, typevar),
             Type::Dynamic(_)
             | Type::Divergent(_)
             | Type::Never
@@ -6867,7 +6868,6 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
             | Type::BoundSuper(_)
             | Type::TypeVar(_)
             | Type::TypedDict(_)
-            | Type::TypeAlias(_)
             | Type::NewTypeInstance(_) => TypeVarVariance::Bivariant,
         };
 

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -328,6 +328,10 @@ type CovariantAlias[T] = Covariant[T]
 type ContravariantAlias[T] = Contravariant[T]
 type InvariantAlias[T] = Invariant[T]
 type BivariantAlias[T] = Bivariant[T]
+type CovariantAliasAlias[T] = CovariantAlias[T]
+type ContravariantAliasAlias[T] = ContravariantAlias[T]
+type InvariantAliasAlias[T] = InvariantAlias[T]
+type BivariantAliasAlias[T] = BivariantAlias[T]
 type ParamSpecContravariantAlias[**P] = Callable[P, None]
 type ParamSpecConcatenateAlias[**P] = Callable[Concatenate[int, P], None]
 type ParamSpecBivariantAlias[**P] = int
@@ -362,6 +366,34 @@ type RecursiveAlias2[T] = None | list[T] | list[RecursiveAlias2[T]]
     assert_eq!(
         KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(bivariant))
             .variance_of(&db, get_bound_typevar(&db, bivariant)),
+        TypeVarVariance::Bivariant
+    );
+
+    let covariant_alias = get_type_alias(&db, "CovariantAliasAlias");
+    assert_eq!(
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(covariant_alias))
+            .variance_of(&db, get_bound_typevar(&db, covariant_alias)),
+        TypeVarVariance::Covariant
+    );
+
+    let contravariant_alias = get_type_alias(&db, "ContravariantAliasAlias");
+    assert_eq!(
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(contravariant_alias))
+            .variance_of(&db, get_bound_typevar(&db, contravariant_alias)),
+        TypeVarVariance::Contravariant
+    );
+
+    let invariant_alias = get_type_alias(&db, "InvariantAliasAlias");
+    assert_eq!(
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(invariant_alias))
+            .variance_of(&db, get_bound_typevar(&db, invariant_alias)),
+        TypeVarVariance::Invariant
+    );
+
+    let bivariant_alias = get_type_alias(&db, "BivariantAliasAlias");
+    assert_eq!(
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(bivariant_alias))
+            .variance_of(&db, get_bound_typevar(&db, bivariant_alias)),
         TypeVarVariance::Bivariant
     );
 

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -3,10 +3,11 @@ use std::fmt::Write;
 use crate::{
     Db,
     types::{
-        ApplyTypeMappingVisitor, GenericContext, Type, TypeContext, TypeMapping,
-        definition_expression_type,
+        ApplyTypeMappingVisitor, BoundTypeVarInstance, GenericContext, Type, TypeContext,
+        TypeMapping, TypeVarVariance, definition_expression_type,
         display::qualified_name_components_from_scope,
         generics::{ApplySpecialization, Specialization},
+        variance::VarianceInferable,
         visitor,
     },
 };
@@ -300,6 +301,17 @@ impl<'db> TypeAliasType<'db> {
     /// Returns a struct that can display the fully qualified name of this type alias.
     pub(crate) fn qualified_name(self, db: &'db dyn Db) -> QualifiedTypeAliasName<'db> {
         QualifiedTypeAliasName::from_type_alias(db, self)
+    }
+}
+
+#[salsa::tracked]
+impl<'db> VarianceInferable<'db> for TypeAliasType<'db> {
+    #[salsa::tracked(
+        cycle_initial=|_, _, _, _| TypeVarVariance::Bivariant,
+        heap_size=ruff_memory_usage::heap_size
+    )]
+    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarVariance {
+        self.value_type(db).variance_of(db, typevar)
     }
 }
 


### PR DESCRIPTION
## Summary

Expand `TypeAliasType` during variance inference so alias-of-alias chains preserve the underlying variance.

Closes https://github.com/astral-sh/ty/issues/3518

## Testing

Added unit test.