### PR TITLE
[ty] Synthesize precise __len__ methods for literals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/expression/len.md
+++ b/crates/ty_python_semantic/resources/mdtest/expression/len.md
@@ -11,6 +11,9 @@ reveal_type(len(r"conca\t" "ena\tion"))  # revealed: Literal[14]
 reveal_type(len(b"ytes lite" rb"al"))  # revealed: Literal[11]
 reveal_type(len("𝒰𝕹🄸©🕲𝕕ℇ"))  # revealed: Literal[7]
 
+reveal_type("abc".__len__)  # revealed: () -> Literal[3]
+reveal_type(b"abc".__len__)  # revealed: () -> Literal[3]
+
 # fmt: off
 
 reveal_type(len(  # revealed: Literal[7]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/len.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/len.md
@@ -74,6 +74,8 @@ python-version = "3.11"
 ```
 
 ```py
+from typing import Literal
+
 def _(val: tuple[int] | tuple[str, str] | tuple[int, *tuple[str, ...], int]):
     if len(val) == 1:
         # revealed: tuple[int] | (tuple[int, *tuple[str, ...], int] & ExactlySized[Literal[1, True]])
@@ -106,6 +108,17 @@ def _(val: tuple[()] | tuple[int]):
     if False == len(val):
         reveal_type(val)  # revealed: tuple[()]
         empty: tuple[()] = val
+
+def _(x: Literal[b"", b"a"], y: Literal["a", "ab"]):
+    if len(x) == 1:
+        reveal_type(x)  # revealed: Literal[b"a"]
+    else:
+        reveal_type(x)  # revealed: Literal[b""]
+
+    if len(y) == 1:
+        reveal_type(y)  # revealed: Literal["a"]
+    else:
+        reveal_type(y)  # revealed: Literal["ab"]
 ```
 
 Exact length comparisons intersect arbitrary `Sized` values with `ExactlySized`. This persists the

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2625,25 +2625,30 @@ impl<'db> Type<'db> {
                 ..
             }) => self.instance_member(db, &name),
 
-            Type::LiteralValue(literal)
-                if name == "__len__"
-                    && let Some(length) = match literal.kind() {
-                        LiteralValueTypeKind::Bytes(bytes) => Some(bytes.python_len(db)),
-                        LiteralValueTypeKind::String(string) => Some(string.python_len(db)),
-                        _ => None,
-                    }
-                    && let Ok(length) = i64::try_from(length) =>
-            {
-                let parameters = Parameters::new(
-                    db,
-                    [Parameter::positional_only(Some(Name::new_static("self")))
-                        .with_annotated_type(self)],
-                );
-                Place::bound(Type::function_like_callable(
-                    db,
-                    Signature::new(parameters, Type::int_literal(length)),
-                ))
-                .into()
+            Type::LiteralValue(literal) if name == "__len__" => {
+                if let Some(length) = match literal.kind() {
+                    LiteralValueTypeKind::Bytes(bytes) => Some(bytes.python_len(db)),
+                    LiteralValueTypeKind::String(string) => Some(string.python_len(db)),
+                    _ => None,
+                } && let Ok(length) = i64::try_from(length)
+                {
+                    let parameters = Parameters::new(
+                        db,
+                        [Parameter::positional_only(Some(Name::new_static("self")))
+                            .with_annotated_type(self)],
+                    );
+                    Place::bound(Type::function_like_callable(
+                        db,
+                        Signature::new(parameters, Type::int_literal(length)),
+                    ))
+                    .into()
+                } else {
+                    self.to_meta_type(db)
+                        .find_name_in_mro_with_policy(db, name.as_str(), policy)
+                        .expect(
+                            "`Type::find_name_in_mro()` should return `Some()` when called on a meta-type",
+                        )
+                }
             }
 
             // `type[Any]` (or `type[Unknown]`, etc.) has an unknown metaclass, but all

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2625,6 +2625,27 @@ impl<'db> Type<'db> {
                 ..
             }) => self.instance_member(db, &name),
 
+            Type::LiteralValue(literal)
+                if name == "__len__"
+                    && let Some(length) = match literal.kind() {
+                        LiteralValueTypeKind::Bytes(bytes) => Some(bytes.python_len(db)),
+                        LiteralValueTypeKind::String(string) => Some(string.python_len(db)),
+                        _ => None,
+                    }
+                    && let Ok(length) = i64::try_from(length) =>
+            {
+                let parameters = Parameters::new(
+                    db,
+                    [Parameter::positional_only(Some(Name::new_static("self")))
+                        .with_annotated_type(self)],
+                );
+                Place::bound(Type::function_like_callable(
+                    db,
+                    Signature::new(parameters, Type::int_literal(length)),
+                ))
+                .into()
+            }
+
             // `type[Any]` (or `type[Unknown]`, etc.) has an unknown metaclass, but all
             // metaclasses inherit from `type`. Check `type`'s class-level attributes
             // first so that data descriptors like `__mro__` and `__bases__` resolve to


### PR DESCRIPTION
## Summary

Small follow-up to #25347.

`len(...)` already returns precise literal lengths for string and bytes literals, but the `__len__` member lookup was returning `int`, which prevented exact-length protocol intersections from eliminating incompatible literal values.

We now synthesize precise `__len__` methods for string and bytes literals so checks such as `len(value) == 1` narrow unions of literals to the values with matching lengths:

```py
def f(x: Literal[b"", b"a"]):
    if len(x) == 1:
        reveal_type(x)  # Literal[b"a"]
```
