### PR TITLE
[ty] Add caching for pattern match narrowing

### DIFF
--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -199,8 +199,7 @@ use crate::{
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
         CallableTypes, ClassLiteral, IntersectionBuilder, KnownClass, NarrowingConstraint, Type,
-        TypeContext, UnionBuilder, UnionType, enum_metadata, infer_expression_type,
-        infer_narrowing_constraint,
+        TypeContext, UnionType, enum_metadata, infer_expression_type, infer_narrowing_constraint,
     },
 };
 use ruff_index::IndexSlice;
@@ -297,21 +296,56 @@ fn pattern_kind_to_type<'db>(db: &'db dyn Db, kind: &PatternPredicateKind<'db>) 
     }
 }
 
-/// Go through the list of previous match cases, and accumulate a union of all types that were already
-/// matched by these patterns.
-fn type_excluded_by_previous_patterns<'db>(
+/// Narrow `subject_ty` by all preceding unguarded match patterns.
+///
+/// Caching each prefix lets the next case reuse the already-normalized subject instead of
+/// rebuilding it from the union of all preceding patterns, which can repeatedly distribute the
+/// same intersections.
+#[salsa::tracked(
+    cycle_initial = |_, id, _, _| Type::divergent(id),
+    cycle_fn = |db, cycle, previous: &Type<'db>, result: Type<'db>, _, _| {
+        result.cycle_normalized(db, *previous, cycle)
+    },
+    heap_size = ruff_memory_usage::heap_size
+)]
+fn type_narrowed_by_previous_patterns<'db>(
     db: &'db dyn Db,
-    mut predicate: PatternPredicate<'db>,
+    predicate: PatternPredicate<'db>,
+    subject_ty: Type<'db>,
 ) -> Type<'db> {
-    let mut builder = UnionBuilder::new(db);
-    while let Some(previous) = predicate.previous_predicate(db) {
-        predicate = *previous;
+    let Some(previous) = predicate.previous_predicate(db) else {
+        return subject_ty;
+    };
+    let previous = *previous;
 
-        if predicate.guard(db).is_none() {
-            builder = builder.add(pattern_kind_to_type(db, predicate.kind(db)));
-        }
+    if previous.guard(db).is_some() {
+        type_narrowed_by_previous_patterns(db, previous, subject_ty)
+    } else {
+        type_narrowed_by_pattern(db, previous, subject_ty)
     }
-    builder.build()
+}
+
+/// Narrow `subject_ty` by a match pattern and all preceding unguarded patterns.
+///
+/// This result is also the preceding-pattern prefix for the next unguarded case.
+#[salsa::tracked(
+    cycle_initial = |_, id, _, _| Type::divergent(id),
+    cycle_fn = |db, cycle, previous: &Type<'db>, result: Type<'db>, _, _| {
+        result.cycle_normalized(db, *previous, cycle)
+    },
+    heap_size = ruff_memory_usage::heap_size
+)]
+fn type_narrowed_by_pattern<'db>(
+    db: &'db dyn Db,
+    predicate: PatternPredicate<'db>,
+    subject_ty: Type<'db>,
+) -> Type<'db> {
+    IntersectionBuilder::new(db)
+        .add_positive(type_narrowed_by_previous_patterns(
+            db, predicate, subject_ty,
+        ))
+        .add_negative(pattern_kind_to_type(db, predicate.kind(db)))
+        .build()
 }
 
 /// Return the enum class and canonical member names represented by an enum-literal subject type.
@@ -506,11 +540,7 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
         return truthiness;
     }
 
-    let narrowed_subject = IntersectionBuilder::new(db)
-        .add_positive(subject_ty)
-        .add_negative(type_excluded_by_previous_patterns(db, predicate));
-
-    let narrowed_subject_ty = narrowed_subject.clone().build();
+    let narrowed_subject_ty = type_narrowed_by_previous_patterns(db, predicate, subject_ty);
 
     // Consider a case where we match on a subject type of `Self` with an upper bound of `Answer`,
     // where `Answer` is a {YES, NO} enum. After a previous pattern matching on `NO`, the narrowed
@@ -521,9 +551,7 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
     // means that subsequent patterns can never match. And we know that if we reach this point,
     // the current pattern will have to match. We return `AlwaysTrue` here, since the call to
     // `analyze_single_pattern_predicate_kind` below would return `Ambiguous` in this case.
-    let next_narrowed_subject_ty = narrowed_subject
-        .add_negative(pattern_kind_to_type(db, predicate.kind(db)))
-        .build();
+    let next_narrowed_subject_ty = type_narrowed_by_pattern(db, predicate, subject_ty);
     if !narrowed_subject_ty.is_never() && next_narrowed_subject_ty.is_never() {
         return Truthiness::AlwaysTrue;
     }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -317,15 +317,17 @@ fn type_narrowed_by_previous_patterns<'db>(
         return subject_ty;
     };
     let previous = *previous;
+    let narrowed_by_previous_patterns =
+        type_narrowed_by_previous_patterns(db, previous, subject_ty);
 
     if previous.guard(db).is_some() {
-        type_narrowed_by_previous_patterns(db, previous, subject_ty)
+        narrowed_by_previous_patterns
     } else {
-        type_narrowed_by_pattern(db, previous, subject_ty)
+        type_narrowed_by_pattern(db, previous, narrowed_by_previous_patterns)
     }
 }
 
-/// Narrow `subject_ty` by a match pattern and all preceding unguarded patterns.
+/// Narrow `subject_ty` by a match pattern.
 ///
 /// This result is also the preceding-pattern prefix for the next unguarded case.
 #[salsa::tracked(
@@ -341,9 +343,7 @@ fn type_narrowed_by_pattern<'db>(
     subject_ty: Type<'db>,
 ) -> Type<'db> {
     IntersectionBuilder::new(db)
-        .add_positive(type_narrowed_by_previous_patterns(
-            db, predicate, subject_ty,
-        ))
+        .add_positive(subject_ty)
         .add_negative(pattern_kind_to_type(db, predicate.kind(db)))
         .build()
 }
@@ -551,7 +551,7 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
     // means that subsequent patterns can never match. And we know that if we reach this point,
     // the current pattern will have to match. We return `AlwaysTrue` here, since the call to
     // `analyze_single_pattern_predicate_kind` below would return `Ambiguous` in this case.
-    let next_narrowed_subject_ty = type_narrowed_by_pattern(db, predicate, subject_ty);
+    let next_narrowed_subject_ty = type_narrowed_by_pattern(db, predicate, narrowed_subject_ty);
     if !narrowed_subject_ty.is_never() && next_narrowed_subject_ty.is_never() {
         return Truthiness::AlwaysTrue;
     }


### PR DESCRIPTION
## Summary

When analyzing a `match` statement, we currently rebuild the narrowed subject for every case by collecting all preceding unguarded patterns into a union and intersecting the subject with its negation. As pattern types become richer, this can repeatedly distribute the same intersections and make a chain of adjacent cases exponentially expensive. For example, without _this_ change, https://github.com/astral-sh/ruff/pull/25493 starts to surface significant slowdowns in select projects.

As a concrete example, this small `match` blows up with a 9x regression after #25493, without the caching introduced here: https://github.com/kornia/kornia/blob/7c2fee7216599a5e6ef149d4ab2fe33dd70f18c3/kornia/io/io.py#L132-L156. Without caching, every branch has to recompute the prefix in `subject & ~(pattern_1 | pattern_2 | ... | pattern_k-1)`; with caching, we turn it into:

```
T_0 = subject
T_i = T_i-1 & ~pattern_i
```

(Prior to #25493, the sequence patterns generally contributed `Never` here, making it inexpensive.)
