### PR TITLE
[ty] sys.implementation.version is not sys.version_info

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -148,7 +148,7 @@ But perhaps the most commonly used tuple subclass instance is the singleton `sys
 ```py
 import sys
 
-# revealed: Overload[(self, index: Literal[-5, 0], /) -> Literal[3], (self, index: Literal[-4, 1], /) -> Literal[11], (self, index: Literal[-3, -1, 2, 4], /) -> int, (self, index: Literal[-2, 3], /) -> Literal["alpha", "beta", "candidate", "final"], (self, index: SupportsIndex, /) -> int | Literal["alpha", "beta", "candidate", "final"], (self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[int | Literal["alpha", "beta", "candidate", "final"], ...]]
+# revealed: Overload[(self, index: Literal[-5, -4, -3, -1, 0, 1, 2, 4], /) -> int, (self, index: Literal[-2, 3], /) -> Literal["alpha", "beta", "candidate", "final"], (self, index: SupportsIndex, /) -> int | Literal["alpha", "beta", "candidate", "final"], (self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[int | Literal["alpha", "beta", "candidate", "final"], ...]]
 reveal_type(type(sys.version_info).__getitem__)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/sys_version_info.md
+++ b/crates/ty_python_semantic/resources/mdtest/sys_version_info.md
@@ -145,3 +145,19 @@ reveal_type(sys.version_info[:3] >= (3, 10, 1))  # revealed: Literal[False]
 reveal_type(sys.version_info[3] == "final")  # revealed: bool
 reveal_type(sys.version_info[3] == "finalllllll")  # revealed: Literal[False]
 ```
+
+## `sys.implementation.version`
+
+The `version` field of `sys.implementation` is also a `_version_info`, but not necessarily the
+Python language version. For example, non-CPython implementations can use a different versioning
+scheme. Only the singleton `sys.version_info` should use ty's configured Python version:
+
+```py
+import sys
+
+reveal_type(sys.implementation.version)  # revealed: _version_info
+reveal_type(sys.implementation.version.major)  # revealed: int
+reveal_type(sys.implementation.version.minor)  # revealed: int
+reveal_type(sys.implementation.version[:2])  # revealed: tuple[int, int]
+reveal_type(sys.implementation.version >= (3, 9))  # revealed: bool
+```

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1145,14 +1145,20 @@ fn symbol_impl<'db>(
         file_to_module(db, scope.file(db)).is_some_and(|module| module.is_known(db, known_module))
     };
 
-    if name == "platform" && is_known_module(KnownModule::Sys) {
-        match Program::get(db).python_platform(db) {
-            crate::PythonPlatform::Identifier(platform) => {
-                return Place::bound(Type::string_literal(db, platform.as_str())).into();
+    if is_known_module(KnownModule::Sys) {
+        match name {
+            "version_info" => {
+                return Place::bound(Type::sys_version_info(db)).into();
             }
-            crate::PythonPlatform::All => {
-                // Fall through to the looked up type
-            }
+            "platform" => match Program::get(db).python_platform(db) {
+                crate::PythonPlatform::Identifier(platform) => {
+                    return Place::bound(Type::string_literal(db, platform.as_str())).into();
+                }
+                crate::PythonPlatform::All => {
+                    // Fall through to the looked up type
+                }
+            },
+            _ => {}
         }
     }
 

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1145,7 +1145,8 @@ fn symbol_impl<'db>(
         file_to_module(db, scope.file(db)).is_some_and(|module| module.is_known(db, known_module))
     };
 
-    if is_known_module(KnownModule::Sys) {
+    // Check the symbol name first to avoid a module-resolution query for every symbol lookup.
+    if matches!(name, "version_info" | "platform") && is_known_module(KnownModule::Sys) {
         match name {
             "version_info" => {
                 return Place::bound(Type::sys_version_info(db)).into();

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1149,7 +1149,7 @@ fn symbol_impl<'db>(
     if matches!(name, "version_info" | "platform") && is_known_module(KnownModule::Sys) {
         match name {
             "version_info" => {
-                return Place::bound(Type::sys_version_info(db)).into();
+                return Place::bound(Type::sys_version_info()).into();
             }
             "platform" => match Program::get(db).python_platform(db) {
                 crate::PythonPlatform::Identifier(platform) => {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3522,8 +3522,7 @@ impl<'db> Type<'db> {
             }
 
             Type::NominalInstance(instance)
-                if matches!(name.as_str(), "major" | "minor")
-                    && instance.has_known_class(db, KnownClass::VersionInfo) =>
+                if matches!(name.as_str(), "major" | "minor") && instance.is_sys_version_info() =>
             {
                 let python_version = Program::get(db).python_version(db);
                 let segment = if name == "major" {

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -1231,7 +1231,6 @@ impl KnownClass {
         match self {
             Self::NoneType
             | Self::NoDefaultType
-            | Self::VersionInfo
             | Self::EllipsisType
             | Self::NotImplementedType => Some(true),
 
@@ -1276,6 +1275,7 @@ impl KnownClass {
             | Self::DefaultDict
             | Self::Deque
             | Self::OrderedDict
+            | Self::VersionInfo
             | Self::SupportsIndex
             | Self::StdlibAlias
             | Self::TypeAliasType
@@ -1332,7 +1332,6 @@ impl KnownClass {
             Self::NoneType
             | Self::EllipsisType
             | Self::NoDefaultType
-            | Self::VersionInfo
             | Self::NotImplementedType => true,
 
             Self::Bool
@@ -1348,6 +1347,7 @@ impl KnownClass {
             | Self::FrozenSet
             | Self::Dict
             | Self::List
+            | Self::VersionInfo
             | Self::Type
             | Self::Slice
             | Self::Property

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -46,7 +46,7 @@ use crate::{
         member::{Member, class_member},
         mro::{Mro, MroIterator},
         signatures::CallableSignature,
-        tuple::{FixedLengthTuple, Tuple, TupleSpec, TupleType},
+        tuple::{FixedLengthTuple, Tuple},
         typed_dict::{TypedDictParams, typed_dict_params_from_class_def},
         variance::VarianceInferable,
         visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard},
@@ -2735,36 +2735,26 @@ impl<'db> StaticClassLiteral<'db> {
     }
 }
 
-/// A single semantic class-base entry after expanding starred tuple bases and synthetic bases.
+/// A single semantic class-base entry after expanding starred tuple bases.
 #[derive(Clone, Copy)]
-pub(crate) enum ExpandedClassBaseEntry<'a, 'db> {
-    /// A base that comes from a concrete expression in the class header.
-    SourceBacked { node: &'a ast::Expr, ty: Type<'db> },
-    /// A base introduced by semantic expansion with no corresponding source expression.
-    Synthetic(Type<'db>),
+pub(crate) struct ExpandedClassBaseEntry<'a, 'db> {
+    source_node: &'a ast::Expr,
+    ty: Type<'db>,
 }
 
 impl<'a, 'db> ExpandedClassBaseEntry<'a, 'db> {
-    /// Returns the source expression for this base entry, if it has one.
-    pub(crate) const fn source_node(self) -> Option<&'a ast::Expr> {
-        match self {
-            Self::SourceBacked { node, .. } => Some(node),
-            Self::Synthetic(_) => None,
-        }
+    /// Returns the source expression for this base entry.
+    pub(crate) const fn source_node(self) -> &'a ast::Expr {
+        self.source_node
     }
 
     /// Returns the semantic type of this base entry.
     pub(crate) const fn ty(self) -> Type<'db> {
-        match self {
-            Self::SourceBacked { ty, .. } | Self::Synthetic(ty) => ty,
-        }
+        self.ty
     }
 }
 
 /// Expands a class's bases into the semantic entries used by [`StaticClassLiteral::explicit_bases`].
-///
-/// Entries are source-backed when they originate from a concrete base expression in the class
-/// header, and synthetic when semantic expansion adds a base with no corresponding source span.
 pub(crate) fn expanded_class_base_entries<'a, 'db>(
     db: &'db dyn Db,
     known_class: Option<KnownClass>,
@@ -2772,18 +2762,6 @@ pub(crate) fn expanded_class_base_entries<'a, 'db>(
     class_definition: Definition<'db>,
 ) -> Vec<ExpandedClassBaseEntry<'a, 'db>> {
     match known_class {
-        Some(KnownClass::VersionInfo) => {
-            let tuple_type = TupleType::new(db, &TupleSpec::version_info_spec(db))
-                .expect("sys.version_info tuple spec should always be a valid tuple");
-
-            vec![
-                ExpandedClassBaseEntry::SourceBacked {
-                    node: &class_stmt.bases()[0],
-                    ty: definition_expression_type(db, class_definition, &class_stmt.bases()[0]),
-                },
-                ExpandedClassBaseEntry::Synthetic(Type::from(tuple_type.to_class_type(db))),
-            ]
-        }
         // Special-case `NotImplementedType`: typeshed says that it inherits from `Any`,
         // but this causes more problems than it fixes.
         Some(KnownClass::NotImplementedType) => vec![],
@@ -2805,8 +2783,8 @@ pub(crate) fn expanded_class_base_entries<'a, 'db>(
                             tuple_literal
                                 .iter()
                                 .zip(tuple.owned_elements().into_vec())
-                                .map(|(node, ty)| ExpandedClassBaseEntry::SourceBacked {
-                                    node,
+                                .map(|(source_node, ty)| ExpandedClassBaseEntry {
+                                    source_node,
                                     ty,
                                 }),
                         );
@@ -2814,8 +2792,8 @@ pub(crate) fn expanded_class_base_entries<'a, 'db>(
                     }
 
                     expanded_bases.extend(tuple.owned_elements().into_vec().into_iter().map(
-                        |ty| ExpandedClassBaseEntry::SourceBacked {
-                            node: base_node,
+                        |ty| ExpandedClassBaseEntry {
+                            source_node: base_node,
                             ty,
                         },
                     ));
@@ -2827,8 +2805,8 @@ pub(crate) fn expanded_class_base_entries<'a, 'db>(
                 } else {
                     definition_expression_type(db, class_definition, base_node)
                 };
-                expanded_bases.push(ExpandedClassBaseEntry::SourceBacked {
-                    node: base_node,
+                expanded_bases.push(ExpandedClassBaseEntry {
+                    source_node: base_node,
                     ty,
                 });
             }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -5135,18 +5135,18 @@ pub(crate) fn report_duplicate_bases(
             class.name(db)
         ),
     );
-    if let Some(first_base) = bases_list[*first_index].source_node() {
-        sub_diagnostic.annotate(Annotation::secondary(context.span(first_base)).message(
-            format_args!("Class `{duplicate_name}` first included in bases list here"),
-        ));
-    }
+    let first_base = bases_list[*first_index].source_node();
+    sub_diagnostic.annotate(
+        Annotation::secondary(context.span(first_base)).message(format_args!(
+            "Class `{duplicate_name}` first included in bases list here"
+        )),
+    );
     for index in later_indices {
-        if let Some(repeated_base) = bases_list[*index].source_node() {
-            sub_diagnostic.annotate(
-                Annotation::primary(context.span(repeated_base))
-                    .message(format_args!("Class `{duplicate_name}` later repeated here")),
-            );
-        }
+        let repeated_base = bases_list[*index].source_node();
+        sub_diagnostic.annotate(
+            Annotation::primary(context.span(repeated_base))
+                .message(format_args!("Class `{duplicate_name}` later repeated here")),
+        );
     }
 
     diagnostic.sub(sub_diagnostic);

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -236,8 +236,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                 Type::SpecialForm(SpecialFormType::NamedTuple)
                     | Type::KnownInstance(KnownInstanceType::SubscriptedGeneric(_))
             )
-            && let Some(node) = source_node
-            && let Some(builder) = context.report_lint(&INVALID_NAMED_TUPLE, node)
+            && let Some(builder) = context.report_lint(&INVALID_NAMED_TUPLE, source_node)
         {
             builder.into_diagnostic(format_args!(
                 "NamedTuple class `{}` cannot use multiple inheritance except with `Generic[]`",
@@ -247,9 +246,7 @@ pub(crate) fn check_static_class_definitions<'db>(
 
         let base_class = match base_class {
             Type::SpecialForm(SpecialFormType::Generic) => {
-                if let Some(node) = source_node
-                    && let Some(builder) = context.report_lint(&INVALID_BASE, node)
-                {
+                if let Some(builder) = context.report_lint(&INVALID_BASE, source_node) {
                     // Unsubscripted `Generic` can appear in the MRO of many classes,
                     // but it is never valid as an explicit base class in user code.
                     builder.into_diagnostic("Cannot inherit from plain `Generic`");
@@ -285,9 +282,7 @@ pub(crate) fn check_static_class_definitions<'db>(
             // but it is semantically invalid.
             Type::KnownInstance(KnownInstanceType::SubscriptedProtocol(generic_context)) => {
                 if let Some(type_params) = class_node.type_params.as_deref() {
-                    let Some(node) = source_node else {
-                        continue;
-                    };
+                    let node = source_node;
                     let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, node) else {
                         continue;
                     };
@@ -308,17 +303,14 @@ pub(crate) fn check_static_class_definitions<'db>(
                             )));
                         }
                     }
-                } else if let Some(node) = source_node
-                    && protocol_base_with_generic_context.is_none()
-                {
-                    protocol_base_with_generic_context = Some((node, generic_context));
+                } else if protocol_base_with_generic_context.is_none() {
+                    protocol_base_with_generic_context = Some((source_node, generic_context));
                 }
                 continue;
             }
             Type::ClassLiteral(class) => ClassType::NonGeneric(class),
             Type::GenericAlias(base_alias) => {
                 if check_explicit_base_variance
-                    && let Some(node) = source_node
                     && let Some(generic_context) = class.generic_context(db)
                     && let Some((typevar, declared_variance, required_variance)) =
                         generic_context.variables(db).find_map(|typevar| {
@@ -333,7 +325,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                                 None
                             }
                         })
-                    && let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, node)
+                    && let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, source_node)
                 {
                     let mut diagnostic = builder.into_diagnostic(format_args!(
                         "Variance of type variable `{}` is incompatible with base class `{}`",
@@ -361,8 +353,7 @@ pub(crate) fn check_static_class_definitions<'db>(
         if is_protocol {
             if !base_class.is_protocol(db)
                 && !base_class.is_object(db)
-                && let Some(node) = source_node
-                && let Some(builder) = context.report_lint(&INVALID_PROTOCOL, node)
+                && let Some(builder) = context.report_lint(&INVALID_PROTOCOL, source_node)
             {
                 builder.into_diagnostic(format_args!(
                     "Protocol class `{}` cannot inherit from non-protocol class `{}`",
@@ -372,8 +363,7 @@ pub(crate) fn check_static_class_definitions<'db>(
             }
         } else if class_kind == Some(CodeGeneratorKind::TypedDict) {
             if !base_class.class_literal(db).is_typed_dict(db)
-                && let Some(node) = source_node
-                && let Some(builder) = context.report_lint(&INVALID_TYPED_DICT_HEADER, node)
+                && let Some(builder) = context.report_lint(&INVALID_TYPED_DICT_HEADER, source_node)
             {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "TypedDict class `{}` can only inherit from TypedDict classes",
@@ -394,8 +384,7 @@ pub(crate) fn check_static_class_definitions<'db>(
         }
 
         if base_class.is_final(db)
-            && let Some(node) = source_node
-            && let Some(builder) = context.report_lint(&SUBCLASS_OF_FINAL_CLASS, node)
+            && let Some(builder) = context.report_lint(&SUBCLASS_OF_FINAL_CLASS, source_node)
         {
             builder.into_diagnostic(format_args!(
                 "Class `{}` cannot inherit from final class `{}`",
@@ -410,25 +399,23 @@ pub(crate) fn check_static_class_definitions<'db>(
                 class.is_frozen_dataclass(db),
             )
             && base_is_frozen != class_is_frozen
-            && let Some(node) = source_node
         {
             report_bad_frozen_dataclass_inheritance(
                 context,
                 class,
                 class_node,
                 base_class_literal,
-                node,
+                source_node,
                 base_is_frozen,
             );
         }
 
-        if let Some(ordered_base_class) = ordered_dataclass_base_class(db, base_class)
-            && let Some(node) = source_node
-        {
+        if let Some(ordered_base_class) = ordered_dataclass_base_class(db, base_class) {
             // Suppress the diagnostic if the child class manually overrides all comparison
             // methods, since the user has explicitly fixed the LSP violation.
             if !class.has_own_comparison_methods(db)
-                && let Some(builder) = context.report_lint(&SUBCLASS_OF_DATACLASS_WITH_ORDER, node)
+                && let Some(builder) =
+                    context.report_lint(&SUBCLASS_OF_DATACLASS_WITH_ORDER, source_node)
             {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Class `{}` inherits from dataclass `{}` which has `order=True`",
@@ -464,9 +451,8 @@ pub(crate) fn check_static_class_definitions<'db>(
             }
             StaticMroErrorKind::InvalidBases(bases) => {
                 for (index, base_ty) in bases {
-                    if let Some(base_node) = expanded_base_entries[*index].source_node() {
-                        report_invalid_or_unsupported_base(context, base_node, *base_ty, class);
-                    }
+                    let base_node = expanded_base_entries[*index].source_node();
+                    report_invalid_or_unsupported_base(context, base_node, *base_ty, class);
                 }
             }
             StaticMroErrorKind::UnresolvableMro {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -642,7 +642,7 @@ enum NominalInstanceInner<'db> {
     SysVersionInfo,
 }
 
-fn sys_version_info_class<'db>(db: &'db dyn Db) -> Option<ClassType<'db>> {
+fn sys_version_info_class(db: &dyn Db) -> Option<ClassType<'_>> {
     KnownClass::VersionInfo
         .try_to_class_literal(db)
         .map(|class| class.default_specialization(db))

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -120,16 +120,11 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) fn sys_version_info(db: &'db dyn Db) -> Self {
-        let Some(class) = KnownClass::VersionInfo
-            .try_to_class_literal(db)
-            .map(|class| class.default_specialization(db))
-        else {
+        if sys_version_info_class(db).is_none() {
             return Type::unknown();
-        };
+        }
 
-        Type::NominalInstance(NominalInstanceType(NominalInstanceInner::SysVersionInfo(
-            class,
-        )))
+        Type::NominalInstance(NominalInstanceType(NominalInstanceInner::SysVersionInfo))
     }
 
     pub(crate) const fn is_nominal_instance(self) -> bool {
@@ -190,9 +185,10 @@ pub(super) fn walk_nominal_instance_type<'db, V: super::visitor::TypeVisitor<'db
             walk_tuple_type(db, tuple, visitor);
         }
         NominalInstanceInner::Object => {}
-        NominalInstanceInner::NonTuple(class) | NominalInstanceInner::SysVersionInfo(class) => {
+        NominalInstanceInner::NonTuple(class) => {
             visitor.visit_type(db, class.into());
         }
+        NominalInstanceInner::SysVersionInfo => {}
     }
 }
 
@@ -226,8 +222,9 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn class(&self, db: &'db dyn Db) -> ClassType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => tuple.to_class_type(db),
-            NominalInstanceInner::NonTuple(class) | NominalInstanceInner::SysVersionInfo(class) => {
-                class
+            NominalInstanceInner::NonTuple(class) => class,
+            NominalInstanceInner::SysVersionInfo => {
+                sys_version_info_class(db).unwrap_or_else(|| ClassType::object(db))
             }
             NominalInstanceInner::Object => ClassType::object(db),
         }
@@ -243,15 +240,14 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn known_class(&self, db: &'db dyn Db) -> Option<KnownClass> {
         match self.0 {
             NominalInstanceInner::ExactTuple(_) => Some(KnownClass::Tuple),
-            NominalInstanceInner::NonTuple(class) | NominalInstanceInner::SysVersionInfo(class) => {
-                class.known(db)
-            }
+            NominalInstanceInner::NonTuple(class) => class.known(db),
+            NominalInstanceInner::SysVersionInfo => Some(KnownClass::VersionInfo),
             NominalInstanceInner::Object => Some(KnownClass::Object),
         }
     }
 
     pub(super) const fn is_sys_version_info(self) -> bool {
-        matches!(self.0, NominalInstanceInner::SysVersionInfo(_))
+        matches!(self.0, NominalInstanceInner::SysVersionInfo)
     }
 
     /// Returns whether this is a nominal instance of a particular [`KnownClass`].
@@ -266,7 +262,7 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn tuple_spec(&self, db: &'db dyn Db) -> Option<Cow<'db, TupleSpec<'db>>> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => Some(Cow::Borrowed(tuple.tuple(db))),
-            NominalInstanceInner::SysVersionInfo(_) => {
+            NominalInstanceInner::SysVersionInfo => {
                 Some(Cow::Owned(TupleSpec::version_info_spec(db)))
             }
             NominalInstanceInner::NonTuple(class) => {
@@ -305,11 +301,9 @@ impl<'db> NominalInstanceType<'db> {
 
     pub(super) fn is_definition_generic(self) -> bool {
         match self.0 {
-            NominalInstanceInner::NonTuple(class) | NominalInstanceInner::SysVersionInfo(class) => {
-                class.is_generic()
-            }
+            NominalInstanceInner::NonTuple(class) => class.is_generic(),
             NominalInstanceInner::ExactTuple(_) => true,
-            NominalInstanceInner::Object => false,
+            NominalInstanceInner::SysVersionInfo | NominalInstanceInner::Object => false,
         }
     }
 
@@ -327,7 +321,7 @@ impl<'db> NominalInstanceType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => Some(Cow::Borrowed(tuple.tuple(db))),
             NominalInstanceInner::NonTuple(_)
-            | NominalInstanceInner::SysVersionInfo(_)
+            | NominalInstanceInner::SysVersionInfo
             | NominalInstanceInner::Object => None,
         }
     }
@@ -340,7 +334,7 @@ impl<'db> NominalInstanceType<'db> {
     pub(crate) fn slice_literal(self, db: &'db dyn Db) -> Option<SliceLiteral> {
         let class = match self.0 {
             NominalInstanceInner::ExactTuple(_)
-            | NominalInstanceInner::SysVersionInfo(_)
+            | NominalInstanceInner::SysVersionInfo
             | NominalInstanceInner::Object => return None,
             NominalInstanceInner::NonTuple(class) => class,
         };
@@ -388,10 +382,8 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::NonTuple(class) => Some(Self(NominalInstanceInner::NonTuple(
                 class.recursive_type_normalized_impl(db, div, nested)?,
             ))),
-            NominalInstanceInner::SysVersionInfo(class) => {
-                Some(Self(NominalInstanceInner::SysVersionInfo(
-                    class.recursive_type_normalized_impl(db, div, nested)?,
-                )))
+            NominalInstanceInner::SysVersionInfo => {
+                Some(Self(NominalInstanceInner::SysVersionInfo))
             }
             NominalInstanceInner::Object => Some(Self(NominalInstanceInner::Object)),
         }
@@ -405,7 +397,7 @@ impl<'db> NominalInstanceType<'db> {
             // See:
             // https://docs.python.org/3/reference/expressions.html#parenthesized-forms
             NominalInstanceInner::ExactTuple(_) | NominalInstanceInner::Object => false,
-            NominalInstanceInner::SysVersionInfo(_) => true,
+            NominalInstanceInner::SysVersionInfo => true,
             NominalInstanceInner::NonTuple(class) => class
                 .known(db)
                 .map(KnownClass::is_singleton)
@@ -417,7 +409,7 @@ impl<'db> NominalInstanceType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => tuple.is_single_valued(db),
             NominalInstanceInner::Object => false,
-            NominalInstanceInner::SysVersionInfo(_) => true,
+            NominalInstanceInner::SysVersionInfo => true,
             NominalInstanceInner::NonTuple(class) => class
                 .known(db)
                 .and_then(KnownClass::is_single_valued)
@@ -446,11 +438,7 @@ impl<'db> NominalInstanceType<'db> {
                     class.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 )))
             }
-            NominalInstanceInner::SysVersionInfo(class) => {
-                Type::NominalInstance(NominalInstanceType(NominalInstanceInner::SysVersionInfo(
-                    class.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                )))
-            }
+            NominalInstanceInner::SysVersionInfo => Type::NominalInstance(self),
             NominalInstanceInner::Object => Type::object(),
         }
     }
@@ -469,10 +457,7 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::NonTuple(class) => {
                 class.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
-            NominalInstanceInner::SysVersionInfo(class) => {
-                class.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
-            }
-            NominalInstanceInner::Object => {}
+            NominalInstanceInner::SysVersionInfo | NominalInstanceInner::Object => {}
         }
     }
 }
@@ -654,7 +639,13 @@ enum NominalInstanceInner<'db> {
     /// because they represent "all instances of a class that is a tuple subclass".
     NonTuple(ClassType<'db>),
     /// The singleton `sys.version_info` value.
-    SysVersionInfo(ClassType<'db>),
+    SysVersionInfo,
+}
+
+fn sys_version_info_class<'db>(db: &'db dyn Db) -> Option<ClassType<'db>> {
+    KnownClass::VersionInfo
+        .try_to_class_literal(db)
+        .map(|class| class.default_specialization(db))
 }
 
 pub(crate) struct SliceLiteral {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -119,11 +119,10 @@ impl<'db> Type<'db> {
         Type::NominalInstance(NominalInstanceType(NominalInstanceInner::ExactTuple(tuple)))
     }
 
-    pub(crate) fn sys_version_info(db: &'db dyn Db) -> Self {
-        if sys_version_info_class(db).is_none() {
-            return Type::unknown();
-        }
-
+    pub(crate) const fn sys_version_info() -> Self {
+        // Keep construction query-free: resolving the backing typeshed class here is on the hot
+        // path for projects with many version guards. Resolve it lazily when class behavior is
+        // actually needed instead.
         Type::NominalInstance(NominalInstanceType(NominalInstanceInner::SysVersionInfo))
     }
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -119,6 +119,19 @@ impl<'db> Type<'db> {
         Type::NominalInstance(NominalInstanceType(NominalInstanceInner::ExactTuple(tuple)))
     }
 
+    pub(crate) fn sys_version_info(db: &'db dyn Db) -> Self {
+        let Some(class) = KnownClass::VersionInfo
+            .try_to_class_literal(db)
+            .map(|class| class.default_specialization(db))
+        else {
+            return Type::unknown();
+        };
+
+        Type::NominalInstance(NominalInstanceType(NominalInstanceInner::SysVersionInfo(
+            class,
+        )))
+    }
+
     pub(crate) const fn is_nominal_instance(self) -> bool {
         matches!(self, Type::NominalInstance(_))
     }
@@ -177,7 +190,7 @@ pub(super) fn walk_nominal_instance_type<'db, V: super::visitor::TypeVisitor<'db
             walk_tuple_type(db, tuple, visitor);
         }
         NominalInstanceInner::Object => {}
-        NominalInstanceInner::NonTuple(class) => {
+        NominalInstanceInner::NonTuple(class) | NominalInstanceInner::SysVersionInfo(class) => {
             visitor.visit_type(db, class.into());
         }
     }
@@ -213,7 +226,9 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn class(&self, db: &'db dyn Db) -> ClassType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => tuple.to_class_type(db),
-            NominalInstanceInner::NonTuple(class) => class,
+            NominalInstanceInner::NonTuple(class) | NominalInstanceInner::SysVersionInfo(class) => {
+                class
+            }
             NominalInstanceInner::Object => ClassType::object(db),
         }
     }
@@ -228,9 +243,15 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn known_class(&self, db: &'db dyn Db) -> Option<KnownClass> {
         match self.0 {
             NominalInstanceInner::ExactTuple(_) => Some(KnownClass::Tuple),
-            NominalInstanceInner::NonTuple(class) => class.known(db),
+            NominalInstanceInner::NonTuple(class) | NominalInstanceInner::SysVersionInfo(class) => {
+                class.known(db)
+            }
             NominalInstanceInner::Object => Some(KnownClass::Object),
         }
+    }
+
+    pub(super) const fn is_sys_version_info(self) -> bool {
+        matches!(self.0, NominalInstanceInner::SysVersionInfo(_))
     }
 
     /// Returns whether this is a nominal instance of a particular [`KnownClass`].
@@ -245,6 +266,9 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn tuple_spec(&self, db: &'db dyn Db) -> Option<Cow<'db, TupleSpec<'db>>> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => Some(Cow::Borrowed(tuple.tuple(db))),
+            NominalInstanceInner::SysVersionInfo(_) => {
+                Some(Cow::Owned(TupleSpec::version_info_spec(db)))
+            }
             NominalInstanceInner::NonTuple(class) => {
                 // Avoid an expensive MRO traversal for common stdlib classes.
                 if class
@@ -257,13 +281,6 @@ impl<'db> NominalInstanceType<'db> {
                     .iter_mro(db)
                     .filter_map(ClassBase::into_class)
                     .find_map(|class| match class.known(db)? {
-                        // N.B. this is a pure optimisation: iterating through the MRO would give us
-                        // the correct tuple spec for `sys._version_info`, since we special-case the class
-                        // in `StmtClassLiteral::explicit_bases()` so that it is inferred as inheriting from
-                        // a tuple type with the correct spec for the user's configured Python version and platform.
-                        KnownClass::VersionInfo => {
-                            Some(Cow::Owned(TupleSpec::version_info_spec(db)))
-                        }
                         KnownClass::Tuple => Some(
                             class
                                 .into_generic_alias()
@@ -288,7 +305,9 @@ impl<'db> NominalInstanceType<'db> {
 
     pub(super) fn is_definition_generic(self) -> bool {
         match self.0 {
-            NominalInstanceInner::NonTuple(class) => class.is_generic(),
+            NominalInstanceInner::NonTuple(class) | NominalInstanceInner::SysVersionInfo(class) => {
+                class.is_generic()
+            }
             NominalInstanceInner::ExactTuple(_) => true,
             NominalInstanceInner::Object => false,
         }
@@ -307,7 +326,9 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn own_tuple_spec(&self, db: &'db dyn Db) -> Option<Cow<'db, TupleSpec<'db>>> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => Some(Cow::Borrowed(tuple.tuple(db))),
-            NominalInstanceInner::NonTuple(_) | NominalInstanceInner::Object => None,
+            NominalInstanceInner::NonTuple(_)
+            | NominalInstanceInner::SysVersionInfo(_)
+            | NominalInstanceInner::Object => None,
         }
     }
 
@@ -318,7 +339,9 @@ impl<'db> NominalInstanceType<'db> {
     /// integers or `None`.
     pub(crate) fn slice_literal(self, db: &'db dyn Db) -> Option<SliceLiteral> {
         let class = match self.0 {
-            NominalInstanceInner::ExactTuple(_) | NominalInstanceInner::Object => return None,
+            NominalInstanceInner::ExactTuple(_)
+            | NominalInstanceInner::SysVersionInfo(_)
+            | NominalInstanceInner::Object => return None,
             NominalInstanceInner::NonTuple(class) => class,
         };
         let (class_literal, specialization) = class.static_class_literal(db)?;
@@ -365,6 +388,11 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::NonTuple(class) => Some(Self(NominalInstanceInner::NonTuple(
                 class.recursive_type_normalized_impl(db, div, nested)?,
             ))),
+            NominalInstanceInner::SysVersionInfo(class) => {
+                Some(Self(NominalInstanceInner::SysVersionInfo(
+                    class.recursive_type_normalized_impl(db, div, nested)?,
+                )))
+            }
             NominalInstanceInner::Object => Some(Self(NominalInstanceInner::Object)),
         }
     }
@@ -377,6 +405,7 @@ impl<'db> NominalInstanceType<'db> {
             // See:
             // https://docs.python.org/3/reference/expressions.html#parenthesized-forms
             NominalInstanceInner::ExactTuple(_) | NominalInstanceInner::Object => false,
+            NominalInstanceInner::SysVersionInfo(_) => true,
             NominalInstanceInner::NonTuple(class) => class
                 .known(db)
                 .map(KnownClass::is_singleton)
@@ -388,6 +417,7 @@ impl<'db> NominalInstanceType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => tuple.is_single_valued(db),
             NominalInstanceInner::Object => false,
+            NominalInstanceInner::SysVersionInfo(_) => true,
             NominalInstanceInner::NonTuple(class) => class
                 .known(db)
                 .and_then(KnownClass::is_single_valued)
@@ -416,6 +446,11 @@ impl<'db> NominalInstanceType<'db> {
                     class.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 )))
             }
+            NominalInstanceInner::SysVersionInfo(class) => {
+                Type::NominalInstance(NominalInstanceType(NominalInstanceInner::SysVersionInfo(
+                    class.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                )))
+            }
             NominalInstanceInner::Object => Type::object(),
         }
     }
@@ -432,6 +467,9 @@ impl<'db> NominalInstanceType<'db> {
                 tuple.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
             NominalInstanceInner::NonTuple(class) => {
+                class.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            }
+            NominalInstanceInner::SysVersionInfo(class) => {
                 class.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
             NominalInstanceInner::Object => {}
@@ -615,6 +653,8 @@ enum NominalInstanceInner<'db> {
     /// This variant includes types that are subtypes of "exact tuple" types,
     /// because they represent "all instances of a class that is a tuple subclass".
     NonTuple(ClassType<'db>),
+    /// The singleton `sys.version_info` value.
+    SysVersionInfo(ClassType<'db>),
 }
 
 pub(crate) struct SliceLiteral {


### PR DESCRIPTION
## Summary

The way we special-cased `sys.version_info` accidentally also treated `sys.implementation.version` as always being the Python version, but this is only true for CPython. This was because both are instances of `sys._version_info` class in typeshed, and our special-casing operated at the level of that class.

Adjust things so that class is no longer treated as a singleton, and our special-casing operates at the instance layer rather than the class layer.

This also allows removing the now-unused `ExpandedClassBaseEntry::Synthetic` variant, which allows simplifying some diagnostic code.

Closes https://github.com/astral-sh/ty/issues/3640

## Testing

Added mdtest.