### PR TITLE
[ty] Add support for `extra_items`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -222,7 +222,9 @@ d8_mapping_fallback: TypedDictOrMapping = {1: 5.2}
 # error: [missing-typed-dict-key]
 # error: [invalid-key]
 d9_invalid_mapping_key: TypedDictOrMapping = {"y": 5.2}
-d10_invalid_mapping_value: TypedDictOrMapping = {1: "bad"}  # error: [missing-typed-dict-key]
+# error: [missing-typed-dict-key]
+# error: [invalid-key]
+d10_invalid_mapping_value: TypedDictOrMapping = {1: "bad"}
 
 def takes_td_or_iterable(value: TD | Iterable[int]) -> None:
     pass

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6372,7 +6372,7 @@ static_assert(not is_assignable_to(SourceWithStrExtra, Target))
 ### Disjointness accounts for openness
 
 A required item on one side can conflict with the other side's closed or extra-items policy. An
-optional mutable item can also conflict with a mutable extra-items policy.
+optional mutable item can also conflict with a closed or explicit extra-items policy.
 
 ```py
 from typing_extensions import NotRequired, ReadOnly, TypedDict
@@ -6405,6 +6405,12 @@ class OptionalReadOnlyInt(TypedDict):
 class OptionalReadOnlyObject(TypedDict):
     value: NotRequired[ReadOnly[object]]
 
+class ClosedOptionalInt(TypedDict, closed=True):
+    value: NotRequired[int]
+
+class ClosedOptionalReadOnlyInt(TypedDict, closed=True):
+    value: NotRequired[ReadOnly[int]]
+
 static_assert(is_disjoint_from(RequiredInt, ClosedEmpty))
 static_assert(not is_disjoint_from(RequiredInt, ReadOnlyIntExtras))
 static_assert(is_disjoint_from(RequiredStr, ReadOnlyIntExtras))
@@ -6431,6 +6437,14 @@ static_assert(is_disjoint_from(OptionalReadOnlyInt, MutableObjectExtras))
 static_assert(not is_disjoint_from(OptionalReadOnlyObject, MutableIntExtras))
 static_assert(not is_disjoint_from(OptionalReadOnlyInt, OpenEmpty))
 static_assert(not is_disjoint_from(OpenEmpty, OptionalReadOnlyInt))
+static_assert(is_disjoint_from(ClosedOptionalInt, ClosedEmpty))
+static_assert(is_disjoint_from(ClosedEmpty, ClosedOptionalInt))
+static_assert(not is_disjoint_from(ClosedOptionalInt, OpenEmpty))
+static_assert(not is_disjoint_from(OpenEmpty, ClosedOptionalInt))
+static_assert(not is_disjoint_from(ClosedOptionalReadOnlyInt, ClosedEmpty))
+static_assert(not is_disjoint_from(ClosedEmpty, ClosedOptionalReadOnlyInt))
+static_assert(not is_disjoint_from(ClosedOptionalReadOnlyInt, ReadOnlyStrExtras))
+static_assert(not is_disjoint_from(ReadOnlyStrExtras, ClosedOptionalReadOnlyInt))
 ```
 
 ### A `TypedDict` with `extra_items: T` is a subtype of `Mapping[str, T1]`, where `T1` is the union of `T` and all declared item types

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5949,16 +5949,23 @@ class IntPatch(TypedDict, extra_items=int):
 class StrPatch(TypedDict, extra_items=str):
     name: NotRequired[str]
 
+class OpenPatch(TypedDict): ...
+
+class MutableExtraOnly(TypedDict, extra_items=int): ...
+
 def _(
     mutable: MutableExtra,
+    mutable_extra_only: MutableExtraOnly,
     read_only: ReadOnlyExtra,
     ints: IntPatch,
     strings: StrPatch,
+    open_patch: OpenPatch,
 ) -> None:
     mutable.update(year=1982)
     mutable.update(ints)
     mutable.update(year="not an int")  # error: [invalid-argument-type]
     mutable.update(strings)  # error: [invalid-argument-type]
+    mutable_extra_only.update(open_patch)  # error: [invalid-argument-type]
 
     read_only.update(year=1982)  # error: [unknown-argument]
     read_only.update(ints)  # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6049,20 +6049,37 @@ def _(
 Extra items behave like non-required items for methods that mutate a specific literal key.
 
 ```py
+from typing import Literal
 from typing_extensions import TypedDict
 
 class Extra(TypedDict, extra_items=int):
     name: str
 
+class ListExtra(TypedDict, extra_items=list[int]):
+    name: str
+
 class ArbitraryPop(TypedDict, total=False, extra_items=int):
     label: str
 
-def _(extra: Extra, arbitrary: ArbitraryPop, key: str) -> None:
+def _(
+    extra: Extra,
+    list_extra: ListExtra,
+    arbitrary: ArbitraryPop,
+    literal_key: Literal["values"],
+    key: str,
+) -> None:
     reveal_type(extra.get("year"))  # revealed: int | None
     reveal_type(extra.get("year", "missing"))  # revealed: int | Literal["missing"]
     reveal_type(extra.pop("year"))  # revealed: int
     reveal_type(extra.pop("year", "missing"))  # revealed: int | Literal["missing"]
     reveal_type(extra.setdefault("year", 1982))  # revealed: int
+
+    reveal_type(list_extra.get(literal_key))  # revealed: list[int] | None
+    reveal_type(list_extra.get(literal_key, []))  # revealed: list[int]
+    reveal_type(list_extra.pop(literal_key))  # revealed: list[int]
+    reveal_type(list_extra.pop(literal_key, []))  # revealed: list[int]
+    reveal_type(list_extra.setdefault(literal_key, []))  # revealed: list[int]
+
     reveal_type(arbitrary.pop(key))  # revealed: str | int
     reveal_type(arbitrary.pop(key, 0))  # revealed: str | int
     reveal_type(arbitrary.pop(key, None))  # revealed: str | int | None

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5994,13 +5994,25 @@ Extra items are implicitly non-required, so deletion is allowed for unknown keys
 literal types. Deletion of declared required keys and keys of type `str` is still an error.
 
 ```py
+from typing import Literal
+
 from typing_extensions import TypedDict
 
 class Extra(TypedDict, extra_items=int):
     name: str
 
-def _(extra: Extra, key: str) -> None:
+def _(
+    extra: Extra,
+    key: str,
+    extra_keys: Literal["year", "rating"],
+    declared_key_union: Literal["year", "name"],
+    mixed_type_key: Literal["year"] | int,
+) -> None:
     del extra["year"]
+    del extra[extra_keys]
+
+    del extra[declared_key_union]  # error: [invalid-argument-type]
+    del extra[mixed_type_key]  # error: [invalid-argument-type]
 
     # error: [invalid-argument-type] "Cannot delete required key "name" from TypedDict `Extra`"
     del extra["name"]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5494,7 +5494,7 @@ static_assert(is_equivalent_to(AliasedExtra, Closed))
 ### Empty closed TypedDict truthiness
 
 An empty `closed=True` TypedDict cannot contain any keys, so it is always empty and always falsy,
-but inferring that precisely is outside the scope of `extra_items` support.
+but inferring that precisely is still TODO.
 
 ```py
 from typing_extensions import TypedDict

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5930,6 +5930,8 @@ def _(extra: Extra, arbitrary: ArbitraryPop, key: str) -> None:
     reveal_type(extra.pop("year", "missing"))  # revealed: int | Literal["missing"]
     reveal_type(extra.setdefault("year", 1982))  # revealed: int
     reveal_type(arbitrary.pop(key))  # revealed: str | int
+    reveal_type(arbitrary.pop(key, 0))  # revealed: str | int
+    reveal_type(arbitrary.pop(key, None))  # revealed: str | int | None
 
     # error: [invalid-argument-type]
     extra.setdefault("year", "not an int")

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6096,9 +6096,16 @@ class GoodSource(TypedDict, extra_items=int):
 class BadSource(TypedDict, extra_items=int):
     source_only: str
 
-def _(good: GoodSource, bad: BadSource) -> None:
+class ClosedTarget(TypedDict, closed=True):
+    keyword: int
+
+class ClosedSource(TypedDict, closed=True):
+    source_only: str
+
+def _(good: GoodSource, bad: BadSource, closed: ClosedSource) -> None:
     Target(good, keyword=1)
     Target(bad, keyword=1)  # error: [invalid-argument-type]
+    ClosedTarget(closed, keyword=1)  # error: [invalid-key]
 
     # An explicit keyword shadows the source key.
     Target(bad, source_only=1)

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6201,8 +6201,8 @@ static_assert(not is_assignable_to(SourceWithStrExtra, Target))
 
 ### Disjointness accounts for openness
 
-A required item on one side can conflict with the other side's closed or extra-items policy.
-An optional mutable item can also conflict with a mutable extra-items policy.
+A required item on one side can conflict with the other side's closed or extra-items policy. An
+optional mutable item can also conflict with a mutable extra-items policy.
 
 ```py
 from typing_extensions import NotRequired, ReadOnly, TypedDict

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6112,7 +6112,7 @@ Extra items behave like non-required items for methods that mutate a specific li
 
 ```py
 from typing import Literal
-from typing_extensions import TypedDict
+from typing_extensions import ReadOnly, TypedDict
 
 class Extra(TypedDict, extra_items=int):
     name: str
@@ -6123,10 +6123,14 @@ class ListExtra(TypedDict, extra_items=list[int]):
 class ArbitraryPop(TypedDict, total=False, extra_items=int):
     label: str
 
+class ReadOnlyExtra(TypedDict, extra_items=ReadOnly[int]):
+    name: str
+
 def _(
     extra: Extra,
     list_extra: ListExtra,
     arbitrary: ArbitraryPop,
+    read_only: ReadOnlyExtra,
     literal_key: Literal["values"],
     key: str,
 ) -> None:
@@ -6145,6 +6149,18 @@ def _(
     reveal_type(arbitrary.pop(key))  # revealed: str | int
     reveal_type(arbitrary.pop(key, 0))  # revealed: str | int
     reveal_type(arbitrary.pop(key, None))  # revealed: str | int | None
+
+    reveal_type(read_only.get("other"))  # revealed: int | None
+    reveal_type(read_only.get("other", "missing"))  # revealed: int | Literal["missing"]
+
+    # error: [invalid-argument-type] "Cannot pop read-only extra item "other" from TypedDict `ReadOnlyExtra`"
+    read_only.pop("other")
+    # error: [invalid-argument-type] "Cannot pop read-only extra item "other" from TypedDict `ReadOnlyExtra`"
+    read_only.pop("other", 0)
+    # error: [invalid-argument-type] "Cannot set default for read-only extra item "other" on TypedDict `ReadOnlyExtra`"
+    read_only.setdefault("other", 0)
+    # error: [invalid-argument-type] "Cannot delete read-only extra item "other" from TypedDict `ReadOnlyExtra`"
+    del read_only["other"]
 
     # error: [invalid-argument-type]
     extra.setdefault("year", "not an int")

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5706,6 +5706,12 @@ The functional syntax also supports `extra_items`:
 
 ```py
 MovieFunctional = TypedDict("MovieFunctional", {"name": str}, extra_items=bool)
+FunctionalIntDict = TypedDict(
+    "FunctionalIntDict",
+    {"count": int},
+    total=False,
+    extra_items=int,
+)
 NonIdentifierFunctional = TypedDict(
     "NonIdentifierFunctional",
     {"x-y": str},
@@ -5713,6 +5719,8 @@ NonIdentifierFunctional = TypedDict(
 )
 
 d: MovieFunctional = {"name": "Blade Runner", "novel_adaptation": True}
+functional_int_dict: FunctionalIntDict = {}
+reveal_type(functional_int_dict.copy())  # revealed: FunctionalIntDict
 NonIdentifierFunctional(**{"x-y": "ok", "other": 1})
 
 # error: [invalid-argument-type]
@@ -6435,6 +6443,7 @@ static_assert(not is_equivalent_to(dict[str, int], IntDict))
 
 def _(int_dict_with_num: IntDictWithNum, key: str) -> None:
     v: dict[str, int] = int_dict_with_num
+    reveal_type(int_dict_with_num.copy())  # revealed: IntDictWithNum
     int_dict_with_num.clear()
     reveal_type(int_dict_with_num.popitem())  # revealed: tuple[str, int]
     int_dict_with_num[key] = 42

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5488,7 +5488,7 @@ from typing_extensions import TypedDict
 class Empty(TypedDict, closed=True): ...
 
 def _(empty: Empty) -> None:
-    # TODO: This can be revealed as `Literal[False]`.
+    # TODO: should be `Literal[False]`
     reveal_type(bool(empty))  # revealed: bool
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6105,6 +6105,8 @@ def _(
 Mutable extra items can be updated, while read-only extra items cannot:
 
 ```py
+from collections.abc import Mapping
+
 from typing_extensions import NotRequired, ReadOnly, TypedDict
 
 class MutableExtra(TypedDict, extra_items=int):
@@ -6140,6 +6142,9 @@ def _(
     ints: IntPatch,
     strings: StrPatch,
     open_patch: OpenPatch,
+    int_dict: dict[str, int],
+    int_mapping: Mapping[str, int],
+    str_mapping: Mapping[str, str],
 ) -> None:
     mutable.update(year=1982)
     mutable.update(ints)
@@ -6148,6 +6153,9 @@ def _(
     mutable_extra_only.update(open_patch)  # error: [invalid-argument-type]
     mutable_extra_only.update([("year", 1982)])
     mutable_extra_only.update([("year", "not an int")])  # error: [invalid-argument-type]
+    mutable_extra_only.update(int_dict)
+    mutable_extra_only.update(int_mapping)
+    mutable_extra_only.update(str_mapping)  # error: [invalid-argument-type]
     all_int_items.update([("other", 1982)])
 
     # An arbitrary key may refer to either the declared `name` item or an extra item.

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5621,6 +5621,27 @@ c: ClosedMovie = {"name": "Blade Runner", "year": 1982}
 ClosedMovie(name="Blade Runner", year=1982)
 ```
 
+Closed and extra-items TypedDicts also reject non-string keys:
+
+```py
+from typing_extensions import TypedDict
+
+class ExtraOnly(TypedDict, extra_items=int): ...
+class ClosedEmpty(TypedDict, closed=True): ...
+
+# error: [invalid-key] "TypedDict `ExtraOnly` requires string keys, got key of type `Literal[1]`"
+extra: ExtraOnly = {1: 1}
+
+# error: [invalid-key] "TypedDict `ClosedEmpty` requires string keys, got key of type `Literal[1]`"
+closed: ClosedEmpty = {1: 1}
+
+# error: [invalid-key] "TypedDict `ExtraOnly` requires string keys, got key of type `Literal[1]`"
+ExtraOnly({1: 1})
+
+# error: [invalid-key] "TypedDict `ClosedEmpty` requires string keys, got key of type `Literal[1]`"
+ClosedEmpty({1: 1})
+```
+
 The functional syntax also supports `extra_items`:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5980,9 +5980,13 @@ class StrPatch(TypedDict, extra_items=str):
 class OpenPatch(TypedDict): ...
 class MutableExtraOnly(TypedDict, extra_items=int): ...
 
+class OpenWithName(TypedDict):
+    name: str
+
 def _(
     mutable: MutableExtra,
     mutable_extra_only: MutableExtraOnly,
+    open_with_name: OpenWithName,
     read_only: ReadOnlyExtra,
     ints: IntPatch,
     strings: StrPatch,
@@ -5993,6 +5997,9 @@ def _(
     mutable.update(year="not an int")  # error: [invalid-argument-type]
     mutable.update(strings)  # error: [invalid-argument-type]
     mutable_extra_only.update(open_patch)  # error: [invalid-argument-type]
+
+    # The extra-items tail may contain the target's declared `name` key with an incompatible type.
+    open_with_name.update(mutable_extra_only)  # error: [invalid-argument-type]
 
     read_only.update(year=1982)  # error: [unknown-argument]
     read_only.update(ints)  # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3407,8 +3407,8 @@ def func(**kwargs: Unpack[TD2]) -> None:
 
 ### Call-site validation
 
-At the call site, required keys must be provided, known keys must be type-checked, and unknown
-keywords are rejected for ordinary open `TypedDict`s.
+At the call site, required keys must be provided and known keys must be type-checked. Extra keywords
+are accepted as `object` for ordinary open `TypedDict`s.
 
 ```py
 from typing_extensions import NotRequired, Required, TypedDict, Unpack
@@ -3427,8 +3427,6 @@ def func(**kwargs: Unpack[TD2]) -> None:
 func()
 func(v1=1, v3="ok")
 func(v1=1, v2="optional", v3="ok")
-
-# error: [unknown-argument]
 func(v1=1, v3="ok", v4=1)
 
 # error: [invalid-argument-type]
@@ -3469,8 +3467,8 @@ closed_movie(name="Blade Runner", year=1982)
 ### Assignability with explicit keyword-only signatures
 
 A callable using `**kwargs: Unpack[TD2]` should line up with equivalent explicit keyword-only
-signatures in either direction. Hidden items in an ordinary open `TypedDict` do not become
-call-site parameters.
+signatures when assigning to the explicit form. The reverse assignment is rejected because an open
+unpacked `TypedDict` may still receive hidden extra items.
 
 ```py
 from functools import partial
@@ -3497,13 +3495,13 @@ explicit_ok: ExplicitKwargs = func
 typed_dict_ok: TypedDictKwargs = func
 
 def _(explicit: ExplicitKwargs, typed_dict: TypedDictKwargs) -> None:
-    typed_dict_2: TypedDictKwargs = explicit
+    typed_dict_2: TypedDictKwargs = explicit  # error: [invalid-assignment]
     explicit_2: ExplicitKwargs = typed_dict
 
 def func7(*, v1: int, v3: str, v2: str = "") -> None:
     pass
 
-typed_dict_from_explicit: TypedDictKwargs = func7
+typed_dict_from_explicit: TypedDictKwargs = func7  # error: [invalid-assignment]
 
 class EmptyOpenTD(TypedDict):
     pass
@@ -3514,7 +3512,7 @@ class EmptyOpenTypedDictKwargs(Protocol):
 def no_kwargs() -> None:
     pass
 
-empty_open_typed_dict_from_explicit: EmptyOpenTypedDictKwargs = no_kwargs
+empty_open_typed_dict_from_explicit: EmptyOpenTypedDictKwargs = no_kwargs  # error: [invalid-assignment]
 
 class ClosedTD(TypedDict, closed=True):
     v1: Required[int]
@@ -3535,7 +3533,8 @@ class TraditionalKwargsTarget(Protocol):
 def traditional_kwargs_source(**kwargs: int) -> None:
     pass
 
-traditional_kwargs_target: TraditionalKwargsTarget = traditional_kwargs_source
+# TODO: This should be accepted because the declared field is assignable to `int`.
+traditional_kwargs_target: TraditionalKwargsTarget = traditional_kwargs_source  # error: [invalid-assignment]
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -3546,7 +3545,7 @@ def preserve_signature(callback: Callable[P, R]) -> Callable[P, R]:
 preserved_typed_dict_target: TypedDictKwargs = preserve_signature(func)
 
 partial_typed_dict_target: TypedDictKwargs = partial(func)
-partial_explicit_target: TypedDictKwargs = partial(func7)
+partial_explicit_target: TypedDictKwargs = partial(func7)  # error: [invalid-assignment]
 ```
 
 ### Missing required keys remain incompatible
@@ -3576,7 +3575,7 @@ missing_required: MissingRequiredKwarg = func
 ### Optional-only unpacked kwargs still expose named keys
 
 An unpacked all-optional open `TypedDict` exposes its declared keys as optional named keyword
-arguments while rejecting unknown keyword arguments.
+arguments while accepting extra keyword arguments as `object`.
 
 ```py
 from typing import Protocol
@@ -3592,8 +3591,6 @@ class WantsA(Protocol):
     def __call__(self, *, a: int = 1) -> None: ...
 
 wants_a: WantsA = accepts_optional_kwargs
-
-# error: [unknown-argument]
 accepts_optional_kwargs(b="whatever")
 
 # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3471,7 +3471,7 @@ signatures when assigning to the explicit form. The reverse assignment is reject
 unpacked `TypedDict` may still receive hidden extra items.
 
 ```py
-from typing import Protocol
+from typing import Callable, ParamSpec, Protocol, TypeVar
 from typing_extensions import NotRequired, Required, TypedDict, Unpack
 
 class TD1(TypedDict):
@@ -3522,6 +3522,14 @@ def traditional_kwargs_source(**kwargs: int) -> None:
     pass
 
 traditional_kwargs_target: TraditionalKwargsTarget = traditional_kwargs_source
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def preserve_signature(callback: Callable[P, R]) -> Callable[P, R]:
+    return callback
+
+preserved_typed_dict_target: TypedDictKwargs = preserve_signature(func)
 ```
 
 ### Missing required keys remain incompatible

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5957,7 +5957,6 @@ class StrPatch(TypedDict, extra_items=str):
     name: NotRequired[str]
 
 class OpenPatch(TypedDict): ...
-
 class MutableExtraOnly(TypedDict, extra_items=int): ...
 
 def _(

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5978,6 +5978,9 @@ class IntSource(TypedDict, extra_items=int):
 class StrSource(TypedDict, extra_items=str):
     name: str
 
+class OpenSource(TypedDict):
+    name: str
+
 class IntTarget(TypedDict, extra_items=int):
     name: str
 
@@ -5992,7 +5995,7 @@ class ExtraOnly(TypedDict, extra_items=int): ...
 def accepts_ints(name: str, **kwargs: int) -> None: ...
 def accepts_name(name: str) -> None: ...
 def accepts_optional_label(*, label: str = "", **kwargs: int) -> None: ...
-def _(ints: IntSource, strings: StrSource, extra_only: ExtraOnly) -> None:
+def _(ints: IntSource, strings: StrSource, open_source: OpenSource, extra_only: ExtraOnly) -> None:
     accepts_ints(**ints)
     accepts_ints(**strings)  # error: [invalid-argument-type]
     accepts_name(**ints)  # error: [unknown-argument]
@@ -6000,7 +6003,10 @@ def _(ints: IntSource, strings: StrSource, extra_only: ExtraOnly) -> None:
 
     IntTarget(**ints)
     IntTarget(**strings)  # error: [invalid-argument-type]
+    IntTarget(**open_source)  # error: [invalid-argument-type]
     ClosedTarget(**ints)  # error: [invalid-key]
+
+    copied: IntTarget = {**open_source}  # error: [invalid-argument-type]
 
     # The extra-items tail may contain the target's optional `label` key with an incompatible type.
     OptionalTarget(**extra_only)  # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3467,7 +3467,8 @@ closed_movie(name="Blade Runner", year=1982)
 ### Assignability with explicit keyword-only signatures
 
 A callable using `**kwargs: Unpack[TD2]` should line up with equivalent explicit keyword-only
-signatures.
+signatures when assigning to the explicit form. The reverse assignment is rejected because an open
+unpacked `TypedDict` may still receive hidden extra items.
 
 ```py
 from typing import Protocol
@@ -3493,15 +3494,23 @@ explicit_ok: ExplicitKwargs = func
 typed_dict_ok: TypedDictKwargs = func
 
 def _(explicit: ExplicitKwargs, typed_dict: TypedDictKwargs) -> None:
-    # TODO: This should be rejected because an open unpacked TypedDict may receive hidden items.
-    typed_dict_2: TypedDictKwargs = explicit
+    typed_dict_2: TypedDictKwargs = explicit  # error: [invalid-assignment]
     explicit_2: ExplicitKwargs = typed_dict
 
 def func7(*, v1: int, v3: str, v2: str = "") -> None:
     pass
 
-# TODO: This should be rejected because an open unpacked TypedDict may receive hidden items.
-typed_dict_from_explicit: TypedDictKwargs = func7
+typed_dict_from_explicit: TypedDictKwargs = func7  # error: [invalid-assignment]
+
+class ClosedTD(TypedDict, closed=True):
+    v1: Required[int]
+    v2: NotRequired[str]
+    v3: Required[str]
+
+class ClosedTypedDictKwargs(Protocol):
+    def __call__(self, **kwargs: Unpack[ClosedTD]) -> None: ...
+
+closed_typed_dict_from_explicit: ClosedTypedDictKwargs = func7
 ```
 
 ### Missing required keys remain incompatible

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -1628,8 +1628,7 @@ alice: Person = alice
 > extra items of type `object`.
 
 That language is at the top of [subtyping section of the `TypedDict` spec][subtyping section]. It
-sounds like an obscure technicality, especially since `extra_items` is still TODO, but it has an
-important interaction with another rule:
+sounds like an obscure technicality, but it has an important interaction with another rule:
 
 > For each item in [the destination type]...If it is non-required...If it is mutable...If \[the
 > source type does not have an item with the same key and also\] has extra items, the extra items
@@ -3409,7 +3408,7 @@ def func(**kwargs: Unpack[TD2]) -> None:
 ### Call-site validation
 
 At the call site, required keys must be provided, known keys must be type-checked, and extra
-keywords are accepted as `object` because ordinary `TypedDict`s are open.
+keywords are rejected unless the `TypedDict` has explicit extra items.
 
 ```py
 from typing_extensions import NotRequired, Required, TypedDict, Unpack
@@ -3428,7 +3427,7 @@ def func(**kwargs: Unpack[TD2]) -> None:
 func()
 func(v1=1, v3="ok")
 func(v1=1, v2="optional", v3="ok")
-func(v1=1, v3="ok", v4=1)
+func(v1=1, v3="ok", v4=1)  # error: [unknown-argument]
 
 # error: [invalid-argument-type]
 func(v1=1, v3=1)
@@ -3450,8 +3449,7 @@ def movie(**kwargs: Unpack[Movie]) -> None:
 
 movie(name="Blade Runner", novel_adaptation=True)
 
-# TODO: Once `extra_items` is supported, this should be an invalid-argument-type error because
-# `year` should be checked against `bool`, not `object`.
+# error: [invalid-argument-type] "Expected `bool`, found `Literal[1982]`"
 movie(name="Blade Runner", year=1982)
 
 class ClosedMovie(TypedDict, closed=True):
@@ -3462,16 +3460,14 @@ def closed_movie(**kwargs: Unpack[ClosedMovie]) -> None:
 
 closed_movie(name="Blade Runner")
 
-# TODO: Once `closed` is supported, this should be an unknown-argument error because closed
-# TypedDicts should not add a trailing `**kwargs` parameter.
+# error: [unknown-argument]
 closed_movie(name="Blade Runner", year=1982)
 ```
 
 ### Assignability with explicit keyword-only signatures
 
 A callable using `**kwargs: Unpack[TD2]` should line up with equivalent explicit keyword-only
-signatures when assigning to the explicit form. The reverse assignment is rejected because an open
-unpacked `TypedDict` also accepts extra keyword arguments.
+signatures.
 
 ```py
 from typing import Protocol
@@ -3497,14 +3493,12 @@ explicit_ok: ExplicitKwargs = func
 typed_dict_ok: TypedDictKwargs = func
 
 def _(explicit: ExplicitKwargs, typed_dict: TypedDictKwargs) -> None:
-    # error: [invalid-assignment]
     typed_dict_2: TypedDictKwargs = explicit
     explicit_2: ExplicitKwargs = typed_dict
 
 def func7(*, v1: int, v3: str, v2: str = "") -> None:
     pass
 
-# error: [invalid-assignment]
 typed_dict_from_explicit: TypedDictKwargs = func7
 ```
 
@@ -3535,7 +3529,7 @@ missing_required: MissingRequiredKwarg = func
 ### Optional-only unpacked kwargs still expose named keys
 
 An unpacked all-optional open `TypedDict` exposes its declared keys as optional named keyword
-arguments while still accepting extra keyword arguments as `object`.
+arguments, but does not accept unknown keyword arguments.
 
 ```py
 from typing import Protocol
@@ -3551,7 +3545,7 @@ class WantsA(Protocol):
     def __call__(self, *, a: int = 1) -> None: ...
 
 wants_a: WantsA = accepts_optional_kwargs
-accepts_optional_kwargs(b="whatever")
+accepts_optional_kwargs(b="whatever")  # error: [unknown-argument]
 
 # error: [invalid-argument-type]
 accepts_optional_kwargs(a="bad")
@@ -5390,14 +5384,11 @@ class Extra(TypedDict, extra_items=int):
     name: str
 
 def _(extra: Extra) -> None:
-    # TODO: should be `dict_keys[str, str | int]`
-    reveal_type(extra.keys())  # revealed: dict_keys[str, object]
+    reveal_type(extra.keys())  # revealed: dict_keys[str, str | int]
 
-    # TODO: should be `dict_values[str, str | int]`
-    reveal_type(extra.values())  # revealed: dict_values[str, object]
+    reveal_type(extra.values())  # revealed: dict_values[str, str | int]
 
-    # TODO: should be `dict_items[str, str | int]`
-    reveal_type(extra.items())  # revealed: dict_items[str, object]
+    reveal_type(extra.items())  # revealed: dict_items[str, str | int]
 
     # iterating over the keys gives `str` types
     for key in extra:
@@ -5407,12 +5398,10 @@ def _(extra: Extra) -> None:
         reveal_type(key)  # revealed: str
 
     for value in extra.values():
-        # TODO: should be `str | int
-        reveal_type(value)  # revealed: object
+        reveal_type(value)  # revealed: str | int
 
     for item in extra.items():
-        # TODO: should be `tuple[str, str | int]`
-        reveal_type(item)  # revealed: tuple[str, object]
+        reveal_type(item)  # revealed: tuple[str, str | int]
 ```
 
 ### A closed `TypedDict` is equivalent to `extra_items=Never`
@@ -5442,8 +5431,7 @@ from typing_extensions import TypedDict
 class Empty(TypedDict, closed=True): ...
 
 def _(empty: Empty) -> None:
-    # TODO: should be `Literal[False]`
-    reveal_type(bool(empty))  # revealed: bool
+    reveal_type(bool(empty))  # revealed: Literal[False]
 ```
 
 ### Closed TypedDict is structurally final but not nominally final
@@ -5464,7 +5452,7 @@ class ClosedChild(Closed): ...
 
 static_assert(is_equivalent_to(ClosedChild, Closed))
 
-# TODO: should be error: [invalid-typed-dict-header] "Cannot add new items to a closed TypedDict"
+# error: [invalid-typed-dict-header] "Cannot add item `age` to closed TypedDict base `Closed`"
 class BadChild(Closed):
     age: int
 ```
@@ -5482,12 +5470,8 @@ class Extra(TypedDict, extra_items=int):
 
 def _(extra: Extra, key: str) -> None:
     reveal_type(extra["name"])  # revealed: str
-    # TODO: should be `int` (the extra_items type) with no error
-    # error: [invalid-key]
-    reveal_type(extra["anything"])  # revealed: Unknown
-    # TODO: should be `str | int` with no error
-    # error: [invalid-key]
-    reveal_type(extra[key])  # revealed: Unknown
+    reveal_type(extra["anything"])  # revealed: int
+    reveal_type(extra[key])  # revealed: str | int
 ```
 
 For closed TypedDicts, indexing into the dictionary with a non-literal `str` is an error, just like
@@ -5520,9 +5504,45 @@ class Child(Base):
 def _(child: Child) -> None:
     reveal_type(child["name"])  # revealed: str
     reveal_type(child["age"])  # revealed: int
-    # TODO: should be `int` (inherited extra_items) with no error
-    # error: [invalid-key]
-    reveal_type(child["other"])  # revealed: Unknown
+    reveal_type(child["other"])  # revealed: int
+```
+
+Generic extra-items types are specialized and inherited:
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class GenericExtra(TypedDict, Generic[T], extra_items=T):
+    value: T
+
+class IntExtra(GenericExtra[int]): ...
+
+def _(generic: GenericExtra[int], inherited: IntExtra) -> None:
+    reveal_type(generic["other"])  # revealed: int
+    generic["other"] = 1
+    generic["other"] = "not an int"  # error: [invalid-assignment]
+
+    reveal_type(inherited["other"])  # revealed: int
+```
+
+PEP 695 type parameters are also supported:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing_extensions import ReadOnly, TypedDict
+
+class NativeGenericExtra[T](TypedDict, extra_items=T): ...
+class NativeReadOnlyExtra[T](TypedDict, extra_items=ReadOnly[T]): ...
+
+def _(extra: NativeGenericExtra[int], read_only: NativeReadOnlyExtra[int]) -> None:
+    reveal_type(extra["other"])  # revealed: int
+    read_only["other"] = 1  # error: [invalid-assignment]
 ```
 
 ### `closed=False` TypedDict cannot inherit from an `extra_items` TypedDict
@@ -5536,13 +5556,13 @@ from typing_extensions import TypedDict
 class ExtraBase(TypedDict, extra_items=int):
     name: str
 
-# TODO: should be error: [invalid-typed-dict-header]
+# error: [invalid-typed-dict-header]
 class BadChild1(ExtraBase, closed=False): ...
 
 class ClosedBase(TypedDict, closed=True):
     name: str
 
-# TODO: should be error: [invalid-typed-dict-header]
+# error: [invalid-typed-dict-header]
 class BadChild2(ClosedBase, closed=False): ...
 ```
 
@@ -5574,15 +5594,14 @@ from typing_extensions import TypedDict
 class Movie(TypedDict, extra_items=bool):
     name: str
 
-# TODO: should be OK (extra key with correct type), no errors
-a: Movie = {"name": "Blade Runner", "novel_adaptation": True}  # error: [invalid-key]
-Movie(name="Blade Runner", novel_adaptation=True)  # error: [invalid-key]
+a: Movie = {"name": "Blade Runner", "novel_adaptation": True}
+Movie(name="Blade Runner", novel_adaptation=True)
 
-# TODO: should be error: [invalid-argument-type] (wrong type for extra key), not [invalid-key]
-b: Movie = {"name": "Blade Runner", "year": 1982}  # error: [invalid-key]
+# error: [invalid-argument-type]
+b: Movie = {"name": "Blade Runner", "year": 1982}
 
-# TODO: should be error: [invalid-argument-type], not [invalid-key]
-Movie(name="Blade Runner", year=1982)  # error: [invalid-key]
+# error: [invalid-argument-type]
+Movie(name="Blade Runner", year=1982)
 
 # Closed TypedDicts reject extra keys entirely
 class ClosedMovie(TypedDict, closed=True):
@@ -5599,12 +5618,20 @@ The functional syntax also supports `extra_items`:
 
 ```py
 MovieFunctional = TypedDict("MovieFunctional", {"name": str}, extra_items=bool)
+NonIdentifierFunctional = TypedDict(
+    "NonIdentifierFunctional",
+    {"x-y": str},
+    extra_items=int,
+)
 
-# TODO: should be OK (extra key with correct type), no errors
-d: MovieFunctional = {"name": "Blade Runner", "novel_adaptation": True}  # error: [invalid-key]
+d: MovieFunctional = {"name": "Blade Runner", "novel_adaptation": True}
+NonIdentifierFunctional(**{"x-y": "ok", "other": 1})
 
-# TODO: should be error: [invalid-argument-type] (wrong type for extra key), not [invalid-key]
-e: MovieFunctional = {"name": "Blade Runner", "year": 1982}  # error: [invalid-key]
+# error: [invalid-argument-type]
+e: MovieFunctional = {"name": "Blade Runner", "year": 1982}
+
+# error: [invalid-argument-type]
+NonIdentifierFunctional(**{"x-y": 1})
 ```
 
 ### `extra_items` parameter must be a valid annotation expression; the only legal type qualifier is `ReadOnly`
@@ -5648,9 +5675,16 @@ class D(TypedDict, extra_items=InitVar[int]):
 It is an error to specify both `closed` and `extra_items`:
 
 ```py
-# TODO: should be error: [invalid-typed-dict-header]
+# error: [invalid-typed-dict-header]
 class E(TypedDict, closed=True, extra_items=int):
     name: str
+```
+
+The same restriction applies to functional TypedDicts:
+
+```py
+# error: [invalid-argument-type]
+FunctionalE = TypedDict("FunctionalE", {"name": str}, closed=True, extra_items=int)
 ```
 
 ### Forward references in `extra_items`
@@ -5718,12 +5752,10 @@ class Extra(TypedDict, extra_items=int):
     name: str
 
 def _(extra: Extra) -> None:
-    # TODO: should be OK (int is assignable to extra_items=int), no error
-    extra["year"] = 1982  # error: [invalid-key]
+    extra["year"] = 1982
     extra["name"] = "Alien"  # OK: str is assignable to str
 
-    # TODO: should be error: [invalid-assignment], not [invalid-key]
-    extra["year"] = "not an int"  # error: [invalid-key]
+    extra["year"] = "not an int"  # error: [invalid-assignment]
 ```
 
 ### If `extra_items` is `ReadOnly`, you can't write to an undeclared literal string key
@@ -5737,8 +5769,8 @@ class ReadOnlyExtra(TypedDict, extra_items=ReadOnly[int]):
 def _(read_only_extra: ReadOnlyExtra) -> None:
     read_only_extra["name"] = "Alien"  # OK: name is a declared mutable field
 
-    # TODO: should be error: [invalid-assignment] "Cannot assign to key "year" on TypedDict `ReadOnlyExtra`: key is marked read-only"
-    read_only_extra["year"] = 1982  # error: [invalid-key]
+    # error: [invalid-assignment] "Cannot assign to key "year" on TypedDict `ReadOnlyExtra`: key is marked read-only"
+    read_only_extra["year"] = 1982
 ```
 
 ### Writing to a `str` key on an `extra_items` TypedDict is only allowed if the type is assignable to all TypedDict items
@@ -5756,19 +5788,16 @@ class Extra2(TypedDict, extra_items=Super):
     field: Sub
 
 def _(extra1: Extra1, extra2: Extra2, key: str) -> None:
-    # TODO: the error message is wrong: `Super` is assignable to the value-type of `field`, but not to `extra_items`
-    #
-    # error: [invalid-key] "TypedDict `Extra1` can only be subscripted with a string literal key, got key of type `str`."
+    # `Super` is assignable to the value type of `field`, but not to `extra_items`.
+    # error: [invalid-assignment] "Expected value assignable to `Sub`"
     extra1[key] = Super()
 
-    # TODO: the error message is wrong: `Super` is assignable to `extra_items`, but not to the value type of `field`
-    #
-    # error: [invalid-key] "TypedDict `Extra2` can only be subscripted with a string literal key, got key of type `str`."
+    # `Super` is assignable to `extra_items`, but not to the value type of `field`.
+    # error: [invalid-assignment] "Expected value assignable to `Sub`"
     extra2[key] = Super()
 
-    # TODO: these should be fine
-    extra1[key] = Sub()  # error: [invalid-key]
-    extra2[key] = Sub()  # error: [invalid-key]
+    extra1[key] = Sub()
+    extra2[key] = Sub()
 ```
 
 ### If `extra_items` is `ReadOnly`, subclasses can override the type covariantly, and/or have mutable `extra_items`
@@ -5792,7 +5821,7 @@ class MutableChild(ReadOnlyBase, extra_items=int): ...
 # OK: close the subclass (only allowed when base extra_items is read-only)
 class ClosedChild(ReadOnlyBase, closed=True): ...
 
-# TODO: should be error: [invalid-typed-dict-header] "'list[str]' is not assignable to 'int | str'"
+# error: [invalid-typed-dict-header] "Extra items type `list[str]` is not assignable to `int | str` from base `ReadOnlyBase`"
 class BadChild(ReadOnlyBase, extra_items=list[str]): ...
 ```
 
@@ -5802,10 +5831,10 @@ When the base has _mutable_ extra items, the child cannot change the extra-items
 class MutableBase(TypedDict, extra_items=int):
     name: str
 
-# TODO: should be error: [invalid-typed-dict-header]
+# error: [invalid-typed-dict-header]
 class BadNarrow(MutableBase, extra_items=bool): ...
 
-# TODO: should be error: [invalid-typed-dict-header]
+# error: [invalid-typed-dict-header]
 class BadClose(MutableBase, closed=True): ...
 ```
 
@@ -5821,11 +5850,11 @@ class Base(TypedDict, extra_items=int | None):
 class GoodChild(Base):
     year: NotRequired[int | None]
 
-# TODO: should be error: [invalid-typed-dict-header] "Required key 'year' is not allowed"
+# error: [invalid-typed-dict-header]
 class ChildWithBadRequiredItem(Base):
     year: int | None
 
-# TODO: should be error: [invalid-typed-dict-header] "Type 'int' is not consistent with 'int | None'"
+# error: [invalid-typed-dict-header]
 class ChildWithBadValueType(Base):
     year: NotRequired[int]
 ```
@@ -5846,7 +5875,7 @@ class WithYear(Base):
 class WithTag(Base):
     tag: NotRequired[str]
 
-# TODO: should be error: [invalid-typed-dict-header] "'list[str]' is not assignable to 'int | str'"
+# error: [invalid-typed-dict-header]
 class BadChild(Base):
     tags: list[str]
 ```
@@ -5863,8 +5892,7 @@ class Extra(TypedDict, extra_items=int):
     name: str
 
 def _(extra: Extra, key: str) -> None:
-    # TODO: should be OK (extra items are non-required)
-    del extra["year"]  # error: [invalid-argument-type]
+    del extra["year"]
 
     # error: [invalid-argument-type] "Cannot delete required key "name" from TypedDict `Extra`"
     del extra["name"]
@@ -5873,6 +5901,104 @@ def _(extra: Extra, key: str) -> None:
     #
     # error: [invalid-argument-type] "Method `__delitem__` of type `(key: Never, /) -> None` cannot be called with key of type `str` on object of type `Extra`"
     del extra[key]
+```
+
+### `pop` and `setdefault` support literal extra-item keys
+
+Extra items behave like non-required items for methods that mutate a specific literal key.
+
+```py
+from typing_extensions import TypedDict
+
+class Extra(TypedDict, extra_items=int):
+    name: str
+
+def _(extra: Extra) -> None:
+    reveal_type(extra.get("year"))  # revealed: int | None
+    reveal_type(extra.get("year", "missing"))  # revealed: int | Literal["missing"]
+    reveal_type(extra.pop("year"))  # revealed: int
+    reveal_type(extra.pop("year", "missing"))  # revealed: int | Literal["missing"]
+    reveal_type(extra.setdefault("year", 1982))  # revealed: int
+
+    # error: [invalid-argument-type]
+    extra.setdefault("year", "not an int")
+```
+
+### `update` accounts for extra items
+
+Mutable extra items can be updated, while read-only extra items cannot:
+
+```py
+from typing_extensions import NotRequired, ReadOnly, TypedDict
+
+class MutableExtra(TypedDict, extra_items=int):
+    name: str
+
+class ReadOnlyExtra(TypedDict, extra_items=ReadOnly[int]):
+    name: str
+
+class IntPatch(TypedDict, extra_items=int):
+    name: NotRequired[str]
+
+class StrPatch(TypedDict, extra_items=str):
+    name: NotRequired[str]
+
+def _(
+    mutable: MutableExtra,
+    read_only: ReadOnlyExtra,
+    ints: IntPatch,
+    strings: StrPatch,
+) -> None:
+    mutable.update(year=1982)
+    mutable.update(ints)
+    mutable.update(year="not an int")  # error: [invalid-argument-type]
+    mutable.update(strings)  # error: [invalid-argument-type]
+
+    read_only.update(year=1982)  # error: [unknown-argument]
+    read_only.update(ints)  # error: [invalid-argument-type]
+```
+
+### Unpacking accounts for extra items
+
+An unpacked extra-items TypedDict can supply arbitrary additional keyword arguments. Its extra-items
+type must therefore be compatible with the target's extra-items policy:
+
+```py
+from typing_extensions import NotRequired, TypedDict
+
+class IntSource(TypedDict, extra_items=int):
+    name: str
+
+class StrSource(TypedDict, extra_items=str):
+    name: str
+
+class IntTarget(TypedDict, extra_items=int):
+    name: str
+
+class ClosedTarget(TypedDict, closed=True):
+    name: str
+
+class OptionalTarget(TypedDict, extra_items=int):
+    label: NotRequired[str]
+
+class ExtraOnly(TypedDict, extra_items=int): ...
+
+def accepts_ints(name: str, **kwargs: int) -> None: ...
+def accepts_name(name: str) -> None: ...
+def accepts_optional_label(*, label: str = "", **kwargs: int) -> None: ...
+def _(ints: IntSource, strings: StrSource, extra_only: ExtraOnly) -> None:
+    accepts_ints(**ints)
+    accepts_ints(**strings)  # error: [invalid-argument-type]
+    accepts_name(**ints)  # error: [unknown-argument]
+    accepts_optional_label(**extra_only)  # error: [invalid-argument-type]
+
+    IntTarget(**ints)
+    IntTarget(**strings)  # error: [invalid-argument-type]
+    ClosedTarget(**ints)  # error: [invalid-key]
+
+    # The extra-items tail may contain the target's optional `label` key with an incompatible type.
+    OptionalTarget(**extra_only)  # error: [invalid-argument-type]
+    optional: OptionalTarget = {**extra_only}  # error: [invalid-argument-type]
 ```
 
 ### Assignability between TypedDicts accounts for the type of extra items
@@ -5889,9 +6015,8 @@ class ExtraStr(TypedDict, extra_items=str):
 
 # Mutable extra items must be equivalent, not just assignable
 #
-# TODO: these should pass
-static_assert(not is_assignable_to(ExtraInt, ExtraStr))  # error: [static-assert-error]
-static_assert(not is_assignable_to(ExtraStr, ExtraInt))  # error: [static-assert-error]
+static_assert(not is_assignable_to(ExtraInt, ExtraStr))
+static_assert(not is_assignable_to(ExtraStr, ExtraInt))
 
 class ReadOnlyExtraInt(TypedDict, extra_items=ReadOnly[int]):
     name: str
@@ -5901,8 +6026,7 @@ class ReadOnlyExtraIntStr(TypedDict, extra_items=ReadOnly[int | str]):
 
 # Read-only extra items: covariant, so narrower is assignable to wider
 static_assert(is_subtype_of(ReadOnlyExtraInt, ReadOnlyExtraIntStr))
-# TODO: should pass
-static_assert(not is_assignable_to(ReadOnlyExtraIntStr, ReadOnlyExtraInt))  # error: [static-assert-error]
+static_assert(not is_assignable_to(ReadOnlyExtraIntStr, ReadOnlyExtraInt))
 
 # A closed TypedDict is assignable to an open one (open implicitly has ReadOnly[object] extras)
 class Closed(TypedDict, closed=True):
@@ -5915,16 +6039,14 @@ static_assert(is_assignable_to(Closed, Open))
 
 # An open TypedDict is not assignable to a closed one (might have extra keys)
 #
-# TODO: should pass
-static_assert(not is_assignable_to(Open, Closed))  # error: [static-assert-error]
+static_assert(not is_assignable_to(Open, Closed))
 
 # An extra-items TypedDict is assignable to an open one
 static_assert(is_assignable_to(ExtraInt, Open))
 
 # But not vice versa
 #
-# TODO: should pass
-static_assert(not is_assignable_to(Open, ExtraInt))  # error: [static-assert-error]
+static_assert(not is_assignable_to(Open, ExtraInt))
 ```
 
 Non-required items in the target that are absent in the source must be accounted for by the source's
@@ -5940,14 +6062,37 @@ class SourceWithIntExtra(TypedDict, extra_items=int):
 
 # SourceExtra can satisfy `Target`'s non-required `ReadOnly` `age` via its `extra_items=int`
 #
-# TODO: should pass
-static_assert(is_assignable_to(SourceWithIntExtra, Target))  # error: [static-assert-error]
+static_assert(is_assignable_to(SourceWithIntExtra, Target))
 
 class SourceWithStrExtra(TypedDict, extra_items=str):
     name: str
 
 # `str` extra items can't satisfy `age: int`
 static_assert(not is_assignable_to(SourceWithStrExtra, Target))
+```
+
+### Disjointness accounts for openness
+
+A required item on one side can conflict with the other side's closed or extra-items policy.
+
+```py
+from typing_extensions import TypedDict, ReadOnly
+from ty_extensions import static_assert, is_disjoint_from
+
+class RequiredInt(TypedDict, closed=True):
+    value: int
+
+class RequiredStr(TypedDict, closed=True):
+    value: str
+
+class ClosedEmpty(TypedDict, closed=True): ...
+class ReadOnlyIntExtras(TypedDict, extra_items=ReadOnly[int]): ...
+class MutableIntExtras(TypedDict, extra_items=int): ...
+
+static_assert(is_disjoint_from(RequiredInt, ClosedEmpty))
+static_assert(not is_disjoint_from(RequiredInt, ReadOnlyIntExtras))
+static_assert(is_disjoint_from(RequiredStr, ReadOnlyIntExtras))
+static_assert(is_disjoint_from(RequiredInt, MutableIntExtras))
 ```
 
 ### A `TypedDict` with `extra_items: T` is a subtype of `Mapping[str, T1]`, where `T1` is the union of `T` and all declared item types
@@ -5961,17 +6106,13 @@ class ExtraStr(TypedDict, extra_items=str):
     name: str
 
 # All value types (str, str) are subtypes of str
-#
-# TODO: should pass
-static_assert(is_assignable_to(ExtraStr, Mapping[str, str]))  # error: [static-assert-error]
+static_assert(is_assignable_to(ExtraStr, Mapping[str, str]))
 
 class ExtraInt(TypedDict, extra_items=int):
     name: str
 
 # Value types are str | int, so it's assignable to Mapping[str, str | int] but not Mapping[str, int]
-#
-# TODO: should pass
-static_assert(is_assignable_to(ExtraInt, Mapping[str, str | int]))  # error: [static-assert-error]
+static_assert(is_assignable_to(ExtraInt, Mapping[str, str | int]))
 static_assert(not is_assignable_to(ExtraInt, Mapping[str, int]))
 
 # Closed TypedDicts also have a known set of value types
@@ -5979,8 +6120,7 @@ class Closed(TypedDict, closed=True):
     name: str
     age: int
 
-# TODO: should pass
-static_assert(is_assignable_to(Closed, Mapping[str, str | int]))  # error: [static-assert-error]
+static_assert(is_assignable_to(Closed, Mapping[str, str | int]))
 static_assert(not is_assignable_to(Closed, Mapping[str, str]))
 ```
 
@@ -6000,25 +6140,21 @@ class IntDictWithNum(IntDict):
     num: NotRequired[int]
 
 # All items non-required + mutable + extra_items=int → assignable to dict[str, int]
-#
-# TODO: these should pass
-static_assert(is_subtype_of(IntDict, dict[str, int]))  # error: [static-assert-error]
-static_assert(is_subtype_of(IntDictWithNum, dict[str, int]))  # error: [static-assert-error]
+static_assert(is_subtype_of(IntDict, dict[str, int]))
+static_assert(is_subtype_of(IntDictWithNum, dict[str, int]))
 
 # But dict[str, int] is not assignable to the TypedDict (could be a dict subclass)
 static_assert(not is_assignable_to(dict[str, int], IntDict))
 static_assert(not is_equivalent_to(dict[str, int], IntDict))
 
 def _(int_dict_with_num: IntDictWithNum, key: str) -> None:
-    # TODO: no errors should be reported here
-    v: dict[str, int] = int_dict_with_num  # error: [invalid-assignment]
-    int_dict_with_num.clear()  # error: [unresolved-attribute]
-    # error: [unresolved-attribute]
-    reveal_type(int_dict_with_num.popitem())  # revealed: Unknown
-    int_dict_with_num[key] = 42  # error: [invalid-key]
-    del int_dict_with_num[key]  # error: [invalid-argument-type]
+    v: dict[str, int] = int_dict_with_num
+    int_dict_with_num.clear()
+    reveal_type(int_dict_with_num.popitem())  # revealed: tuple[str, int]
+    int_dict_with_num[key] = 42
+    del int_dict_with_num[key]
 
-class BoolDictWithNum(IntDict, extra_items=int):
+class BoolDictWithNum(TypedDict, extra_items=int):
     condition: NotRequired[bool]
 
 # All keys must be equivalent to the value-type of the dict in order for
@@ -6026,6 +6162,10 @@ class BoolDictWithNum(IntDict, extra_items=int):
 static_assert(not is_assignable_to(BoolDictWithNum, dict[str, int]))
 static_assert(not is_subtype_of(BoolDictWithNum, dict[str, int]))
 static_assert(not is_equivalent_to(BoolDictWithNum, dict[str, int]))
+
+def _(bool_dict_with_num: BoolDictWithNum) -> None:
+    bool_dict_with_num.clear()
+    reveal_type(bool_dict_with_num.popitem())  # revealed: tuple[str, int]
 ```
 
 A TypedDict with a required key is not assignable to `dict[str, VT]`:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5407,6 +5407,11 @@ def _(extra: Extra) -> None:
 
 ### A closed `TypedDict` is equivalent to `extra_items=Never`
 
+```toml
+[environment]
+python-version = "3.12"
+```
+
 ```py
 from typing_extensions import TypedDict, Never
 from ty_extensions import static_assert, is_equivalent_to, is_subtype_of
@@ -5417,9 +5422,15 @@ class Extra(TypedDict, extra_items=Never):
 class Closed(TypedDict, closed=True):
     x: int
 
+type Bottom = Never
+
+class AliasedExtra(TypedDict, extra_items=Bottom):
+    x: int
+
 static_assert(is_equivalent_to(Extra, Closed))
 static_assert(is_subtype_of(Extra, Closed))
 static_assert(is_subtype_of(Closed, Extra))
+static_assert(is_equivalent_to(AliasedExtra, Closed))
 ```
 
 ### Empty closed TypedDict is known to be falsy

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6033,6 +6033,24 @@ def _(
     optional: OptionalTarget = {**extra_only}  # error: [invalid-argument-type]
 ```
 
+### Non-literal keys in an `extra_items` TypedDict constructor must be safe for every possible key
+
+```py
+from typing_extensions import NotRequired, TypedDict
+
+class ExtraIntOnly(TypedDict, extra_items=int): ...
+
+class WithDeclaredItem(TypedDict, extra_items=int):
+    label: NotRequired[str]
+
+def _(key: str) -> None:
+    bad_literal: ExtraIntOnly = {key: "bad"}  # error: [invalid-argument-type]
+    ExtraIntOnly({key: "bad"})  # error: [invalid-argument-type]
+
+    # The runtime key may be `label`, so the value must also be assignable to `str`.
+    bad_declared_item: WithDeclaredItem = {key: 1}  # error: [invalid-argument-type]
+```
+
 ### Assignability between TypedDicts accounts for the type of extra items
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3467,7 +3467,8 @@ closed_movie(name="Blade Runner", year=1982)
 ### Assignability with explicit keyword-only signatures
 
 A callable using `**kwargs: Unpack[TD2]` should line up with equivalent explicit keyword-only
-signatures.
+signatures when assigning to the explicit form. The reverse assignment is rejected because an open
+unpacked `TypedDict` may still receive hidden extra items.
 
 ```py
 from typing import Protocol
@@ -3493,13 +3494,13 @@ explicit_ok: ExplicitKwargs = func
 typed_dict_ok: TypedDictKwargs = func
 
 def _(explicit: ExplicitKwargs, typed_dict: TypedDictKwargs) -> None:
-    typed_dict_2: TypedDictKwargs = explicit
+    typed_dict_2: TypedDictKwargs = explicit  # error: [invalid-assignment]
     explicit_2: ExplicitKwargs = typed_dict
 
 def func7(*, v1: int, v3: str, v2: str = "") -> None:
     pass
 
-typed_dict_from_explicit: TypedDictKwargs = func7
+typed_dict_from_explicit: TypedDictKwargs = func7  # error: [invalid-assignment]
 ```
 
 ### Missing required keys remain incompatible

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3502,6 +3502,17 @@ def func7(*, v1: int, v3: str, v2: str = "") -> None:
 
 typed_dict_from_explicit: TypedDictKwargs = func7  # error: [invalid-assignment]
 
+class EmptyOpenTD(TypedDict):
+    pass
+
+class EmptyOpenTypedDictKwargs(Protocol):
+    def __call__(self, **kwargs: Unpack[EmptyOpenTD]) -> None: ...
+
+def no_kwargs() -> None:
+    pass
+
+empty_open_typed_dict_from_explicit: EmptyOpenTypedDictKwargs = no_kwargs  # error: [invalid-assignment]
+
 class ClosedTD(TypedDict, closed=True):
     v1: Required[int]
     v2: NotRequired[str]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6056,7 +6056,7 @@ def _(
     mutable.update(strings)  # error: [invalid-argument-type]
     mutable_extra_only.update(open_patch)  # error: [invalid-argument-type]
 
-    # The extra-items tail may contain the target's declared `name` key with an incompatible type.
+    # The source's extra items may contain the target's declared `name` key with an incompatible type.
     open_with_name.update(mutable_extra_only)  # error: [invalid-argument-type]
 
     read_only.update(year=1982)  # error: [unknown-argument]
@@ -6140,17 +6140,16 @@ def _(
     # An arbitrary mapping key may collide with the target's declared `label` item.
     OptionalTarget(**int_mapping)  # error: [invalid-argument-type]
 
-    # The extra-items tail may contain the target's optional `label` key with an incompatible type.
+    # The source's extra items may contain the target's optional `label` key with an incompatible type.
     OptionalTarget(**extra_only)  # error: [invalid-argument-type]
     optional: OptionalTarget = {**extra_only}  # error: [invalid-argument-type]
 
-    # A later value for `label` shadows the potentially incompatible value from the extra-items
-    # tail.
+    # A later value for `label` shadows the potentially incompatible extra-item value.
     OptionalTarget(**{**extra_only, "label": "ok"})
     shadowed: OptionalTarget = {**extra_only, "label": "ok"}
     OptionalTarget(extra_only, label="ok")
 
-    # In the reverse order, the extra-items tail may overwrite `label`.
+    # In the reverse order, the source's extra items may overwrite `label`.
     OptionalTarget(**{"label": "ok", **extra_only})  # error: [invalid-argument-type]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3551,7 +3551,6 @@ class TraditionalKwargsTarget(Protocol):
 def traditional_kwargs_source(**kwargs: int) -> None:
     pass
 
-# TODO: This should be accepted because the declared field is assignable to `int`.
 traditional_kwargs_target: TraditionalKwargsTarget = traditional_kwargs_source  # error: [invalid-assignment]
 
 P = ParamSpec("P")

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6202,9 +6202,10 @@ static_assert(not is_assignable_to(SourceWithStrExtra, Target))
 ### Disjointness accounts for openness
 
 A required item on one side can conflict with the other side's closed or extra-items policy.
+An optional mutable item can also conflict with a mutable extra-items policy.
 
 ```py
-from typing_extensions import TypedDict, ReadOnly
+from typing_extensions import NotRequired, ReadOnly, TypedDict
 from ty_extensions import static_assert, is_disjoint_from
 
 class RequiredInt(TypedDict, closed=True):
@@ -6220,6 +6221,9 @@ class ReadOnlyStrExtras(TypedDict, extra_items=ReadOnly[str]): ...
 class MutableIntExtras(TypedDict, extra_items=int): ...
 class MutableStrExtras(TypedDict, extra_items=str): ...
 
+class OptionalInt(TypedDict):
+    value: NotRequired[int]
+
 static_assert(is_disjoint_from(RequiredInt, ClosedEmpty))
 static_assert(not is_disjoint_from(RequiredInt, ReadOnlyIntExtras))
 static_assert(is_disjoint_from(RequiredStr, ReadOnlyIntExtras))
@@ -6230,6 +6234,9 @@ static_assert(is_disjoint_from(MutableIntExtras, ReadOnlyStrExtras))
 static_assert(not is_disjoint_from(MutableIntExtras, ReadOnlyIntExtras))
 static_assert(not is_disjoint_from(ClosedEmpty, ReadOnlyIntExtras))
 static_assert(not is_disjoint_from(OpenEmpty, MutableIntExtras))
+static_assert(is_disjoint_from(OptionalInt, MutableStrExtras))
+static_assert(is_disjoint_from(MutableStrExtras, OptionalInt))
+static_assert(not is_disjoint_from(OptionalInt, MutableIntExtras))
 ```
 
 ### A `TypedDict` with `extra_items: T` is a subtype of `Mapping[str, T1]`, where `T1` is the union of `T` and all declared item types

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3471,6 +3471,7 @@ signatures when assigning to the explicit form. The reverse assignment is reject
 unpacked `TypedDict` may still receive hidden extra items.
 
 ```py
+from functools import partial
 from typing import Callable, ParamSpec, Protocol, TypeVar
 from typing_extensions import NotRequired, Required, TypedDict, Unpack
 
@@ -3541,6 +3542,9 @@ def preserve_signature(callback: Callable[P, R]) -> Callable[P, R]:
     return callback
 
 preserved_typed_dict_target: TypedDictKwargs = preserve_signature(func)
+
+partial_typed_dict_target: TypedDictKwargs = partial(func)
+partial_explicit_target: TypedDictKwargs = partial(func7)  # error: [invalid-assignment]
 ```
 
 ### Missing required keys remain incompatible

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6051,6 +6051,27 @@ def _(key: str) -> None:
     bad_declared_item: WithDeclaredItem = {key: 1}  # error: [invalid-argument-type]
 ```
 
+### Mixed constructors validate source-only keys against `extra_items`
+
+```py
+from typing_extensions import TypedDict
+
+class Target(TypedDict, extra_items=int): ...
+
+class GoodSource(TypedDict, extra_items=int):
+    source_only: int
+
+class BadSource(TypedDict, extra_items=int):
+    source_only: str
+
+def _(good: GoodSource, bad: BadSource) -> None:
+    Target(good, keyword=1)
+    Target(bad, keyword=1)  # error: [invalid-argument-type]
+
+    # An explicit keyword shadows the source key.
+    Target(bad, source_only=1)
+```
+
 ### Assignability between TypedDicts accounts for the type of extra items
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3511,6 +3511,17 @@ class ClosedTypedDictKwargs(Protocol):
     def __call__(self, **kwargs: Unpack[ClosedTD]) -> None: ...
 
 closed_typed_dict_from_explicit: ClosedTypedDictKwargs = func7
+
+class TraditionalKwargsTD(TypedDict):
+    value: int
+
+class TraditionalKwargsTarget(Protocol):
+    def __call__(self, **kwargs: Unpack[TraditionalKwargsTD]) -> None: ...
+
+def traditional_kwargs_source(**kwargs: int) -> None:
+    pass
+
+traditional_kwargs_target: TraditionalKwargsTarget = traditional_kwargs_source
 ```
 
 ### Missing required keys remain incompatible

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6102,10 +6102,19 @@ class ClosedTarget(TypedDict, closed=True):
 class ClosedSource(TypedDict, closed=True):
     source_only: str
 
-def _(good: GoodSource, bad: BadSource, closed: ClosedSource) -> None:
+class AllKeywordsTarget(TypedDict, extra_items=int):
+    keyword: int
+
+def _(
+    good: GoodSource,
+    bad: BadSource,
+    closed: ClosedSource,
+    bad_mapping: dict[str, str],
+) -> None:
     Target(good, keyword=1)
     Target(bad, keyword=1)  # error: [invalid-argument-type]
     ClosedTarget(closed, keyword=1)  # error: [invalid-key]
+    AllKeywordsTarget(bad_mapping, keyword=1)  # error: [invalid-argument-type]
 
     # An explicit keyword shadows the source key.
     Target(bad, source_only=1)

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5434,9 +5434,10 @@ static_assert(is_subtype_of(Closed, Extra))
 static_assert(is_equivalent_to(AliasedExtra, Closed))
 ```
 
-### Empty closed TypedDict is known to be falsy
+### Empty closed TypedDict truthiness
 
-An empty `closed=True` TypedDict cannot contain any keys, so it is always empty and always falsy.
+An empty `closed=True` TypedDict cannot contain any keys, so it is always empty and always falsy,
+but inferring that precisely is outside the scope of `extra_items` support.
 
 ```py
 from typing_extensions import TypedDict
@@ -5444,7 +5445,8 @@ from typing_extensions import TypedDict
 class Empty(TypedDict, closed=True): ...
 
 def _(empty: Empty) -> None:
-    reveal_type(bool(empty))  # revealed: Literal[False]
+    # TODO: This can be revealed as `Literal[False]`.
+    reveal_type(bool(empty))  # revealed: bool
 ```
 
 ### Closed TypedDict is structurally final but not nominally final

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5536,6 +5536,7 @@ python-version = "3.12"
 
 ```py
 from typing_extensions import ReadOnly, TypedDict
+from ty_extensions import is_subtype_of, static_assert
 
 class NativeGenericExtra[T](TypedDict, extra_items=T): ...
 class NativeReadOnlyExtra[T](TypedDict, extra_items=ReadOnly[T]): ...
@@ -5543,6 +5544,11 @@ class NativeReadOnlyExtra[T](TypedDict, extra_items=ReadOnly[T]): ...
 def _(extra: NativeGenericExtra[int], read_only: NativeReadOnlyExtra[int]) -> None:
     reveal_type(extra["other"])  # revealed: int
     read_only["other"] = 1  # error: [invalid-assignment]
+
+static_assert(not is_subtype_of(NativeGenericExtra[int], NativeGenericExtra[object]))
+static_assert(not is_subtype_of(NativeGenericExtra[object], NativeGenericExtra[int]))
+static_assert(is_subtype_of(NativeReadOnlyExtra[int], NativeReadOnlyExtra[object]))
+static_assert(not is_subtype_of(NativeReadOnlyExtra[object], NativeReadOnlyExtra[int]))
 ```
 
 ### `closed=False` TypedDict cannot inherit from an `extra_items` TypedDict

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6066,6 +6066,18 @@ def _(key: str) -> None:
     bad_declared_item: WithDeclaredItem = {key: 1}  # error: [invalid-argument-type]
 ```
 
+### Non-literal keys in a closed TypedDict constructor are rejected
+
+```py
+from typing_extensions import TypedDict
+
+class Closed(TypedDict, closed=True): ...
+
+def _(key: str) -> None:
+    assigned: Closed = {key: 1}  # error: [invalid-key]
+    Closed({key: 1})  # error: [invalid-key]
+```
+
 ### Mixed constructors validate source-only keys against `extra_items`
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3407,8 +3407,8 @@ def func(**kwargs: Unpack[TD2]) -> None:
 
 ### Call-site validation
 
-At the call site, required keys must be provided and known keys must be type-checked. Extra keywords
-are accepted as `object` for ordinary open `TypedDict`s.
+At the call site, required keys must be provided, known keys must be type-checked, and unknown
+keywords are rejected for ordinary open `TypedDict`s.
 
 ```py
 from typing_extensions import NotRequired, Required, TypedDict, Unpack
@@ -3427,6 +3427,8 @@ def func(**kwargs: Unpack[TD2]) -> None:
 func()
 func(v1=1, v3="ok")
 func(v1=1, v2="optional", v3="ok")
+
+# error: [unknown-argument]
 func(v1=1, v3="ok", v4=1)
 
 # error: [invalid-argument-type]
@@ -3467,8 +3469,8 @@ closed_movie(name="Blade Runner", year=1982)
 ### Assignability with explicit keyword-only signatures
 
 A callable using `**kwargs: Unpack[TD2]` should line up with equivalent explicit keyword-only
-signatures when assigning to the explicit form. The reverse assignment is rejected because an open
-unpacked `TypedDict` may still receive hidden extra items.
+signatures in either direction. Hidden items in an ordinary open `TypedDict` do not become
+call-site parameters.
 
 ```py
 from functools import partial
@@ -3495,13 +3497,13 @@ explicit_ok: ExplicitKwargs = func
 typed_dict_ok: TypedDictKwargs = func
 
 def _(explicit: ExplicitKwargs, typed_dict: TypedDictKwargs) -> None:
-    typed_dict_2: TypedDictKwargs = explicit  # error: [invalid-assignment]
+    typed_dict_2: TypedDictKwargs = explicit
     explicit_2: ExplicitKwargs = typed_dict
 
 def func7(*, v1: int, v3: str, v2: str = "") -> None:
     pass
 
-typed_dict_from_explicit: TypedDictKwargs = func7  # error: [invalid-assignment]
+typed_dict_from_explicit: TypedDictKwargs = func7
 
 class EmptyOpenTD(TypedDict):
     pass
@@ -3512,7 +3514,7 @@ class EmptyOpenTypedDictKwargs(Protocol):
 def no_kwargs() -> None:
     pass
 
-empty_open_typed_dict_from_explicit: EmptyOpenTypedDictKwargs = no_kwargs  # error: [invalid-assignment]
+empty_open_typed_dict_from_explicit: EmptyOpenTypedDictKwargs = no_kwargs
 
 class ClosedTD(TypedDict, closed=True):
     v1: Required[int]
@@ -3533,8 +3535,7 @@ class TraditionalKwargsTarget(Protocol):
 def traditional_kwargs_source(**kwargs: int) -> None:
     pass
 
-# TODO: This should be accepted because the declared field is assignable to `int`.
-traditional_kwargs_target: TraditionalKwargsTarget = traditional_kwargs_source  # error: [invalid-assignment]
+traditional_kwargs_target: TraditionalKwargsTarget = traditional_kwargs_source
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -3545,7 +3546,7 @@ def preserve_signature(callback: Callable[P, R]) -> Callable[P, R]:
 preserved_typed_dict_target: TypedDictKwargs = preserve_signature(func)
 
 partial_typed_dict_target: TypedDictKwargs = partial(func)
-partial_explicit_target: TypedDictKwargs = partial(func7)  # error: [invalid-assignment]
+partial_explicit_target: TypedDictKwargs = partial(func7)
 ```
 
 ### Missing required keys remain incompatible
@@ -3575,7 +3576,7 @@ missing_required: MissingRequiredKwarg = func
 ### Optional-only unpacked kwargs still expose named keys
 
 An unpacked all-optional open `TypedDict` exposes its declared keys as optional named keyword
-arguments while accepting extra keyword arguments as `object`.
+arguments while rejecting unknown keyword arguments.
 
 ```py
 from typing import Protocol
@@ -3591,6 +3592,8 @@ class WantsA(Protocol):
     def __call__(self, *, a: int = 1) -> None: ...
 
 wants_a: WantsA = accepts_optional_kwargs
+
+# error: [unknown-argument]
 accepts_optional_kwargs(b="whatever")
 
 # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -86,9 +86,12 @@ bad_key_updates: list[tuple[int, str]] = [(1, "Bobby")]
 
 bob.update(name_update)
 bob.update({"name": "Robert"})
+# error: [invalid-argument-type]
 bob.update([("name", "Bobby")])
+# error: [invalid-argument-type]
 bob.update([("age", 27)])
 bob.update(name_update, age=26)
+# error: [invalid-argument-type]
 bob.update([("name", "Bobby")], age=26)
 
 # error: [invalid-argument-type]
@@ -111,10 +114,13 @@ bob.update({"other": 1})
 # error: [invalid-argument-type]
 bob.update({"age": "bad"})
 
+# error: [invalid-argument-type]
 bob.update([("other", 1)])
 
+# error: [invalid-argument-type]
 bob.update([("age", "bad")])
 
+# error: [invalid-argument-type]
 bob.update(string_key_updates)
 
 # error: [invalid-argument-type]
@@ -6025,6 +6031,11 @@ class MutableExtra(TypedDict, extra_items=int):
 class ReadOnlyExtra(TypedDict, extra_items=ReadOnly[int]):
     name: str
 
+class ReadOnlyExtraOnly(TypedDict, extra_items=ReadOnly[int]): ...
+
+class AllIntItems(TypedDict, extra_items=int):
+    year: int
+
 class IntPatch(TypedDict, extra_items=int):
     name: NotRequired[str]
 
@@ -6040,8 +6051,10 @@ class OpenWithName(TypedDict):
 def _(
     mutable: MutableExtra,
     mutable_extra_only: MutableExtraOnly,
+    all_int_items: AllIntItems,
     open_with_name: OpenWithName,
     read_only: ReadOnlyExtra,
+    read_only_extra_only: ReadOnlyExtraOnly,
     ints: IntPatch,
     strings: StrPatch,
     open_patch: OpenPatch,
@@ -6051,12 +6064,20 @@ def _(
     mutable.update(year="not an int")  # error: [invalid-argument-type]
     mutable.update(strings)  # error: [invalid-argument-type]
     mutable_extra_only.update(open_patch)  # error: [invalid-argument-type]
+    mutable_extra_only.update([("year", 1982)])
+    mutable_extra_only.update([("year", "not an int")])  # error: [invalid-argument-type]
+    all_int_items.update([("other", 1982)])
+
+    # An arbitrary key may refer to either the declared `name` item or an extra item.
+    mutable.update([("year", 1982)])  # error: [invalid-argument-type]
 
     # The source's extra items may contain the target's declared `name` key with an incompatible type.
     open_with_name.update(mutable_extra_only)  # error: [invalid-argument-type]
 
     read_only.update(year=1982)  # error: [unknown-argument]
     read_only.update(ints)  # error: [invalid-argument-type]
+    read_only.update([("year", 1982)])  # error: [invalid-argument-type]
+    read_only_extra_only.update([("year", 1982)])  # error: [invalid-argument-type]
 ```
 
 ### Unpacking accounts for extra items

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6171,13 +6171,22 @@ class RequiredStr(TypedDict, closed=True):
     value: str
 
 class ClosedEmpty(TypedDict, closed=True): ...
+class OpenEmpty(TypedDict): ...
 class ReadOnlyIntExtras(TypedDict, extra_items=ReadOnly[int]): ...
+class ReadOnlyStrExtras(TypedDict, extra_items=ReadOnly[str]): ...
 class MutableIntExtras(TypedDict, extra_items=int): ...
+class MutableStrExtras(TypedDict, extra_items=str): ...
 
 static_assert(is_disjoint_from(RequiredInt, ClosedEmpty))
 static_assert(not is_disjoint_from(RequiredInt, ReadOnlyIntExtras))
 static_assert(is_disjoint_from(RequiredStr, ReadOnlyIntExtras))
 static_assert(is_disjoint_from(RequiredInt, MutableIntExtras))
+static_assert(is_disjoint_from(ClosedEmpty, MutableIntExtras))
+static_assert(is_disjoint_from(MutableIntExtras, MutableStrExtras))
+static_assert(is_disjoint_from(MutableIntExtras, ReadOnlyStrExtras))
+static_assert(not is_disjoint_from(MutableIntExtras, ReadOnlyIntExtras))
+static_assert(not is_disjoint_from(ClosedEmpty, ReadOnlyIntExtras))
+static_assert(not is_disjoint_from(OpenEmpty, MutableIntExtras))
 ```
 
 ### A `TypedDict` with `extra_items: T` is a subtype of `Mapping[str, T1]`, where `T1` is the union of `T` and all declared item types

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3467,8 +3467,7 @@ closed_movie(name="Blade Runner", year=1982)
 ### Assignability with explicit keyword-only signatures
 
 A callable using `**kwargs: Unpack[TD2]` should line up with equivalent explicit keyword-only
-signatures when assigning to the explicit form. The reverse assignment is rejected because an open
-unpacked `TypedDict` may still receive hidden extra items.
+signatures.
 
 ```py
 from typing import Protocol
@@ -3494,13 +3493,15 @@ explicit_ok: ExplicitKwargs = func
 typed_dict_ok: TypedDictKwargs = func
 
 def _(explicit: ExplicitKwargs, typed_dict: TypedDictKwargs) -> None:
-    typed_dict_2: TypedDictKwargs = explicit  # error: [invalid-assignment]
+    # TODO: This should be rejected because an open unpacked TypedDict may receive hidden items.
+    typed_dict_2: TypedDictKwargs = explicit
     explicit_2: ExplicitKwargs = typed_dict
 
 def func7(*, v1: int, v3: str, v2: str = "") -> None:
     pass
 
-typed_dict_from_explicit: TypedDictKwargs = func7  # error: [invalid-assignment]
+# TODO: This should be rejected because an open unpacked TypedDict may receive hidden items.
+typed_dict_from_explicit: TypedDictKwargs = func7
 ```
 
 ### Missing required keys remain incompatible

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5999,6 +5999,51 @@ def _(extra: Extra, key: str) -> None:
     del extra[key]
 ```
 
+### Deleting optional items from closed TypedDicts is permitted
+
+A closed TypedDict with only non-required, mutable items can safely support operations that may
+delete any item:
+
+```py
+from typing_extensions import ReadOnly, TypedDict
+
+class ClosedPartial(TypedDict, total=False, closed=True):
+    name: str
+    year: int
+
+FunctionalClosedPartial = TypedDict(
+    "FunctionalClosedPartial",
+    {"name": str, "year": int},
+    total=False,
+    closed=True,
+)
+
+class ClosedRequired(TypedDict, closed=True):
+    name: str
+
+class ClosedReadOnly(TypedDict, total=False, closed=True):
+    name: ReadOnly[str]
+
+def _(
+    partial: ClosedPartial,
+    functional: FunctionalClosedPartial,
+    required: ClosedRequired,
+    read_only: ClosedReadOnly,
+    key: str,
+) -> None:
+    partial.clear()
+    reveal_type(partial.popitem())  # revealed: tuple[str, str | int]
+    reveal_type(partial.pop(key))  # revealed: str | int
+    del partial[key]
+
+    functional.clear()
+    reveal_type(functional.popitem())  # revealed: tuple[str, str | int]
+    del functional[key]
+
+    required.clear()  # error: [unresolved-attribute]
+    read_only.clear()  # error: [unresolved-attribute]
+```
+
 ### `pop` and `setdefault` support literal extra-item keys
 
 Extra items behave like non-required items for methods that mutate a specific literal key.

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6244,11 +6244,22 @@ class ClosedEmpty(TypedDict, closed=True): ...
 class OpenEmpty(TypedDict): ...
 class ReadOnlyIntExtras(TypedDict, extra_items=ReadOnly[int]): ...
 class ReadOnlyStrExtras(TypedDict, extra_items=ReadOnly[str]): ...
+class ReadOnlyObjectExtras(TypedDict, extra_items=ReadOnly[object]): ...
 class MutableIntExtras(TypedDict, extra_items=int): ...
 class MutableStrExtras(TypedDict, extra_items=str): ...
+class MutableObjectExtras(TypedDict, extra_items=object): ...
 
 class OptionalInt(TypedDict):
     value: NotRequired[int]
+
+class OptionalObject(TypedDict):
+    value: NotRequired[object]
+
+class OptionalReadOnlyInt(TypedDict):
+    value: NotRequired[ReadOnly[int]]
+
+class OptionalReadOnlyObject(TypedDict):
+    value: NotRequired[ReadOnly[object]]
 
 static_assert(is_disjoint_from(RequiredInt, ClosedEmpty))
 static_assert(not is_disjoint_from(RequiredInt, ReadOnlyIntExtras))
@@ -6263,6 +6274,19 @@ static_assert(not is_disjoint_from(OpenEmpty, MutableIntExtras))
 static_assert(is_disjoint_from(OptionalInt, MutableStrExtras))
 static_assert(is_disjoint_from(MutableStrExtras, OptionalInt))
 static_assert(not is_disjoint_from(OptionalInt, MutableIntExtras))
+static_assert(is_disjoint_from(OptionalInt, ReadOnlyStrExtras))
+static_assert(is_disjoint_from(ReadOnlyStrExtras, OptionalInt))
+static_assert(not is_disjoint_from(OptionalInt, ReadOnlyIntExtras))
+static_assert(not is_disjoint_from(OptionalInt, ReadOnlyObjectExtras))
+static_assert(is_disjoint_from(OptionalObject, ReadOnlyIntExtras))
+static_assert(is_disjoint_from(ReadOnlyIntExtras, OptionalObject))
+static_assert(is_disjoint_from(OptionalReadOnlyInt, MutableStrExtras))
+static_assert(is_disjoint_from(MutableStrExtras, OptionalReadOnlyInt))
+static_assert(not is_disjoint_from(OptionalReadOnlyInt, MutableIntExtras))
+static_assert(is_disjoint_from(OptionalReadOnlyInt, MutableObjectExtras))
+static_assert(not is_disjoint_from(OptionalReadOnlyObject, MutableIntExtras))
+static_assert(not is_disjoint_from(OptionalReadOnlyInt, OpenEmpty))
+static_assert(not is_disjoint_from(OpenEmpty, OptionalReadOnlyInt))
 ```
 
 ### A `TypedDict` with `extra_items: T` is a subtype of `Mapping[str, T1]`, where `T1` is the union of `T` and all declared item types

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6258,6 +6258,9 @@ def _(
     accepts_ints(**strings)  # error: [invalid-argument-type]
     accepts_ints(**open_source)  # error: [invalid-argument-type]
     accepts_name(**ints)  # error: [unknown-argument]
+
+    # For backwards compatibility, implicit extra items on an ordinary open TypedDict are ignored
+    # when checking whether unpacking may supply unexpected arguments. Explicit extra items are not.
     accepts_name(**open_source)
     accepts_optional_int_label(**open_source)
     accepts_optional_label(**extra_only)  # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6002,7 +6002,14 @@ class ExtraOnly(TypedDict, extra_items=int): ...
 def accepts_ints(name: str, **kwargs: int) -> None: ...
 def accepts_name(name: str) -> None: ...
 def accepts_optional_label(*, label: str = "", **kwargs: int) -> None: ...
-def _(ints: IntSource, strings: StrSource, open_source: OpenSource, extra_only: ExtraOnly) -> None:
+def _(
+    ints: IntSource,
+    strings: StrSource,
+    open_source: OpenSource,
+    extra_only: ExtraOnly,
+    int_mapping: dict[str, int],
+    str_mapping: dict[str, str],
+) -> None:
     accepts_ints(**ints)
     accepts_ints(**strings)  # error: [invalid-argument-type]
     accepts_name(**ints)  # error: [unknown-argument]
@@ -6014,6 +6021,12 @@ def _(ints: IntSource, strings: StrSource, open_source: OpenSource, extra_only: 
     ClosedTarget(**ints)  # error: [invalid-key]
 
     copied: IntTarget = {**open_source}  # error: [invalid-argument-type]
+
+    ExtraOnly(**str_mapping)  # error: [invalid-argument-type]
+    copied_from_mapping: ExtraOnly = {**str_mapping}  # error: [invalid-argument-type]
+
+    # An arbitrary mapping key may collide with the target's declared `label` item.
+    OptionalTarget(**int_mapping)  # error: [invalid-argument-type]
 
     # The extra-items tail may contain the target's optional `label` key with an incompatible type.
     OptionalTarget(**extra_only)  # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4913,14 +4913,12 @@ class ClosedBar(TypedDict, closed=True):
 
 def _(u: ClosedFoo | ClosedBar, v: Literal["foo"]):
     if "foo" in u:
-        # TODO: should be `ClosedFoo`
-        reveal_type(u)  # revealed: ClosedFoo | (ClosedBar & <TypedDict with items 'foo'>)
+        reveal_type(u)  # revealed: ClosedFoo
     else:
         reveal_type(u)  # revealed: ClosedBar
 
     if v in u:
-        # TODO: should be `ClosedFoo`
-        reveal_type(u)  # revealed: ClosedFoo | (ClosedBar & <TypedDict with items 'foo'>)
+        reveal_type(u)  # revealed: ClosedFoo
     else:
         reveal_type(u)  # revealed: ClosedBar
 ```
@@ -4940,8 +4938,7 @@ def _(
     if "bar" not in u:
         reveal_type(u)  # revealed: ClosedFoo
     else:
-        # TODO: should be `ClosedBar & Any`
-        reveal_type(u)  # revealed: (ClosedFoo & <TypedDict with items 'bar'>) | (ClosedBar & Any)
+        reveal_type(u)  # revealed: ClosedBar & Any
 
     if "bar" not in v:
         reveal_type(v)  # revealed: Never
@@ -4951,8 +4948,7 @@ def _(
     if w not in u:
         reveal_type(u)  # revealed: ClosedFoo
     else:
-        # TODO: should be `ClosedBar & Any`
-        reveal_type(u)  # revealed: (ClosedFoo & <TypedDict with items 'bar'>) | (ClosedBar & Any)
+        reveal_type(u)  # revealed: ClosedBar & Any
 ```
 
 ## Narrowing tagged unions of `TypedDict`s with `match` statements

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5920,12 +5920,16 @@ from typing_extensions import TypedDict
 class Extra(TypedDict, extra_items=int):
     name: str
 
-def _(extra: Extra) -> None:
+class ArbitraryPop(TypedDict, total=False, extra_items=int):
+    label: str
+
+def _(extra: Extra, arbitrary: ArbitraryPop, key: str) -> None:
     reveal_type(extra.get("year"))  # revealed: int | None
     reveal_type(extra.get("year", "missing"))  # revealed: int | Literal["missing"]
     reveal_type(extra.pop("year"))  # revealed: int
     reveal_type(extra.pop("year", "missing"))  # revealed: int | Literal["missing"]
     reveal_type(extra.setdefault("year", 1982))  # revealed: int
+    reveal_type(arbitrary.pop(key))  # revealed: str | int
 
     # error: [invalid-argument-type]
     extra.setdefault("year", "not an int")

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6036,6 +6036,15 @@ def _(
     # The extra-items tail may contain the target's optional `label` key with an incompatible type.
     OptionalTarget(**extra_only)  # error: [invalid-argument-type]
     optional: OptionalTarget = {**extra_only}  # error: [invalid-argument-type]
+
+    # A later value for `label` shadows the potentially incompatible value from the extra-items
+    # tail.
+    OptionalTarget(**{**extra_only, "label": "ok"})
+    shadowed: OptionalTarget = {**extra_only, "label": "ok"}
+    OptionalTarget(extra_only, label="ok")
+
+    # In the reverse order, the extra-items tail may overwrite `label`.
+    OptionalTarget(**{"label": "ok", **extra_only})  # error: [invalid-argument-type]
 ```
 
 ### Non-literal keys in an `extra_items` TypedDict constructor must be safe for every possible key

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6023,6 +6023,9 @@ class StrSource(TypedDict, extra_items=str):
 class OpenSource(TypedDict):
     name: str
 
+class OpenTarget(TypedDict):
+    name: str
+
 class IntTarget(TypedDict, extra_items=int):
     name: str
 
@@ -6053,6 +6056,9 @@ def _(
     accepts_ints(**strings)  # error: [invalid-argument-type]
     accepts_name(**ints)  # error: [unknown-argument]
     accepts_optional_label(**extra_only)  # error: [invalid-argument-type]
+
+    OpenTarget(name="ok", **extra_only)  # error: [invalid-key]
+    copied_into_open: OpenTarget = {"name": "ok", **extra_only}  # error: [invalid-key]
 
     IntTarget(**ints)
     IntTarget(**strings)  # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6417,10 +6417,14 @@ class ExtraInt(TypedDict, extra_items=int):
 class ExtraStr(TypedDict, extra_items=str):
     name: str
 
-# Mutable extra items must be equivalent, not just assignable
-#
+class ExtraBool(TypedDict, extra_items=bool):
+    name: str
+
+# Mutable extra items must be equivalent, not just assignable.
 static_assert(not is_assignable_to(ExtraInt, ExtraStr))
 static_assert(not is_assignable_to(ExtraStr, ExtraInt))
+static_assert(not is_assignable_to(ExtraBool, ExtraInt))
+static_assert(not is_assignable_to(ExtraInt, ExtraBool))
 
 class ReadOnlyExtraInt(TypedDict, extra_items=ReadOnly[int]):
     name: str
@@ -6428,9 +6432,14 @@ class ReadOnlyExtraInt(TypedDict, extra_items=ReadOnly[int]):
 class ReadOnlyExtraIntStr(TypedDict, extra_items=ReadOnly[int | str]):
     name: str
 
-# Read-only extra items: covariant, so narrower is assignable to wider
+class ReadOnlyExtraBool(TypedDict, extra_items=ReadOnly[bool]):
+    name: str
+
+# Read-only extra items are covariant, so narrower is assignable to wider.
 static_assert(is_subtype_of(ReadOnlyExtraInt, ReadOnlyExtraIntStr))
 static_assert(not is_assignable_to(ReadOnlyExtraIntStr, ReadOnlyExtraInt))
+static_assert(is_assignable_to(ReadOnlyExtraBool, ReadOnlyExtraInt))
+static_assert(not is_assignable_to(ReadOnlyExtraInt, ReadOnlyExtraBool))
 
 # A closed TypedDict is assignable to an open one (open implicitly has ReadOnly[object] extras)
 class Closed(TypedDict, closed=True):
@@ -6451,6 +6460,43 @@ static_assert(is_assignable_to(ExtraInt, Open))
 # But not vice versa
 #
 static_assert(not is_assignable_to(Open, ExtraInt))
+
+class ClosedWithBool(TypedDict, closed=True):
+    name: str
+    source_only: bool
+
+class ClosedWithInt(TypedDict, closed=True):
+    name: str
+    source_only: int
+
+# A closed target rejects source-only items.
+static_assert(not is_assignable_to(ClosedWithInt, Closed))
+
+# Read-only extra items accept source-only fields covariantly.
+static_assert(is_assignable_to(ClosedWithBool, ReadOnlyExtraInt))
+static_assert(not is_assignable_to(ClosedWithInt, ReadOnlyExtraBool))
+
+class MutableSourceValid(TypedDict, extra_items=int):
+    name: str
+    source_only: NotRequired[int]
+
+class MutableSourceReadOnly(TypedDict, extra_items=int):
+    name: str
+    source_only: NotRequired[ReadOnly[int]]
+
+class MutableSourceRequired(TypedDict, extra_items=int):
+    name: str
+    source_only: int
+
+class MutableSourceBool(TypedDict, extra_items=int):
+    name: str
+    source_only: NotRequired[bool]
+
+# Mutable extra items require source-only fields to be mutable, non-required, and equivalent.
+static_assert(is_assignable_to(MutableSourceValid, ExtraInt))
+static_assert(not is_assignable_to(MutableSourceReadOnly, ExtraInt))
+static_assert(not is_assignable_to(MutableSourceRequired, ExtraInt))
+static_assert(not is_assignable_to(MutableSourceBool, ExtraInt))
 ```
 
 Non-required items in the target that are absent in the source must be accounted for by the source's

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -567,6 +567,7 @@ class SharedKwargsTD(TypedDict):
     x: int
 
 # error: [invalid-argument-type]
+# error: [invalid-key] "TypedDict `SharedKwargsTD` requires string keys, got key of type `Literal[1]`"
 SharedKwargsTD(**{"x": 1, 1: 2})
 
 # error: [invalid-argument-type]
@@ -5692,13 +5693,16 @@ c: ClosedMovie = {"name": "Blade Runner", "year": 1982}
 ClosedMovie(name="Blade Runner", year=1982)
 ```
 
-Closed and extra-items TypedDicts also reject non-string keys:
+TypedDicts reject non-string keys regardless of their openness:
 
 ```py
 from typing_extensions import TypedDict
 
 class ExtraOnly(TypedDict, extra_items=int): ...
 class ClosedEmpty(TypedDict, closed=True): ...
+
+class OpenSource(TypedDict):
+    name: str
 
 # error: [invalid-key] "TypedDict `ExtraOnly` requires string keys, got key of type `Literal[1]`"
 extra: ExtraOnly = {1: 1}
@@ -5711,6 +5715,16 @@ ExtraOnly({1: 1})
 
 # error: [invalid-key] "TypedDict `ClosedEmpty` requires string keys, got key of type `Literal[1]`"
 ClosedEmpty({1: 1})
+
+# error: [invalid-key] "TypedDict `OpenSource` requires string keys, got key of type `Literal[1]`"
+open_source: OpenSource = {"name": "x", 1: 1}
+
+# error: [invalid-key] "TypedDict `OpenSource` requires string keys, got key of type `Literal[1]`"
+OpenSource({"name": "x", 1: 1})
+
+def _(int_keys: dict[int, int]) -> None:
+    merged: OpenSource = {"name": "x", **int_keys}  # error: [invalid-argument-type]
+    OpenSource({"name": "x", **int_keys})  # error: [invalid-argument-type]
 ```
 
 The functional syntax also supports `extra_items`:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3512,6 +3512,14 @@ class TypedDictKwargs(Protocol):
 explicit_ok: ExplicitKwargs = func
 typed_dict_ok: TypedDictKwargs = func
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def preserve_signature(callback: Callable[P, R]) -> Callable[P, R]:
+    return callback
+
+preserved_typed_dict_target: TypedDictKwargs = preserve_signature(func)
+
 def _(explicit: ExplicitKwargs, typed_dict: TypedDictKwargs) -> None:
     typed_dict_2: TypedDictKwargs = explicit  # error: [invalid-assignment]
     explicit_2: ExplicitKwargs = typed_dict
@@ -3552,14 +3560,6 @@ def traditional_kwargs_source(**kwargs: int) -> None:
     pass
 
 traditional_kwargs_target: TraditionalKwargsTarget = traditional_kwargs_source  # error: [invalid-assignment]
-
-P = ParamSpec("P")
-R = TypeVar("R")
-
-def preserve_signature(callback: Callable[P, R]) -> Callable[P, R]:
-    return callback
-
-preserved_typed_dict_target: TypedDictKwargs = preserve_signature(func)
 
 partial_typed_dict_target: TypedDictKwargs = partial(func)
 partial_explicit_target: TypedDictKwargs = partial(func7)  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6313,6 +6313,9 @@ def _(
     # For backwards compatibility, implicit extra items on an ordinary open TypedDict are ignored
     # when checking whether unpacking may supply unexpected arguments. Explicit extra items are not.
     accepts_name(**open_source)
+
+    # TODO: This should arguably be rejected because `open_source` may contain a hidden `label`
+    # whose value is not assignable to `int`, but no other type checker rejects it.
     accepts_optional_int_label(**open_source)
     accepts_optional_label(**extra_only)  # error: [invalid-argument-type]
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6069,6 +6069,15 @@ def _(key: str) -> None:
 
     # The runtime key may be `label`, so the value must also be assignable to `str`.
     bad_declared_item: WithDeclaredItem = {key: 1}  # error: [invalid-argument-type]
+
+    # A later literal value overrides the arbitrary key if it resolves to `label`.
+    shadowed_declared_item: WithDeclaredItem = {key: 1, "label": "ok"}
+
+    # In the reverse order, the arbitrary key may overwrite `label`.
+    bad_shadowing_declared_item: WithDeclaredItem = {
+        "label": "ok",
+        key: 1,  # error: [invalid-argument-type]
+    }
 ```
 
 ### Non-literal keys in a closed TypedDict constructor are rejected

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2594,15 +2594,21 @@ def _(p: Person) -> None:
 `TypedDict` class definitions have some special properties that can be used for introspection:
 
 ```py
-from typing import TypedDict
+from typing_extensions import TypedDict
 
 class Person(TypedDict):
     name: str
     age: int | None
 
+FunctionalPerson = TypedDict("FunctionalPerson", {"name": str, "age": int | None})
+
 reveal_type(Person.__total__)  # revealed: bool
 reveal_type(Person.__required_keys__)  # revealed: frozenset[str]
 reveal_type(Person.__optional_keys__)  # revealed: frozenset[str]
+reveal_type(Person.__closed__)  # revealed: bool | None
+reveal_type(Person.__extra_items__)  # revealed: Any
+reveal_type(FunctionalPerson.__closed__)  # revealed: bool | None
+reveal_type(FunctionalPerson.__extra_items__)  # revealed: Any
 ```
 
 These attributes cannot be accessed on inhabitants:
@@ -2612,6 +2618,8 @@ def _(person: Person) -> None:
     person.__total__  # error: [unresolved-attribute]
     person.__required_keys__  # error: [unresolved-attribute]
     person.__optional_keys__  # error: [unresolved-attribute]
+    person.__closed__  # error: [unresolved-attribute]
+    person.__extra_items__  # error: [unresolved-attribute]
 ```
 
 Also, they cannot be accessed on `type(person)`, as that would be `dict` at runtime:
@@ -2621,6 +2629,8 @@ def _(person: Person) -> None:
     type(person).__total__  # error: [unresolved-attribute]
     type(person).__required_keys__  # error: [unresolved-attribute]
     type(person).__optional_keys__  # error: [unresolved-attribute]
+    type(person).__closed__  # error: [unresolved-attribute]
+    type(person).__extra_items__  # error: [unresolved-attribute]
 ```
 
 But they _can_ be accessed on `type[Person]`, because this function would accept the class object
@@ -2631,6 +2641,8 @@ def accepts_typed_dict_class(t_person: type[Person]) -> None:
     reveal_type(t_person.__total__)  # revealed: bool
     reveal_type(t_person.__required_keys__)  # revealed: frozenset[str]
     reveal_type(t_person.__optional_keys__)  # revealed: frozenset[str]
+    reveal_type(t_person.__closed__)  # revealed: bool | None
+    reveal_type(t_person.__extra_items__)  # revealed: Any
 
 accepts_typed_dict_class(Person)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3407,8 +3407,8 @@ def func(**kwargs: Unpack[TD2]) -> None:
 
 ### Call-site validation
 
-At the call site, required keys must be provided, known keys must be type-checked, and extra
-keywords are rejected unless the `TypedDict` has explicit extra items.
+At the call site, required keys must be provided and known keys must be type-checked. Extra keywords
+are accepted as `object` for ordinary open `TypedDict`s.
 
 ```py
 from typing_extensions import NotRequired, Required, TypedDict, Unpack
@@ -3427,7 +3427,7 @@ def func(**kwargs: Unpack[TD2]) -> None:
 func()
 func(v1=1, v3="ok")
 func(v1=1, v2="optional", v3="ok")
-func(v1=1, v3="ok", v4=1)  # error: [unknown-argument]
+func(v1=1, v3="ok", v4=1)
 
 # error: [invalid-argument-type]
 func(v1=1, v3=1)
@@ -3533,7 +3533,8 @@ class TraditionalKwargsTarget(Protocol):
 def traditional_kwargs_source(**kwargs: int) -> None:
     pass
 
-traditional_kwargs_target: TraditionalKwargsTarget = traditional_kwargs_source
+# TODO: This should be accepted because the declared field is assignable to `int`.
+traditional_kwargs_target: TraditionalKwargsTarget = traditional_kwargs_source  # error: [invalid-assignment]
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -3574,7 +3575,7 @@ missing_required: MissingRequiredKwarg = func
 ### Optional-only unpacked kwargs still expose named keys
 
 An unpacked all-optional open `TypedDict` exposes its declared keys as optional named keyword
-arguments, but does not accept unknown keyword arguments.
+arguments while accepting extra keyword arguments as `object`.
 
 ```py
 from typing import Protocol
@@ -3590,7 +3591,7 @@ class WantsA(Protocol):
     def __call__(self, *, a: int = 1) -> None: ...
 
 wants_a: WantsA = accepts_optional_kwargs
-accepts_optional_kwargs(b="whatever")  # error: [unknown-argument]
+accepts_optional_kwargs(b="whatever")
 
 # error: [invalid-argument-type]
 accepts_optional_kwargs(a="bad")

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6056,6 +6056,31 @@ def _(
     read_only.clear()  # error: [unresolved-attribute]
 ```
 
+### `get` accounts for closed TypedDicts
+
+An arbitrary string key can only refer to a declared item on a closed TypedDict:
+
+```py
+from typing_extensions import TypedDict
+
+class Closed(TypedDict, closed=True):
+    name: str
+    year: int
+
+FunctionalClosed = TypedDict(
+    "FunctionalClosed",
+    {"name": str, "year": int},
+    closed=True,
+)
+
+class EmptyClosed(TypedDict, closed=True): ...
+
+def _(closed: Closed, functional: FunctionalClosed, empty: EmptyClosed, key: str) -> None:
+    reveal_type(closed.get(key))  # revealed: str | int | None
+    reveal_type(functional.get(key))  # revealed: str | int | None
+    reveal_type(empty.get(key))  # revealed: None
+```
+
 ### `pop` and `setdefault` support literal extra-item keys
 
 Extra items behave like non-required items for methods that mutate a specific literal key.

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6000,6 +6000,8 @@ class IntTarget(TypedDict, extra_items=int):
 class ClosedTarget(TypedDict, closed=True):
     name: str
 
+class ClosedOnly(TypedDict, closed=True): ...
+
 class OptionalTarget(TypedDict, extra_items=int):
     label: NotRequired[str]
 
@@ -6030,6 +6032,9 @@ def _(
 
     ExtraOnly(**str_mapping)  # error: [invalid-argument-type]
     copied_from_mapping: ExtraOnly = {**str_mapping}  # error: [invalid-argument-type]
+
+    ClosedOnly(**int_mapping)  # error: [invalid-key]
+    copied_into_closed: ClosedOnly = {**int_mapping}  # error: [invalid-key]
 
     # An arbitrary mapping key may collide with the target's declared `label` item.
     OptionalTarget(**int_mapping)  # error: [invalid-argument-type]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6004,6 +6004,7 @@ An unpacked extra-items TypedDict can supply arbitrary additional keyword argume
 type must therefore be compatible with the target's extra-items policy:
 
 ```py
+from collections.abc import Mapping
 from typing_extensions import NotRequired, TypedDict
 
 class IntSource(TypedDict, extra_items=int):
@@ -6038,6 +6039,8 @@ def _(
     extra_only: ExtraOnly,
     int_mapping: dict[str, int],
     str_mapping: dict[str, str],
+    int_key_dict: dict[int, int],
+    int_key_mapping: Mapping[int, int],
 ) -> None:
     accepts_ints(**ints)
     accepts_ints(**strings)  # error: [invalid-argument-type]
@@ -6053,6 +6056,8 @@ def _(
 
     ExtraOnly(**str_mapping)  # error: [invalid-argument-type]
     copied_from_mapping: ExtraOnly = {**str_mapping}  # error: [invalid-argument-type]
+    copied_from_int_key_dict: ExtraOnly = {**int_key_dict}  # error: [invalid-argument-type]
+    copied_from_int_key_mapping: ExtraOnly = {**int_key_mapping}  # error: [invalid-argument-type]
 
     ClosedOnly(**int_mapping)  # error: [invalid-key]
     copied_into_closed: ClosedOnly = {**int_mapping}  # error: [invalid-key]

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3504,14 +3504,31 @@ class TD2(TD1):
 def func(**kwargs: Unpack[TD2]) -> None:
     pass
 
+class ExtraTD(TypedDict, extra_items=int):
+    name: str
+
+def extra_typed_dict(**kwargs: Unpack[ExtraTD]) -> None:
+    pass
+
+def extra_explicit(*, name: str, **kwargs: int) -> None:
+    pass
+
 class ExplicitKwargs(Protocol):
     def __call__(self, *, v1: int, v3: str, v2: str = "") -> None: ...
 
 class TypedDictKwargs(Protocol):
     def __call__(self, **kwargs: Unpack[TD2]) -> None: ...
 
+class ExtraExplicitKwargs(Protocol):
+    def __call__(self, *, name: str, **kwargs: int) -> None: ...
+
+class ExtraTypedDictKwargs(Protocol):
+    def __call__(self, **kwargs: Unpack[ExtraTD]) -> None: ...
+
 explicit_ok: ExplicitKwargs = func
 typed_dict_ok: TypedDictKwargs = func
+extra_explicit_from_typed_dict: ExtraExplicitKwargs = extra_typed_dict
+extra_typed_dict_from_explicit: ExtraTypedDictKwargs = extra_explicit
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -3520,6 +3537,8 @@ def preserve_signature(callback: Callable[P, R]) -> Callable[P, R]:
     return callback
 
 preserved_typed_dict_target: TypedDictKwargs = preserve_signature(func)
+preserved_extra_explicit: ExtraExplicitKwargs = preserve_signature(extra_typed_dict)
+preserved_extra_typed_dict: ExtraTypedDictKwargs = preserve_signature(extra_explicit)
 
 def _(explicit: ExplicitKwargs, typed_dict: TypedDictKwargs) -> None:
     typed_dict_2: TypedDictKwargs = explicit  # error: [invalid-assignment]
@@ -3564,6 +3583,8 @@ traditional_kwargs_target: TraditionalKwargsTarget = traditional_kwargs_source  
 
 partial_typed_dict_target: TypedDictKwargs = partial(func)
 partial_explicit_target: TypedDictKwargs = partial(func7)  # error: [invalid-assignment]
+partial_extra_explicit: ExtraExplicitKwargs = partial(extra_typed_dict)
+partial_extra_typed_dict: ExtraTypedDictKwargs = partial(extra_explicit)
 ```
 
 ### Missing required keys remain incompatible

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -189,6 +189,40 @@ bob |= {"age": 27}
 bob |= name_update
 ```
 
+In-place merges cannot supply read-only items, while non-mutating merges can:
+
+```py
+from typing_extensions import NotRequired, ReadOnly, TypedDict
+
+class R(TypedDict):
+    readonly: NotRequired[ReadOnly[int]]
+    mutable: int
+
+class MutableExtras(TypedDict, extra_items=int): ...
+class ReadOnlyExtras(TypedDict, extra_items=ReadOnly[int]): ...
+
+def _(
+    r: R,
+    another_r: R,
+    mutable_extras: MutableExtras,
+    readonly_extras: ReadOnlyExtras,
+    value: int,
+) -> None:
+    reveal_type(r | {"readonly": value})  # revealed: R
+
+    # error: [unsupported-operator] "Operator `|=` is not supported between objects of type `R` and `dict[str, int]`"
+    r |= {"readonly": value}
+
+    # error: [unsupported-operator] "Operator `|=` is not supported between two objects of type `R`"
+    r |= another_r
+
+    r |= {"mutable": value}
+    mutable_extras |= {"x": value}
+
+    # error: [unsupported-operator] "Operator `|=` is not supported between objects of type `ReadOnlyExtras` and `dict[str, int]`"
+    readonly_extras |= {"x": value}
+```
+
 TODO: protocol matching for synthesized `TypedDict.__or__` should also accept these cases:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6259,6 +6259,7 @@ keys. The reverse is not true, however. `dict[str, VT]` is not assignable to suc
 type, as an inhabitant of this type might be an instance of a subclass of `dict`.
 
 ```py
+from typing import Any
 from typing_extensions import TypedDict, NotRequired
 from ty_extensions import static_assert, is_subtype_of, is_assignable_to, is_equivalent_to
 
@@ -6294,6 +6295,13 @@ static_assert(not is_equivalent_to(BoolDictWithNum, dict[str, int]))
 def _(bool_dict_with_num: BoolDictWithNum) -> None:
     bool_dict_with_num.clear()
     reveal_type(bool_dict_with_num.popitem())  # revealed: tuple[str, int]
+
+class GradualIntDict(TypedDict, extra_items=int):
+    value: NotRequired[Any]
+
+# Assignability uses consistency for gradual item types, while subtyping remains strict.
+static_assert(is_assignable_to(GradualIntDict, dict[str, int]))
+static_assert(not is_subtype_of(GradualIntDict, dict[str, int]))
 ```
 
 A TypedDict with a required key is not assignable to `dict[str, VT]`:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -6099,6 +6099,7 @@ class ExtraOnly(TypedDict, extra_items=int): ...
 
 def accepts_ints(name: str, **kwargs: int) -> None: ...
 def accepts_name(name: str) -> None: ...
+def accepts_optional_int_label(name: str, *, label: int = 0) -> None: ...
 def accepts_optional_label(*, label: str = "", **kwargs: int) -> None: ...
 def _(
     ints: IntSource,
@@ -6112,7 +6113,10 @@ def _(
 ) -> None:
     accepts_ints(**ints)
     accepts_ints(**strings)  # error: [invalid-argument-type]
+    accepts_ints(**open_source)  # error: [invalid-argument-type]
     accepts_name(**ints)  # error: [unknown-argument]
+    accepts_name(**open_source)
+    accepts_optional_int_label(**open_source)
     accepts_optional_label(**extra_only)  # error: [invalid-argument-type]
 
     OpenTarget(name="ok", **extra_only)  # error: [invalid-key]

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -248,6 +248,26 @@ fn definition_expression_type<'db>(
     }
 }
 
+/// Return the qualifiers for a deferred annotation expression that is a sub-expression of a
+/// [`Definition`].
+///
+/// Supports expressions that are evaluated within a type-params sub-scope.
+fn definition_expression_qualifiers<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+    expression: &ast::Expr,
+) -> TypeQualifiers {
+    let file = definition.file(db);
+    let index = semantic_index(db, file);
+    let file_scope = index.expression_scope_id(expression);
+    let scope = file_scope.to_scope_id(db, file);
+    if scope == definition.scope(db) {
+        infer_deferred_types(db, definition).qualifiers(expression)
+    } else {
+        infer_complete_scope_types(db, scope).qualifiers(expression)
+    }
+}
+
 struct ApplyDefaultTypeMapping;
 struct ApplyTopMaterialization;
 struct ApplyBottomMaterialization;

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -219,9 +219,8 @@ impl<'db> Type<'db> {
             Type::TypedDict(td) => {
                 if td.items(db).values().any(TypedDictField::is_required) {
                     Truthiness::AlwaysTrue
-                } else if td.items(db).is_empty() && td.openness(db).is_closed() {
-                    Truthiness::AlwaysFalse
                 } else {
+                    // TODO: Empty closed TypedDicts can be inferred as always falsy.
                     Truthiness::Ambiguous
                 }
             }

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -219,9 +219,9 @@ impl<'db> Type<'db> {
             Type::TypedDict(td) => {
                 if td.items(db).values().any(TypedDictField::is_required) {
                     Truthiness::AlwaysTrue
+                } else if td.items(db).is_empty() && td.openness(db).is_closed() {
+                    Truthiness::AlwaysFalse
                 } else {
-                    // We can potentially infer empty typeddicts as always falsy if they're `closed=True`,
-                    // but as of 22-01-26 we don't yet support PEP 728.
                     Truthiness::Ambiguous
                 }
             }

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -247,14 +247,6 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         self.items.iter().map(|item| (item.argument, &item.types))
     }
 
-    pub(crate) fn iter_mut(
-        &mut self,
-    ) -> impl Iterator<Item = (Argument<'a>, &mut CallArgumentTypes<'db>)> + '_ {
-        self.items
-            .iter_mut()
-            .map(|item| (item.argument, &mut item.types))
-    }
-
     /// Create a new [`CallArguments`] starting from the specified index.
     pub(crate) fn start_from(&self, index: usize) -> Self {
         Self {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -55,7 +55,9 @@ use crate::types::signatures::{
     PartialApplication, PartialSignatureApplication,
 };
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
-use crate::types::typed_dict::extract_unpacked_typed_dict_from_value_type;
+use crate::types::typed_dict::{
+    UnpackedTypedDictTail, extract_unpacked_typed_dict_from_value_type,
+};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarNonceGenerator};
 use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
 use crate::types::{
@@ -4673,6 +4675,8 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         if let Some(unpacked) =
             argument_type.and_then(|ty| extract_unpacked_typed_dict_from_value_type(db, ty))
         {
+            let tail = unpacked.tail;
+
             // Special case TypedDict-shaped values because we know which keys are present.
             for (name, unpacked_key) in unpacked.keys {
                 let _ = self.match_keyword(
@@ -4682,11 +4686,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     name.as_str(),
                 );
             }
-            if let Some(extra_items_ty) = unpacked.extra_items_ty {
-                self.match_typed_dict_extra_items(argument_index, extra_items_ty);
-            } else if !unpacked.is_closed {
-                self.match_open_typed_dict_extra_items(argument_index);
-            }
+            self.match_typed_dict_tail(argument_index, tail);
         } else {
             for (parameter_index, parameter) in self.parameters.iter().enumerate() {
                 if self.parameter_info[parameter_index].matched && !parameter.is_keyword_variadic()
@@ -4728,34 +4728,15 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         }
     }
 
-    /// Match the possible hidden keyword arguments in an implicitly-open `TypedDict`.
+    /// Match the possible arbitrary keyword arguments represented by a `TypedDict` tail.
     ///
-    /// Hidden extra items can constrain an existing keyword-variadic parameter, but they should
-    /// not cause unknown-key errors when the destination has no `**kwargs`.
-    fn match_open_typed_dict_extra_items(&mut self, argument_index: usize) {
-        let Some((parameter_index, parameter)) = self.parameters.keyword_variadic() else {
+    /// Explicit tail items can constrain named parameters without satisfying required parameters,
+    /// and require a keyword-variadic parameter to accept all remaining names. A hidden open tail
+    /// only constrains an existing keyword-variadic parameter.
+    fn match_typed_dict_tail(&mut self, argument_index: usize, tail: UnpackedTypedDictTail<'db>) {
+        let Some(extra_items_ty) = tail.value_ty() else {
             return;
         };
-
-        self.assign_argument(
-            argument_index,
-            Argument::Keywords,
-            // TODO: Use the `TypedDict`'s extra-items type once PEP 728 is fully supported, and
-            // omit this match for closed `TypedDict`s.
-            Some(Type::object()),
-            InvalidArgumentTypeProvenance::OpenTypedDictExtraItems,
-            parameter_index,
-            parameter,
-            false,
-            true,
-        );
-    }
-
-    /// Match the possible arbitrary keyword arguments exposed by explicit `TypedDict` extra items.
-    ///
-    /// Extra items are non-required, so they can constrain named parameters without satisfying
-    /// required parameters. Any remaining names are accepted only by a keyword-variadic parameter.
-    fn match_typed_dict_extra_items(&mut self, argument_index: usize, extra_items_ty: Type<'db>) {
         let mut has_keyword_variadic = false;
 
         for (parameter_index, parameter) in self.parameters.iter().enumerate() {
@@ -4775,13 +4756,17 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     argument_index,
                     Argument::Keywords,
                     Some(extra_items_ty),
-                    InvalidArgumentTypeProvenance::Argument,
+                    if matches!(tail, UnpackedTypedDictTail::Hidden) {
+                        InvalidArgumentTypeProvenance::OpenTypedDictExtraItems
+                    } else {
+                        InvalidArgumentTypeProvenance::Argument
+                    },
                     parameter_index,
                     parameter,
                     false,
                     true,
                 );
-            } else {
+            } else if tail.is_explicit() {
                 let matched_argument = &mut self.argument_matches[argument_index];
                 matched_argument.parameters.push(MatchedParameter {
                     index: parameter_index,
@@ -4791,7 +4776,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             }
         }
 
-        if !has_keyword_variadic {
+        if tail.is_explicit() && !has_keyword_variadic {
             self.errors
                 .push(BindingError::UnknownKeywordVariadicArgument {
                     argument_index: self.get_argument_index(argument_index),

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4736,41 +4736,19 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         argument_index: usize,
         openness: TypedDictOpenness<'db>,
     ) {
-        let Some(extra_items) = openness.effective_extra_items() else {
-            return;
+        let (extra_items_ty, has_explicit_extra_items) = match openness {
+            TypedDictOpenness::Open => (Type::object(), false),
+            TypedDictOpenness::Closed => return,
+            TypedDictOpenness::Extra(extra_items) => (extra_items.declared_ty, true),
         };
-        let extra_items_ty = extra_items.declared_ty;
-        let has_explicit_extra_items = openness.explicit_extra_items().is_some();
-        let mut has_keyword_variadic = false;
 
-        for (parameter_index, parameter) in self.parameters.iter().enumerate() {
-            if self.parameter_info[parameter_index].matched && !parameter.is_keyword_variadic() {
-                continue;
-            }
-            if matches!(
-                parameter.kind(),
-                ParameterKind::PositionalOnly { .. } | ParameterKind::Variadic { .. }
-            ) {
-                continue;
-            }
-
-            if parameter.is_keyword_variadic() {
-                has_keyword_variadic = true;
-                self.assign_argument(
-                    argument_index,
-                    Argument::Keywords,
-                    Some(extra_items_ty),
-                    if openness.is_open() {
-                        InvalidArgumentTypeProvenance::OpenTypedDictExtraItems
-                    } else {
-                        InvalidArgumentTypeProvenance::Argument
-                    },
-                    parameter_index,
-                    parameter,
-                    false,
-                    true,
-                );
-            } else if has_explicit_extra_items {
+        if has_explicit_extra_items {
+            for (parameter_index, parameter) in self.parameters.iter().enumerate() {
+                if self.parameter_info[parameter_index].matched
+                    || parameter.keyword_name().is_none()
+                {
+                    continue;
+                }
                 let matched_argument = &mut self.argument_matches[argument_index];
                 matched_argument.parameters.push(MatchedParameter {
                     index: parameter_index,
@@ -4780,7 +4758,22 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             }
         }
 
-        if has_explicit_extra_items && !has_keyword_variadic {
+        if let Some((parameter_index, parameter)) = self.parameters.keyword_variadic() {
+            self.assign_argument(
+                argument_index,
+                Argument::Keywords,
+                Some(extra_items_ty),
+                if openness.is_open() {
+                    InvalidArgumentTypeProvenance::OpenTypedDictExtraItems
+                } else {
+                    InvalidArgumentTypeProvenance::Argument
+                },
+                parameter_index,
+                parameter,
+                false,
+                true,
+            );
+        } else if has_explicit_extra_items {
             self.errors
                 .push(BindingError::UnknownKeywordVariadicArgument {
                     argument_index: self.get_argument_index(argument_index),

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4737,7 +4737,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         openness: TypedDictOpenness<'db>,
     ) {
         let (extra_items_ty, has_explicit_extra_items) = match openness {
-            TypedDictOpenness::Open => (Type::object(), false),
+            TypedDictOpenness::ImplicitlyOpen => (Type::object(), false),
             TypedDictOpenness::Closed => return,
             TypedDictOpenness::Extra(extra_items) => (extra_items.declared_ty, true),
         };
@@ -4763,7 +4763,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                 argument_index,
                 Argument::Keywords,
                 Some(extra_items_ty),
-                if openness.is_open() {
+                if openness.is_implicitly_open() {
                     InvalidArgumentTypeProvenance::OpenTypedDictExtraItems
                 } else {
                     InvalidArgumentTypeProvenance::Argument

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -55,9 +55,7 @@ use crate::types::signatures::{
     PartialApplication, PartialSignatureApplication,
 };
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
-use crate::types::typed_dict::{
-    UnpackedTypedDictTail, extract_unpacked_typed_dict_from_value_type,
-};
+use crate::types::typed_dict::{TypedDictOpenness, extract_unpacked_typed_dict_from_value_type};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarNonceGenerator};
 use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
 use crate::types::{
@@ -4675,7 +4673,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         if let Some(unpacked) =
             argument_type.and_then(|ty| extract_unpacked_typed_dict_from_value_type(db, ty))
         {
-            let tail = unpacked.tail;
+            let openness = unpacked.openness;
 
             // Special case TypedDict-shaped values because we know which keys are present.
             for (name, unpacked_key) in unpacked.keys {
@@ -4686,7 +4684,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     name.as_str(),
                 );
             }
-            self.match_typed_dict_tail(argument_index, tail);
+            self.match_typed_dict_openness(argument_index, openness);
         } else {
             for (parameter_index, parameter) in self.parameters.iter().enumerate() {
                 if self.parameter_info[parameter_index].matched && !parameter.is_keyword_variadic()
@@ -4728,15 +4726,21 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         }
     }
 
-    /// Match the possible arbitrary keyword arguments represented by a `TypedDict` tail.
+    /// Match the possible arbitrary keyword arguments represented by a `TypedDict`'s openness.
     ///
-    /// Explicit tail items can constrain named parameters without satisfying required parameters,
-    /// and require a keyword-variadic parameter to accept all remaining names. A hidden open tail
+    /// Explicit extra items can constrain named parameters without satisfying required parameters,
+    /// and require a keyword-variadic parameter to accept all remaining names. An open `TypedDict`
     /// only constrains an existing keyword-variadic parameter.
-    fn match_typed_dict_tail(&mut self, argument_index: usize, tail: UnpackedTypedDictTail<'db>) {
-        let Some(extra_items_ty) = tail.value_ty() else {
+    fn match_typed_dict_openness(
+        &mut self,
+        argument_index: usize,
+        openness: TypedDictOpenness<'db>,
+    ) {
+        let Some(extra_items) = openness.effective_extra_items() else {
             return;
         };
+        let extra_items_ty = extra_items.declared_ty;
+        let has_explicit_extra_items = openness.explicit_extra_items().is_some();
         let mut has_keyword_variadic = false;
 
         for (parameter_index, parameter) in self.parameters.iter().enumerate() {
@@ -4756,7 +4760,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     argument_index,
                     Argument::Keywords,
                     Some(extra_items_ty),
-                    if matches!(tail, UnpackedTypedDictTail::Hidden) {
+                    if openness.is_open() {
                         InvalidArgumentTypeProvenance::OpenTypedDictExtraItems
                     } else {
                         InvalidArgumentTypeProvenance::Argument
@@ -4766,7 +4770,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     false,
                     true,
                 );
-            } else if tail.is_explicit() {
+            } else if has_explicit_extra_items {
                 let matched_argument = &mut self.argument_matches[argument_index];
                 matched_argument.parameters.push(MatchedParameter {
                     index: parameter_index,
@@ -4776,7 +4780,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             }
         }
 
-        if tail.is_explicit() && !has_keyword_variadic {
+        if has_explicit_extra_items && !has_keyword_variadic {
             self.errors
                 .push(BindingError::UnknownKeywordVariadicArgument {
                     argument_index: self.get_argument_index(argument_index),

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -55,7 +55,7 @@ use crate::types::signatures::{
     PartialApplication, PartialSignatureApplication,
 };
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
-use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_value_type;
+use crate::types::typed_dict::extract_unpacked_typed_dict_from_value_type;
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarNonceGenerator};
 use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
 use crate::types::{
@@ -3064,7 +3064,11 @@ impl<'db> CallableBinding<'db> {
                             continue;
                         }
                         relevant_count += 1;
-                        if matches!(error, BindingError::UnknownArgument { .. }) {
+                        if matches!(
+                            error,
+                            BindingError::UnknownArgument { .. }
+                                | BindingError::UnknownKeywordVariadicArgument { .. }
+                        ) {
                             unknown_argument_count += 1;
                         }
                     }
@@ -4666,11 +4670,11 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         argument_index: usize,
         argument_type: Option<Type<'db>>,
     ) {
-        if let Some(unpacked_keys) =
-            argument_type.and_then(|ty| extract_unpacked_typed_dict_keys_from_value_type(db, ty))
+        if let Some(unpacked) =
+            argument_type.and_then(|ty| extract_unpacked_typed_dict_from_value_type(db, ty))
         {
             // Special case TypedDict-shaped values because we know which keys are present.
-            for (name, unpacked_key) in unpacked_keys {
+            for (name, unpacked_key) in unpacked.keys {
                 let _ = self.match_keyword(
                     argument_index,
                     Argument::Keywords,
@@ -4678,7 +4682,11 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     name.as_str(),
                 );
             }
-            self.match_open_typed_dict_extra_items(argument_index);
+            if let Some(extra_items_ty) = unpacked.extra_items_ty {
+                self.match_typed_dict_extra_items(argument_index, extra_items_ty);
+            } else if !unpacked.is_closed {
+                self.match_open_typed_dict_extra_items(argument_index);
+            }
         } else {
             for (parameter_index, parameter) in self.parameters.iter().enumerate() {
                 if self.parameter_info[parameter_index].matched && !parameter.is_keyword_variadic()
@@ -4741,6 +4749,54 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             false,
             true,
         );
+    }
+
+    /// Match the possible arbitrary keyword arguments exposed by explicit `TypedDict` extra items.
+    ///
+    /// Extra items are non-required, so they can constrain named parameters without satisfying
+    /// required parameters. Any remaining names are accepted only by a keyword-variadic parameter.
+    fn match_typed_dict_extra_items(&mut self, argument_index: usize, extra_items_ty: Type<'db>) {
+        let mut has_keyword_variadic = false;
+
+        for (parameter_index, parameter) in self.parameters.iter().enumerate() {
+            if self.parameter_info[parameter_index].matched && !parameter.is_keyword_variadic() {
+                continue;
+            }
+            if matches!(
+                parameter.kind(),
+                ParameterKind::PositionalOnly { .. } | ParameterKind::Variadic { .. }
+            ) {
+                continue;
+            }
+
+            if parameter.is_keyword_variadic() {
+                has_keyword_variadic = true;
+                self.assign_argument(
+                    argument_index,
+                    Argument::Keywords,
+                    Some(extra_items_ty),
+                    InvalidArgumentTypeProvenance::Argument,
+                    parameter_index,
+                    parameter,
+                    false,
+                    true,
+                );
+            } else {
+                let matched_argument = &mut self.argument_matches[argument_index];
+                matched_argument.parameters.push(MatchedParameter {
+                    index: parameter_index,
+                    argument_type: Some(extra_items_ty),
+                    provenance: InvalidArgumentTypeProvenance::Argument,
+                });
+            }
+        }
+
+        if !has_keyword_variadic {
+            self.errors
+                .push(BindingError::UnknownKeywordVariadicArgument {
+                    argument_index: self.get_argument_index(argument_index),
+                });
+        }
     }
 
     fn finish(self) -> Box<[MatchedArgument<'db>]> {
@@ -5566,7 +5622,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         argument_type: Type<'db>,
         paramspec_component_start: Option<usize>,
     ) {
-        if extract_unpacked_typed_dict_keys_from_value_type(self.db, argument_type).is_some() {
+        if extract_unpacked_typed_dict_from_value_type(self.db, argument_type).is_some() {
             for matched_parameter in self.argument_matches[argument_index].iter() {
                 let parameter_index = matched_parameter.index;
                 if paramspec_component_start.is_some_and(|start| parameter_index >= start) {
@@ -6466,6 +6522,7 @@ impl<'db> Binding<'db> {
                 error,
                 BindingError::MissingArguments { .. }
                     | BindingError::UnknownArgument { .. }
+                    | BindingError::UnknownKeywordVariadicArgument { .. }
                     | BindingError::PositionalOnlyParameterAsKwarg { .. }
                     | BindingError::TooManyPositionalArguments { .. }
                     | BindingError::ParameterAlreadyAssigned { .. }
@@ -6966,6 +7023,10 @@ pub(crate) enum BindingError<'db> {
         argument_name: ast::name::Name,
         argument_index: Option<usize>,
     },
+    /// An unpacked keyword argument may contain names that don't match any parameter.
+    UnknownKeywordVariadicArgument {
+        argument_index: Option<usize>,
+    },
     /// A positional-only parameter is passed as keyword argument.
     PositionalOnlyParameterAsKwarg {
         argument_index: Option<usize>,
@@ -7019,6 +7080,7 @@ impl BindingError<'_> {
             Self::InvalidArgumentType { .. }
                 | Self::InvalidKeyType { .. }
                 | Self::UnknownArgument { .. }
+                | Self::UnknownKeywordVariadicArgument { .. }
                 | Self::PositionalOnlyParameterAsKwarg { .. }
                 | Self::TooManyPositionalArguments { .. }
                 | Self::ParameterAlreadyAssigned { .. }
@@ -7067,6 +7129,7 @@ impl BindingError<'_> {
             BindingError::InvalidArgumentType { argument_index, .. }
             | BindingError::InvalidKeyType { argument_index, .. }
             | BindingError::UnknownArgument { argument_index, .. }
+            | BindingError::UnknownKeywordVariadicArgument { argument_index }
             | BindingError::PositionalOnlyParameterAsKwarg { argument_index, .. }
             | BindingError::ParameterAlreadyAssigned { argument_index, .. }
             | BindingError::SpecializationError { argument_index, .. } => {
@@ -7153,6 +7216,7 @@ impl<'db> BindingError<'db> {
             | Self::InvalidKeyType { .. }
             | Self::MissingArguments { .. }
             | Self::UnknownArgument { .. }
+            | Self::UnknownKeywordVariadicArgument { .. }
             | Self::PositionalOnlyParameterAsKwarg { .. }
             | Self::TooManyPositionalArguments { .. }
             | Self::ParameterAlreadyAssigned { .. }
@@ -7422,6 +7486,28 @@ impl<'db> BindingError<'db> {
                 if let Some(builder) = context.report_lint(&UNKNOWN_ARGUMENT, node) {
                     let mut diag = builder.into_diagnostic(format_args!(
                         "Argument `{argument_name}` does not match any known parameter{}",
+                        callable_description
+                            .map(|description| format!(" of {description}"))
+                            .unwrap_or_default()
+                    ));
+                    if let Some(compound_diag) = compound_diag {
+                        compound_diag.add_context(context.db(), &mut diag);
+                    } else if let Some(spans) = callable_ty.function_spans(context.db()) {
+                        let mut sub = SubDiagnostic::new(
+                            SubDiagnosticSeverity::Info,
+                            format_args!("{callable_kind} signature here"),
+                        );
+                        sub.annotate(Annotation::primary(spans.signature));
+                        diag.sub(sub);
+                    }
+                }
+            }
+
+            Self::UnknownKeywordVariadicArgument { argument_index } => {
+                let node = Self::get_node(node, *argument_index);
+                if let Some(builder) = context.report_lint(&UNKNOWN_ARGUMENT, node) {
+                    let mut diag = builder.into_diagnostic(format_args!(
+                        "Unpacked argument may contain keyword arguments that do not match any known parameter{}",
                         callable_description
                             .map(|description| format!(" of {description}"))
                             .unwrap_or_default()

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5420,7 +5420,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     constraints,
                     argument_index,
                     adjusted_argument_index,
-                    argument,
                     // Splatted arguments are inferred without type context.
                     argument_types.get_default().unwrap_or(Type::unknown()),
                     paramspec_component_start,
@@ -5600,29 +5599,17 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         constraints: &ConstraintSetBuilder<'db>,
         argument_index: usize,
         adjusted_argument_index: Option<usize>,
-        argument: Argument<'a>,
         argument_type: Type<'db>,
         paramspec_component_start: Option<usize>,
     ) {
         if extract_unpacked_typed_dict_from_value_type(self.db, argument_type).is_some() {
-            for matched_parameter in self.argument_matches[argument_index].iter() {
-                let parameter_index = matched_parameter.index;
-                if paramspec_component_start.is_some_and(|start| parameter_index >= start) {
-                    continue;
-                }
-
-                self.check_argument_type(
-                    constraints,
-                    argument_index,
-                    adjusted_argument_index,
-                    argument,
-                    matched_parameter
-                        .argument_type
-                        .unwrap_or_else(Type::unknown),
-                    matched_parameter,
-                );
-            }
-
+            self.check_variadic_argument_type(
+                constraints,
+                argument_index,
+                adjusted_argument_index,
+                Argument::Keywords,
+                paramspec_component_start,
+            );
             return;
         }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -3046,8 +3046,23 @@ impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
                 })
             });
 
+        let extra_items_variance = TypedDictType::new(self.identity_specialization(db))
+            .explicit_extra_items(db)
+            .map(|extra_items| {
+                let polarity = if extra_items.is_read_only() {
+                    TypeVarVariance::Covariant
+                } else {
+                    TypeVarVariance::Invariant
+                };
+                extra_items
+                    .declared_ty
+                    .with_polarity(polarity)
+                    .variance_of(db, typevar)
+            });
+
         attribute_variances
             .chain(explicit_bases_variances)
+            .chain(extra_items_variance)
             .collect()
     }
 }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -46,7 +46,7 @@ use crate::{
         member::{Member, class_member},
         mro::{Mro, MroIterator},
         signatures::CallableSignature,
-        tuple::{FixedLengthTuple, Tuple, TupleSpec, TupleType},
+        tuple::{FixedLengthTuple, Tuple},
         typed_dict::{TypedDictParams, TypedDictType, typed_dict_params_from_class_def},
         variance::VarianceInferable,
         visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard},

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -46,8 +46,8 @@ use crate::{
         member::{Member, class_member},
         mro::{Mro, MroIterator},
         signatures::CallableSignature,
-        tuple::{FixedLengthTuple, Tuple},
-        typed_dict::{TypedDictParams, typed_dict_params_from_class_def},
+        tuple::{FixedLengthTuple, Tuple, TupleSpec, TupleType},
+        typed_dict::{TypedDictParams, TypedDictType, typed_dict_params_from_class_def},
         variance::VarianceInferable,
         visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard},
     },
@@ -1099,9 +1099,13 @@ impl<'db> StaticClassLiteral<'db> {
 
         match result {
             ClassMemberResult::Done(result) => result.finalize(db),
-            ClassMemberResult::TypedDict => {
-                typed_dict_class_member(db, ClassLiteral::Static(self), policy, name)
-            }
+            ClassMemberResult::TypedDict => typed_dict_class_member(
+                db,
+                TypedDictType::new(self.identity_specialization(db)),
+                ClassLiteral::Static(self),
+                policy,
+                name,
+            ),
         }
     }
 
@@ -1636,11 +1640,14 @@ impl<'db> StaticClassLiteral<'db> {
                         Type::heterogeneous_tuple(db, slots)
                     })
             }
-            (CodeGeneratorKind::TypedDict, name) => {
-                synthesize_typed_dict_method(db, instance_ty, name, || {
-                    TypedDictFields::Static(self.fields(db, specialization, field_policy))
-                })
-            }
+            (CodeGeneratorKind::TypedDict, name) => synthesize_typed_dict_method(
+                db,
+                instance_ty
+                    .as_typed_dict()
+                    .expect("TypedDict code generation should use a TypedDict instance"),
+                name,
+                || TypedDictFields::Static(self.fields(db, specialization, field_policy)),
+            ),
             _ => None,
         }
     }
@@ -1758,22 +1765,13 @@ impl<'db> StaticClassLiteral<'db> {
         if let Some(member) = self.own_synthesized_member(db, specialization, None, name) {
             Place::bound(member).into()
         } else {
-            KnownClass::TypedDictFallback
-                .to_class_literal(db)
-                .find_name_in_mro_with_policy(db, name, policy)
-                .expect("`find_name_in_mro_with_policy` will return `Some()` when called on class literal")
-                .map_type(|ty| {
-                    let new_upper_bound = determine_upper_bound(
-                        db,
-                        ClassLiteral::Static(self),
-                        ClassBase::is_typed_dict
-                    );
-                    ty.apply_type_mapping(
-                        db,
-                        &TypeMapping::ReplaceSelf { new_upper_bound },
-                        TypeContext::default(),
-                    )
-                })
+            let class = match specialization {
+                Some(specialization) => {
+                    ClassType::Generic(GenericAlias::new(db, self, specialization))
+                }
+                None => self.identity_specialization(db),
+            };
+            typed_dict_class_member(db, TypedDictType::new(class), self.into(), policy, name)
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -8,19 +8,22 @@ use ruff_python_ast::NodeIndex;
 use ruff_python_ast::name::Name;
 use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_text_size::{Ranged, TextRange};
+use ty_module_resolver::KnownModule;
 
 use crate::place::PlaceAndQualifiers;
+use crate::place::known_module_symbol;
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::generics::GenericContext;
 use crate::types::member::Member;
 use crate::types::mro::Mro;
 use crate::types::signatures::{CallableSignature, Parameter, Parameters, Signature};
 use crate::types::typed_dict::{
-    TypedDictField, TypedDictSchema, deferred_functional_typed_dict_schema,
+    TypedDictField, TypedDictOpenness, TypedDictSchema, deferred_functional_typed_dict_openness,
+    deferred_functional_typed_dict_schema,
 };
 use crate::types::{
     BoundTypeVarInstance, CallableType, ClassBase, ClassLiteral, ClassType, KnownClass,
-    MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeVarVariance, UnionType,
+    MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeVarVariance, TypedDictType, UnionType,
     determine_upper_bound,
 };
 use crate::{Db, FxIndexMap};
@@ -29,19 +32,26 @@ use ty_python_core::scope::ScopeId;
 
 pub(super) fn synthesize_typed_dict_method<'db>(
     db: &'db dyn Db,
-    instance_ty: Type<'db>,
+    typed_dict: TypedDictType<'db>,
     method_name: &str,
     fields: impl Fn() -> TypedDictFields<'db>,
 ) -> Option<Type<'db>> {
+    let instance_ty = Type::TypedDict(typed_dict);
     match method_name {
-        "__init__" => Some(synthesize_typed_dict_init(db, instance_ty, fields())),
-        "__getitem__" => Some(synthesize_typed_dict_getitem(db, instance_ty, fields())),
-        "__setitem__" => Some(synthesize_typed_dict_setitem(db, instance_ty, fields())),
-        "__delitem__" => Some(synthesize_typed_dict_delitem(db, instance_ty, fields())),
-        "get" => Some(synthesize_typed_dict_get(db, instance_ty, fields())),
-        "update" => Some(synthesize_typed_dict_update(db, instance_ty, fields())),
-        "pop" => Some(synthesize_typed_dict_pop(db, instance_ty, fields())),
-        "setdefault" => Some(synthesize_typed_dict_setdefault(db, instance_ty, fields())),
+        "__init__" => Some(synthesize_typed_dict_init(db, typed_dict, fields())),
+        "__getitem__" => Some(synthesize_typed_dict_getitem(db, typed_dict, fields())),
+        "__setitem__" => Some(synthesize_typed_dict_setitem(db, typed_dict, fields())),
+        "__delitem__" => Some(synthesize_typed_dict_delitem(db, typed_dict, fields())),
+        "get" => Some(synthesize_typed_dict_get(db, typed_dict, fields())),
+        "update" => Some(synthesize_typed_dict_update(db, typed_dict, fields())),
+        "pop" => Some(synthesize_typed_dict_pop(db, typed_dict, fields())),
+        "setdefault" => Some(synthesize_typed_dict_setdefault(db, typed_dict, fields())),
+        "clear" | "popitem" if typed_dict.supports_arbitrary_key_deletion(db) => Some(
+            synthesize_typed_dict_arbitrary_deletion_method(db, typed_dict, method_name),
+        ),
+        "items" | "keys" | "values" if typed_dict.explicit_extra_items(db).is_some() => Some(
+            synthesize_typed_dict_view_method(db, typed_dict, method_name),
+        ),
         "__or__" | "__ror__" | "__ior__" => {
             Some(synthesize_typed_dict_merge(db, instance_ty, method_name))
         }
@@ -93,16 +103,25 @@ impl<'db> TypedDictFields<'db> {
 ///    Keyword-only. Fields that are not valid Python identifiers are collapsed into `**kwargs`.
 fn synthesize_typed_dict_init<'db>(
     db: &'db dyn Db,
-    instance_ty: Type<'db>,
+    typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
+    let instance_ty = Type::TypedDict(typed_dict);
     let keyword_fields: Vec<_> = fields
         .iter()
         .filter(|(name, _)| is_identifier(name))
         .collect();
 
-    let keyword_rest_param = (keyword_fields.len() != fields.len())
-        .then(|| Parameter::keyword_variadic(Name::new_static("kwargs")));
+    let keyword_rest_param = typed_dict
+        .explicit_extra_items(db)
+        .map(|extra_items| {
+            Parameter::keyword_variadic(Name::new_static("kwargs"))
+                .with_annotated_type(extra_items.declared_ty)
+        })
+        .or_else(|| {
+            (keyword_fields.len() != fields.len())
+                .then(|| Parameter::keyword_variadic(Name::new_static("kwargs")))
+        });
 
     let self_param =
         Parameter::positional_only(Some(Name::new_static("self"))).with_annotated_type(instance_ty);
@@ -160,9 +179,10 @@ fn synthesize_typed_dict_init<'db>(
 /// Synthesize the `__getitem__` method for a `TypedDict`.
 fn synthesize_typed_dict_getitem<'db>(
     db: &'db dyn Db,
-    instance_ty: Type<'db>,
+    typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
+    let instance_ty = Type::TypedDict(typed_dict);
     let overloads = fields
         .iter()
         .map(|(field_name, field)| {
@@ -185,7 +205,11 @@ fn synthesize_typed_dict_getitem<'db>(
                         .with_annotated_type(KnownClass::Str.to_instance(db)),
                 ],
             ),
-            Type::object(),
+            if typed_dict.explicit_extra_items(db).is_some() {
+                typed_dict.value_type(db)
+            } else {
+                Type::object()
+            },
         )));
 
     Type::Callable(CallableType::new(
@@ -199,15 +223,17 @@ fn synthesize_typed_dict_getitem<'db>(
 /// Synthesize the `__setitem__` method for a `TypedDict`.
 fn synthesize_typed_dict_setitem<'db>(
     db: &'db dyn Db,
-    instance_ty: Type<'db>,
+    typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
+    let instance_ty = Type::TypedDict(typed_dict);
     let mut writable_fields = fields
         .iter()
         .filter(|(_, field)| !field.is_read_only())
         .peekable();
+    let arbitrary_key_write_type = typed_dict.arbitrary_key_write_type(db);
 
-    if writable_fields.peek().is_none() {
+    if writable_fields.peek().is_none() && arbitrary_key_write_type.is_none() {
         let parameters = [
             Parameter::positional_only(Some(Name::new_static("self")))
                 .with_annotated_type(instance_ty),
@@ -220,17 +246,30 @@ fn synthesize_typed_dict_setitem<'db>(
         return Type::function_like_callable(db, signature);
     }
 
-    let overloads = writable_fields.map(|(field_name, field)| {
-        let key_type = Type::string_literal(db, field_name);
-        let parameters = [
-            Parameter::positional_only(Some(Name::new_static("self")))
-                .with_annotated_type(instance_ty),
-            Parameter::positional_only(Some(Name::new_static("key"))).with_annotated_type(key_type),
-            Parameter::positional_only(Some(Name::new_static("value")))
-                .with_annotated_type(field.declared_ty),
-        ];
-        Signature::new(Parameters::new(db, parameters), Type::none(db))
-    });
+    let overloads = writable_fields
+        .map(|(field_name, field)| {
+            let key_type = Type::string_literal(db, field_name);
+            let parameters = [
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("key")))
+                    .with_annotated_type(key_type),
+                Parameter::positional_only(Some(Name::new_static("value")))
+                    .with_annotated_type(field.declared_ty),
+            ];
+            Signature::new(Parameters::new(db, parameters), Type::none(db))
+        })
+        .chain(arbitrary_key_write_type.map(|value_ty| {
+            let parameters = [
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("key")))
+                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+                Parameter::positional_only(Some(Name::new_static("value")))
+                    .with_annotated_type(value_ty),
+            ];
+            Signature::new(Parameters::new(db, parameters), Type::none(db))
+        }));
 
     Type::Callable(CallableType::new(
         db,
@@ -243,15 +282,16 @@ fn synthesize_typed_dict_setitem<'db>(
 /// Synthesize the `__delitem__` method for a `TypedDict`.
 fn synthesize_typed_dict_delitem<'db>(
     db: &'db dyn Db,
-    instance_ty: Type<'db>,
+    typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
+    let instance_ty = Type::TypedDict(typed_dict);
     let mut deletable_fields = fields
         .iter()
-        .filter(|(_, field)| !field.is_required())
+        .filter(|(_, field)| !field.is_required() && !field.is_read_only())
         .peekable();
 
-    if deletable_fields.peek().is_none() {
+    if deletable_fields.peek().is_none() && !typed_dict.supports_arbitrary_key_deletion(db) {
         let parameters = [
             Parameter::positional_only(Some(Name::new_static("self")))
                 .with_annotated_type(instance_ty),
@@ -262,15 +302,26 @@ fn synthesize_typed_dict_delitem<'db>(
         return Type::function_like_callable(db, signature);
     }
 
-    let overloads = deletable_fields.map(|(field_name, _)| {
-        let key_type = Type::string_literal(db, field_name);
-        let parameters = [
-            Parameter::positional_only(Some(Name::new_static("self")))
-                .with_annotated_type(instance_ty),
-            Parameter::positional_only(Some(Name::new_static("key"))).with_annotated_type(key_type),
-        ];
-        Signature::new(Parameters::new(db, parameters), Type::none(db))
-    });
+    let overloads = deletable_fields
+        .map(|(field_name, _)| {
+            let key_type = Type::string_literal(db, field_name);
+            let parameters = [
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("key")))
+                    .with_annotated_type(key_type),
+            ];
+            Signature::new(Parameters::new(db, parameters), Type::none(db))
+        })
+        .chain(typed_dict.supports_arbitrary_key_deletion(db).then(|| {
+            let parameters = [
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("key")))
+                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+            ];
+            Signature::new(Parameters::new(db, parameters), Type::none(db))
+        }));
 
     Type::Callable(CallableType::new(
         db,
@@ -283,9 +334,15 @@ fn synthesize_typed_dict_delitem<'db>(
 /// Synthesize the `get` method for a `TypedDict`.
 fn synthesize_typed_dict_get<'db>(
     db: &'db dyn Db,
-    instance_ty: Type<'db>,
+    typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
+    let instance_ty = Type::TypedDict(typed_dict);
+    let fallback_value_ty = if typed_dict.explicit_extra_items(db).is_some() {
+        typed_dict.value_type(db)
+    } else {
+        Type::unknown()
+    };
     let overloads = fields
         .iter()
         .flat_map(|(field_name, field)| {
@@ -367,7 +424,7 @@ fn synthesize_typed_dict_get<'db>(
                         .with_annotated_type(KnownClass::Str.to_instance(db)),
                 ],
             ),
-            UnionType::from_two_elements(db, Type::unknown(), Type::none(db)),
+            UnionType::from_two_elements(db, fallback_value_ty, Type::none(db)),
         )))
         .chain(std::iter::once({
             let t_default = BoundTypeVarInstance::synthetic(
@@ -388,7 +445,7 @@ fn synthesize_typed_dict_get<'db>(
             Signature::new_generic(
                 Some(GenericContext::from_typevar_instances(db, [t_default])),
                 Parameters::new(db, parameterss),
-                UnionType::from_two_elements(db, Type::unknown(), Type::TypeVar(t_default)),
+                UnionType::from_two_elements(db, fallback_value_ty, Type::TypeVar(t_default)),
             )
         }));
 
@@ -403,26 +460,34 @@ fn synthesize_typed_dict_get<'db>(
 /// Synthesize the `update` method for a `TypedDict`.
 fn synthesize_typed_dict_update<'db>(
     db: &'db dyn Db,
-    instance_ty: Type<'db>,
+    typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
-    let keyword_parameters = fields.iter().map(|(field_name, field)| {
-        let ty = if field.is_read_only() {
-            Type::Never
-        } else {
-            field.declared_ty
-        };
-        Parameter::keyword_only(field_name.clone())
-            .with_annotated_type(ty)
-            .with_default_type(ty)
-            .with_definition(field.first_declaration())
-    });
+    let instance_ty = Type::TypedDict(typed_dict);
+    let keyword_parameters = fields
+        .iter()
+        .map(|(field_name, field)| {
+            let ty = if field.is_read_only() {
+                Type::Never
+            } else {
+                field.declared_ty
+            };
+            Parameter::keyword_only(field_name.clone())
+                .with_annotated_type(ty)
+                .with_default_type(ty)
+                .with_definition(field.first_declaration())
+        })
+        .chain(
+            typed_dict
+                .explicit_extra_items(db)
+                .filter(|extra_items| !extra_items.is_read_only())
+                .map(|extra_items| {
+                    Parameter::keyword_variadic(Name::new_static("kwargs"))
+                        .with_annotated_type(extra_items.declared_ty)
+                }),
+        );
 
-    let update_patch_ty = if let Type::TypedDict(typed_dict) = instance_ty {
-        Type::TypedDict(typed_dict.to_update_patch(db))
-    } else {
-        instance_ty
-    };
+    let update_patch_ty = Type::TypedDict(typed_dict.to_update_patch(db));
 
     let str_object_tuple =
         Type::heterogeneous_tuple(db, [KnownClass::Str.to_instance(db), Type::object()]);
@@ -449,12 +514,13 @@ fn synthesize_typed_dict_update<'db>(
 /// Synthesize the `pop` method for a `TypedDict`.
 fn synthesize_typed_dict_pop<'db>(
     db: &'db dyn Db,
-    instance_ty: Type<'db>,
+    typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
+    let instance_ty = Type::TypedDict(typed_dict);
     let overloads = fields
         .iter()
-        .filter(|(_, field)| !field.is_required())
+        .filter(|(_, field)| !field.is_required() && !field.is_read_only())
         .flat_map(|(field_name, field)| {
             let key_type = Type::string_literal(db, field_name);
 
@@ -504,7 +570,20 @@ fn synthesize_typed_dict_pop<'db>(
             );
 
             [pop_sig, pop_with_typed_default_sig, pop_with_default_sig]
-        });
+        })
+        .chain(typed_dict.supports_arbitrary_key_deletion(db).then(|| {
+            let value_ty = typed_dict
+                .explicit_extra_items(db)
+                .expect("arbitrary deletion requires explicit extra items")
+                .declared_ty;
+            let pop_parameters = [
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("key")))
+                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+            ];
+            Signature::new(Parameters::new(db, pop_parameters), value_ty)
+        }));
 
     Type::Callable(CallableType::new(
         db,
@@ -517,21 +596,37 @@ fn synthesize_typed_dict_pop<'db>(
 /// Synthesize the `setdefault` method for a `TypedDict`.
 fn synthesize_typed_dict_setdefault<'db>(
     db: &'db dyn Db,
-    instance_ty: Type<'db>,
+    typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
-    let overloads = fields.iter().map(|(field_name, field)| {
-        let key_type = Type::string_literal(db, field_name);
-        let parameters = [
-            Parameter::positional_only(Some(Name::new_static("self")))
-                .with_annotated_type(instance_ty),
-            Parameter::positional_only(Some(Name::new_static("key"))).with_annotated_type(key_type),
-            Parameter::positional_only(Some(Name::new_static("default")))
-                .with_annotated_type(field.declared_ty),
-        ];
+    let instance_ty = Type::TypedDict(typed_dict);
+    let overloads = fields
+        .iter()
+        .filter(|(_, field)| !field.is_read_only())
+        .map(|(field_name, field)| {
+            let key_type = Type::string_literal(db, field_name);
+            let parameters = [
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("key")))
+                    .with_annotated_type(key_type),
+                Parameter::positional_only(Some(Name::new_static("default")))
+                    .with_annotated_type(field.declared_ty),
+            ];
 
-        Signature::new(Parameters::new(db, parameters), field.declared_ty)
-    });
+            Signature::new(Parameters::new(db, parameters), field.declared_ty)
+        })
+        .chain(typed_dict.arbitrary_key_write_type(db).map(|default_ty| {
+            let parameters = [
+                Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty),
+                Parameter::positional_only(Some(Name::new_static("key")))
+                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+                Parameter::positional_only(Some(Name::new_static("default")))
+                    .with_annotated_type(default_ty),
+            ];
+            Signature::new(Parameters::new(db, parameters), typed_dict.value_type(db))
+        }));
 
     Type::Callable(CallableType::new(
         db,
@@ -539,6 +634,74 @@ fn synthesize_typed_dict_setdefault<'db>(
         CallableTypeKind::FunctionLike,
         CallableFunctionProvenance::None,
     ))
+}
+
+/// Synthesize `clear` or `popitem` when every possible key can be deleted.
+fn synthesize_typed_dict_arbitrary_deletion_method<'db>(
+    db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
+    name: &str,
+) -> Type<'db> {
+    let return_ty = match name {
+        "clear" => Type::none(db),
+        "popitem" => Type::heterogeneous_tuple(
+            db,
+            [KnownClass::Str.to_instance(db), typed_dict.value_type(db)],
+        ),
+        _ => return Type::unknown(),
+    };
+    Type::function_like_callable(
+        db,
+        Signature::new(
+            Parameters::new(
+                db,
+                [Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(Type::TypedDict(typed_dict))],
+            ),
+            return_ty,
+        ),
+    )
+}
+
+/// Synthesize `items`, `keys`, or `values` for a `TypedDict` with explicit extra items.
+fn synthesize_typed_dict_view_method<'db>(
+    db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
+    name: &str,
+) -> Type<'db> {
+    let instance_ty = Type::TypedDict(typed_dict);
+    let view_name = match name {
+        "items" => "dict_items",
+        "keys" => "dict_keys",
+        "values" => "dict_values",
+        _ => return Type::unknown(),
+    };
+    let return_ty = known_module_symbol(db, KnownModule::CollectionsAbcInternal, view_name)
+        .place
+        .ignore_possibly_undefined()
+        .and_then(Type::as_class_literal)
+        .map(|class| {
+            class.apply_specialization(db, |generic_context| {
+                generic_context.specialize(
+                    db,
+                    &[KnownClass::Str.to_instance(db), typed_dict.value_type(db)],
+                )
+            })
+        })
+        .and_then(|class| Type::from(class).to_instance(db))
+        .unwrap_or_else(Type::unknown);
+
+    Type::function_like_callable(
+        db,
+        Signature::new(
+            Parameters::new(
+                db,
+                [Parameter::positional_only(Some(Name::new_static("self")))
+                    .with_annotated_type(instance_ty)],
+            ),
+            return_ty,
+        ),
+    )
 }
 
 /// Synthesize a merge operator (`__or__`, `__ror__`, or `__ior__`) for a `TypedDict`.
@@ -635,6 +798,7 @@ pub enum DynamicTypedDictAnchor<'db> {
         scope: ScopeId<'db>,
         offset: u32,
         schema: TypedDictSchema<'db>,
+        openness: TypedDictOpenness<'db>,
     },
 }
 
@@ -651,10 +815,12 @@ impl<'db> DynamicTypedDictAnchor<'db> {
                 scope,
                 offset,
                 schema,
+                openness,
             } => Some(Self::ScopeOffset {
                 scope: *scope,
                 offset: *offset,
                 schema: schema.recursive_type_normalized_impl(db, div, nested)?,
+                openness: openness.recursive_type_normalized_impl(db, div, nested)?,
             }),
         }
     }
@@ -713,11 +879,6 @@ impl<'db> DynamicTypedDictLiteral<'db> {
         }
     }
 
-    /// Returns an instance type for this dynamic `TypedDict`.
-    pub(crate) fn to_instance(self) -> Type<'db> {
-        Type::typed_dict(ClassType::NonGeneric(ClassLiteral::DynamicTypedDict(self)))
-    }
-
     /// Returns the range of the `TypedDict` call expression.
     pub(crate) fn header_range(self, db: &'db dyn Db) -> TextRange {
         let scope = self.scope(db);
@@ -768,6 +929,15 @@ impl<'db> DynamicTypedDictLiteral<'db> {
         }
     }
 
+    pub(crate) fn openness(self, db: &'db dyn Db) -> TypedDictOpenness<'db> {
+        match self.anchor(db) {
+            DynamicTypedDictAnchor::Definition(definition) => {
+                deferred_functional_typed_dict_openness(db, *definition)
+            }
+            DynamicTypedDictAnchor::ScopeOffset { openness, .. } => *openness,
+        }
+    }
+
     /// Get the MRO for this `TypedDict`.
     ///
     /// Functional `TypedDict` classes have the same MRO as class-based ones:
@@ -793,7 +963,9 @@ impl<'db> DynamicTypedDictLiteral<'db> {
 
     /// Look up a class-level member defined directly on this `TypedDict` (not inherited).
     pub(super) fn own_class_member(self, db: &'db dyn Db, name: &str) -> Member<'db> {
-        synthesize_typed_dict_method(db, self.to_instance(), name, || {
+        let typed_dict =
+            TypedDictType::new(ClassType::NonGeneric(ClassLiteral::DynamicTypedDict(self)));
+        synthesize_typed_dict_method(db, typed_dict, name, || {
             TypedDictFields::Dynamic(self.items(db))
         })
         .map(Member::definitely_declared)
@@ -815,16 +987,33 @@ impl<'db> DynamicTypedDictLiteral<'db> {
 
         // Fall back to TypedDictFallback for methods like __contains__, items, keys, etc.
         // This mirrors the behavior of StaticClassLiteral::typed_dict_member.
-        typed_dict_class_member(db, ClassLiteral::DynamicTypedDict(self), policy, name)
+        typed_dict_class_member(
+            db,
+            TypedDictType::new(ClassType::NonGeneric(ClassLiteral::DynamicTypedDict(self))),
+            ClassLiteral::DynamicTypedDict(self),
+            policy,
+            name,
+        )
     }
 }
 
 pub(super) fn typed_dict_class_member<'db>(
     db: &'db dyn Db,
+    typed_dict: TypedDictType<'db>,
     self_class: ClassLiteral<'db>,
     lookup_policy: MemberLookupPolicy,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
+    if let Some(value_ty) = typed_dict.dict_value_type(db)
+        && let Some(dict_class) = KnownClass::Dict
+            .to_specialized_class_type(db, &[KnownClass::Str.to_instance(db), value_ty])
+    {
+        let member = dict_class.class_member(db, name, lookup_policy);
+        if !member.is_undefined() {
+            return member;
+        }
+    }
+
     KnownClass::TypedDictFallback
         .to_class_literal(db)
         .find_name_in_mro_with_policy(db, name, lookup_policy)

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -518,71 +518,59 @@ fn synthesize_typed_dict_pop<'db>(
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
     let instance_ty = Type::TypedDict(typed_dict);
+    let pop_overloads = |key_ty, value_ty| {
+        let pop_parameters = [
+            Parameter::positional_only(Some(Name::new_static("self")))
+                .with_annotated_type(instance_ty),
+            Parameter::positional_only(Some(Name::new_static("key"))).with_annotated_type(key_ty),
+        ];
+        let pop_sig = Signature::new(Parameters::new(db, pop_parameters), value_ty);
+
+        // Non-generic overload that accepts the value type as the default,
+        // providing bidirectional inference context for the default argument.
+        let pop_with_typed_default_parameters = [
+            Parameter::positional_only(Some(Name::new_static("self")))
+                .with_annotated_type(instance_ty),
+            Parameter::positional_only(Some(Name::new_static("key"))).with_annotated_type(key_ty),
+            Parameter::positional_only(Some(Name::new_static("default")))
+                .with_annotated_type(value_ty),
+        ];
+        let pop_with_typed_default_sig = Signature::new(
+            Parameters::new(db, pop_with_typed_default_parameters),
+            value_ty,
+        );
+
+        let t_default =
+            BoundTypeVarInstance::synthetic(db, Name::new_static("T"), TypeVarVariance::Covariant);
+        let pop_with_default_parameters = [
+            Parameter::positional_only(Some(Name::new_static("self")))
+                .with_annotated_type(instance_ty),
+            Parameter::positional_only(Some(Name::new_static("key"))).with_annotated_type(key_ty),
+            Parameter::positional_only(Some(Name::new_static("default")))
+                .with_annotated_type(Type::TypeVar(t_default)),
+        ];
+        let pop_with_default_sig = Signature::new_generic(
+            Some(GenericContext::from_typevar_instances(db, [t_default])),
+            Parameters::new(db, pop_with_default_parameters),
+            UnionType::from_two_elements(db, value_ty, Type::TypeVar(t_default)),
+        );
+
+        [pop_sig, pop_with_typed_default_sig, pop_with_default_sig]
+    };
+
     let overloads = fields
         .iter()
         .filter(|(_, field)| !field.is_required() && !field.is_read_only())
         .flat_map(|(field_name, field)| {
-            let key_type = Type::string_literal(db, field_name);
-
-            let pop_parameters = [
-                Parameter::positional_only(Some(Name::new_static("self")))
-                    .with_annotated_type(instance_ty),
-                Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(key_type),
-            ];
-            let pop_sig = Signature::new(Parameters::new(db, pop_parameters), field.declared_ty);
-
-            // Non-generic overload that accepts the field type as the default,
-            // providing bidirectional inference context for the default argument.
-            let pop_with_typed_default_sig = Signature::new(
-                Parameters::new(
-                    db,
-                    [
-                        Parameter::positional_only(Some(Name::new_static("self")))
-                            .with_annotated_type(instance_ty),
-                        Parameter::positional_only(Some(Name::new_static("key")))
-                            .with_annotated_type(key_type),
-                        Parameter::positional_only(Some(Name::new_static("default")))
-                            .with_annotated_type(field.declared_ty),
-                    ],
-                ),
-                field.declared_ty,
-            );
-
-            let t_default = BoundTypeVarInstance::synthetic(
-                db,
-                Name::new_static("T"),
-                TypeVarVariance::Covariant,
-            );
-
-            let pop_with_default_parameters = [
-                Parameter::positional_only(Some(Name::new_static("self")))
-                    .with_annotated_type(instance_ty),
-                Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(key_type),
-                Parameter::positional_only(Some(Name::new_static("default")))
-                    .with_annotated_type(Type::TypeVar(t_default)),
-            ];
-            let pop_with_default_sig = Signature::new_generic(
-                Some(GenericContext::from_typevar_instances(db, [t_default])),
-                Parameters::new(db, pop_with_default_parameters),
-                UnionType::from_two_elements(db, field.declared_ty, Type::TypeVar(t_default)),
-            );
-
-            [pop_sig, pop_with_typed_default_sig, pop_with_default_sig]
+            pop_overloads(Type::string_literal(db, field_name), field.declared_ty)
         })
-        .chain(typed_dict.supports_arbitrary_key_deletion(db).then(|| {
-            let pop_parameters = [
-                Parameter::positional_only(Some(Name::new_static("self")))
-                    .with_annotated_type(instance_ty),
-                Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(KnownClass::Str.to_instance(db)),
-            ];
-            Signature::new(
-                Parameters::new(db, pop_parameters),
-                typed_dict.value_type(db),
-            )
-        }));
+        .chain(
+            typed_dict
+                .supports_arbitrary_key_deletion(db)
+                .then(|| pop_overloads(KnownClass::Str.to_instance(db), typed_dict.value_type(db)))
+                .into_iter()
+                .flatten(),
+        );
 
     Type::Callable(CallableType::new(
         db,

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -505,14 +505,12 @@ fn synthesize_typed_dict_update<'db>(
 
     let update_patch_ty = Type::TypedDict(typed_dict.to_update_patch(db));
 
-    let str_object_tuple =
-        Type::heterogeneous_tuple(db, [KnownClass::Str.to_instance(db), Type::object()]);
-
-    let value_ty = UnionType::from_two_elements(
-        db,
-        update_patch_ty,
-        KnownClass::Iterable.to_specialized_instance(db, &[str_object_tuple]),
-    );
+    let iterable_ty = typed_dict.arbitrary_key_write_type(db).map(|value_ty| {
+        let item_ty = Type::heterogeneous_tuple(db, [KnownClass::Str.to_instance(db), value_ty]);
+        KnownClass::Iterable.to_specialized_instance(db, &[item_ty])
+    });
+    let value_ty =
+        UnionType::from_elements(db, std::iter::once(update_patch_ty).chain(iterable_ty));
 
     let parameters = [
         Parameter::positional_only(Some(Name::new_static("self"))).with_annotated_type(instance_ty),

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -354,10 +354,10 @@ fn synthesize_typed_dict_get<'db>(
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
     let instance_ty = Type::TypedDict(typed_dict);
-    let fallback_value_ty = if typed_dict.explicit_extra_items(db).is_some() {
-        typed_dict.value_type(db)
-    } else {
+    let fallback_value_ty = if typed_dict.openness(db).is_open() {
         Type::unknown()
+    } else {
+        typed_dict.value_type(db)
     };
     let overloads = fields
         .iter()

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -699,10 +699,18 @@ fn synthesize_typed_dict_merge<'db>(
 ) -> Type<'db> {
     let mut overloads: smallvec::SmallVec<[Signature<'db>; 3]>;
 
+    let first_overload_value_ty = if name == "__ior__"
+        && let Type::TypedDict(typed_dict) = instance_ty
+    {
+        Type::TypedDict(typed_dict.to_update_patch(db))
+    } else {
+        instance_ty
+    };
+
     let first_overload_parameters = [
         Parameter::positional_only(Some(Name::new_static("self"))).with_annotated_type(instance_ty),
         Parameter::positional_only(Some(Name::new_static("value")))
-            .with_annotated_type(instance_ty),
+            .with_annotated_type(first_overload_value_ty),
     ];
 
     overloads = smallvec::smallvec![Signature::new(

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -354,7 +354,7 @@ fn synthesize_typed_dict_get<'db>(
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
     let instance_ty = Type::TypedDict(typed_dict);
-    let fallback_value_ty = if typed_dict.openness(db).is_open() {
+    let fallback_value_ty = if typed_dict.openness(db).is_implicitly_open() {
         Type::unknown()
     } else {
         typed_dict.value_type(db)

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -979,6 +979,19 @@ pub(super) fn typed_dict_class_member<'db>(
     lookup_policy: MemberLookupPolicy,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
+    let fallback_member = KnownClass::TypedDictFallback
+        .to_class_literal(db)
+        .find_name_in_mro_with_policy(db, name, lookup_policy)
+        .expect("Will return Some() when called on class literal")
+        .map_type(|ty| {
+            let new_upper_bound = determine_upper_bound(db, self_class, ClassBase::is_typed_dict);
+            let mapping = TypeMapping::ReplaceSelf { new_upper_bound };
+            ty.apply_type_mapping(db, &mapping, TypeContext::default())
+        });
+    if !fallback_member.is_undefined() {
+        return fallback_member;
+    }
+
     if let Some(value_ty) = typed_dict.dict_value_type(db)
         && let Some(dict_class) = KnownClass::Dict
             .to_specialized_class_type(db, &[KnownClass::Str.to_instance(db), value_ty])
@@ -989,13 +1002,5 @@ pub(super) fn typed_dict_class_member<'db>(
         }
     }
 
-    KnownClass::TypedDictFallback
-        .to_class_literal(db)
-        .find_name_in_mro_with_policy(db, name, lookup_policy)
-        .expect("Will return Some() when called on class literal")
-        .map_type(|ty| {
-            let new_upper_bound = determine_upper_bound(db, self_class, ClassBase::is_typed_dict);
-            let mapping = TypeMapping::ReplaceSelf { new_upper_bound };
-            ty.apply_type_mapping(db, &mapping, TypeContext::default())
-        })
+    fallback_member
 }

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -305,8 +305,9 @@ fn synthesize_typed_dict_delitem<'db>(
         .iter()
         .filter(|(_, field)| !field.is_required() && !field.is_read_only())
         .peekable();
+    let supports_arbitrary_key_deletion = typed_dict.supports_arbitrary_key_deletion(db);
 
-    if deletable_fields.peek().is_none() && !typed_dict.supports_arbitrary_key_deletion(db) {
+    if deletable_fields.peek().is_none() && !supports_arbitrary_key_deletion {
         let parameters = [
             Parameter::positional_only(Some(Name::new_static("self")))
                 .with_annotated_type(instance_ty),
@@ -328,7 +329,7 @@ fn synthesize_typed_dict_delitem<'db>(
             ];
             Signature::new(Parameters::new(db, parameters), Type::none(db))
         })
-        .chain(typed_dict.supports_arbitrary_key_deletion(db).then(|| {
+        .chain(supports_arbitrary_key_deletion.then(|| {
             let parameters = [
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -572,17 +572,16 @@ fn synthesize_typed_dict_pop<'db>(
             [pop_sig, pop_with_typed_default_sig, pop_with_default_sig]
         })
         .chain(typed_dict.supports_arbitrary_key_deletion(db).then(|| {
-            let value_ty = typed_dict
-                .explicit_extra_items(db)
-                .expect("arbitrary deletion requires explicit extra items")
-                .declared_ty;
             let pop_parameters = [
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
                 Parameter::positional_only(Some(Name::new_static("key")))
                     .with_annotated_type(KnownClass::Str.to_instance(db)),
             ];
-            Signature::new(Parameters::new(db, pop_parameters), value_ty)
+            Signature::new(
+                Parameters::new(db, pop_parameters),
+                typed_dict.value_type(db),
+            )
         }));
 
     Type::Callable(CallableType::new(

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -46,11 +46,26 @@ pub(super) fn synthesize_typed_dict_method<'db>(
         "update" => Some(synthesize_typed_dict_update(db, typed_dict, fields())),
         "pop" => Some(synthesize_typed_dict_pop(db, typed_dict, fields())),
         "setdefault" => Some(synthesize_typed_dict_setdefault(db, typed_dict, fields())),
-        "clear" | "popitem" if typed_dict.supports_arbitrary_key_deletion(db) => Some(
-            synthesize_typed_dict_arbitrary_deletion_method(db, typed_dict, method_name),
+        "clear" if typed_dict.supports_arbitrary_key_deletion(db) => Some(
+            synthesize_typed_dict_no_argument_method(db, typed_dict, Type::none(db)),
         ),
-        "items" | "keys" | "values" if typed_dict.explicit_extra_items(db).is_some() => Some(
-            synthesize_typed_dict_view_method(db, typed_dict, method_name),
+        "popitem" if typed_dict.supports_arbitrary_key_deletion(db) => {
+            let return_ty = Type::heterogeneous_tuple(
+                db,
+                [KnownClass::Str.to_instance(db), typed_dict.value_type(db)],
+            );
+            Some(synthesize_typed_dict_no_argument_method(
+                db, typed_dict, return_ty,
+            ))
+        }
+        "items" if typed_dict.explicit_extra_items(db).is_some() => Some(
+            synthesize_typed_dict_view_method(db, typed_dict, "dict_items"),
+        ),
+        "keys" if typed_dict.explicit_extra_items(db).is_some() => Some(
+            synthesize_typed_dict_view_method(db, typed_dict, "dict_keys"),
+        ),
+        "values" if typed_dict.explicit_extra_items(db).is_some() => Some(
+            synthesize_typed_dict_view_method(db, typed_dict, "dict_values"),
         ),
         "__or__" | "__ror__" | "__ior__" => {
             Some(synthesize_typed_dict_merge(db, instance_ty, method_name))
@@ -623,20 +638,11 @@ fn synthesize_typed_dict_setdefault<'db>(
     ))
 }
 
-/// Synthesize `clear` or `popitem` when every possible key can be deleted.
-fn synthesize_typed_dict_arbitrary_deletion_method<'db>(
+fn synthesize_typed_dict_no_argument_method<'db>(
     db: &'db dyn Db,
     typed_dict: TypedDictType<'db>,
-    name: &str,
+    return_ty: Type<'db>,
 ) -> Type<'db> {
-    let return_ty = match name {
-        "clear" => Type::none(db),
-        "popitem" => Type::heterogeneous_tuple(
-            db,
-            [KnownClass::Str.to_instance(db), typed_dict.value_type(db)],
-        ),
-        _ => return Type::unknown(),
-    };
     Type::function_like_callable(
         db,
         Signature::new(
@@ -654,15 +660,8 @@ fn synthesize_typed_dict_arbitrary_deletion_method<'db>(
 fn synthesize_typed_dict_view_method<'db>(
     db: &'db dyn Db,
     typed_dict: TypedDictType<'db>,
-    name: &str,
+    view_name: &str,
 ) -> Type<'db> {
-    let instance_ty = Type::TypedDict(typed_dict);
-    let view_name = match name {
-        "items" => "dict_items",
-        "keys" => "dict_keys",
-        "values" => "dict_values",
-        _ => return Type::unknown(),
-    };
     let return_ty = known_module_symbol(db, KnownModule::CollectionsAbcInternal, view_name)
         .place
         .ignore_possibly_undefined()
@@ -678,17 +677,7 @@ fn synthesize_typed_dict_view_method<'db>(
         .and_then(|class| Type::from(class).to_instance(db))
         .unwrap_or_else(Type::unknown);
 
-    Type::function_like_callable(
-        db,
-        Signature::new(
-            Parameters::new(
-                db,
-                [Parameter::positional_only(Some(Name::new_static("self")))
-                    .with_annotated_type(instance_ty)],
-            ),
-            return_ty,
-        ),
-    )
+    synthesize_typed_dict_no_argument_method(db, typed_dict, return_ty)
 }
 
 /// Synthesize a merge operator (`__or__`, `__ror__`, or `__ior__`) for a `TypedDict`.

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -246,9 +246,9 @@ fn synthesize_typed_dict_setitem<'db>(
         .iter()
         .filter(|(_, field)| !field.is_read_only())
         .peekable();
-    let arbitrary_key_write_type = typed_dict.arbitrary_key_write_type(db);
+    let arbitrary_key_mutation_type = typed_dict.arbitrary_key_mutation_type(db);
 
-    if writable_fields.peek().is_none() && arbitrary_key_write_type.is_none() {
+    if writable_fields.peek().is_none() && arbitrary_key_mutation_type.is_none() {
         let parameters = [
             Parameter::positional_only(Some(Name::new_static("self")))
                 .with_annotated_type(instance_ty),
@@ -274,7 +274,7 @@ fn synthesize_typed_dict_setitem<'db>(
             ];
             Signature::new(Parameters::new(db, parameters), Type::none(db))
         })
-        .chain(arbitrary_key_write_type.map(|value_ty| {
+        .chain(arbitrary_key_mutation_type.map(|value_ty| {
             let parameters = [
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
@@ -509,7 +509,7 @@ fn synthesize_typed_dict_update<'db>(
         KnownClass::Mapping
             .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), value_ty])
     });
-    let iterable_ty = typed_dict.arbitrary_key_write_type(db).map(|value_ty| {
+    let iterable_ty = typed_dict.arbitrary_key_mutation_type(db).map(|value_ty| {
         let item_ty = Type::heterogeneous_tuple(db, [KnownClass::Str.to_instance(db), value_ty]);
         KnownClass::Iterable.to_specialized_instance(db, &[item_ty])
     });
@@ -625,17 +625,21 @@ fn synthesize_typed_dict_setdefault<'db>(
 
             Signature::new(Parameters::new(db, parameters), field.declared_ty)
         })
-        .chain(typed_dict.arbitrary_key_write_type(db).map(|default_ty| {
-            let parameters = [
-                Parameter::positional_only(Some(Name::new_static("self")))
-                    .with_annotated_type(instance_ty),
-                Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(KnownClass::Str.to_instance(db)),
-                Parameter::positional_only(Some(Name::new_static("default")))
-                    .with_annotated_type(default_ty),
-            ];
-            Signature::new(Parameters::new(db, parameters), typed_dict.value_type(db))
-        }));
+        .chain(
+            typed_dict
+                .arbitrary_key_mutation_type(db)
+                .map(|default_ty| {
+                    let parameters = [
+                        Parameter::positional_only(Some(Name::new_static("self")))
+                            .with_annotated_type(instance_ty),
+                        Parameter::positional_only(Some(Name::new_static("key")))
+                            .with_annotated_type(KnownClass::Str.to_instance(db)),
+                        Parameter::positional_only(Some(Name::new_static("default")))
+                            .with_annotated_type(default_ty),
+                    ];
+                    Signature::new(Parameters::new(db, parameters), typed_dict.value_type(db))
+                }),
+        );
 
     Type::Callable(CallableType::new(
         db,

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -505,12 +505,20 @@ fn synthesize_typed_dict_update<'db>(
 
     let update_patch_ty = Type::TypedDict(typed_dict.to_update_patch(db));
 
+    let mapping_ty = typed_dict.dict_value_type(db).map(|value_ty| {
+        KnownClass::Mapping
+            .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), value_ty])
+    });
     let iterable_ty = typed_dict.arbitrary_key_write_type(db).map(|value_ty| {
         let item_ty = Type::heterogeneous_tuple(db, [KnownClass::Str.to_instance(db), value_ty]);
         KnownClass::Iterable.to_specialized_instance(db, &[item_ty])
     });
-    let value_ty =
-        UnionType::from_elements(db, std::iter::once(update_patch_ty).chain(iterable_ty));
+    let value_ty = UnionType::from_elements(
+        db,
+        std::iter::once(update_patch_ty)
+            .chain(mapping_ty)
+            .chain(iterable_ty),
+    );
 
     let parameters = [
         Parameter::positional_only(Some(Name::new_static("self"))).with_annotated_type(instance_ty),

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -5621,6 +5621,8 @@ pub(crate) fn report_cannot_pop_required_field_on_typed_dict<'db>(
 pub(crate) enum TypedDictDeleteErrorKind {
     /// The key exists but is required (not `NotRequired`)
     RequiredKey,
+    /// The key refers to a read-only extra item.
+    ReadOnlyExtraItem,
     /// The key does not exist in the `TypedDict`
     UnknownKey,
 }
@@ -5643,6 +5645,9 @@ pub(crate) fn report_cannot_delete_typed_dict_key<'db>(
     let mut diagnostic = match error_kind {
         TypedDictDeleteErrorKind::RequiredKey => builder.into_diagnostic(format_args!(
             "Cannot delete required key \"{field_name}\" from TypedDict `{typed_dict_name}`"
+        )),
+        TypedDictDeleteErrorKind::ReadOnlyExtraItem => builder.into_diagnostic(format_args!(
+            "Cannot delete read-only extra item \"{field_name}\" from TypedDict `{typed_dict_name}`"
         )),
         TypedDictDeleteErrorKind::UnknownKey => builder.into_diagnostic(format_args!(
             "Cannot delete unknown key \"{field_name}\" from TypedDict `{typed_dict_name}`"

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -761,6 +761,9 @@ struct ScopeInferenceExtra<'db> {
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
 
+    /// Type qualifiers (`Required`, `NotRequired`, etc.) for annotation expressions.
+    qualifiers: FrozenMap<ExpressionNodeKey, TypeQualifiers>,
+
     /// Expected types for expression nodes tracked for IDE completion.
     expected_types: FrozenMap<ExpressionNodeKey, Type<'db>>,
 
@@ -819,6 +822,14 @@ impl<'db> ScopeInference<'db> {
             .get(&expression.into())
             .copied()
             .or_else(|| self.fallback_type())
+    }
+
+    /// Get qualifiers for an annotation expression.
+    pub(crate) fn qualifiers(&self, expression: impl Into<ExpressionNodeKey>) -> TypeQualifiers {
+        self.extra
+            .as_deref()
+            .and_then(|extra| extra.qualifiers.get(&expression.into()).copied())
+            .unwrap_or_default()
     }
 
     pub(crate) fn try_expected_type(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -91,6 +91,7 @@ use crate::types::subclass_of::SubclassOfInner;
 use crate::types::tuple::promotion::TupleSizePromotionConstraints;
 use crate::types::tuple::{Tuple, TupleLength, TupleSpecBuilder, TupleType};
 use crate::types::type_alias::{ManualPEP695TypeAliasType, PEP695TypeAliasType};
+use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
 use crate::types::{
     BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType,
@@ -5398,39 +5399,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .unwrap_or(return_ty)
     }
 
-    /// Infer the argument types for a single binding.
-    fn infer_argument_types<'a>(
-        &mut self,
-        ast_arguments: &ast::Arguments,
-        arguments: &mut CallArguments<'a, 'db>,
-        argument_forms: &[Option<ParameterForm>],
-    ) {
-        debug_assert!(
-            ast_arguments.len() == arguments.len() && arguments.len() == argument_forms.len()
-        );
-
-        let iter = itertools::izip!(
-            arguments.iter_mut(),
-            argument_forms.iter().copied(),
-            ast_arguments.iter_source_order()
-        );
-
-        for ((_, argument_types), argument_form, ast_argument) in iter {
-            // Splatted arguments are inferred before parameter matching to
-            // determine their length.
-            if ast_argument.is_variadic() {
-                continue;
-            }
-
-            let ty = self.infer_argument_type(
-                ast_argument.value(),
-                argument_form,
-                TypeContext::default(),
-            );
-            argument_types.insert(TypeContext::default(), ty);
-        }
-    }
-
     #[expect(clippy::too_many_arguments)]
     fn infer_and_try_call_dunder(
         &mut self,
@@ -5833,18 +5801,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     self.teardown_expression_cache();
                 }
             }
-        }
-    }
-
-    fn infer_argument_type(
-        &mut self,
-        ast_argument: &ast::Expr,
-        form: Option<ParameterForm>,
-        tcx: TypeContext<'db>,
-    ) -> Type<'db> {
-        match form {
-            None | Some(ParameterForm::Value) => self.infer_expression(ast_argument, tcx),
-            Some(ParameterForm::Type) => self.infer_type_expression(ast_argument),
         }
     }
 
@@ -8233,7 +8189,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let value_type = self.expression_type(value);
 
             if let Type::TypedDict(typed_dict_ty) = value_type
-                && matches!(attr.id.as_str(), "pop" | "setdefault")
+                && matches!(attr.id.as_str(), "get" | "pop" | "setdefault")
                 && !arguments.args.is_empty()
 
                 // Validate the key argument for `TypedDict` methods
@@ -8246,13 +8202,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let key = key_literal.to_str();
                 let items = typed_dict_ty.items(self.db());
 
-                // Check if key exists
-                if let Some((_, field)) = items
-                    .iter()
-                    .find(|(field_name, _)| field_name.as_str() == key)
-                {
+                if let Some(field) = typed_dict_ty.item(self.db(), key) {
                     // Key exists - check if it's a `pop()` on a required field
-                    if attr.id.as_str() == "pop" && field.is_required() {
+                    if items.contains_key(key) && attr.id.as_str() == "pop" && field.is_required() {
                         report_cannot_pop_required_field_on_typed_dict(
                             &self.context,
                             first_arg.into(),
@@ -8261,7 +8213,73 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         );
                         return Type::unknown();
                     }
-                } else {
+
+                    if !items.contains_key(key)
+                        && attr.id.as_str() == "get"
+                        && arguments.keywords.is_empty()
+                        && matches!(arguments.args.len(), 1 | 2)
+                    {
+                        let default_ty = if let Some(default) = arguments.args.get(1) {
+                            self.get_or_infer_expression(default, TypeContext::default())
+                        } else {
+                            Type::none(self.db())
+                        };
+                        return UnionType::from_two_elements(
+                            self.db(),
+                            field.declared_ty,
+                            default_ty,
+                        );
+                    }
+
+                    // Unknown literal keys are concrete extra items, so mutating operations can
+                    // use their extra-items type even when arbitrary `str` keys are unsafe.
+                    if !items.contains_key(key) && !field.is_read_only() {
+                        match attr.id.as_str() {
+                            "pop"
+                                if arguments.keywords.is_empty()
+                                    && matches!(arguments.args.len(), 1 | 2) =>
+                            {
+                                return arguments.args.get(1).map_or(
+                                    field.declared_ty,
+                                    |default| {
+                                        UnionType::from_two_elements(
+                                            self.db(),
+                                            field.declared_ty,
+                                            self.get_or_infer_expression(
+                                                default,
+                                                TypeContext::default(),
+                                            ),
+                                        )
+                                    },
+                                );
+                            }
+                            "setdefault"
+                                if arguments.keywords.is_empty() && arguments.args.len() == 2 =>
+                            {
+                                let default = &arguments.args[1];
+                                let default_ty = self.get_or_infer_expression(
+                                    default,
+                                    TypeContext::new(Some(field.declared_ty)),
+                                );
+                                TypedDictKeyAssignment {
+                                    context: &self.context,
+                                    typed_dict: typed_dict_ty,
+                                    full_object_ty: None,
+                                    key,
+                                    value_ty: default_ty,
+                                    typed_dict_node: value.as_ref().into(),
+                                    key_node: first_arg.into(),
+                                    value_node: default.into(),
+                                    assignment_kind: TypedDictAssignmentKind::Constructor,
+                                    emit_diagnostic: true,
+                                }
+                                .validate();
+                                return field.declared_ty;
+                            }
+                            _ => {}
+                        }
+                    }
+                } else if attr.id.as_str() != "get" {
                     // Key not found, report error with suggestion and return early
                     let key_ty = Type::string_literal(self.db(), key);
                     report_invalid_key_on_typed_dict(
@@ -10606,12 +10624,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions,
             scope,
             cycle_recovery,
+            qualifiers,
 
             // Ignored, never leaked into other scopes
             deferred: _,
             bindings: _,
             declarations: _,
-            qualifiers: _,
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
@@ -10636,11 +10654,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             || !diagnostics.is_empty()
             || cycle_recovery.is_some()
             || !type_expression_flags.is_empty()
-            || !collection_use_constraints.is_empty())
+            || !collection_use_constraints.is_empty()
+            || !qualifiers.is_empty())
         .then(|| {
             collection_use_constraints.shrink_to_fit();
             Box::new(ScopeInferenceExtra {
                 string_annotations: FrozenSet::from(string_annotations),
+                qualifiers: FrozenMap::from(qualifiers),
                 expected_types: FrozenMap::from(expected_types),
                 type_expression_flags: FrozenMap::from(type_expression_flags),
                 collection_use_constraints,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8195,12 +8195,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 // Validate the key argument for `TypedDict` methods
                 && let Some(first_arg) = arguments.args.first()
-                    && let ast::Expr::StringLiteral(ast::ExprStringLiteral {
+                && let Some(key) = (match first_arg {
+                    ast::Expr::StringLiteral(ast::ExprStringLiteral {
                         value: key_literal,
                         ..
-                    }) = first_arg
+                    }) => Some(key_literal.to_str()),
+                    _ => self
+                        .speculate()
+                        .get_or_infer_expression(first_arg, TypeContext::default())
+                        .as_string_literal()
+                        .map(|key_literal| key_literal.value(self.db())),
+                })
             {
-                let key = key_literal.to_str();
                 let items = typed_dict_ty.items(self.db());
                 let is_declared = items.contains_key(key);
 
@@ -8222,7 +8228,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         && matches!(arguments.args.len(), 1 | 2)
                     {
                         let default_ty = if let Some(default) = arguments.args.get(1) {
-                            self.get_or_infer_expression(default, TypeContext::default())
+                            self.get_or_infer_expression(
+                                default,
+                                TypeContext::new(Some(field.declared_ty)),
+                            )
                         } else {
                             Type::none(self.db())
                         };
@@ -8249,7 +8258,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             field.declared_ty,
                                             self.get_or_infer_expression(
                                                 default,
-                                                TypeContext::default(),
+                                                TypeContext::new(Some(field.declared_ty)),
                                             ),
                                         )
                                     },

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8242,6 +8242,34 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         );
                     }
 
+                    if !is_declared && field.is_read_only() {
+                        let mutation = match method_name {
+                            "pop"
+                                if arguments.keywords.is_empty()
+                                    && matches!(arguments.args.len(), 1 | 2) =>
+                            {
+                                Some(("pop", "from"))
+                            }
+                            "setdefault"
+                                if arguments.keywords.is_empty() && arguments.args.len() == 2 =>
+                            {
+                                Some(("set default for", "on"))
+                            }
+                            _ => None,
+                        };
+                        if let Some((action, preposition)) = mutation {
+                            if let Some(builder) =
+                                self.context.report_lint(&INVALID_ARGUMENT_TYPE, first_arg)
+                            {
+                                builder.into_diagnostic(format_args!(
+                                    "Cannot {action} read-only extra item \"{key}\" {preposition} TypedDict `{}`",
+                                    Type::TypedDict(typed_dict_ty).display(self.db()),
+                                ));
+                            }
+                            return Type::unknown();
+                        }
+                    }
+
                     // Unknown literal keys are concrete extra items, so mutating operations can
                     // use their extra-items type even when arbitrary `str` keys are unsafe.
                     if !is_declared && !field.is_read_only() {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8187,9 +8187,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Special handling for `TypedDict` method calls
         if let ast::Expr::Attribute(ast::ExprAttribute { value, attr, .. }) = func.as_ref() {
             let value_type = self.expression_type(value);
+            let method_name = attr.id.as_str();
 
             if let Type::TypedDict(typed_dict_ty) = value_type
-                && matches!(attr.id.as_str(), "get" | "pop" | "setdefault")
+                && matches!(method_name, "get" | "pop" | "setdefault")
                 && !arguments.args.is_empty()
 
                 // Validate the key argument for `TypedDict` methods
@@ -8201,10 +8202,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             {
                 let key = key_literal.to_str();
                 let items = typed_dict_ty.items(self.db());
+                let is_declared = items.contains_key(key);
 
                 if let Some(field) = typed_dict_ty.item(self.db(), key) {
                     // Key exists - check if it's a `pop()` on a required field
-                    if items.contains_key(key) && attr.id.as_str() == "pop" && field.is_required() {
+                    if is_declared && method_name == "pop" && field.is_required() {
                         report_cannot_pop_required_field_on_typed_dict(
                             &self.context,
                             first_arg.into(),
@@ -8214,8 +8216,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         return Type::unknown();
                     }
 
-                    if !items.contains_key(key)
-                        && attr.id.as_str() == "get"
+                    if !is_declared
+                        && method_name == "get"
                         && arguments.keywords.is_empty()
                         && matches!(arguments.args.len(), 1 | 2)
                     {
@@ -8233,8 +8235,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     // Unknown literal keys are concrete extra items, so mutating operations can
                     // use their extra-items type even when arbitrary `str` keys are unsafe.
-                    if !items.contains_key(key) && !field.is_read_only() {
-                        match attr.id.as_str() {
+                    if !is_declared && !field.is_read_only() {
+                        match method_name {
                             "pop"
                                 if arguments.keywords.is_empty()
                                     && matches!(arguments.args.len(), 1 | 2) =>
@@ -8279,7 +8281,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             _ => {}
                         }
                     }
-                } else if attr.id.as_str() != "get" {
+                } else if method_name != "get" {
                     // Key not found, report error with suggestion and return early
                     let key_ty = Type::string_literal(self.db(), key);
                     report_invalid_key_on_typed_dict(

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -204,9 +204,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// (e.g., `missing-typed-dict-key`, `invalid-key`) when the RHS doesn't exactly match
     /// the `TypedDict` schema. We probe here to decide the outcome without those side effects.
     ///
-    /// Returns `None` when the exact `__ior__` would succeed, letting the normal path run
-    /// (which handles bidirectional inference, `reveal_type`, and other diagnostics properly).
-    /// Returns `Some` for subset updates or incompatible operands.
+    /// Returns `Some` after handling either a compatible or incompatible operand.
     pub(super) fn try_infer_typed_dict_pep_584_augmented_assignment(
         &mut self,
         assignment: &ast::StmtAugAssign,
@@ -222,33 +220,30 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             return None;
         };
 
-        // If the exact `__ior__` would succeed, let the normal path handle it so that
-        // bidirectional inference, `reveal_type`, and other diagnostics work properly.
+        let typed_dict_ty = Type::TypedDict(typed_dict);
+
+        // Prefer the full TypedDict as context when possible so exact-shape literals preserve the
+        // named type in bidirectional inference.
         if self
             .try_typed_dict_pep_584_dunder(value_expr, typed_dict, typed_dict, "__ior__")
             .is_some()
         {
-            return None;
+            infer_value_ty(self, TypeContext::new(Some(typed_dict_ty)));
+            return Some(typed_dict_ty);
         }
 
-        // The exact path failed. Try patch-style semantics for subset updates
-        // (e.g., a TypedDict with fewer keys or a partial dict literal).
+        // Subset updates use the mutation-safe patch as context.
+        let update_patch = typed_dict.to_update_patch(self.db());
         if self
-            .try_typed_dict_pep_584_dunder(
-                value_expr,
-                typed_dict.to_partial(self.db()),
-                typed_dict,
-                "__or__",
-            )
-            .is_some_and(|return_ty| {
-                return_ty.is_assignable_to(self.db(), Type::TypedDict(typed_dict))
-            })
+            .try_typed_dict_pep_584_dunder(value_expr, update_patch, typed_dict, "__ior__")
+            .is_some()
         {
-            return Some(Type::TypedDict(typed_dict));
+            infer_value_ty(self, TypeContext::new(Some(Type::TypedDict(update_patch))));
+            return Some(typed_dict_ty);
         }
 
-        // Both probes failed. Infer the RHS without TypedDict context so we
-        // report only the operator failure, not spurious typed-dict diagnostics.
+        // The probe failed. Infer the RHS without TypedDict context so we report only the operator
+        // failure, not spurious typed-dict diagnostics.
         let value_ty = infer_value_ty(self, TypeContext::default());
         report_unsupported_augmented_assignment(&self.context, assignment, target_type, value_ty);
         Some(target_type)

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -38,6 +38,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let in_stub = self.in_stub();
             let previous_deferred_state =
                 std::mem::replace(&mut self.deferred_state, in_stub.into());
+
+            // PEP 695 class headers are inferred in the type-parameter scope, before the completed
+            // class type is available. Infer the bases first because `extra_items=T` is an
+            // annotation in `class C[T](TypedDict, extra_items=T)`, but an ordinary value argument
+            // in `class C[T](Base, extra_items=T)`.
             let mut is_typed_dict = false;
 
             for base in class.bases() {

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -10,7 +10,6 @@ use crate::types::{
         builder::{DeclaredAndInferredType, DeferredExpressionState},
         original_class_type,
     },
-    signatures::ParameterForm,
     special_form::TypeQualifier,
 };
 use ruff_python_ast::name::Name;
@@ -35,22 +34,36 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         self.infer_type_parameters(type_params);
 
-        if let Some(arguments) = class.arguments.as_deref() {
+        if class.arguments.is_some() {
             let in_stub = self.in_stub();
             let previous_deferred_state =
                 std::mem::replace(&mut self.deferred_state, in_stub.into());
-            let mut call_arguments =
-                CallArguments::from_arguments(arguments, |arg_or_keyword, splatted_value| {
-                    let ty = self.infer_expression(splatted_value, TypeContext::default());
-                    if let ast::ArgOrKeyword::Arg(argument) = arg_or_keyword
-                        && argument.is_starred_expr()
-                    {
-                        self.store_expression_type(argument, ty);
-                    }
+            let mut is_typed_dict = false;
+
+            for base in class.bases() {
+                let ty = if let ast::Expr::Starred(starred) = base {
+                    let ty = self.infer_expression(&starred.value, TypeContext::default());
+                    self.store_expression_type(base, ty);
                     ty
-                });
-            let argument_forms = vec![Some(ParameterForm::Value); call_arguments.len()];
-            self.infer_argument_types(arguments, &mut call_arguments, &argument_forms);
+                } else {
+                    self.infer_expression(base, TypeContext::default())
+                };
+                is_typed_dict |= match ty {
+                    Type::SpecialForm(SpecialFormType::TypedDict) => true,
+                    Type::ClassLiteral(class) => class.is_typed_dict(self.db()),
+                    Type::GenericAlias(alias) => alias.is_typed_dict(self.db()),
+                    _ => false,
+                };
+            }
+
+            for keyword in class.keywords() {
+                if is_typed_dict && keyword.arg.as_deref() == Some("extra_items") {
+                    self.infer_extra_items_kwarg(&keyword.value);
+                } else {
+                    self.infer_expression(&keyword.value, TypeContext::default());
+                }
+            }
+
             self.deferred_state = previous_deferred_state;
         }
 
@@ -407,7 +420,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.infer_expression(base, TypeContext::default());
             }
         }
-        self.typevar_binding_context = previous_typevar_binding_context;
 
         if let Some(arguments) = class.arguments.as_deref()
             && let Some(extra_items_keyword) = arguments.find_keyword("extra_items")
@@ -426,6 +438,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.infer_expression(&extra_items_keyword.value, TypeContext::default());
             }
         }
+
+        self.typevar_binding_context = previous_typevar_binding_context;
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
@@ -172,7 +172,7 @@ fn validate_typed_dict_openness<'db>(
         let base_items = base_typed_dict.items(db);
 
         match base_openness {
-            TypedDictOpenness::Open => {}
+            TypedDictOpenness::ImplicitlyOpen => {}
             TypedDictOpenness::Closed => {
                 if !child_openness.is_closed() {
                     report_invalid_typed_dict_openness(
@@ -203,7 +203,7 @@ fn validate_typed_dict_openness<'db>(
             }
             TypedDictOpenness::Extra(base_extra_items) if base_extra_items.is_read_only() => {
                 match child_openness {
-                    TypedDictOpenness::Open => {
+                    TypedDictOpenness::ImplicitlyOpen => {
                         report_invalid_typed_dict_openness(
                             context,
                             class,

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
@@ -12,8 +12,10 @@ use crate::{
         ClassType, StaticClassLiteral, Type, TypedDictType,
         class::CodeGeneratorKind,
         context::InferContext,
-        diagnostic::{INVALID_TYPED_DICT_FIELD, INVALID_TYPED_DICT_STATEMENT},
-        typed_dict::TypedDictField,
+        diagnostic::{
+            INVALID_TYPED_DICT_FIELD, INVALID_TYPED_DICT_HEADER, INVALID_TYPED_DICT_STATEMENT,
+        },
+        typed_dict::{TypedDictField, TypedDictOpenness},
     },
 };
 use ty_python_core::definition::Definition;
@@ -26,6 +28,7 @@ pub(super) fn validate_typed_dict_class<'db>(
 ) {
     validate_typed_dict_class_body(context, class_node);
     validate_typed_dict_field_overrides(context, class, direct_bases);
+    validate_typed_dict_openness(context, class, class_node, direct_bases);
 }
 
 fn validate_typed_dict_class_body(context: &InferContext<'_, '_>, class_node: &ast::StmtClassDef) {
@@ -138,6 +141,189 @@ fn validate_typed_dict_field_overrides<'db>(
                 inherited_field_definition,
             );
         }
+    }
+}
+
+fn validate_typed_dict_openness<'db>(
+    context: &InferContext<'db, '_>,
+    class: StaticClassLiteral<'db>,
+    class_node: &ast::StmtClassDef,
+    direct_bases: &[ClassType<'db>],
+) {
+    let db = context.db();
+    let child = TypedDictType::new(class.identity_specialization(db));
+    let child_openness = child.openness(db);
+    let child_items = child.items(db);
+
+    if let Some(arguments) = class_node.arguments.as_deref()
+        && arguments.find_keyword("closed").is_some()
+        && arguments.find_keyword("extra_items").is_some()
+    {
+        report_invalid_typed_dict_openness(
+            context,
+            class,
+            "`closed` and `extra_items` cannot both be specified",
+        );
+    }
+
+    for base in direct_bases {
+        let base_typed_dict = TypedDictType::new(*base);
+        let base_openness = base_typed_dict.openness(db);
+        let base_items = base_typed_dict.items(db);
+
+        match base_openness {
+            TypedDictOpenness::Open => {}
+            TypedDictOpenness::Closed => {
+                if !child_openness.is_closed() {
+                    report_invalid_typed_dict_openness(
+                        context,
+                        class,
+                        format_args!(
+                            "TypedDict `{}` must remain closed because base `{}` is closed",
+                            class.name(db),
+                            base.name(db),
+                        ),
+                    );
+                    continue;
+                }
+
+                if let Some((field_name, _)) = child_items
+                    .iter()
+                    .find(|(field_name, _)| !base_items.contains_key(*field_name))
+                {
+                    report_invalid_typed_dict_openness(
+                        context,
+                        class,
+                        format_args!(
+                            "Cannot add item `{field_name}` to closed TypedDict base `{}`",
+                            base.name(db),
+                        ),
+                    );
+                }
+            }
+            TypedDictOpenness::Extra(base_extra_items) if base_extra_items.is_read_only() => {
+                match child_openness {
+                    TypedDictOpenness::Open => {
+                        report_invalid_typed_dict_openness(
+                            context,
+                            class,
+                            format_args!(
+                                "TypedDict `{}` cannot be open because base `{}` has extra items",
+                                class.name(db),
+                                base.name(db),
+                            ),
+                        );
+                        continue;
+                    }
+                    TypedDictOpenness::Closed => {}
+                    TypedDictOpenness::Extra(child_extra_items) => {
+                        if !child_extra_items
+                            .declared_ty
+                            .is_assignable_to(db, base_extra_items.declared_ty)
+                        {
+                            report_invalid_typed_dict_openness(
+                                context,
+                                class,
+                                format_args!(
+                                    "Extra items type `{}` is not assignable to `{}` from base `{}`",
+                                    child_extra_items.declared_ty.display(db),
+                                    base_extra_items.declared_ty.display(db),
+                                    base.name(db),
+                                ),
+                            );
+                            continue;
+                        }
+                    }
+                }
+
+                if let Some((field_name, field)) = child_items.iter().find(|(field_name, field)| {
+                    !base_items.contains_key(*field_name)
+                        && !field
+                            .declared_ty
+                            .is_assignable_to(db, base_extra_items.declared_ty)
+                }) {
+                    report_invalid_typed_dict_openness(
+                        context,
+                        class,
+                        format_args!(
+                            "Item `{field_name}` of type `{}` is not assignable to extra items type `{}` from base `{}`",
+                            field.declared_ty.display(db),
+                            base_extra_items.declared_ty.display(db),
+                            base.name(db),
+                        ),
+                    );
+                }
+            }
+            TypedDictOpenness::Extra(base_extra_items) => {
+                let Some(child_extra_items) = child_openness.explicit_extra_items() else {
+                    report_invalid_typed_dict_openness(
+                        context,
+                        class,
+                        format_args!(
+                            "TypedDict `{}` must preserve mutable extra items from base `{}`",
+                            class.name(db),
+                            base.name(db),
+                        ),
+                    );
+                    continue;
+                };
+
+                if child_extra_items.is_read_only()
+                    || !child_extra_items
+                        .declared_ty
+                        .is_assignable_to(db, base_extra_items.declared_ty)
+                    || !base_extra_items
+                        .declared_ty
+                        .is_assignable_to(db, child_extra_items.declared_ty)
+                {
+                    report_invalid_typed_dict_openness(
+                        context,
+                        class,
+                        format_args!(
+                            "TypedDict `{}` must preserve mutable extra items type `{}` from base `{}`",
+                            class.name(db),
+                            base_extra_items.declared_ty.display(db),
+                            base.name(db),
+                        ),
+                    );
+                    continue;
+                }
+
+                if let Some((field_name, _)) = child_items.iter().find(|(field_name, field)| {
+                    !base_items.contains_key(*field_name)
+                        && (field.is_required()
+                            || field.is_read_only()
+                            || !field
+                                .declared_ty
+                                .is_assignable_to(db, base_extra_items.declared_ty)
+                            || !base_extra_items
+                                .declared_ty
+                                .is_assignable_to(db, field.declared_ty))
+                }) {
+                    report_invalid_typed_dict_openness(
+                        context,
+                        class,
+                        format_args!(
+                            "Item `{field_name}` must be mutable, not required, and consistent with extra items type `{}` from base `{}`",
+                            base_extra_items.declared_ty.display(db),
+                            base.name(db),
+                        ),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn report_invalid_typed_dict_openness(
+    context: &InferContext<'_, '_>,
+    class: StaticClassLiteral<'_>,
+    message: impl std::fmt::Display,
+) {
+    if let Some(builder) =
+        context.report_lint(&INVALID_TYPED_DICT_HEADER, class.header_range(context.db()))
+    {
+        builder.into_diagnostic(message);
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1880,6 +1880,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                                     Some(field),
                                                     TypedDictDeleteErrorKind::RequiredKey,
                                                 );
+                                            } else if typed_dict
+                                                .explicit_extra_items(db)
+                                                .is_some_and(|extra_items| {
+                                                    extra_items.is_read_only()
+                                                })
+                                            {
+                                                report_cannot_delete_typed_dict_key(
+                                                    &self.context,
+                                                    (&*target.slice).into(),
+                                                    typed_dict,
+                                                    key,
+                                                    None,
+                                                    TypedDictDeleteErrorKind::ReadOnlyExtraItem,
+                                                );
                                             } else {
                                                 // Key doesn't exist.
                                                 report_cannot_delete_typed_dict_key(

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1806,6 +1806,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             _ => {
                 if let Type::TypedDict(typed_dict) = object_ty {
+                    // A known undeclared key can only refer to an explicit extra item, so it can
+                    // be deleted whenever those items are mutable. An arbitrary string key could
+                    // instead refer to any declared field, so deletion is only safe when all
+                    // possible fields are optional and mutable.
                     let can_delete_extra_literal =
                         slice_ty.as_string_literal().is_some_and(|literal| {
                             !typed_dict.items(db).contains_key(literal.value(db))

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -14,8 +14,7 @@ use crate::types::diagnostic::{
     CALL_NON_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_KEY,
     INVALID_TYPE_ARGUMENTS, INVALID_TYPE_FORM, NOT_SUBSCRIPTABLE, POSSIBLY_MISSING_IMPLICIT_CALL,
     TypedDictDeleteErrorKind, report_cannot_delete_typed_dict_key,
-    report_invalid_arguments_to_annotated, report_invalid_key_on_typed_dict,
-    report_not_subscriptable,
+    report_invalid_arguments_to_annotated, report_not_subscriptable,
 };
 use crate::types::generics::{GenericContext, InferableTypeVars, bind_typevar};
 use crate::types::infer::builder::annotation_expression::PEP613Policy;
@@ -51,6 +50,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ) -> Option<Type<'db>> {
             match ty {
                 Type::TypedDict(typed_dict) => {
+                    if typed_dict.explicit_extra_items(db).is_some() {
+                        return Some(KnownClass::Str.to_instance(db));
+                    }
                     let keys = typed_dict
                         .items(db)
                         .keys()
@@ -1432,8 +1434,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let mut valid = true;
                 let slice_ty = infer_slice_ty(self, TypeContext::default());
                 let Some(keys) = key_literals(db, slice_ty) else {
-                    let rhs_value_ty = infer_rhs_value(self, TypeContext::default());
-
                     // Check if the key has a valid type. We only allow string literals, a union of string literals,
                     // or a dynamic type like `Any`. We can do this by checking assignability to `LiteralString`,
                     // but we need to exclude `LiteralString` itself. This check would technically allow weird key
@@ -1444,6 +1444,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         return true;
                     }
 
+                    if slice_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
+                        && let Some(expected_ty) = typed_dict.arbitrary_key_write_type(db)
+                    {
+                        let rhs_value_ty =
+                            infer_rhs_value(self, TypeContext::new(Some(expected_ty)));
+                        if rhs_value_ty.is_assignable_to(db, expected_ty) {
+                            return true;
+                        }
+
+                        if emit_diagnostic
+                            && let Some(builder) = self
+                                .context
+                                .report_lint(&INVALID_ASSIGNMENT, rhs_value_node)
+                        {
+                            let mut diagnostic = builder.into_diagnostic(format_args!(
+                                "Cannot assign value of type `{}` to key of type `{}` on TypedDict `{}`",
+                                rhs_value_ty.display(db),
+                                slice_ty.display(db),
+                                object_ty.display(db),
+                            ));
+                            diagnostic.set_primary_message(format_args!(
+                                "Expected value assignable to `{}`",
+                                expected_ty.display(db)
+                            ));
+                            attach_original_type_info(&mut diagnostic);
+                        }
+                        return false;
+                    }
+
+                    let rhs_value_ty = infer_rhs_value(self, TypeContext::default());
                     let assigned_d = rhs_value_ty.display(db);
                     let value_d = object_ty.display(db);
 
@@ -1481,31 +1511,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let mut infer_rhs_value = MultiInferenceGuard::new(infer_rhs_value);
 
                 for key in keys {
-                    let items = typed_dict.items(db);
-
-                    // Check if the key exists on the `TypedDict`
-                    let Some((_, item)) = items.iter().find(|(name, _)| *name == key) else {
-                        if emit_diagnostic {
-                            report_invalid_key_on_typed_dict(
-                                &self.context,
-                                target.value.as_ref().into(),
-                                target.slice.as_ref().into(),
-                                object_ty,
-                                full_object_ty,
-                                Type::string_literal(db, key),
-                                items,
-                            );
-                        }
-
-                        valid = false;
-                        continue;
-                    };
-
                     // Infer the value with type context.
-                    let value_ty = infer_rhs_value
-                        .infer_silent(self, TypeContext::new(Some(item.declared_ty)));
+                    let item = typed_dict.item(db, key);
+                    let value_ty = infer_rhs_value.infer_silent(
+                        self,
+                        TypeContext::new(item.as_ref().map(|item| item.declared_ty)),
+                    );
 
-                    key_count += 1;
+                    if item.is_some() {
+                        key_count += 1;
+                    }
                     valid &= TypedDictKeyAssignment {
                         context: &self.context,
                         typed_dict,
@@ -1790,6 +1805,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ),
 
             _ => {
+                if let Type::TypedDict(typed_dict) = object_ty {
+                    let can_delete_extra_literal =
+                        slice_ty.as_string_literal().is_some_and(|literal| {
+                            !typed_dict.items(db).contains_key(literal.value(db))
+                                && typed_dict
+                                    .explicit_extra_items(db)
+                                    .is_some_and(|extra_items| !extra_items.is_read_only())
+                        });
+                    let can_delete_arbitrary_key = slice_ty
+                        .is_assignable_to(db, KnownClass::Str.to_instance(db))
+                        && typed_dict.supports_arbitrary_key_deletion(db);
+                    if can_delete_extra_literal || can_delete_arbitrary_key {
+                        return;
+                    }
+                }
+
                 match object_ty.try_call_dunder(
                     db,
                     "__delitem__",

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1448,7 +1448,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
 
                     if slice_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
-                        && let Some(expected_ty) = typed_dict.arbitrary_key_write_type(db)
+                        && let Some(expected_ty) = typed_dict.arbitrary_key_mutation_type(db)
                     {
                         let rhs_value_ty =
                             infer_rhs_value(self, TypeContext::new(Some(expected_ty)));

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -37,6 +37,29 @@ use ty_python_core::definition::Definition;
 use ty_python_core::place::{PlaceExpr, PlaceExprRef};
 use ty_python_core::scope::FileScopeId;
 
+/// Given a string literal or a union of string literals, return an iterator over the contained
+/// strings, or `None` if the type is neither.
+fn string_literal_values<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<impl Iterator<Item = &'db str> + 'db> {
+    if let Some(literal) = ty.as_string_literal() {
+        Some(Either::Left(std::iter::once(literal.value(db))))
+    } else {
+        let elements = ty.as_union()?.elements(db);
+        elements
+            .iter()
+            .all(|ty| ty.as_string_literal().is_some())
+            .then(|| {
+                Either::Right(
+                    elements
+                        .iter()
+                        .filter_map(|ty| ty.as_string_literal().map(|lit| lit.value(db))),
+                )
+            })
+    }
+}
+
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     pub(super) fn typed_dict_key_expected_type(&self, ty: Type<'db>) -> Option<Type<'db>> {
         struct TypedDictKeyExpectedType;
@@ -1318,26 +1341,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         infer_rhs_value: &mut dyn FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
         emit_diagnostic: bool,
     ) -> bool {
-        /// Given a string literal or a union of string literals, return an iterator over the contained
-        /// strings, or `None`, if the type is neither.
-        fn key_literals<'db>(
-            db: &'db dyn Db,
-            slice_ty: Type<'db>,
-        ) -> Option<impl Iterator<Item = &'db str> + 'db> {
-            if let Some(literal) = slice_ty.as_string_literal() {
-                Some(Either::Left(std::iter::once(literal.value(db))))
-            } else {
-                slice_ty.as_union().map(|union| {
-                    Either::Right(
-                        union
-                            .elements(db)
-                            .iter()
-                            .filter_map(|ty| ty.as_string_literal().map(|lit| lit.value(db))),
-                    )
-                })
-            }
-        }
-
         let db = self.db();
 
         let attach_original_type_info = |diagnostic: &mut LintDiagnosticGuard| {
@@ -1433,7 +1436,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 let mut valid = true;
                 let slice_ty = infer_slice_ty(self, TypeContext::default());
-                let Some(keys) = key_literals(db, slice_ty) else {
+                let Some(keys) = string_literal_values(db, slice_ty) else {
                     // Check if the key has a valid type. We only allow string literals, a union of string literals,
                     // or a dynamic type like `Any`. We can do this by checking assignability to `LiteralString`,
                     // but we need to exclude `LiteralString` itself. This check would technically allow weird key
@@ -1806,21 +1809,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             _ => {
                 if let Type::TypedDict(typed_dict) = object_ty {
-                    // A known undeclared key can only refer to an explicit extra item, so it can
-                    // be deleted whenever those items are mutable. An arbitrary string key could
+                    // Known undeclared keys can only refer to explicit extra items, so they can be
+                    // deleted whenever those items are mutable. An arbitrary string key could
                     // instead refer to any declared field, so deletion is only safe when all
                     // possible fields are optional and mutable.
-                    let can_delete_extra_literal =
-                        slice_ty.as_string_literal().is_some_and(|literal| {
-                            !typed_dict.items(db).contains_key(literal.value(db))
-                                && typed_dict
-                                    .explicit_extra_items(db)
-                                    .is_some_and(|extra_items| !extra_items.is_read_only())
+                    let can_delete_extra_literals = typed_dict
+                        .explicit_extra_items(db)
+                        .is_some_and(|extra_items| !extra_items.is_read_only())
+                        && string_literal_values(db, slice_ty).is_some_and(|mut literals| {
+                            literals.all(|literal| !typed_dict.items(db).contains_key(literal))
                         });
                     let can_delete_arbitrary_key = slice_ty
                         .is_assignable_to(db, KnownClass::Str.to_instance(db))
                         && typed_dict.supports_arbitrary_key_deletion(db);
-                    if can_delete_extra_literal || can_delete_arbitrary_key {
+                    if can_delete_extra_literals || can_delete_arbitrary_key {
                         return;
                     }
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -308,7 +308,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     openness: extra_items.unwrap_or(if closed {
                         TypedDictOpenness::Closed
                     } else {
-                        TypedDictOpenness::Open
+                        TypedDictOpenness::ImplicitlyOpen
                     }),
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -14,9 +14,9 @@ use crate::types::diagnostic::{
 use crate::types::infer::builder::DeferredExpressionState;
 use crate::types::special_form::TypeQualifier;
 use crate::types::typed_dict::{
-    TypedDictSchema, collect_guaranteed_keyword_keys, functional_typed_dict_field,
-    infer_unpacked_keyword_types, typed_dict_with_relaxed_keys, validate_typed_dict_constructor,
-    validate_typed_dict_dict_literal,
+    TypedDictOpenness, TypedDictSchema, collect_guaranteed_keyword_keys,
+    functional_typed_dict_field, infer_unpacked_keyword_types, typed_dict_with_relaxed_keys,
+    validate_typed_dict_constructor, validate_typed_dict_dict_literal,
 };
 use crate::types::{
     IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictType,
@@ -142,6 +142,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
 
         let mut total = true;
+        let mut closed = false;
+        let mut extra_items = None;
 
         for kw in keywords {
             let Some(arg) = &kw.arg else {
@@ -170,11 +172,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         } else if !kw_type.bool(db).is_always_true() {
                             total = true;
                         }
+                    } else {
+                        closed = kw_type.bool(db).is_always_true();
                     }
                 }
                 "extra_items" => {
                     if definition.is_none() {
-                        self.infer_extra_items_kwarg(&kw.value);
+                        let annotation = self.infer_extra_items_kwarg(&kw.value);
+                        extra_items = Some(TypedDictOpenness::extra(
+                            annotation.inner_type(),
+                            annotation.qualifiers().contains(TypeQualifiers::READ_ONLY),
+                        ));
                     }
                 }
                 unknown_kwarg => {
@@ -186,6 +194,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                 }
             }
+        }
+
+        if let Some(extra_items_kwarg) = call_expr.arguments.find_keyword("extra_items")
+            && call_expr.arguments.find_keyword("closed").is_some()
+            && let Some(builder) = self
+                .context
+                .report_lint(&INVALID_ARGUMENT_TYPE, extra_items_kwarg)
+        {
+            builder.into_diagnostic("`closed` and `extra_items` cannot both be specified");
         }
 
         if !starred_arguments.is_empty() || !double_starred_arguments.is_empty() {
@@ -287,6 +304,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     scope,
                     offset: call_u32 - anchor_u32,
                     schema,
+                    openness: extra_items.unwrap_or(if closed {
+                        TypedDictOpenness::Closed
+                    } else {
+                        TypedDictOpenness::Open
+                    }),
                 }
             }
         };
@@ -307,7 +329,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             items,
         } = dict;
 
-        let typed_dict_items = typed_dict.items(self.db());
         let key_tcx =
             TypeContext::new(self.typed_dict_key_expected_type(Type::TypedDict(typed_dict)));
 
@@ -319,7 +340,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             let value_ty = if let Some(key_ty) = key_ty
                 && let Some(key) = key_ty.as_string_literal()
-                && let Some(field) = typed_dict_items.get(key.value(self.db()))
+                && let Some(field) = typed_dict.item(self.db(), key.value(self.db()))
             {
                 self.infer_expression(&item.value, TypeContext::new(Some(field.declared_ty)))
             } else {
@@ -421,12 +442,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         typed_dict: TypedDictType<'db>,
         arguments: &ast::Arguments,
     ) {
-        let items = typed_dict.items(self.db());
         for keyword in &arguments.keywords {
             let value_tcx = keyword
                 .arg
                 .as_ref()
-                .and_then(|arg_name| items.get(arg_name.id.as_str()))
+                .and_then(|arg_name| typed_dict.item(self.db(), arg_name.id.as_str()))
                 .map(|field| TypeContext::new(Some(field.declared_ty)))
                 .unwrap_or_default();
             self.get_or_infer_expression(&keyword.value, value_tcx);
@@ -444,7 +464,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         typed_dict: TypedDictType<'db>,
         dict_expr: &ast::ExprDict,
     ) {
-        let items = typed_dict.items(self.db());
         let key_tcx =
             TypeContext::new(self.typed_dict_key_expected_type(Type::TypedDict(typed_dict)));
 
@@ -454,7 +473,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .as_ref()
                 .map(|key| self.get_or_infer_expression(key, key_tcx))
                 .and_then(Type::as_string_literal)
-                .and_then(|key| items.get(key.value(self.db())))
+                .and_then(|key| typed_dict.item(self.db(), key.value(self.db())))
                 .map(|field| TypeContext::new(Some(field.declared_ty)))
                 .unwrap_or_default();
             self.get_or_infer_expression(&item.value, value_tcx);

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -346,7 +346,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 self.infer_expression(&item.value, TypeContext::new(Some(field.declared_ty)))
             } else if key_ty.is_some_and(|key_ty| {
                 key_ty.is_assignable_to(self.db(), KnownClass::Str.to_instance(self.db()))
-            }) && let Some(value_ty) = typed_dict.arbitrary_key_value_type(self.db())
+            }) && let Some(value_ty) =
+                typed_dict.arbitrary_key_initialization_type(self.db())
             {
                 self.infer_expression(&item.value, TypeContext::new(Some(value_ty)))
             } else {
@@ -485,7 +486,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             } else if key_ty.is_some_and(|key_ty| {
                 key_ty.is_assignable_to(self.db(), KnownClass::Str.to_instance(self.db()))
             }) {
-                TypeContext::new(typed_dict.arbitrary_key_value_type(self.db()))
+                TypeContext::new(typed_dict.arbitrary_key_initialization_type(self.db()))
             } else {
                 TypeContext::default()
             };

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -180,6 +180,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     if definition.is_none() {
                         let annotation = self.infer_extra_items_kwarg(&kw.value);
                         extra_items = Some(TypedDictOpenness::extra(
+                            db,
                             annotation.inner_type(),
                             annotation.qualifiers().contains(TypeQualifiers::READ_ONLY),
                         ));

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -343,6 +343,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 && let Some(field) = typed_dict.item(self.db(), key.value(self.db()))
             {
                 self.infer_expression(&item.value, TypeContext::new(Some(field.declared_ty)))
+            } else if key_ty.is_some_and(|key_ty| {
+                key_ty.is_assignable_to(self.db(), KnownClass::Str.to_instance(self.db()))
+            }) && let Some(value_ty) = typed_dict.arbitrary_key_value_type(self.db())
+            {
+                self.infer_expression(&item.value, TypeContext::new(Some(value_ty)))
             } else {
                 self.infer_expression(&item.value, TypeContext::default())
             };
@@ -468,14 +473,21 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             TypeContext::new(self.typed_dict_key_expected_type(Type::TypedDict(typed_dict)));
 
         for item in &dict_expr.items {
-            let value_tcx = item
+            let key_ty = item
                 .key
                 .as_ref()
-                .map(|key| self.get_or_infer_expression(key, key_tcx))
-                .and_then(Type::as_string_literal)
-                .and_then(|key| typed_dict.item(self.db(), key.value(self.db())))
-                .map(|field| TypeContext::new(Some(field.declared_ty)))
-                .unwrap_or_default();
+                .map(|key| self.get_or_infer_expression(key, key_tcx));
+            let value_tcx = if let Some(key) = key_ty.and_then(Type::as_string_literal)
+                && let Some(field) = typed_dict.item(self.db(), key.value(self.db()))
+            {
+                TypeContext::new(Some(field.declared_ty))
+            } else if key_ty.is_some_and(|key_ty| {
+                key_ty.is_assignable_to(self.db(), KnownClass::Str.to_instance(self.db()))
+            }) {
+                TypeContext::new(typed_dict.arbitrary_key_value_type(self.db()))
+            } else {
+                TypeContext::default()
+            };
             self.get_or_infer_expression(&item.value, value_tcx);
         }
     }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1781,14 +1781,17 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 })
             }
 
-            // TODO: When we support `closed` and/or `extra_items`, we could allow assignments to other
-            // compatible `Mapping`s. `extra_items` could also allow for some assignments to `dict`, as
-            // long as `total=False`. (But then again, does anyone want a non-total `TypedDict` where all
-            // key types are a supertype of the extra items type?)
             (Type::TypedDict(typed_dict), _) => self.with_recursion_guard(source, target, || {
-                let spec = &[KnownClass::Str.to_instance(db), Type::object()];
-                let str_object_map = KnownClass::Mapping.to_specialized_instance(db, spec);
-                let result = self.check_type_pair(db, str_object_map, target);
+                let fallback = if let Some(value_ty) = typed_dict.dict_value_type(db) {
+                    KnownClass::Dict
+                        .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), value_ty])
+                } else {
+                    KnownClass::Mapping.to_specialized_instance(
+                        db,
+                        &[KnownClass::Str.to_instance(db), typed_dict.value_type(db)],
+                    )
+                };
+                let result = self.check_type_pair(db, fallback, target);
                 if result.is_never_satisfied(db) {
                     if let Type::NominalInstance(instance) = target
                         && instance.class(db).is_known(db, KnownClass::Dict)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1782,7 +1782,15 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             (Type::TypedDict(typed_dict), _) => self.with_recursion_guard(source, target, || {
-                let fallback = if let Some(value_ty) = typed_dict.dict_value_type(db) {
+                let dict_value_type = if matches!(
+                    self.relation,
+                    TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability
+                ) {
+                    typed_dict.assignable_dict_value_type(db)
+                } else {
+                    typed_dict.dict_value_type(db)
+                };
+                let fallback = if let Some(value_ty) = dict_value_type {
                     KnownClass::Dict
                         .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), value_ty])
                 } else {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -769,6 +769,7 @@ impl<'db> Signature<'db> {
                     .zip(previous.parameters.iter())
                     .map(|(curr, prev)| curr.cycle_normalized(db, prev, cycle)),
             )
+            .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail())
         } else {
             debug_assert_eq!(previous.parameters, Parameters::bottom());
             self.parameters.clone()
@@ -802,6 +803,7 @@ impl<'db> Signature<'db> {
                 parameters.push(param.recursive_type_normalized_impl(db, div, nested)?);
             }
             Parameters::new(db, parameters)
+                .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail())
         };
         Some(Self {
             generic_context: self.generic_context,
@@ -986,7 +988,8 @@ impl<'db> Signature<'db> {
             parameters.next();
         }
 
-        let mut parameters = Parameters::new(db, parameters);
+        let mut parameters = Parameters::new(db, parameters)
+            .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail());
         let mut return_ty = self.return_ty;
         let binding_context = self.definition.map(BindingContext::Definition);
         if let Some(self_type) = self_type
@@ -1176,7 +1179,11 @@ impl<'db> Signature<'db> {
 
         // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
         // below can separate them, which would otherwise prevent expansion.
-        let remaining = Parameters::new(db, remaining).expand_paramspec_variadics(db);
+        let remaining = Parameters::new(db, remaining)
+            .with_hidden_open_typed_dict_tail(
+                signature.parameters().has_hidden_open_typed_dict_tail(),
+            )
+            .expand_paramspec_variadics(db);
 
         let mut reordered = Vec::with_capacity(remaining.len());
         let mut keyword_only = Vec::new();
@@ -1204,7 +1211,10 @@ impl<'db> Signature<'db> {
         reordered.extend(keyword_variadic);
 
         signature
-            .with_parameters(Parameters::new(db, reordered))
+            .with_parameters(
+                Parameters::new(db, reordered)
+                    .with_hidden_open_typed_dict_tail(remaining.has_hidden_open_typed_dict_tail()),
+            )
             .with_return_type(return_ty)
     }
 
@@ -3101,6 +3111,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         }
 
+        if target.parameters.has_hidden_open_typed_dict_tail() {
+            let source_hidden_tail = source
+                .parameters
+                .has_hidden_open_typed_dict_tail()
+                .then_some(Type::object());
+            let Some(source_tail_ty) = source_keyword_variadic.or(source_hidden_tail) else {
+                return self.never();
+            };
+            if !check_types(Type::object(), source_tail_ty, None, target_index) {
+                return result;
+            }
+        }
+
         // If there are still unmatched keyword parameters from `source`, then they should be
         // optional otherwise the subtype relation is invalid.
         #[expect(
@@ -3191,6 +3214,11 @@ struct ParametersData<'db> {
     // TODO: use SmallVec here once invariance bug is fixed
     value: Box<[Parameter<'db>]>,
     kind: ParametersKind<'db>,
+    /// Whether this parameter list came from `**kwargs: Unpack[OpenTypedDict]`.
+    ///
+    /// Open `TypedDict`s do not expose arbitrary keywords to direct calls, but hidden items still
+    /// need to participate when the unpacked signature is the target of a callable relation.
+    has_hidden_open_typed_dict_tail: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -3200,10 +3228,19 @@ pub(crate) struct Parameters<'db> {
 
 impl<'db> Parameters<'db> {
     fn from_parts(value: impl Into<Box<[Parameter<'db>]>>, kind: ParametersKind<'db>) -> Self {
+        Self::from_parts_with_hidden_open_typed_dict_tail(value, kind, false)
+    }
+
+    fn from_parts_with_hidden_open_typed_dict_tail(
+        value: impl Into<Box<[Parameter<'db>]>>,
+        kind: ParametersKind<'db>,
+        has_hidden_open_typed_dict_tail: bool,
+    ) -> Self {
         Self {
             data: Arc::new(ParametersData {
                 value: value.into(),
                 kind,
+                has_hidden_open_typed_dict_tail,
             }),
         }
     }
@@ -3222,9 +3259,11 @@ impl<'db> Parameters<'db> {
     ) -> Self {
         let parameters = parameters.into_iter();
         let mut value: Vec<Parameter<'db>> = Vec::with_capacity(parameters.size_hint().0);
+        let mut has_hidden_open_typed_dict_tail = false;
 
         for parameter in parameters {
             if let Some(unpacked_typed_dict) = parameter.unpacked_typed_dict(db) {
+                has_hidden_open_typed_dict_tail |= unpacked_typed_dict.openness(db).is_open();
                 let unpacked_keys = parameter
                     .unpacked_typed_dict_keys(db)
                     .expect("a TypedDict should expose unpacked keys");
@@ -3337,7 +3376,11 @@ impl<'db> Parameters<'db> {
             }
         }
 
-        Self::from_parts(value, kind)
+        Self::from_parts_with_hidden_open_typed_dict_tail(
+            value,
+            kind,
+            has_hidden_open_typed_dict_tail,
+        )
     }
 
     /// Create an empty parameter list.
@@ -3674,8 +3717,22 @@ impl<'db> Parameters<'db> {
             .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
             .collect();
 
-        Self::from_parts(value, self.data.kind)
+        Self::from_parts_with_hidden_open_typed_dict_tail(
+            value,
+            self.data.kind,
+            self.data.has_hidden_open_typed_dict_tail,
+        )
     }
+
+    fn with_hidden_open_typed_dict_tail(mut self, has_hidden_tail: bool) -> Self {
+        Arc::make_mut(&mut self.data).has_hidden_open_typed_dict_tail |= has_hidden_tail;
+        self
+    }
+
+    fn has_hidden_open_typed_dict_tail(&self) -> bool {
+        self.data.has_hidden_open_typed_dict_tail
+    }
+
     pub(crate) fn len(&self) -> usize {
         self.data.value.len()
     }
@@ -3797,6 +3854,7 @@ impl<'db> Parameters<'db> {
         expanded.extend_from_slice(mapped_signature.parameters().as_slice());
         expanded.extend_from_slice(&self.data.value[variadic_index + 2..]);
         Parameters::new(db, expanded)
+            .with_hidden_open_typed_dict_tail(self.has_hidden_open_typed_dict_tail())
     }
 }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3174,8 +3174,8 @@ pub(crate) enum ParametersKind<'db> {
 /// The `value` field should contain the parameters that participate in the callable signature
 /// proper. For example, even if this represents a `Gradual` form, the `value` field should still
 /// contain the `*args: Any` and `**kwargs: Any` parameter. A `**kwargs: Unpack[TypedDict]`
-/// parameter is normalized to the keyword-only parameters exposed to callers plus a possible
-/// trailing `**kwargs` parameter for explicit extra items or an open `TypedDict`.
+/// parameter is normalized to the keyword-only parameters exposed to callers plus a trailing
+/// `**kwargs` parameter for explicit extra items.
 ///
 /// The `kind` field is used to indicate the specific form of the parameter list which can,
 /// optionally, include additional information such as the bound `ParamSpec` type variable.
@@ -3210,8 +3210,8 @@ impl<'db> Parameters<'db> {
     /// if the parameter list contains `*args` and `**kwargs`, then it checks their annotated types
     /// and the presence of other parameter kinds to determine if they represent a gradual form, a
     /// `ParamSpec`, or a `Concatenate` form. `**kwargs: Unpack[TypedDict]` is normalized here by
-    /// synthesizing keyword-only parameters for the unpacked keys and a possible trailing
-    /// `**kwargs` parameter for explicit extra items or an open `TypedDict`.
+    /// synthesizing keyword-only parameters for the unpacked keys and a trailing `**kwargs`
+    /// parameter for explicit extra items.
     pub(crate) fn new(
         db: &'db dyn Db,
         parameters: impl IntoIterator<Item = Parameter<'db>>,
@@ -3244,8 +3244,7 @@ impl<'db> Parameters<'db> {
                     );
                 }
 
-                if let Some(extra_items) = unpacked_typed_dict.openness(db).effective_extra_items()
-                {
+                if let Some(extra_items) = unpacked_typed_dict.explicit_extra_items(db) {
                     value.push(
                         Parameter::keyword_variadic(kwargs_name)
                             .with_annotated_type(extra_items.declared_ty),

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3174,8 +3174,8 @@ pub(crate) enum ParametersKind<'db> {
 /// The `value` field should contain the parameters that participate in the callable signature
 /// proper. For example, even if this represents a `Gradual` form, the `value` field should still
 /// contain the `*args: Any` and `**kwargs: Any` parameter. A `**kwargs: Unpack[TypedDict]`
-/// parameter is normalized to the keyword-only parameters exposed to callers plus a trailing
-/// `**kwargs` parameter for explicit extra items.
+/// parameter is normalized to the keyword-only parameters exposed to callers plus a possible
+/// trailing `**kwargs` parameter for explicit extra items or an open `TypedDict`.
 ///
 /// The `kind` field is used to indicate the specific form of the parameter list which can,
 /// optionally, include additional information such as the bound `ParamSpec` type variable.
@@ -3210,8 +3210,8 @@ impl<'db> Parameters<'db> {
     /// if the parameter list contains `*args` and `**kwargs`, then it checks their annotated types
     /// and the presence of other parameter kinds to determine if they represent a gradual form, a
     /// `ParamSpec`, or a `Concatenate` form. `**kwargs: Unpack[TypedDict]` is normalized here by
-    /// synthesizing keyword-only parameters for the unpacked keys and a trailing `**kwargs`
-    /// parameter for explicit extra items.
+    /// synthesizing keyword-only parameters for the unpacked keys and a possible trailing
+    /// `**kwargs` parameter for explicit extra items or an open `TypedDict`.
     pub(crate) fn new(
         db: &'db dyn Db,
         parameters: impl IntoIterator<Item = Parameter<'db>>,
@@ -3244,7 +3244,8 @@ impl<'db> Parameters<'db> {
                     );
                 }
 
-                if let Some(extra_items) = unpacked_typed_dict.explicit_extra_items(db) {
+                if let Some(extra_items) = unpacked_typed_dict.openness(db).effective_extra_items()
+                {
                     value.push(
                         Parameter::keyword_variadic(kwargs_name)
                             .with_annotated_type(extra_items.declared_ty),

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -10,7 +10,6 @@
 //! argument types and return types. For each callable type in the union, the call expression's
 //! arguments must match _at least one_ overload.
 
-use std::collections::BTreeMap;
 use std::slice::Iter;
 use std::sync::Arc;
 
@@ -31,10 +30,7 @@ use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
 use crate::types::relation::{
     HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
-use crate::types::typed_dict::{
-    UnpackedTypedDictKey, extract_unpacked_typed_dict_keys_from_kwargs_annotation,
-    extract_unpacked_typed_dict_keys_from_value_type,
-};
+use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation;
 use crate::types::typevar::{BoundTypeVarIdentity, max_typevar_freshness_matching_generic_context};
 use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, ErrorContext,
@@ -3225,15 +3221,12 @@ impl<'db> Parameters<'db> {
 
         for parameter in parameters {
             if let Some(unpacked_typed_dict) = parameter.unpacked_typed_dict(db) {
-                let unpacked_keys = parameter
-                    .unpacked_typed_dict_keys(db)
-                    .expect("a TypedDict should expose unpacked keys");
                 let kwargs_name = parameter
                     .name()
                     .expect("keyword variadic parameter always has a name")
                     .clone();
 
-                for (name, unpacked_key) in unpacked_keys {
+                for (name, field) in unpacked_typed_dict.items(db) {
                     if value
                         .iter()
                         .any(|existing| existing.callable_by_name(name.as_str()))
@@ -3242,16 +3235,17 @@ impl<'db> Parameters<'db> {
                     }
 
                     value.push(
-                        Parameter::keyword_only(name)
-                            .with_annotated_type(unpacked_key.value_ty)
+                        Parameter::keyword_only(name.clone())
+                            .with_annotated_type(field.declared_ty)
                             .with_optional_default_type(
-                                (!unpacked_key.is_required).then_some(Type::unknown()),
+                                (!field.is_required()).then_some(Type::unknown()),
                             )
-                            .with_definition(unpacked_key.definition),
+                            .with_definition(field.first_declaration()),
                     );
                 }
 
-                if let Some(extra_items) = unpacked_typed_dict.effective_extra_items(db) {
+                if let Some(extra_items) = unpacked_typed_dict.openness(db).effective_extra_items()
+                {
                     value.push(
                         Parameter::keyword_variadic(kwargs_name)
                             .with_annotated_type(extra_items.declared_ty),
@@ -4176,17 +4170,6 @@ impl<'db> Parameter<'db> {
             } => param_name == name,
             _ => false,
         }
-    }
-
-    /// Returns the unpacked `TypedDict` keys if this is a `**kwargs: Unpack[TypedDict]`
-    /// parameter.
-    pub(crate) fn unpacked_typed_dict_keys(
-        &self,
-        db: &'db dyn Db,
-    ) -> Option<BTreeMap<Name, UnpackedTypedDictKey<'db>>> {
-        self.unpacked_typed_dict(db).and_then(|typed_dict| {
-            extract_unpacked_typed_dict_keys_from_value_type(db, Type::TypedDict(typed_dict))
-        })
     }
 
     fn unpacked_typed_dict(&self, db: &'db dyn Db) -> Option<TypedDictType<'db>> {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -769,7 +769,6 @@ impl<'db> Signature<'db> {
                     .zip(previous.parameters.iter())
                     .map(|(curr, prev)| curr.cycle_normalized(db, prev, cycle)),
             )
-            .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail())
         } else {
             debug_assert_eq!(previous.parameters, Parameters::bottom());
             self.parameters.clone()
@@ -803,7 +802,6 @@ impl<'db> Signature<'db> {
                 parameters.push(param.recursive_type_normalized_impl(db, div, nested)?);
             }
             Parameters::new(db, parameters)
-                .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail())
         };
         Some(Self {
             generic_context: self.generic_context,
@@ -988,8 +986,7 @@ impl<'db> Signature<'db> {
             parameters.next();
         }
 
-        let mut parameters = Parameters::new(db, parameters)
-            .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail());
+        let mut parameters = Parameters::new(db, parameters);
         let mut return_ty = self.return_ty;
         let binding_context = self.definition.map(BindingContext::Definition);
         if let Some(self_type) = self_type
@@ -1179,11 +1176,7 @@ impl<'db> Signature<'db> {
 
         // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
         // below can separate them, which would otherwise prevent expansion.
-        let remaining = Parameters::new(db, remaining)
-            .with_hidden_open_typed_dict_tail(
-                signature.parameters().has_hidden_open_typed_dict_tail(),
-            )
-            .expand_paramspec_variadics(db);
+        let remaining = Parameters::new(db, remaining).expand_paramspec_variadics(db);
 
         let mut reordered = Vec::with_capacity(remaining.len());
         let mut keyword_only = Vec::new();
@@ -1211,10 +1204,7 @@ impl<'db> Signature<'db> {
         reordered.extend(keyword_variadic);
 
         signature
-            .with_parameters(
-                Parameters::new(db, reordered)
-                    .with_hidden_open_typed_dict_tail(remaining.has_hidden_open_typed_dict_tail()),
-            )
+            .with_parameters(Parameters::new(db, reordered))
             .with_return_type(return_ty)
     }
 
@@ -1920,17 +1910,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 )
             }
         }
-
-        let source_with_hidden_tail = source
-            .parameters
-            .with_hidden_open_typed_dict_tail_for_relation()
-            .map(|parameters| source.clone().with_parameters(parameters));
-        let target_with_hidden_tail = target
-            .parameters
-            .with_hidden_open_typed_dict_tail_for_relation()
-            .map(|parameters| target.clone().with_parameters(parameters));
-        let source = source_with_hidden_tail.as_ref().unwrap_or(source);
-        let target = target_with_hidden_tail.as_ref().unwrap_or(target);
 
         // Fast path: if the target accepts positional calls that the source cannot accept, reject
         // without checking return types or individual parameter types. The full parameter
@@ -3212,11 +3191,6 @@ struct ParametersData<'db> {
     // TODO: use SmallVec here once invariance bug is fixed
     value: Box<[Parameter<'db>]>,
     kind: ParametersKind<'db>,
-    /// Whether this parameter list came from `**kwargs: Unpack[OpenTypedDict]`.
-    ///
-    /// Open `TypedDict`s do not expose arbitrary keywords to direct calls, but hidden items still
-    /// need to participate in callable assignability.
-    has_hidden_open_typed_dict_tail: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -3226,19 +3200,10 @@ pub(crate) struct Parameters<'db> {
 
 impl<'db> Parameters<'db> {
     fn from_parts(value: impl Into<Box<[Parameter<'db>]>>, kind: ParametersKind<'db>) -> Self {
-        Self::from_parts_with_hidden_open_typed_dict_tail(value, kind, false)
-    }
-
-    fn from_parts_with_hidden_open_typed_dict_tail(
-        value: impl Into<Box<[Parameter<'db>]>>,
-        kind: ParametersKind<'db>,
-        has_hidden_open_typed_dict_tail: bool,
-    ) -> Self {
         Self {
             data: Arc::new(ParametersData {
                 value: value.into(),
                 kind,
-                has_hidden_open_typed_dict_tail,
             }),
         }
     }
@@ -3257,11 +3222,9 @@ impl<'db> Parameters<'db> {
     ) -> Self {
         let parameters = parameters.into_iter();
         let mut value: Vec<Parameter<'db>> = Vec::with_capacity(parameters.size_hint().0);
-        let mut has_hidden_open_typed_dict_tail = false;
 
         for parameter in parameters {
             if let Some(unpacked_typed_dict) = parameter.unpacked_typed_dict(db) {
-                has_hidden_open_typed_dict_tail |= unpacked_typed_dict.openness(db).is_open();
                 let unpacked_keys = parameter
                     .unpacked_typed_dict_keys(db)
                     .expect("a TypedDict should expose unpacked keys");
@@ -3374,11 +3337,7 @@ impl<'db> Parameters<'db> {
             }
         }
 
-        Self::from_parts_with_hidden_open_typed_dict_tail(
-            value,
-            kind,
-            has_hidden_open_typed_dict_tail,
-        )
+        Self::from_parts(value, kind)
     }
 
     /// Create an empty parameter list.
@@ -3715,35 +3674,8 @@ impl<'db> Parameters<'db> {
             .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
             .collect();
 
-        Self::from_parts_with_hidden_open_typed_dict_tail(
-            value,
-            self.data.kind,
-            self.data.has_hidden_open_typed_dict_tail,
-        )
+        Self::from_parts(value, self.data.kind)
     }
-
-    fn with_hidden_open_typed_dict_tail(mut self, has_hidden_tail: bool) -> Self {
-        Arc::make_mut(&mut self.data).has_hidden_open_typed_dict_tail = has_hidden_tail;
-        self
-    }
-
-    fn has_hidden_open_typed_dict_tail(&self) -> bool {
-        self.data.has_hidden_open_typed_dict_tail
-    }
-
-    fn with_hidden_open_typed_dict_tail_for_relation(&self) -> Option<Self> {
-        if !self.has_hidden_open_typed_dict_tail() {
-            return None;
-        }
-
-        let mut parameters = self.as_slice().to_vec();
-        parameters.push(
-            Parameter::keyword_variadic(Name::new_static("kwargs"))
-                .with_annotated_type(Type::object()),
-        );
-        Some(Self::from_parts(parameters, self.kind()))
-    }
-
     pub(crate) fn len(&self) -> usize {
         self.data.value.len()
     }
@@ -3865,7 +3797,6 @@ impl<'db> Parameters<'db> {
         expanded.extend_from_slice(mapped_signature.parameters().as_slice());
         expanded.extend_from_slice(&self.data.value[variadic_index + 2..]);
         Parameters::new(db, expanded)
-            .with_hidden_open_typed_dict_tail(self.has_hidden_open_typed_dict_tail())
     }
 }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3111,17 +3111,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         }
 
-        if target.parameters.has_hidden_open_typed_dict_tail() {
-            let source_hidden_tail = source
-                .parameters
-                .has_hidden_open_typed_dict_tail()
-                .then_some(Type::object());
-            let Some(source_tail_ty) = source_keyword_variadic.or(source_hidden_tail) else {
-                return self.never();
-            };
-            if !check_types(Type::object(), source_tail_ty, None, target_index) {
-                return result;
-            }
+        if target.parameters.has_hidden_open_typed_dict_tail()
+            && source_keyword_variadic.is_none()
+            && !source.parameters.has_hidden_open_typed_dict_tail()
+        {
+            return self.never();
         }
 
         // If there are still unmatched keyword parameters from `source`, then they should be

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -40,8 +40,7 @@ use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, ErrorContext,
     ErrorContextTree, FindLegacyTypeVarsVisitor, KnownClass, MaterializationKind,
     ParamSpecAttrKind, ParameterDescription, SelfBinding, TypeContext, TypeMapping, TypeVarNonce,
-    TypedDictType,
-    UnionBuilder, VarianceInferable, infer_complete_scope_types, todo_type,
+    TypedDictType, UnionBuilder, VarianceInferable, infer_complete_scope_types, todo_type,
 };
 use crate::{Db, FxOrderSet};
 use ruff_python_ast::{self as ast, name::Name};
@@ -770,6 +769,7 @@ impl<'db> Signature<'db> {
                     .zip(previous.parameters.iter())
                     .map(|(curr, prev)| curr.cycle_normalized(db, prev, cycle)),
             )
+            .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail())
         } else {
             debug_assert_eq!(previous.parameters, Parameters::bottom());
             self.parameters.clone()
@@ -803,6 +803,7 @@ impl<'db> Signature<'db> {
                 parameters.push(param.recursive_type_normalized_impl(db, div, nested)?);
             }
             Parameters::new(db, parameters)
+                .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail())
         };
         Some(Self {
             generic_context: self.generic_context,
@@ -987,7 +988,8 @@ impl<'db> Signature<'db> {
             parameters.next();
         }
 
-        let mut parameters = Parameters::new(db, parameters);
+        let mut parameters = Parameters::new(db, parameters)
+            .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail());
         let mut return_ty = self.return_ty;
         let binding_context = self.definition.map(BindingContext::Definition);
         if let Some(self_type) = self_type
@@ -1177,7 +1179,11 @@ impl<'db> Signature<'db> {
 
         // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
         // below can separate them, which would otherwise prevent expansion.
-        let remaining = Parameters::new(db, remaining).expand_paramspec_variadics(db);
+        let remaining = Parameters::new(db, remaining)
+            .with_hidden_open_typed_dict_tail(
+                signature.parameters().has_hidden_open_typed_dict_tail(),
+            )
+            .expand_paramspec_variadics(db);
 
         let mut reordered = Vec::with_capacity(remaining.len());
         let mut keyword_only = Vec::new();
@@ -1205,7 +1211,10 @@ impl<'db> Signature<'db> {
         reordered.extend(keyword_variadic);
 
         signature
-            .with_parameters(Parameters::new(db, reordered))
+            .with_parameters(
+                Parameters::new(db, reordered)
+                    .with_hidden_open_typed_dict_tail(remaining.has_hidden_open_typed_dict_tail()),
+            )
             .with_return_type(return_ty)
     }
 
@@ -1911,6 +1920,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 )
             }
         }
+
+        let source_with_hidden_tail = source
+            .parameters
+            .with_hidden_open_typed_dict_tail_for_relation()
+            .map(|parameters| source.clone().with_parameters(parameters));
+        let target_with_hidden_tail = target
+            .parameters
+            .with_hidden_open_typed_dict_tail_for_relation()
+            .map(|parameters| target.clone().with_parameters(parameters));
+        let source = source_with_hidden_tail.as_ref().unwrap_or(source);
+        let target = target_with_hidden_tail.as_ref().unwrap_or(target);
 
         // Fast path: if the target accepts positional calls that the source cannot accept, reject
         // without checking return types or individual parameter types. The full parameter
@@ -3192,6 +3212,11 @@ struct ParametersData<'db> {
     // TODO: use SmallVec here once invariance bug is fixed
     value: Box<[Parameter<'db>]>,
     kind: ParametersKind<'db>,
+    /// Whether this parameter list came from `**kwargs: Unpack[OpenTypedDict]`.
+    ///
+    /// Open `TypedDict`s do not expose arbitrary keywords to direct calls, but hidden items still
+    /// need to participate in callable assignability.
+    has_hidden_open_typed_dict_tail: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -3201,10 +3226,19 @@ pub(crate) struct Parameters<'db> {
 
 impl<'db> Parameters<'db> {
     fn from_parts(value: impl Into<Box<[Parameter<'db>]>>, kind: ParametersKind<'db>) -> Self {
+        Self::from_parts_with_hidden_open_typed_dict_tail(value, kind, false)
+    }
+
+    fn from_parts_with_hidden_open_typed_dict_tail(
+        value: impl Into<Box<[Parameter<'db>]>>,
+        kind: ParametersKind<'db>,
+        has_hidden_open_typed_dict_tail: bool,
+    ) -> Self {
         Self {
             data: Arc::new(ParametersData {
                 value: value.into(),
                 kind,
+                has_hidden_open_typed_dict_tail,
             }),
         }
     }
@@ -3223,9 +3257,11 @@ impl<'db> Parameters<'db> {
     ) -> Self {
         let parameters = parameters.into_iter();
         let mut value: Vec<Parameter<'db>> = Vec::with_capacity(parameters.size_hint().0);
+        let mut has_hidden_open_typed_dict_tail = false;
 
         for parameter in parameters {
             if let Some(unpacked_typed_dict) = parameter.unpacked_typed_dict(db) {
+                has_hidden_open_typed_dict_tail |= unpacked_typed_dict.openness(db).is_open();
                 let unpacked_keys = parameter
                     .unpacked_typed_dict_keys(db)
                     .expect("a TypedDict should expose unpacked keys");
@@ -3338,7 +3374,11 @@ impl<'db> Parameters<'db> {
             }
         }
 
-        Self::from_parts(value, kind)
+        Self::from_parts_with_hidden_open_typed_dict_tail(
+            value,
+            kind,
+            has_hidden_open_typed_dict_tail,
+        )
     }
 
     /// Create an empty parameter list.
@@ -3675,7 +3715,33 @@ impl<'db> Parameters<'db> {
             .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
             .collect();
 
-        Self::from_parts(value, self.data.kind)
+        Self::from_parts_with_hidden_open_typed_dict_tail(
+            value,
+            self.data.kind,
+            self.data.has_hidden_open_typed_dict_tail,
+        )
+    }
+
+    fn with_hidden_open_typed_dict_tail(mut self, has_hidden_tail: bool) -> Self {
+        Arc::make_mut(&mut self.data).has_hidden_open_typed_dict_tail = has_hidden_tail;
+        self
+    }
+
+    fn has_hidden_open_typed_dict_tail(&self) -> bool {
+        self.data.has_hidden_open_typed_dict_tail
+    }
+
+    fn with_hidden_open_typed_dict_tail_for_relation(&self) -> Option<Self> {
+        if !self.has_hidden_open_typed_dict_tail() {
+            return None;
+        }
+
+        let mut parameters = self.as_slice().to_vec();
+        parameters.push(
+            Parameter::keyword_variadic(Name::new_static("kwargs"))
+                .with_annotated_type(Type::object()),
+        );
+        Some(Self::from_parts(parameters, self.kind()))
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -3799,6 +3865,7 @@ impl<'db> Parameters<'db> {
         expanded.extend_from_slice(mapped_signature.parameters().as_slice());
         expanded.extend_from_slice(&self.data.value[variadic_index + 2..]);
         Parameters::new(db, expanded)
+            .with_hidden_open_typed_dict_tail(self.has_hidden_open_typed_dict_tail())
     }
 }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -342,6 +342,9 @@ impl<'db> CallableSignature<'db> {
                                         })
                                         .chain(signature.parameters().iter().cloned()),
                                 )
+                                .with_hidden_open_typed_dict_tail(
+                                    signature.parameters().has_hidden_open_typed_dict_tail(),
+                                )
                             },
                             return_ty: self_signature.return_ty.apply_type_mapping_impl(
                                 db,
@@ -2393,7 +2396,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         db,
                         CallableSignature::single(Signature::new_generic(
                             source.generic_context,
-                            Parameters::new(db, source_params.cloned()),
+                            Parameters::new(db, source_params.cloned())
+                                .with_hidden_open_typed_dict_tail(
+                                    source.parameters.has_hidden_open_typed_dict_tail(),
+                                ),
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
@@ -2526,7 +2532,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         db,
                         CallableSignature::single(Signature::new_generic(
                             target.generic_context,
-                            Parameters::new(db, target_params.cloned()),
+                            Parameters::new(db, target_params.cloned())
+                                .with_hidden_open_typed_dict_tail(
+                                    target.parameters.has_hidden_open_typed_dict_tail(),
+                                ),
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
@@ -3849,6 +3858,11 @@ impl<'db> Parameters<'db> {
         expanded.extend_from_slice(&self.data.value[variadic_index + 2..]);
         Parameters::new(db, expanded)
             .with_hidden_open_typed_dict_tail(self.has_hidden_open_typed_dict_tail())
+            .with_hidden_open_typed_dict_tail(
+                mapped_signature
+                    .parameters()
+                    .has_hidden_open_typed_dict_tail(),
+            )
     }
 }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2790,6 +2790,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let mut target_keywords = Vec::new();
         let mut target_index = 0usize;
 
+        if target.parameters.has_hidden_open_typed_dict_tail()
+            && !source.parameters.has_hidden_open_typed_dict_tail()
+            && !source.parameters.iter().any(Parameter::is_keyword_variadic)
+        {
+            return self.never();
+        }
+
         loop {
             let Some(next_parameter) = parameters.next() else {
                 if target_keywords.is_empty() {
@@ -3118,13 +3125,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     return self.never();
                 }
             }
-        }
-
-        if target.parameters.has_hidden_open_typed_dict_tail()
-            && source_keyword_variadic.is_none()
-            && !source.parameters.has_hidden_open_typed_dict_tail()
-        {
-            return self.never();
         }
 
         // If there are still unmatched keyword parameters from `source`, then they should be

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -342,9 +342,6 @@ impl<'db> CallableSignature<'db> {
                                         })
                                         .chain(signature.parameters().iter().cloned()),
                                 )
-                                .with_hidden_open_typed_dict_tail(
-                                    signature.parameters().has_hidden_open_typed_dict_tail(),
-                                )
                             },
                             return_ty: self_signature.return_ty.apply_type_mapping_impl(
                                 db,
@@ -772,7 +769,6 @@ impl<'db> Signature<'db> {
                     .zip(previous.parameters.iter())
                     .map(|(curr, prev)| curr.cycle_normalized(db, prev, cycle)),
             )
-            .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail())
         } else {
             debug_assert_eq!(previous.parameters, Parameters::bottom());
             self.parameters.clone()
@@ -806,7 +802,6 @@ impl<'db> Signature<'db> {
                 parameters.push(param.recursive_type_normalized_impl(db, div, nested)?);
             }
             Parameters::new(db, parameters)
-                .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail())
         };
         Some(Self {
             generic_context: self.generic_context,
@@ -991,8 +986,7 @@ impl<'db> Signature<'db> {
             parameters.next();
         }
 
-        let mut parameters = Parameters::new(db, parameters)
-            .with_hidden_open_typed_dict_tail(self.parameters.has_hidden_open_typed_dict_tail());
+        let mut parameters = Parameters::new(db, parameters);
         let mut return_ty = self.return_ty;
         let binding_context = self.definition.map(BindingContext::Definition);
         if let Some(self_type) = self_type
@@ -1182,11 +1176,7 @@ impl<'db> Signature<'db> {
 
         // Expand `P.args`/`P.kwargs` while the pair is still adjacent. The keyword-only reshuffle
         // below can separate them, which would otherwise prevent expansion.
-        let remaining = Parameters::new(db, remaining)
-            .with_hidden_open_typed_dict_tail(
-                signature.parameters().has_hidden_open_typed_dict_tail(),
-            )
-            .expand_paramspec_variadics(db);
+        let remaining = Parameters::new(db, remaining).expand_paramspec_variadics(db);
 
         let mut reordered = Vec::with_capacity(remaining.len());
         let mut keyword_only = Vec::new();
@@ -1214,10 +1204,7 @@ impl<'db> Signature<'db> {
         reordered.extend(keyword_variadic);
 
         signature
-            .with_parameters(
-                Parameters::new(db, reordered)
-                    .with_hidden_open_typed_dict_tail(remaining.has_hidden_open_typed_dict_tail()),
-            )
+            .with_parameters(Parameters::new(db, reordered))
             .with_return_type(return_ty)
     }
 
@@ -2396,10 +2383,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         db,
                         CallableSignature::single(Signature::new_generic(
                             source.generic_context,
-                            Parameters::new(db, source_params.cloned())
-                                .with_hidden_open_typed_dict_tail(
-                                    source.parameters.has_hidden_open_typed_dict_tail(),
-                                ),
+                            Parameters::new(db, source_params.cloned()),
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
@@ -2532,10 +2516,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         db,
                         CallableSignature::single(Signature::new_generic(
                             target.generic_context,
-                            Parameters::new(db, target_params.cloned())
-                                .with_hidden_open_typed_dict_tail(
-                                    target.parameters.has_hidden_open_typed_dict_tail(),
-                                ),
+                            Parameters::new(db, target_params.cloned()),
                             Type::unknown(),
                         )),
                         CallableTypeKind::ParamSpecValue,
@@ -2789,13 +2770,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // parameter which means that the keyword variant is still unmatched.
         let mut target_keywords = Vec::new();
         let mut target_index = 0usize;
-
-        if target.parameters.has_hidden_open_typed_dict_tail()
-            && !source.parameters.has_hidden_open_typed_dict_tail()
-            && !source.parameters.iter().any(Parameter::is_keyword_variadic)
-        {
-            return self.never();
-        }
 
         loop {
             let Some(next_parameter) = parameters.next() else {
@@ -3205,7 +3179,7 @@ pub(crate) enum ParametersKind<'db> {
 /// proper. For example, even if this represents a `Gradual` form, the `value` field should still
 /// contain the `*args: Any` and `**kwargs: Any` parameter. A `**kwargs: Unpack[TypedDict]`
 /// parameter is normalized to the keyword-only parameters exposed to callers plus a possible
-/// trailing `**kwargs` parameter for explicit extra items.
+/// trailing `**kwargs` parameter for explicit extra items or an open `TypedDict`.
 ///
 /// The `kind` field is used to indicate the specific form of the parameter list which can,
 /// optionally, include additional information such as the bound `ParamSpec` type variable.
@@ -3217,11 +3191,6 @@ struct ParametersData<'db> {
     // TODO: use SmallVec here once invariance bug is fixed
     value: Box<[Parameter<'db>]>,
     kind: ParametersKind<'db>,
-    /// Whether this parameter list came from `**kwargs: Unpack[OpenTypedDict]`.
-    ///
-    /// Open `TypedDict`s do not expose arbitrary keywords to direct calls, but hidden items still
-    /// need to participate when the unpacked signature is the target of a callable relation.
-    has_hidden_open_typed_dict_tail: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -3231,19 +3200,10 @@ pub(crate) struct Parameters<'db> {
 
 impl<'db> Parameters<'db> {
     fn from_parts(value: impl Into<Box<[Parameter<'db>]>>, kind: ParametersKind<'db>) -> Self {
-        Self::from_parts_with_hidden_open_typed_dict_tail(value, kind, false)
-    }
-
-    fn from_parts_with_hidden_open_typed_dict_tail(
-        value: impl Into<Box<[Parameter<'db>]>>,
-        kind: ParametersKind<'db>,
-        has_hidden_open_typed_dict_tail: bool,
-    ) -> Self {
         Self {
             data: Arc::new(ParametersData {
                 value: value.into(),
                 kind,
-                has_hidden_open_typed_dict_tail,
             }),
         }
     }
@@ -3254,19 +3214,17 @@ impl<'db> Parameters<'db> {
     /// if the parameter list contains `*args` and `**kwargs`, then it checks their annotated types
     /// and the presence of other parameter kinds to determine if they represent a gradual form, a
     /// `ParamSpec`, or a `Concatenate` form. `**kwargs: Unpack[TypedDict]` is normalized here by
-    /// synthesizing keyword-only parameters for the unpacked keys and a trailing `**kwargs`
-    /// parameter for explicit extra items.
+    /// synthesizing keyword-only parameters for the unpacked keys and a possible trailing
+    /// `**kwargs` parameter for explicit extra items or an open `TypedDict`.
     pub(crate) fn new(
         db: &'db dyn Db,
         parameters: impl IntoIterator<Item = Parameter<'db>>,
     ) -> Self {
         let parameters = parameters.into_iter();
         let mut value: Vec<Parameter<'db>> = Vec::with_capacity(parameters.size_hint().0);
-        let mut has_hidden_open_typed_dict_tail = false;
 
         for parameter in parameters {
             if let Some(unpacked_typed_dict) = parameter.unpacked_typed_dict(db) {
-                has_hidden_open_typed_dict_tail |= unpacked_typed_dict.openness(db).is_open();
                 let unpacked_keys = parameter
                     .unpacked_typed_dict_keys(db)
                     .expect("a TypedDict should expose unpacked keys");
@@ -3293,7 +3251,7 @@ impl<'db> Parameters<'db> {
                     );
                 }
 
-                if let Some(extra_items) = unpacked_typed_dict.explicit_extra_items(db) {
+                if let Some(extra_items) = unpacked_typed_dict.effective_extra_items(db) {
                     value.push(
                         Parameter::keyword_variadic(kwargs_name)
                             .with_annotated_type(extra_items.declared_ty),
@@ -3379,11 +3337,7 @@ impl<'db> Parameters<'db> {
             }
         }
 
-        Self::from_parts_with_hidden_open_typed_dict_tail(
-            value,
-            kind,
-            has_hidden_open_typed_dict_tail,
-        )
+        Self::from_parts(value, kind)
     }
 
     /// Create an empty parameter list.
@@ -3720,22 +3674,8 @@ impl<'db> Parameters<'db> {
             .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
             .collect();
 
-        Self::from_parts_with_hidden_open_typed_dict_tail(
-            value,
-            self.data.kind,
-            self.data.has_hidden_open_typed_dict_tail,
-        )
+        Self::from_parts(value, self.data.kind)
     }
-
-    fn with_hidden_open_typed_dict_tail(mut self, has_hidden_tail: bool) -> Self {
-        Arc::make_mut(&mut self.data).has_hidden_open_typed_dict_tail |= has_hidden_tail;
-        self
-    }
-
-    fn has_hidden_open_typed_dict_tail(&self) -> bool {
-        self.data.has_hidden_open_typed_dict_tail
-    }
-
     pub(crate) fn len(&self) -> usize {
         self.data.value.len()
     }
@@ -3857,12 +3797,6 @@ impl<'db> Parameters<'db> {
         expanded.extend_from_slice(mapped_signature.parameters().as_slice());
         expanded.extend_from_slice(&self.data.value[variadic_index + 2..]);
         Parameters::new(db, expanded)
-            .with_hidden_open_typed_dict_tail(self.has_hidden_open_typed_dict_tail())
-            .with_hidden_open_typed_dict_tail(
-                mapped_signature
-                    .parameters()
-                    .has_hidden_open_typed_dict_tail(),
-            )
     }
 }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -40,6 +40,7 @@ use crate::types::{
     ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallableType, ErrorContext,
     ErrorContextTree, FindLegacyTypeVarsVisitor, KnownClass, MaterializationKind,
     ParamSpecAttrKind, ParameterDescription, SelfBinding, TypeContext, TypeMapping, TypeVarNonce,
+    TypedDictType,
     UnionBuilder, VarianceInferable, infer_complete_scope_types, todo_type,
 };
 use crate::{Db, FxOrderSet};
@@ -3179,7 +3180,7 @@ pub(crate) enum ParametersKind<'db> {
 /// proper. For example, even if this represents a `Gradual` form, the `value` field should still
 /// contain the `*args: Any` and `**kwargs: Any` parameter. A `**kwargs: Unpack[TypedDict]`
 /// parameter is normalized to the keyword-only parameters exposed to callers plus a possible
-/// trailing `**kwargs` parameter for the extra items accepted by open `TypedDict`s.
+/// trailing `**kwargs` parameter for explicit extra items.
 ///
 /// The `kind` field is used to indicate the specific form of the parameter list which can,
 /// optionally, include additional information such as the bound `ParamSpec` type variable.
@@ -3214,8 +3215,8 @@ impl<'db> Parameters<'db> {
     /// if the parameter list contains `*args` and `**kwargs`, then it checks their annotated types
     /// and the presence of other parameter kinds to determine if they represent a gradual form, a
     /// `ParamSpec`, or a `Concatenate` form. `**kwargs: Unpack[TypedDict]` is normalized here by
-    /// synthesizing keyword-only parameters for the unpacked keys and keeping a trailing
-    /// `**kwargs` parameter for extra items on open `TypedDict`s.
+    /// synthesizing keyword-only parameters for the unpacked keys and a trailing `**kwargs`
+    /// parameter for explicit extra items.
     pub(crate) fn new(
         db: &'db dyn Db,
         parameters: impl IntoIterator<Item = Parameter<'db>>,
@@ -3224,7 +3225,10 @@ impl<'db> Parameters<'db> {
         let mut value: Vec<Parameter<'db>> = Vec::with_capacity(parameters.size_hint().0);
 
         for parameter in parameters {
-            if let Some(unpacked_keys) = parameter.unpacked_typed_dict_keys(db) {
+            if let Some(unpacked_typed_dict) = parameter.unpacked_typed_dict(db) {
+                let unpacked_keys = parameter
+                    .unpacked_typed_dict_keys(db)
+                    .expect("a TypedDict should expose unpacked keys");
                 let kwargs_name = parameter
                     .name()
                     .expect("keyword variadic parameter always has a name")
@@ -3248,11 +3252,12 @@ impl<'db> Parameters<'db> {
                     );
                 }
 
-                // TODO: Use the unpacked `TypedDict`'s `extra_items` type instead of `object`.
-                // TODO: Omit `**kwargs` here for closed `TypedDict`s.
-                value.push(
-                    Parameter::keyword_variadic(kwargs_name).with_annotated_type(Type::object()),
-                );
+                if let Some(extra_items) = unpacked_typed_dict.explicit_extra_items(db) {
+                    value.push(
+                        Parameter::keyword_variadic(kwargs_name)
+                            .with_annotated_type(extra_items.declared_ty),
+                    );
+                }
             } else {
                 value.push(parameter);
             }
@@ -4181,12 +4186,18 @@ impl<'db> Parameter<'db> {
         &self,
         db: &'db dyn Db,
     ) -> Option<BTreeMap<Name, UnpackedTypedDictKey<'db>>> {
+        self.unpacked_typed_dict(db).and_then(|typed_dict| {
+            extract_unpacked_typed_dict_keys_from_value_type(db, Type::TypedDict(typed_dict))
+        })
+    }
+
+    fn unpacked_typed_dict(&self, db: &'db dyn Db) -> Option<TypedDictType<'db>> {
         (self.is_keyword_variadic()
             && matches!(
                 self.annotation_kind,
                 ParameterAnnotationKind::UnpackedTypedDictKwargs
             ))
-        .then(|| extract_unpacked_typed_dict_keys_from_value_type(db, self.annotated_type))
+        .then(|| self.annotated_type.resolve_type_alias(db).as_typed_dict())
         .flatten()
     }
 

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -485,6 +485,11 @@ fn typed_dict_subscript<'db>(
         .as_string_literal()
         .map(|literal| literal.value(db))
     else {
+        if typed_dict.explicit_extra_items(db).is_some()
+            && slice_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
+        {
+            return Ok(typed_dict.value_type(db));
+        }
         return Err(SubscriptError::new(
             Type::unknown(),
             SubscriptErrorKind::InvalidTypedDictKey {
@@ -495,7 +500,7 @@ fn typed_dict_subscript<'db>(
         ));
     };
 
-    typed_dict.items(db).get(key).map_or_else(
+    typed_dict.item(db, key).map_or_else(
         || {
             Err(SubscriptError::new(
                 Type::unknown(),

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -988,7 +988,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                 }
             });
 
-        common_fields_disjoint.or(db, self.constraints, || {
+        let required_fields_disjoint = common_fields_disjoint.or(db, self.constraints, || {
             left_items
                 .iter()
                 .filter(|(name, field)| field.is_required() && !right_items.contains_key(*name))
@@ -1035,6 +1035,68 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                         }
                     }
                 })
+        });
+
+        required_fields_disjoint.or(db, self.constraints, || {
+            let left_openness = left.openness(db);
+            let right_openness = right.openness(db);
+            let relation_checker = self.as_relation_checker(TypeRelation::Assignability);
+
+            match (left_openness, right_openness) {
+                (TypedDictOpenness::Closed, TypedDictOpenness::Extra(extra_items))
+                | (TypedDictOpenness::Extra(extra_items), TypedDictOpenness::Closed)
+                    if !extra_items.is_read_only() =>
+                {
+                    self.always()
+                }
+                (TypedDictOpenness::Extra(left_extra), TypedDictOpenness::Extra(right_extra))
+                    if !left_extra.is_read_only() && !right_extra.is_read_only() =>
+                {
+                    relation_checker
+                        .check_type_pair(db, left_extra.declared_ty, right_extra.declared_ty)
+                        .and(db, self.constraints, || {
+                            relation_checker.check_type_pair(
+                                db,
+                                right_extra.declared_ty,
+                                left_extra.declared_ty,
+                            )
+                        })
+                        .negate(db, self.constraints)
+                }
+                (TypedDictOpenness::Extra(mutable_extra), other)
+                    if !mutable_extra.is_read_only() =>
+                {
+                    other.effective_extra_items().map_or_else(
+                        || self.always(),
+                        |other_extra| {
+                            relation_checker
+                                .check_type_pair(
+                                    db,
+                                    mutable_extra.declared_ty,
+                                    other_extra.declared_ty,
+                                )
+                                .negate(db, self.constraints)
+                        },
+                    )
+                }
+                (other, TypedDictOpenness::Extra(mutable_extra))
+                    if !mutable_extra.is_read_only() =>
+                {
+                    other.effective_extra_items().map_or_else(
+                        || self.always(),
+                        |other_extra| {
+                            relation_checker
+                                .check_type_pair(
+                                    db,
+                                    mutable_extra.declared_ty,
+                                    other_extra.declared_ty,
+                                )
+                                .negate(db, self.constraints)
+                        },
+                    )
+                }
+                _ => self.never(),
+            }
         })
     }
 }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -2689,8 +2689,18 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
 
         return unpacked_valid;
     } else if !typed_dict.openness(db).is_open()
-        && let Some((_, value_ty)) = unpacked_type.unpack_keys_and_items(db)
+        && let Some((key_ty, value_ty)) = unpacked_type.unpack_keys_and_items(db)
     {
+        if !key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db)) {
+            if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, nodes.value) {
+                builder.into_diagnostic(format_args!(
+                    "Unpacked argument has key type `{}` that is not assignable to `str`",
+                    key_ty.display(db),
+                ));
+            }
+            return false;
+        }
+
         return validate_extracted_typed_dict_extra_items(
             context,
             typed_dict,

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -10,7 +10,7 @@ use ruff_python_ast::Arguments;
 use ruff_python_ast::{self as ast, AnyNodeRef, StmtClassDef, name::Name};
 use ruff_text_size::Ranged;
 
-use super::class::{ClassLiteral, ClassType, CodeGeneratorKind, Field};
+use super::class::{ClassLiteral, ClassType, CodeGeneratorKind, Field, KnownClass};
 use super::context::InferContext;
 use super::diagnostic::{
     self, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_KEY, PARAMETER_ALREADY_ASSIGNED,
@@ -308,17 +308,26 @@ impl<'db> TypedDictType<'db> {
         })
     }
 
-    pub(crate) fn arbitrary_key_write_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn arbitrary_key_value_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
         let extra_items = self.explicit_extra_items(db)?;
-        if extra_items.is_read_only() || self.items(db).values().any(TypedDictField::is_read_only) {
-            return None;
-        }
 
         Some(IntersectionType::from_elements(
             db,
             std::iter::once(extra_items.declared_ty)
                 .chain(self.items(db).values().map(|field| field.declared_ty)),
         ))
+    }
+
+    pub(crate) fn arbitrary_key_write_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        if self
+            .explicit_extra_items(db)
+            .is_some_and(TypedDictExtraItems::is_read_only)
+            || self.items(db).values().any(TypedDictField::is_read_only)
+        {
+            return None;
+        }
+
+        self.arbitrary_key_value_type(db)
     }
 
     pub(crate) fn supports_arbitrary_key_deletion(self, db: &'db dyn Db) -> bool {
@@ -2344,6 +2353,25 @@ fn validate_merged_dict_literal<'db, 'ast>(
         if let Some(key_expr) = &item.key {
             let key_ty = expression_type_fn(key_expr, TypeContext::default());
             let Some(key_literal) = key_ty.as_string_literal() else {
+                if key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
+                    && let Some(expected_ty) = typed_dict.arbitrary_key_value_type(db)
+                {
+                    let value_ty =
+                        expression_type_fn(&item.value, TypeContext::new(Some(expected_ty)));
+                    if !value_ty.is_assignable_to(db, expected_ty) {
+                        valid = false;
+                        if let Some(builder) =
+                            context.report_lint(&INVALID_ARGUMENT_TYPE, &item.value)
+                        {
+                            builder.into_diagnostic(format_args!(
+                                "Value of type `{}` is not assignable to arbitrary key value type `{}` on TypedDict `{}`",
+                                value_ty.display(db),
+                                expected_ty.display(db),
+                                Type::TypedDict(typed_dict).display(db),
+                            ));
+                        }
+                    }
+                }
                 continue;
             };
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -2456,20 +2456,28 @@ fn validate_merged_dict_literal<'db, 'ast>(
         if let Some(key_expr) = &item.key {
             let key_ty = expression_type_fn(key_expr, TypeContext::default());
             let Some(key_literal) = key_ty.as_string_literal() else {
-                if key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
-                    && let Some(expected_ty) = typed_dict.arbitrary_key_value_type(db)
-                {
-                    let value_ty =
-                        expression_type_fn(&item.value, TypeContext::new(Some(expected_ty)));
-                    if !value_ty.is_assignable_to(db, expected_ty) {
+                if key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db)) {
+                    if let Some(expected_ty) = typed_dict.arbitrary_key_value_type(db) {
+                        let value_ty =
+                            expression_type_fn(&item.value, TypeContext::new(Some(expected_ty)));
+                        if !value_ty.is_assignable_to(db, expected_ty) {
+                            valid = false;
+                            if let Some(builder) =
+                                context.report_lint(&INVALID_ARGUMENT_TYPE, &item.value)
+                            {
+                                builder.into_diagnostic(format_args!(
+                                    "Value of type `{}` is not assignable to arbitrary key value type `{}` on TypedDict `{}`",
+                                    value_ty.display(db),
+                                    expected_ty.display(db),
+                                    Type::TypedDict(typed_dict).display(db),
+                                ));
+                            }
+                        }
+                    } else if typed_dict.openness(db).is_closed() {
                         valid = false;
-                        if let Some(builder) =
-                            context.report_lint(&INVALID_ARGUMENT_TYPE, &item.value)
-                        {
+                        if let Some(builder) = context.report_lint(&INVALID_KEY, key_expr) {
                             builder.into_diagnostic(format_args!(
-                                "Value of type `{}` is not assignable to arbitrary key value type `{}` on TypedDict `{}`",
-                                value_ty.display(db),
-                                expected_ty.display(db),
+                                "Non-literal string key may be unknown for TypedDict `{}`",
                                 Type::TypedDict(typed_dict).display(db),
                             ));
                         }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -5,7 +5,11 @@ use std::ops::{Deref, DerefMut};
 use bitflags::bitflags;
 use ordermap::OrderSet;
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
+#[cfg(test)]
+use ruff_db::files::system_path_to_file;
 use ruff_db::parsed::parsed_module;
+#[cfg(test)]
+use ruff_db::system::DbWithWritableSystem as _;
 use ruff_python_ast::Arguments;
 use ruff_python_ast::{self as ast, AnyNodeRef, StmtClassDef, name::Name};
 use ruff_text_size::Ranged;
@@ -22,6 +26,10 @@ use super::{
     UnionBuilder, definition_expression_qualifiers, definition_expression_type, visitor,
 };
 use crate::Db;
+#[cfg(test)]
+use crate::db::tests::setup_db;
+#[cfg(test)]
+use crate::place::global_symbol;
 use crate::types::TypeContext;
 use crate::types::TypeDefinition;
 use crate::types::class::FieldKind;
@@ -289,6 +297,10 @@ impl<'db> TypedDictType<'db> {
     }
 
     pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+        if self.openness(db).is_open() {
+            return Type::object();
+        }
+
         let mut builder = UnionBuilder::new(db);
         for field in self.items(db).values() {
             builder = builder.add(field.declared_ty);
@@ -3066,4 +3078,47 @@ fn test_btreemap_overlapping_items() {
             .next()
             .is_none()
     );
+}
+
+#[test]
+fn open_value_type_does_not_compute_items() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented(
+        "src/a.py",
+        "
+        from typing import TypedDict
+
+        class TD(TypedDict):
+            field: int
+        ",
+    )?;
+
+    let file = system_path_to_file(&db, "src/a.py").unwrap();
+    {
+        let class = global_symbol(&db, file, "TD")
+            .place
+            .expect_type()
+            .expect_class_literal();
+        let typed_dict = TypedDictType::new(ClassType::NonGeneric(class));
+        assert!(typed_dict.openness(&db).is_open());
+    }
+    db.clear_salsa_events();
+
+    {
+        let class = global_symbol(&db, file, "TD")
+            .place
+            .expect_type()
+            .expect_class_literal();
+        let typed_dict = TypedDictType::new(ClassType::NonGeneric(class));
+        assert_eq!(typed_dict.value_type(&db), Type::object());
+    }
+    let events = db.take_salsa_events();
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event.kind, salsa::EventKind::WillExecute { .. })),
+        "Computing the value type of an open TypedDict should not require its items: {events:#?}"
+    );
+
+    Ok(())
 }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -475,9 +475,12 @@ impl<'db> TypedDictType<'db> {
             })
             .collect();
 
-        let openness = match self.explicit_extra_items(db) {
-            Some(extra_items) if !extra_items.is_read_only() => self.openness(db),
-            Some(_) | None => TypedDictOpenness::Closed,
+        let openness = match self.openness(db) {
+            TypedDictOpenness::Open => TypedDictOpenness::Open,
+            TypedDictOpenness::Extra(extra_items) if !extra_items.is_read_only() => {
+                TypedDictOpenness::Extra(extra_items)
+            }
+            TypedDictOpenness::Closed | TypedDictOpenness::Extra(_) => TypedDictOpenness::Closed,
         };
 
         Self::from_patch_items(db, items, openness)
@@ -538,7 +541,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
             }
 
-            if let Some(source_extra_items) = source.openness(db).effective_extra_items() {
+            if !target_openness.is_open()
+                && let Some(source_extra_items) = source.openness(db).effective_extra_items()
+            {
                 for (target_item_name, target_item_field) in target_items {
                     if source_items.contains_key(target_item_name) {
                         continue;
@@ -1907,6 +1912,10 @@ fn validate_extracted_typed_dict_extra_items<'db, 'ast>(
 ) -> bool {
     let db = context.db();
     let typed_dict_ty = Type::TypedDict(typed_dict);
+
+    if typed_dict.openness(db).is_open() {
+        return true;
+    }
 
     if let Some(target_extra_items) = typed_dict.explicit_extra_items(db) {
         if let Some((target_name, target_field)) =

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -2552,6 +2552,15 @@ fn validate_merged_dict_literal<'db, 'ast>(
                             ));
                         }
                     }
+                } else if !typed_dict.openness(db).is_open() {
+                    valid = false;
+                    if let Some(builder) = context.report_lint(&INVALID_KEY, key_expr) {
+                        builder.into_diagnostic(format_args!(
+                            "TypedDict `{}` requires string keys, got key of type `{}`",
+                            Type::TypedDict(typed_dict).display(db),
+                            key_ty.display(db),
+                        ));
+                    }
                 }
                 continue;
             };

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -62,13 +62,25 @@ impl Default for TypedDictParams {
 /// most operations. `TypedDict`s with explicit extra items expose those items with a known type.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::Update)]
 pub enum TypedDictOpenness<'db> {
+    /// Undeclared items may exist at runtime, but are not directly accessible through most
+    /// `TypedDict` operations.
     #[default]
     Open,
+    /// Undeclared items cannot exist.
     Closed,
+    /// Undeclared items are explicitly exposed with the given value type and mutability.
     Extra(TypedDictExtraItems<'db>),
 }
 
 impl<'db> TypedDictOpenness<'db> {
+    /// Creates an explicit extra-items policy, canonicalizing `Never` to [`Self::Closed`].
+    ///
+    /// This makes the two equivalent declarations below share the same internal representation:
+    ///
+    /// ```python
+    /// class ByExtraItems(TypedDict, extra_items=Never): ...
+    /// class ByClosed(TypedDict, closed=True): ...
+    /// ```
     pub(crate) fn extra(db: &'db dyn Db, declared_ty: Type<'db>, is_read_only: bool) -> Self {
         if declared_ty.resolve_type_alias(db).is_never() {
             Self::Closed
@@ -80,6 +92,11 @@ impl<'db> TypedDictOpenness<'db> {
         }
     }
 
+    /// Returns extra items only when they were explicitly declared.
+    ///
+    /// An ordinary open `TypedDict` returns `None` here because its hidden items are not directly
+    /// accessible. Use [`Self::effective_extra_items`] for structural relations that must account
+    /// for those hidden items.
     pub(crate) const fn explicit_extra_items(self) -> Option<TypedDictExtraItems<'db>> {
         match self {
             Self::Extra(extra_items) => Some(extra_items),
@@ -152,6 +169,10 @@ impl<'db> TypedDictOpenness<'db> {
     }
 }
 
+/// The value type and mutability of a `TypedDict`'s extra items.
+///
+/// This represents either an explicit `extra_items` declaration or the synthetic read-only
+/// `object` policy returned for an open `TypedDict` by [`TypedDictOpenness::effective_extra_items`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::Update)]
 pub struct TypedDictExtraItems<'db> {
     pub(crate) declared_ty: Type<'db>,
@@ -213,6 +234,10 @@ impl<'db> TypedDictType<'db> {
         }
     }
 
+    /// Returns whether this `TypedDict` is open, closed, or has explicitly typed extra items.
+    ///
+    /// A class-based `TypedDict` inherits the first non-open policy from its bases unless it
+    /// declares its own `closed` or `extra_items` argument.
     pub(crate) fn openness(self, db: &'db dyn Db) -> TypedDictOpenness<'db> {
         #[salsa::tracked(
             cycle_initial=|_, _, _| TypedDictOpenness::Open,
@@ -288,14 +313,23 @@ impl<'db> TypedDictType<'db> {
         }
     }
 
+    /// Returns extra items only when they were explicitly declared.
     pub(crate) fn explicit_extra_items(self, db: &'db dyn Db) -> Option<TypedDictExtraItems<'db>> {
         self.openness(db).explicit_extra_items()
     }
 
+    /// Returns the extra-items policy used by structural relations.
+    ///
+    /// Unlike [`Self::explicit_extra_items`], this treats an ordinary open `TypedDict` as having
+    /// read-only extra items of type `object`.
     pub(crate) fn effective_extra_items(self, db: &'db dyn Db) -> Option<TypedDictExtraItems<'db>> {
         self.openness(db).effective_extra_items()
     }
 
+    /// Returns a type that contains every value that may be stored in this `TypedDict`.
+    ///
+    /// An ordinary open `TypedDict` immediately returns `object` because hidden items may have any
+    /// value type. This also avoids unnecessarily materializing its declared items.
     pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
         let openness = self.openness(db);
         if openness.is_open() {
@@ -312,6 +346,10 @@ impl<'db> TypedDictType<'db> {
         builder.build()
     }
 
+    /// Returns the field exposed by a literal key.
+    ///
+    /// Undeclared keys synthesize a field only for explicit extra items. Hidden items on an
+    /// ordinary open `TypedDict` are intentionally not directly accessible.
     pub(crate) fn item(self, db: &'db dyn Db, key: &str) -> Option<TypedDictField<'db>> {
         self.items(db).get(key).cloned().or_else(|| {
             let extra_items = self.explicit_extra_items(db)?;
@@ -323,10 +361,18 @@ impl<'db> TypedDictType<'db> {
         })
     }
 
+    /// Returns the value type that is safe to read through an arbitrary string key.
+    ///
+    /// The runtime key may name either an extra item or any declared item, so the result is the
+    /// intersection of all of those value types. Returns `None` unless extra items are explicit.
     pub(crate) fn arbitrary_key_value_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
         self.arbitrary_key_value_type_excluding(db, &OrderSet::new())
     }
 
+    /// Returns the arbitrary-key read type after excluding keys that are known to be shadowed.
+    ///
+    /// This is used while validating merged dictionary literals, where later entries determine the
+    /// final value for a known key.
     fn arbitrary_key_value_type_excluding(
         self,
         db: &'db dyn Db,
@@ -345,6 +391,10 @@ impl<'db> TypedDictType<'db> {
         ))
     }
 
+    /// Returns the value type that is safe to write through an arbitrary string key.
+    ///
+    /// A write may target any declared or extra item, so no such write is allowed if any possible
+    /// destination is read-only.
     pub(crate) fn arbitrary_key_write_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
         if self
             .explicit_extra_items(db)
@@ -357,6 +407,10 @@ impl<'db> TypedDictType<'db> {
         self.arbitrary_key_value_type(db)
     }
 
+    /// Returns whether operations that delete an arbitrary key are safe.
+    ///
+    /// Operations such as `clear()` and `popitem()` require mutable explicit extra items and cannot
+    /// be exposed when any declared item is required or read-only.
     pub(crate) fn supports_arbitrary_key_deletion(self, db: &'db dyn Db) -> bool {
         self.explicit_extra_items(db)
             .is_some_and(|extra_items| !extra_items.is_read_only())
@@ -367,6 +421,9 @@ impl<'db> TypedDictType<'db> {
     }
 
     /// Returns the value type if this `TypedDict` is a subtype of `dict[str, VT]`.
+    ///
+    /// This requires mutable explicit extra items and optional, mutable declared items whose value
+    /// types are equivalent to the extra-items type.
     pub(crate) fn dict_value_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
         let extra_items = self.explicit_extra_items(db)?;
         if extra_items.is_read_only()
@@ -384,6 +441,9 @@ impl<'db> TypedDictType<'db> {
     }
 
     /// Returns the value type if this `TypedDict` is assignable to `dict[str, VT]`.
+    ///
+    /// This uses mutual assignability rather than equivalence so gradual value types can satisfy
+    /// the mutable `dict` contract.
     pub(crate) fn assignable_dict_value_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
         let extra_items = self.explicit_extra_items(db)?;
         if extra_items.is_read_only()
@@ -474,6 +534,7 @@ impl<'db> TypedDictType<'db> {
         Self::from_schema_items_with_openness(db, items, TypedDictOpenness::Open)
     }
 
+    /// Creates a synthesized schema while preserving its undeclared-item policy.
     pub(crate) fn from_schema_items_with_openness(
         db: &'db dyn Db,
         items: TypedDictSchema<'db>,
@@ -1232,6 +1293,14 @@ pub(super) fn deferred_functional_typed_dict_schema<'db>(
     schema
 }
 
+/// Resolves the undeclared-item policy of a functional `TypedDict` definition.
+///
+/// The `extra_items` expression is inferred as an annotation so qualifiers such as `ReadOnly` are
+/// preserved. `extra_items=Never` is canonicalized to the same closed policy as `closed=True`.
+///
+/// ```python
+/// Movie = TypedDict("Movie", {"name": str}, extra_items=ReadOnly[int])
+/// ```
 #[salsa::tracked(
     cycle_initial = |_, _, _| TypedDictOpenness::Open,
     heap_size = ruff_memory_usage::heap_size
@@ -1518,10 +1587,18 @@ pub(crate) struct UnpackedTypedDictKey<'db> {
     pub(crate) definition: Option<Definition<'db>>,
 }
 
+/// A normalized view of a `TypedDict`-shaped value used when expanding `**kwargs`.
+///
+/// Union and intersection inputs are combined into one set of possible keys. The caller chooses
+/// whether `extra_items_ty` includes only explicit extra items or also the effective `object` tail
+/// of an ordinary open `TypedDict`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct UnpackedTypedDict<'db> {
+    /// Declared keys that may be present after unpacking.
     pub(crate) keys: BTreeMap<Name, UnpackedTypedDictKey<'db>>,
+    /// The type of arbitrary undeclared keys, according to the selected tail policy.
     pub(crate) extra_items_ty: Option<Type<'db>>,
+    /// Whether the normalized shape cannot contain undeclared keys.
     pub(crate) is_closed: bool,
 }
 
@@ -1542,6 +1619,10 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
 }
 
 /// Extracts the declared keys and explicit extra-items tail from a `TypedDict`-shaped value.
+///
+/// Ordinary open `TypedDict`s contribute no tail here because their hidden items are not directly
+/// accessible. Use the effective-tail variant when structural compatibility must account for those
+/// hidden items.
 pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -1549,7 +1630,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
     extract_unpacked_typed_dict_from_value_type_impl(db, ty, UnpackedTypedDictTail::Explicit)
 }
 
-/// Extracts the declared keys and effective extra-items tail from a `TypedDict`-shaped value.
+/// Extracts declared keys while treating ordinary open `TypedDict`s as having an `object` tail.
 fn extract_unpacked_typed_dict_with_effective_tail_from_value_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -1574,12 +1655,20 @@ fn extract_unpacked_typed_dict_for_constructor<'db>(
     }
 }
 
+/// Selects whether unpack extraction includes only directly accessible extra items or the
+/// effective tail used by structural relations.
 #[derive(Clone, Copy)]
 enum UnpackedTypedDictTail {
+    /// Include only an explicit `extra_items` declaration.
     Explicit,
+    /// Also treat an ordinary open `TypedDict` as having an `object` tail.
     Effective,
 }
 
+/// Extracts and combines the `TypedDict` shapes contained in `ty`.
+///
+/// Intersections combine keys and tails with intersections; unions combine them with unions and
+/// only keep a key required if every union arm requires it.
 fn extract_unpacked_typed_dict_from_value_type_impl<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -2068,6 +2157,11 @@ fn validate_extracted_typed_dict_keys<'db, 'ast>(
     (provided_keys, valid)
 }
 
+/// Validates the arbitrary-key tail of a `TypedDict`-shaped constructor argument.
+///
+/// The source tail must be valid for every target field it could provide and for the target's
+/// explicit extra-items type. When validated, targets without explicit extra items reject such a
+/// tail.
 fn validate_extracted_typed_dict_extra_items<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
@@ -2762,6 +2856,7 @@ pub struct SynthesizedTypedDictType<'db> {
     #[returns(ref)]
     pub(crate) items: TypedDictSchema<'db>,
     pub(crate) kind: SynthesizedTypedDictKind,
+    /// Whether keys absent from `items` are hidden, forbidden, or explicitly typed.
     pub(crate) openness: TypedDictOpenness<'db>,
 }
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -350,19 +350,22 @@ impl<'db> TypedDictType<'db> {
         })
     }
 
-    /// Returns the value type that is safe to read through an arbitrary string key.
+    /// Returns the type that a value must be assignable to when initializing an arbitrary string
+    /// key.
     ///
     /// The runtime key may name either an extra item or any declared item, so the result is the
-    /// intersection of all of those value types. Returns `None` unless extra items are explicit.
-    pub(crate) fn arbitrary_key_value_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        self.arbitrary_key_value_type_excluding(db, &OrderSet::new())
+    /// intersection of all possible destination item types. Returns `None` unless extra items are
+    /// explicit.
+    pub(crate) fn arbitrary_key_initialization_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        self.arbitrary_key_initialization_type_excluding(db, &OrderSet::new())
     }
 
-    /// Returns the arbitrary-key read type after excluding keys that are known to be shadowed.
+    /// Returns the arbitrary-key initialization type after excluding keys that are known to be
+    /// shadowed.
     ///
     /// This is used while validating merged dictionary literals, where later entries determine the
     /// final value for a known key.
-    fn arbitrary_key_value_type_excluding(
+    fn arbitrary_key_initialization_type_excluding(
         self,
         db: &'db dyn Db,
         excluded_keys: &OrderSet<Name>,
@@ -380,11 +383,11 @@ impl<'db> TypedDictType<'db> {
         ))
     }
 
-    /// Returns the value type that is safe to write through an arbitrary string key.
+    /// Returns the type that a value must be assignable to when mutating an arbitrary string key.
     ///
-    /// A write may target any declared or extra item, so no such write is allowed if any possible
-    /// destination is read-only.
-    pub(crate) fn arbitrary_key_write_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    /// A mutation may target any declared or extra item, so no such mutation is allowed if any
+    /// possible destination is read-only.
+    pub(crate) fn arbitrary_key_mutation_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
         if self
             .explicit_extra_items(db)
             .is_some_and(TypedDictExtraItems::is_read_only)
@@ -393,7 +396,7 @@ impl<'db> TypedDictType<'db> {
             return None;
         }
 
-        self.arbitrary_key_value_type(db)
+        self.arbitrary_key_initialization_type(db)
     }
 
     /// Returns whether operations that delete an arbitrary key are safe.
@@ -2625,7 +2628,7 @@ fn validate_merged_dict_literal<'db, 'ast>(
             let Some(key_literal) = key_ty.as_string_literal() else {
                 if key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db)) {
                     if let Some(expected_ty) =
-                        typed_dict.arbitrary_key_value_type_excluding(db, shadowed_keys)
+                        typed_dict.arbitrary_key_initialization_type_excluding(db, shadowed_keys)
                     {
                         let value_ty =
                             expression_type_fn(&item.value, TypeContext::new(Some(expected_ty)));

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -755,12 +755,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             } else {
                 // `NotRequired[]` target fields
                 if target_item_field.is_read_only() {
-                    // As above, for `NotRequired[]` + `ReadOnly[]` fields in the target. It's
-                    // tempting to refactor things and unify some of these calls to
-                    // `check_typeddict_pair`, but this branch will get more complicated when we
-                    // add support for `closed` and `extra_items` (which is why the rules in the
-                    // spec are structured like they are), and following the structure of the spec
-                    // makes it easier to check the logic here.
+                    // A missing read-only field is checked against the source's effective extra
+                    // items. Missing mutable fields below require explicit mutable extra items and
+                    // a relation in both directions.
                     if let Some(source_item_field) = source_items.get(target_item_name) {
                         self.check_type_pair(
                             db,

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1589,17 +1589,89 @@ pub(crate) struct UnpackedTypedDictKey<'db> {
 
 /// A normalized view of a `TypedDict`-shaped value used when expanding `**kwargs`.
 ///
-/// Union and intersection inputs are combined into one set of possible keys. The caller chooses
-/// whether `extra_items_ty` includes only explicit extra items or also the effective `object` tail
-/// of an ordinary open `TypedDict`.
+/// Union and intersection inputs are combined into one set of possible keys and one tail describing
+/// arbitrary undeclared keys.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct UnpackedTypedDict<'db> {
     /// Declared keys that may be present after unpacking.
     pub(crate) keys: BTreeMap<Name, UnpackedTypedDictKey<'db>>,
-    /// The type of arbitrary undeclared keys, according to the selected tail policy.
-    pub(crate) extra_items_ty: Option<Type<'db>>,
-    /// Whether the normalized shape cannot contain undeclared keys.
-    pub(crate) is_closed: bool,
+    pub(crate) tail: UnpackedTypedDictTail<'db>,
+}
+
+/// The arbitrary-key tail of a normalized `TypedDict` shape.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum UnpackedTypedDictTail<'db> {
+    /// The shape cannot contain undeclared keys.
+    Closed,
+    /// An ordinary open `TypedDict` may contain undeclared values of type `object`.
+    ///
+    /// Hidden values constrain an existing `**kwargs` parameter but do not themselves cause an
+    /// unknown-key error when the destination has no `**kwargs`.
+    Hidden,
+    /// Undeclared keys are explicitly exposed with this value type.
+    Explicit(Type<'db>),
+}
+
+impl<'db> UnpackedTypedDictTail<'db> {
+    pub(crate) const fn value_ty(self) -> Option<Type<'db>> {
+        match self {
+            Self::Closed => None,
+            Self::Hidden => Some(Type::object()),
+            Self::Explicit(value_ty) => Some(value_ty),
+        }
+    }
+
+    pub(crate) const fn is_explicit(self) -> bool {
+        matches!(self, Self::Explicit(_))
+    }
+
+    fn intersection(
+        db: &'db dyn Db,
+        tails: impl IntoIterator<Item = UnpackedTypedDictTail<'db>>,
+    ) -> Self {
+        let mut explicit_value_types = Vec::new();
+
+        for tail in tails {
+            match tail {
+                Self::Closed => return Self::Closed,
+                Self::Hidden => {}
+                Self::Explicit(value_ty) => explicit_value_types.push(value_ty),
+            }
+        }
+
+        if explicit_value_types.is_empty() {
+            Self::Hidden
+        } else {
+            Self::Explicit(IntersectionType::from_elements(db, explicit_value_types))
+        }
+    }
+
+    fn union(db: &'db dyn Db, tails: impl IntoIterator<Item = UnpackedTypedDictTail<'db>>) -> Self {
+        let mut value_types = UnionBuilder::new(db);
+        let mut has_hidden_tail = false;
+        let mut has_explicit_tail = false;
+
+        for tail in tails {
+            match tail {
+                Self::Closed => {}
+                Self::Hidden => has_hidden_tail = true,
+                Self::Explicit(value_ty) => {
+                    value_types = value_types.add(value_ty);
+                    has_explicit_tail = true;
+                }
+            }
+        }
+
+        if has_hidden_tail && has_explicit_tail {
+            Self::Explicit(Type::object())
+        } else if has_hidden_tail {
+            Self::Hidden
+        } else if has_explicit_tail {
+            Self::Explicit(value_types.build())
+        } else {
+            Self::Closed
+        }
+    }
 }
 
 /// Extracts `TypedDict` keys, their value types, and whether they are required when an unpacked
@@ -1618,61 +1690,10 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
     extract_unpacked_typed_dict_from_value_type(db, ty).map(|unpacked| unpacked.keys)
 }
 
-/// Extracts the declared keys and explicit extra-items tail from a `TypedDict`-shaped value.
-///
-/// Ordinary open `TypedDict`s contribute no tail here because their hidden items are not directly
-/// accessible. Use the effective-tail variant when structural compatibility must account for those
-/// hidden items.
+/// Extracts the declared keys and arbitrary-key tail from a `TypedDict`-shaped value.
 pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
-) -> Option<UnpackedTypedDict<'db>> {
-    extract_unpacked_typed_dict_from_value_type_impl(db, ty, UnpackedTypedDictTail::Explicit)
-}
-
-/// Extracts declared keys while treating ordinary open `TypedDict`s as having an `object` tail.
-fn extract_unpacked_typed_dict_with_effective_tail_from_value_type<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-) -> Option<UnpackedTypedDict<'db>> {
-    extract_unpacked_typed_dict_from_value_type_impl(db, ty, UnpackedTypedDictTail::Effective)
-}
-
-/// Extracts the tail that must be checked when constructing `target`.
-///
-/// Ordinary open `TypedDict`s have hidden items, but open constructors retain ty's existing
-/// leniency for those items. Explicit extra items must still be rejected because open constructors
-/// accept no unrecognized keys.
-fn extract_unpacked_typed_dict_for_constructor<'db>(
-    db: &'db dyn Db,
-    target: TypedDictType<'db>,
-    ty: Type<'db>,
-) -> Option<UnpackedTypedDict<'db>> {
-    if target.openness(db).is_open() {
-        extract_unpacked_typed_dict_from_value_type(db, ty)
-    } else {
-        extract_unpacked_typed_dict_with_effective_tail_from_value_type(db, ty)
-    }
-}
-
-/// Selects whether unpack extraction includes only directly accessible extra items or the
-/// effective tail used by structural relations.
-#[derive(Clone, Copy)]
-enum UnpackedTypedDictTail {
-    /// Include only an explicit `extra_items` declaration.
-    Explicit,
-    /// Also treat an ordinary open `TypedDict` as having an `object` tail.
-    Effective,
-}
-
-/// Extracts and combines the `TypedDict` shapes contained in `ty`.
-///
-/// Intersections combine keys and tails with intersections; unions combine them with unions and
-/// only keep a key required if every union arm requires it.
-fn extract_unpacked_typed_dict_from_value_type_impl<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    tail: UnpackedTypedDictTail,
 ) -> Option<UnpackedTypedDict<'db>> {
     match ty {
         Type::TypedDict(td) => {
@@ -1690,24 +1711,21 @@ fn extract_unpacked_typed_dict_from_value_type_impl<'db>(
                     )
                 })
                 .collect();
-            let extra_items = match tail {
-                UnpackedTypedDictTail::Explicit => td.explicit_extra_items(db),
-                UnpackedTypedDictTail::Effective => td.effective_extra_items(db),
+            let tail = match td.openness(db) {
+                TypedDictOpenness::Open => UnpackedTypedDictTail::Hidden,
+                TypedDictOpenness::Closed => UnpackedTypedDictTail::Closed,
+                TypedDictOpenness::Extra(extra_items) => {
+                    UnpackedTypedDictTail::Explicit(extra_items.declared_ty)
+                }
             };
-            Some(UnpackedTypedDict {
-                keys,
-                extra_items_ty: extra_items.map(|extra| extra.declared_ty),
-                is_closed: td.openness(db).is_closed(),
-            })
+            Some(UnpackedTypedDict { keys, tail })
         }
         Type::Intersection(intersection) => {
             // Collect TypedDict shapes from all TypedDicts in the intersection.
             let unpacked_elements: Vec<_> = intersection
                 .positive(db)
                 .iter()
-                .filter_map(|element| {
-                    extract_unpacked_typed_dict_from_value_type_impl(db, *element, tail)
-                })
+                .filter_map(|element| extract_unpacked_typed_dict_from_value_type(db, *element))
                 .collect();
 
             if unpacked_elements.is_empty() {
@@ -1742,7 +1760,7 @@ fn extract_unpacked_typed_dict_from_value_type_impl<'db>(
                     if unpacked.keys.contains_key(key) {
                         continue;
                     }
-                    if let Some(extra_items_ty) = unpacked.extra_items_ty {
+                    if let Some(extra_items_ty) = unpacked.tail.value_ty() {
                         unpacked_key.value_ty = IntersectionType::from_two_elements(
                             db,
                             unpacked_key.value_ty,
@@ -1753,28 +1771,18 @@ fn extract_unpacked_typed_dict_from_value_type_impl<'db>(
                 }
             }
 
-            let is_closed = unpacked_elements.iter().any(|unpacked| unpacked.is_closed);
-            let extra_items_ty = if is_closed {
-                None
-            } else {
-                let extra_items: Vec<_> = unpacked_elements
-                    .iter()
-                    .filter_map(|unpacked| unpacked.extra_items_ty)
-                    .collect();
-                (!extra_items.is_empty()).then(|| IntersectionType::from_elements(db, extra_items))
-            };
+            let tail = UnpackedTypedDictTail::intersection(
+                db,
+                unpacked_elements.iter().map(|unpacked| unpacked.tail),
+            );
 
-            Some(UnpackedTypedDict {
-                keys: result,
-                extra_items_ty,
-                is_closed,
-            })
+            Some(UnpackedTypedDict { keys: result, tail })
         }
         Type::Union(union) => {
             let unpacked_elements: Vec<_> = union
                 .elements(db)
                 .iter()
-                .map(|element| extract_unpacked_typed_dict_from_value_type_impl(db, *element, tail))
+                .map(|element| extract_unpacked_typed_dict_from_value_type(db, *element))
                 .collect::<Option<_>>()?;
 
             let all_keys: OrderSet<Name> = unpacked_elements
@@ -1799,7 +1807,7 @@ fn extract_unpacked_typed_dict_from_value_type_impl<'db>(
                         } else {
                             unpacked_key.definition
                         });
-                    } else if let Some(extra_items_ty) = unpacked.extra_items_ty {
+                    } else if let Some(extra_items_ty) = unpacked.tail.value_ty() {
                         saw_key = true;
                         value_ty = value_ty.add(extra_items_ty);
                         is_required = false;
@@ -1822,23 +1830,15 @@ fn extract_unpacked_typed_dict_from_value_type_impl<'db>(
                 }
             }
 
-            let mut extra_items = UnionBuilder::new(db);
-            let mut has_extra_items = false;
-            for unpacked in &unpacked_elements {
-                if let Some(extra_items_ty) = unpacked.extra_items_ty {
-                    has_extra_items = true;
-                    extra_items = extra_items.add(extra_items_ty);
-                }
-            }
+            let tail = UnpackedTypedDictTail::union(
+                db,
+                unpacked_elements.iter().map(|unpacked| unpacked.tail),
+            );
 
-            Some(UnpackedTypedDict {
-                keys: result,
-                extra_items_ty: has_extra_items.then(|| extra_items.build()),
-                is_closed: unpacked_elements.iter().all(|unpacked| unpacked.is_closed),
-            })
+            Some(UnpackedTypedDict { keys: result, tail })
         }
         Type::TypeAlias(alias) => {
-            extract_unpacked_typed_dict_from_value_type_impl(db, alias.value_type(db), tail)
+            extract_unpacked_typed_dict_from_value_type(db, alias.value_type(db))
         }
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)
@@ -2160,17 +2160,25 @@ fn validate_extracted_typed_dict_keys<'db, 'ast>(
 /// Validates the arbitrary-key tail of a `TypedDict`-shaped constructor argument.
 ///
 /// The source tail must be valid for every target field it could provide and for the target's
-/// explicit extra-items type. When validated, targets without explicit extra items reject such a
-/// tail.
-fn validate_extracted_typed_dict_extra_items<'db, 'ast>(
+/// explicit extra-items type. Hidden open tails retain ty's existing leniency when constructing
+/// another open `TypedDict`.
+fn validate_extracted_typed_dict_tail<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
     source_keys: &BTreeMap<Name, UnpackedTypedDictKey<'db>>,
-    extra_items_ty: Type<'db>,
+    tail: UnpackedTypedDictTail<'db>,
     nodes: TypedDictAssignmentNodes<'ast>,
     ignored_keys: &OrderSet<Name>,
 ) -> bool {
     let db = context.db();
+    let Some(extra_items_ty) = tail.value_ty() else {
+        return true;
+    };
+
+    if typed_dict.openness(db).is_open() && !tail.is_explicit() {
+        return true;
+    }
+
     let typed_dict_ty = Type::TypedDict(typed_dict);
 
     if let Some(target_extra_items) = typed_dict.explicit_extra_items(db) {
@@ -2248,7 +2256,8 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
 ) -> Option<OrderSet<Name>> {
     let db = context.db();
     let typed_dict_items = typed_dict.items(db);
-    let unpacked = extract_unpacked_typed_dict_for_constructor(db, typed_dict, arg_ty)?;
+    let unpacked = extract_unpacked_typed_dict_from_value_type(db, arg_ty)?;
+    let tail = unpacked.tail;
     let validate_extra_keys = !typed_dict.openness(db).is_open();
     let unpacked_keys = unpacked
         .keys
@@ -2270,16 +2279,14 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
         ignored_keys,
     )
     .0;
-    if let Some(extra_items_ty) = unpacked.extra_items_ty {
-        validate_extracted_typed_dict_extra_items(
-            context,
-            typed_dict,
-            &unpacked_keys,
-            extra_items_ty,
-            nodes,
-            ignored_keys,
-        );
-    }
+    validate_extracted_typed_dict_tail(
+        context,
+        typed_dict,
+        &unpacked_keys,
+        tail,
+        nodes,
+        ignored_keys,
+    );
 
     Some(provided_keys)
 }
@@ -2749,9 +2756,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             guaranteed_keys.entry(key_name.clone()).or_insert(None);
         }
         return true;
-    } else if let Some(unpacked) =
-        extract_unpacked_typed_dict_for_constructor(db, typed_dict, unpacked_type)
-    {
+    } else if let Some(unpacked) = extract_unpacked_typed_dict_from_value_type(db, unpacked_type) {
         let ignored_keys = shadowed_keys.clone();
         let (_, mut unpacked_valid) = validate_extracted_typed_dict_keys(
             context,
@@ -2761,16 +2766,14 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             full_object_ty_annotation(unpacked_type),
             &ignored_keys,
         );
-        if let Some(extra_items_ty) = unpacked.extra_items_ty {
-            unpacked_valid &= validate_extracted_typed_dict_extra_items(
-                context,
-                typed_dict,
-                &unpacked.keys,
-                extra_items_ty,
-                nodes,
-                &ignored_keys,
-            );
-        }
+        unpacked_valid &= validate_extracted_typed_dict_tail(
+            context,
+            typed_dict,
+            &unpacked.keys,
+            unpacked.tail,
+            nodes,
+            &ignored_keys,
+        );
 
         for (key_name, unpacked_key) in unpacked.keys {
             if unpacked_key.is_required && !ignored_keys.contains(&key_name) {
@@ -2800,11 +2803,11 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             return false;
         }
 
-        return validate_extracted_typed_dict_extra_items(
+        return validate_extracted_typed_dict_tail(
             context,
             typed_dict,
             &BTreeMap::new(),
-            value_ty,
+            UnpackedTypedDictTail::Explicit(value_ty),
             nodes,
             shadowed_keys,
         );

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -241,13 +241,16 @@ impl<'db> TypedDictType<'db> {
             db: &'db dyn Db,
             class: ClassType<'db>,
         ) -> TypedDictOpenness<'db> {
-            let class_literal = class.class_literal(db);
-            if let ClassLiteral::DynamicTypedDict(dynamic) = class_literal {
-                return dynamic.openness(db);
-            }
-
-            let Some((static_class, specialization)) = class.static_class_literal(db) else {
-                return TypedDictOpenness::ImplicitlyOpen;
+            let (class_literal, specialization) = class.class_literal_and_specialization(db);
+            let static_class = match class_literal {
+                ClassLiteral::Static(static_class) => static_class,
+                ClassLiteral::DynamicTypedDict(dynamic) => return dynamic.openness(db),
+                ClassLiteral::Dynamic(_)
+                | ClassLiteral::DynamicNamedTuple(_)
+                | ClassLiteral::DynamicEnum(_) => {
+                    // A `TypedDictType::Class` is only constructed from classes known to be TypedDicts.
+                    unreachable!("non-TypedDict dynamic class wrapped in `TypedDictType`")
+                }
             };
 
             let module = parsed_module(db, static_class.file(db)).load(db);

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -2084,7 +2084,7 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
     let db = context.db();
     let typed_dict_items = typed_dict.items(db);
     let unpacked = extract_unpacked_typed_dict_with_effective_tail_from_value_type(db, arg_ty)?;
-    let validate_extra_keys = typed_dict.explicit_extra_items(db).is_some();
+    let validate_extra_keys = !typed_dict.openness(db).is_open();
     let unpacked_keys = unpacked
         .keys
         .into_iter()

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -573,9 +573,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
             }
 
-            if !target_openness.is_open()
-                && let Some(source_extra_items) = source.openness(db).effective_extra_items()
-            {
+            let source_extra_items = if target_openness.is_open() {
+                source.explicit_extra_items(db)
+            } else {
+                source.openness(db).effective_extra_items()
+            };
+            if let Some(source_extra_items) = source_extra_items {
                 for (target_item_name, target_item_field) in target_items {
                     if source_items.contains_key(target_item_name) {
                         continue;

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -356,6 +356,26 @@ impl<'db> TypedDictType<'db> {
         Some(extra_items.declared_ty)
     }
 
+    /// Returns the value type if this `TypedDict` is assignable to `dict[str, VT]`.
+    pub(crate) fn assignable_dict_value_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        let extra_items = self.explicit_extra_items(db)?;
+        if extra_items.is_read_only()
+            || self.items(db).values().any(|field| {
+                field.is_required()
+                    || field.is_read_only()
+                    || !field
+                        .declared_ty
+                        .is_assignable_to(db, extra_items.declared_ty)
+                    || !extra_items
+                        .declared_ty
+                        .is_assignable_to(db, field.declared_ty)
+            })
+        {
+            return None;
+        }
+        Some(extra_items.declared_ty)
+    }
+
     pub(crate) fn items(self, db: &'db dyn Db) -> &'db TypedDictSchema<'db> {
         // Field annotations can recursively inspect this schema while the class fields are still
         // being collected, e.g. through `typing.Self` in a `TypedDict` field.

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -13,13 +13,13 @@ use ruff_text_size::Ranged;
 use super::class::{ClassLiteral, ClassType, CodeGeneratorKind, Field};
 use super::context::InferContext;
 use super::diagnostic::{
-    self, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, PARAMETER_ALREADY_ASSIGNED,
+    self, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_KEY, PARAMETER_ALREADY_ASSIGNED,
     TOO_MANY_POSITIONAL_ARGUMENTS, report_invalid_key_on_typed_dict, report_missing_typed_dict_key,
 };
 use super::infer::{TypeExpressionFlags, infer_deferred_types};
 use super::{
     ApplyTypeMappingVisitor, ErrorContext, IntersectionType, Type, TypeMapping, TypeQualifiers,
-    UnionBuilder, definition_expression_type, visitor,
+    UnionBuilder, definition_expression_qualifiers, definition_expression_type, visitor,
 };
 use crate::Db;
 use crate::types::TypeContext;
@@ -45,6 +45,113 @@ impl get_size2::GetSize for TypedDictParams {}
 impl Default for TypedDictParams {
     fn default() -> Self {
         Self::TOTAL
+    }
+}
+
+/// The openness of a `TypedDict`.
+///
+/// Open `TypedDict`s may contain hidden items, but those items are not directly accessible through
+/// most operations. `TypedDict`s with explicit extra items expose those items with a known type.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::Update)]
+pub enum TypedDictOpenness<'db> {
+    #[default]
+    Open,
+    Closed,
+    Extra(TypedDictExtraItems<'db>),
+}
+
+impl<'db> TypedDictOpenness<'db> {
+    pub(crate) fn extra(declared_ty: Type<'db>, is_read_only: bool) -> Self {
+        if declared_ty.is_never() {
+            Self::Closed
+        } else {
+            Self::Extra(TypedDictExtraItems {
+                declared_ty,
+                is_read_only,
+            })
+        }
+    }
+
+    pub(crate) const fn explicit_extra_items(self) -> Option<TypedDictExtraItems<'db>> {
+        match self {
+            Self::Extra(extra_items) => Some(extra_items),
+            Self::Open | Self::Closed => None,
+        }
+    }
+
+    /// Returns the effective extra-items type used by structural relations.
+    ///
+    /// An open `TypedDict` behaves like it has read-only extra items of type `object` for these
+    /// purposes, while a closed `TypedDict` has no extra items.
+    pub(crate) fn effective_extra_items(self) -> Option<TypedDictExtraItems<'db>> {
+        match self {
+            Self::Open => Some(TypedDictExtraItems {
+                declared_ty: Type::object(),
+                is_read_only: true,
+            }),
+            Self::Closed => None,
+            Self::Extra(extra_items) => Some(extra_items),
+        }
+    }
+
+    pub(crate) const fn is_open(self) -> bool {
+        matches!(self, Self::Open)
+    }
+
+    pub(crate) const fn is_closed(self) -> bool {
+        matches!(self, Self::Closed)
+    }
+
+    fn apply_type_mapping_impl<'a>(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'a, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        match self {
+            Self::Open | Self::Closed => self,
+            Self::Extra(extra_items) => Self::extra(
+                extra_items
+                    .declared_ty
+                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                extra_items.is_read_only,
+            ),
+        }
+    }
+
+    pub(crate) fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        match self {
+            Self::Open | Self::Closed => Some(self),
+            Self::Extra(extra_items) => {
+                let declared_ty = extra_items
+                    .declared_ty
+                    .recursive_type_normalized_impl(db, div, true);
+                let declared_ty = if nested {
+                    declared_ty?
+                } else {
+                    declared_ty.unwrap_or(div)
+                };
+                Some(Self::extra(declared_ty, extra_items.is_read_only))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::Update)]
+pub struct TypedDictExtraItems<'db> {
+    pub(crate) declared_ty: Type<'db>,
+    is_read_only: bool,
+}
+
+impl TypedDictExtraItems<'_> {
+    pub(crate) const fn is_read_only(self) -> bool {
+        self.is_read_only
     }
 }
 
@@ -95,6 +202,149 @@ impl<'db> TypedDictType<'db> {
             Self::Class(defining_class) => Some(defining_class),
             Self::Synthesized(_) => None,
         }
+    }
+
+    pub(crate) fn openness(self, db: &'db dyn Db) -> TypedDictOpenness<'db> {
+        #[salsa::tracked(
+            cycle_initial=|_, _, _| TypedDictOpenness::Open,
+            heap_size=ruff_memory_usage::heap_size
+        )]
+        fn class_based_openness<'db>(
+            db: &'db dyn Db,
+            class: ClassType<'db>,
+        ) -> TypedDictOpenness<'db> {
+            let class_literal = class.class_literal(db);
+            if let ClassLiteral::DynamicTypedDict(dynamic) = class_literal {
+                return dynamic.openness(db);
+            }
+
+            let Some((static_class, specialization)) = class.static_class_literal(db) else {
+                return TypedDictOpenness::Open;
+            };
+
+            let module = parsed_module(db, static_class.file(db)).load(db);
+            let class_definition = static_class.definition(db);
+            let class_stmt = class_definition
+                .kind(db)
+                .as_class()
+                .expect("StaticClassLiteral definition should be a class")
+                .node(&module);
+
+            if let Some(arguments) = &class_stmt.arguments {
+                if let Some(extra_items) = arguments.find_keyword("extra_items") {
+                    let declared_ty =
+                        definition_expression_type(db, class_definition, &extra_items.value)
+                            .apply_optional_specialization(db, specialization);
+                    let qualifiers =
+                        definition_expression_qualifiers(db, class_definition, &extra_items.value);
+                    return TypedDictOpenness::extra(
+                        declared_ty,
+                        qualifiers.contains(TypeQualifiers::READ_ONLY),
+                    );
+                }
+
+                if let Some(closed) = arguments.find_keyword("closed") {
+                    let closed_ty = definition_expression_type(db, class_definition, &closed.value);
+                    return if closed_ty.bool(db).is_always_true() {
+                        TypedDictOpenness::Closed
+                    } else {
+                        TypedDictOpenness::Open
+                    };
+                }
+            }
+
+            for base in static_class.explicit_bases(db) {
+                let base = base.apply_optional_specialization(db, specialization);
+                let base_class = match base {
+                    Type::ClassLiteral(base) => ClassType::NonGeneric(base),
+                    Type::GenericAlias(base) => ClassType::Generic(base),
+                    _ => continue,
+                };
+
+                if base_class.class_literal(db).is_typed_dict(db) {
+                    let openness = TypedDictType::new(base_class).openness(db);
+                    if !openness.is_open() {
+                        return openness;
+                    }
+                }
+            }
+
+            TypedDictOpenness::Open
+        }
+
+        match self {
+            Self::Class(defining_class) => class_based_openness(db, defining_class),
+            Self::Synthesized(synthesized) => synthesized.openness(db),
+        }
+    }
+
+    pub(crate) fn explicit_extra_items(self, db: &'db dyn Db) -> Option<TypedDictExtraItems<'db>> {
+        self.openness(db).explicit_extra_items()
+    }
+
+    pub(crate) fn effective_extra_items(self, db: &'db dyn Db) -> Option<TypedDictExtraItems<'db>> {
+        self.openness(db).effective_extra_items()
+    }
+
+    pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+        let mut builder = UnionBuilder::new(db);
+        for field in self.items(db).values() {
+            builder = builder.add(field.declared_ty);
+        }
+        if let Some(extra_items) = self.effective_extra_items(db) {
+            builder = builder.add(extra_items.declared_ty);
+        }
+        builder.build()
+    }
+
+    pub(crate) fn item(self, db: &'db dyn Db, key: &str) -> Option<TypedDictField<'db>> {
+        self.items(db).get(key).cloned().or_else(|| {
+            let extra_items = self.explicit_extra_items(db)?;
+            Some(
+                TypedDictFieldBuilder::new(extra_items.declared_ty)
+                    .read_only(extra_items.is_read_only())
+                    .build(),
+            )
+        })
+    }
+
+    pub(crate) fn arbitrary_key_write_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        let extra_items = self.explicit_extra_items(db)?;
+        if extra_items.is_read_only() || self.items(db).values().any(TypedDictField::is_read_only) {
+            return None;
+        }
+
+        Some(IntersectionType::from_elements(
+            db,
+            std::iter::once(extra_items.declared_ty)
+                .chain(self.items(db).values().map(|field| field.declared_ty)),
+        ))
+    }
+
+    pub(crate) fn supports_arbitrary_key_deletion(self, db: &'db dyn Db) -> bool {
+        self.explicit_extra_items(db)
+            .is_some_and(|extra_items| !extra_items.is_read_only())
+            && self
+                .items(db)
+                .values()
+                .all(|field| !field.is_required() && !field.is_read_only())
+    }
+
+    /// Returns the value type if this `TypedDict` is a subtype of `dict[str, VT]`.
+    pub(crate) fn dict_value_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        let extra_items = self.explicit_extra_items(db)?;
+        if extra_items.is_read_only()
+            || self.items(db).values().any(|field| {
+                field.is_required()
+                    || field.is_read_only()
+                    || !field
+                        .declared_ty
+                        .is_equivalent_to(db, extra_items.declared_ty)
+            })
+        {
+            return None;
+        }
+        Some(extra_items.declared_ty)
     }
 
     pub(crate) fn items(self, db: &'db dyn Db) -> &'db TypedDictSchema<'db> {
@@ -165,11 +415,23 @@ impl<'db> TypedDictType<'db> {
     }
 
     pub(crate) fn from_schema_items(db: &'db dyn Db, items: TypedDictSchema<'db>) -> Self {
-        Self::Synthesized(SynthesizedTypedDictType::schema(db, items))
+        Self::from_schema_items_with_openness(db, items, TypedDictOpenness::Open)
     }
 
-    fn from_patch_items(db: &'db dyn Db, items: TypedDictSchema<'db>) -> Self {
-        Self::Synthesized(SynthesizedTypedDictType::patch(db, items))
+    pub(crate) fn from_schema_items_with_openness(
+        db: &'db dyn Db,
+        items: TypedDictSchema<'db>,
+        openness: TypedDictOpenness<'db>,
+    ) -> Self {
+        Self::Synthesized(SynthesizedTypedDictType::schema(db, items, openness))
+    }
+
+    fn from_patch_items(
+        db: &'db dyn Db,
+        items: TypedDictSchema<'db>,
+        openness: TypedDictOpenness<'db>,
+    ) -> Self {
+        Self::Synthesized(SynthesizedTypedDictType::patch(db, items, openness))
     }
 
     /// Returns a partial version of this `TypedDict` where all fields are optional. This is used
@@ -183,7 +445,7 @@ impl<'db> TypedDictType<'db> {
             .map(|(name, field)| (name.clone(), field.clone().with_required(false)))
             .collect();
 
-        Self::from_patch_items(db, items)
+        Self::from_patch_items(db, items, self.openness(db))
     }
 
     /// Returns a patch version of this `TypedDict` for `TypedDict.update()`.
@@ -204,7 +466,12 @@ impl<'db> TypedDictType<'db> {
             })
             .collect();
 
-        Self::from_patch_items(db, items)
+        let openness = match self.explicit_extra_items(db) {
+            Some(extra_items) if !extra_items.is_read_only() => self.openness(db),
+            Some(_) | None => TypedDictOpenness::Closed,
+        };
+
+        Self::from_patch_items(db, items, openness)
     }
 
     pub fn definition(self, db: &'db dyn Db) -> Option<Definition<'db>> {
@@ -236,25 +503,65 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         {
             let source_items = source.items(db);
             let target_items = synthesized_target.items(db);
+            let target_openness = synthesized_target.openness(db);
             let mut result = self.always();
 
             for (source_item_name, source_item_field) in source_items {
-                let Some(target_item_field) = target_items.get(source_item_name) else {
-                    continue;
+                let target_ty = if let Some(target_item_field) = target_items.get(source_item_name)
+                {
+                    target_item_field.declared_ty
+                } else {
+                    match target_openness {
+                        TypedDictOpenness::Open => continue,
+                        TypedDictOpenness::Closed => return self.never(),
+                        TypedDictOpenness::Extra(extra_items) => extra_items.declared_ty,
+                    }
                 };
 
                 result.intersect(
                     db,
                     self.constraints,
-                    self.check_type_pair(
-                        db,
-                        source_item_field.declared_ty,
-                        target_item_field.declared_ty,
-                    ),
+                    self.check_type_pair(db, source_item_field.declared_ty, target_ty),
                 );
 
                 if result.is_never_satisfied(db) {
                     return result;
+                }
+            }
+
+            if let Some(source_extra_items) = source.openness(db).explicit_extra_items() {
+                for (target_item_name, target_item_field) in target_items {
+                    if source_items.contains_key(target_item_name) {
+                        continue;
+                    }
+                    result.intersect(
+                        db,
+                        self.constraints,
+                        self.check_type_pair(
+                            db,
+                            source_extra_items.declared_ty,
+                            target_item_field.declared_ty,
+                        ),
+                    );
+                    if result.is_never_satisfied(db) {
+                        return result;
+                    }
+                }
+
+                match target_openness {
+                    TypedDictOpenness::Open => {}
+                    TypedDictOpenness::Closed => return self.never(),
+                    TypedDictOpenness::Extra(target_extra_items) => {
+                        result.intersect(
+                            db,
+                            self.constraints,
+                            self.check_type_pair(
+                                db,
+                                source_extra_items.declared_ty,
+                                target_extra_items.declared_ty,
+                            ),
+                        );
+                    }
                 }
             }
 
@@ -273,6 +580,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         let source_items = source.items(db);
         let target_items = target.items(db);
+        let source_openness = source.openness(db);
+        let target_openness = target.openness(db);
         // Many rules violations short-circuit with "never", but asking whether one field is
         // [relation] to/of another can produce more complicated constraints, and we collect those.
         let mut result = self.always();
@@ -350,23 +659,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             target_item_field.declared_ty,
                         )
                     } else {
-                        // `source` is missing this not-required, read-only item. However, since all
-                        // `TypedDict`s by default are allowed to have "extra items" of any type
-                        // (until we support `closed` and explicit `extra_items`), this key could
-                        // actually turn out to have a value. To make sure this is type-safe, the
-                        // not-required field in the target needs to be assignable from `object`.
-                        // TODO: `closed` and `extra_items` support will go here.
-                        Type::object().when_assignable_to(
-                            db,
-                            target_item_field.declared_ty,
-                            self.constraints,
-                            self.inferable,
-                        )
+                        match source_openness.effective_extra_items() {
+                            // A closed source cannot contain this key, so the check succeeds.
+                            None => self.always(),
+                            Some(source_extra_items) => self.check_type_pair(
+                                db,
+                                source_extra_items.declared_ty,
+                                target_item_field.declared_ty,
+                            ),
+                        }
                     }
                 } else {
-                    // As above, for `NotRequired[]` mutable fields in the target. Again the logic
-                    // is largely the same for now, but it will get more complicated with `closed`
-                    // and `extra_items`.
                     if let Some(source_item_field) = source_items.get(target_item_name) {
                         if source_item_field.is_read_only() {
                             // A read-only field can't be assigned to a mutable target.
@@ -405,14 +708,25 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             )
                         })
                     } else {
-                        // `source` is missing this not-required, mutable field. This isn't OK if
-                        // `source has read-only extra items, which all `TypedDict`s effectively
-                        // do until we support `closed` and explicit `extra_items`. See "A subtle
-                        // interaction between two structural assignability rules prevents
-                        // unsoundness" in `typed_dict.md`.
-                        //
-                        // TODO: `closed` and `extra_items` support will go here.
-                        self.never()
+                        let Some(source_extra_items) = source_openness.explicit_extra_items()
+                        else {
+                            return self.never();
+                        };
+                        if source_extra_items.is_read_only() {
+                            return self.never();
+                        }
+                        self.check_type_pair(
+                            db,
+                            source_extra_items.declared_ty,
+                            target_item_field.declared_ty,
+                        )
+                        .and(db, self.constraints, || {
+                            self.check_type_pair(
+                                db,
+                                target_item_field.declared_ty,
+                                source_extra_items.declared_ty,
+                            )
+                        })
                     }
                 }
             };
@@ -430,6 +744,122 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 return result;
             }
         }
+
+        match target_openness {
+            TypedDictOpenness::Closed => {
+                if !source_openness.is_closed()
+                    || source_items
+                        .keys()
+                        .any(|source_item_name| !target_items.contains_key(source_item_name))
+                {
+                    return self.never();
+                }
+            }
+            TypedDictOpenness::Open => {
+                // An open target behaves like it has read-only extra items of type `object`.
+                let target_extra_items = target_openness
+                    .effective_extra_items()
+                    .expect("open TypedDict should have effective extra items");
+                if let Some(source_extra_items) = source_openness.effective_extra_items() {
+                    result.intersect(
+                        db,
+                        self.constraints,
+                        self.check_type_pair(
+                            db,
+                            source_extra_items.declared_ty,
+                            target_extra_items.declared_ty,
+                        ),
+                    );
+                }
+                for (source_item_name, source_item_field) in source_items {
+                    if !target_items.contains_key(source_item_name) {
+                        result.intersect(
+                            db,
+                            self.constraints,
+                            self.check_type_pair(
+                                db,
+                                source_item_field.declared_ty,
+                                target_extra_items.declared_ty,
+                            ),
+                        );
+                    }
+                }
+            }
+            TypedDictOpenness::Extra(target_extra_items) if target_extra_items.is_read_only() => {
+                if let Some(source_extra_items) = source_openness.effective_extra_items() {
+                    result.intersect(
+                        db,
+                        self.constraints,
+                        self.check_type_pair(
+                            db,
+                            source_extra_items.declared_ty,
+                            target_extra_items.declared_ty,
+                        ),
+                    );
+                }
+                for (source_item_name, source_item_field) in source_items {
+                    if !target_items.contains_key(source_item_name) {
+                        result.intersect(
+                            db,
+                            self.constraints,
+                            self.check_type_pair(
+                                db,
+                                source_item_field.declared_ty,
+                                target_extra_items.declared_ty,
+                            ),
+                        );
+                    }
+                }
+            }
+            TypedDictOpenness::Extra(target_extra_items) => {
+                let Some(source_extra_items) = source_openness.explicit_extra_items() else {
+                    return self.never();
+                };
+                if source_extra_items.is_read_only() {
+                    return self.never();
+                }
+                result.intersect(
+                    db,
+                    self.constraints,
+                    self.check_type_pair(
+                        db,
+                        source_extra_items.declared_ty,
+                        target_extra_items.declared_ty,
+                    )
+                    .and(db, self.constraints, || {
+                        self.check_type_pair(
+                            db,
+                            target_extra_items.declared_ty,
+                            source_extra_items.declared_ty,
+                        )
+                    }),
+                );
+                for (source_item_name, source_item_field) in source_items {
+                    if !target_items.contains_key(source_item_name) {
+                        if source_item_field.is_required() || source_item_field.is_read_only() {
+                            return self.never();
+                        }
+                        result.intersect(
+                            db,
+                            self.constraints,
+                            self.check_type_pair(
+                                db,
+                                source_item_field.declared_ty,
+                                target_extra_items.declared_ty,
+                            )
+                            .and(db, self.constraints, || {
+                                self.check_type_pair(
+                                    db,
+                                    target_extra_items.declared_ty,
+                                    source_item_field.declared_ty,
+                                )
+                            }),
+                        );
+                    }
+                }
+            }
+        }
+
         result
     }
 }
@@ -439,9 +869,9 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
     /// `TypedDict` `C` that's fully-static and assignable to both of them.
     ///
     /// `TypedDict` assignability is determined field-by-field, so we determine disjointness
-    /// similarly. For any field that's only in `A`, it's always possible for our hypothetical `C`
-    /// to copy/paste that field without losing assignability to `B` (and vice versa), so we only
-    /// need to consider fields that are present in both `A` and `B`.
+    /// similarly. Fields that are present in both `A` and `B` can conflict directly. A required
+    /// field that's only in one side can also conflict with the other side's openness: a closed
+    /// `TypedDict` rejects it, and explicit extra items constrain whether it can be present.
     ///
     /// There are three properties of each field to consider: the declared type, whether it's
     /// mutable ("mut" vs "imm" below), and whether it's required ("req" vs "opt" below). Here's a
@@ -493,53 +923,104 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
     /// 4. If both sides are immutable, and their types are disjoint. (Because the type in `C` must
     ///    be assignable to both.)
     ///
-    /// TODO: Adding support for `closed` and `extra_items` will complicate this.
     pub(super) fn check_typeddict_pair(
         &self,
         db: &'db dyn Db,
         left: TypedDictType<'db>,
         right: TypedDictType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let fields_in_common = btreemap_values_with_same_key(left.items(db), right.items(db));
-        fields_in_common.when_any(db, self.constraints, |(left_field, right_field)| {
-            // Condition 1 above.
-            if left_field.is_required() || right_field.is_required() {
-                if (!left_field.is_required() && !left_field.is_read_only())
-                    || (!right_field.is_required() && !right_field.is_read_only())
-                {
-                    // One side demands a `Required` source field, while the other side demands a
-                    // `NotRequired` one. They must be disjoint.
-                    return self.always();
+        let left_items = left.items(db);
+        let right_items = right.items(db);
+        let fields_in_common = btreemap_values_with_same_key(left_items, right_items);
+        let common_fields_disjoint =
+            fields_in_common.when_any(db, self.constraints, |(left_field, right_field)| {
+                // Condition 1 above.
+                if left_field.is_required() || right_field.is_required() {
+                    if (!left_field.is_required() && !left_field.is_read_only())
+                        || (!right_field.is_required() && !right_field.is_read_only())
+                    {
+                        // One side demands a `Required` source field, while the other side demands a
+                        // `NotRequired` one. They must be disjoint.
+                        return self.always();
+                    }
                 }
-            }
-            if !left_field.is_read_only() && !right_field.is_read_only() {
-                // Condition 2 above. This field is mutable on both sides, so the so the types must
-                // be compatible, i.e. mutually assignable.
-                let relation_checker = self.as_relation_checker(TypeRelation::Assignability);
-                relation_checker
-                    .check_type_pair(db, left_field.declared_ty, right_field.declared_ty)
-                    .and(db, self.constraints, || {
-                        relation_checker.check_type_pair(
-                            db,
-                            right_field.declared_ty,
-                            left_field.declared_ty,
-                        )
-                    })
-                    .negate(db, self.constraints)
-            } else if !left_field.is_read_only() {
-                // Half of condition 3 above.
-                self.as_relation_checker(TypeRelation::Assignability)
-                    .check_type_pair(db, left_field.declared_ty, right_field.declared_ty)
-                    .negate(db, self.constraints)
-            } else if !right_field.is_read_only() {
-                // The other half of condition 3 above.
-                self.as_relation_checker(TypeRelation::Assignability)
-                    .check_type_pair(db, right_field.declared_ty, left_field.declared_ty)
-                    .negate(db, self.constraints)
-            } else {
-                // Condition 4 above.
-                self.check_type_pair(db, left_field.declared_ty, right_field.declared_ty)
-            }
+                if !left_field.is_read_only() && !right_field.is_read_only() {
+                    // Condition 2 above. This field is mutable on both sides, so the so the types must
+                    // be compatible, i.e. mutually assignable.
+                    let relation_checker = self.as_relation_checker(TypeRelation::Assignability);
+                    relation_checker
+                        .check_type_pair(db, left_field.declared_ty, right_field.declared_ty)
+                        .and(db, self.constraints, || {
+                            relation_checker.check_type_pair(
+                                db,
+                                right_field.declared_ty,
+                                left_field.declared_ty,
+                            )
+                        })
+                        .negate(db, self.constraints)
+                } else if !left_field.is_read_only() {
+                    // Half of condition 3 above.
+                    self.as_relation_checker(TypeRelation::Assignability)
+                        .check_type_pair(db, left_field.declared_ty, right_field.declared_ty)
+                        .negate(db, self.constraints)
+                } else if !right_field.is_read_only() {
+                    // The other half of condition 3 above.
+                    self.as_relation_checker(TypeRelation::Assignability)
+                        .check_type_pair(db, right_field.declared_ty, left_field.declared_ty)
+                        .negate(db, self.constraints)
+                } else {
+                    // Condition 4 above.
+                    self.check_type_pair(db, left_field.declared_ty, right_field.declared_ty)
+                }
+            });
+
+        common_fields_disjoint.or(db, self.constraints, || {
+            left_items
+                .iter()
+                .filter(|(name, field)| field.is_required() && !right_items.contains_key(*name))
+                .map(|(_, field)| (field, right.openness(db)))
+                .chain(
+                    right_items
+                        .iter()
+                        .filter(|(name, field)| {
+                            field.is_required() && !left_items.contains_key(*name)
+                        })
+                        .map(|(_, field)| (field, left.openness(db))),
+                )
+                .when_any(db, self.constraints, |(required_field, other_openness)| {
+                    match other_openness {
+                        TypedDictOpenness::Closed => self.always(),
+                        TypedDictOpenness::Extra(extra_items) if !extra_items.is_read_only() => {
+                            self.always()
+                        }
+                        TypedDictOpenness::Open => {
+                            if required_field.is_read_only() {
+                                self.check_type_pair(db, required_field.declared_ty, Type::object())
+                            } else {
+                                self.as_relation_checker(TypeRelation::Assignability)
+                                    .check_type_pair(db, required_field.declared_ty, Type::object())
+                                    .negate(db, self.constraints)
+                            }
+                        }
+                        TypedDictOpenness::Extra(extra_items) => {
+                            if required_field.is_read_only() {
+                                self.check_type_pair(
+                                    db,
+                                    required_field.declared_ty,
+                                    extra_items.declared_ty,
+                                )
+                            } else {
+                                self.as_relation_checker(TypeRelation::Assignability)
+                                    .check_type_pair(
+                                        db,
+                                        required_field.declared_ty,
+                                        extra_items.declared_ty,
+                                    )
+                                    .negate(db, self.constraints)
+                            }
+                        }
+                    }
+                })
         })
     }
 }
@@ -556,6 +1037,9 @@ pub(crate) fn walk_typed_dict_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
         TypedDictType::Synthesized(synthesized) => {
             for field in synthesized.items(db).values() {
                 visitor.visit_type(db, field.declared_ty);
+            }
+            if let Some(extra_items) = synthesized.openness(db).explicit_extra_items() {
+                visitor.visit_type(db, extra_items.declared_ty);
             }
         }
     }
@@ -613,6 +1097,42 @@ pub(super) fn deferred_functional_typed_dict_schema<'db>(
     }
 
     schema
+}
+
+#[salsa::tracked(
+    cycle_initial = |_, _, _| TypedDictOpenness::Open,
+    heap_size = ruff_memory_usage::heap_size
+)]
+pub(super) fn deferred_functional_typed_dict_openness<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+) -> TypedDictOpenness<'db> {
+    let module = parsed_module(db, definition.file(db)).load(db);
+    let node = definition
+        .kind(db)
+        .value(&module)
+        .expect("Expected `TypedDict` definition to be an assignment")
+        .as_call_expr()
+        .expect("Expected `TypedDict` definition r.h.s. to be a call expression");
+
+    if let Some(extra_items) = node.arguments.find_keyword("extra_items") {
+        let deferred_inference = infer_deferred_types(db, definition);
+        return TypedDictOpenness::extra(
+            deferred_inference.expression_type(&extra_items.value),
+            deferred_inference
+                .qualifiers(&extra_items.value)
+                .contains(TypeQualifiers::READ_ONLY),
+        );
+    }
+
+    if let Some(closed) = node.arguments.find_keyword("closed") {
+        let closed_ty = definition_expression_type(db, definition, &closed.value);
+        if closed_ty.bool(db).is_always_true() {
+            return TypedDictOpenness::Closed;
+        }
+    }
+
+    TypedDictOpenness::Open
 }
 
 pub(super) fn typed_dict_params_from_class_def(class_stmt: &StmtClassDef) -> TypedDictParams {
@@ -684,8 +1204,8 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
         let db = self.context.db();
         let items = self.typed_dict.items(db);
 
-        // Check if key exists in `TypedDict`
-        let Some((_, item)) = items.iter().find(|(name, _)| *name == self.key) else {
+        // Check if key exists in `TypedDict` or is accepted by explicit extra items.
+        let Some(item) = self.typed_dict.item(db, self.key) else {
             if self.emit_diagnostic {
                 report_invalid_key_on_typed_dict(
                     self.context,
@@ -719,7 +1239,7 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
                 self.add_object_type_annotation(db, &mut diagnostic);
                 Self::add_item_definition_subdiagnostic(
                     db,
-                    item,
+                    &item,
                     &mut diagnostic,
                     "Read-only item declared here",
                 );
@@ -765,7 +1285,7 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
 
             Self::add_item_definition_subdiagnostic(
                 db,
-                item,
+                &item,
                 &mut diagnostic,
                 "Item declared here",
             );
@@ -864,6 +1384,13 @@ pub(crate) struct UnpackedTypedDictKey<'db> {
     pub(crate) definition: Option<Definition<'db>>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct UnpackedTypedDict<'db> {
+    pub(crate) keys: BTreeMap<Name, UnpackedTypedDictKey<'db>>,
+    pub(crate) extra_items_ty: Option<Type<'db>>,
+    pub(crate) is_closed: bool,
+}
+
 /// Extracts `TypedDict` keys, their value types, and whether they are required when an unpacked
 /// `**kwargs` value has this type, resolving type aliases and handling intersections and unions.
 ///
@@ -877,6 +1404,14 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> Option<BTreeMap<Name, UnpackedTypedDictKey<'db>>> {
+    extract_unpacked_typed_dict_from_value_type(db, ty).map(|unpacked| unpacked.keys)
+}
+
+/// Extracts the declared keys and explicit extra-items tail from a `TypedDict`-shaped value.
+pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<UnpackedTypedDict<'db>> {
     match ty {
         Type::TypedDict(td) => {
             let keys = td
@@ -893,29 +1428,31 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
                     )
                 })
                 .collect();
-            Some(keys)
+            Some(UnpackedTypedDict {
+                keys,
+                extra_items_ty: td.explicit_extra_items(db).map(|extra| extra.declared_ty),
+                is_closed: td.openness(db).is_closed(),
+            })
         }
         Type::Intersection(intersection) => {
-            // Collect key maps from all TypedDicts in the intersection
-            let all_key_maps: Vec<_> = intersection
+            // Collect TypedDict shapes from all TypedDicts in the intersection.
+            let unpacked_elements: Vec<_> = intersection
                 .positive(db)
                 .iter()
-                .filter_map(|element| {
-                    extract_unpacked_typed_dict_keys_from_value_type(db, *element)
-                })
+                .filter_map(|element| extract_unpacked_typed_dict_from_value_type(db, *element))
                 .collect();
 
-            if all_key_maps.is_empty() {
+            if unpacked_elements.is_empty() {
                 return None;
             }
 
             // Union all keys from all TypedDicts, intersecting value types for shared keys.
             let mut result: BTreeMap<Name, UnpackedTypedDictKey<'db>> = BTreeMap::new();
 
-            for key_map in all_key_maps {
-                for (key, unpacked_key) in key_map {
+            for unpacked in &unpacked_elements {
+                for (key, unpacked_key) in &unpacked.keys {
                     result
-                        .entry(key)
+                        .entry(key.clone())
                         .and_modify(|existing| {
                             existing.value_ty = IntersectionType::from_two_elements(
                                 db,
@@ -928,22 +1465,53 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
                                 unpacked_key.definition,
                             );
                         })
-                        .or_insert(unpacked_key);
+                        .or_insert(*unpacked_key);
                 }
             }
 
-            Some(result)
+            for (key, unpacked_key) in &mut result {
+                for unpacked in &unpacked_elements {
+                    if unpacked.keys.contains_key(key) {
+                        continue;
+                    }
+                    if let Some(extra_items_ty) = unpacked.extra_items_ty {
+                        unpacked_key.value_ty = IntersectionType::from_two_elements(
+                            db,
+                            unpacked_key.value_ty,
+                            extra_items_ty,
+                        );
+                        unpacked_key.definition = None;
+                    }
+                }
+            }
+
+            let is_closed = unpacked_elements.iter().any(|unpacked| unpacked.is_closed);
+            let extra_items_ty = if is_closed {
+                None
+            } else {
+                let extra_items: Vec<_> = unpacked_elements
+                    .iter()
+                    .filter_map(|unpacked| unpacked.extra_items_ty)
+                    .collect();
+                (!extra_items.is_empty()).then(|| IntersectionType::from_elements(db, extra_items))
+            };
+
+            Some(UnpackedTypedDict {
+                keys: result,
+                extra_items_ty,
+                is_closed,
+            })
         }
         Type::Union(union) => {
-            let key_maps: Vec<_> = union
+            let unpacked_elements: Vec<_> = union
                 .elements(db)
                 .iter()
-                .map(|element| extract_unpacked_typed_dict_keys_from_value_type(db, *element))
+                .map(|element| extract_unpacked_typed_dict_from_value_type(db, *element))
                 .collect::<Option<_>>()?;
 
-            let all_keys: OrderSet<Name> = key_maps
+            let all_keys: OrderSet<Name> = unpacked_elements
                 .iter()
-                .flat_map(|key_map| key_map.keys().cloned())
+                .flat_map(|unpacked| unpacked.keys.keys().cloned())
                 .collect();
             let mut result = BTreeMap::new();
 
@@ -953,8 +1521,8 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
                 let mut definition = None;
                 let mut saw_key = false;
 
-                for key_map in &key_maps {
-                    if let Some(unpacked_key) = key_map.get(&key) {
+                for unpacked in &unpacked_elements {
+                    if let Some(unpacked_key) = unpacked.keys.get(&key) {
                         saw_key = true;
                         value_ty = value_ty.add(unpacked_key.value_ty);
                         is_required &= unpacked_key.is_required;
@@ -963,6 +1531,11 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
                         } else {
                             unpacked_key.definition
                         });
+                    } else if let Some(extra_items_ty) = unpacked.extra_items_ty {
+                        saw_key = true;
+                        value_ty = value_ty.add(extra_items_ty);
+                        is_required = false;
+                        definition = Some(None);
                     } else {
                         is_required = false;
                         definition = Some(None);
@@ -981,10 +1554,23 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
                 }
             }
 
-            Some(result)
+            let mut extra_items = UnionBuilder::new(db);
+            let mut has_extra_items = false;
+            for unpacked in &unpacked_elements {
+                if let Some(extra_items_ty) = unpacked.extra_items_ty {
+                    has_extra_items = true;
+                    extra_items = extra_items.add(extra_items_ty);
+                }
+            }
+
+            Some(UnpackedTypedDict {
+                keys: result,
+                extra_items_ty: has_extra_items.then(|| extra_items.build()),
+                is_closed: unpacked_elements.iter().all(|unpacked| unpacked.is_closed),
+            })
         }
         Type::TypeAlias(alias) => {
-            extract_unpacked_typed_dict_keys_from_value_type(db, alias.value_type(db))
+            extract_unpacked_typed_dict_from_value_type(db, alias.value_type(db))
         }
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)
@@ -1203,7 +1789,7 @@ pub(super) fn typed_dict_without_keys<'db>(
         .map(|(name, field)| (name.clone(), field.clone()))
         .collect();
 
-    TypedDictType::from_schema_items(db, filtered_items)
+    TypedDictType::from_schema_items_with_openness(db, filtered_items, typed_dict.openness(db))
 }
 
 /// Returns a `TypedDict` schema for mixed positional-constructor inference.
@@ -1233,7 +1819,7 @@ pub(super) fn typed_dict_with_relaxed_keys<'db>(
         })
         .collect();
 
-    TypedDictType::from_schema_items(db, relaxed_items)
+    TypedDictType::from_schema_items_with_openness(db, relaxed_items, typed_dict.openness(db))
 }
 
 fn full_object_ty_annotation(ty: Type<'_>) -> Option<Type<'_>> {
@@ -1303,6 +1889,73 @@ fn validate_extracted_typed_dict_keys<'db, 'ast>(
     (provided_keys, valid)
 }
 
+fn validate_extracted_typed_dict_extra_items<'db, 'ast>(
+    context: &InferContext<'db, 'ast>,
+    typed_dict: TypedDictType<'db>,
+    source_keys: &BTreeMap<Name, UnpackedTypedDictKey<'db>>,
+    extra_items_ty: Type<'db>,
+    nodes: TypedDictAssignmentNodes<'ast>,
+) -> bool {
+    let db = context.db();
+    let typed_dict_ty = Type::TypedDict(typed_dict);
+
+    if let Some(target_extra_items) = typed_dict.explicit_extra_items(db) {
+        if let Some((target_name, target_field)) =
+            typed_dict.items(db).iter().find(|(name, field)| {
+                !source_keys.contains_key(*name)
+                    && !extra_items_ty.is_assignable_to(db, field.declared_ty)
+            })
+        {
+            if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, nodes.value) {
+                let mut diagnostic = builder.into_diagnostic(format_args!(
+                    "Unpacked argument has extra items of type `{}` that are not assignable to item `{target_name}` with type `{}` on TypedDict `{}`",
+                    extra_items_ty.display(db),
+                    target_field.declared_ty.display(db),
+                    typed_dict_ty.display(db),
+                ));
+                diagnostic.annotate(
+                    context
+                        .secondary(nodes.typed_dict)
+                        .message(format_args!("TypedDict `{}`", typed_dict_ty.display(db))),
+                );
+            }
+            return false;
+        }
+
+        if extra_items_ty.is_assignable_to(db, target_extra_items.declared_ty) {
+            return true;
+        }
+
+        if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, nodes.value) {
+            let mut diagnostic = builder.into_diagnostic(format_args!(
+                "Unpacked argument has extra items of type `{}` that are not assignable to extra items type `{}` on TypedDict `{}`",
+                extra_items_ty.display(db),
+                target_extra_items.declared_ty.display(db),
+                typed_dict_ty.display(db),
+            ));
+            diagnostic.annotate(
+                context
+                    .secondary(nodes.typed_dict)
+                    .message(format_args!("TypedDict `{}`", typed_dict_ty.display(db))),
+            );
+        }
+        return false;
+    }
+
+    if let Some(builder) = context.report_lint(&INVALID_KEY, nodes.key) {
+        let mut diagnostic = builder.into_diagnostic(format_args!(
+            "Unpacked argument may contain unknown keys for TypedDict `{}`",
+            typed_dict_ty.display(db),
+        ));
+        diagnostic.annotate(
+            context
+                .secondary(nodes.typed_dict)
+                .message(format_args!("TypedDict `{}`", typed_dict_ty.display(db))),
+        );
+    }
+    false
+}
+
 /// Validates a mixed-constructor positional argument when its type can be viewed as a `TypedDict`.
 ///
 /// If `arg_ty` exposes concrete `TypedDict` keys, only keys that overlap the constructor target
@@ -1320,26 +1973,38 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
 ) -> Option<OrderSet<Name>> {
     let db = context.db();
     let typed_dict_items = typed_dict.items(db);
-    let unpacked_keys = extract_unpacked_typed_dict_keys_from_value_type(db, arg_ty)?
+    let unpacked = extract_unpacked_typed_dict_from_value_type(db, arg_ty)?;
+    let unpacked_keys = unpacked
+        .keys
         .into_iter()
         .filter(|(key_name, _)| typed_dict_items.contains_key(key_name))
         .collect();
 
-    Some(
-        validate_extracted_typed_dict_keys(
+    let nodes = TypedDictAssignmentNodes {
+        typed_dict: typed_dict_node,
+        key: arg.into(),
+        value: arg.into(),
+    };
+    let provided_keys = validate_extracted_typed_dict_keys(
+        context,
+        typed_dict,
+        &unpacked_keys,
+        nodes,
+        full_object_ty_annotation(arg_ty),
+        ignored_keys,
+    )
+    .0;
+    if let Some(extra_items_ty) = unpacked.extra_items_ty {
+        validate_extracted_typed_dict_extra_items(
             context,
             typed_dict,
             &unpacked_keys,
-            TypedDictAssignmentNodes {
-                typed_dict: typed_dict_node,
-                key: arg.into(),
-                value: arg.into(),
-            },
-            full_object_ty_annotation(arg_ty),
-            ignored_keys,
-        )
-        .0,
-    )
+            extra_items_ty,
+            nodes,
+        );
+    }
+
+    Some(provided_keys)
 }
 
 fn report_duplicate_typed_dict_constructor_key<'db, 'ast>(
@@ -1577,7 +2242,6 @@ fn validate_from_keywords<'db, 'ast>(
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> OrderSet<Name> {
     let db = context.db();
-    let items = typed_dict.items(db);
     debug_assert_eq!(arguments.keywords.len(), unpacked_keyword_types.len());
 
     let mut guaranteed_keys = BTreeMap::new();
@@ -1600,8 +2264,8 @@ fn validate_from_keywords<'db, 'ast>(
                 keyword_node,
             );
 
-            let value_tcx = items
-                .get(arg_name.id.as_str())
+            let value_tcx = typed_dict
+                .item(db, arg_name.id.as_str())
                 .map(|field| TypeContext::new(Some(field.declared_ty)))
                 .unwrap_or_default();
             let value_ty = expression_type_fn(&keyword.value, value_tcx);
@@ -1674,7 +2338,6 @@ fn validate_merged_dict_literal<'db, 'ast>(
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> bool {
     let db = context.db();
-    let items = typed_dict.items(db);
     let mut valid = true;
 
     for item in dict_expr.items.iter().rev() {
@@ -1688,8 +2351,8 @@ fn validate_merged_dict_literal<'db, 'ast>(
             let is_shadowed = shadowed_keys.contains(&key);
 
             if !is_shadowed {
-                let field = items.get(key.as_str());
-                let value_tcx = field
+                let value_tcx = typed_dict
+                    .item(db, key.as_str())
                     .map(|field| TypeContext::new(Some(field.declared_ty)))
                     .unwrap_or_default();
                 let value_ty = expression_type_fn(&item.value, value_tcx);
@@ -1769,20 +2432,27 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             guaranteed_keys.entry(key_name.clone()).or_insert(None);
         }
         return true;
-    } else if let Some(unpacked_keys) =
-        extract_unpacked_typed_dict_keys_from_value_type(db, unpacked_type)
-    {
+    } else if let Some(unpacked) = extract_unpacked_typed_dict_from_value_type(db, unpacked_type) {
         let ignored_keys = shadowed_keys.clone();
-        let (_, unpacked_valid) = validate_extracted_typed_dict_keys(
+        let (_, mut unpacked_valid) = validate_extracted_typed_dict_keys(
             context,
             typed_dict,
-            &unpacked_keys,
+            &unpacked.keys,
             nodes,
             full_object_ty_annotation(unpacked_type),
             &ignored_keys,
         );
+        if let Some(extra_items_ty) = unpacked.extra_items_ty {
+            unpacked_valid &= validate_extracted_typed_dict_extra_items(
+                context,
+                typed_dict,
+                &unpacked.keys,
+                extra_items_ty,
+                nodes,
+            );
+        }
 
-        for (key_name, unpacked_key) in unpacked_keys {
+        for (key_name, unpacked_key) in unpacked.keys {
             if unpacked_key.is_required && !ignored_keys.contains(&key_name) {
                 guaranteed_keys
                     .entry(key_name.clone())
@@ -1845,18 +2515,27 @@ pub struct SynthesizedTypedDictType<'db> {
     #[returns(ref)]
     pub(crate) items: TypedDictSchema<'db>,
     pub(crate) kind: SynthesizedTypedDictKind,
+    pub(crate) openness: TypedDictOpenness<'db>,
 }
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for SynthesizedTypedDictType<'_> {}
 
 impl<'db> SynthesizedTypedDictType<'db> {
-    fn schema(db: &'db dyn Db, items: TypedDictSchema<'db>) -> Self {
-        Self::new(db, items, SynthesizedTypedDictKind::Schema)
+    fn schema(
+        db: &'db dyn Db,
+        items: TypedDictSchema<'db>,
+        openness: TypedDictOpenness<'db>,
+    ) -> Self {
+        Self::new(db, items, SynthesizedTypedDictKind::Schema, openness)
     }
 
-    fn patch(db: &'db dyn Db, items: TypedDictSchema<'db>) -> Self {
-        Self::new(db, items, SynthesizedTypedDictKind::Patch)
+    fn patch(
+        db: &'db dyn Db,
+        items: TypedDictSchema<'db>,
+        openness: TypedDictOpenness<'db>,
+    ) -> Self {
+        Self::new(db, items, SynthesizedTypedDictKind::Patch, openness)
     }
 
     fn is_patch(self, db: &'db dyn Db) -> bool {
@@ -1882,9 +2561,13 @@ impl<'db> SynthesizedTypedDictType<'db> {
             })
             .collect::<TypedDictSchema<'db>>();
 
+        let openness = self
+            .openness(db)
+            .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+
         match self.kind(db) {
-            SynthesizedTypedDictKind::Schema => Self::schema(db, items),
-            SynthesizedTypedDictKind::Patch => Self::patch(db, items),
+            SynthesizedTypedDictKind::Schema => Self::schema(db, items, openness),
+            SynthesizedTypedDictKind::Patch => Self::patch(db, items, openness),
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1589,88 +1589,69 @@ pub(crate) struct UnpackedTypedDictKey<'db> {
 
 /// A normalized view of a `TypedDict`-shaped value used when expanding `**kwargs`.
 ///
-/// Union and intersection inputs are combined into one set of possible keys and one tail describing
-/// arbitrary undeclared keys.
+/// Union and intersection inputs are combined into one set of possible keys and one openness
+/// policy describing arbitrary undeclared keys.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct UnpackedTypedDict<'db> {
     /// Declared keys that may be present after unpacking.
     pub(crate) keys: BTreeMap<Name, UnpackedTypedDictKey<'db>>,
-    pub(crate) tail: UnpackedTypedDictTail<'db>,
+    pub(crate) openness: TypedDictOpenness<'db>,
 }
 
-/// The arbitrary-key tail of a normalized `TypedDict` shape.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum UnpackedTypedDictTail<'db> {
-    /// The shape cannot contain undeclared keys.
-    Closed,
-    /// An ordinary open `TypedDict` may contain undeclared values of type `object`.
-    ///
-    /// Hidden values constrain an existing `**kwargs` parameter but do not themselves cause an
-    /// unknown-key error when the destination has no `**kwargs`.
-    Hidden,
-    /// Undeclared keys are explicitly exposed with this value type.
-    Explicit(Type<'db>),
+fn intersect_unpacked_typed_dict_openness<'db>(
+    db: &'db dyn Db,
+    openness: impl IntoIterator<Item = TypedDictOpenness<'db>>,
+) -> TypedDictOpenness<'db> {
+    let mut explicit_value_types = Vec::new();
+
+    for openness in openness {
+        match openness {
+            TypedDictOpenness::Closed => return TypedDictOpenness::Closed,
+            TypedDictOpenness::Open => {}
+            TypedDictOpenness::Extra(extra_items) => {
+                explicit_value_types.push(extra_items.declared_ty);
+            }
+        }
+    }
+
+    if explicit_value_types.is_empty() {
+        TypedDictOpenness::Open
+    } else {
+        TypedDictOpenness::extra(
+            db,
+            IntersectionType::from_elements(db, explicit_value_types),
+            true,
+        )
+    }
 }
 
-impl<'db> UnpackedTypedDictTail<'db> {
-    pub(crate) const fn value_ty(self) -> Option<Type<'db>> {
-        match self {
-            Self::Closed => None,
-            Self::Hidden => Some(Type::object()),
-            Self::Explicit(value_ty) => Some(value_ty),
-        }
-    }
+fn union_unpacked_typed_dict_openness<'db>(
+    db: &'db dyn Db,
+    openness: impl IntoIterator<Item = TypedDictOpenness<'db>>,
+) -> TypedDictOpenness<'db> {
+    let mut value_types = UnionBuilder::new(db);
+    let mut has_open = false;
+    let mut has_explicit_extra_items = false;
 
-    pub(crate) const fn is_explicit(self) -> bool {
-        matches!(self, Self::Explicit(_))
-    }
-
-    fn intersection(
-        db: &'db dyn Db,
-        tails: impl IntoIterator<Item = UnpackedTypedDictTail<'db>>,
-    ) -> Self {
-        let mut explicit_value_types = Vec::new();
-
-        for tail in tails {
-            match tail {
-                Self::Closed => return Self::Closed,
-                Self::Hidden => {}
-                Self::Explicit(value_ty) => explicit_value_types.push(value_ty),
+    for openness in openness {
+        match openness {
+            TypedDictOpenness::Closed => {}
+            TypedDictOpenness::Open => has_open = true,
+            TypedDictOpenness::Extra(extra_items) => {
+                value_types = value_types.add(extra_items.declared_ty);
+                has_explicit_extra_items = true;
             }
         }
-
-        if explicit_value_types.is_empty() {
-            Self::Hidden
-        } else {
-            Self::Explicit(IntersectionType::from_elements(db, explicit_value_types))
-        }
     }
 
-    fn union(db: &'db dyn Db, tails: impl IntoIterator<Item = UnpackedTypedDictTail<'db>>) -> Self {
-        let mut value_types = UnionBuilder::new(db);
-        let mut has_hidden_tail = false;
-        let mut has_explicit_tail = false;
-
-        for tail in tails {
-            match tail {
-                Self::Closed => {}
-                Self::Hidden => has_hidden_tail = true,
-                Self::Explicit(value_ty) => {
-                    value_types = value_types.add(value_ty);
-                    has_explicit_tail = true;
-                }
-            }
-        }
-
-        if has_hidden_tail && has_explicit_tail {
-            Self::Explicit(Type::object())
-        } else if has_hidden_tail {
-            Self::Hidden
-        } else if has_explicit_tail {
-            Self::Explicit(value_types.build())
-        } else {
-            Self::Closed
-        }
+    if has_open && has_explicit_extra_items {
+        TypedDictOpenness::extra(db, Type::object(), true)
+    } else if has_open {
+        TypedDictOpenness::Open
+    } else if has_explicit_extra_items {
+        TypedDictOpenness::extra(db, value_types.build(), true)
+    } else {
+        TypedDictOpenness::Closed
     }
 }
 
@@ -1690,7 +1671,7 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
     extract_unpacked_typed_dict_from_value_type(db, ty).map(|unpacked| unpacked.keys)
 }
 
-/// Extracts the declared keys and arbitrary-key tail from a `TypedDict`-shaped value.
+/// Extracts the declared keys and openness from a `TypedDict`-shaped value.
 pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -1711,14 +1692,10 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                     )
                 })
                 .collect();
-            let tail = match td.openness(db) {
-                TypedDictOpenness::Open => UnpackedTypedDictTail::Hidden,
-                TypedDictOpenness::Closed => UnpackedTypedDictTail::Closed,
-                TypedDictOpenness::Extra(extra_items) => {
-                    UnpackedTypedDictTail::Explicit(extra_items.declared_ty)
-                }
-            };
-            Some(UnpackedTypedDict { keys, tail })
+            Some(UnpackedTypedDict {
+                keys,
+                openness: td.openness(db),
+            })
         }
         Type::Intersection(intersection) => {
             // Collect TypedDict shapes from all TypedDicts in the intersection.
@@ -1760,23 +1737,26 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                     if unpacked.keys.contains_key(key) {
                         continue;
                     }
-                    if let Some(extra_items_ty) = unpacked.tail.value_ty() {
+                    if let Some(extra_items) = unpacked.openness.effective_extra_items() {
                         unpacked_key.value_ty = IntersectionType::from_two_elements(
                             db,
                             unpacked_key.value_ty,
-                            extra_items_ty,
+                            extra_items.declared_ty,
                         );
                         unpacked_key.definition = None;
                     }
                 }
             }
 
-            let tail = UnpackedTypedDictTail::intersection(
+            let openness = intersect_unpacked_typed_dict_openness(
                 db,
-                unpacked_elements.iter().map(|unpacked| unpacked.tail),
+                unpacked_elements.iter().map(|unpacked| unpacked.openness),
             );
 
-            Some(UnpackedTypedDict { keys: result, tail })
+            Some(UnpackedTypedDict {
+                keys: result,
+                openness,
+            })
         }
         Type::Union(union) => {
             let unpacked_elements: Vec<_> = union
@@ -1807,9 +1787,9 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                         } else {
                             unpacked_key.definition
                         });
-                    } else if let Some(extra_items_ty) = unpacked.tail.value_ty() {
+                    } else if let Some(extra_items) = unpacked.openness.effective_extra_items() {
                         saw_key = true;
-                        value_ty = value_ty.add(extra_items_ty);
+                        value_ty = value_ty.add(extra_items.declared_ty);
                         is_required = false;
                         definition = Some(None);
                     } else {
@@ -1830,12 +1810,15 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                 }
             }
 
-            let tail = UnpackedTypedDictTail::union(
+            let openness = union_unpacked_typed_dict_openness(
                 db,
-                unpacked_elements.iter().map(|unpacked| unpacked.tail),
+                unpacked_elements.iter().map(|unpacked| unpacked.openness),
             );
 
-            Some(UnpackedTypedDict { keys: result, tail })
+            Some(UnpackedTypedDict {
+                keys: result,
+                openness,
+            })
         }
         Type::TypeAlias(alias) => {
             extract_unpacked_typed_dict_from_value_type(db, alias.value_type(db))
@@ -2157,25 +2140,26 @@ fn validate_extracted_typed_dict_keys<'db, 'ast>(
     (provided_keys, valid)
 }
 
-/// Validates the arbitrary-key tail of a `TypedDict`-shaped constructor argument.
+/// Validates the arbitrary keys of a `TypedDict`-shaped constructor argument.
 ///
-/// The source tail must be valid for every target field it could provide and for the target's
-/// explicit extra-items type. Hidden open tails retain ty's existing leniency when constructing
-/// another open `TypedDict`.
-fn validate_extracted_typed_dict_tail<'db, 'ast>(
+/// The source's effective extra items must be valid for every target field they could provide and
+/// for the target's explicit extra-items type. Open sources retain ty's existing leniency when
+/// constructing another open `TypedDict`.
+fn validate_extracted_typed_dict_openness<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
     source_keys: &BTreeMap<Name, UnpackedTypedDictKey<'db>>,
-    tail: UnpackedTypedDictTail<'db>,
+    source_openness: TypedDictOpenness<'db>,
     nodes: TypedDictAssignmentNodes<'ast>,
     ignored_keys: &OrderSet<Name>,
 ) -> bool {
     let db = context.db();
-    let Some(extra_items_ty) = tail.value_ty() else {
+    let Some(extra_items) = source_openness.effective_extra_items() else {
         return true;
     };
+    let extra_items_ty = extra_items.declared_ty;
 
-    if typed_dict.openness(db).is_open() && !tail.is_explicit() {
+    if typed_dict.openness(db).is_open() && source_openness.is_open() {
         return true;
     }
 
@@ -2257,7 +2241,7 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
     let db = context.db();
     let typed_dict_items = typed_dict.items(db);
     let unpacked = extract_unpacked_typed_dict_from_value_type(db, arg_ty)?;
-    let tail = unpacked.tail;
+    let source_openness = unpacked.openness;
     let validate_extra_keys = !typed_dict.openness(db).is_open();
     let unpacked_keys = unpacked
         .keys
@@ -2279,11 +2263,11 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
         ignored_keys,
     )
     .0;
-    validate_extracted_typed_dict_tail(
+    validate_extracted_typed_dict_openness(
         context,
         typed_dict,
         &unpacked_keys,
-        tail,
+        source_openness,
         nodes,
         ignored_keys,
     );
@@ -2766,11 +2750,11 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             full_object_ty_annotation(unpacked_type),
             &ignored_keys,
         );
-        unpacked_valid &= validate_extracted_typed_dict_tail(
+        unpacked_valid &= validate_extracted_typed_dict_openness(
             context,
             typed_dict,
             &unpacked.keys,
-            unpacked.tail,
+            unpacked.openness,
             nodes,
             &ignored_keys,
         );
@@ -2803,11 +2787,11 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             return false;
         }
 
-        return validate_extracted_typed_dict_tail(
+        return validate_extracted_typed_dict_openness(
             context,
             typed_dict,
             &BTreeMap::new(),
-            UnpackedTypedDictTail::Explicit(value_ty),
+            TypedDictOpenness::extra(db, value_ty, true),
             nodes,
             shadowed_keys,
         );

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -955,9 +955,10 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
     /// `TypedDict` `C` that's fully-static and assignable to both of them.
     ///
     /// `TypedDict` assignability is determined field-by-field, so we determine disjointness
-    /// similarly. Fields that are present in both `A` and `B` can conflict directly. A required
-    /// field that's only in one side can also conflict with the other side's openness: a closed
-    /// `TypedDict` rejects it, and explicit extra items constrain whether it can be present.
+    /// similarly. Fields that are present in both `A` and `B` can conflict directly. A required or
+    /// mutable optional field that's only in one side can also conflict with the other side's
+    /// openness: a closed `TypedDict` rejects it, and explicit extra items constrain whether it can
+    /// be present.
     ///
     /// There are three properties of each field to consider: the declared type, whether it's
     /// mutable ("mut" vs "imm" below), and whether it's required ("req" vs "opt" below). Here's a
@@ -1110,13 +1111,22 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                     if field.is_required() || other_items.contains_key(name) {
                         return None;
                     }
-                    let TypedDictOpenness::Extra(extra_items) = other_openness else {
-                        return None;
-                    };
-                    (!field.is_read_only() || !extra_items.is_read_only())
-                        .then_some((field, extra_items))
+                    match other_openness {
+                        TypedDictOpenness::Closed if !field.is_read_only() => Some((field, None)),
+                        TypedDictOpenness::Extra(extra_items)
+                            if !field.is_read_only() || !extra_items.is_read_only() =>
+                        {
+                            Some((field, Some(extra_items)))
+                        }
+                        TypedDictOpenness::Open
+                        | TypedDictOpenness::Closed
+                        | TypedDictOpenness::Extra(_) => None,
+                    }
                 })
                 .when_any(db, self.constraints, |(field, extra_items)| {
+                    let Some(extra_items) = extra_items else {
+                        return self.always();
+                    };
                     let relation_checker = self.as_relation_checker(TypeRelation::Assignability);
                     if field.is_read_only() {
                         relation_checker

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -48,16 +48,17 @@ impl Default for TypedDictParams {
     }
 }
 
-/// The openness of a `TypedDict`.
+/// The undeclared-item policy of a `TypedDict`.
 ///
-/// Open `TypedDict`s may contain hidden items, but those items are not directly accessible through
-/// most operations. `TypedDict`s with explicit extra items expose those items with a known type.
+/// An implicitly open `TypedDict` may contain hidden items, but those items are not directly
+/// accessible through most operations. A `TypedDict` with explicit extra items exposes those items
+/// with a known type.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::Update)]
 pub enum TypedDictOpenness<'db> {
     /// Undeclared items may exist at runtime, but are not directly accessible through most
     /// `TypedDict` operations.
     #[default]
-    Open,
+    ImplicitlyOpen,
     /// Undeclared items cannot exist.
     Closed,
     /// Undeclared items are explicitly exposed with the given value type and mutability.
@@ -86,23 +87,23 @@ impl<'db> TypedDictOpenness<'db> {
 
     /// Returns extra items only when they were explicitly declared.
     ///
-    /// An ordinary open `TypedDict` returns `None` here because its hidden items are not directly
+    /// An implicitly open `TypedDict` returns `None` here because its hidden items are not directly
     /// accessible. Use [`Self::effective_extra_items`] for structural relations that must account
     /// for those hidden items.
     pub(crate) const fn explicit_extra_items(self) -> Option<TypedDictExtraItems<'db>> {
         match self {
             Self::Extra(extra_items) => Some(extra_items),
-            Self::Open | Self::Closed => None,
+            Self::ImplicitlyOpen | Self::Closed => None,
         }
     }
 
     /// Returns the effective extra-items policy.
     ///
-    /// An open `TypedDict` behaves like it has read-only extra items of type `object` for these
-    /// purposes, while a closed `TypedDict` has no extra items.
+    /// An implicitly open `TypedDict` behaves like it has read-only extra items of type `object`
+    /// for these purposes, while a closed `TypedDict` has no extra items.
     pub(crate) fn effective_extra_items(self) -> Option<TypedDictExtraItems<'db>> {
         match self {
-            Self::Open => Some(TypedDictExtraItems {
+            Self::ImplicitlyOpen => Some(TypedDictExtraItems {
                 declared_ty: Type::object(),
                 is_read_only: true,
             }),
@@ -111,8 +112,8 @@ impl<'db> TypedDictOpenness<'db> {
         }
     }
 
-    pub(crate) const fn is_open(self) -> bool {
-        matches!(self, Self::Open)
+    pub(crate) const fn is_implicitly_open(self) -> bool {
+        matches!(self, Self::ImplicitlyOpen)
     }
 
     pub(crate) const fn is_closed(self) -> bool {
@@ -127,7 +128,7 @@ impl<'db> TypedDictOpenness<'db> {
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         match self {
-            Self::Open | Self::Closed => self,
+            Self::ImplicitlyOpen | Self::Closed => self,
             Self::Extra(extra_items) => Self::extra(
                 db,
                 extra_items
@@ -145,7 +146,7 @@ impl<'db> TypedDictOpenness<'db> {
         nested: bool,
     ) -> Option<Self> {
         match self {
-            Self::Open | Self::Closed => Some(self),
+            Self::ImplicitlyOpen | Self::Closed => Some(self),
             Self::Extra(extra_items) => {
                 let declared_ty = extra_items
                     .declared_ty
@@ -164,7 +165,8 @@ impl<'db> TypedDictOpenness<'db> {
 /// The value type and mutability of a `TypedDict`'s extra items.
 ///
 /// This represents either an explicit `extra_items` declaration or the synthetic read-only
-/// `object` policy returned for an open `TypedDict` by [`TypedDictOpenness::effective_extra_items`].
+/// `object` policy returned for an implicitly open `TypedDict` by
+/// [`TypedDictOpenness::effective_extra_items`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::Update)]
 pub struct TypedDictExtraItems<'db> {
     pub(crate) declared_ty: Type<'db>,
@@ -226,13 +228,13 @@ impl<'db> TypedDictType<'db> {
         }
     }
 
-    /// Returns whether this `TypedDict` is open, closed, or has explicitly typed extra items.
+    /// Returns whether this `TypedDict` is implicitly open, closed, or has explicit extra items.
     ///
-    /// A class-based `TypedDict` inherits the first non-open policy from its bases unless it
+    /// A class-based `TypedDict` inherits the first explicit policy from its bases unless it
     /// declares its own `closed` or `extra_items` argument.
     pub(crate) fn openness(self, db: &'db dyn Db) -> TypedDictOpenness<'db> {
         #[salsa::tracked(
-            cycle_initial=|_, _, _| TypedDictOpenness::Open,
+            cycle_initial=|_, _, _| TypedDictOpenness::ImplicitlyOpen,
             heap_size=ruff_memory_usage::heap_size
         )]
         fn class_based_openness<'db>(
@@ -245,7 +247,7 @@ impl<'db> TypedDictType<'db> {
             }
 
             let Some((static_class, specialization)) = class.static_class_literal(db) else {
-                return TypedDictOpenness::Open;
+                return TypedDictOpenness::ImplicitlyOpen;
             };
 
             let module = parsed_module(db, static_class.file(db)).load(db);
@@ -275,7 +277,7 @@ impl<'db> TypedDictType<'db> {
                     return if closed_ty.bool(db).is_always_true() {
                         TypedDictOpenness::Closed
                     } else {
-                        TypedDictOpenness::Open
+                        TypedDictOpenness::ImplicitlyOpen
                     };
                 }
             }
@@ -290,13 +292,13 @@ impl<'db> TypedDictType<'db> {
 
                 if base_class.class_literal(db).is_typed_dict(db) {
                     let openness = TypedDictType::new(base_class).openness(db);
-                    if !openness.is_open() {
+                    if !openness.is_implicitly_open() {
                         return openness;
                     }
                 }
             }
 
-            TypedDictOpenness::Open
+            TypedDictOpenness::ImplicitlyOpen
         }
 
         match self {
@@ -312,11 +314,11 @@ impl<'db> TypedDictType<'db> {
 
     /// Returns a type that contains every value that may be stored in this `TypedDict`.
     ///
-    /// An ordinary open `TypedDict` immediately returns `object` because hidden items may have any
-    /// value type. This also avoids unnecessarily materializing its declared items.
+    /// An implicitly open `TypedDict` immediately returns `object` because hidden items may have
+    /// any value type. This also avoids unnecessarily materializing its declared items.
     pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
         let openness = self.openness(db);
-        if openness.is_open() {
+        if openness.is_implicitly_open() {
             return Type::object();
         }
 
@@ -333,7 +335,7 @@ impl<'db> TypedDictType<'db> {
     /// Returns the field exposed by a literal key.
     ///
     /// Undeclared keys synthesize a field only for explicit extra items. Hidden items on an
-    /// ordinary open `TypedDict` are intentionally not directly accessible.
+    /// implicitly open `TypedDict` are intentionally not directly accessible.
     pub(crate) fn item(self, db: &'db dyn Db, key: &str) -> Option<TypedDictField<'db>> {
         self.items(db).get(key).cloned().or_else(|| {
             let extra_items = self.explicit_extra_items(db)?;
@@ -397,7 +399,7 @@ impl<'db> TypedDictType<'db> {
     /// extra items, and cannot be exposed when any declared item is required or read-only.
     pub(crate) fn supports_arbitrary_key_deletion(self, db: &'db dyn Db) -> bool {
         let openness_supports_deletion = match self.openness(db) {
-            TypedDictOpenness::Open => false,
+            TypedDictOpenness::ImplicitlyOpen => false,
             TypedDictOpenness::Closed => true,
             TypedDictOpenness::Extra(extra_items) => !extra_items.is_read_only(),
         };
@@ -520,7 +522,7 @@ impl<'db> TypedDictType<'db> {
     }
 
     pub(crate) fn from_schema_items(db: &'db dyn Db, items: TypedDictSchema<'db>) -> Self {
-        Self::from_schema_items_with_openness(db, items, TypedDictOpenness::Open)
+        Self::from_schema_items_with_openness(db, items, TypedDictOpenness::ImplicitlyOpen)
     }
 
     /// Creates a synthesized schema while preserving its undeclared-item policy.
@@ -573,7 +575,7 @@ impl<'db> TypedDictType<'db> {
             .collect();
 
         let openness = match self.openness(db) {
-            TypedDictOpenness::Open => TypedDictOpenness::Open,
+            TypedDictOpenness::ImplicitlyOpen => TypedDictOpenness::ImplicitlyOpen,
             TypedDictOpenness::Extra(extra_items) if !extra_items.is_read_only() => {
                 TypedDictOpenness::Extra(extra_items)
             }
@@ -621,7 +623,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     target_item_field.declared_ty
                 } else {
                     match target_openness {
-                        TypedDictOpenness::Open => continue,
+                        TypedDictOpenness::ImplicitlyOpen => continue,
                         TypedDictOpenness::Closed => return self.never(),
                         TypedDictOpenness::Extra(extra_items) => extra_items.declared_ty,
                     }
@@ -638,7 +640,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
             }
 
-            let source_extra_items = if target_openness.is_open() {
+            let source_extra_items = if target_openness.is_implicitly_open() {
                 source.explicit_extra_items(db)
             } else {
                 source.openness(db).effective_extra_items()
@@ -663,7 +665,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
 
                 match target_openness {
-                    TypedDictOpenness::Open => {}
+                    TypedDictOpenness::ImplicitlyOpen => {}
                     TypedDictOpenness::Closed => return self.never(),
                     TypedDictOpenness::Extra(target_extra_items) => {
                         result.intersect(
@@ -913,7 +915,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     }
                 }
             }
-            TypedDictOpenness::Open | TypedDictOpenness::Extra(_) => {
+            TypedDictOpenness::ImplicitlyOpen | TypedDictOpenness::Extra(_) => {
                 // An open target shares the read-only extra-items path, using `object` as its
                 // effective extra-items type.
                 let target_extra_items = target_openness.effective_extra_items().expect(
@@ -1090,7 +1092,9 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                         TypedDictOpenness::Extra(extra_items) if !extra_items.is_read_only() => {
                             self.always()
                         }
-                        TypedDictOpenness::Open => check_read_only_extra_items(Type::object()),
+                        TypedDictOpenness::ImplicitlyOpen => {
+                            check_read_only_extra_items(Type::object())
+                        }
                         TypedDictOpenness::Extra(extra_items) => {
                             check_read_only_extra_items(extra_items.declared_ty)
                         }
@@ -1118,7 +1122,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                         {
                             Some((field, Some(extra_items)))
                         }
-                        TypedDictOpenness::Open
+                        TypedDictOpenness::ImplicitlyOpen
                         | TypedDictOpenness::Closed
                         | TypedDictOpenness::Extra(_) => None,
                     }
@@ -1283,7 +1287,7 @@ pub(super) fn deferred_functional_typed_dict_schema<'db>(
 /// Movie = TypedDict("Movie", {"name": str}, extra_items=ReadOnly[int])
 /// ```
 #[salsa::tracked(
-    cycle_initial = |_, _, _| TypedDictOpenness::Open,
+    cycle_initial = |_, _, _| TypedDictOpenness::ImplicitlyOpen,
     heap_size = ruff_memory_usage::heap_size
 )]
 pub(super) fn deferred_functional_typed_dict_openness<'db>(
@@ -1316,7 +1320,7 @@ pub(super) fn deferred_functional_typed_dict_openness<'db>(
         }
     }
 
-    TypedDictOpenness::Open
+    TypedDictOpenness::ImplicitlyOpen
 }
 
 pub(super) fn typed_dict_params_from_class_def(class_stmt: &StmtClassDef) -> TypedDictParams {
@@ -1581,9 +1585,10 @@ pub(crate) struct UnpackedTypedDict<'db> {
 
 /// Combines the openness policies of intersected `TypedDict`-shaped values.
 ///
-/// An intersection must satisfy every constituent, so `Closed` dominates, `Open` adds no
+/// An intersection must satisfy every constituent, so `Closed` dominates, `ImplicitlyOpen` adds no
 /// constraint, and explicit extra-item value types are intersected. Conceptually,
-/// `Open & Extra[int]` becomes a read-only `Extra[int]`, while `Closed & Extra[int]` is `Closed`.
+/// `ImplicitlyOpen & Extra[int]` becomes a read-only `Extra[int]`, while
+/// `Closed & Extra[int]` is `Closed`.
 ///
 /// The combined explicit policy can be read-only because unpacking observes extra items but never
 /// writes through the synthesized policy.
@@ -1596,7 +1601,7 @@ fn intersect_unpacked_typed_dict_openness<'db>(
     for openness in openness {
         match openness {
             TypedDictOpenness::Closed => return TypedDictOpenness::Closed,
-            TypedDictOpenness::Open => {}
+            TypedDictOpenness::ImplicitlyOpen => {}
             TypedDictOpenness::Extra(extra_items) => {
                 explicit_value_types.push(extra_items.declared_ty);
             }
@@ -1604,7 +1609,7 @@ fn intersect_unpacked_typed_dict_openness<'db>(
     }
 
     if explicit_value_types.is_empty() {
-        TypedDictOpenness::Open
+        TypedDictOpenness::ImplicitlyOpen
     } else {
         TypedDictOpenness::extra(
             db,
@@ -1617,10 +1622,11 @@ fn intersect_unpacked_typed_dict_openness<'db>(
 /// Combines the openness policies of unioned `TypedDict`-shaped values.
 ///
 /// A union may contain extra items from any constituent, so `Closed` contributes no values and
-/// explicit extra-item value types are unioned. An `Open` constituent widens explicit extra items
-/// to `object` while preserving explicit-extra-item behavior: conceptually,
-/// `Open | Extra[int]` becomes a read-only `Extra[object]`. With no explicit extra items, any open
-/// constituent makes the result `Open`; otherwise the result is `Closed`.
+/// explicit extra-item value types are unioned. An `ImplicitlyOpen` constituent widens explicit
+/// extra items to `object` while preserving explicit-extra-item behavior: conceptually,
+/// `ImplicitlyOpen | Extra[int]` becomes a read-only `Extra[object]`. With no explicit extra items,
+/// any implicitly open constituent makes the result `ImplicitlyOpen`; otherwise the result is
+/// `Closed`.
 ///
 /// As with intersections, a synthesized explicit policy is read-only because unpacking only
 /// observes its values.
@@ -1629,13 +1635,13 @@ fn union_unpacked_typed_dict_openness<'db>(
     openness: impl IntoIterator<Item = TypedDictOpenness<'db>>,
 ) -> TypedDictOpenness<'db> {
     let mut value_types = UnionBuilder::new(db);
-    let mut has_open = false;
+    let mut has_implicitly_open = false;
     let mut has_explicit_extra_items = false;
 
     for openness in openness {
         match openness {
             TypedDictOpenness::Closed => {}
-            TypedDictOpenness::Open => has_open = true,
+            TypedDictOpenness::ImplicitlyOpen => has_implicitly_open = true,
             TypedDictOpenness::Extra(extra_items) => {
                 value_types = value_types.add(extra_items.declared_ty);
                 has_explicit_extra_items = true;
@@ -1643,10 +1649,10 @@ fn union_unpacked_typed_dict_openness<'db>(
         }
     }
 
-    if has_open && has_explicit_extra_items {
+    if has_implicitly_open && has_explicit_extra_items {
         TypedDictOpenness::extra(db, Type::object(), true)
-    } else if has_open {
-        TypedDictOpenness::Open
+    } else if has_implicitly_open {
+        TypedDictOpenness::ImplicitlyOpen
     } else if has_explicit_extra_items {
         TypedDictOpenness::extra(db, value_types.build(), true)
     } else {
@@ -2142,8 +2148,8 @@ fn validate_extracted_typed_dict_keys<'db, 'ast>(
 /// Validates the arbitrary keys of a `TypedDict`-shaped constructor argument.
 ///
 /// The source's effective extra items must be valid for every target field they could provide and
-/// for the target's explicit extra-items type. Open sources retain ty's existing leniency when
-/// constructing another open `TypedDict`.
+/// for the target's explicit extra-items type. Implicitly open sources retain ty's existing
+/// leniency when constructing another implicitly open `TypedDict`.
 fn validate_extracted_typed_dict_openness<'db, 'ast>(
     context: &InferContext<'db, 'ast>,
     typed_dict: TypedDictType<'db>,
@@ -2159,7 +2165,7 @@ fn validate_extracted_typed_dict_openness<'db, 'ast>(
     let extra_items_ty = extra_items.declared_ty;
     let target_openness = typed_dict.openness(db);
 
-    if target_openness.is_open() && source_openness.is_open() {
+    if target_openness.is_implicitly_open() && source_openness.is_implicitly_open() {
         return true;
     }
 
@@ -2242,7 +2248,7 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
     let typed_dict_items = typed_dict.items(db);
     let unpacked = extract_unpacked_typed_dict_from_value_type(db, arg_ty)?;
     let source_openness = unpacked.openness;
-    let validate_extra_keys = !typed_dict.openness(db).is_open();
+    let validate_extra_keys = !typed_dict.openness(db).is_implicitly_open();
     let unpacked_keys = unpacked
         .keys
         .into_iter()
@@ -2387,8 +2393,8 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
             let positional_inference_target =
                 typed_dict_with_relaxed_keys(db, typed_dict, &keyword_keys);
             let positional_target = typed_dict_without_keys(db, typed_dict, &keyword_keys);
-            let positional_target_is_unconstrained =
-                positional_target.items(db).is_empty() && positional_target.openness(db).is_open();
+            let positional_target_is_unconstrained = positional_target.items(db).is_empty()
+                && positional_target.openness(db).is_implicitly_open();
             let positional_target_ty = Type::TypedDict(positional_target);
             let positional_inference_target_ty = Type::TypedDict(positional_inference_target);
             let arg_ty =
@@ -2785,7 +2791,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             return false;
         }
 
-        if !typed_dict.openness(db).is_open() {
+        if !typed_dict.openness(db).is_implicitly_open() {
             return validate_extracted_typed_dict_openness(
                 context,
                 typed_dict,

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -2467,6 +2467,16 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
         }
 
         return unpacked_valid;
+    } else if typed_dict.explicit_extra_items(db).is_some()
+        && let Some((_, value_ty)) = unpacked_type.unpack_keys_and_items(db)
+    {
+        return validate_extracted_typed_dict_extra_items(
+            context,
+            typed_dict,
+            &BTreeMap::new(),
+            value_ty,
+            nodes,
+        );
     }
 
     true

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1909,6 +1909,7 @@ fn validate_extracted_typed_dict_extra_items<'db, 'ast>(
     source_keys: &BTreeMap<Name, UnpackedTypedDictKey<'db>>,
     extra_items_ty: Type<'db>,
     nodes: TypedDictAssignmentNodes<'ast>,
+    ignored_keys: &OrderSet<Name>,
 ) -> bool {
     let db = context.db();
     let typed_dict_ty = Type::TypedDict(typed_dict);
@@ -1921,6 +1922,7 @@ fn validate_extracted_typed_dict_extra_items<'db, 'ast>(
         if let Some((target_name, target_field)) =
             typed_dict.items(db).iter().find(|(name, field)| {
                 !source_keys.contains_key(*name)
+                    && !ignored_keys.contains(*name)
                     && !extra_items_ty.is_assignable_to(db, field.declared_ty)
             })
         {
@@ -2020,6 +2022,7 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
             &unpacked_keys,
             extra_items_ty,
             nodes,
+            ignored_keys,
         );
     }
 
@@ -2487,6 +2490,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
                 &unpacked.keys,
                 extra_items_ty,
                 nodes,
+                &ignored_keys,
             );
         }
 
@@ -2514,6 +2518,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             &BTreeMap::new(),
             value_ty,
             nodes,
+            shadowed_keys,
         );
     }
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1069,7 +1069,41 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                 })
         });
 
-        required_fields_disjoint.or(db, self.constraints, || {
+        let unshared_fields_disjoint = required_fields_disjoint.or(db, self.constraints, || {
+            left_items
+                .iter()
+                .map(|(name, field)| (name, field, right_items, right.openness(db)))
+                .chain(
+                    right_items
+                        .iter()
+                        .map(|(name, field)| (name, field, left_items, left.openness(db))),
+                )
+                .filter_map(|(name, field, other_items, other_openness)| {
+                    if field.is_required() || field.is_read_only() || other_items.contains_key(name)
+                    {
+                        return None;
+                    }
+                    let TypedDictOpenness::Extra(extra_items) = other_openness else {
+                        return None;
+                    };
+                    (!extra_items.is_read_only()).then_some((field, extra_items))
+                })
+                .when_any(db, self.constraints, |(field, extra_items)| {
+                    let relation_checker = self.as_relation_checker(TypeRelation::Assignability);
+                    relation_checker
+                        .check_type_pair(db, field.declared_ty, extra_items.declared_ty)
+                        .and(db, self.constraints, || {
+                            relation_checker.check_type_pair(
+                                db,
+                                extra_items.declared_ty,
+                                field.declared_ty,
+                            )
+                        })
+                        .negate(db, self.constraints)
+                })
+        });
+
+        unshared_fields_disjoint.or(db, self.constraints, || {
             let left_openness = left.openness(db);
             let right_openness = right.openness(db);
             let relation_checker = self.as_relation_checker(TypeRelation::Assignability);

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1407,7 +1407,7 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
     extract_unpacked_typed_dict_from_value_type(db, ty).map(|unpacked| unpacked.keys)
 }
 
-/// Extracts the declared keys and explicit extra-items tail from a `TypedDict`-shaped value.
+/// Extracts the declared keys and effective extra-items tail from a `TypedDict`-shaped value.
 pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -1430,7 +1430,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                 .collect();
             Some(UnpackedTypedDict {
                 keys,
-                extra_items_ty: td.explicit_extra_items(db).map(|extra| extra.declared_ty),
+                extra_items_ty: td.effective_extra_items(db).map(|extra| extra.declared_ty),
                 is_closed: td.openness(db).is_closed(),
             })
         }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -297,7 +297,8 @@ impl<'db> TypedDictType<'db> {
     }
 
     pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
-        if self.openness(db).is_open() {
+        let openness = self.openness(db);
+        if openness.is_open() {
             return Type::object();
         }
 
@@ -305,7 +306,7 @@ impl<'db> TypedDictType<'db> {
         for field in self.items(db).values() {
             builder = builder.add(field.declared_ty);
         }
-        if let Some(extra_items) = self.effective_extra_items(db) {
+        if let Some(extra_items) = openness.effective_extra_items() {
             builder = builder.add(extra_items.declared_ty);
         }
         builder.build()
@@ -818,63 +819,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     return self.never();
                 }
             }
-            TypedDictOpenness::Open => {
-                // An open target behaves like it has read-only extra items of type `object`.
-                let target_extra_items = target_openness
-                    .effective_extra_items()
-                    .expect("open TypedDict should have effective extra items");
-                if let Some(source_extra_items) = source_openness.effective_extra_items() {
-                    result.intersect(
-                        db,
-                        self.constraints,
-                        self.check_type_pair(
-                            db,
-                            source_extra_items.declared_ty,
-                            target_extra_items.declared_ty,
-                        ),
-                    );
-                }
-                for (source_item_name, source_item_field) in source_items {
-                    if !target_items.contains_key(source_item_name) {
-                        result.intersect(
-                            db,
-                            self.constraints,
-                            self.check_type_pair(
-                                db,
-                                source_item_field.declared_ty,
-                                target_extra_items.declared_ty,
-                            ),
-                        );
-                    }
-                }
-            }
-            TypedDictOpenness::Extra(target_extra_items) if target_extra_items.is_read_only() => {
-                if let Some(source_extra_items) = source_openness.effective_extra_items() {
-                    result.intersect(
-                        db,
-                        self.constraints,
-                        self.check_type_pair(
-                            db,
-                            source_extra_items.declared_ty,
-                            target_extra_items.declared_ty,
-                        ),
-                    );
-                }
-                for (source_item_name, source_item_field) in source_items {
-                    if !target_items.contains_key(source_item_name) {
-                        result.intersect(
-                            db,
-                            self.constraints,
-                            self.check_type_pair(
-                                db,
-                                source_item_field.declared_ty,
-                                target_extra_items.declared_ty,
-                            ),
-                        );
-                    }
-                }
-            }
-            TypedDictOpenness::Extra(target_extra_items) => {
+            TypedDictOpenness::Extra(target_extra_items) if !target_extra_items.is_read_only() => {
                 let Some(source_extra_items) = source_openness.explicit_extra_items() else {
                     return self.never();
                 };
@@ -917,6 +862,37 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                     source_item_field.declared_ty,
                                 )
                             }),
+                        );
+                    }
+                }
+            }
+            TypedDictOpenness::Open | TypedDictOpenness::Extra(_) => {
+                // An open target shares the read-only extra-items path, using `object` as its
+                // effective extra-items type.
+                let target_extra_items = target_openness.effective_extra_items().expect(
+                    "open or read-only extra-items TypedDict should have effective extra items",
+                );
+                if let Some(source_extra_items) = source_openness.effective_extra_items() {
+                    result.intersect(
+                        db,
+                        self.constraints,
+                        self.check_type_pair(
+                            db,
+                            source_extra_items.declared_ty,
+                            target_extra_items.declared_ty,
+                        ),
+                    );
+                }
+                for (source_item_name, source_item_field) in source_items {
+                    if !target_items.contains_key(source_item_name) {
+                        result.intersect(
+                            db,
+                            self.constraints,
+                            self.check_type_pair(
+                                db,
+                                source_item_field.declared_ty,
+                                target_extra_items.declared_ty,
+                            ),
                         );
                     }
                 }
@@ -1051,36 +1027,24 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                         .map(|(_, field)| (field, left.openness(db))),
                 )
                 .when_any(db, self.constraints, |(required_field, other_openness)| {
+                    let check_read_only_extra_items = |extra_items_ty| {
+                        if required_field.is_read_only() {
+                            self.check_type_pair(db, required_field.declared_ty, extra_items_ty)
+                        } else {
+                            self.as_relation_checker(TypeRelation::Assignability)
+                                .check_type_pair(db, required_field.declared_ty, extra_items_ty)
+                                .negate(db, self.constraints)
+                        }
+                    };
+
                     match other_openness {
                         TypedDictOpenness::Closed => self.always(),
                         TypedDictOpenness::Extra(extra_items) if !extra_items.is_read_only() => {
                             self.always()
                         }
-                        TypedDictOpenness::Open => {
-                            if required_field.is_read_only() {
-                                self.check_type_pair(db, required_field.declared_ty, Type::object())
-                            } else {
-                                self.as_relation_checker(TypeRelation::Assignability)
-                                    .check_type_pair(db, required_field.declared_ty, Type::object())
-                                    .negate(db, self.constraints)
-                            }
-                        }
+                        TypedDictOpenness::Open => check_read_only_extra_items(Type::object()),
                         TypedDictOpenness::Extra(extra_items) => {
-                            if required_field.is_read_only() {
-                                self.check_type_pair(
-                                    db,
-                                    required_field.declared_ty,
-                                    extra_items.declared_ty,
-                                )
-                            } else {
-                                self.as_relation_checker(TypeRelation::Assignability)
-                                    .check_type_pair(
-                                        db,
-                                        required_field.declared_ty,
-                                        extra_items.declared_ty,
-                                    )
-                                    .negate(db, self.constraints)
-                            }
+                            check_read_only_extra_items(extra_items.declared_ty)
                         }
                     }
                 })

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1983,10 +1983,11 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
     let db = context.db();
     let typed_dict_items = typed_dict.items(db);
     let unpacked = extract_unpacked_typed_dict_from_value_type(db, arg_ty)?;
+    let validate_extra_keys = typed_dict.explicit_extra_items(db).is_some();
     let unpacked_keys = unpacked
         .keys
         .into_iter()
-        .filter(|(key_name, _)| typed_dict_items.contains_key(key_name))
+        .filter(|(key_name, _)| validate_extra_keys || typed_dict_items.contains_key(key_name))
         .collect();
 
     let nodes = TypedDictAssignmentNodes {

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -549,9 +549,9 @@ impl<'db> TypedDictType<'db> {
     }
 
     /// Returns a partial version of this `TypedDict` where all fields are optional. This is used
-    /// to model PEP 584 update operands, accepting dictionary literals that update any subset of
-    /// known keys, and also accepting other `TypedDict`s as long as any overlapping keys are
-    /// compatible.
+    /// to model non-mutating PEP 584 merge operands, accepting dictionary literals that supply any
+    /// subset of known keys, and also accepting other `TypedDict`s as long as any overlapping keys
+    /// are compatible.
     pub(crate) fn to_partial(self, db: &'db dyn Db) -> Self {
         let items: TypedDictSchema<'db> = self
             .items(db)
@@ -562,11 +562,12 @@ impl<'db> TypedDictType<'db> {
         Self::from_patch_items_with_openness(db, items, self.openness(db))
     }
 
-    /// Returns a patch version of this `TypedDict` for `TypedDict.update()`.
+    /// Returns a patch version of this `TypedDict` for in-place mutations such as `update()` and
+    /// `__ior__` (`|=`).
     ///
     /// All fields become optional, and read-only fields become bottom-typed. This preserves the
-    /// PEP 705 rule that `update()` must reject any source that can write a read-only key, while
-    /// still accepting `NotRequired[Never]` placeholders for keys that cannot be present.
+    /// PEP 705 rule that these operations must reject any source that can write a read-only key,
+    /// while still accepting `NotRequired[Never]` placeholders for keys that cannot be present.
     pub(crate) fn to_update_patch(self, db: &'db dyn Db) -> Self {
         let items: TypedDictSchema<'db> = self
             .items(db)

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -309,12 +309,24 @@ impl<'db> TypedDictType<'db> {
     }
 
     pub(crate) fn arbitrary_key_value_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        self.arbitrary_key_value_type_excluding(db, &OrderSet::new())
+    }
+
+    fn arbitrary_key_value_type_excluding(
+        self,
+        db: &'db dyn Db,
+        excluded_keys: &OrderSet<Name>,
+    ) -> Option<Type<'db>> {
         let extra_items = self.explicit_extra_items(db)?;
 
         Some(IntersectionType::from_elements(
             db,
-            std::iter::once(extra_items.declared_ty)
-                .chain(self.items(db).values().map(|field| field.declared_ty)),
+            std::iter::once(extra_items.declared_ty).chain(
+                self.items(db)
+                    .iter()
+                    .filter(|(name, _)| !excluded_keys.contains(*name))
+                    .map(|(_, field)| field.declared_ty),
+            ),
         ))
     }
 
@@ -2479,7 +2491,9 @@ fn validate_merged_dict_literal<'db, 'ast>(
             let key_ty = expression_type_fn(key_expr, TypeContext::default());
             let Some(key_literal) = key_ty.as_string_literal() else {
                 if key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db)) {
-                    if let Some(expected_ty) = typed_dict.arbitrary_key_value_type(db) {
+                    if let Some(expected_ty) =
+                        typed_dict.arbitrary_key_value_type_excluding(db, shadowed_keys)
+                    {
                         let value_ty =
                             expression_type_fn(&item.value, TypeContext::new(Some(expected_ty)));
                         if !value_ty.is_assignable_to(db, expected_ty) {

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -61,8 +61,8 @@ pub enum TypedDictOpenness<'db> {
 }
 
 impl<'db> TypedDictOpenness<'db> {
-    pub(crate) fn extra(declared_ty: Type<'db>, is_read_only: bool) -> Self {
-        if declared_ty.is_never() {
+    pub(crate) fn extra(db: &'db dyn Db, declared_ty: Type<'db>, is_read_only: bool) -> Self {
+        if declared_ty.resolve_type_alias(db).is_never() {
             Self::Closed
         } else {
             Self::Extra(TypedDictExtraItems {
@@ -112,6 +112,7 @@ impl<'db> TypedDictOpenness<'db> {
         match self {
             Self::Open | Self::Closed => self,
             Self::Extra(extra_items) => Self::extra(
+                db,
                 extra_items
                     .declared_ty
                     .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
@@ -137,7 +138,7 @@ impl<'db> TypedDictOpenness<'db> {
                 } else {
                     declared_ty.unwrap_or(div)
                 };
-                Some(Self::extra(declared_ty, extra_items.is_read_only))
+                Some(Self::extra(db, declared_ty, extra_items.is_read_only))
             }
         }
     }
@@ -238,6 +239,7 @@ impl<'db> TypedDictType<'db> {
                     let qualifiers =
                         definition_expression_qualifiers(db, class_definition, &extra_items.value);
                     return TypedDictOpenness::extra(
+                        db,
                         declared_ty,
                         qualifiers.contains(TypeQualifiers::READ_ONLY),
                     );
@@ -1273,6 +1275,7 @@ pub(super) fn deferred_functional_typed_dict_openness<'db>(
     if let Some(extra_items) = node.arguments.find_keyword("extra_items") {
         let deferred_inference = infer_deferred_types(db, definition);
         return TypedDictOpenness::extra(
+            db,
             deferred_inference.expression_type(&extra_items.value),
             deferred_inference
                 .qualifiers(&extra_items.value)

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -2642,7 +2642,7 @@ fn validate_merged_dict_literal<'db, 'ast>(
                             ));
                         }
                     }
-                } else if !typed_dict.openness(db).is_open() {
+                } else {
                     valid = false;
                     if let Some(builder) = context.report_lint(&INVALID_KEY, key_expr) {
                         builder.into_diagnostic(format_args!(
@@ -2774,9 +2774,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
         }
 
         return unpacked_valid;
-    } else if !typed_dict.openness(db).is_open()
-        && let Some((key_ty, value_ty)) = unpacked_type.unpack_keys_and_items(db)
-    {
+    } else if let Some((key_ty, value_ty)) = unpacked_type.unpack_keys_and_items(db) {
         if !key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db)) {
             if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, nodes.value) {
                 builder.into_diagnostic(format_args!(
@@ -2787,14 +2785,16 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             return false;
         }
 
-        return validate_extracted_typed_dict_openness(
-            context,
-            typed_dict,
-            &BTreeMap::new(),
-            TypedDictOpenness::extra(db, value_ty, true),
-            nodes,
-            shadowed_keys,
-        );
+        if !typed_dict.openness(db).is_open() {
+            return validate_extracted_typed_dict_openness(
+                context,
+                typed_dict,
+                &BTreeMap::new(),
+                TypedDictOpenness::extra(db, value_ty, true),
+                nodes,
+                shadowed_keys,
+            );
+        }
     }
 
     true

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -5,11 +5,7 @@ use std::ops::{Deref, DerefMut};
 use bitflags::bitflags;
 use ordermap::OrderSet;
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
-#[cfg(test)]
-use ruff_db::files::system_path_to_file;
 use ruff_db::parsed::parsed_module;
-#[cfg(test)]
-use ruff_db::system::DbWithWritableSystem as _;
 use ruff_python_ast::Arguments;
 use ruff_python_ast::{self as ast, AnyNodeRef, StmtClassDef, name::Name};
 use ruff_text_size::Ranged;
@@ -26,10 +22,6 @@ use super::{
     UnionBuilder, definition_expression_qualifiers, definition_expression_type, visitor,
 };
 use crate::Db;
-#[cfg(test)]
-use crate::db::tests::setup_db;
-#[cfg(test)]
-use crate::place::global_symbol;
 use crate::types::TypeContext;
 use crate::types::TypeDefinition;
 use crate::types::class::FieldKind;
@@ -104,7 +96,7 @@ impl<'db> TypedDictOpenness<'db> {
         }
     }
 
-    /// Returns the effective extra-items type used by structural relations.
+    /// Returns the effective extra-items policy.
     ///
     /// An open `TypedDict` behaves like it has read-only extra items of type `object` for these
     /// purposes, while a closed `TypedDict` has no extra items.
@@ -316,14 +308,6 @@ impl<'db> TypedDictType<'db> {
     /// Returns extra items only when they were explicitly declared.
     pub(crate) fn explicit_extra_items(self, db: &'db dyn Db) -> Option<TypedDictExtraItems<'db>> {
         self.openness(db).explicit_extra_items()
-    }
-
-    /// Returns the extra-items policy used by structural relations.
-    ///
-    /// Unlike [`Self::explicit_extra_items`], this treats an ordinary open `TypedDict` as having
-    /// read-only extra items of type `object`.
-    pub(crate) fn effective_extra_items(self, db: &'db dyn Db) -> Option<TypedDictExtraItems<'db>> {
-        self.openness(db).effective_extra_items()
     }
 
     /// Returns a type that contains every value that may be stored in this `TypedDict`.
@@ -1587,7 +1571,7 @@ pub(crate) struct UnpackedTypedDictKey<'db> {
     pub(crate) definition: Option<Definition<'db>>,
 }
 
-/// A normalized view of a `TypedDict`-shaped value used when expanding `**kwargs`.
+/// A normalized view of a `TypedDict`-shaped value used when unpacking it.
 ///
 /// Union and intersection inputs are combined into one set of possible keys and one openness
 /// policy describing arbitrary undeclared keys.
@@ -1598,6 +1582,14 @@ pub(crate) struct UnpackedTypedDict<'db> {
     pub(crate) openness: TypedDictOpenness<'db>,
 }
 
+/// Combines the openness policies of intersected `TypedDict`-shaped values.
+///
+/// An intersection must satisfy every constituent, so `Closed` dominates, `Open` adds no
+/// constraint, and explicit extra-item value types are intersected. Conceptually,
+/// `Open & Extra[int]` becomes a read-only `Extra[int]`, while `Closed & Extra[int]` is `Closed`.
+///
+/// The combined explicit policy can be read-only because unpacking observes extra items but never
+/// writes through the synthesized policy.
 fn intersect_unpacked_typed_dict_openness<'db>(
     db: &'db dyn Db,
     openness: impl IntoIterator<Item = TypedDictOpenness<'db>>,
@@ -1625,6 +1617,16 @@ fn intersect_unpacked_typed_dict_openness<'db>(
     }
 }
 
+/// Combines the openness policies of unioned `TypedDict`-shaped values.
+///
+/// A union may contain extra items from any constituent, so `Closed` contributes no values and
+/// explicit extra-item value types are unioned. An `Open` constituent widens explicit extra items
+/// to `object` while preserving explicit-extra-item behavior: conceptually,
+/// `Open | Extra[int]` becomes a read-only `Extra[object]`. With no explicit extra items, any open
+/// constituent makes the result `Open`; otherwise the result is `Closed`.
+///
+/// As with intersections, a synthesized explicit policy is read-only because unpacking only
+/// observes its values.
 fn union_unpacked_typed_dict_openness<'db>(
     db: &'db dyn Db,
     openness: impl IntoIterator<Item = TypedDictOpenness<'db>>,
@@ -3124,47 +3126,4 @@ fn test_btreemap_overlapping_items() {
             .next()
             .is_none()
     );
-}
-
-#[test]
-fn open_value_type_does_not_compute_items() -> anyhow::Result<()> {
-    let mut db = setup_db();
-    db.write_dedented(
-        "src/a.py",
-        "
-        from typing import TypedDict
-
-        class TD(TypedDict):
-            field: int
-        ",
-    )?;
-
-    let file = system_path_to_file(&db, "src/a.py").unwrap();
-    {
-        let class = global_symbol(&db, file, "TD")
-            .place
-            .expect_type()
-            .expect_class_literal();
-        let typed_dict = TypedDictType::new(ClassType::NonGeneric(class));
-        assert!(typed_dict.openness(&db).is_open());
-    }
-    db.clear_salsa_events();
-
-    {
-        let class = global_symbol(&db, file, "TD")
-            .place
-            .expect_type()
-            .expect_class_literal();
-        let typed_dict = TypedDictType::new(ClassType::NonGeneric(class));
-        assert_eq!(typed_dict.value_type(&db), Type::object());
-    }
-    let events = db.take_salsa_events();
-    assert!(
-        !events
-            .iter()
-            .any(|event| matches!(event.kind, salsa::EventKind::WillExecute { .. })),
-        "Computing the value type of an open TypedDict should not require its items: {events:#?}"
-    );
-
-    Ok(())
 }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -2231,7 +2231,8 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
             let positional_inference_target =
                 typed_dict_with_relaxed_keys(db, typed_dict, &keyword_keys);
             let positional_target = typed_dict_without_keys(db, typed_dict, &keyword_keys);
-            let positional_target_is_empty = positional_target.items(db).is_empty();
+            let positional_target_is_unconstrained =
+                positional_target.items(db).is_empty() && positional_target.openness(db).is_open();
             let positional_target_ty = Type::TypedDict(positional_target);
             let positional_inference_target_ty = Type::TypedDict(positional_inference_target);
             let arg_ty =
@@ -2247,7 +2248,8 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
             ) {
                 provided_keys
             } else {
-                if !positional_target_is_empty && !arg_ty.is_assignable_to(db, positional_target_ty)
+                if !positional_target_is_unconstrained
+                    && !arg_ty.is_assignable_to(db, positional_target_ty)
                 {
                     if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg) {
                         builder.into_diagnostic(format_args!(

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -540,7 +540,7 @@ impl<'db> TypedDictType<'db> {
         Self::Synthesized(SynthesizedTypedDictType::schema(db, items, openness))
     }
 
-    fn from_patch_items(
+    fn from_patch_items_with_openness(
         db: &'db dyn Db,
         items: TypedDictSchema<'db>,
         openness: TypedDictOpenness<'db>,
@@ -559,7 +559,7 @@ impl<'db> TypedDictType<'db> {
             .map(|(name, field)| (name.clone(), field.clone().with_required(false)))
             .collect();
 
-        Self::from_patch_items(db, items, self.openness(db))
+        Self::from_patch_items_with_openness(db, items, self.openness(db))
     }
 
     /// Returns a patch version of this `TypedDict` for `TypedDict.update()`.
@@ -588,7 +588,7 @@ impl<'db> TypedDictType<'db> {
             TypedDictOpenness::Closed | TypedDictOpenness::Extra(_) => TypedDictOpenness::Closed,
         };
 
-        Self::from_patch_items(db, items, openness)
+        Self::from_patch_items_with_openness(db, items, openness)
     }
 
     pub fn definition(self, db: &'db dyn Db) -> Option<Definition<'db>> {

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1578,6 +1578,23 @@ fn extract_unpacked_typed_dict_with_effective_tail_from_value_type<'db>(
     extract_unpacked_typed_dict_from_value_type_impl(db, ty, UnpackedTypedDictTail::Effective)
 }
 
+/// Extracts the tail that must be checked when constructing `target`.
+///
+/// Ordinary open `TypedDict`s have hidden items, but open constructors retain ty's existing
+/// leniency for those items. Explicit extra items must still be rejected because open constructors
+/// accept no unrecognized keys.
+fn extract_unpacked_typed_dict_for_constructor<'db>(
+    db: &'db dyn Db,
+    target: TypedDictType<'db>,
+    ty: Type<'db>,
+) -> Option<UnpackedTypedDict<'db>> {
+    if target.openness(db).is_open() {
+        extract_unpacked_typed_dict_from_value_type(db, ty)
+    } else {
+        extract_unpacked_typed_dict_with_effective_tail_from_value_type(db, ty)
+    }
+}
+
 #[derive(Clone, Copy)]
 enum UnpackedTypedDictTail {
     Explicit,
@@ -2083,10 +2100,6 @@ fn validate_extracted_typed_dict_extra_items<'db, 'ast>(
     let db = context.db();
     let typed_dict_ty = Type::TypedDict(typed_dict);
 
-    if typed_dict.openness(db).is_open() {
-        return true;
-    }
-
     if let Some(target_extra_items) = typed_dict.explicit_extra_items(db) {
         if let Some((target_name, target_field)) =
             typed_dict.items(db).iter().find(|(name, field)| {
@@ -2162,7 +2175,7 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
 ) -> Option<OrderSet<Name>> {
     let db = context.db();
     let typed_dict_items = typed_dict.items(db);
-    let unpacked = extract_unpacked_typed_dict_with_effective_tail_from_value_type(db, arg_ty)?;
+    let unpacked = extract_unpacked_typed_dict_for_constructor(db, typed_dict, arg_ty)?;
     let validate_extra_keys = !typed_dict.openness(db).is_open();
     let unpacked_keys = unpacked
         .keys
@@ -2664,7 +2677,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
         }
         return true;
     } else if let Some(unpacked) =
-        extract_unpacked_typed_dict_with_effective_tail_from_value_type(db, unpacked_type)
+        extract_unpacked_typed_dict_for_constructor(db, typed_dict, unpacked_type)
     {
         let ignored_keys = shadowed_keys.clone();
         let (_, mut unpacked_valid) = validate_extracted_typed_dict_keys(

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -529,7 +529,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
             }
 
-            if let Some(source_extra_items) = source.openness(db).explicit_extra_items() {
+            if let Some(source_extra_items) = source.openness(db).effective_extra_items() {
                 for (target_item_name, target_item_field) in target_items {
                     if source_items.contains_key(target_item_name) {
                         continue;

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -2609,7 +2609,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
         }
 
         return unpacked_valid;
-    } else if typed_dict.explicit_extra_items(db).is_some()
+    } else if !typed_dict.openness(db).is_open()
         && let Some((_, value_ty)) = unpacked_type.unpack_keys_and_items(db)
     {
         return validate_extracted_typed_dict_extra_items(

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -393,11 +393,16 @@ impl<'db> TypedDictType<'db> {
 
     /// Returns whether operations that delete an arbitrary key are safe.
     ///
-    /// Operations such as `clear()` and `popitem()` require mutable explicit extra items and cannot
-    /// be exposed when any declared item is required or read-only.
+    /// Operations such as `clear()` and `popitem()` require a closed `TypedDict` or mutable explicit
+    /// extra items, and cannot be exposed when any declared item is required or read-only.
     pub(crate) fn supports_arbitrary_key_deletion(self, db: &'db dyn Db) -> bool {
-        self.explicit_extra_items(db)
-            .is_some_and(|extra_items| !extra_items.is_read_only())
+        let openness_supports_deletion = match self.openness(db) {
+            TypedDictOpenness::Open => false,
+            TypedDictOpenness::Closed => true,
+            TypedDictOpenness::Extra(extra_items) => !extra_items.is_read_only(),
+        };
+
+        openness_supports_deletion
             && self
                 .items(db)
                 .values()

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -324,7 +324,7 @@ impl<'db> TypedDictType<'db> {
         for field in self.items(db).values() {
             builder = builder.add(field.declared_ty);
         }
-        if let Some(extra_items) = openness.effective_extra_items() {
+        if let Some(extra_items) = openness.explicit_extra_items() {
             builder = builder.add(extra_items.declared_ty);
         }
         builder.build()
@@ -1163,22 +1163,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                         .negate(db, self.constraints)
                 }
                 (TypedDictOpenness::Extra(mutable_extra), other)
-                    if !mutable_extra.is_read_only() =>
-                {
-                    other.effective_extra_items().map_or_else(
-                        || self.always(),
-                        |other_extra| {
-                            relation_checker
-                                .check_type_pair(
-                                    db,
-                                    mutable_extra.declared_ty,
-                                    other_extra.declared_ty,
-                                )
-                                .negate(db, self.constraints)
-                        },
-                    )
-                }
-                (other, TypedDictOpenness::Extra(mutable_extra))
+                | (other, TypedDictOpenness::Extra(mutable_extra))
                     if !mutable_extra.is_read_only() =>
                 {
                     other.effective_extra_items().map_or_else(
@@ -2157,14 +2142,15 @@ fn validate_extracted_typed_dict_openness<'db, 'ast>(
         return true;
     };
     let extra_items_ty = extra_items.declared_ty;
+    let target_openness = typed_dict.openness(db);
 
-    if typed_dict.openness(db).is_open() && source_openness.is_open() {
+    if target_openness.is_open() && source_openness.is_open() {
         return true;
     }
 
     let typed_dict_ty = Type::TypedDict(typed_dict);
 
-    if let Some(target_extra_items) = typed_dict.explicit_extra_items(db) {
+    if let Some(target_extra_items) = target_openness.explicit_extra_items() {
         if let Some((target_name, target_field)) =
             typed_dict.items(db).iter().find(|(name, field)| {
                 !source_keys.contains_key(*name)

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1079,27 +1079,37 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                         .map(|(name, field)| (name, field, left_items, left.openness(db))),
                 )
                 .filter_map(|(name, field, other_items, other_openness)| {
-                    if field.is_required() || field.is_read_only() || other_items.contains_key(name)
-                    {
+                    if field.is_required() || other_items.contains_key(name) {
                         return None;
                     }
                     let TypedDictOpenness::Extra(extra_items) = other_openness else {
                         return None;
                     };
-                    (!extra_items.is_read_only()).then_some((field, extra_items))
+                    (!field.is_read_only() || !extra_items.is_read_only())
+                        .then_some((field, extra_items))
                 })
                 .when_any(db, self.constraints, |(field, extra_items)| {
                     let relation_checker = self.as_relation_checker(TypeRelation::Assignability);
-                    relation_checker
-                        .check_type_pair(db, field.declared_ty, extra_items.declared_ty)
-                        .and(db, self.constraints, || {
-                            relation_checker.check_type_pair(
-                                db,
-                                extra_items.declared_ty,
-                                field.declared_ty,
-                            )
-                        })
-                        .negate(db, self.constraints)
+                    if field.is_read_only() {
+                        relation_checker
+                            .check_type_pair(db, extra_items.declared_ty, field.declared_ty)
+                            .negate(db, self.constraints)
+                    } else if extra_items.is_read_only() {
+                        relation_checker
+                            .check_type_pair(db, field.declared_ty, extra_items.declared_ty)
+                            .negate(db, self.constraints)
+                    } else {
+                        relation_checker
+                            .check_type_pair(db, field.declared_ty, extra_items.declared_ty)
+                            .and(db, self.constraints, || {
+                                relation_checker.check_type_pair(
+                                    db,
+                                    extra_items.declared_ty,
+                                    field.declared_ty,
+                                )
+                            })
+                            .negate(db, self.constraints)
+                    }
                 })
         });
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -1483,10 +1483,32 @@ pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
     extract_unpacked_typed_dict_from_value_type(db, ty).map(|unpacked| unpacked.keys)
 }
 
-/// Extracts the declared keys and effective extra-items tail from a `TypedDict`-shaped value.
+/// Extracts the declared keys and explicit extra-items tail from a `TypedDict`-shaped value.
 pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
+) -> Option<UnpackedTypedDict<'db>> {
+    extract_unpacked_typed_dict_from_value_type_impl(db, ty, UnpackedTypedDictTail::Explicit)
+}
+
+/// Extracts the declared keys and effective extra-items tail from a `TypedDict`-shaped value.
+fn extract_unpacked_typed_dict_with_effective_tail_from_value_type<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<UnpackedTypedDict<'db>> {
+    extract_unpacked_typed_dict_from_value_type_impl(db, ty, UnpackedTypedDictTail::Effective)
+}
+
+#[derive(Clone, Copy)]
+enum UnpackedTypedDictTail {
+    Explicit,
+    Effective,
+}
+
+fn extract_unpacked_typed_dict_from_value_type_impl<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    tail: UnpackedTypedDictTail,
 ) -> Option<UnpackedTypedDict<'db>> {
     match ty {
         Type::TypedDict(td) => {
@@ -1504,9 +1526,13 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                     )
                 })
                 .collect();
+            let extra_items = match tail {
+                UnpackedTypedDictTail::Explicit => td.explicit_extra_items(db),
+                UnpackedTypedDictTail::Effective => td.effective_extra_items(db),
+            };
             Some(UnpackedTypedDict {
                 keys,
-                extra_items_ty: td.effective_extra_items(db).map(|extra| extra.declared_ty),
+                extra_items_ty: extra_items.map(|extra| extra.declared_ty),
                 is_closed: td.openness(db).is_closed(),
             })
         }
@@ -1515,7 +1541,9 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
             let unpacked_elements: Vec<_> = intersection
                 .positive(db)
                 .iter()
-                .filter_map(|element| extract_unpacked_typed_dict_from_value_type(db, *element))
+                .filter_map(|element| {
+                    extract_unpacked_typed_dict_from_value_type_impl(db, *element, tail)
+                })
                 .collect();
 
             if unpacked_elements.is_empty() {
@@ -1582,7 +1610,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
             let unpacked_elements: Vec<_> = union
                 .elements(db)
                 .iter()
-                .map(|element| extract_unpacked_typed_dict_from_value_type(db, *element))
+                .map(|element| extract_unpacked_typed_dict_from_value_type_impl(db, *element, tail))
                 .collect::<Option<_>>()?;
 
             let all_keys: OrderSet<Name> = unpacked_elements
@@ -1646,7 +1674,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
             })
         }
         Type::TypeAlias(alias) => {
-            extract_unpacked_typed_dict_from_value_type(db, alias.value_type(db))
+            extract_unpacked_typed_dict_from_value_type_impl(db, alias.value_type(db), tail)
         }
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)
@@ -2055,7 +2083,7 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
 ) -> Option<OrderSet<Name>> {
     let db = context.db();
     let typed_dict_items = typed_dict.items(db);
-    let unpacked = extract_unpacked_typed_dict_from_value_type(db, arg_ty)?;
+    let unpacked = extract_unpacked_typed_dict_with_effective_tail_from_value_type(db, arg_ty)?;
     let validate_extra_keys = typed_dict.explicit_extra_items(db).is_some();
     let unpacked_keys = unpacked
         .keys
@@ -2535,7 +2563,9 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             guaranteed_keys.entry(key_name.clone()).or_insert(None);
         }
         return true;
-    } else if let Some(unpacked) = extract_unpacked_typed_dict_from_value_type(db, unpacked_type) {
+    } else if let Some(unpacked) =
+        extract_unpacked_typed_dict_with_effective_tail_from_value_type(db, unpacked_type)
+    {
         let ignored_keys = shadowed_keys.clone();
         let (_, mut unpacked_valid) = validate_extracted_typed_dict_keys(
             context,

--- a/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
@@ -28,6 +28,8 @@ class TypedDictFallback(Mapping[str, object], metaclass=ABCMeta):
     if sys.version_info >= (3, 13):
         __readonly_keys__: ClassVar[frozenset[str]]
         __mutable_keys__: ClassVar[frozenset[str]]
+    __closed__: ClassVar[bool | None]
+    __extra_items__: ClassVar[Any]
 
     def copy(self) -> typing_extensions.Self: ...
     # Using Never so that only calls using mypy plugin hook that specialize the signature


### PR DESCRIPTION
## Summary

This PR adds support for [PEP 728](https://peps.python.org/pep-0728/): `extra_items` and `closed` semantics for TypedDict.

In addition to the declared items, we now also model the open/closed policy for a TypedDict schema:

```rust
enum TypedDictOpenness {
    Open,
    Closed,
    Extra(TypedDictExtraItems),
}
```

Extra records both the declared value type and whether the extra items are read-only, and `extra_items=Never` is canonicalized to `Closed`.

Explicit extra items and implicitly-open TypedDicts are treated slightly differently. Explicit extra items are directly accessible through operations like indexing, assignment, deletion, `get`, `pop`, `setdefault`, `update`, etc., while an ordinary open TypedDict does not expose its hidden items through those operations. For structural relations and unpacking, though, an open TypedDict behaves as though it has read-only extra items of type object.

A literal undeclared key uses the explicit extra-items type. An arbitrary `str` key may refer to any declared or extra item, so its safe value type is the intersection of all possible destinations. Arbitrary writes are rejected if any possible destination is read-only, and arbitrary deletion is available only when every possible item is optional and mutable:

```python
class Options(TypedDict, extra_items=int):
    label: NotRequired[str]

def update(options: Options, key: str) -> None:
    options["year"] = 2026  # allowed
    options[key] = 2026     # rejected: key may be "label"
```

The same schema capabilities determine when a TypedDict can use a `dict[str, T]` fallback. This requires mutable explicit extra items and optional, mutable declared items whose types satisfy the mutable dict contract.

## Remaining limitations

The core PEP 728 `open`, `closed`, and `extra_items` semantics are implemented, but this PR intentionally leaves several closed-TypedDict precision improvements for follow-up work (https://github.com/astral-sh/ruff/pull/25651):

```python
class Closed(TypedDict, closed=True):
    name: str
    age: int
```

- `keys()`, `values()`, `items()`, and iteration currently produce `str` and `object`-based types instead of literal keys and declared-value unions.
- `bool()` on an empty closed TypedDict is currently `bool` rather than `Literal[False]`.
- Indexing a closed TypedDict with a non-literal `str` correctly reports an invalid-key diagnostic, but the resulting type is `Unknown` rather than the union of its declared value types.
