### PR TITLE
[`numpy`] Drop autofix for `np.in1d` (`NPY201`)

### DIFF
--- a/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
+++ b/crates/ruff_linter/src/rules/numpy/rules/numpy_2_0_deprecation.rs
@@ -323,10 +323,10 @@ pub(crate) fn numpy_2_0_deprecation(checker: &Checker, expr: &Expr) {
         },
         ["numpy", "in1d"] => Replacement {
             existing: "in1d",
-            details: Details::AutoImport {
-                path: "numpy",
-                name: "isin",
-                compatibility: Compatibility::BackwardsCompatible,
+            details: Details::Manual {
+                guideline: Some(
+                    "Use `np.isin` instead. Unlike `np.in1d`, `np.isin` preserves the shape of its input, so `np.in1d(ar1, ar2)` is equivalent to `np.isin(ar1, ar2).ravel()`.",
+                ),
             },
         },
         ["numpy", "INF"] => Replacement {

--- a/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
+++ b/crates/ruff_linter/src/rules/numpy/snapshots/ruff_linter__rules__numpy__tests__numpy2-deprecation_NPY201_2.py.snap
@@ -405,7 +405,7 @@ help: Replace with `numpy.trapezoid` (requires NumPy 2.0 or greater)
 53 |
 note: This is an unsafe fix and may change runtime behavior
 
-NPY201 [*] `np.in1d` will be removed in NumPy 2.0. Use `numpy.isin` instead.
+NPY201 `np.in1d` will be removed in NumPy 2.0. Use `np.isin` instead. Unlike `np.in1d`, `np.isin` preserves the shape of its input, so `np.in1d(ar1, ar2)` is equivalent to `np.isin(ar1, ar2).ravel()`.
   --> NPY201_2.py:52:5
    |
 50 |     np.trapz([1, 2, 3])
@@ -415,15 +415,6 @@ NPY201 [*] `np.in1d` will be removed in NumPy 2.0. Use `numpy.isin` instead.
 53 |
 54 |     np.AxisError
    |
-help: Replace with `numpy.isin`
-49 |
-50 |     np.trapz([1, 2, 3])
-51 |
-   -     np.in1d([1, 2], [1, 3, 5])
-52 +     np.isin([1, 2], [1, 3, 5])
-53 |
-54 |     np.AxisError
-55 |
 
 NPY201 [*] `np.AxisError` will be removed in NumPy 2.0. Use `numpy.exceptions.AxisError` instead.
   --> NPY201_2.py:54:5


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

`np.isin` is not a drop-in replacement for `np.in1d`: for non-1D inputs, `np.isin` preserves the input shape whereas `np.in1d` always returns a flat array. Auto-fixing `np.in1d(x)` to `np.isin(x)` could therefore silently change behavior, so the replacement is now reported as a manual fix with a guideline pointing at `np.isin(...).ravel()`.

This addresses issue #25604

## Test Plan

This was tested by running `ruff check --select NPY201` on a test file with `np.in1d` in it.