### PR TITLE
[ty] Compact retained definition kinds

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1250,12 +1250,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 self.add_standalone_type_expression(&ann_assign.annotation);
                 let assignment = self.add_definition(
                     place_id,
-                    AnnotatedAssignmentDefinitionNodeRef {
-                        node: ann_assign,
-                        annotation: &ann_assign.annotation,
-                        value: ann_assign.value.as_deref(),
-                        target: expr,
-                    },
+                    AnnotatedAssignmentDefinitionNodeRef { node: ann_assign },
                 );
 
                 if let Some(value) = ann_assign.value.as_deref() {
@@ -1274,9 +1269,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     place_id,
                     ForStmtDefinitionNodeRef {
                         unpack,
-                        iterable: &node.iter,
+                        node,
                         target: expr,
-                        is_async: node.is_async,
                     },
                 );
             }
@@ -1295,10 +1289,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     place_id,
                     ComprehensionDefinitionNodeRef {
                         unpack,
-                        iterable: &node.iter,
+                        node,
                         target: expr,
                         first,
-                        is_async: node.is_async,
                     },
                 );
             }
@@ -1311,7 +1304,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     place_id,
                     WithItemDefinitionNodeRef {
                         unpack,
-                        context_expr: &item.context_expr,
+                        item,
                         target: expr,
                         is_async,
                     },
@@ -2741,7 +2734,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     // Record whether this is equivalent to `from . import ...`
                     is_self_import = module_name == thispackage;
 
-                    if let Some(module_node) = &node.module
+                    if node.module.is_some()
                         && let Some(relative_submodule) = module_name.relative_to(&thispackage)
                         && let Some(direct_submodule) = relative_submodule.components().next()
                         && !self.seen_submodule_imports.contains(direct_submodule)
@@ -2764,11 +2757,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         };
                         self.add_definition(
                             symbol.into(),
-                            ImportFromSubmoduleDefinitionNodeRef {
-                                node,
-                                module: module_node,
-                                module_index,
-                            },
+                            ImportFromSubmoduleDefinitionNodeRef { node, module_index },
                         );
                     }
                 }

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -436,7 +436,6 @@ pub(crate) struct ImportFromDefinitionNodeRef<'ast> {
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct ImportFromSubmoduleDefinitionNodeRef<'ast> {
     pub(crate) node: &'ast ast::StmtImportFrom,
-    pub(crate) module: &'ast ast::Identifier,
     pub(crate) module_index: usize,
 }
 
@@ -450,9 +449,6 @@ pub(crate) struct AssignmentDefinitionNodeRef<'ast, 'db> {
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct AnnotatedAssignmentDefinitionNodeRef<'ast> {
     pub(crate) node: &'ast ast::StmtAnnAssign,
-    pub(crate) annotation: &'ast ast::Expr,
-    pub(crate) value: Option<&'ast ast::Expr>,
-    pub(crate) target: &'ast ast::Expr,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -465,7 +461,7 @@ pub(crate) struct DictKeyAssignmentNodeRef<'ast, 'db> {
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct WithItemDefinitionNodeRef<'ast, 'db> {
     pub(crate) unpack: Option<(UnpackPosition, Unpack<'db>)>,
-    pub(crate) context_expr: &'ast ast::Expr,
+    pub(crate) item: &'ast ast::WithItem,
     pub(crate) target: &'ast ast::Expr,
     pub(crate) is_async: bool,
 }
@@ -473,9 +469,8 @@ pub(crate) struct WithItemDefinitionNodeRef<'ast, 'db> {
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct ForStmtDefinitionNodeRef<'ast, 'db> {
     pub(crate) unpack: Option<(UnpackPosition, Unpack<'db>)>,
-    pub(crate) iterable: &'ast ast::Expr,
+    pub(crate) node: &'ast ast::StmtFor,
     pub(crate) target: &'ast ast::Expr,
-    pub(crate) is_async: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -500,10 +495,9 @@ pub(crate) enum LoopStmtRef<'ast> {
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct ComprehensionDefinitionNodeRef<'ast, 'db> {
     pub(crate) unpack: Option<(UnpackPosition, Unpack<'db>)>,
-    pub(crate) iterable: &'ast ast::Expr,
+    pub(crate) node: &'ast ast::Comprehension,
     pub(crate) target: &'ast ast::Expr,
     pub(crate) first: bool,
-    pub(crate) is_async: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -586,11 +580,9 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
             }),
             DefinitionNodeRef::ImportFromSubmodule(ImportFromSubmoduleDefinitionNodeRef {
                 node,
-                module,
                 module_index,
             }) => DefinitionKind::ImportFromSubmodule(ImportFromSubmoduleDefinitionKind {
                 node: AstNodeRef::new(parsed, node),
-                module: AstNodeRef::new(parsed, module),
                 module_index: module_index
                     .try_into()
                     .expect("import-from submodule index should fit in u32"),
@@ -624,14 +616,9 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
                 target: AstNodeRef::new(parsed, target),
             }),
             DefinitionNodeRef::AnnotatedAssignment(AnnotatedAssignmentDefinitionNodeRef {
-                node: _,
-                annotation,
-                value,
-                target,
+                node,
             }) => DefinitionKind::AnnotatedAssignment(AnnotatedAssignmentDefinitionKind {
-                target: AstNodeRef::new(parsed, target),
-                annotation: AstNodeRef::new(parsed, annotation),
-                value: value.map(|v| AstNodeRef::new(parsed, v)),
+                node: AstNodeRef::new(parsed, node),
             }),
             DefinitionNodeRef::AugmentedAssignment(augmented_assignment) => {
                 DefinitionKind::AugmentedAssignment(AstNodeRef::new(parsed, augmented_assignment))
@@ -647,27 +634,27 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
             }),
             DefinitionNodeRef::For(ForStmtDefinitionNodeRef {
                 unpack,
-                iterable,
+                node,
                 target,
-                is_async,
             }) => DefinitionKind::For(ForStmtDefinitionKind {
-                target_kind: TargetKind::from(unpack),
-                iterable: AstNodeRef::new(parsed, iterable),
+                unpack: unpack.map(|(_, unpack)| unpack),
+                unpack_position: unpack.map_or(UnpackPosition::First, |(position, _)| position),
+                node: AstNodeRef::new(parsed, node),
                 target: AstNodeRef::new(parsed, target),
-                is_async,
+                is_async: node.is_async,
             }),
             DefinitionNodeRef::Comprehension(ComprehensionDefinitionNodeRef {
                 unpack,
-                iterable,
+                node,
                 target,
                 first,
-                is_async,
             }) => DefinitionKind::Comprehension(ComprehensionDefinitionKind {
-                target_kind: TargetKind::from(unpack),
-                iterable: AstNodeRef::new(parsed, iterable),
+                unpack: unpack.map(|(_, unpack)| unpack),
+                unpack_position: unpack.map_or(UnpackPosition::First, |(position, _)| position),
+                node: AstNodeRef::new(parsed, node),
                 target: AstNodeRef::new(parsed, target),
                 first,
-                is_async,
+                is_async: node.is_async,
             }),
             DefinitionNodeRef::Parameter(parameter) => {
                 DefinitionKind::Parameter(parameter.into_owned(parsed))
@@ -677,18 +664,21 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
                 parameter,
                 lambda,
             }) => DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
-                index,
+                index: index
+                    .try_into()
+                    .expect("lambda parameter index should fit in u32"),
                 parameter: parameter.into_owned(parsed),
                 lambda: AstNodeRef::new(parsed, lambda),
             }),
             DefinitionNodeRef::WithItem(WithItemDefinitionNodeRef {
                 unpack,
-                context_expr,
+                item,
                 target,
                 is_async,
             }) => DefinitionKind::WithItem(WithItemDefinitionKind {
-                target_kind: TargetKind::from(unpack),
-                context_expr: AstNodeRef::new(parsed, context_expr),
+                unpack: unpack.map(|(_, unpack)| unpack),
+                unpack_position: unpack.map_or(UnpackPosition::First, |(position, _)| position),
+                item: AstNodeRef::new(parsed, item),
                 target: AstNodeRef::new(parsed, target),
                 is_async,
             }),
@@ -773,9 +763,8 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
             Self::DictKeyAssignment(node) => DefinitionNodeKey(NodeKey::from_node(node.key)),
             Self::For(ForStmtDefinitionNodeRef {
                 target,
-                iterable: _,
+                node: _,
                 unpack: _,
-                is_async: _,
             }) => DefinitionNodeKey(NodeKey::from_node(target)),
             Self::Comprehension(ComprehensionDefinitionNodeRef { target, .. }) => {
                 DefinitionNodeKey(NodeKey::from_node(target))
@@ -785,7 +774,7 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
             }
             Self::Parameter(parameter) => parameter.key(),
             Self::WithItem(WithItemDefinitionNodeRef {
-                context_expr: _,
+                item: _,
                 unpack: _,
                 is_async: _,
                 target,
@@ -956,22 +945,22 @@ impl<'db> DefinitionKind<'db> {
             DefinitionKind::Class(class) => class.node(module).name.range(),
             DefinitionKind::TypeAlias(type_alias) => type_alias.node(module).name.range(),
             DefinitionKind::NamedExpression(named) => named.node(module).target.range(),
-            DefinitionKind::Assignment(assignment) => assignment.target.node(module).range(),
-            DefinitionKind::AnnotatedAssignment(assign) => assign.target.node(module).range(),
+            DefinitionKind::Assignment(assignment) => assignment.target(module).range(),
+            DefinitionKind::AnnotatedAssignment(assign) => assign.target(module).range(),
             DefinitionKind::AugmentedAssignment(aug_assign) => {
                 aug_assign.node(module).target.range()
             }
             DefinitionKind::DictKeyAssignment(dict_key_assignment) => {
                 dict_key_assignment.key.node(module).range()
             }
-            DefinitionKind::For(for_stmt) => for_stmt.target.node(module).range(),
+            DefinitionKind::For(for_stmt) => for_stmt.target(module).range(),
             DefinitionKind::Comprehension(comp) => comp.target(module).range(),
             DefinitionKind::Parameter(parameter) => parameter.target_range(module),
             DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
                 parameter,
                 ..
             }) => parameter.target_range(module),
-            DefinitionKind::WithItem(with_item) => with_item.target.node(module).range(),
+            DefinitionKind::WithItem(with_item) => with_item.target(module).range(),
             DefinitionKind::MatchPattern(match_pattern) => {
                 match_pattern.identifier.node(module).range()
             }
@@ -1007,16 +996,16 @@ impl<'db> DefinitionKind<'db> {
             DefinitionKind::TypeAlias(type_alias) => type_alias.node(module).range(),
             DefinitionKind::NamedExpression(named) => named.node(module).range(),
             DefinitionKind::Assignment(assign) => {
-                let target_range = assign.target.node(module).range();
-                let value_range = assign.value.node(module).range();
+                let target_range = assign.target(module).range();
+                let value_range = assign.value(module).range();
                 target_range.cover(value_range)
             }
             DefinitionKind::AnnotatedAssignment(assign) => {
-                let mut full_range = assign.target.node(module).range();
-                full_range = full_range.cover(assign.annotation.node(module).range());
+                let mut full_range = assign.target(module).range();
+                full_range = full_range.cover(assign.annotation(module).range());
 
-                if let Some(ref value) = assign.value {
-                    full_range = full_range.cover(value.node(module).range());
+                if let Some(value) = assign.value(module) {
+                    full_range = full_range.cover(value.range());
                 }
 
                 full_range
@@ -1025,14 +1014,14 @@ impl<'db> DefinitionKind<'db> {
             DefinitionKind::DictKeyAssignment(dict_key_assignment) => {
                 dict_key_assignment.key.node(module).range()
             }
-            DefinitionKind::For(for_stmt) => for_stmt.target.node(module).range(),
+            DefinitionKind::For(for_stmt) => for_stmt.target(module).range(),
             DefinitionKind::Comprehension(comp) => comp.target(module).range(),
             DefinitionKind::Parameter(parameter) => parameter.full_range(module),
             DefinitionKind::LambdaParameter(LambdaParameterDefinitionNodeKind {
                 parameter,
                 ..
             }) => parameter.full_range(module),
-            DefinitionKind::WithItem(with_item) => with_item.target.node(module).range(),
+            DefinitionKind::WithItem(with_item) => with_item.target(module).range(),
             DefinitionKind::MatchPattern(match_pattern) => {
                 match_pattern.identifier.node(module).range()
             }
@@ -1070,7 +1059,7 @@ impl<'db> DefinitionKind<'db> {
             // Annotated assignment is always a declaration. It is also a binding if there is a RHS
             // or if we are in a stub file. Unfortunately, it is common for stubs to omit even an `...` value placeholder.
             DefinitionKind::AnnotatedAssignment(ann_assign) => {
-                if in_stub || ann_assign.value.is_some() {
+                if in_stub || ann_assign.value(module).is_some() {
                     DefinitionCategory::DeclarationAndBinding
                 } else {
                     DefinitionCategory::Declaration
@@ -1116,6 +1105,15 @@ impl<'db> From<Option<(UnpackPosition, Unpack<'db>)>> for TargetKind<'db> {
     fn from(value: Option<(UnpackPosition, Unpack<'db>)>) -> Self {
         match value {
             Some((unpack_position, unpack)) => TargetKind::Sequence(unpack_position, unpack),
+            None => TargetKind::Single,
+        }
+    }
+}
+
+impl<'db> TargetKind<'db> {
+    fn from_unpack(unpack: Option<Unpack<'db>>, unpack_position: UnpackPosition) -> Self {
+        match unpack {
+            Some(unpack) => TargetKind::Sequence(unpack_position, unpack),
             None => TargetKind::Single,
         }
     }
@@ -1175,20 +1173,21 @@ impl MatchPatternDefinitionKind {
 /// TODO: currently we don't model this correctly and simply assume that it is in a scope outside the comprehension.
 #[derive(Clone, Debug, get_size2::GetSize)]
 pub struct ComprehensionDefinitionKind<'db> {
-    target_kind: TargetKind<'db>,
-    iterable: AstNodeRef<ast::Expr>,
+    unpack: Option<Unpack<'db>>,
+    node: AstNodeRef<ast::Comprehension>,
     target: AstNodeRef<ast::Expr>,
     first: bool,
     is_async: bool,
+    unpack_position: UnpackPosition,
 }
 
 impl<'db> ComprehensionDefinitionKind<'db> {
     pub fn iterable<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Expr {
-        self.iterable.node(module)
+        &self.node.node(module).iter
     }
 
     pub fn target_kind(&self) -> TargetKind<'db> {
-        self.target_kind
+        TargetKind::from_unpack(self.unpack, self.unpack_position)
     }
 
     pub fn target<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Expr {
@@ -1258,7 +1257,7 @@ impl ParameterDefinitionNodeKind {
 
 #[derive(Clone, Debug, get_size2::GetSize)]
 pub struct LambdaParameterDefinitionNodeKind {
-    pub index: usize,
+    pub index: u32,
     pub lambda: AstNodeRef<ast::ExprLambda>,
     pub parameter: ParameterDefinitionNodeKind,
 }
@@ -1307,7 +1306,6 @@ impl ImportFromDefinitionKind {
 #[derive(Clone, Debug, get_size2::GetSize)]
 pub struct ImportFromSubmoduleDefinitionKind {
     node: AstNodeRef<ast::StmtImportFrom>,
-    module: AstNodeRef<ast::Identifier>,
     module_index: u32,
 }
 
@@ -1317,7 +1315,10 @@ impl ImportFromSubmoduleDefinitionKind {
     }
 
     pub fn module<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Identifier {
-        self.module.node(module)
+        self.import(module)
+            .module
+            .as_ref()
+            .expect("import-from submodule definitions should always have a module identifier")
     }
 
     pub fn target_range(&self, module: &ParsedModuleRef) -> TextRange {
@@ -1369,22 +1370,24 @@ impl<'db> AssignmentDefinitionKind<'db> {
 
 #[derive(Clone, Debug, get_size2::GetSize)]
 pub struct AnnotatedAssignmentDefinitionKind {
-    annotation: AstNodeRef<ast::Expr>,
-    value: Option<AstNodeRef<ast::Expr>>,
-    target: AstNodeRef<ast::Expr>,
+    node: AstNodeRef<ast::StmtAnnAssign>,
 }
 
 impl AnnotatedAssignmentDefinitionKind {
+    fn node<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::StmtAnnAssign {
+        self.node.node(module)
+    }
+
     pub fn value<'ast>(&self, module: &'ast ParsedModuleRef) -> Option<&'ast ast::Expr> {
-        self.value.as_ref().map(|value| value.node(module))
+        self.node(module).value.as_deref()
     }
 
     pub fn annotation<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Expr {
-        self.annotation.node(module)
+        &self.node(module).annotation
     }
 
     pub fn target<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Expr {
-        self.target.node(module)
+        &self.node(module).target
     }
 }
 
@@ -1411,19 +1414,20 @@ impl<'db> DictKeyAssignmentKind<'db> {
 
 #[derive(Clone, Debug, get_size2::GetSize)]
 pub struct WithItemDefinitionKind<'db> {
-    target_kind: TargetKind<'db>,
-    context_expr: AstNodeRef<ast::Expr>,
+    unpack: Option<Unpack<'db>>,
+    item: AstNodeRef<ast::WithItem>,
     target: AstNodeRef<ast::Expr>,
     is_async: bool,
+    unpack_position: UnpackPosition,
 }
 
 impl<'db> WithItemDefinitionKind<'db> {
     pub fn context_expr<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Expr {
-        self.context_expr.node(module)
+        &self.item.node(module).context_expr
     }
 
     pub fn target_kind(&self) -> TargetKind<'db> {
-        self.target_kind
+        TargetKind::from_unpack(self.unpack, self.unpack_position)
     }
 
     pub fn target<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Expr {
@@ -1437,19 +1441,20 @@ impl<'db> WithItemDefinitionKind<'db> {
 
 #[derive(Clone, Debug, get_size2::GetSize)]
 pub struct ForStmtDefinitionKind<'db> {
-    target_kind: TargetKind<'db>,
-    iterable: AstNodeRef<ast::Expr>,
+    unpack: Option<Unpack<'db>>,
+    node: AstNodeRef<ast::StmtFor>,
     target: AstNodeRef<ast::Expr>,
     is_async: bool,
+    unpack_position: UnpackPosition,
 }
 
 impl<'db> ForStmtDefinitionKind<'db> {
     pub fn iterable<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Expr {
-        self.iterable.node(module)
+        &self.node.node(module).iter
     }
 
     pub fn target_kind(&self) -> TargetKind<'db> {
-        self.target_kind
+        TargetKind::from_unpack(self.unpack, self.unpack_position)
     }
 
     pub fn target<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Expr {

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -1084,7 +1084,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// in the lambda body scope.
     pub(super) fn infer_lambda_parameter_definition(
         &mut self,
-        index: usize,
+        index: u32,
         parameter_with_default: &'ast ast::ParameterWithDefault,
         lambda: &'ast ast::ExprLambda,
         definition: Definition<'db>,
@@ -1114,7 +1114,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// in a lambda expression.
     pub(super) fn infer_variadic_positional_lambda_parameter_definition(
         &mut self,
-        index: usize,
+        index: u32,
         parameter: &'ast ast::Parameter,
         lambda: &'ast ast::ExprLambda,
         definition: Definition<'db>,
@@ -1150,7 +1150,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// lambda expression, based on a `Callable` type annotation, if present.
     fn annotated_lambda_parameter_type(
         &mut self,
-        index: usize,
+        index: u32,
         lambda: &'ast ast::ExprLambda,
     ) -> Option<Type<'db>> {
         let enclosing_stmt = infer_statement_types(
@@ -1163,7 +1163,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return None;
         };
 
-        let parameter_type = signature.parameters().as_slice()[index].annotated_type();
+        let parameter_type = signature.parameters().as_slice()[index as usize].annotated_type();
         if parameter_type.is_unknown() || parameter_type.has_unspecialized_type_var(self.db()) {
             None
         } else {


### PR DESCRIPTION
## Summary

Several common `DefinitionKind` variants retain separate references to child AST nodes even though their parent node already retains those children. Lambda parameter definitions also retain a `usize` index.

Retain parent nodes for annotated assignments, import-from submodules, for statements, comprehensions, and with items, recovering their child nodes through the parent when needed. Store lambda parameter indices as `u32`.

On oaiproto, this reduces retained memory by 1,175,760 bytes (0.289%).