### PR TITLE
Share check command helper

### DIFF
--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -13,14 +13,6 @@ use crate::CliTest;
 const BIN_NAME: &str = "ruff";
 const STDIN_BASE_OPTIONS: &[&str] = &["check", "--no-cache", "--output-format", "concise"];
 
-impl CliTest {
-    fn check_command(&self) -> Command {
-        let mut command = self.command();
-        command.args(STDIN_BASE_OPTIONS);
-        command
-    }
-}
-
 #[test]
 fn top_level_options() -> Result<()> {
     let test = CliTest::new()?;
@@ -475,9 +467,10 @@ ignore = ["D203", "D212"]
 }
 
 #[test]
-fn nonexistent_config_file() {
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-        .args(STDIN_BASE_OPTIONS)
+fn nonexistent_config_file() -> Result<()> {
+    let test = CliTest::new()?;
+
+    assert_cmd_snapshot!(test.check_command()
         .args(["--config", "foo.toml", "."]), @"
     success: false
     exit_code: 2
@@ -495,12 +488,15 @@ fn nonexistent_config_file() {
 
     For more information, try '--help'.
     ");
+
+    Ok(())
 }
 
 #[test]
-fn config_override_rejected_if_invalid_toml() {
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-        .args(STDIN_BASE_OPTIONS)
+fn config_override_rejected_if_invalid_toml() -> Result<()> {
+    let test = CliTest::new()?;
+
+    assert_cmd_snapshot!(test.check_command()
         .args(["--config", "foo = bar", "."]), @"
     success: false
     exit_code: 2
@@ -523,6 +519,8 @@ fn config_override_rejected_if_invalid_toml() {
 
     For more information, try '--help'.
     ");
+
+    Ok(())
 }
 
 #[test]
@@ -553,9 +551,10 @@ fn too_many_config_files() -> Result<()> {
 }
 
 #[test]
-fn extend_passed_via_config_argument() {
-    assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
-        .args(STDIN_BASE_OPTIONS)
+fn extend_passed_via_config_argument() -> Result<()> {
+    let test = CliTest::new()?;
+
+    assert_cmd_snapshot!(test.check_command()
         .args(["--config", "extend = 'foo.toml'", "."]), @"
     success: false
     exit_code: 2
@@ -568,6 +567,8 @@ fn extend_passed_via_config_argument() {
 
     For more information, try '--help'.
     ");
+
+    Ok(())
 }
 
 #[test]

--- a/crates/ruff/tests/cli/main.rs
+++ b/crates/ruff/tests/cli/main.rs
@@ -22,6 +22,7 @@ mod show_settings;
 mod version;
 
 const BIN_NAME: &str = "ruff";
+const CHECK_BASE_OPTIONS: &[&str] = &["check", "--no-cache", "--output-format", "concise"];
 
 /// Creates a regex filter for replacing temporary directory paths in snapshots
 pub(crate) fn tempdir_filter(path: impl AsRef<str>) -> String {
@@ -213,6 +214,12 @@ impl CliTest {
         // Unset all environment variables because they can affect test behavior.
         command.env_clear();
 
+        command
+    }
+
+    pub(crate) fn check_command(&self) -> Command {
+        let mut command = self.command();
+        command.args(CHECK_BASE_OPTIONS);
         command
     }
 


### PR DESCRIPTION
## Summary
- move the CLI check command helper onto `CliTest`
- use it in a few lint tests that still built the command directly

Closes #19016? No; this only trims one leftover spot.

## Test
- `CARGO_PROFILE_DEV_OPT_LEVEL=1 CARGO_PROFILE_DEV_DEBUG="line-tables-only" cargo test -p ruff --test cli`
- `cargo clippy -p ruff --test cli -- -D warnings`
- `uvx prek run --files crates/ruff/tests/cli/main.rs crates/ruff/tests/cli/lint.rs`