### PR TITLE
[ty] Compact retained definition and expression identities

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -325,6 +325,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.current_scope_info().file_scope_id
     }
 
+    fn current_scope_id(&self) -> ScopeId<'db> {
+        self.scope_ids_by_scope[self.current_scope()]
+    }
+
     pub(crate) fn expect_single_definition(
         &self,
         definition_key: impl Into<DefinitionNodeKey> + std::fmt::Debug + Copy,
@@ -1380,13 +1384,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let category = kind.category(self.source_type.is_stub(), self.module);
         let is_reexported = kind.is_reexported();
 
-        let definition: Definition<'db> = Definition::create(
-            self.db,
-            self.scope_ids_by_scope[self.current_scope()],
-            place,
-            kind,
-            is_reexported,
-        );
+        let definition: Definition<'db> =
+            Definition::new(self.db, self.current_scope_id(), place, kind, is_reexported);
 
         let num_definitions = if is_loop_header {
             // Loop headers are internal use-def definitions. They are retrieved through the loop
@@ -1626,9 +1625,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
 
             let place: ScopedPlaceId = self.add_symbol(name.clone()).into();
-            let definition = Definition::create(
+            let definition = Definition::new(
                 self.db,
-                self.scope_ids_by_scope[self.current_scope()],
+                self.current_scope_id(),
                 place,
                 DefinitionKind::NestedBindings(Box::new(NestedBindingsDefinitionKind {
                     name,
@@ -2056,7 +2055,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     ) -> Expression<'db> {
         let expression = Expression::new(
             self.db,
-            self.scope_ids_by_scope[self.current_scope()],
+            self.current_scope_id(),
             AstNodeRef::new(self.module, expression_node),
             assigned_to.map(|assigned_to| AstNodeRef::new(self.module, assigned_to)),
             expression_kind,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1119,8 +1119,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             };
             let aliased_expression = Expression::new(
                 self.db,
-                self.file,
-                alias.expression_scope,
+                self.scope_ids_by_scope[alias.expression_scope],
                 AstNodeRef::new(self.module, alias.expression),
                 None,
                 ExpressionKind::Normal,
@@ -1381,10 +1380,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let category = kind.category(self.source_type.is_stub(), self.module);
         let is_reexported = kind.is_reexported();
 
-        let definition: Definition<'db> = Definition::new(
+        let definition: Definition<'db> = Definition::create(
             self.db,
-            self.file,
-            self.current_scope(),
+            self.scope_ids_by_scope[self.current_scope()],
             place,
             kind,
             is_reexported,
@@ -1628,10 +1626,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
 
             let place: ScopedPlaceId = self.add_symbol(name.clone()).into();
-            let definition = Definition::new(
+            let definition = Definition::create(
                 self.db,
-                self.file,
-                self.current_scope(),
+                self.scope_ids_by_scope[self.current_scope()],
                 place,
                 DefinitionKind::NestedBindings(Box::new(NestedBindingsDefinitionKind {
                     name,
@@ -2059,8 +2056,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     ) -> Expression<'db> {
         let expression = Expression::new(
             self.db,
-            self.file,
-            self.current_scope(),
+            self.scope_ids_by_scope[self.current_scope()],
             AstNodeRef::new(self.module, expression_node),
             assigned_to.map(|assigned_to| AstNodeRef::new(self.module, assigned_to)),
             expression_kind,

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -28,10 +28,17 @@ use crate::unpack::{Unpack, UnpackPosition};
 /// because a new scope gets inserted before the `Definition` or a new place is inserted
 /// before this `Definition`. However, the ID can be considered stable and it is okay to use
 /// `Definition` in cross-module` salsa queries or as a field on other salsa tracked structs.
-#[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::tracked(
+    debug,
+    constructor = new_internal,
+    heap_size = ruff_memory_usage::heap_size
+)]
 #[derive(Ord, PartialOrd)]
 pub struct Definition<'db> {
     /// The scope in which the definition occurs.
+    ///
+    /// Storing the interned scope avoids retaining the file and file-local scope separately, at
+    /// the cost of database lookups when either of those values is needed.
     pub scope_id: ScopeId<'db>,
 
     /// The place ID and re-export state of the definition.
@@ -49,14 +56,14 @@ pub struct Definition<'db> {
 impl get_size2::GetSize for Definition<'_> {}
 
 impl<'db> Definition<'db> {
-    pub(crate) fn create(
+    pub(crate) fn new(
         db: &'db dyn Db,
         scope_id: ScopeId<'db>,
         place: ScopedPlaceId,
         kind: DefinitionKind<'db>,
         is_reexported: bool,
     ) -> Self {
-        Self::new(
+        Self::new_internal(
             db,
             scope_id,
             DefinitionPlace::new(place, is_reexported),
@@ -161,10 +168,12 @@ impl<'db> Definition<'db> {
     }
 }
 
-#[derive(
-    Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, salsa::Update, get_size2::GetSize,
-)]
-#[doc(hidden)]
+/// The identity of the place defined by a [`Definition`] and whether it is re-exported.
+///
+/// Keeping the re-export state in the enum lets it share the place ID's otherwise-unused
+/// representation space. Storing it as a separate field on [`Definition`] would add padding to
+/// every tracked definition.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
 pub enum DefinitionPlace {
     Symbol {
         id: ScopedSymbolId,

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -12,6 +12,7 @@ use smallvec::SmallVec;
 use crate::Db;
 use crate::LoopToken;
 use crate::ast_node_ref::AstNodeRef;
+use crate::member::ScopedMemberId;
 use crate::node_key::NodeKey;
 use crate::place::ScopedPlaceId;
 use crate::scope::{FileScopeId, ScopeId};
@@ -30,14 +31,11 @@ use crate::unpack::{Unpack, UnpackPosition};
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 #[derive(Ord, PartialOrd)]
 pub struct Definition<'db> {
-    /// The file in which the definition occurs.
-    pub file: File,
-
     /// The scope in which the definition occurs.
-    pub file_scope: FileScopeId,
+    pub scope_id: ScopeId<'db>,
 
-    /// The place ID of the definition.
-    pub place: ScopedPlaceId,
+    /// The place ID and re-export state of the definition.
+    place_info: DefinitionPlace,
 
     /// WARNING: Only access this field when doing type inference for the same
     /// file as where `Definition` is defined to avoid cross-file query dependencies.
@@ -45,17 +43,45 @@ pub struct Definition<'db> {
     #[returns(ref)]
     #[tracked]
     pub kind: DefinitionKind<'db>,
-
-    /// This is a dedicated field to avoid accessing `kind` to compute this value.
-    pub is_reexported: bool,
 }
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for Definition<'_> {}
 
 impl<'db> Definition<'db> {
+    pub(crate) fn create(
+        db: &'db dyn Db,
+        scope_id: ScopeId<'db>,
+        place: ScopedPlaceId,
+        kind: DefinitionKind<'db>,
+        is_reexported: bool,
+    ) -> Self {
+        Self::new(
+            db,
+            scope_id,
+            DefinitionPlace::new(place, is_reexported),
+            kind,
+        )
+    }
+
     pub fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
-        self.file_scope(db).to_scope_id(db, self.file(db))
+        self.scope_id(db)
+    }
+
+    pub fn file(self, db: &'db dyn Db) -> File {
+        self.scope_id(db).file(db)
+    }
+
+    pub fn file_scope(self, db: &'db dyn Db) -> FileScopeId {
+        self.scope_id(db).file_scope_id(db)
+    }
+
+    pub fn place(self, db: &'db dyn Db) -> ScopedPlaceId {
+        self.place_info(db).place()
+    }
+
+    pub fn is_reexported(self, db: &'db dyn Db) -> bool {
+        self.place_info(db).is_reexported()
     }
 
     pub fn full_range(self, db: &'db dyn Db, module: &ParsedModuleRef) -> FileRange {
@@ -131,6 +157,45 @@ impl<'db> Definition<'db> {
                     .map(|docstring_expr| docstring_expr.value.to_str().to_owned())
             }
             _ => None,
+        }
+    }
+}
+
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, salsa::Update, get_size2::GetSize,
+)]
+#[doc(hidden)]
+pub enum DefinitionPlace {
+    Symbol {
+        id: ScopedSymbolId,
+        is_reexported: bool,
+    },
+    Member {
+        id: ScopedMemberId,
+        is_reexported: bool,
+    },
+}
+
+impl DefinitionPlace {
+    fn new(place: ScopedPlaceId, is_reexported: bool) -> Self {
+        match place {
+            ScopedPlaceId::Symbol(id) => Self::Symbol { id, is_reexported },
+            ScopedPlaceId::Member(id) => Self::Member { id, is_reexported },
+        }
+    }
+
+    fn place(self) -> ScopedPlaceId {
+        match self {
+            Self::Symbol { id, .. } => ScopedPlaceId::Symbol(id),
+            Self::Member { id, .. } => ScopedPlaceId::Member(id),
+        }
+    }
+
+    fn is_reexported(self) -> bool {
+        match self {
+            Self::Symbol { is_reexported, .. } | Self::Member { is_reexported, .. } => {
+                is_reexported
+            }
         }
     }
 }

--- a/crates/ty_python_core/src/expression.rs
+++ b/crates/ty_python_core/src/expression.rs
@@ -32,11 +32,8 @@ pub enum ExpressionKind {
 /// * an argument of a cross-module query
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct Expression<'db> {
-    /// The file in which the expression occurs.
-    pub file: File,
-
     /// The scope in which the expression occurs.
-    pub file_scope: FileScopeId,
+    pub scope_id: ScopeId<'db>,
 
     /// The expression node.
     #[no_eq]
@@ -64,6 +61,14 @@ impl get_size2::GetSize for Expression<'_> {}
 
 impl<'db> Expression<'db> {
     pub fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
-        self.file_scope(db).to_scope_id(db, self.file(db))
+        self.scope_id(db)
+    }
+
+    pub fn file(self, db: &'db dyn Db) -> File {
+        self.scope_id(db).file(db)
+    }
+
+    pub fn file_scope(self, db: &'db dyn Db) -> FileScopeId {
+        self.scope_id(db).file_scope_id(db)
     }
 }

--- a/crates/ty_python_core/src/expression.rs
+++ b/crates/ty_python_core/src/expression.rs
@@ -1,6 +1,6 @@
 use crate::ast_node_ref::AstNodeRef;
 use crate::db::Db;
-use crate::scope::{FileScopeId, ScopeId};
+use crate::scope::ScopeId;
 use ruff_db::files::File;
 use ruff_python_ast as ast;
 use salsa;
@@ -33,6 +33,9 @@ pub enum ExpressionKind {
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct Expression<'db> {
     /// The scope in which the expression occurs.
+    ///
+    /// Storing the interned scope avoids retaining the file and file-local scope separately, at
+    /// the cost of database lookups when either of those values is needed.
     pub scope_id: ScopeId<'db>,
 
     /// The expression node.
@@ -66,9 +69,5 @@ impl<'db> Expression<'db> {
 
     pub fn file(self, db: &'db dyn Db) -> File {
         self.scope_id(db).file(db)
-    }
-
-    pub fn file_scope(self, db: &'db dyn Db) -> FileScopeId {
-        self.scope_id(db).file_scope_id(db)
     }
 }


### PR DESCRIPTION
## Summary

The semantic index includes a huge number of `Definition` and `Expression` ingredients. Both retain file and file-local scope fields, even though the existing `ScopeId` identifies both.

This PR modifies the representations to store definition and expression scopes through `ScopeId`, and pack a definition place and re-export state into one enum field. This preserves the existing accessors while reducing the fields retained by each tracked ingredient.

I don't _think_ I'm breaking any Salsa rules here, but I've been wrong before!
