### PR TITLE
[ty] Require literal booleans for TypedDict flags

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Class_header_validat…_(25381f371caa1401).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Class_header_validat…_(25381f371caa1401).snap
@@ -33,6 +33,8 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/typed_dict.md
 18 | class Ham(TypedDict, metaclass=type): ...  # error: [invalid-typed-dict-header]
 19 | def f(kwargs: dict):
 20 |     class Eggs(TypedDict, **kwargs): ...  # error: [invalid-typed-dict-header]
+21 | class Qux(TypedDict, total=1 == 1): ...  # error: [invalid-argument-type]
+22 | class Quux(TypedDict, closed=1 == 1): ...  # error: [invalid-argument-type]
 ```
 
 # Diagnostics
@@ -133,6 +135,26 @@ error[invalid-typed-dict-header]: Keyword-variadic arguments are not supported i
    |
 20 |     class Eggs(TypedDict, **kwargs): ...  # error: [invalid-typed-dict-header]
    |                           ^^^^^^^^
+   |
+
+```
+
+```
+error[invalid-argument-type]: Invalid argument to parameter `total` in `TypedDict` definition
+  --> src/mdtest_snippet.py:21:22
+   |
+21 | class Qux(TypedDict, total=1 == 1): ...  # error: [invalid-argument-type]
+   |                      ^^^^^^^^^^^^ Expected either `True` or `False`, got object of type `Literal[True]`
+   |
+
+```
+
+```
+error[invalid-argument-type]: Invalid argument to parameter `closed` in `TypedDict` definition
+  --> src/mdtest_snippet.py:22:23
+   |
+22 | class Quux(TypedDict, closed=1 == 1): ...  # error: [invalid-argument-type]
+   |                       ^^^^^^^^^^^^^ Expected either `True` or `False`, got object of type `Literal[True]`
    |
 
 ```

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3019,6 +3019,10 @@ TotalNone = TypedDict("TotalNone", {"id": int}, total=None)
 def f(total: bool) -> None:
     # error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
     TotalDynamic = TypedDict("TotalDynamic", {"id": int}, total=total)
+
+# An expression that evaluates to a bool literal is still not a literal expression:
+# error: [invalid-argument-type] "Invalid argument to parameter `total` of `TypedDict()`"
+TotalExpression = TypedDict("TotalExpression", {"id": int}, total=1 == 1)
 ```
 
 ## Function syntax with `Required` and `NotRequired`
@@ -3088,6 +3092,10 @@ ClosedNone = TypedDict("ClosedNone", {"id": int}, closed=None)
 def f(closed: bool) -> None:
     # error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
     ClosedDynamic = TypedDict("ClosedDynamic", {"id": int}, closed=closed)
+
+# An expression that evaluates to a bool literal is still not a literal expression:
+# error: [invalid-argument-type] "Invalid argument to parameter `closed` of `TypedDict()`"
+ClosedExpression = TypedDict("ClosedExpression", {"id": int}, closed=1 == 1)
 ```
 
 ## Function syntax with `extra_items`
@@ -5089,6 +5097,13 @@ And variadic keywords are also banned:
 ```py
 def f(kwargs: dict):
     class Eggs(TypedDict, **kwargs): ...  # error: [invalid-typed-dict-header]
+```
+
+Literal-valued expressions are not literal arguments:
+
+```py
+class Qux(TypedDict, total=1 == 1): ...  # error: [invalid-argument-type]
+class Quux(TypedDict, closed=1 == 1): ...  # error: [invalid-argument-type]
 ```
 
 ## PEP 728 (`closed` and `extra_items`)

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -655,9 +655,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                 match keyword.arg.as_deref() {
                     Some(arg_name @ ("total" | "closed")) => {
                         let passed_type = file_expression_type(&keyword.value);
-                        if passed_type
-                            .as_literal_value()
-                            .is_none_or(|literal| !literal.is_bool())
+                        if !keyword.value.is_boolean_literal_expr()
                             && let Some(builder) =
                                 context.report_lint(&INVALID_ARGUMENT_TYPE, keyword)
                         {

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -151,9 +151,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             match &**arg {
                 arg_name @ ("total" | "closed") => {
                     let kw_type = self.infer_expression(&kw.value, TypeContext::default());
-                    if kw_type
-                        .as_literal_value()
-                        .is_none_or(|literal| !literal.is_bool())
+                    if !kw.value.is_boolean_literal_expr()
                         && let Some(builder) =
                             self.context.report_lint(&INVALID_ARGUMENT_TYPE, &kw.value)
                     {


### PR DESCRIPTION
## Summary

The TypedDict spec requires `total` and `closed` to be literal `True` or `False`. We currently accept any expression whose inferred type is a boolean literal, such as `closed=42 == 42`. This changes class-header and functional `TypedDict(...)` validation to inspect the argument syntax instead of its inferred type.