### PR TITLE
[ty] Refactor how we identify reStructuredText parameters in docstrings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4553,6 +4553,7 @@ dependencies = [
  "camino",
  "compact_str",
  "get-size2",
+ "indexmap",
  "insta",
  "itertools 0.14.0",
  "memchr",

--- a/crates/ty_ide/Cargo.toml
+++ b/crates/ty_ide/Cargo.toml
@@ -34,6 +34,7 @@ ty_python_core = { workspace = true, features = ["serde"] }
 
 compact_str = { workspace = true }
 get-size2 = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
 rayon = { workspace = true }

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -9,11 +9,11 @@
 mod markdown;
 mod rest;
 
+use indexmap::IndexMap;
 use regex::Regex;
 use ruff_python_trivia::{PythonWhitespace, leading_indentation};
 use ruff_source_file::UniversalNewlines;
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use crate::MarkupKind;
@@ -69,8 +69,8 @@ impl Docstring {
 
     /// Extract parameter documentation from popular docstring formats.
     /// Returns a map of parameter names to their documentation.
-    pub fn parameter_documentation(&self) -> HashMap<String, String> {
-        let mut param_docs = HashMap::new();
+    pub fn parameter_documentation(&self) -> IndexMap<String, String> {
+        let mut param_docs = IndexMap::new();
 
         // Google-style docstrings
         param_docs.extend(extract_google_style_params(&self.0));
@@ -495,8 +495,8 @@ fn render_markdown(docstring: &str) -> String {
 }
 
 /// Extract parameter documentation from Google-style docstrings.
-fn extract_google_style_params(docstring: &str) -> HashMap<String, String> {
-    let mut param_docs = HashMap::new();
+fn extract_google_style_params(docstring: &str) -> IndexMap<String, String> {
+    let mut param_docs = IndexMap::new();
 
     let mut in_args_section = false;
     let mut current_param: Option<String> = None;
@@ -588,8 +588,8 @@ fn get_indentation_level(line: &str) -> usize {
 }
 
 /// Extract parameter documentation from NumPy-style docstrings.
-fn extract_numpy_style_params(docstring: &str) -> HashMap<String, String> {
-    let mut param_docs = HashMap::new();
+fn extract_numpy_style_params(docstring: &str) -> IndexMap<String, String> {
+    let mut param_docs = IndexMap::new();
 
     let mut lines = docstring
         .universal_newlines()
@@ -755,8 +755,8 @@ fn extract_numpy_style_params(docstring: &str) -> HashMap<String, String> {
 }
 
 /// Extract parameter documentation from reST/Sphinx-style docstrings.
-fn extract_rest_style_params(docstring: &str) -> HashMap<String, String> {
-    let mut param_docs = HashMap::new();
+fn extract_rest_style_params(docstring: &str) -> IndexMap<String, String> {
+    let mut param_docs = IndexMap::new();
 
     for parameter in rest::Docstring::parse(docstring).parameter_documentation() {
         param_docs.insert(parameter.name.into_string(), parameter.description);

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -7,6 +7,7 @@
 //! logic needs to be tolerant of variations.
 
 mod markdown;
+mod rest;
 
 use regex::Regex;
 use ruff_python_trivia::{PythonWhitespace, leading_indentation};
@@ -34,11 +35,6 @@ static NUMPY_SECTION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 
 static NUMPY_UNDERLINE_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\s*-+\s*$").expect("NumPy underline regex should be valid"));
-
-static REST_PARAM_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^\s*:param\s+(?:(\w+)\s+)?(\w+)\s*:\s*(.+)")
-        .expect("reST parameter regex should be valid")
-});
 
 /// A docstring which hasn't yet been interpreted or rendered
 ///
@@ -762,68 +758,8 @@ fn extract_numpy_style_params(docstring: &str) -> HashMap<String, String> {
 fn extract_rest_style_params(docstring: &str) -> HashMap<String, String> {
     let mut param_docs = HashMap::new();
 
-    let mut current_param: Option<String> = None;
-    let mut current_doc = String::new();
-
-    for line_obj in docstring.universal_newlines() {
-        let line = line_obj.as_str();
-        if let Some(captures) = REST_PARAM_REGEX.captures(line) {
-            // Save previous parameter if exists
-            if let Some(param_name) = current_param.take() {
-                param_docs.insert(param_name, current_doc.trim().to_string());
-                current_doc.clear();
-            }
-
-            // Extract parameter name and description
-            if let (Some(param_match), Some(desc_match)) = (captures.get(2), captures.get(3)) {
-                current_param = Some(param_match.as_str().to_string());
-                current_doc = desc_match.as_str().to_string();
-            }
-        } else if current_param.is_some() {
-            let trimmed = line.trim();
-
-            // Check if this is a new section - stop processing if we hit section headers
-            if trimmed == "Parameters" || trimmed == "Args" || trimmed == "Arguments" {
-                // Save current param and stop processing
-                if let Some(param_name) = current_param.take() {
-                    param_docs.insert(param_name, current_doc.trim().to_string());
-                    current_doc.clear();
-                }
-                break;
-            }
-
-            // Check if this is another directive line starting with ':'
-            if trimmed.starts_with(':') {
-                // This is a new directive, save current param
-                if let Some(param_name) = current_param.take() {
-                    param_docs.insert(param_name, current_doc.trim().to_string());
-                    current_doc.clear();
-                }
-                // Let the next iteration handle this directive
-                continue;
-            }
-
-            // Check if this is a continuation line (indented)
-            if line.starts_with("    ") && !trimmed.is_empty() {
-                // This is a continuation line
-                if !current_doc.is_empty() {
-                    current_doc.push('\n');
-                }
-                current_doc.push_str(trimmed);
-            } else if !trimmed.is_empty() && !line.starts_with(' ') && !line.starts_with('\t') {
-                // This is a non-indented line - likely end of the current parameter
-                if let Some(param_name) = current_param.take() {
-                    param_docs.insert(param_name, current_doc.trim().to_string());
-                    current_doc.clear();
-                }
-                break;
-            }
-        }
-    }
-
-    // Don't forget the last parameter
-    if let Some(param_name) = current_param {
-        param_docs.insert(param_name, current_doc.trim().to_string());
+    for parameter in rest::Docstring::parse(docstring).parameter_documentation() {
+        param_docs.insert(parameter.name.into_string(), parameter.description);
     }
 
     param_docs

--- a/crates/ty_ide/src/docstring/rest.rs
+++ b/crates/ty_ide/src/docstring/rest.rs
@@ -1,0 +1,1010 @@
+use std::iter::{Enumerate, Peekable};
+
+use compact_str::{CompactString, ToCompactString};
+use ruff_python_trivia::leading_indentation;
+use ruff_source_file::{UniversalNewlineIterator, UniversalNewlines};
+use ruff_text_size::TextSize;
+
+use super::markdown;
+
+/// Represents a parsed restructured text (reST) docstring.
+pub(super) struct Docstring {
+    field_lists: Vec<FieldList>,
+}
+
+impl Docstring {
+    /// Constructs a parsed representation from a raw docstring.
+    pub(super) fn parse(raw: &str) -> Self {
+        let field_lists = FieldList::parse_all(raw);
+        Self { field_lists }
+    }
+
+    /// Returns the parameter documentation that we were able to recognize in a docstring.
+    pub(super) fn parameter_documentation(&self) -> Vec<ParameterDocumentation> {
+        let mut parameters = Vec::new();
+
+        for field_list in &self.field_lists {
+            for field in &field_list.fields {
+                let Field::Parameter {
+                    lookup_name,
+                    description,
+                    ..
+                } = field
+                else {
+                    continue;
+                };
+
+                if description.is_empty() {
+                    continue;
+                }
+
+                parameters.push(ParameterDocumentation {
+                    name: lookup_name.clone(),
+                    description: description.clone(),
+                });
+            }
+        }
+
+        parameters
+    }
+}
+
+/// Cursor over docstring lines and their line numbers.
+#[derive(Clone)]
+struct Lines<'a> {
+    inner: Peekable<Enumerate<UniversalNewlineIterator<'a>>>,
+}
+
+impl<'a> Lines<'a> {
+    /// Constructs a line cursor from raw docstring text.
+    fn new(raw: &'a str) -> Self {
+        Self {
+            inner: raw.universal_newlines().enumerate().peekable(),
+        }
+    }
+
+    /// Returns the next line without advancing the cursor.
+    fn peek(&mut self) -> Option<(usize, &'a str)> {
+        let (index, line) = self.inner.peek()?;
+        Some((*index, line.as_str()))
+    }
+
+    /// Advances the cursor and returns the next line.
+    fn next(&mut self) -> Option<(usize, &'a str)> {
+        let (index, line) = self.inner.next()?;
+        Some((index, line.as_str()))
+    }
+}
+
+/// Represents a contiguous list of reST fields.
+///
+/// <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#field-lists>
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FieldList {
+    start_line: usize,
+    end_line: usize,
+    indent: TextSize,
+    fields: Vec<Field>,
+}
+
+impl FieldList {
+    /// Parse all the field lists in the given lines of a docstring.
+    fn parse_all(raw: &str) -> Vec<Self> {
+        let mut field_lists = Vec::new();
+        let mut preformatted_blocks = PreformattedBlockScanner::default();
+        let mut lines = Lines::new(raw);
+
+        while let Some((_, line)) = lines.peek() {
+            if preformatted_blocks.consume_preformatted_line(line) {
+                lines.next();
+                continue;
+            }
+
+            let Some(field_list) = Self::parse(&mut lines) else {
+                preformatted_blocks.observe_non_field_line(line);
+                lines.next();
+                continue;
+            };
+
+            field_lists.push(field_list);
+        }
+
+        field_lists
+    }
+
+    /// Attempt to parse a single field list from the given lines of a docstring.
+    fn parse(lines: &mut Lines<'_>) -> Option<Self> {
+        let (start_line, line) = lines.peek()?;
+        let header = FieldHeader::parse(line)?;
+        lines.next();
+
+        let field_list_indent = header.indent;
+        let mut fields = Vec::new();
+        let mut current = FieldBuilder::new(header);
+        let mut end_line = start_line + 1;
+
+        while let Some((line_index, line)) = lines.peek() {
+            if line.trim().is_empty() {
+                // Blank lines continue the field list only before another field or a continuation.
+
+                if !Self::blank_line_continues_field_list(lines, field_list_indent) {
+                    break;
+                }
+
+                current.lines.push(line);
+                lines.next();
+                end_line = line_index + 1;
+                continue;
+            }
+
+            if let Some(header) = FieldHeader::at_indent(line, field_list_indent) {
+                // Same-indent field header starts the next field in this list.
+
+                let previous = std::mem::replace(&mut current, FieldBuilder::new(header));
+                fields.push(previous.finish());
+                lines.next();
+                end_line = line_index + 1;
+                continue;
+            }
+
+            if FieldHeader::indentation(line) <= field_list_indent {
+                // Same- or less-indented content ends this field list.
+                break;
+            }
+
+            // More-indented non-blank lines continue the current field body
+            // (and hence also the current field list).
+            current.lines.push(line);
+            lines.next();
+            end_line = line_index + 1;
+        }
+
+        // Finalize the last field.
+        fields.push(current.finish());
+
+        Some(Self {
+            start_line,
+            end_line,
+            indent: field_list_indent,
+            fields,
+        })
+    }
+
+    /// Returns whether a blank line keeps the current field list open.
+    ///
+    /// A blank line before an indented continuation stays in the current field list:
+    ///
+    /// ```rst
+    /// :param x: First paragraph.
+    ///
+    ///     Second paragraph.
+    /// :param y: Next parameter.
+    /// ```
+    ///
+    /// A blank line before another same-indent field also stays in the current field list:
+    ///
+    /// ```rst
+    /// :param x: First parameter.
+    ///
+    /// :param y: Second parameter.
+    /// ```
+    ///
+    /// A blank line before same-indent prose ends the field list:
+    ///
+    /// ```rst
+    /// :param x: First parameter.
+    ///
+    /// This is normal prose.
+    /// ```
+    fn blank_line_continues_field_list(lines: &Lines<'_>, indent: TextSize) -> bool {
+        let mut next = lines.clone();
+        while let Some((_, line)) = next.peek()
+            && line.trim().is_empty()
+        {
+            next.next();
+        }
+
+        let Some((_, non_blank_line)) = next.peek() else {
+            return false;
+        };
+
+        FieldHeader::indentation(non_blank_line) > indent
+            || FieldHeader::at_indent(non_blank_line, indent).is_some()
+    }
+}
+
+/// Recognizes preformatted blocks that may occur within a docstring (e.g. a markdown fence).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct PreformattedBlockScanner<'a> {
+    active_markdown_fence: Option<markdown::MarkdownFence<'a>>,
+    active_doctest: bool,
+    preformatted_block_state: PreformattedBlockState,
+}
+
+/// The set of characters that can each be used to denote a block quote.
+///
+/// <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#quoted-literal-blocks>
+const QUOTED_LITERAL_BLOCK_QUOTE_CHARACTERS: &str = r##"!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"##;
+
+impl<'a> PreformattedBlockScanner<'a> {
+    /// Updates internal state to reflect the given line and returns whether or
+    /// not the given line is contained within a preformatted block.
+    fn consume_preformatted_line(&mut self, line: &'a str) -> bool {
+        if let Some(fence) = self.active_markdown_fence {
+            if fence.is_closed_by(line) {
+                self.active_markdown_fence = None;
+            }
+            return true;
+        }
+
+        if self.is_within_preformatted_block(line) {
+            return true;
+        }
+
+        let trimmed = line.trim_start_matches(' ');
+        if self.active_doctest {
+            if trimmed.is_empty() {
+                self.active_doctest = false;
+            }
+            return true;
+        }
+
+        if trimmed.starts_with(">>>") {
+            self.active_doctest = true;
+            return true;
+        }
+
+        if let Some(fence) = markdown::MarkdownFence::find(line) {
+            self.active_markdown_fence = Some(fence);
+            return true;
+        }
+
+        false
+    }
+
+    /// Whether or not the given line is specifically within a preformatted block
+    /// introduced by reST syntax.
+    fn is_within_preformatted_block(&mut self, line: &str) -> bool {
+        let current_indent = FieldHeader::indentation(line);
+        let line_is_empty = line.trim_start().is_empty();
+
+        match self.preformatted_block_state {
+            PreformattedBlockState::Active(PreformattedBlockKind::Indented { marker_indent }) => {
+                if !line_is_empty && current_indent <= marker_indent {
+                    // We've reached the de-dent that marks the end of the preformatted block.
+                    self.preformatted_block_state = PreformattedBlockState::Inactive;
+                    false
+                } else {
+                    true
+                }
+            }
+            PreformattedBlockState::Active(PreformattedBlockKind::QuotedLiteral {
+                indent,
+                quote,
+            }) => {
+                if line_is_empty {
+                    self.preformatted_block_state = PreformattedBlockState::Inactive;
+                    false
+                } else if Self::quote_character(line, indent) == Some(quote) {
+                    true
+                } else {
+                    self.preformatted_block_state = PreformattedBlockState::Inactive;
+                    false
+                }
+            }
+            PreformattedBlockState::Pending {
+                marker_indent,
+                allows_quoted_literal_block,
+            } if !line_is_empty => {
+                if current_indent > marker_indent {
+                    // We just entered a new preformatted block.
+                    self.preformatted_block_state =
+                        PreformattedBlockState::Active(PreformattedBlockKind::Indented {
+                            marker_indent,
+                        });
+                    true
+                } else if allows_quoted_literal_block
+                    && let Some(quote) = Self::quote_character(line, marker_indent)
+                {
+                    self.preformatted_block_state =
+                        PreformattedBlockState::Active(PreformattedBlockKind::QuotedLiteral {
+                            indent: marker_indent,
+                            quote,
+                        });
+                    true
+                } else {
+                    self.preformatted_block_state = PreformattedBlockState::Inactive;
+                    false
+                }
+            }
+            PreformattedBlockState::Pending { .. } | PreformattedBlockState::Inactive => false,
+        }
+    }
+
+    /// Updates internal state that allows us to detect preformatted blocks introduced by reST
+    /// syntax.
+    fn observe_non_field_line(&mut self, line: &str) {
+        if matches!(
+            self.preformatted_block_state,
+            PreformattedBlockState::Inactive
+        ) && Self::starts_preformatted_block(line.trim_start())
+        {
+            self.preformatted_block_state = PreformattedBlockState::Pending {
+                marker_indent: FieldHeader::indentation(line),
+                allows_quoted_literal_block: Self::allows_quoted_literal_block(line.trim_start()),
+            };
+        }
+    }
+
+    /// Whether or not the given line marks the start of a preformatted block.
+    fn starts_preformatted_block(line: &str) -> bool {
+        let Some(marker) = Self::preformatted_block_marker(line) else {
+            return false;
+        };
+
+        !matches!(
+            marker,
+            PreformattedBlockMarker::Directive(
+                "attention"
+                    | "caution"
+                    | "danger"
+                    | "error"
+                    | "hint"
+                    | "important"
+                    | "note"
+                    | "tip"
+                    | "warning"
+                    | "admonition"
+                    | "seealso"
+                    | "versionadded"
+                    | "version-added"
+                    | "versionchanged"
+                    | "version-changed"
+                    | "version-deprecated"
+                    | "deprecated"
+                    | "version-removed"
+                    | "versionremoved"
+            )
+        )
+    }
+
+    /// Tries to identify a marker that introduces a preformatted block.
+    fn preformatted_block_marker(line: &str) -> Option<PreformattedBlockMarker<'_>> {
+        let marker = if let Some(marker) = line.strip_suffix("::") {
+            marker
+        } else {
+            let (before_language, _language) = line.rsplit_once(' ')?;
+            before_language.trim_end().strip_suffix("::")?
+        };
+
+        if let Some(directive) = marker.strip_prefix(".. ") {
+            Some(PreformattedBlockMarker::Directive(directive))
+        } else {
+            Some(PreformattedBlockMarker::Paragraph)
+        }
+    }
+
+    /// Whether or not a particular preformatted block can contain an unindented quoted literal block.
+    fn allows_quoted_literal_block(line: &str) -> bool {
+        line.ends_with("::")
+            && matches!(
+                Self::preformatted_block_marker(line),
+                Some(PreformattedBlockMarker::Paragraph)
+            )
+    }
+
+    /// Returns the quote character for a quoted literal block line.
+    fn quote_character(line: &str, indent: TextSize) -> Option<char> {
+        if FieldHeader::indentation(line) != indent {
+            return None;
+        }
+
+        let quote = line.get(indent.to_usize()..)?.chars().next()?;
+        QUOTED_LITERAL_BLOCK_QUOTE_CHARACTERS
+            .contains(quote)
+            .then_some(quote)
+    }
+}
+
+/// Identifies the syntax that introduced a potential preformatted block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PreformattedBlockMarker<'a> {
+    Paragraph,
+    Directive(&'a str),
+}
+
+/// Tracks the state of a preformatted block introduced by reST syntax.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+enum PreformattedBlockState {
+    #[default]
+    Inactive,
+    Pending {
+        marker_indent: TextSize,
+        allows_quoted_literal_block: bool,
+    },
+    Active(PreformattedBlockKind),
+}
+
+/// Tracks the type of an active preformatted block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PreformattedBlockKind {
+    Indented { marker_indent: TextSize },
+    QuotedLiteral { indent: TextSize, quote: char },
+}
+
+/// Constructs new instances of the model for a reST field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FieldBuilder<'a> {
+    indent: TextSize,
+    kind: FieldKind<'a>,
+    body: &'a str,
+    lines: Vec<&'a str>,
+}
+
+impl<'a> FieldBuilder<'a> {
+    /// Initializes a builder object for a new field instance.
+    fn new(header: FieldHeader<'a>) -> Self {
+        Self {
+            indent: header.indent,
+            kind: header.kind,
+            body: header.body,
+            lines: vec![header.raw],
+        }
+    }
+
+    /// Emits the field that was constructed with this builder.
+    fn finish(self) -> Field {
+        let body = self.normalized_body();
+
+        match self.kind {
+            FieldKind::Parameter {
+                display_name,
+                lookup_name,
+                ty,
+            } => Field::Parameter {
+                display_name: display_name.to_compact_string(),
+                lookup_name: lookup_name.to_compact_string(),
+                ty: ty.map(|ty| ty.to_compact_string()),
+                description: body,
+            },
+            FieldKind::Unknown { name, argument } => Field::Unknown {
+                name: name.to_compact_string(),
+                argument: argument.to_compact_string(),
+                body,
+            },
+        }
+    }
+
+    /// Normalizes the text of the body of a field (e.g., the documentation for a parameter).
+    fn normalized_body(&self) -> String {
+        // Skip the field header line.
+        let continuation_lines = self.lines.iter().skip(1);
+
+        // Use the smallest indentation from all non-blank continuation lines as the normalized
+        // continuation indent.
+        let continuation_indent = continuation_lines
+            .clone()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| FieldHeader::indentation(line))
+            .min()
+            .unwrap_or_default();
+
+        let mut lines = Vec::with_capacity(self.lines.len());
+
+        // Begin with the inline body text parsed from the field header line.
+        lines.push(self.body.trim_end().to_string());
+
+        // Then normalize and add all continuation lines.
+        lines.extend(continuation_lines.map(|line| {
+            if line.trim().is_empty() {
+                // Any pure whitespace line becomes an empty line.
+                String::new()
+            } else {
+                // For any other line we strip the shared continuation indent and trailing whitespace.
+                line.get(continuation_indent.to_usize()..)
+                    .unwrap_or_default()
+                    .trim_end()
+                    .to_string()
+            }
+        }));
+
+        // Find non-empty start and end lines.
+        let Some(start) = lines.iter().position(|line| !line.is_empty()) else {
+            return String::new();
+        };
+        let end = lines
+            .iter()
+            .rposition(|line| !line.is_empty())
+            .map_or(start, |index| index + 1);
+
+        // Trim empty lines from either end of the result.
+        lines[start..end].join("\n")
+    }
+}
+
+/// Represents a parsed reST field header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FieldHeader<'a> {
+    indent: TextSize,
+    kind: FieldKind<'a>,
+    body: &'a str,
+    raw: &'a str,
+}
+
+impl<'a> FieldHeader<'a> {
+    /// Finds the start of a reST field (if any) on the given line and at the
+    /// given indentation level.
+    fn at_indent(line: &'a str, indent: TextSize) -> Option<Self> {
+        (Self::indentation(line) == indent)
+            .then(|| Self::parse(line))
+            .flatten()
+    }
+
+    /// Parses a reST field header of the form `:name [argument]: [body]`.
+    ///
+    /// The argument may consist of multiple, whitespace-delimited tokens, and both the argument
+    /// and the body are optional, so all of the following are accepted:
+    ///
+    /// ```rst
+    /// :meta:
+    /// :param count:
+    /// :param int count:
+    /// :param int count: Number of items.
+    /// ```
+    ///
+    /// Leading indentation is allowed and recorded, so this is also accepted:
+    ///
+    /// ```rst
+    ///     :param int count: Number of items.
+    /// ```
+    ///
+    /// Lines without a field name or without whitespace before a non-empty body are rejected:
+    ///
+    /// ```rst
+    /// ::
+    /// :param name:Description.
+    /// ```
+    fn parse(line: &'a str) -> Option<Self> {
+        let trimmed = line.trim_start();
+        let after_opening_colon = trimmed.strip_prefix(':')?;
+        let (name_and_argument, body) = after_opening_colon.split_once(':')?;
+        if body
+            .chars()
+            .next()
+            .is_some_and(|char| !char.is_whitespace())
+        {
+            return None;
+        }
+
+        let name_and_argument = name_and_argument.trim();
+        if name_and_argument.is_empty() {
+            return None;
+        }
+
+        let name_end = name_and_argument
+            .find(char::is_whitespace)
+            .unwrap_or(name_and_argument.len());
+        let name = &name_and_argument[..name_end];
+        let argument = name_and_argument[name_end..].trim();
+
+        Some(Self {
+            indent: Self::indentation(line),
+            kind: FieldKind::parse(name, argument),
+            body: body.trim_start(),
+            raw: line,
+        })
+    }
+
+    /// Returns the leading indentation of the given source line.
+    fn indentation(line: &str) -> TextSize {
+        TextSize::of(leading_indentation(line))
+    }
+}
+
+/// Categorizes the type of a field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldKind<'a> {
+    Parameter {
+        display_name: &'a str,
+        lookup_name: &'a str,
+        ty: Option<&'a str>,
+    },
+    Unknown {
+        name: &'a str,
+        argument: &'a str,
+    },
+}
+
+impl<'a> FieldKind<'a> {
+    /// Categorizes a parsed field as a supported parameter field or an unknown field.
+    fn parse(name: &'a str, argument: &'a str) -> Self {
+        match name {
+            "param" | "parameter" | "arg" | "argument" | "key" | "keyword" | "kwarg"
+            | "kwparam" => Self::parse_parameter_argument(argument)
+                .map(|(ty, name)| Self::Parameter {
+                    display_name: name.display,
+                    lookup_name: name.lookup,
+                    ty,
+                })
+                .unwrap_or(Self::Unknown { name, argument }),
+            _ => Self::Unknown { name, argument },
+        }
+    }
+
+    /// Parses a parameter name and an optional parameter type from a raw field argument.
+    /// Returns None if we fail to parse the argument.
+    fn parse_parameter_argument(argument: &'a str) -> Option<(Option<&'a str>, ParameterName<'a>)> {
+        let argument = argument.trim();
+        if argument.is_empty() {
+            return None;
+        }
+
+        let (ty, name) = Self::split_parameter_type_and_name(argument);
+        Some((ty, Self::parse_parameter_name(name)?))
+    }
+
+    /// Splits up a field argument into an optional parameter type and a parameter name.
+    fn split_parameter_type_and_name(argument: &'a str) -> (Option<&'a str>, &'a str) {
+        for (index, char) in argument.char_indices().rev() {
+            if char.is_whitespace() {
+                let ty = argument[..index].trim();
+                let name = &argument[index + char.len_utf8()..];
+                return ((!ty.is_empty()).then_some(ty), name);
+            }
+        }
+
+        (None, argument)
+    }
+
+    /// Normalizes a parameter name into display and lookup identifiers.
+    fn parse_parameter_name(name: &'a str) -> Option<ParameterName<'a>> {
+        let display = name.trim();
+        let lookup = display.trim_start_matches('*');
+        (!lookup.is_empty()).then_some(ParameterName { display, lookup })
+    }
+}
+
+/// Represents the reST fields captured by the parser.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Field {
+    Parameter {
+        display_name: CompactString,
+        lookup_name: CompactString,
+        ty: Option<CompactString>,
+        description: String,
+    },
+    Unknown {
+        name: CompactString,
+        argument: CompactString,
+        body: String,
+    },
+}
+
+/// Parameter documentation extracted from a reST field list.
+pub(super) struct ParameterDocumentation {
+    pub(super) name: CompactString,
+    pub(super) description: String,
+}
+
+/// Container for the display name (shown to the user) and the lookup name
+/// (used to look up semantic information) for a particular parameter.
+///
+/// For instance, typical variadic positional parameters will have a `display`
+/// of "*args" and `lookup` of "args".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ParameterName<'a> {
+    display: &'a str,
+    lookup: &'a str,
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::{assert_debug_snapshot, assert_snapshot};
+
+    use super::Docstring;
+
+    #[test]
+    fn parameter_documentation_extracts_rest_parameters() {
+        let docstring = r#"
+        This is a function description.
+
+        :param str param1: The first parameter description
+        :param int param2: The second parameter description
+            This is a continuation of param2 description.
+        :param **kwargs: Extra keyword arguments.
+        :returns: The return value description
+        "#;
+        let param_docs = parameter_documentation(docstring);
+
+        assert_snapshot!(param_docs, @r"
+        param1: The first parameter description
+        param2: The second parameter description
+          This is a continuation of param2 description.
+        kwargs: Extra keyword arguments.
+        ");
+    }
+
+    #[test]
+    fn parameter_documentation_supports_parameter_aliases() {
+        let docstring = r#"
+        :parameter first: The first parameter.
+        :arg second: The second parameter.
+        :argument third: The third parameter.
+        :key fourth: The fourth parameter.
+        :keyword fifth: The fifth parameter.
+        :kwarg sixth: The sixth parameter.
+        :kwparam seventh: The seventh parameter.
+        "#;
+        let param_docs = parameter_documentation(docstring);
+        assert_snapshot!(param_docs, @r"
+        first: The first parameter.
+        second: The second parameter.
+        third: The third parameter.
+        fourth: The fourth parameter.
+        fifth: The fifth parameter.
+        sixth: The sixth parameter.
+        seventh: The seventh parameter.
+        ");
+    }
+
+    #[test]
+    fn parser_supports_complex_inline_parameter_types() {
+        let parsed = Docstring::parse(
+            "\
+:param list[str] items: Item descriptions.
+:param dict[str, list[int | None]] mapping: Mapping description.
+:param Callable[[int, str], bool] callback: Callback description.",
+        );
+
+        assert_debug_snapshot!(&parsed.field_lists[0].fields, @r#"
+        [
+            Parameter {
+                display_name: "items",
+                lookup_name: "items",
+                ty: Some(
+                    "list[str]",
+                ),
+                description: "Item descriptions.",
+            },
+            Parameter {
+                display_name: "mapping",
+                lookup_name: "mapping",
+                ty: Some(
+                    "dict[str, list[int | None]]",
+                ),
+                description: "Mapping description.",
+            },
+            Parameter {
+                display_name: "callback",
+                lookup_name: "callback",
+                ty: Some(
+                    "Callable[[int, str], bool]",
+                ),
+                description: "Callback description.",
+            },
+        ]
+        "#);
+    }
+
+    #[test]
+    fn parameter_documentation_stops_at_field_boundaries() {
+        let docstring = r#"
+        :param param: The parameter description
+        :type param: bool
+        :returns value: The return value description
+        :rtype: str
+        "#;
+        let param_docs = parameter_documentation(docstring);
+
+        assert_snapshot!(param_docs, @"param: The parameter description");
+    }
+
+    #[test]
+    fn parameter_documentation_ignores_parameters_without_names_after_normalization() {
+        assert_snapshot!(
+            parameter_documentation(":param **: Missing a parameter name."),
+            @""
+        );
+    }
+
+    #[test]
+    fn parser_preserves_supported_and_unknown_fields() {
+        let parsed = Docstring::parse(
+            "\
+:param tuple[str, ...] *args: Extra positional arguments.
+:meta private:
+:unknown with argument: Unknown description.",
+        );
+
+        assert_eq!(parsed.field_lists[0].start_line, 0);
+        assert_eq!(parsed.field_lists[0].end_line, 3);
+        assert_debug_snapshot!(&parsed.field_lists[0].fields, @r#"
+        [
+            Parameter {
+                display_name: "*args",
+                lookup_name: "args",
+                ty: Some(
+                    "tuple[str, ...]",
+                ),
+                description: "Extra positional arguments.",
+            },
+            Unknown {
+                name: "meta",
+                argument: "private",
+                body: "",
+            },
+            Unknown {
+                name: "unknown",
+                argument: "with argument",
+                body: "Unknown description.",
+            },
+        ]
+        "#);
+    }
+
+    #[test]
+    fn parser_recovers_from_partial_and_malformed_fields() {
+        let param_docs = parameter_documentation(
+            "\
+:param first: Parsed before malformed input.
+:param missing-space:This is malformed because body text must be separated by whitespace.
+:param:
+:param **: Invalid after parameter-name normalization.
+:param empty:
+:param list[str] second: Parsed after malformed and partial fields.
+:param
+:param third: Parsed after an incomplete field marker.",
+        );
+
+        assert_snapshot!(param_docs, @r"
+        first: Parsed before malformed input.
+        second: Parsed after malformed and partial fields.
+        third: Parsed after an incomplete field marker.
+        ");
+    }
+
+    #[test]
+    fn parameter_documentation_supports_continuation_only_descriptions() {
+        let param_docs = parameter_documentation(
+            "\
+:param value:
+  First paragraph.
+
+  Second paragraph.
+:param other: Other parameter.",
+        );
+
+        assert_snapshot!(param_docs, @r"
+        value: First paragraph.
+
+          Second paragraph.
+        other: Other parameter.
+        ");
+    }
+
+    #[test]
+    fn parser_treats_indented_field_like_text_as_continuation() {
+        let param_docs = parameter_documentation(
+            "\
+:param first: First line.
+    :param fake: This is continuation text, not a new field.
+:param second: Real second parameter.",
+        );
+
+        assert_snapshot!(param_docs, @r"
+        first: First line.
+          :param fake: This is continuation text, not a new field.
+        second: Real second parameter.
+        ");
+    }
+
+    #[test]
+    fn literal_blocks_take_precedence_over_markdown_fences_in_preformatted_blocks() {
+        let docstring = "\
+Literal block::
+
+    ```python
+    :param fake: This is sample input.
+    ```
+
+:param real: Real parameter.";
+
+        let param_docs = parameter_documentation(docstring);
+
+        assert_snapshot!(param_docs, @"real: Real parameter.");
+    }
+
+    #[test]
+    fn literal_blocks_use_marker_indentation_as_exit_threshold() {
+        let docstring = "\
+Literal block::
+
+        sample
+    :param fake: This is sample input.
+
+:param real: Real parameter.";
+
+        let param_docs = parameter_documentation(docstring);
+
+        assert_snapshot!(param_docs, @"real: Real parameter.");
+    }
+
+    #[test]
+    fn quoted_literal_blocks_are_preformatted_blocks() {
+        let docstring = "\
+Literal block::
+
+:param fake: This is sample input.
+:param also_fake: This is more sample input.
+
+:param real: Real parameter.";
+
+        let param_docs = parameter_documentation(docstring);
+
+        assert_snapshot!(param_docs, @"real: Real parameter.");
+    }
+
+    #[test]
+    fn parameter_documentation_recovers_after_same_indent_one_line_directive() {
+        let docstring = "\
+.. seealso:: other
+:param value: Value parameter.
+
+Section::
+
+    :param fake: This is sample input.
+
+:param next: Next parameter.";
+
+        let param_docs = parameter_documentation(docstring);
+
+        assert_snapshot!(param_docs, @r"
+        value: Value parameter.
+        next: Next parameter.
+        ");
+    }
+
+    #[test]
+    fn doctests_take_precedence_over_markdown_fences_in_preformatted_blocks() {
+        let docstring = "\
+>>> print(\"field list\")
+```
+:param fake: This is doctest output.
+
+:param real: Real parameter.";
+
+        let param_docs = parameter_documentation(docstring);
+
+        assert_snapshot!(param_docs, @"real: Real parameter.");
+    }
+
+    fn parameter_documentation(docstring: &str) -> String {
+        let parameters = Docstring::parse(docstring).parameter_documentation();
+        let mut rendered = String::new();
+
+        for parameter in parameters {
+            if !rendered.is_empty() {
+                rendered.push('\n');
+            }
+
+            rendered.push_str(parameter.name.as_str());
+            rendered.push_str(": ");
+
+            let mut lines = parameter.description.lines();
+            let Some(first_line) = lines.next() else {
+                continue;
+            };
+            rendered.push_str(first_line);
+
+            for line in lines {
+                rendered.push('\n');
+                if !line.is_empty() {
+                    rendered.push_str("  ");
+                    rendered.push_str(line);
+                }
+            }
+        }
+
+        rendered
+    }
+}

--- a/crates/ty_ide/src/signature_help.rs
+++ b/crates/ty_ide/src/signature_help.rs
@@ -236,7 +236,7 @@ fn create_parameters<'db>(
     let param_docs = if let Some(docstring) = docstring {
         docstring.parameter_documentation()
     } else {
-        std::collections::HashMap::new()
+        indexmap::IndexMap::new()
     };
 
     parameters


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This replaces the regex-based approach to identifying reStructuredText (reST) parameter documentation with a small parser written for that purpose.

The parser continues to support the same well-formed parameter docs that we recognized before (i.e, `:param [type] name: description`), but it now also:

- Recognizes more Sphinx-style parameter fields, including aliases like `:arg`, `:argument`, `:keyword`, and `:kwparam`
- Supports complex inline type strings like `list[str]`
- Supports variadic names like `*args` and `**kwargs`
- Supports more forms of multi-line and indented descriptions
- Avoids several false positives by ignoring field-looking text inside doctests, Markdown fences, and reST literal blocks.

Finally, introducing a more fully-featured parser sets us up to extend both the parser and its model for future docstring rendering features, such as [Markdown rendering for reST field lists](https://github.com/astral-sh/ty/issues/3454) and [support for reST hyperlinks](https://github.com/astral-sh/ty/issues/3529).

/xref https://github.com/astral-sh/ty/issues/3454
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

- Please see included tests for new functionality.
- Prior test coverage, which has not been modified, helps demonstrate that this refactor preserves existing behaviour.
<!-- How was it tested? -->
