### PR TITLE
[ty] Compact retained definition inference results

### DIFF
--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -43,6 +43,7 @@
 //! of iterations, so if we fail to converge, Salsa will eventually panic. (This should of course
 //! be considered a bug.)
 
+use itertools::Either;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange};
@@ -874,21 +875,178 @@ pub(crate) struct DefinitionInference<'db> {
     #[cfg(debug_assertions)]
     scope: ScopeId<'db>,
 
-    /// The types of every binding in this region.
-    ///
-    /// Almost all definition regions have less than 10 bindings. There are very few with more than 10 (but still less than 20).
-    /// Because of that, use a slice with linear search over a hash map.
-    pub(crate) bindings: Box<[(Definition<'db>, Type<'db>)]>,
-
-    /// The types and type qualifiers of every valid declaration in this region.
-    ///
-    /// About 50% of the definition inference regions have no declarations.
-    /// The other 50% have less than 10 declarations. Because of that, use a
-    /// slice with linear search over a hash map.
-    declarations: Box<[(Definition<'db>, TypeAndQualifiers<'db>)]>,
+    /// The binding and declaration types inferred in this region.
+    types: DefinitionTypes<'db>,
 
     /// The extra data that is only present for few inference regions.
     extra: Option<Box<DefinitionInferenceExtra<'db>>>,
+}
+
+/// The binding and declaration types inferred for a definition region.
+///
+/// Almost all regions contain a single binding, optionally paired with a declaration for the same
+/// definition and type. Keep those cases in a single allocation instead of retaining two separate
+/// allocations.
+#[derive(Debug, Default, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+enum DefinitionTypes<'db> {
+    #[default]
+    Empty,
+    Binding(Box<DefinitionBinding<'db>>),
+    Declaration(Box<DefinitionDeclaration<'db>>),
+    BindingAndDeclaration(Box<DefinitionDeclaration<'db>>),
+    Other(Box<OtherDefinitionTypes<'db>>),
+}
+
+type DefinitionBinding<'db> = (Definition<'db>, Type<'db>);
+type DefinitionDeclaration<'db> = (Definition<'db>, TypeAndQualifiers<'db>);
+
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+struct OtherDefinitionTypes<'db> {
+    bindings: Box<[DefinitionBinding<'db>]>,
+    declarations: Box<[DefinitionDeclaration<'db>]>,
+}
+
+impl<'db> DefinitionTypes<'db> {
+    fn from_parts(
+        bindings: Vec<DefinitionBinding<'db>>,
+        declarations: Vec<DefinitionDeclaration<'db>>,
+    ) -> Self {
+        match (&*bindings, &*declarations) {
+            ([], []) => Self::Empty,
+            ([binding], []) => Self::Binding(Box::new(*binding)),
+            ([], [declaration]) => Self::Declaration(Box::new(*declaration)),
+            ([(binding, binding_ty)], [(declaration, declaration_ty)])
+                if binding == declaration && *binding_ty == declaration_ty.inner_type() =>
+            {
+                Self::BindingAndDeclaration(Box::new((*declaration, *declaration_ty)))
+            }
+            _ => Self::Other(Box::new(OtherDefinitionTypes {
+                bindings: bindings.into_boxed_slice(),
+                declarations: declarations.into_boxed_slice(),
+            })),
+        }
+    }
+
+    fn binding_type(&self, definition: Definition<'db>) -> Option<Type<'db>> {
+        self.bindings()
+            .find_map(|(candidate, ty)| (candidate == definition).then_some(ty))
+    }
+
+    fn declaration_type(&self, definition: Definition<'db>) -> Option<TypeAndQualifiers<'db>> {
+        self.declarations()
+            .find_map(|(candidate, ty)| (candidate == definition).then_some(ty))
+    }
+
+    fn normalize_binding(
+        db: &'db dyn Db,
+        previous: &DefinitionTypes<'db>,
+        cycle: &salsa::Cycle,
+        definition: Definition<'db>,
+        ty: Type<'db>,
+    ) -> Type<'db> {
+        if let Some(previous_ty) = previous.binding_type(definition) {
+            ty.cycle_normalized(db, previous_ty, cycle)
+        } else {
+            ty.recursive_type_normalized(db, cycle)
+        }
+    }
+
+    fn normalize_declaration(
+        db: &'db dyn Db,
+        previous: &DefinitionTypes<'db>,
+        cycle: &salsa::Cycle,
+        definition: Definition<'db>,
+        ty: TypeAndQualifiers<'db>,
+    ) -> TypeAndQualifiers<'db> {
+        if let Some(previous_ty) = previous.declaration_type(definition) {
+            ty.map_type(|inner| inner.cycle_normalized(db, previous_ty.inner_type(), cycle))
+        } else {
+            ty.map_type(|inner| inner.recursive_type_normalized(db, cycle))
+        }
+    }
+
+    fn cycle_normalized(
+        self,
+        db: &'db dyn Db,
+        previous: &DefinitionTypes<'db>,
+        cycle: &salsa::Cycle,
+    ) -> Self {
+        match self {
+            Self::Empty => Self::Empty,
+            Self::Binding(mut binding) => {
+                let (definition, ty) = &mut *binding;
+                *ty = Self::normalize_binding(db, previous, cycle, *definition, *ty);
+                Self::Binding(binding)
+            }
+            Self::Declaration(mut declaration) => {
+                let (definition, ty) = &mut *declaration;
+                *ty = Self::normalize_declaration(db, previous, cycle, *definition, *ty);
+                Self::Declaration(declaration)
+            }
+            Self::BindingAndDeclaration(mut declaration) => {
+                let (definition, declaration_ty) = *declaration;
+                let binding_ty = Self::normalize_binding(
+                    db,
+                    previous,
+                    cycle,
+                    definition,
+                    declaration_ty.inner_type(),
+                );
+                let declaration_ty =
+                    Self::normalize_declaration(db, previous, cycle, definition, declaration_ty);
+
+                if binding_ty == declaration_ty.inner_type() {
+                    declaration.1 = declaration_ty;
+                    Self::BindingAndDeclaration(declaration)
+                } else {
+                    Self::Other(Box::new(OtherDefinitionTypes {
+                        bindings: Box::new([(definition, binding_ty)]),
+                        declarations: Box::new([(definition, declaration_ty)]),
+                    }))
+                }
+            }
+            Self::Other(mut other) => {
+                for (definition, ty) in &mut other.bindings {
+                    *ty = Self::normalize_binding(db, previous, cycle, *definition, *ty);
+                }
+                for (definition, ty) in &mut other.declarations {
+                    *ty = Self::normalize_declaration(db, previous, cycle, *definition, *ty);
+                }
+
+                match (&*other.bindings, &*other.declarations) {
+                    ([(binding, binding_ty)], [(declaration, declaration_ty)])
+                        if binding == declaration && *binding_ty == declaration_ty.inner_type() =>
+                    {
+                        Self::BindingAndDeclaration(Box::new((*declaration, *declaration_ty)))
+                    }
+                    _ => Self::Other(other),
+                }
+            }
+        }
+    }
+
+    fn bindings(&self) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> {
+        match self {
+            Self::Binding(binding) => Either::Left(std::iter::once(**binding)),
+            Self::BindingAndDeclaration(declaration) => {
+                Either::Left(std::iter::once((declaration.0, declaration.1.inner_type())))
+            }
+            Self::Other(other) => Either::Right(other.bindings.iter().copied()),
+            Self::Empty | Self::Declaration(..) => Either::Right([].iter().copied()),
+        }
+    }
+
+    fn declarations(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (Definition<'db>, TypeAndQualifiers<'db>)> {
+        match self {
+            Self::Declaration(declaration) | Self::BindingAndDeclaration(declaration) => {
+                Either::Left(std::iter::once(**declaration))
+            }
+            Self::Other(other) => Either::Right(other.declarations.iter().copied()),
+            Self::Empty | Self::Binding(..) => Either::Right([].iter().copied()),
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::Update, Default)]
@@ -935,7 +1093,7 @@ impl<'db> DefinitionInference<'db> {
         definition: Definition<'db>,
         cycle_recovery: Type<'db>,
     ) -> Self {
-        let mut bindings: Box<[_]> = Box::new([]);
+        let mut types = DefinitionTypes::Empty;
 
         // Eagerly store more precise types for collection literals to avoid an extra
         // cycle iteration, i.e., by inferring `list[Divergent]` instead of `Divergent`.
@@ -956,14 +1114,16 @@ impl<'db> DefinitionInference<'db> {
                         generic_context.repeat_specialization(db, cycle_recovery)
                     });
 
-                bindings = Box::new([(definition, Type::instance(db, divergent_collection))]);
+                types = DefinitionTypes::Binding(Box::new((
+                    definition,
+                    Type::instance(db, divergent_collection),
+                )));
             }
         }
 
         Self {
-            bindings,
             expressions: FrozenMap::default(),
-            declarations: Box::default(),
+            types,
             #[cfg(debug_assertions)]
             scope: definition.scope(db),
             extra: Some(Box::new(DefinitionInferenceExtra {
@@ -983,31 +1143,8 @@ impl<'db> DefinitionInference<'db> {
             let previous_ty = previous_inference.expression_type(*expr);
             *ty = ty.cycle_normalized(db, previous_ty, cycle);
         }
-        for (binding, binding_ty) in &mut self.bindings {
-            if let Some((_, previous_binding)) = previous_inference
-                .bindings
-                .iter()
-                .find(|(previous_binding, _)| previous_binding == binding)
-            {
-                *binding_ty = binding_ty.cycle_normalized(db, *previous_binding, cycle);
-            } else {
-                *binding_ty = binding_ty.recursive_type_normalized(db, cycle);
-            }
-        }
-        for (declaration, declaration_ty) in &mut self.declarations {
-            if let Some((_, previous_declaration)) = previous_inference
-                .declarations
-                .iter()
-                .find(|(previous_declaration, _)| previous_declaration == declaration)
-            {
-                *declaration_ty = declaration_ty.map_type(|decl_ty| {
-                    decl_ty.cycle_normalized(db, previous_declaration.inner_type(), cycle)
-                });
-            } else {
-                *declaration_ty =
-                    declaration_ty.map_type(|decl_ty| decl_ty.recursive_type_normalized(db, cycle));
-            }
-        }
+        self.types =
+            std::mem::take(&mut self.types).cycle_normalized(db, &previous_inference.types, cycle);
 
         self
     }
@@ -1058,13 +1195,9 @@ impl<'db> DefinitionInference<'db> {
 
     #[track_caller]
     pub(crate) fn binding_type(&self, definition: Definition<'db>) -> Type<'db> {
-        self.bindings
-            .iter()
-            .find_map(
-                |(def, ty)| {
-                    if def == &definition { Some(*ty) } else { None }
-                },
-            )
+        self.types
+            .bindings()
+            .find_map(|(def, ty)| if def == definition { Some(ty) } else { None })
             .or_else(|| self.fallback_type())
             .expect(
                 "definition should belong to this TypeInference region and \
@@ -1073,18 +1206,18 @@ impl<'db> DefinitionInference<'db> {
     }
 
     fn bindings(&self) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> {
-        self.bindings.iter().copied()
+        self.types.bindings()
     }
 
     pub(crate) fn inferred_declaration(
         &self,
         definition: Definition<'db>,
     ) -> InferredDeclaration<'db> {
-        self.declarations
-            .iter()
+        self.types
+            .declarations()
             .find_map(|(def, declaration)| {
-                if def == &definition {
-                    Some(InferredDeclaration::Declared(*declaration))
+                if def == definition {
+                    Some(InferredDeclaration::Declared(declaration))
                 } else {
                     None
                 }
@@ -1100,11 +1233,11 @@ impl<'db> DefinitionInference<'db> {
     fn declarations(
         &self,
     ) -> impl ExactSizeIterator<Item = (Definition<'db>, TypeAndQualifiers<'db>)> {
-        self.declarations.iter().copied()
+        self.types.declarations()
     }
 
     fn declaration_types(&self) -> impl ExactSizeIterator<Item = TypeAndQualifiers<'db>> {
-        self.declarations.iter().map(|(_, qualifiers)| *qualifiers)
+        self.declarations().map(|(_, qualifiers)| qualifiers)
     }
 
     pub(crate) fn fallback_type(&self) -> Option<Type<'db>> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -22,10 +22,10 @@ use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
 use super::{
-    DefinitionInference, DefinitionInferenceExtra, ExpressionInference, ExpressionInferenceExtra,
-    FrozenMap, FrozenSet, FunctionDecoratorInference, InferenceRegion, ScopeInference,
-    ScopeInferenceExtra, infer_deferred_types, infer_definition_types, infer_expression_types,
-    infer_same_file_expression_type, infer_unpack_types,
+    DefinitionInference, DefinitionInferenceExtra, DefinitionTypes, ExpressionInference,
+    ExpressionInferenceExtra, FrozenMap, FrozenSet, FunctionDecoratorInference, InferenceRegion,
+    ScopeInference, ScopeInferenceExtra, infer_deferred_types, infer_definition_types,
+    infer_expression_types, infer_same_file_expression_type, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -10476,8 +10476,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions: FrozenMap::from(expressions),
             #[cfg(debug_assertions)]
             scope,
-            bindings: bindings.into_boxed_slice(),
-            declarations: declarations.into_boxed_slice(),
+            types: DefinitionTypes::from_parts(bindings.into_vec(), declarations.into_vec()),
             extra,
         }
     }
@@ -10913,6 +10912,10 @@ impl<K, V> VecMap<K, V> {
 
     fn into_boxed_slice(self) -> Box<[(K, V)]> {
         self.0.into_boxed_slice()
+    }
+
+    fn into_vec(self) -> Vec<(K, V)> {
+        self.0
     }
 }
 


### PR DESCRIPTION
## Summary

Definition inference results currently retain separate boxed slices for bindings and declarations. Nearly every result has at most one binding and one declaration, and the binding and declaration usually refer to the same definition and type.

Store common singleton results in compact boxed variants, sharing the declaration type with its matching binding when possible. Preserve the existing boxed-slice representation for uncommon multi-entry results.

This reduces retained memory and removes redundant allocations without changing inference behavior or lookup semantics.