### PR TITLE
[ty] Avoid retaining duplicate function signatures

### DIFF
--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -786,6 +786,11 @@ impl<'db> FunctionLiteral<'db> {
         (overloads.as_ref(), *implementation)
     }
 
+    fn has_separate_implementation(self, db: &'db dyn Db) -> bool {
+        !self.last_definition.is_overload(db)
+            && self.last_definition.previous_overload(db).is_some()
+    }
+
     fn iter_overloads_and_implementation(
         self,
         db: &'db dyn Db,
@@ -958,12 +963,12 @@ pub struct FunctionType<'db> {
     #[returns(as_ref)]
     updated_signature: Option<CallableSignature<'db>>,
 
-    /// Contains a potentially modified signature for the last overload or the implementation of this
-    /// function literal, in case certain operations (like type mappings) have been applied to it.
+    /// Contains a potentially modified signature for the implementation of an overloaded function,
+    /// in case certain operations (like type mappings) have been applied to it.
     ///
     /// See also: [`FunctionLiteral::last_definition_signature`].
     #[returns(as_ref)]
-    updated_last_definition_signature: Option<Signature<'db>>,
+    updated_implementation_signature: Option<Signature<'db>>,
 }
 
 // The Salsa heap is tracked separately.
@@ -979,7 +984,7 @@ pub(super) fn walk_function_type<'db, V: super::visitor::TypeVisitor<'db> + ?Siz
             walk_signature(db, signature, visitor);
         }
     }
-    if let Some(signature) = function.updated_last_definition_signature(db) {
+    if let Some(signature) = function.updated_implementation_signature(db) {
         walk_signature(db, signature, visitor);
     }
 }
@@ -994,15 +999,17 @@ impl<'db> FunctionType<'db> {
         let updated_signature = self
             .signature(db)
             .with_inherited_generic_context(db, inherited_generic_context);
-        let updated_last_definition_signature = self
-            .last_definition_signature(db)
-            .clone()
-            .with_inherited_generic_context(db, inherited_generic_context);
+        let literal = self.literal(db);
+        let updated_implementation_signature = literal.has_separate_implementation(db).then(|| {
+            self.last_definition_signature(db)
+                .clone()
+                .with_inherited_generic_context(db, inherited_generic_context)
+        });
         Self::new(
             db,
-            self.literal(db),
+            literal,
             Some(updated_signature),
-            Some(updated_last_definition_signature),
+            updated_implementation_signature,
         )
     }
 
@@ -1015,7 +1022,8 @@ impl<'db> FunctionType<'db> {
     ) -> Self {
         // Returned-callable rescoping and type-alias specialization should not rebuild signatures from the
         // function literal; doing so can re-enter recursive `TypeOf` evaluation.
-        let (updated_signature, updated_last_definition_signature) = if matches!(
+        let literal = self.literal(db);
+        let (updated_signature, updated_implementation_signature) = if matches!(
             type_mapping,
             TypeMapping::ApplySpecialization(
                 ApplySpecialization::ReturnCallables(_) | ApplySpecialization::TypeAlias(_)
@@ -1029,7 +1037,7 @@ impl<'db> FunctionType<'db> {
                 self.updated_signature(db).map(|signature| {
                     signature.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
                 }),
-                self.updated_last_definition_signature(db).map(|signature| {
+                self.updated_implementation_signature(db).map(|signature| {
                     signature.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
                 }),
             )
@@ -1039,23 +1047,25 @@ impl<'db> FunctionType<'db> {
                     self.signature(db)
                         .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ),
-                Some(self.last_definition_signature(db).apply_type_mapping_impl(
-                    db,
-                    type_mapping,
-                    tcx,
-                    visitor,
-                )),
+                literal.has_separate_implementation(db).then(|| {
+                    self.last_definition_signature(db).apply_type_mapping_impl(
+                        db,
+                        type_mapping,
+                        tcx,
+                        visitor,
+                    )
+                }),
             )
         };
 
-        if updated_signature.is_none() && updated_last_definition_signature.is_none() {
+        if updated_signature.is_none() && updated_implementation_signature.is_none() {
             self
         } else {
             Self::new(
                 db,
-                self.literal(db),
+                literal,
                 updated_signature,
-                updated_last_definition_signature,
+                updated_implementation_signature,
             )
         }
     }
@@ -1317,9 +1327,16 @@ impl<'db> FunctionType<'db> {
         heap_size=ruff_memory_usage::heap_size,
     )]
     pub(crate) fn last_definition_signature(self, db: &'db dyn Db) -> Signature<'db> {
-        self.updated_last_definition_signature(db)
-            .cloned()
-            .unwrap_or_else(|| self.literal(db).last_definition_signature(db))
+        let literal = self.literal(db);
+        if literal.has_separate_implementation(db) {
+            self.updated_implementation_signature(db)
+                .cloned()
+                .unwrap_or_else(|| literal.last_definition_signature(db))
+        } else {
+            self.updated_signature(db)
+                .and_then(|signature| signature.overloads.last().cloned())
+                .unwrap_or_else(|| literal.last_definition_signature(db))
+        }
     }
 
     /// Typed externally-visible "raw" signature of the last overload or implementation of this function.
@@ -1402,8 +1419,8 @@ impl<'db> FunctionType<'db> {
                     }
                     None => None,
                 };
-                let updated_last_definition_signature =
-                    match self.updated_last_definition_signature(db) {
+                let updated_implementation_signature =
+                    match self.updated_implementation_signature(db) {
                         Some(signature) => {
                             Some(signature.recursive_type_normalized_impl(db, div, nested)?)
                         }
@@ -1413,7 +1430,7 @@ impl<'db> FunctionType<'db> {
                     db,
                     literal,
                     updated_signature,
-                    updated_last_definition_signature,
+                    updated_implementation_signature,
                 ))
             },
         )


### PR DESCRIPTION
## Summary

A `FunctionType` currently retains a potentially updated public callable signature and a potentially updated signature for its last definition. For ordinary functions and overload-only functions, the last definition is already part of the public callable signature; only an overloaded function with a separate implementation needs an additional retained signature.

Represent the additional field as an implementation-only signature. Ordinary functions and overload-only functions recover their last-definition signature from the updated public signature, while overloaded functions with a separate implementation continue to retain that implementation signature explicitly.
