### PR TITLE
[ty] Remove special-cased inference for `len()` with `Literal` types

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3844,16 +3844,6 @@ impl<'db> Type<'db> {
             }
         }
 
-        let usize_len = match self.as_literal_value_kind() {
-            Some(LiteralValueTypeKind::Bytes(bytes)) => Some(bytes.python_len(db)),
-            Some(LiteralValueTypeKind::String(string)) => Some(string.python_len(db)),
-            _ => None,
-        };
-
-        if let Some(usize_len) = usize_len {
-            return usize_len.try_into().ok().map(Type::int_literal);
-        }
-
         let return_ty = match self.try_call_dunder(
             db,
             "__len__",


### PR DESCRIPTION
## Summary

This special-cased inference is unnecessary following https://github.com/astral-sh/ruff/pull/25600: we now have this implemented in a more generalised way elsewhere, so we can remove this without any tests failing. It's possibly slightly slower but it's unlikely to be a hot path.

## Test Plan

existing tests