### PR TITLE
[`flake8-pytest-style`] Clarify diagnostic message for single parameters (`PT007`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -212,12 +212,20 @@ impl Violation for PytestParametrizeValuesWrongType {
     #[derive_message_formats]
     fn message(&self) -> String {
         let PytestParametrizeValuesWrongType { values, row } = self;
-        format!("Wrong values type in `pytest.mark.parametrize` expected `{values}` of `{row}`")
+        if values.to_string() == row.to_string() {
+            format!("Wrong values type in `pytest.mark.parametrize` expected `{values}`")
+        } else {
+            format!("Wrong values type in `pytest.mark.parametrize` expected `{values}` of `{row}`")
+        }
     }
 
     fn fix_title(&self) -> Option<String> {
         let PytestParametrizeValuesWrongType { values, row } = self;
-        Some(format!("Use `{values}` of `{row}` for parameter values"))
+        if values.to_string() == row.to_string() {
+            Some(format!("Use `{values}` for parameter values"))
+        } else {
+            Some(format!("Use `{values}` of `{row}` for parameter values"))
+        }
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -204,6 +204,7 @@ impl Violation for PytestParametrizeNamesWrongType {
 pub(crate) struct PytestParametrizeValuesWrongType {
     values: types::ParametrizeValuesType,
     row: types::ParametrizeValuesRowType,
+    is_single_param: bool,
 }
 
 impl Violation for PytestParametrizeValuesWrongType {
@@ -211,8 +212,12 @@ impl Violation for PytestParametrizeValuesWrongType {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let PytestParametrizeValuesWrongType { values, row } = self;
-        if values.to_string() == row.to_string() {
+        let PytestParametrizeValuesWrongType {
+            values,
+            row,
+            is_single_param,
+        } = self;
+        if *is_single_param {
             format!("Wrong values type in `pytest.mark.parametrize` expected `{values}`")
         } else {
             format!("Wrong values type in `pytest.mark.parametrize` expected `{values}` of `{row}`")
@@ -220,8 +225,12 @@ impl Violation for PytestParametrizeValuesWrongType {
     }
 
     fn fix_title(&self) -> Option<String> {
-        let PytestParametrizeValuesWrongType { values, row } = self;
-        if values.to_string() == row.to_string() {
+        let PytestParametrizeValuesWrongType {
+            values,
+            row,
+            is_single_param,
+        } = self;
+        if *is_single_param {
             Some(format!("Use `{values}` for parameter values"))
         } else {
             Some(format!("Use `{values}` of `{row}` for parameter values"))
@@ -532,6 +541,7 @@ fn check_values(checker: &Checker, names: &Expr, values: &Expr) {
                     PytestParametrizeValuesWrongType {
                         values: values_type,
                         row: values_row_type,
+                        is_single_param: !is_multi_named,
                     },
                     values.range(),
                 );
@@ -579,6 +589,7 @@ fn check_values(checker: &Checker, names: &Expr, values: &Expr) {
                     PytestParametrizeValuesWrongType {
                         values: values_type,
                         row: values_row_type,
+                        is_single_param: !is_multi_named,
                     },
                     values.range(),
                 );
@@ -800,6 +811,7 @@ fn handle_value_rows(
                     PytestParametrizeValuesWrongType {
                         values: values_type,
                         row: values_row_type,
+                        is_single_param: false,
                     },
                     elt.range(),
                 );
@@ -839,6 +851,7 @@ fn handle_value_rows(
                     PytestParametrizeValuesWrongType {
                         values: values_type,
                         row: values_row_type,
+                        is_single_param: false,
                     },
                     elt.range(),
                 );

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_lists.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_lists.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
+assertion_line: 358
 ---
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
  --> PT007.py:4:35
   |
 4 | @pytest.mark.parametrize("param", (1, 2))
@@ -9,7 +10,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 5 | def test_tuple(param):
 6 |     ...
   |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 1 | import pytest
 2 |
 3 |
@@ -20,7 +21,7 @@ help: Use `list` of `list` for parameter values
 7 |
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
   --> PT007.py:11:5
    |
  9 |   @pytest.mark.parametrize(
@@ -33,7 +34,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 15 |   )
 16 |   def test_tuple_of_tuples(param1, param2):
    |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 8  |
 9  | @pytest.mark.parametrize(
 10 |     ("param1", "param2"),
@@ -48,7 +49,7 @@ help: Use `list` of `list` for parameter values
 17 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
   --> PT007.py:12:9
    |
 10 |     ("param1", "param2"),
@@ -58,7 +59,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 13 |         (3, 4),
 14 |     ),
    |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 9  | @pytest.mark.parametrize(
 10 |     ("param1", "param2"),
 11 |     (
@@ -69,7 +70,7 @@ help: Use `list` of `list` for parameter values
 15 | )
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
   --> PT007.py:13:9
    |
 11 |     (
@@ -79,7 +80,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 14 |     ),
 15 | )
    |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 10 |     ("param1", "param2"),
 11 |     (
 12 |         (1, 2),
@@ -90,7 +91,7 @@ help: Use `list` of `list` for parameter values
 16 | def test_tuple_of_tuples(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
   --> PT007.py:22:5
    |
 20 |   @pytest.mark.parametrize(
@@ -103,7 +104,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 26 |   )
 27 |   def test_tuple_of_lists(param1, param2):
    |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 19 |
 20 | @pytest.mark.parametrize(
 21 |     ("param1", "param2"),
@@ -118,7 +119,7 @@ help: Use `list` of `list` for parameter values
 28 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
   --> PT007.py:39:9
    |
 37 |     ("param1", "param2"),
@@ -128,7 +129,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 40 |         (3, 4),
 41 |     ],
    |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 36 | @pytest.mark.parametrize(
 37 |     ("param1", "param2"),
 38 |     [
@@ -139,7 +140,7 @@ help: Use `list` of `list` for parameter values
 42 | )
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
   --> PT007.py:40:9
    |
 38 |     [
@@ -149,7 +150,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 41 |     ],
 42 | )
    |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 37 |     ("param1", "param2"),
 38 |     [
 39 |         (1, 2),
@@ -160,7 +161,7 @@ help: Use `list` of `list` for parameter values
 43 | def test_list_of_tuples(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
   --> PT007.py:81:38
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -169,7 +170,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 82 | @pytest.mark.parametrize("d", [3,])
 83 | @pytest.mark.parametrize(
    |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 78 |
 79 |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -180,7 +181,7 @@ help: Use `list` of `list` for parameter values
 84 |     "d",
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
   --> PT007.py:81:39
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -189,7 +190,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 82 | @pytest.mark.parametrize("d", [3,])
 83 | @pytest.mark.parametrize(
    |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 78 |
 79 |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -200,7 +201,7 @@ help: Use `list` of `list` for parameter values
 84 |     "d",
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
   --> PT007.py:81:47
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -209,7 +210,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `lis
 82 | @pytest.mark.parametrize("d", [3,])
 83 | @pytest.mark.parametrize(
    |
-help: Use `list` of `list` for parameter values
+help: Use `list` for parameter values
 78 |
 79 |
 80 | @pytest.mark.parametrize("a", [1, 2])

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_lists.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_lists.snap
@@ -21,7 +21,7 @@ help: Use `list` for parameter values
 7 |
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
   --> PT007.py:11:5
    |
  9 |   @pytest.mark.parametrize(
@@ -34,7 +34,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
 15 |   )
 16 |   def test_tuple_of_tuples(param1, param2):
    |
-help: Use `list` for parameter values
+help: Use `list` of `list` for parameter values
 8  |
 9  | @pytest.mark.parametrize(
 10 |     ("param1", "param2"),
@@ -49,7 +49,7 @@ help: Use `list` for parameter values
 17 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
   --> PT007.py:12:9
    |
 10 |     ("param1", "param2"),
@@ -59,7 +59,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
 13 |         (3, 4),
 14 |     ),
    |
-help: Use `list` for parameter values
+help: Use `list` of `list` for parameter values
 9  | @pytest.mark.parametrize(
 10 |     ("param1", "param2"),
 11 |     (
@@ -70,7 +70,7 @@ help: Use `list` for parameter values
 15 | )
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
   --> PT007.py:13:9
    |
 11 |     (
@@ -80,7 +80,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
 14 |     ),
 15 | )
    |
-help: Use `list` for parameter values
+help: Use `list` of `list` for parameter values
 10 |     ("param1", "param2"),
 11 |     (
 12 |         (1, 2),
@@ -91,7 +91,7 @@ help: Use `list` for parameter values
 16 | def test_tuple_of_tuples(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
   --> PT007.py:22:5
    |
 20 |   @pytest.mark.parametrize(
@@ -104,7 +104,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
 26 |   )
 27 |   def test_tuple_of_lists(param1, param2):
    |
-help: Use `list` for parameter values
+help: Use `list` of `list` for parameter values
 19 |
 20 | @pytest.mark.parametrize(
 21 |     ("param1", "param2"),
@@ -119,7 +119,7 @@ help: Use `list` for parameter values
 28 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
   --> PT007.py:39:9
    |
 37 |     ("param1", "param2"),
@@ -129,7 +129,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
 40 |         (3, 4),
 41 |     ],
    |
-help: Use `list` for parameter values
+help: Use `list` of `list` for parameter values
 36 | @pytest.mark.parametrize(
 37 |     ("param1", "param2"),
 38 |     [
@@ -140,7 +140,7 @@ help: Use `list` for parameter values
 42 | )
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
   --> PT007.py:40:9
    |
 38 |     [
@@ -150,7 +150,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
 41 |     ],
 42 | )
    |
-help: Use `list` for parameter values
+help: Use `list` of `list` for parameter values
 37 |     ("param1", "param2"),
 38 |     [
 39 |         (1, 2),
@@ -161,7 +161,7 @@ help: Use `list` for parameter values
 43 | def test_list_of_tuples(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
   --> PT007.py:81:38
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -170,7 +170,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
 82 | @pytest.mark.parametrize("d", [3,])
 83 | @pytest.mark.parametrize(
    |
-help: Use `list` for parameter values
+help: Use `list` of `list` for parameter values
 78 |
 79 |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -181,7 +181,7 @@ help: Use `list` for parameter values
 84 |     "d",
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
   --> PT007.py:81:39
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -190,7 +190,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
 82 | @pytest.mark.parametrize("d", [3,])
 83 | @pytest.mark.parametrize(
    |
-help: Use `list` for parameter values
+help: Use `list` of `list` for parameter values
 78 |
 79 |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -201,7 +201,7 @@ help: Use `list` for parameter values
 84 |     "d",
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `list`
   --> PT007.py:81:47
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -210,7 +210,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
 82 | @pytest.mark.parametrize("d", [3,])
 83 | @pytest.mark.parametrize(
    |
-help: Use `list` for parameter values
+help: Use `list` of `list` for parameter values
 78 |
 79 |
 80 | @pytest.mark.parametrize("a", [1, 2])

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_tuples.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_list_of_tuples.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
+assertion_line: 358
 ---
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list`
  --> PT007.py:4:35
   |
 4 | @pytest.mark.parametrize("param", (1, 2))
@@ -9,7 +10,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `list` of `tup
 5 | def test_tuple(param):
 6 |     ...
   |
-help: Use `list` of `tuple` for parameter values
+help: Use `list` for parameter values
 1 | import pytest
 2 |
 3 |

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_lists.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_lists.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
+assertion_line: 358
 ---
 PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
   --> PT007.py:12:9
@@ -43,7 +44,7 @@ help: Use `tuple` of `list` for parameter values
 16 | def test_tuple_of_tuples(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:31:35
    |
 31 | @pytest.mark.parametrize("param", [1, 2])
@@ -51,7 +52,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 32 | def test_list(param):
 33 |     ...
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 28 |     ...
 29 |
 30 |
@@ -188,7 +189,7 @@ help: Use `tuple` of `list` for parameter values
 66 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:71:5
    |
 69 |   @pytest.mark.parametrize(
@@ -201,7 +202,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 75 |   )
 76 |   def test_single_list_of_lists(param):
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 68 |
 69 | @pytest.mark.parametrize(
 70 |     "param",
@@ -216,7 +217,7 @@ help: Use `tuple` of `list` for parameter values
 77 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:80:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -224,7 +225,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
 82 | @pytest.mark.parametrize("d", [3,])
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 77 |     ...
 78 |
 79 |
@@ -275,7 +276,7 @@ help: Use `tuple` of `list` for parameter values
 84 |     "d",
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:82:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -285,7 +286,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 83 | @pytest.mark.parametrize(
 84 |     "d",
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 79 |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
@@ -296,7 +297,7 @@ help: Use `tuple` of `list` for parameter values
 85 |     [("3", "4")],
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:85:5
    |
 83 | @pytest.mark.parametrize(
@@ -306,7 +307,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 86 | )
 87 | @pytest.mark.parametrize(
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 82 | @pytest.mark.parametrize("d", [3,])
 83 | @pytest.mark.parametrize(
 84 |     "d",
@@ -317,7 +318,7 @@ help: Use `tuple` of `list` for parameter values
 88 |     "e",
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `list`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:89:5
    |
 87 | @pytest.mark.parametrize(
@@ -327,7 +328,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `li
 90 | )
 91 | def test_multiple_decorators(a, b, c, d, e):
    |
-help: Use `tuple` of `list` for parameter values
+help: Use `tuple` for parameter values
 86 | )
 87 | @pytest.mark.parametrize(
 88 |     "e",

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
@@ -2,7 +2,7 @@
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
 assertion_line: 358
 ---
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
   --> PT007.py:23:9
    |
 21 |     ("param1", "param2"),
@@ -12,7 +12,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
 24 |         [3, 4],
 25 |     ),
    |
-help: Use `tuple` for parameter values
+help: Use `tuple` of `tuple` for parameter values
 20 | @pytest.mark.parametrize(
 21 |     ("param1", "param2"),
 22 |     (
@@ -23,7 +23,7 @@ help: Use `tuple` for parameter values
 26 | )
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
   --> PT007.py:24:9
    |
 22 |     (
@@ -33,7 +33,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
 25 |     ),
 26 | )
    |
-help: Use `tuple` for parameter values
+help: Use `tuple` of `tuple` for parameter values
 21 |     ("param1", "param2"),
 22 |     (
 23 |         [1, 2],
@@ -63,7 +63,7 @@ help: Use `tuple` for parameter values
 34 |
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
   --> PT007.py:38:5
    |
 36 |   @pytest.mark.parametrize(
@@ -76,7 +76,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
 42 |   )
 43 |   def test_list_of_tuples(param1, param2):
    |
-help: Use `tuple` for parameter values
+help: Use `tuple` of `tuple` for parameter values
 35 |
 36 | @pytest.mark.parametrize(
 37 |     ("param1", "param2"),
@@ -91,7 +91,7 @@ help: Use `tuple` for parameter values
 44 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
   --> PT007.py:49:5
    |
 47 |   @pytest.mark.parametrize(
@@ -104,7 +104,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
 53 |   )
 54 |   def test_list_of_lists(param1, param2):
    |
-help: Use `tuple` for parameter values
+help: Use `tuple` of `tuple` for parameter values
 46 |
 47 | @pytest.mark.parametrize(
 48 |     ("param1", "param2"),
@@ -119,7 +119,7 @@ help: Use `tuple` for parameter values
 55 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
   --> PT007.py:50:9
    |
 48 |     ("param1", "param2"),
@@ -129,7 +129,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
 51 |         [3, 4],
 52 |     ],
    |
-help: Use `tuple` for parameter values
+help: Use `tuple` of `tuple` for parameter values
 47 | @pytest.mark.parametrize(
 48 |     ("param1", "param2"),
 49 |     [
@@ -140,7 +140,7 @@ help: Use `tuple` for parameter values
 53 | )
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
   --> PT007.py:51:9
    |
 49 |     [
@@ -150,7 +150,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
 52 |     ],
 53 | )
    |
-help: Use `tuple` for parameter values
+help: Use `tuple` of `tuple` for parameter values
 48 |     ("param1", "param2"),
 49 |     [
 50 |         [1, 2],
@@ -161,7 +161,7 @@ help: Use `tuple` for parameter values
 54 | def test_list_of_lists(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
   --> PT007.py:60:5
    |
 58 |   @pytest.mark.parametrize(
@@ -174,7 +174,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
 64 |   )
 65 |   def test_csv_name_list_of_lists(param1, param2):
    |
-help: Use `tuple` for parameter values
+help: Use `tuple` of `tuple` for parameter values
 57 |
 58 | @pytest.mark.parametrize(
 59 |     "param1,param2",
@@ -189,7 +189,7 @@ help: Use `tuple` for parameter values
 66 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
   --> PT007.py:61:9
    |
 59 |     "param1,param2",
@@ -199,7 +199,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
 62 |         [3, 4],
 63 |     ],
    |
-help: Use `tuple` for parameter values
+help: Use `tuple` of `tuple` for parameter values
 58 | @pytest.mark.parametrize(
 59 |     "param1,param2",
 60 |     [
@@ -210,7 +210,7 @@ help: Use `tuple` for parameter values
 64 | )
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
   --> PT007.py:62:9
    |
 60 |     [
@@ -220,7 +220,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
 63 |     ],
 64 | )
    |
-help: Use `tuple` for parameter values
+help: Use `tuple` of `tuple` for parameter values
 59 |     "param1,param2",
 60 |     [
 61 |         [1, 2],

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/snapshots/ruff_linter__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pytest_style/mod.rs
+assertion_line: 358
 ---
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:23:9
    |
 21 |     ("param1", "param2"),
@@ -11,7 +12,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 24 |         [3, 4],
 25 |     ),
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 20 | @pytest.mark.parametrize(
 21 |     ("param1", "param2"),
 22 |     (
@@ -22,7 +23,7 @@ help: Use `tuple` of `tuple` for parameter values
 26 | )
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:24:9
    |
 22 |     (
@@ -32,7 +33,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 25 |     ),
 26 | )
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 21 |     ("param1", "param2"),
 22 |     (
 23 |         [1, 2],
@@ -43,7 +44,7 @@ help: Use `tuple` of `tuple` for parameter values
 27 | def test_tuple_of_lists(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:31:35
    |
 31 | @pytest.mark.parametrize("param", [1, 2])
@@ -51,7 +52,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 32 | def test_list(param):
 33 |     ...
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 28 |     ...
 29 |
 30 |
@@ -62,7 +63,7 @@ help: Use `tuple` of `tuple` for parameter values
 34 |
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:38:5
    |
 36 |   @pytest.mark.parametrize(
@@ -75,7 +76,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 42 |   )
 43 |   def test_list_of_tuples(param1, param2):
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 35 |
 36 | @pytest.mark.parametrize(
 37 |     ("param1", "param2"),
@@ -90,7 +91,7 @@ help: Use `tuple` of `tuple` for parameter values
 44 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:49:5
    |
 47 |   @pytest.mark.parametrize(
@@ -103,7 +104,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 53 |   )
 54 |   def test_list_of_lists(param1, param2):
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 46 |
 47 | @pytest.mark.parametrize(
 48 |     ("param1", "param2"),
@@ -118,7 +119,7 @@ help: Use `tuple` of `tuple` for parameter values
 55 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:50:9
    |
 48 |     ("param1", "param2"),
@@ -128,7 +129,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 51 |         [3, 4],
 52 |     ],
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 47 | @pytest.mark.parametrize(
 48 |     ("param1", "param2"),
 49 |     [
@@ -139,7 +140,7 @@ help: Use `tuple` of `tuple` for parameter values
 53 | )
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:51:9
    |
 49 |     [
@@ -149,7 +150,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 52 |     ],
 53 | )
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 48 |     ("param1", "param2"),
 49 |     [
 50 |         [1, 2],
@@ -160,7 +161,7 @@ help: Use `tuple` of `tuple` for parameter values
 54 | def test_list_of_lists(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:60:5
    |
 58 |   @pytest.mark.parametrize(
@@ -173,7 +174,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 64 |   )
 65 |   def test_csv_name_list_of_lists(param1, param2):
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 57 |
 58 | @pytest.mark.parametrize(
 59 |     "param1,param2",
@@ -188,7 +189,7 @@ help: Use `tuple` of `tuple` for parameter values
 66 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:61:9
    |
 59 |     "param1,param2",
@@ -198,7 +199,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 62 |         [3, 4],
 63 |     ],
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 58 | @pytest.mark.parametrize(
 59 |     "param1,param2",
 60 |     [
@@ -209,7 +210,7 @@ help: Use `tuple` of `tuple` for parameter values
 64 | )
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:62:9
    |
 60 |     [
@@ -219,7 +220,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 63 |     ],
 64 | )
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 59 |     "param1,param2",
 60 |     [
 61 |         [1, 2],
@@ -230,7 +231,7 @@ help: Use `tuple` of `tuple` for parameter values
 65 | def test_csv_name_list_of_lists(param1, param2):
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:71:5
    |
 69 |   @pytest.mark.parametrize(
@@ -243,7 +244,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 75 |   )
 76 |   def test_single_list_of_lists(param):
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 68 |
 69 | @pytest.mark.parametrize(
 70 |     "param",
@@ -258,7 +259,7 @@ help: Use `tuple` of `tuple` for parameter values
 77 |     ...
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:80:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -266,7 +267,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
 82 | @pytest.mark.parametrize("d", [3,])
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 77 |     ...
 78 |
 79 |
@@ -277,7 +278,7 @@ help: Use `tuple` of `tuple` for parameter values
 83 | @pytest.mark.parametrize(
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:82:31
    |
 80 | @pytest.mark.parametrize("a", [1, 2])
@@ -287,7 +288,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 83 | @pytest.mark.parametrize(
 84 |     "d",
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 79 |
 80 | @pytest.mark.parametrize("a", [1, 2])
 81 | @pytest.mark.parametrize(("b", "c"), ((3, 4), (5, 6)))
@@ -298,7 +299,7 @@ help: Use `tuple` of `tuple` for parameter values
 85 |     [("3", "4")],
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:85:5
    |
 83 | @pytest.mark.parametrize(
@@ -308,7 +309,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 86 | )
 87 | @pytest.mark.parametrize(
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 82 | @pytest.mark.parametrize("d", [3,])
 83 | @pytest.mark.parametrize(
 84 |     "d",
@@ -319,7 +320,7 @@ help: Use `tuple` of `tuple` for parameter values
 88 |     "e",
 note: This is an unsafe fix and may change runtime behavior
 
-PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tuple`
+PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple`
   --> PT007.py:89:5
    |
 87 | @pytest.mark.parametrize(
@@ -329,7 +330,7 @@ PT007 [*] Wrong values type in `pytest.mark.parametrize` expected `tuple` of `tu
 90 | )
 91 | def test_multiple_decorators(a, b, c, d, e):
    |
-help: Use `tuple` of `tuple` for parameter values
+help: Use `tuple` for parameter values
 86 | )
 87 | @pytest.mark.parametrize(
 88 |     "e",


### PR DESCRIPTION
## Summary

Clarifies the PT007 diagnostic message when a single parameter is provided. In this case, the row type doesn't really matter and can be confusing, so we now omit it from the diagnostic.

## Test plan

Updated snapshot tests

## Related

Fixes #14743