### PR TITLE
[ty] Removing myself from ty's codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,14 +15,14 @@
 /python/py-fuzzer/ @AlexWaygood
 
 # ty
-/crates/ty* @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager @ibraheemdev
-/crates/ruff_db/ @carljm @MichaReiser @sharkdp @dcreager
-/crates/ty_project/ @carljm @MichaReiser @sharkdp @dcreager @Gankra
-/crates/ty_ide/ @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager @Gankra @BurntSushi
-/crates/ty_server/ @carljm @MichaReiser @sharkdp @dcreager @Gankra @BurntSushi
-/crates/ty/ @carljm @MichaReiser @sharkdp @dcreager @ibraheemdev
-/crates/ty_wasm/ @carljm @MichaReiser @sharkdp @dcreager @Gankra
-/scripts/ty_benchmark/ @carljm @MichaReiser @AlexWaygood @sharkdp @dcreager @ibraheemdev
+/crates/ty* @carljm @AlexWaygood @sharkdp @dcreager @ibraheemdev
+/crates/ruff_db/ @carljm @sharkdp @dcreager
+/crates/ty_project/ @carljm @sharkdp @dcreager @Gankra
+/crates/ty_ide/ @carljm @@AlexWaygood @sharkdp @dcreager @Gankra @BurntSushi
+/crates/ty_server/ @carljm @sharkdp @dcreager @Gankra @BurntSushi
+/crates/ty/ @carljm @sharkdp @dcreager @ibraheemdev
+/crates/ty_wasm/ @carljm @sharkdp @dcreager @Gankra
+/scripts/ty_benchmark/ @carljm @AlexWaygood @sharkdp @dcreager @ibraheemdev
 /crates/ty_python_core/ @carljm @sharkdp @dcreager @ibraheemdev
 /crates/ty_python_semantic/ @carljm @AlexWaygood @sharkdp @dcreager @ibraheemdev
-/crates/ty_module_resolver/ @carljm @MichaReiser @AlexWaygood @Gankra @BurntSushi
+/crates/ty_module_resolver/ @carljm @AlexWaygood @Gankra @BurntSushi


### PR DESCRIPTION
## Summary

We use our astral bot to assign reviewers. The bot both makes the person a reviewer and assigns the PR to them.
This makes the codeowner file mostly redundant. 

This PR removes me from all ty's codeowner assignments. 


## Test Plan

After land
