### PR TITLE
[ty] Propagate deprecation through decorator replacements

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -183,6 +183,18 @@ for _ in range(1):
     @replace_with(replacement)
     def loop_binding() -> None: ...
 
+mixed_loop_binding = other
+for _ in range(1):
+    if is_replacement(mixed_loop_binding):
+        mixed_loop_binding()  # error: [deprecated] "mixed loop binding"
+
+    if flag:
+        @deprecated("mixed loop binding")
+        @replace_with(replacement)
+        def mixed_loop_binding() -> None: ...
+    else:
+        mixed_loop_binding = other
+
 def nested_binding():
     @deprecated("nested binding")
     @replace_with(replacement)
@@ -195,6 +207,21 @@ def nested_binding():
         def old() -> None: ...
 
     old()  # error: [deprecated] "nested binding"
+
+def mixed_nested_binding():
+    old = other
+
+    def rebind():
+        nonlocal old
+        if flag:
+            @deprecated("mixed nested binding")
+            @replace_with(replacement)
+            def old() -> None: ...
+        else:
+            old = other
+
+    if is_replacement(old):
+        old()  # error: [deprecated] "mixed nested binding"
 
 if True:
     @deprecated("reachable binding")

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -528,6 +528,10 @@ second_alias()
 annotated_alias: Callable[..., Any] = depr_func  # error: [deprecated] "Use other_func instead"
 annotated_alias()
 
+separate_alias: TypeOf[depr_func]  # ty: ignore[deprecated]
+separate_alias = depr_func  # error: [deprecated] "Use other_func instead"
+separate_alias()
+
 ExplicitAlias: TypeAlias = DeprType  # error: [deprecated] "Use OtherType instead"
 explicit_value: ExplicitAlias
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -584,6 +584,11 @@ def narrowed_alias(flag: bool, unknown: object):
     if is_depr_func(narrowed_value):
         narrowed_value()  # error: [deprecated] "Use other_func instead"
 
+def narrowed_union_alias(value: TypeOf[depr_func] | None):  # ty: ignore[deprecated]
+    union_value = value
+    if union_value is not None:
+        union_value()  # error: [deprecated] "Use other_func instead"
+
 def loop_alias():
     alias = depr_func  # error: [deprecated] "Use other_func instead"
     for _ in range(1):

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -320,6 +320,23 @@ if is_replacement_class(MetaBindingWithFallback.binding):
     # error: [possibly-missing-attribute]
     MetaBindingWithFallback.binding()  # error: [deprecated] "metaclass replacement"
 
+class DecoratedUnionMember:
+    @deprecated("union replacement")
+    @replace_with(ReplacementClass)
+    def binding(self) -> None: ...
+
+class UndecoratedUnionMember:
+    binding = OtherReplacementClass
+
+def use_mixed_union(instance: DecoratedUnionMember | UndecoratedUnionMember) -> None:
+    if is_replacement_class(instance.binding):
+        instance.binding()  # error: [deprecated] "union replacement"
+
+    alias = instance.binding
+    if is_replacement_class(alias):
+        # TODO: Expression inference does not retain binding-level deprecation metadata.
+        alias()  # TODO: error: [deprecated] "union replacement"
+
 T = TypeVar("T", D, E)
 
 def use_union(instance: D | E) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -115,6 +115,33 @@ conditionally_defined()  # TODO: error: [deprecated]
 Deprecation attached to a decorated binding is currently only reported for direct module-level name
 loads with a single live binding. Merging this metadata across control flow is future work.
 
+## Deferred annotations
+
+```py
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar
+from typing_extensions import deprecated
+
+C = TypeVar("C", bound=type)
+
+def replace_with(replacement: C) -> Callable[[Callable[..., Any]], C]:
+    def decorator(_: Callable[..., Any]) -> C:
+        return replacement
+    return decorator
+
+class Replacement: ...
+
+@deprecated("use Replacement")
+@replace_with(Replacement)
+def Old() -> None: ...
+
+value: Old  # TODO: error: [deprecated] "use Replacement"
+```
+
+Deprecation attached to decorated bindings is not yet propagated into deferred annotation scopes.
+
 ## Syntax
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -72,6 +72,10 @@ def is_callable(value: object) -> TypeGuard[Callable[..., Any]]:
     return True
 
 class ReplacementClass: ...
+class OtherReplacementClass: ...
+
+def is_replacement_class(value: object) -> TypeGuard[TypeOf[ReplacementClass]]:
+    return True
 
 class CallableReplacement:
     def __call__(self) -> str:
@@ -268,6 +272,31 @@ C().deprecated_binding  # error: [deprecated] "use replacement directly"
 
 class D(C): ...
 class E(C): ...
+
+class BaseWithFallback:
+    binding = other
+
+class ChildWithFallback(BaseWithFallback):
+    if flag:
+        @deprecated("child replacement")
+        @replace_with(replacement)
+        def binding() -> None: ...
+
+if is_replacement(ChildWithFallback.binding):
+    # TODO: This requires preserving function-literal identity through descriptor binding.
+    ChildWithFallback.binding()  # TODO: error: [deprecated] "child replacement"
+
+class ClassBaseWithFallback:
+    binding = OtherReplacementClass
+
+class ClassChildWithFallback(ClassBaseWithFallback):
+    if flag:
+        @deprecated("child class replacement")
+        @replace_with(ReplacementClass)
+        def binding() -> None: ...
+
+if is_replacement_class(ClassChildWithFallback.binding):
+    ClassChildWithFallback.binding()  # error: [deprecated] "child class replacement"
 
 T = TypeVar("T", D, E)
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -580,6 +580,17 @@ def nested_alias():
         alias = depr_func  # error: [deprecated] "Use other_func instead"
 
     alias()
+
+# TODO: Attribute and loop-target assignments should also avoid transitive deprecation.
+class AliasHolder:
+    alias: Callable[..., Any]
+
+holder = AliasHolder()
+holder.alias = depr_func  # error: [deprecated] "Use other_func instead"
+holder.alias()  # error: [deprecated] "Use other_func instead"
+
+for loop_target_alias in (depr_func,):  # error: [deprecated] "Use other_func instead"
+    loop_target_alias()  # error: [deprecated] "Use other_func instead"
 ```
 
 ## Dunders

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -359,6 +359,10 @@ def use_mixed_union(instance: DecoratedUnionMember | UndecoratedUnionMember) -> 
     if is_replacement_class(casted):
         casted()  # error: [deprecated] "union replacement"
 
+    annotated: TypeOf[ReplacementClass] | TypeOf[OtherReplacementClass] = instance.binding
+    if is_replacement_class(annotated):
+        annotated()  # error: [deprecated] "union replacement"
+
 H = TypeVar("H", DecoratedUnionMember, UndecoratedUnionMember)
 
 def use_mixed_typevar(instance: H) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -46,7 +46,7 @@ replacement function itself as deprecated.
 
 ```py
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any, TypeVar, overload
 from ty_extensions import TypeOf, is_equivalent_to, static_assert
 from typing_extensions import deprecated
 
@@ -58,6 +58,10 @@ def replacement() -> str:
 
 def other() -> str:
     return "other"
+
+@deprecated("deprecated replacement")
+def deprecated_replacement() -> str:
+    return "deprecated replacement"
 
 def replace_with(replacement: F) -> Callable[[Callable[..., Any]], F]:
     def decorator(_: Callable[..., Any]) -> F:
@@ -93,6 +97,10 @@ def deprecated_object_binding() -> None: ...
 @deprecated("use ReplacementClass directly")
 @replace_with(ReplacementClass)
 def deprecated_class_binding() -> None: ...
+@deprecated("overload binding")
+@overload
+@replace_with(deprecated_replacement)  # error: [deprecated] "deprecated replacement"
+def deprecated_overload_binding() -> str: ...
 
 deprecated_binding()  # error: [deprecated] "use replacement directly"
 replacement()
@@ -101,6 +109,7 @@ deprecated_union_binding  # error: [deprecated] "use replacement or other direct
 deprecated_outer_binding()  # error: [deprecated] "outer deprecation"
 deprecated_object_binding
 deprecated_class_binding  # TODO: error: [deprecated] "use ReplacementClass directly"
+deprecated_overload_binding()  # error: [deprecated] "deprecated replacement"
 
 static_assert(is_equivalent_to(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -46,7 +46,7 @@ replacement function itself as deprecated.
 
 ```py
 from collections.abc import Callable
-from typing import Any, TypeVar, cast, overload
+from typing import Any, Protocol, TypeVar, cast, overload, runtime_checkable
 from ty_extensions import TypeOf, is_equivalent_to, static_assert
 from typing_extensions import TypeGuard, deprecated
 
@@ -413,6 +413,28 @@ def use_mixed_typevar(instance: H) -> None:
     alias = instance.binding
     if is_replacement_class(alias):
         alias()  # error: [deprecated] "union replacement"
+
+@runtime_checkable
+class DecoratedProtocol(Protocol):
+    @deprecated("protocol replacement")
+    @replace_with(ReplacementClass)
+    def binding(self) -> None: ...
+
+@runtime_checkable
+class PlainProtocol(Protocol):
+    binding: TypeOf[ReplacementClass] | TypeOf[OtherReplacementClass]
+
+def use_decorated_protocol(value: DecoratedProtocol) -> None:
+    value.binding  # error: [deprecated] "protocol replacement"
+
+def use_intersection(value: object) -> None:
+    if isinstance(value, DecoratedProtocol) and isinstance(value, PlainProtocol):
+        if is_replacement_class(value.binding):  # error: [deprecated] "protocol replacement"
+            value.binding()  # error: [deprecated] "protocol replacement"
+
+        alias = value.binding  # error: [deprecated] "protocol replacement"
+        if is_replacement_class(alias):
+            alias()
 
 T = TypeVar("T", D, E)
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -88,6 +88,9 @@ static_assert(is_equivalent_to(TypeOf[deprecated_binding], TypeOf[replacement]))
 static_assert(is_subtype_of(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]
 static_assert(is_assignable_to(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]
 
+if deprecated_binding is not replacement:  # error: [deprecated] "use replacement directly"
+    deprecated_binding()
+
 flag = bool(input())
 if flag:
     @deprecated("use replacement directly")

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -162,6 +162,30 @@ else:
 
 same_message()  # error: [deprecated] "same message"
 
+@deprecated("loop binding")
+@replace_with(replacement)
+def loop_binding() -> None: ...
+
+for _ in range(1):
+    loop_binding()  # error: [deprecated] "loop binding"
+
+    @deprecated("loop binding")
+    @replace_with(replacement)
+    def loop_binding() -> None: ...
+
+def nested_binding():
+    @deprecated("nested binding")
+    @replace_with(replacement)
+    def old() -> None: ...
+    def rebind():
+        nonlocal old
+
+        @deprecated("nested binding")
+        @replace_with(replacement)
+        def old() -> None: ...
+
+    old()  # error: [deprecated] "nested binding"
+
 if True:
     @deprecated("reachable binding")
     @replace_with(replacement)
@@ -516,6 +540,21 @@ def union_alias(flag: bool):
     optional_alias = depr_func if flag else None  # error: [deprecated] "Use other_func instead"
     if optional_alias is not None:
         optional_alias()
+
+def loop_alias():
+    alias = depr_func  # error: [deprecated] "Use other_func instead"
+    for _ in range(1):
+        alias()
+        alias = depr_func  # error: [deprecated] "Use other_func instead"
+
+def nested_alias():
+    alias = depr_func  # error: [deprecated] "Use other_func instead"
+
+    def rebind():
+        nonlocal alias
+        alias = depr_func  # error: [deprecated] "Use other_func instead"
+
+    alias()
 ```
 
 ## Dunders

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -520,6 +520,7 @@ module.deprecated_binding  # error: [deprecated] "use replacement directly"
 ```py
 from collections.abc import Callable
 from typing import Any, TypeVar
+from ty_extensions import TypeOf
 from typing_extensions import deprecated
 
 R = TypeVar("R")
@@ -529,6 +530,13 @@ def replacement() -> str:
 
 def other() -> str:
     return "other"
+
+@deprecated("ordinary deprecated")
+def ordinary() -> str:
+    return "ordinary"
+
+def ordinary_factory() -> TypeOf[ordinary]:  # ty: ignore[deprecated]
+    return ordinary  # ty: ignore[deprecated]
 
 def replace_with(value: R) -> Callable[[Callable[..., Any]], R]:
     raise NotImplementedError
@@ -542,6 +550,14 @@ else:
     @deprecated("use other directly")
     @replace_with(other)
     def old() -> None: ...
+
+if bool(input()):
+    @deprecated("deprecated replacement binding")
+    @replace_with(replacement)
+    def mixed() -> None: ...
+
+else:
+    mixed = ordinary_factory()
 ```
 
 `main.py`:
@@ -550,6 +566,7 @@ else:
 from ty_extensions import TypeOf
 from typing_extensions import TypeGuard
 
+import module
 from module import old, other, replacement
 
 def is_replacement(value: object) -> TypeGuard[TypeOf[replacement]]:
@@ -558,11 +575,23 @@ def is_replacement(value: object) -> TypeGuard[TypeOf[replacement]]:
 def is_other(value: object) -> TypeGuard[TypeOf[other]]:
     return True
 
+def is_ordinary(
+    value: object,
+) -> TypeGuard[TypeOf[module.ordinary]]:  # ty: ignore[deprecated]
+    return True
+
 if is_replacement(old):
     old()  # error: [deprecated] "use replacement directly"
 
 if is_other(old):
     old()  # error: [deprecated] "use other directly"
+
+mixed_alias = module.mixed
+if is_replacement(mixed_alias):
+    mixed_alias()  # error: [deprecated] "deprecated replacement binding"
+
+if is_ordinary(mixed_alias):
+    mixed_alias()  # error: [deprecated] "ordinary deprecated"
 ```
 
 ## Syntax

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -760,6 +760,8 @@ class DeprType: ...
 @deprecated("Use other_func instead")
 def depr_func(): ...
 
+def regular_func(): ...
+
 class C:
     @deprecated("Use other_method instead")
     def depr_method(self): ...
@@ -836,6 +838,12 @@ def mixed_alias(flag: bool):
 
 def is_depr_func(value: object) -> TypeGuard[TypeOf[depr_func]]:  # ty: ignore[deprecated]
     return True
+
+def chained_union_alias(flag: bool):
+    mixed = depr_func if flag else regular_func  # error: [deprecated] "Use other_func instead"
+    second = mixed
+    if is_depr_func(second):
+        second()
 
 def narrowed_alias(flag: bool, unknown: object):
     if flag:

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -83,6 +83,10 @@ def replaced_deprecated_function() -> None: ...
 @deprecated("use replacement or other directly")
 @replace_with_one_of(replacement, other)
 def deprecated_union_binding() -> None: ...
+@deprecated("outer deprecation")
+@replace_with(replacement)
+@deprecated("inner deprecation")
+def deprecated_outer_binding() -> None: ...
 @deprecated("this object is not callable")
 @replace_with_object
 def deprecated_object_binding() -> None: ...
@@ -94,6 +98,7 @@ deprecated_binding()  # error: [deprecated] "use replacement directly"
 replacement()
 replaced_deprecated_function()
 deprecated_union_binding  # error: [deprecated] "use replacement or other directly"
+deprecated_outer_binding()  # error: [deprecated] "outer deprecation"
 deprecated_object_binding
 deprecated_class_binding  # TODO: error: [deprecated] "use ReplacementClass directly"
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -533,6 +533,9 @@ explicit_value: ExplicitAlias
 (named_alias := depr_func)  # error: [deprecated] "Use other_func instead"
 named_alias()
 
+(inline_alias := depr_func)()  # error: [deprecated] "Use other_func instead"
+inline_alias()
+
 (unpacked_alias,) = (depr_func,)  # error: [deprecated] "Use other_func instead"
 unpacked_alias()
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -501,6 +501,7 @@ redundant and annoying.
 ```py
 from collections.abc import Callable
 from typing import Any, TypeAlias
+from ty_extensions import TypeOf
 from typing_extensions import deprecated
 
 @deprecated("Use OtherType instead")
@@ -543,6 +544,12 @@ def union_alias(flag: bool):
     optional_alias = depr_func if flag else None  # error: [deprecated] "Use other_func instead"
     if optional_alias is not None:
         optional_alias()
+
+def factory() -> TypeOf[depr_func]:  # ty: ignore[deprecated]
+    return depr_func  # ty: ignore[deprecated]
+
+factory_alias = factory()
+factory_alias()  # error: [deprecated] "Use other_func instead"
 
 def loop_alias():
     alias = depr_func  # error: [deprecated] "Use other_func instead"

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -485,11 +485,17 @@ class DeprType: ...
 @deprecated("Use other_func instead")
 def depr_func(): ...
 
+class C:
+    @deprecated("Use other_method instead")
+    def depr_method(self): ...
+
 alias_func = depr_func  # error: [deprecated] "Use other_func instead"
 AliasClass = DeprType  # error: [deprecated] "Use OtherType instead"
+alias_method = C().depr_method  # error: [deprecated] "Use other_method instead"
 
 alias_func()
 AliasClass()
+alias_method()
 
 second_alias = alias_func
 second_alias()

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -48,7 +48,7 @@ replacement function itself as deprecated.
 from collections.abc import Callable
 from typing import Any, TypeVar, overload
 from ty_extensions import TypeOf, is_equivalent_to, static_assert
-from typing_extensions import deprecated
+from typing_extensions import TypeGuard, deprecated
 
 F = TypeVar("F", bound=Callable[..., Any])
 G = TypeVar("G", bound=Callable[..., Any])
@@ -76,8 +76,16 @@ def replace_with_one_of(first: F, second: G) -> Callable[[Callable[..., Any]], F
 def replace_with_object(_: Callable[..., Any]) -> object:
     return object()
 
+def is_replacement(value: object) -> TypeGuard[TypeOf[replacement]]:
+    return True
+
+def is_callable(value: object) -> TypeGuard[Callable[..., Any]]:
+    return True
+
 class ReplacementClass: ...
 
+@deprecated("ordinary deprecated function")
+def ordinary_deprecated_function() -> None: ...
 @deprecated("use replacement directly")
 @replace_with(replacement)
 def deprecated_binding() -> None: ...
@@ -115,6 +123,12 @@ static_assert(is_equivalent_to(TypeOf[deprecated_binding], TypeOf[replacement]))
 
 if deprecated_binding is not replacement:  # error: [deprecated] "use replacement directly"
     deprecated_binding()
+
+if is_replacement(ordinary_deprecated_function):  # error: [deprecated] "ordinary deprecated function"
+    ordinary_deprecated_function()
+
+if is_callable(deprecated_binding):  # error: [deprecated] "use replacement directly"
+    deprecated_binding()  # error: [deprecated] "use replacement directly"
 
 flag = bool(input())
 if flag:

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -560,6 +560,9 @@ def branch_alias(flag: bool):
 def factory() -> TypeOf[depr_func]:  # ty: ignore[deprecated]
     return depr_func  # ty: ignore[deprecated]
 
+constant_alias = depr_func if True else factory()  # error: [deprecated] "Use other_func instead"
+constant_alias()
+
 factory_alias = factory()
 factory_alias()  # error: [deprecated] "Use other_func instead"
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -496,6 +496,9 @@ second_alias()
 
 annotated_alias: Callable[..., Any] = depr_func  # error: [deprecated] "Use other_func instead"
 annotated_alias()
+
+(unpacked_alias,) = (depr_func,)  # error: [deprecated] "Use other_func instead"
+unpacked_alias()
 ```
 
 ## Dunders

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -143,6 +143,16 @@ deprecated_callable_instance_binding()  # error: [deprecated] "use callable_repl
 callable_replacement()
 deprecated_overload_binding()  # error: [deprecated] "deprecated replacement"
 
+class StaticMethodReplacement:
+    @staticmethod
+    @deprecated("use replacement directly")
+    @replace_with(replacement)
+    def old() -> None: ...
+
+StaticMethodReplacement.old()  # error: [deprecated] "use replacement directly"
+static_method_alias = StaticMethodReplacement.old  # error: [deprecated] "use replacement directly"
+static_method_alias()
+
 copy_of_deprecated_binding = deprecated_binding  # error: [deprecated] "use replacement directly"
 copy_of_deprecated_binding()
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -535,8 +535,15 @@ def other() -> str:
 def ordinary() -> str:
     return "ordinary"
 
+@deprecated("shared message")
+def shared_ordinary() -> str:
+    return "shared ordinary"
+
 def ordinary_factory() -> TypeOf[ordinary]:  # ty: ignore[deprecated]
     return ordinary  # ty: ignore[deprecated]
+
+def shared_ordinary_factory() -> TypeOf[shared_ordinary]:  # ty: ignore[deprecated]
+    return shared_ordinary  # ty: ignore[deprecated]
 
 def replace_with(value: R) -> Callable[[Callable[..., Any]], R]:
     raise NotImplementedError
@@ -558,6 +565,14 @@ if bool(input()):
 
 else:
     mixed = ordinary_factory()
+
+if bool(input()):
+    @deprecated("shared message")
+    @replace_with(replacement)
+    def shared() -> None: ...
+
+else:
+    shared = shared_ordinary_factory()
 ```
 
 `main.py`:
@@ -592,6 +607,10 @@ if is_replacement(mixed_alias):
 
 if is_ordinary(mixed_alias):
     mixed_alias()  # error: [deprecated] "ordinary deprecated"
+
+module.shared()  # error: [deprecated] "shared message"
+shared_alias = module.shared  # error: [deprecated] "shared message"
+shared_alias()
 ```
 
 ## Syntax

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -502,7 +502,7 @@ redundant and annoying.
 from collections.abc import Callable
 from typing import Any, TypeAlias
 from ty_extensions import TypeOf
-from typing_extensions import deprecated
+from typing_extensions import TypeGuard, deprecated
 
 @deprecated("Use OtherType instead")
 class DeprType: ...
@@ -572,6 +572,17 @@ def mixed_alias(flag: bool):
     else:
         mixed_value = factory()
     mixed_value()  # error: [deprecated] "Use other_func instead"
+
+def is_depr_func(value: object) -> TypeGuard[TypeOf[depr_func]]:  # ty: ignore[deprecated]
+    return True
+
+def narrowed_alias(flag: bool, unknown: object):
+    if flag:
+        narrowed_value = depr_func  # error: [deprecated] "Use other_func instead"
+    else:
+        narrowed_value = unknown
+    if is_depr_func(narrowed_value):
+        narrowed_value()  # error: [deprecated] "Use other_func instead"
 
 def loop_alias():
     alias = depr_func  # error: [deprecated] "Use other_func instead"

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -320,6 +320,47 @@ if is_replacement_class(MetaBindingWithFallback.binding):
     # error: [possibly-missing-attribute]
     MetaBindingWithFallback.binding()  # error: [deprecated] "metaclass replacement"
 
+class ReplacementDescriptor:
+    def __call__(self) -> str:
+        return "replacement"
+
+    def __get__(
+        self,
+        instance: object | None,
+        owner: type,
+    ) -> TypeOf[replacement]:
+        return replacement
+
+class OtherDescriptor:
+    def __call__(self) -> str:
+        return "other"
+
+    def __get__(
+        self,
+        instance: object | None,
+        owner: type,
+    ) -> TypeOf[other]:
+        return other
+
+replacement_descriptor = ReplacementDescriptor()
+other_descriptor = OtherDescriptor()
+
+class MixedDescriptor:
+    if flag:
+        @deprecated("descriptor replacement")
+        @replace_with(replacement_descriptor)
+        def binding(self) -> None: ...
+    else:
+        binding = other_descriptor
+
+def use_mixed_descriptor(instance: MixedDescriptor) -> None:
+    if is_replacement(instance.binding):
+        instance.binding()  # error: [deprecated] "descriptor replacement"
+
+    alias = instance.binding
+    if is_replacement(alias):
+        alias()  # error: [deprecated] "descriptor replacement"
+
 class DecoratedUnionMember:
     @deprecated("union replacement")
     @replace_with(ReplacementClass)

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -559,6 +559,13 @@ def factory() -> TypeOf[depr_func]:  # ty: ignore[deprecated]
 factory_alias = factory()
 factory_alias()  # error: [deprecated] "Use other_func instead"
 
+selected_factory_alias = (depr_func, factory())[1]  # error: [deprecated] "Use other_func instead"
+selected_factory_alias()  # error: [deprecated] "Use other_func instead"
+
+first_alias, unpacked_factory_alias = depr_func, factory()  # error: [deprecated] "Use other_func instead"
+first_alias()
+unpacked_factory_alias()  # error: [deprecated] "Use other_func instead"
+
 def mixed_alias(flag: bool):
     if flag:
         mixed_value = depr_func  # error: [deprecated] "Use other_func instead"

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -69,6 +69,9 @@ def replace_with_one_of(first: F, second: G) -> Callable[[Callable[..., Any]], F
         return first
     return decorator
 
+def replace_with_object(_: Callable[..., Any]) -> object:
+    return object()
+
 @deprecated("use replacement directly")
 @replace_with(replacement)
 def deprecated_binding() -> None: ...
@@ -78,11 +81,15 @@ def replaced_deprecated_function() -> None: ...
 @deprecated("use replacement or other directly")
 @replace_with_one_of(replacement, other)
 def deprecated_union_binding() -> None: ...
+@deprecated("this object is not callable")
+@replace_with_object
+def deprecated_object_binding() -> None: ...
 
 deprecated_binding()  # error: [deprecated] "use replacement directly"
 replacement()
 replaced_deprecated_function()
 deprecated_union_binding  # error: [deprecated] "use replacement or other directly"
+deprecated_object_binding
 
 static_assert(is_equivalent_to(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]
 static_assert(is_subtype_of(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -168,6 +168,10 @@ else:
 if is_replacement(narrowed_binding):
     narrowed_binding()  # error: [deprecated] "use replacement directly"
 
+narrowed_binding_alias = narrowed_binding
+if is_replacement(narrowed_binding_alias):
+    narrowed_binding_alias()  # error: [deprecated] "use replacement directly"
+
 if flag:
     chained_source = ordinary_deprecated_function  # error: [deprecated] "ordinary deprecated function"
 elif bool(input()):

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -336,6 +336,29 @@ def use_mixed_union(instance: DecoratedUnionMember | UndecoratedUnionMember) -> 
     if is_replacement_class(alias):
         alias()  # error: [deprecated] "union replacement"
 
+    outer = (inner := instance.binding)
+    if is_replacement_class(inner):
+        inner()  # error: [deprecated] "union replacement"
+    if is_replacement_class(outer):
+        outer()  # error: [deprecated] "union replacement"
+
+    (unpacked_outer,) = ((unpacked_inner := instance.binding),)
+    if is_replacement_class(unpacked_inner):
+        unpacked_inner()  # error: [deprecated] "union replacement"
+    if is_replacement_class(unpacked_outer):
+        unpacked_outer()  # error: [deprecated] "union replacement"
+
+    conditional = instance.binding if flag else OtherReplacementClass
+    if is_replacement_class(conditional):
+        conditional()  # error: [deprecated] "union replacement"
+
+    casted = cast(  # error: [redundant-cast]
+        TypeOf[ReplacementClass] | TypeOf[OtherReplacementClass],
+        instance.binding,
+    )
+    if is_replacement_class(casted):
+        casted()  # error: [deprecated] "union replacement"
+
 H = TypeVar("H", DecoratedUnionMember, UndecoratedUnionMember)
 
 def use_mixed_typevar(instance: H) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -562,6 +562,10 @@ factory_alias()  # error: [deprecated] "Use other_func instead"
 selected_factory_alias = (depr_func, factory())[1]  # error: [deprecated] "Use other_func instead"
 selected_factory_alias()  # error: [deprecated] "Use other_func instead"
 
+starred_factory_alias = (*[factory(), factory()], depr_func)[1]  # error: [deprecated] "Use other_func instead"
+# TODO: Preserve deprecated function-literal identity through starred tuple inference.
+starred_factory_alias()
+
 first_alias, unpacked_factory_alias = depr_func, factory()  # error: [deprecated] "Use other_func instead"
 first_alias()
 unpacked_factory_alias()  # error: [deprecated] "Use other_func instead"

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -172,6 +172,10 @@ narrowed_binding_alias = narrowed_binding
 if is_replacement(narrowed_binding_alias):
     narrowed_binding_alias()  # error: [deprecated] "use replacement directly"
 
+second_narrowed_binding_alias = narrowed_binding_alias
+if is_replacement(second_narrowed_binding_alias):
+    second_narrowed_binding_alias()  # error: [deprecated] "use replacement directly"
+
 if flag:
     chained_source = ordinary_deprecated_function  # error: [deprecated] "ordinary deprecated function"
 elif bool(input()):

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -511,6 +511,11 @@ named_alias()
 
 (unpacked_alias,) = (depr_func,)  # error: [deprecated] "Use other_func instead"
 unpacked_alias()
+
+def union_alias(flag: bool):
+    optional_alias = depr_func if flag else None  # error: [deprecated] "Use other_func instead"
+    if optional_alias is not None:
+        optional_alias()
 ```
 
 ## Dunders

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -736,6 +736,7 @@ class DeprType: ...
 
 @deprecated("Use other_func instead")
 def depr_func(): ...
+def regular_func(): ...
 
 class C:
     @deprecated("Use other_method instead")
@@ -789,6 +790,15 @@ def factory() -> TypeOf[depr_func]:  # ty: ignore[deprecated]
 
 constant_alias = depr_func if True else factory()  # error: [deprecated] "Use other_func instead"
 constant_alias()
+
+left_or_alias = depr_func or regular_func  # error: [deprecated] "Use other_func instead"
+left_or_alias()
+
+right_or_alias = None or depr_func  # error: [deprecated] "Use other_func instead"
+right_or_alias()
+
+right_and_alias = regular_func and depr_func  # error: [deprecated] "Use other_func instead"
+right_and_alias()
 
 factory_alias = factory()
 factory_alias()  # error: [deprecated] "Use other_func instead"

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -334,8 +334,17 @@ def use_mixed_union(instance: DecoratedUnionMember | UndecoratedUnionMember) -> 
 
     alias = instance.binding
     if is_replacement_class(alias):
-        # TODO: Expression inference does not retain binding-level deprecation metadata.
-        alias()  # TODO: error: [deprecated] "union replacement"
+        alias()  # error: [deprecated] "union replacement"
+
+H = TypeVar("H", DecoratedUnionMember, UndecoratedUnionMember)
+
+def use_mixed_typevar(instance: H) -> None:
+    if is_replacement_class(instance.binding):
+        instance.binding()  # error: [deprecated] "union replacement"
+
+    alias = instance.binding
+    if is_replacement_class(alias):
+        alias()  # error: [deprecated] "union replacement"
 
 T = TypeVar("T", D, E)
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -46,12 +46,11 @@ replacement function itself as deprecated.
 
 ```py
 from collections.abc import Callable
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar, cast, overload
 from ty_extensions import TypeOf, is_equivalent_to, static_assert
 from typing_extensions import TypeGuard, deprecated
 
-F = TypeVar("F", bound=Callable[..., Any])
-G = TypeVar("G", bound=Callable[..., Any])
+R = TypeVar("R")
 
 def replacement() -> str:
     return "replacement"
@@ -63,21 +62,8 @@ def other() -> str:
 def deprecated_replacement() -> str:
     return "deprecated replacement"
 
-def replace_with(replacement: F) -> Callable[[Callable[..., Any]], F]:
-    def decorator(_: Callable[..., Any]) -> F:
-        return replacement
-    return decorator
-
-def replace_with_one_of(first: F, second: G) -> Callable[[Callable[..., Any]], F | G]:
-    def decorator(_: Callable[..., Any]) -> F | G:
-        return first
-    return decorator
-
-def replace_with_object(_: Callable[..., Any]) -> object:
-    return object()
-
-def replace_with_callable(_: Callable[..., Any]) -> Callable[[], str]:
-    return replacement
+def replace_with(replacement: R) -> Callable[[Callable[..., Any]], R]:
+    raise NotImplementedError
 
 def is_replacement(value: object) -> TypeGuard[TypeOf[replacement]]:
     return True
@@ -96,17 +82,17 @@ def deprecated_binding() -> None: ...
 @deprecated("only the replaced function is deprecated")
 def replaced_deprecated_function() -> None: ...
 @deprecated("use replacement or other directly")
-@replace_with_one_of(replacement, other)
+@replace_with(cast(TypeOf[replacement] | TypeOf[other], replacement))
 def deprecated_union_binding() -> None: ...
 @deprecated("outer deprecation")
 @replace_with(replacement)
 @deprecated("inner deprecation")
 def deprecated_outer_binding() -> None: ...
 @deprecated("this object is not callable")
-@replace_with_object
+@replace_with(object())
 def deprecated_object_binding() -> None: ...
 @deprecated("callable replacement")
-@replace_with_callable
+@replace_with(cast(Callable[[], str], replacement))
 def deprecated_callable_binding() -> None: ...
 @deprecated("use ReplacementClass directly")
 @replace_with(ReplacementClass)
@@ -215,9 +201,7 @@ def replacement() -> str:
     return "replacement"
 
 def replace_with(replacement: F) -> Callable[[Callable[..., Any]], F]:
-    def decorator(_: Callable[..., Any]) -> F:
-        return replacement
-    return decorator
+    raise NotImplementedError
 
 @deprecated("use replacement directly")
 @replace_with(replacement)

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -38,6 +38,73 @@ MyClass.afunc()  # error: [deprecated] "use something else"
 MyClass().amethod()  # error: [deprecated] "don't use this!"
 ```
 
+## Decorator order
+
+`@deprecated` applies to the result of any inner decorators. If an inner decorator replaces a
+function with a different function, the public binding should be deprecated without marking the
+replacement function itself as deprecated.
+
+```py
+from collections.abc import Callable
+from typing import Any, TypeVar
+from ty_extensions import TypeOf, is_assignable_to, is_equivalent_to, is_subtype_of, static_assert
+from typing_extensions import deprecated
+
+F = TypeVar("F", bound=Callable[..., Any])
+G = TypeVar("G", bound=Callable[..., Any])
+
+def replacement() -> str:
+    return "replacement"
+
+def other() -> str:
+    return "other"
+
+def replace_with(replacement: F) -> Callable[[Callable[..., Any]], F]:
+    def decorator(_: Callable[..., Any]) -> F:
+        return replacement
+    return decorator
+
+def replace_with_one_of(first: F, second: G) -> Callable[[Callable[..., Any]], F | G]:
+    def decorator(_: Callable[..., Any]) -> F | G:
+        return first
+    return decorator
+
+@deprecated("use replacement directly")
+@replace_with(replacement)
+def deprecated_binding() -> None: ...
+@replace_with(replacement)
+@deprecated("only the replaced function is deprecated")
+def replaced_deprecated_function() -> None: ...
+@deprecated("use replacement or other directly")
+@replace_with_one_of(replacement, other)
+def deprecated_union_binding() -> None: ...
+
+deprecated_binding()  # error: [deprecated] "use replacement directly"
+replacement()
+replaced_deprecated_function()
+deprecated_union_binding  # error: [deprecated] "use replacement or other directly"
+
+static_assert(is_equivalent_to(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]
+static_assert(is_subtype_of(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]
+static_assert(is_assignable_to(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]
+
+flag = bool(input())
+if flag:
+    @deprecated("use replacement directly")
+    @replace_with(replacement)
+    def conditionally_defined() -> None: ...
+
+else:
+    @deprecated("use other directly")
+    @replace_with(other)
+    def conditionally_defined() -> None: ...
+
+conditionally_defined()  # TODO: error: [deprecated]
+```
+
+Deprecation attached to a decorated binding is currently only reported for direct module-level name
+loads with a single live binding. Merging this metadata across control flow is future work.
+
 ## Syntax
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -736,7 +736,6 @@ class DeprType: ...
 
 @deprecated("Use other_func instead")
 def depr_func(): ...
-def regular_func(): ...
 
 class C:
     @deprecated("Use other_method instead")
@@ -790,15 +789,6 @@ def factory() -> TypeOf[depr_func]:  # ty: ignore[deprecated]
 
 constant_alias = depr_func if True else factory()  # error: [deprecated] "Use other_func instead"
 constant_alias()
-
-left_or_alias = depr_func or regular_func  # error: [deprecated] "Use other_func instead"
-left_or_alias()
-
-right_or_alias = None or depr_func  # error: [deprecated] "Use other_func instead"
-right_or_alias()
-
-right_and_alias = regular_func and depr_func  # error: [deprecated] "Use other_func instead"
-right_and_alias()
 
 factory_alias = factory()
 factory_alias()  # error: [deprecated] "Use other_func instead"

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -503,6 +503,9 @@ second_alias()
 annotated_alias: Callable[..., Any] = depr_func  # error: [deprecated] "Use other_func instead"
 annotated_alias()
 
+(named_alias := depr_func)  # error: [deprecated] "Use other_func instead"
+named_alias()
+
 (unpacked_alias,) = (depr_func,)  # error: [deprecated] "Use other_func instead"
 unpacked_alias()
 ```

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -76,6 +76,9 @@ def replace_with_one_of(first: F, second: G) -> Callable[[Callable[..., Any]], F
 def replace_with_object(_: Callable[..., Any]) -> object:
     return object()
 
+def replace_with_callable(_: Callable[..., Any]) -> Callable[[], str]:
+    return replacement
+
 def is_replacement(value: object) -> TypeGuard[TypeOf[replacement]]:
     return True
 
@@ -102,6 +105,9 @@ def deprecated_outer_binding() -> None: ...
 @deprecated("this object is not callable")
 @replace_with_object
 def deprecated_object_binding() -> None: ...
+@deprecated("callable replacement")
+@replace_with_callable
+def deprecated_callable_binding() -> None: ...
 @deprecated("use ReplacementClass directly")
 @replace_with(ReplacementClass)
 def deprecated_class_binding() -> None: ...
@@ -116,6 +122,7 @@ replaced_deprecated_function()
 deprecated_union_binding  # error: [deprecated] "use replacement or other directly"
 deprecated_outer_binding()  # error: [deprecated] "outer deprecation"
 deprecated_object_binding
+deprecated_callable_binding()  # error: [deprecated] "callable replacement"
 deprecated_class_binding  # TODO: error: [deprecated] "use ReplacementClass directly"
 deprecated_overload_binding()  # error: [deprecated] "deprecated replacement"
 
@@ -142,37 +149,92 @@ else:
     def conditionally_defined() -> None: ...
 
 conditionally_defined()  # TODO: error: [deprecated]
+
+if flag:
+    @deprecated("same message")
+    @replace_with(replacement)
+    def same_message() -> None: ...
+
+else:
+    @deprecated("same message")
+    @replace_with(other)
+    def same_message() -> None: ...
+
+same_message()  # error: [deprecated] "same message"
+
+if True:
+    @deprecated("reachable binding")
+    @replace_with(replacement)
+    def statically_reachable() -> None: ...
+
+else:
+    @deprecated("unreachable binding")
+    @replace_with(other)
+    def statically_reachable() -> None: ...
+
+statically_reachable()  # error: [deprecated] "reachable binding"
+
+class C:
+    def replacement(self) -> str:
+        return "replacement"
+
+    @deprecated("use replacement directly")
+    @replace_with(replacement)
+    def deprecated_binding(self) -> None: ...
+
+C.deprecated_binding  # error: [deprecated] "use replacement directly"
+C().deprecated_binding  # error: [deprecated] "use replacement directly"
+
+class D(C): ...
+class E(C): ...
+
+T = TypeVar("T", D, E)
+
+def use_union(instance: D | E) -> None:
+    instance.deprecated_binding  # error: [deprecated] "use replacement directly"
+
+def use_typevar(instance: T) -> None:
+    instance.deprecated_binding  # error: [deprecated] "use replacement directly"
 ```
 
-Deprecation attached to a decorated binding is currently only reported for direct module-level name
-loads with a single live binding. Following it through multiple live bindings is future work.
+If control flow exposes multiple live decorated bindings with different deprecation messages, there
+is no single message to report.
 
-## Deferred annotations
+## Imported decorated binding
+
+`module.py`:
 
 ```py
-from __future__ import annotations
-
 from collections.abc import Callable
 from typing import Any, TypeVar
 from typing_extensions import deprecated
 
-C = TypeVar("C", bound=type)
+F = TypeVar("F", bound=Callable[..., Any])
 
-def replace_with(replacement: C) -> Callable[[Callable[..., Any]], C]:
-    def decorator(_: Callable[..., Any]) -> C:
+def replacement() -> str:
+    return "replacement"
+
+def replace_with(replacement: F) -> Callable[[Callable[..., Any]], F]:
+    def decorator(_: Callable[..., Any]) -> F:
         return replacement
     return decorator
 
-class Replacement: ...
-
-@deprecated("use Replacement")
-@replace_with(Replacement)
-def Old() -> None: ...
-
-value: Old  # TODO: error: [deprecated] "use Replacement"
+@deprecated("use replacement directly")
+@replace_with(replacement)
+def deprecated_binding() -> None: ...
 ```
 
-Deprecation attached to decorated bindings is not yet propagated into deferred annotation scopes.
+`main.py`:
+
+```py
+import module
+
+# error: [deprecated] "use replacement directly"
+from module import deprecated_binding
+
+deprecated_binding()  # error: [deprecated] "use replacement directly"
+module.deprecated_binding  # error: [deprecated] "use replacement directly"
+```
 
 ## Syntax
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -249,6 +249,18 @@ def mixed_nested_binding():
     if is_replacement(old):
         old()  # error: [deprecated] "mixed nested binding"
 
+@replace_with(replacement)
+def rebound_global() -> None: ...
+@deprecated("rebound global")
+@replace_with(replacement)
+def rebound_global() -> None: ...
+def use_rebound_global():
+    # TODO: Public types merge all reachable global bindings, including bindings before this
+    # function was defined. This also loses deprecation for ordinary decorated functions.
+    rebound_global()
+
+rebound_global()  # error: [deprecated] "rebound global"
+
 if True:
     @deprecated("reachable binding")
     @replace_with(replacement)

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -85,7 +85,6 @@ callable_replacement = CallableReplacement()
 
 @deprecated("ordinary deprecated function")
 def ordinary_deprecated_function() -> None: ...
-
 def deprecated_factory() -> TypeOf[ordinary_deprecated_function]:  # ty: ignore[deprecated]
     return ordinary_deprecated_function  # ty: ignore[deprecated]
 
@@ -155,6 +154,7 @@ if flag:
     @deprecated("use replacement directly")
     @replace_with(replacement)
     def narrowed_binding() -> None: ...
+
 else:
     narrowed_binding = other
 
@@ -216,6 +216,7 @@ for _ in range(1):
         @deprecated("mixed loop binding")
         @replace_with(replacement)
         def mixed_loop_binding() -> None: ...
+
     else:
         mixed_loop_binding = other
 
@@ -241,6 +242,7 @@ def mixed_nested_binding():
             @deprecated("mixed nested binding")
             @replace_with(replacement)
             def old() -> None: ...
+
         else:
             old = other
 
@@ -350,6 +352,7 @@ class MixedDescriptor:
         @deprecated("descriptor replacement")
         @replace_with(replacement_descriptor)
         def binding(self) -> None: ...
+
     else:
         binding = other_descriptor
 

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -102,6 +102,12 @@ def replaced_deprecated_function() -> None: ...
 @deprecated("use replacement or other directly")
 @replace_with(cast(TypeOf[replacement] | TypeOf[other], replacement))
 def deprecated_union_binding() -> None: ...
+@deprecated("deprecated union arm")
+def deprecated_union_arm() -> str:
+    return "deprecated union arm"
+@deprecated("outer union binding")
+@replace_with(cast(TypeOf[deprecated_union_arm] | TypeOf[other], deprecated_union_arm))  # ty: ignore[deprecated]
+def duplicate_policy_binding() -> None: ...
 @deprecated("outer deprecation")
 @replace_with(replacement)
 @deprecated("inner deprecation")
@@ -127,6 +133,7 @@ deprecated_binding()  # error: [deprecated] "use replacement directly"
 replacement()
 replaced_deprecated_function()
 deprecated_union_binding  # error: [deprecated] "use replacement or other directly"
+duplicate_policy_alias = duplicate_policy_binding  # error: [deprecated] "outer union binding"
 deprecated_outer_binding()  # error: [deprecated] "outer deprecation"
 deprecated_object_binding
 deprecated_callable_binding()  # error: [deprecated] "callable replacement"

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -141,6 +141,16 @@ flag = bool(input())
 if flag:
     @deprecated("use replacement directly")
     @replace_with(replacement)
+    def narrowed_binding() -> None: ...
+else:
+    narrowed_binding = other
+
+if is_replacement(narrowed_binding):
+    narrowed_binding()  # error: [deprecated] "use replacement directly"
+
+if flag:
+    @deprecated("use replacement directly")
+    @replace_with(replacement)
     def conditionally_defined() -> None: ...
 
 else:

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -298,6 +298,28 @@ class ClassChildWithFallback(ClassBaseWithFallback):
 if is_replacement_class(ClassChildWithFallback.binding):
     ClassChildWithFallback.binding()  # error: [deprecated] "child class replacement"
 
+class ReplacementMeta(type):
+    if flag:
+        @deprecated("metaclass replacement")
+        @replace_with(ReplacementClass)
+        def binding() -> None: ...
+
+class DirectMetaBinding(metaclass=ReplacementMeta): ...
+
+class MetaBindingWithFallback(metaclass=ReplacementMeta):
+    if flag:
+        binding = OtherReplacementClass
+
+# error: [possibly-missing-attribute]
+if is_replacement_class(DirectMetaBinding.binding):  # error: [deprecated] "metaclass replacement"
+    # error: [possibly-missing-attribute]
+    DirectMetaBinding.binding()  # error: [deprecated] "metaclass replacement"
+
+# error: [possibly-missing-attribute]
+if is_replacement_class(MetaBindingWithFallback.binding):
+    # error: [possibly-missing-attribute]
+    MetaBindingWithFallback.binding()  # error: [deprecated] "metaclass replacement"
+
 T = TypeVar("T", D, E)
 
 def use_union(instance: D | E) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -512,6 +512,57 @@ deprecated_binding()  # error: [deprecated] "use replacement directly"
 module.deprecated_binding  # error: [deprecated] "use replacement directly"
 ```
 
+## Imported conditional decorated binding
+
+`module.py`:
+
+```py
+from collections.abc import Callable
+from typing import Any, TypeVar
+from typing_extensions import deprecated
+
+R = TypeVar("R")
+
+def replacement() -> str:
+    return "replacement"
+
+def other() -> str:
+    return "other"
+
+def replace_with(value: R) -> Callable[[Callable[..., Any]], R]:
+    raise NotImplementedError
+
+if bool(input()):
+    @deprecated("use replacement directly")
+    @replace_with(replacement)
+    def old() -> None: ...
+else:
+    @deprecated("use other directly")
+    @replace_with(other)
+    def old() -> None: ...
+```
+
+`main.py`:
+
+```py
+from ty_extensions import TypeOf
+from typing_extensions import TypeGuard
+
+from module import old, other, replacement
+
+def is_replacement(value: object) -> TypeGuard[TypeOf[replacement]]:
+    return True
+
+def is_other(value: object) -> TypeGuard[TypeOf[other]]:
+    return True
+
+if is_replacement(old):
+    old()  # error: [deprecated] "use replacement directly"
+
+if is_other(old):
+    old()  # error: [deprecated] "use other directly"
+```
+
 ## Syntax
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -73,6 +73,12 @@ def is_callable(value: object) -> TypeGuard[Callable[..., Any]]:
 
 class ReplacementClass: ...
 
+class CallableReplacement:
+    def __call__(self) -> str:
+        return "replacement"
+
+callable_replacement = CallableReplacement()
+
 @deprecated("ordinary deprecated function")
 def ordinary_deprecated_function() -> None: ...
 @deprecated("use replacement directly")
@@ -97,6 +103,9 @@ def deprecated_callable_binding() -> None: ...
 @deprecated("use ReplacementClass directly")
 @replace_with(ReplacementClass)
 def deprecated_class_binding() -> None: ...
+@deprecated("use callable_replacement directly")
+@replace_with(callable_replacement)
+def deprecated_callable_instance_binding() -> None: ...
 @deprecated("overload binding")
 @overload
 @replace_with(deprecated_replacement)  # error: [deprecated] "deprecated replacement"
@@ -109,7 +118,9 @@ deprecated_union_binding  # error: [deprecated] "use replacement or other direct
 deprecated_outer_binding()  # error: [deprecated] "outer deprecation"
 deprecated_object_binding
 deprecated_callable_binding()  # error: [deprecated] "callable replacement"
-deprecated_class_binding  # TODO: error: [deprecated] "use ReplacementClass directly"
+deprecated_class_binding  # error: [deprecated] "use ReplacementClass directly"
+deprecated_callable_instance_binding()  # error: [deprecated] "use callable_replacement directly"
+callable_replacement()
 deprecated_overload_binding()  # error: [deprecated] "deprecated replacement"
 
 copy_of_deprecated_binding = deprecated_binding  # error: [deprecated] "use replacement directly"

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -105,6 +105,7 @@ def deprecated_union_binding() -> None: ...
 @deprecated("deprecated union arm")
 def deprecated_union_arm() -> str:
     return "deprecated union arm"
+
 @deprecated("outer union binding")
 @replace_with(cast(TypeOf[deprecated_union_arm] | TypeOf[other], deprecated_union_arm))  # ty: ignore[deprecated]
 def duplicate_policy_binding() -> None: ...
@@ -536,6 +537,7 @@ if bool(input()):
     @deprecated("use replacement directly")
     @replace_with(replacement)
     def old() -> None: ...
+
 else:
     @deprecated("use other directly")
     @replace_with(other)
@@ -814,7 +816,6 @@ class DeprType: ...
 
 @deprecated("Use other_func instead")
 def depr_func(): ...
-
 def regular_func(): ...
 
 class C:

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -112,6 +112,9 @@ deprecated_callable_binding()  # error: [deprecated] "callable replacement"
 deprecated_class_binding  # TODO: error: [deprecated] "use ReplacementClass directly"
 deprecated_overload_binding()  # error: [deprecated] "deprecated replacement"
 
+copy_of_deprecated_binding = deprecated_binding  # error: [deprecated] "use replacement directly"
+copy_of_deprecated_binding()
+
 static_assert(is_equivalent_to(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]
 
 if deprecated_binding is not replacement:  # error: [deprecated] "use replacement directly"
@@ -461,6 +464,8 @@ the deprecated symbol to assign it to something else. These kinds of diagnostics
 redundant and annoying.
 
 ```py
+from collections.abc import Callable
+from typing import Any
 from typing_extensions import deprecated
 
 @deprecated("Use OtherType instead")
@@ -472,9 +477,14 @@ def depr_func(): ...
 alias_func = depr_func  # error: [deprecated] "Use other_func instead"
 AliasClass = DeprType  # error: [deprecated] "Use OtherType instead"
 
-# TODO: these diagnostics ideally shouldn't fire
-alias_func()  # error: [deprecated] "Use other_func instead"
-AliasClass()  # error: [deprecated] "Use OtherType instead"
+alias_func()
+AliasClass()
+
+second_alias = alias_func
+second_alias()
+
+annotated_alias: Callable[..., Any] = depr_func  # error: [deprecated] "Use other_func instead"
+annotated_alias()
 ```
 
 ## Dunders

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -81,6 +81,15 @@ callable_replacement = CallableReplacement()
 
 @deprecated("ordinary deprecated function")
 def ordinary_deprecated_function() -> None: ...
+
+def deprecated_factory() -> TypeOf[ordinary_deprecated_function]:  # ty: ignore[deprecated]
+    return ordinary_deprecated_function  # ty: ignore[deprecated]
+
+def is_ordinary_deprecated(
+    value: object,
+) -> TypeGuard[TypeOf[ordinary_deprecated_function]]:  # ty: ignore[deprecated]
+    return True
+
 @deprecated("use replacement directly")
 @replace_with(replacement)
 def deprecated_binding() -> None: ...
@@ -147,6 +156,17 @@ else:
 
 if is_replacement(narrowed_binding):
     narrowed_binding()  # error: [deprecated] "use replacement directly"
+
+if flag:
+    chained_source = ordinary_deprecated_function  # error: [deprecated] "ordinary deprecated function"
+elif bool(input()):
+    chained_source = deprecated_factory()
+else:
+    chained_source = replacement
+
+chained_alias = chained_source
+if is_ordinary_deprecated(chained_alias):
+    chained_alias()  # error: [deprecated] "ordinary deprecated function"
 
 if flag:
     @deprecated("use replacement directly")

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -545,11 +545,26 @@ def union_alias(flag: bool):
     if optional_alias is not None:
         optional_alias()
 
+def branch_alias(flag: bool):
+    if flag:
+        branch_value = depr_func  # error: [deprecated] "Use other_func instead"
+    else:
+        branch_value = None
+    if branch_value is not None:
+        branch_value()
+
 def factory() -> TypeOf[depr_func]:  # ty: ignore[deprecated]
     return depr_func  # ty: ignore[deprecated]
 
 factory_alias = factory()
 factory_alias()  # error: [deprecated] "Use other_func instead"
+
+def mixed_alias(flag: bool):
+    if flag:
+        mixed_value = depr_func  # error: [deprecated] "Use other_func instead"
+    else:
+        mixed_value = factory()
+    mixed_value()  # error: [deprecated] "Use other_func instead"
 
 def loop_alias():
     alias = depr_func  # error: [deprecated] "Use other_func instead"

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -476,7 +476,7 @@ redundant and annoying.
 
 ```py
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TypeAlias
 from typing_extensions import deprecated
 
 @deprecated("Use OtherType instead")
@@ -502,6 +502,9 @@ second_alias()
 
 annotated_alias: Callable[..., Any] = depr_func  # error: [deprecated] "Use other_func instead"
 annotated_alias()
+
+ExplicitAlias: TypeAlias = DeprType  # error: [deprecated] "Use OtherType instead"
+explicit_value: ExplicitAlias
 
 (named_alias := depr_func)  # error: [deprecated] "Use other_func instead"
 named_alias()

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -47,7 +47,7 @@ replacement function itself as deprecated.
 ```py
 from collections.abc import Callable
 from typing import Any, TypeVar
-from ty_extensions import TypeOf, is_assignable_to, is_equivalent_to, is_subtype_of, static_assert
+from ty_extensions import TypeOf, is_equivalent_to, static_assert
 from typing_extensions import deprecated
 
 F = TypeVar("F", bound=Callable[..., Any])
@@ -72,6 +72,8 @@ def replace_with_one_of(first: F, second: G) -> Callable[[Callable[..., Any]], F
 def replace_with_object(_: Callable[..., Any]) -> object:
     return object()
 
+class ReplacementClass: ...
+
 @deprecated("use replacement directly")
 @replace_with(replacement)
 def deprecated_binding() -> None: ...
@@ -84,16 +86,18 @@ def deprecated_union_binding() -> None: ...
 @deprecated("this object is not callable")
 @replace_with_object
 def deprecated_object_binding() -> None: ...
+@deprecated("use ReplacementClass directly")
+@replace_with(ReplacementClass)
+def deprecated_class_binding() -> None: ...
 
 deprecated_binding()  # error: [deprecated] "use replacement directly"
 replacement()
 replaced_deprecated_function()
 deprecated_union_binding  # error: [deprecated] "use replacement or other directly"
 deprecated_object_binding
+deprecated_class_binding  # TODO: error: [deprecated] "use ReplacementClass directly"
 
 static_assert(is_equivalent_to(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]
-static_assert(is_subtype_of(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]
-static_assert(is_assignable_to(TypeOf[deprecated_binding], TypeOf[replacement]))  # error: [deprecated]
 
 if deprecated_binding is not replacement:  # error: [deprecated] "use replacement directly"
     deprecated_binding()
@@ -113,7 +117,7 @@ conditionally_defined()  # TODO: error: [deprecated]
 ```
 
 Deprecation attached to a decorated binding is currently only reported for direct module-level name
-loads with a single live binding. Merging this metadata across control flow is future work.
+loads with a single live binding. Following it through multiple live bindings is future work.
 
 ## Deferred annotations
 

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -449,7 +449,7 @@ python-version = "3.11"
 ```
 
 ```py
-from typing_extensions import Annotated, Literal, TypeAlias
+from typing_extensions import Annotated, Literal, TypeAlias, deprecated
 
 GoodTypeAlias: TypeAlias = Annotated[int, (1, 3.14, lambda x: x)]
 GoodTypeAlias: TypeAlias = tuple[int, *tuple[str, ...]]
@@ -470,6 +470,11 @@ BadTypeAlias10: TypeAlias = True  # error: [invalid-type-form]
 BadTypeAlias11: TypeAlias = 1  # error: [invalid-type-form]
 BadTypeAlias12: TypeAlias = list or set  # error: [invalid-type-form]
 BadTypeAlias13: TypeAlias = f"{'int'}"  # error: [invalid-type-form]
+
+@deprecated("Use NewType instead")
+class OldType: ...
+
+DeprecatedConditionalAlias: TypeAlias = OldType if bool() else int  # error: [invalid-type-form]  # error: [deprecated] "Use NewType instead"
 
 # bonus ones from Alex:
 #

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -474,7 +474,9 @@ BadTypeAlias13: TypeAlias = f"{'int'}"  # error: [invalid-type-form]
 @deprecated("Use NewType instead")
 class OldType: ...
 
-DeprecatedConditionalAlias: TypeAlias = OldType if bool() else int  # error: [invalid-type-form]  # error: [deprecated] "Use NewType instead"
+DeprecatedConditionalAlias: TypeAlias = (
+    OldType if bool() else int  # error: [invalid-type-form]  # error: [deprecated] "Use NewType instead"
+)
 
 # bonus ones from Alex:
 #

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1849,14 +1849,14 @@ fn place_from_bindings_impl<'db>(
     let ty = if let Some((first, first_reachability)) = types.next() {
         Some(if let Some((second, second_reachability)) = types.next() {
             let mut builder = PublicTypeBuilder::new(db);
-            builder.add(first, first_reachability);
-            builder.add(second, second_reachability);
+            builder.add(first, (), first_reachability);
+            builder.add(second, (), second_reachability);
 
             for (ty, reachability) in types {
-                builder.add(ty, reachability);
+                builder.add(ty, (), reachability);
             }
 
-            builder.build()
+            builder.build().0
         } else {
             first
         })
@@ -1928,32 +1928,35 @@ impl<'db> PlaceWithDefinition<'db> {
 /// `@overload`ed function literal types are discarded if they are definitely followed
 /// by their implementation. This is to ensure that we do not merge all of them into the
 /// union type. The last one will include the other overloads already.
-struct PublicTypeBuilder<'db> {
+struct PublicTypeBuilder<'db, M> {
     db: &'db dyn Db,
-    queue: Option<Type<'db>>,
+    queue: Option<(Type<'db>, M)>,
     builder: UnionBuilder<'db>,
+    accepted: Vec<(Type<'db>, M)>,
 }
 
-impl<'db> PublicTypeBuilder<'db> {
+impl<'db, M> PublicTypeBuilder<'db, M> {
     fn new(db: &'db dyn Db) -> Self {
         PublicTypeBuilder {
             db,
             queue: None,
             builder: UnionBuilder::new(db),
+            accepted: Vec::new(),
         }
     }
 
-    fn add_to_union(&mut self, element: Type<'db>) {
+    fn add_to_union(&mut self, element: Type<'db>, metadata: M) {
         self.builder.add_in_place(element);
+        self.accepted.push((element, metadata));
     }
 
     fn drain_queue(&mut self) {
-        if let Some(queued_element) = self.queue.take() {
-            self.add_to_union(queued_element);
+        if let Some((queued_element, metadata)) = self.queue.take() {
+            self.add_to_union(queued_element, metadata);
         }
     }
 
-    fn add(&mut self, element: Type<'db>, reachability: Truthiness) -> bool {
+    fn add(&mut self, element: Type<'db>, metadata: M, reachability: Truthiness) -> bool {
         match element {
             Type::FunctionLiteral(function) => {
                 let last_definition = function.literal(self.db).last_definition;
@@ -1961,8 +1964,8 @@ impl<'db> PublicTypeBuilder<'db> {
                     // Distinct overloaded function values can be assigned to the same public
                     // symbol in separate branches. Preserve the queued value unless the next
                     // overload belongs to the same place.
-                    if !self.queue.is_some_and(|queued| {
-                        let Type::FunctionLiteral(queued_function) = queued else {
+                    if !self.queue.as_ref().is_some_and(|queued| {
+                        let Type::FunctionLiteral(queued_function) = queued.0 else {
                             return false;
                         };
                         function.has_same_place_as(self.db, queued_function)
@@ -1970,15 +1973,15 @@ impl<'db> PublicTypeBuilder<'db> {
                         self.drain_queue();
                     }
 
-                    self.queue = Some(element);
+                    self.queue = Some((element, metadata));
                     false
                 } else {
                     // An unconditional implementation shadows preceding overload definitions. A
                     // conditional definition, however, can be only one public possibility among
                     // several, so keep any unrelated queued overloaded function in the union.
                     if reachability.is_always_true()
-                        || self.queue.is_some_and(|queued| {
-                            let Type::FunctionLiteral(queued_function) = queued else {
+                        || self.queue.as_ref().is_some_and(|queued| {
+                            let Type::FunctionLiteral(queued_function) = queued.0 else {
                                 return false;
                             };
                             let queued_definition = queued_function.last_definition(self.db);
@@ -1989,30 +1992,29 @@ impl<'db> PublicTypeBuilder<'db> {
                     } else {
                         self.drain_queue();
                     }
-                    self.add_to_union(element);
+                    self.add_to_union(element, metadata);
                     true
                 }
             }
             _ => {
                 self.drain_queue();
-                self.add_to_union(element);
+                self.add_to_union(element, metadata);
                 true
             }
         }
     }
 
-    fn build(mut self) -> Type<'db> {
+    fn build(mut self) -> (Type<'db>, Vec<(Type<'db>, M)>) {
         self.drain_queue();
-        self.builder.build()
+        (self.builder.build(), self.accepted)
     }
 }
 
 /// Accumulates multiple (potentially conflicting) declared types and type qualifiers,
 /// and eventually builds a union from them.
 struct DeclaredTypeBuilder<'db> {
-    inner: PublicTypeBuilder<'db>,
+    inner: PublicTypeBuilder<'db, DeprecationPolicy<'db>>,
     qualifiers: TypeQualifiers,
-    deprecation: DeprecationBuilder<'db>,
     first_type: Option<Type<'db>>,
     conflicting_types: FxOrderSet<Type<'db>>,
 }
@@ -2022,7 +2024,6 @@ impl<'db> DeclaredTypeBuilder<'db> {
         DeclaredTypeBuilder {
             inner: PublicTypeBuilder::new(db),
             qualifiers: TypeQualifiers::empty(),
-            deprecation: DeprecationBuilder::default(),
             first_type: None,
             conflicting_types: FxOrderSet::default(),
         }
@@ -2031,7 +2032,10 @@ impl<'db> DeclaredTypeBuilder<'db> {
     fn add(&mut self, element: &TypeAndQualifiers<'db>, reachability: Truthiness) {
         let element_ty = element.inner_type();
 
-        if self.inner.add(element_ty, reachability) {
+        if self
+            .inner
+            .add(element_ty, element.deprecation_policy(), reachability)
+        {
             if let Some(first_ty) = self.first_type {
                 if !first_ty.is_equivalent_to(self.inner.db, element_ty) {
                     self.conflicting_types.insert(element_ty);
@@ -2042,13 +2046,16 @@ impl<'db> DeclaredTypeBuilder<'db> {
         }
 
         self.qualifiers = self.qualifiers.union(element.qualifiers());
-        self.deprecation.add_policy(element.deprecation_policy());
     }
 
     fn build(mut self) -> DeclaredTypeAndConflictingTypes<'db> {
-        let type_and_quals =
-            TypeAndQualifiers::new(self.inner.build(), TypeOrigin::Declared, self.qualifiers)
-                .with_deprecation_policy(self.deprecation.build_policy());
+        let db = self.inner.db;
+        let (ty, deprecation_alternatives) = self.inner.build();
+        let type_and_quals = TypeAndQualifiers::new(ty, TypeOrigin::Declared, self.qualifiers)
+            .with_deprecation_policy(DeprecationPolicy::from_alternatives(
+                db,
+                deprecation_alternatives,
+            ));
         if self.conflicting_types.is_empty() {
             (type_and_quals, None)
         } else {

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -117,7 +117,10 @@ impl<'db> DeprecationPolicy<'db> {
         let mut deprecation = BindingDeprecationBuilder::default();
         for (alternative_ty, policy) in alternatives.alternatives(db) {
             if !deprecation_alternative_is_eliminated(db, *alternative_ty, ty) {
-                deprecation.add_policy(policy.resolve_for_type(db, ty), ty.is_deprecated(db));
+                deprecation.add_policy(
+                    policy.resolve_for_type(db, ty),
+                    alternative_ty.is_deprecated(db),
+                );
             }
         }
         deprecation.build_policy()
@@ -133,24 +136,16 @@ impl<'db> DeprecationPolicy<'db> {
         for (alternative_ty, policy) in alternatives.alternatives(db) {
             if deprecation_types_share_single_value(db, *alternative_ty, ty) {
                 has_matching_alternative = true;
-                deprecation.add_policy(policy.resolve_for_type(db, ty), ty.is_deprecated(db));
+                deprecation.add_policy(
+                    policy.resolve_for_type(db, ty),
+                    alternative_ty.is_deprecated(db),
+                );
             }
         }
         if has_matching_alternative {
             deprecation.build_policy()
         } else {
             self.resolve_for_type(db, ty)
-        }
-    }
-
-    pub(crate) fn contains_deprecated(self, db: &'db dyn Db) -> bool {
-        match self {
-            Self::Deprecated(_) => true,
-            Self::Alternatives(alternatives) => alternatives
-                .alternatives(db)
-                .iter()
-                .any(|(_, policy)| policy.contains_deprecated(db)),
-            Self::Inherit | Self::Suppress => false,
         }
     }
 }

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -59,7 +59,7 @@ pub(crate) enum TypeOrigin {
 }
 
 /// Controls how deprecation is reported when a place is loaded.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+#[derive(Debug, Clone, Copy, Default, Hash, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub(crate) enum DeprecationPolicy<'db> {
     /// Inspect the inferred type for deprecation.
     #[default]
@@ -68,6 +68,91 @@ pub(crate) enum DeprecationPolicy<'db> {
     Suppress,
     /// Report deprecation attached directly to this binding.
     Deprecated(DeprecatedInstance<'db>),
+    /// Preserve policies for typed alternatives across merged bindings.
+    Alternatives(DeprecationAlternatives<'db>),
+}
+
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+pub(crate) struct DeprecationAlternatives<'db> {
+    #[returns(ref)]
+    alternatives: Box<[(Type<'db>, DeprecationPolicy<'db>)]>,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for DeprecationAlternatives<'_> {}
+
+impl<'db> DeprecationPolicy<'db> {
+    pub(crate) fn from_alternatives(
+        db: &'db dyn Db,
+        alternatives: impl IntoIterator<Item = (Type<'db>, Self)>,
+    ) -> Self {
+        let mut flattened = Vec::new();
+        for (ty, policy) in alternatives {
+            match policy {
+                Self::Alternatives(alternatives) => {
+                    flattened.extend_from_slice(alternatives.alternatives(db));
+                }
+                _ => flattened.push((ty, policy)),
+            }
+        }
+
+        let Some((_, first)) = flattened.first().copied() else {
+            return Self::Inherit;
+        };
+        if flattened.iter().all(|(_, policy)| *policy == first) {
+            first
+        } else {
+            Self::Alternatives(DeprecationAlternatives::new(
+                db,
+                flattened.into_boxed_slice(),
+            ))
+        }
+    }
+
+    pub(crate) fn resolve_for_type(self, db: &'db dyn Db, ty: Type<'db>) -> Self {
+        let Self::Alternatives(alternatives) = self else {
+            return self;
+        };
+
+        let mut deprecation = BindingDeprecationBuilder::default();
+        for (alternative_ty, policy) in alternatives.alternatives(db) {
+            if !deprecation_alternative_is_eliminated(db, *alternative_ty, ty) {
+                deprecation.add_policy(policy.resolve_for_type(db, ty), ty.is_deprecated(db));
+            }
+        }
+        deprecation.build_policy()
+    }
+}
+
+fn deprecation_alternative_is_eliminated<'db>(
+    db: &'db dyn Db,
+    original: Type<'db>,
+    narrowed: Type<'db>,
+) -> bool {
+    fn has_same_single_value<'db>(
+        db: &'db dyn Db,
+        original: Type<'db>,
+        narrowed: Type<'db>,
+    ) -> bool {
+        match (original, narrowed) {
+            (Type::Union(union), narrowed) => union
+                .elements(db)
+                .iter()
+                .any(|element| has_same_single_value(db, *element, narrowed)),
+            (original, Type::Union(union)) => union
+                .elements(db)
+                .iter()
+                .any(|element| has_same_single_value(db, original, *element)),
+            (Type::FunctionLiteral(left), Type::FunctionLiteral(right)) => {
+                left.literal(db) == right.literal(db)
+            }
+            _ => original == narrowed,
+        }
+    }
+
+    !has_same_single_value(db, original, narrowed)
+        && (original.is_disjoint_from(db, narrowed)
+            || (original.is_single_valued(db) && narrowed.is_single_valued(db)))
 }
 
 impl TypeOrigin {
@@ -1588,7 +1673,7 @@ fn place_from_bindings_impl<'db>(
     let mut first_definition = None;
     // special handling for synthetic loop header definitions and nested bindings definitions
     let mut only_non_shadowing_bindings = true;
-    let mut deprecation = BindingDeprecationBuilder::default();
+    let mut deprecation_alternatives = Vec::new();
 
     let mut types = bindings_with_constraints.filter_map(
         |BindingWithConstraints {
@@ -1702,23 +1787,17 @@ fn place_from_bindings_impl<'db>(
             let binding_ty = inference.binding_type(binding);
             let narrowed_ty = narrowing_constraint.narrow(db, binding_ty, binding.place(db));
             first_definition.get_or_insert(binding);
-            let same_single_value = match (binding_ty, narrowed_ty) {
-                (Type::FunctionLiteral(left), Type::FunctionLiteral(right)) => {
-                    left.literal(db) == right.literal(db)
-                }
-                _ => binding_ty == narrowed_ty,
-            };
-            let binding_is_eliminated = !same_single_value
-                && (binding_ty.is_disjoint_from(db, narrowed_ty)
-                    || (binding_ty.is_single_valued(db) && narrowed_ty.is_single_valued(db)));
             let binding_deprecation = inference
                 .inferred_declaration(binding)
                 .declared()
                 .map_or(DeprecationPolicy::Inherit, |declaration| {
                     declaration.deprecation_policy()
-                });
-            if !narrowed_ty.is_never() && !binding_is_eliminated {
-                deprecation.add_policy(binding_deprecation, narrowed_ty.is_deprecated(db));
+                })
+                .resolve_for_type(db, narrowed_ty);
+            if !narrowed_ty.is_never()
+                && !deprecation_alternative_is_eliminated(db, binding_ty, narrowed_ty)
+            {
+                deprecation_alternatives.push((narrowed_ty, binding_deprecation));
             }
             Some((narrowed_ty, static_reachability))
         },
@@ -1777,9 +1856,8 @@ fn place_from_bindings_impl<'db>(
     let deprecation = if place.is_undefined() {
         DeprecationPolicy::Inherit
     } else {
-        deprecation.build_policy()
+        DeprecationPolicy::from_alternatives(db, deprecation_alternatives)
     };
-
     PlaceWithDefinition {
         place,
         first_definition,

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1698,17 +1698,28 @@ fn place_from_bindings_impl<'db>(
                 only_non_shadowing_bindings = false;
             }
 
-            first_definition.get_or_insert(binding);
             let inference = infer_definition_types(db, binding);
             let binding_ty = inference.binding_type(binding);
+            let narrowed_ty = narrowing_constraint.narrow(db, binding_ty, binding.place(db));
+            first_definition.get_or_insert(binding);
+            let same_single_value = match (binding_ty, narrowed_ty) {
+                (Type::FunctionLiteral(left), Type::FunctionLiteral(right)) => {
+                    left.literal(db) == right.literal(db)
+                }
+                _ => binding_ty == narrowed_ty,
+            };
+            let binding_is_eliminated = !same_single_value
+                && (binding_ty.is_disjoint_from(db, narrowed_ty)
+                    || (binding_ty.is_single_valued(db) && narrowed_ty.is_single_valued(db)));
             let binding_deprecation = inference
                 .inferred_declaration(binding)
                 .declared()
                 .map_or(DeprecationPolicy::Inherit, |declaration| {
                     declaration.deprecation_policy()
                 });
-            let narrowed_ty = narrowing_constraint.narrow(db, binding_ty, binding.place(db));
-            deprecation.add_policy(binding_deprecation, narrowed_ty.is_deprecated(db));
+            if !narrowed_ty.is_never() && !binding_is_eliminated {
+                deprecation.add_policy(binding_deprecation, narrowed_ty.is_deprecated(db));
+            }
             Some((narrowed_ty, static_reachability))
         },
     );

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1275,9 +1275,9 @@ pub(crate) fn place_by_id<'db>(
             let boundness_analysis = bindings.boundness_analysis();
             let inferred = place_from_bindings_impl(db, bindings, requires_explicit_reexport);
 
-            let place = match inferred.place {
+            let (place, deprecation) = match inferred.place {
                 // Place is possibly undeclared and definitely unbound
-                Place::Undefined => {
+                Place::Undefined => (
                     // TODO: We probably don't want to report `AlwaysDefined` here. This requires a bit of
                     // design work though as we might want a different behavior for stubs and for
                     // normal modules.
@@ -1286,32 +1286,39 @@ pub(crate) fn place_by_id<'db>(
                         origin,
                         definedness: Definedness::AlwaysDefined,
                         public_type_policy: PublicTypePolicy::Raw,
-                    })
-                }
+                    }),
+                    merge_deprecation_policy(declared_deprecation, inferred.deprecation),
+                ),
                 // Place is possibly undeclared and (possibly) bound
                 Place::Defined(DefinedPlace {
                     ty: inferred_ty,
                     origin,
                     definedness: boundness,
                     ..
-                }) => Place::Defined(DefinedPlace {
-                    ty: UnionType::from_two_elements(db, inferred_ty, declared_ty),
-                    origin,
-                    definedness: if boundness_analysis == BoundnessAnalysis::AssumeBound {
-                        Definedness::AlwaysDefined
-                    } else {
-                        boundness
-                    },
-                    public_type_policy: PublicTypePolicy::Raw,
-                }),
+                }) => (
+                    Place::Defined(DefinedPlace {
+                        ty: UnionType::from_two_elements(db, inferred_ty, declared_ty),
+                        origin,
+                        definedness: if boundness_analysis == BoundnessAnalysis::AssumeBound {
+                            Definedness::AlwaysDefined
+                        } else {
+                            boundness
+                        },
+                        public_type_policy: PublicTypePolicy::Raw,
+                    }),
+                    DeprecationPolicy::from_alternatives(
+                        db,
+                        [
+                            (declared_ty, declared_deprecation),
+                            (inferred_ty, inferred.deprecation),
+                        ],
+                    ),
+                ),
             };
 
             place
                 .with_qualifiers(qualifiers)
-                .with_deprecation_policy(merge_deprecation_policy(
-                    declared_deprecation,
-                    inferred.deprecation,
-                ))
+                .with_deprecation_policy(deprecation)
         }
         // Place is undeclared, infer the type from bindings
         (Place::Undefined, _, _) => {

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -122,6 +122,47 @@ impl<'db> DeprecationPolicy<'db> {
         }
         deprecation.build_policy()
     }
+
+    pub(crate) fn resolve_for_alternative_type(self, db: &'db dyn Db, ty: Type<'db>) -> Self {
+        let Self::Alternatives(alternatives) = self else {
+            return self;
+        };
+
+        let mut deprecation = BindingDeprecationBuilder::default();
+        let mut has_matching_alternative = false;
+        for (alternative_ty, policy) in alternatives.alternatives(db) {
+            if deprecation_types_share_single_value(db, *alternative_ty, ty) {
+                has_matching_alternative = true;
+                deprecation.add_policy(policy.resolve_for_type(db, ty), ty.is_deprecated(db));
+            }
+        }
+        if has_matching_alternative {
+            deprecation.build_policy()
+        } else {
+            self.resolve_for_type(db, ty)
+        }
+    }
+}
+
+fn deprecation_types_share_single_value<'db>(
+    db: &'db dyn Db,
+    original: Type<'db>,
+    narrowed: Type<'db>,
+) -> bool {
+    match (original, narrowed) {
+        (Type::Union(union), narrowed) => union
+            .elements(db)
+            .iter()
+            .any(|element| deprecation_types_share_single_value(db, *element, narrowed)),
+        (original, Type::Union(union)) => union
+            .elements(db)
+            .iter()
+            .any(|element| deprecation_types_share_single_value(db, original, *element)),
+        (Type::FunctionLiteral(left), Type::FunctionLiteral(right)) => {
+            left.literal(db) == right.literal(db)
+        }
+        _ => original == narrowed,
+    }
 }
 
 fn deprecation_alternative_is_eliminated<'db>(
@@ -129,28 +170,7 @@ fn deprecation_alternative_is_eliminated<'db>(
     original: Type<'db>,
     narrowed: Type<'db>,
 ) -> bool {
-    fn has_same_single_value<'db>(
-        db: &'db dyn Db,
-        original: Type<'db>,
-        narrowed: Type<'db>,
-    ) -> bool {
-        match (original, narrowed) {
-            (Type::Union(union), narrowed) => union
-                .elements(db)
-                .iter()
-                .any(|element| has_same_single_value(db, *element, narrowed)),
-            (original, Type::Union(union)) => union
-                .elements(db)
-                .iter()
-                .any(|element| has_same_single_value(db, original, *element)),
-            (Type::FunctionLiteral(left), Type::FunctionLiteral(right)) => {
-                left.literal(db) == right.literal(db)
-            }
-            _ => original == narrowed,
-        }
-    }
-
-    !has_same_single_value(db, original, narrowed)
+    !deprecation_types_share_single_value(db, original, narrowed)
         && (original.is_disjoint_from(db, narrowed)
             || (original.is_single_valued(db) && narrowed.is_single_valued(db)))
 }

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -434,40 +434,32 @@ impl<'db> LookupError<'db> {
             (LookupError::Undefined(_), _) => fallback,
             (LookupError::PossiblyUndefined { .. }, Err(LookupError::Undefined(_))) => Err(self),
             (LookupError::PossiblyUndefined(ty), Ok(ty2)) => {
-                let policy = DeprecationPolicy::from_alternatives(
-                    db,
-                    [
-                        (ty.inner_type(), ty.deprecation_policy()),
-                        (ty2.inner_type(), ty2.deprecation_policy()),
-                    ],
-                );
-                Ok(TypeAndQualifiers::new(
-                    UnionType::from_two_elements(db, ty.inner_type(), ty2.inner_type()),
-                    ty.origin().merge(ty2.origin()),
-                    ty.qualifiers().union(ty2.qualifiers()),
-                )
-                .with_deprecation_policy(policy))
+                Ok(union_type_and_qualifiers(db, ty, ty2))
             }
-            (LookupError::PossiblyUndefined(ty), Err(LookupError::PossiblyUndefined(ty2))) => {
-                Err(LookupError::PossiblyUndefined(
-                    TypeAndQualifiers::new(
-                        UnionType::from_two_elements(db, ty.inner_type(), ty2.inner_type()),
-                        ty.origin().merge(ty2.origin()),
-                        ty.qualifiers().union(ty2.qualifiers()),
-                    )
-                    .with_deprecation_policy(
-                        DeprecationPolicy::from_alternatives(
-                            db,
-                            [
-                                (ty.inner_type(), ty.deprecation_policy()),
-                                (ty2.inner_type(), ty2.deprecation_policy()),
-                            ],
-                        ),
-                    ),
-                ))
-            }
+            (LookupError::PossiblyUndefined(ty), Err(LookupError::PossiblyUndefined(ty2))) => Err(
+                LookupError::PossiblyUndefined(union_type_and_qualifiers(db, ty, ty2)),
+            ),
         }
     }
+}
+
+fn union_type_and_qualifiers<'db>(
+    db: &'db dyn Db,
+    left: &TypeAndQualifiers<'db>,
+    right: &TypeAndQualifiers<'db>,
+) -> TypeAndQualifiers<'db> {
+    TypeAndQualifiers::new(
+        UnionType::from_two_elements(db, left.inner_type(), right.inner_type()),
+        left.origin().merge(right.origin()),
+        left.qualifiers().union(right.qualifiers()),
+    )
+    .with_deprecation_policy(DeprecationPolicy::from_alternatives(
+        db,
+        [
+            (left.inner_type(), left.deprecation_policy()),
+            (right.inner_type(), right.deprecation_policy()),
+        ],
+    ))
 }
 
 pub(crate) fn merge_deprecation_policy<'db>(
@@ -929,6 +921,14 @@ impl<'db> PlaceAndQualifiers<'db> {
             Self::WithoutDeprecation { .. } => DeprecationPolicy::Inherit,
             Self::WithDeprecation(deprecated) => deprecated.deprecation,
         }
+    }
+
+    pub(crate) fn deprecation_policy_for_type(
+        &self,
+        db: &'db dyn Db,
+        ty: Type<'db>,
+    ) -> DeprecationPolicy<'db> {
+        self.deprecation_policy().resolve_for_type(db, ty)
     }
 
     pub(crate) fn into_parts(self) -> (Place<'db>, TypeQualifiers, DeprecationPolicy<'db>) {

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -407,6 +407,59 @@ impl<'db> DeprecationBuilder<'db> {
     }
 }
 
+/// Merges policies from alternative bindings.
+///
+/// A suppressed deprecated binding can be joined with an inherited nondeprecated binding without
+/// re-enabling transitive deprecation. An inherited deprecated binding remains conservative,
+/// because that alternative has not already reported the warning.
+pub(crate) struct BindingDeprecationBuilder<'db> {
+    first: DeprecationPolicy<'db>,
+    has_candidate: bool,
+    all_same: bool,
+    has_suppress: bool,
+    can_suppress: bool,
+}
+
+impl Default for BindingDeprecationBuilder<'_> {
+    fn default() -> Self {
+        Self {
+            first: DeprecationPolicy::Inherit,
+            has_candidate: false,
+            all_same: true,
+            has_suppress: false,
+            can_suppress: true,
+        }
+    }
+}
+
+impl<'db> BindingDeprecationBuilder<'db> {
+    pub(crate) fn add_policy(
+        &mut self,
+        candidate: DeprecationPolicy<'db>,
+        type_is_deprecated: bool,
+    ) {
+        if self.has_candidate {
+            self.all_same &= candidate == self.first;
+        } else {
+            self.first = candidate;
+            self.has_candidate = true;
+        }
+        self.has_suppress |= candidate == DeprecationPolicy::Suppress;
+        self.can_suppress &= candidate == DeprecationPolicy::Suppress
+            || (candidate == DeprecationPolicy::Inherit && !type_is_deprecated);
+    }
+
+    pub(crate) fn build_policy(self) -> DeprecationPolicy<'db> {
+        if self.all_same {
+            self.first
+        } else if self.has_suppress && self.can_suppress {
+            DeprecationPolicy::Suppress
+        } else {
+            DeprecationPolicy::Inherit
+        }
+    }
+}
+
 /// A [`Result`] type in which the `Ok` variant represents a definitely bound place
 /// and the `Err` variant represents a place that is either definitely or possibly unbound.
 ///
@@ -1526,7 +1579,7 @@ fn place_from_bindings_impl<'db>(
     let mut first_definition = None;
     // special handling for synthetic loop header definitions and nested bindings definitions
     let mut only_non_shadowing_bindings = true;
-    let mut deprecation = DeprecationBuilder::default();
+    let mut deprecation = BindingDeprecationBuilder::default();
 
     let mut types = bindings_with_constraints.filter_map(
         |BindingWithConstraints {
@@ -1645,7 +1698,7 @@ fn place_from_bindings_impl<'db>(
                 .map_or(DeprecationPolicy::Inherit, |declaration| {
                     declaration.deprecation_policy()
                 });
-            deprecation.add_policy(binding_deprecation);
+            deprecation.add_policy(binding_deprecation, binding_ty.is_deprecated(db));
             Some((
                 narrowing_constraint.narrow(db, binding_ty, binding.place(db)),
                 static_reachability,

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -142,6 +142,17 @@ impl<'db> DeprecationPolicy<'db> {
             self.resolve_for_type(db, ty)
         }
     }
+
+    pub(crate) fn contains_deprecated(self, db: &'db dyn Db) -> bool {
+        match self {
+            Self::Deprecated(_) => true,
+            Self::Alternatives(alternatives) => alternatives
+                .alternatives(db)
+                .iter()
+                .any(|(_, policy)| policy.contains_deprecated(db)),
+            Self::Inherit | Self::Suppress => false,
+        }
+    }
 }
 
 fn deprecation_types_share_single_value<'db>(

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1836,8 +1836,7 @@ fn place_from_bindings_impl<'db>(
                 .declared()
                 .map_or(DeprecationPolicy::Inherit, |declaration| {
                     declaration.deprecation_policy()
-                })
-                .resolve_for_type(db, narrowed_ty);
+                });
             if !narrowed_ty.is_never()
                 && !deprecation_alternative_is_eliminated(db, binding_ty, narrowed_ty)
             {

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -58,6 +58,18 @@ pub(crate) enum TypeOrigin {
     Inferred,
 }
 
+/// Controls how deprecation is reported when a place is loaded.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+pub(crate) enum DeprecationPolicy<'db> {
+    /// Inspect the inferred type for deprecation.
+    #[default]
+    Inherit,
+    /// The binding operation already reported the deprecation.
+    Suppress,
+    /// Report deprecation attached directly to this binding.
+    Deprecated(DeprecatedInstance<'db>),
+}
+
 impl TypeOrigin {
     pub(crate) const fn is_declared(self) -> bool {
         matches!(self, TypeOrigin::Declared)
@@ -243,7 +255,7 @@ impl<'db> Place<'db> {
         PlaceAndQualifiers {
             place: self,
             qualifiers,
-            deprecation: None,
+            deprecation: DeprecationPolicy::Inherit,
         }
     }
 
@@ -306,7 +318,7 @@ impl<'db> From<LookupResult<'db>> for PlaceAndQualifiers<'db> {
                     .with_origin(type_and_qualifiers.origin()),
             )
             .with_qualifiers(type_and_qualifiers.qualifiers())
-            .with_deprecation(type_and_qualifiers.deprecation()),
+            .with_deprecation_policy(type_and_qualifiers.deprecation_policy()),
             Err(LookupError::Undefined(qualifiers)) => Place::Undefined.with_qualifiers(qualifiers),
             Err(LookupError::PossiblyUndefined(type_and_qualifiers)) => Place::Defined(
                 DefinedPlace::new(type_and_qualifiers.inner_type())
@@ -314,7 +326,7 @@ impl<'db> From<LookupResult<'db>> for PlaceAndQualifiers<'db> {
                     .with_definedness(Definedness::PossiblyUndefined),
             )
             .with_qualifiers(type_and_qualifiers.qualifiers())
-            .with_deprecation(type_and_qualifiers.deprecation()),
+            .with_deprecation_policy(type_and_qualifiers.deprecation_policy()),
         }
     }
 }
@@ -342,7 +354,10 @@ impl<'db> LookupError<'db> {
                 ty.origin().merge(ty2.origin()),
                 ty.qualifiers().union(ty2.qualifiers()),
             )
-            .with_deprecation(merge_deprecation(ty.deprecation(), ty2.deprecation()))),
+            .with_deprecation_policy(merge_deprecation_policy(
+                ty.deprecation_policy(),
+                ty2.deprecation_policy(),
+            ))),
             (LookupError::PossiblyUndefined(ty), Err(LookupError::PossiblyUndefined(ty2))) => {
                 Err(LookupError::PossiblyUndefined(
                     TypeAndQualifiers::new(
@@ -350,40 +365,45 @@ impl<'db> LookupError<'db> {
                         ty.origin().merge(ty2.origin()),
                         ty.qualifiers().union(ty2.qualifiers()),
                     )
-                    .with_deprecation(merge_deprecation(ty.deprecation(), ty2.deprecation())),
+                    .with_deprecation_policy(merge_deprecation_policy(
+                        ty.deprecation_policy(),
+                        ty2.deprecation_policy(),
+                    )),
                 ))
             }
         }
     }
 }
 
-/// Retain a binding deprecation only if both alternatives have the same message.
-pub(crate) fn merge_deprecation<'db>(
-    left: Option<DeprecatedInstance<'db>>,
-    right: Option<DeprecatedInstance<'db>>,
-) -> Option<DeprecatedInstance<'db>> {
-    (left == right).then_some(left).flatten()
+pub(crate) fn merge_deprecation_policy<'db>(
+    left: DeprecationPolicy<'db>,
+    right: DeprecationPolicy<'db>,
+) -> DeprecationPolicy<'db> {
+    if left == right {
+        left
+    } else {
+        DeprecationPolicy::default()
+    }
 }
 
 /// Accumulates deprecation metadata across alternatives, retaining only a shared message.
 #[derive(Default)]
 pub(crate) struct DeprecationBuilder<'db> {
-    deprecation: Option<DeprecatedInstance<'db>>,
+    deprecation: DeprecationPolicy<'db>,
     has_candidate: bool,
 }
 
 impl<'db> DeprecationBuilder<'db> {
-    /// Adds a viable alternative. `None` represents an alternative that is not deprecated.
-    pub(crate) fn add(&mut self, candidate: Option<DeprecatedInstance<'db>>) {
+    pub(crate) fn add_policy(&mut self, candidate: DeprecationPolicy<'db>) {
         self.deprecation = if self.has_candidate {
-            merge_deprecation(self.deprecation, candidate)
+            merge_deprecation_policy(self.deprecation, candidate)
         } else {
             self.has_candidate = true;
             candidate
         };
     }
 
-    pub(crate) fn build(self) -> Option<DeprecatedInstance<'db>> {
+    pub(crate) fn build_policy(self) -> DeprecationPolicy<'db> {
         self.deprecation
     }
 }
@@ -697,8 +717,7 @@ impl<'db> PlaceFromDeclarationsResult<'db> {
 pub(crate) struct PlaceAndQualifiers<'db> {
     pub(crate) place: Place<'db>,
     pub(crate) qualifiers: TypeQualifiers,
-    /// Deprecation attached to the place rather than its inferred type.
-    pub(crate) deprecation: Option<DeprecatedInstance<'db>>,
+    pub(crate) deprecation: DeprecationPolicy<'db>,
 }
 
 impl<'db> PlaceAndQualifiers<'db> {
@@ -740,7 +759,7 @@ impl<'db> PlaceAndQualifiers<'db> {
     }
 
     #[must_use]
-    pub(crate) fn with_deprecation(mut self, deprecation: Option<DeprecatedInstance<'db>>) -> Self {
+    pub(crate) fn with_deprecation_policy(mut self, deprecation: DeprecationPolicy<'db>) -> Self {
         self.deprecation = deprecation;
         self
     }
@@ -788,7 +807,7 @@ impl<'db> PlaceAndQualifiers<'db> {
             } => {
                 let ty = place.public_type_policy.apply_if_needed(db, place.ty);
                 let type_and_qualifiers = TypeAndQualifiers::new(ty, place.origin, qualifiers)
-                    .with_deprecation(deprecation);
+                    .with_deprecation_policy(deprecation);
                 match place.definedness {
                     Definedness::AlwaysDefined => Ok(type_and_qualifiers),
                     Definedness::PossiblyUndefined => {
@@ -853,7 +872,7 @@ impl<'db> PlaceAndQualifiers<'db> {
         let deprecation = if cycle.iteration() <= 1 {
             self.deprecation
         } else {
-            merge_deprecation(previous_place.deprecation, self.deprecation)
+            merge_deprecation_policy(previous_place.deprecation, self.deprecation)
         };
         let place = match (previous_place.place, self.place) {
             // In fixed-point iteration of type inference, the member result must be monotonically
@@ -958,7 +977,7 @@ pub(crate) fn place_by_id<'db>(
         return inferred
             .place
             .with_qualifiers(qualifiers)
-            .with_deprecation(inferred.deprecation);
+            .with_deprecation_policy(inferred.deprecation);
     }
 
     match declared {
@@ -990,7 +1009,7 @@ pub(crate) fn place_by_id<'db>(
                     public_type_policy: PublicTypePolicy::Raw,
                 })
                 .with_qualifiers(qualifiers)
-                .with_deprecation(inferred.deprecation),
+                .with_deprecation_policy(inferred.deprecation),
                 Place::Undefined => Place::Defined(DefinedPlace {
                     ty: Type::unknown(),
                     origin,
@@ -1060,7 +1079,7 @@ pub(crate) fn place_by_id<'db>(
             PlaceAndQualifiers {
                 place,
                 qualifiers,
-                deprecation: merge_deprecation(declared_deprecation, inferred.deprecation),
+                deprecation: merge_deprecation_policy(declared_deprecation, inferred.deprecation),
             }
         }
         // Place is undeclared, infer the type from bindings
@@ -1122,7 +1141,7 @@ pub(crate) fn place_by_id<'db>(
             {
                 place
                     .with_qualifiers(TypeQualifiers::empty())
-                    .with_deprecation(deprecation)
+                    .with_deprecation_policy(deprecation)
             } else {
                 // Public inferred types should expose a promoted view rather than their raw
                 // inferred literal form. The adjustment is applied lazily when converting to
@@ -1130,7 +1149,7 @@ pub(crate) fn place_by_id<'db>(
                 place
                     .with_public_type_policy(PublicTypePolicy::Promote)
                     .with_qualifiers(TypeQualifiers::empty())
-                    .with_deprecation(deprecation)
+                    .with_deprecation_policy(deprecation)
             }
         }
     }
@@ -1554,8 +1573,10 @@ fn place_from_bindings_impl<'db>(
             let binding_deprecation = inference
                 .inferred_declaration(binding)
                 .declared()
-                .and_then(|declaration| declaration.deprecation());
-            deprecation.add(binding_deprecation);
+                .map_or(DeprecationPolicy::Inherit, |declaration| {
+                    declaration.deprecation_policy()
+                });
+            deprecation.add_policy(binding_deprecation);
             Some((
                 narrowing_constraint.narrow(db, binding_ty, binding.place(db)),
                 static_reachability,
@@ -1614,9 +1635,9 @@ fn place_from_bindings_impl<'db>(
         Place::Undefined
     };
     let deprecation = if place.is_undefined() {
-        None
+        DeprecationPolicy::Inherit
     } else {
-        deprecation.build()
+        deprecation.build_policy()
     };
 
     PlaceWithDefinition {
@@ -1629,14 +1650,16 @@ fn place_from_bindings_impl<'db>(
 pub(super) struct PlaceWithDefinition<'db> {
     pub(super) place: Place<'db>,
     pub(super) first_definition: Option<Definition<'db>>,
-    deprecation: Option<DeprecatedInstance<'db>>,
+    deprecation: DeprecationPolicy<'db>,
 }
 
 impl<'db> PlaceWithDefinition<'db> {
     pub(super) fn into_place_and_qualifiers(self) -> PlaceAndQualifiers<'db> {
-        self.place
-            .with_qualifiers(TypeQualifiers::empty())
-            .with_deprecation(self.deprecation)
+        PlaceAndQualifiers {
+            place: self.place,
+            qualifiers: TypeQualifiers::empty(),
+            deprecation: self.deprecation,
+        }
     }
 }
 
@@ -1760,13 +1783,13 @@ impl<'db> DeclaredTypeBuilder<'db> {
         }
 
         self.qualifiers = self.qualifiers.union(element.qualifiers());
-        self.deprecation.add(element.deprecation());
+        self.deprecation.add_policy(element.deprecation_policy());
     }
 
     fn build(mut self) -> DeclaredTypeAndConflictingTypes<'db> {
         let type_and_quals =
             TypeAndQualifiers::new(self.inner.build(), TypeOrigin::Declared, self.qualifiers)
-                .with_deprecation(self.deprecation.build());
+                .with_deprecation_policy(self.deprecation.build_policy());
         if self.conflicting_types.is_empty() {
             (type_and_quals, None)
         } else {
@@ -1871,7 +1894,7 @@ fn place_from_declarations_impl<'db>(
                 .with_definedness(boundness),
         )
         .with_qualifiers(declared.qualifiers())
-        .with_deprecation(declared.deprecation());
+        .with_deprecation_policy(declared.deprecation_policy());
 
         if let Some(conflicting) = conflicting {
             PlaceFromDeclarationsResult::conflict(place_and_quals, conflicting, first_declaration)

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -119,7 +119,7 @@ impl<'db> DeprecationPolicy<'db> {
             if !deprecation_alternative_is_eliminated(db, *alternative_ty, ty) {
                 deprecation.add_policy(
                     policy.resolve_for_type(db, ty),
-                    alternative_ty.is_deprecated(db),
+                    inherited_deprecation_policy(db, *alternative_ty),
                 );
             }
         }
@@ -138,7 +138,7 @@ impl<'db> DeprecationPolicy<'db> {
                 has_matching_alternative = true;
                 deprecation.add_policy(
                     policy.resolve_for_type(db, ty),
-                    alternative_ty.is_deprecated(db),
+                    inherited_deprecation_policy(db, *alternative_ty),
                 );
             }
         }
@@ -147,6 +147,29 @@ impl<'db> DeprecationPolicy<'db> {
         } else {
             self.resolve_for_type(db, ty)
         }
+    }
+}
+
+fn inherited_deprecation_policy<'db>(db: &'db dyn Db, ty: Type<'db>) -> DeprecationPolicy<'db> {
+    match ty {
+        Type::FunctionLiteral(function) => function
+            .implementation_deprecated(db)
+            .map_or(DeprecationPolicy::Inherit, DeprecationPolicy::Deprecated),
+        Type::BoundMethod(bound) => bound
+            .function(db)
+            .implementation_deprecated(db)
+            .map_or(DeprecationPolicy::Inherit, DeprecationPolicy::Deprecated),
+        Type::ClassLiteral(class) => class
+            .deprecated(db)
+            .map_or(DeprecationPolicy::Inherit, DeprecationPolicy::Deprecated),
+        Type::Union(union) => {
+            let mut deprecation = DeprecationBuilder::default();
+            for element in union.elements(db) {
+                deprecation.add_policy(inherited_deprecation_policy(db, *element));
+            }
+            deprecation.build_policy()
+        }
+        _ => DeprecationPolicy::Inherit,
     }
 }
 
@@ -542,10 +565,17 @@ impl<'db> BindingDeprecationBuilder<'db> {
     pub(crate) fn add_policy(
         &mut self,
         candidate: DeprecationPolicy<'db>,
-        type_is_deprecated: bool,
+        inherited: DeprecationPolicy<'db>,
     ) {
-        let candidate_is_suppressible = candidate == DeprecationPolicy::Suppress
-            || (candidate == DeprecationPolicy::Inherit && !type_is_deprecated);
+        let candidate = if candidate == DeprecationPolicy::Inherit {
+            inherited
+        } else {
+            candidate
+        };
+        let candidate_is_suppressible = matches!(
+            candidate,
+            DeprecationPolicy::Inherit | DeprecationPolicy::Suppress
+        );
         *self = match std::mem::take(self) {
             Self::Empty => Self::Uniform {
                 policy: candidate,

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1698,11 +1698,9 @@ fn place_from_bindings_impl<'db>(
                 .map_or(DeprecationPolicy::Inherit, |declaration| {
                     declaration.deprecation_policy()
                 });
-            deprecation.add_policy(binding_deprecation, binding_ty.is_deprecated(db));
-            Some((
-                narrowing_constraint.narrow(db, binding_ty, binding.place(db)),
-                static_reachability,
-            ))
+            let narrowed_ty = narrowing_constraint.narrow(db, binding_ty, binding.place(db));
+            deprecation.add_policy(binding_deprecation, narrowed_ty.is_deprecated(db));
+            Some((narrowed_ty, static_reachability))
         },
     );
 

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -252,10 +252,9 @@ impl<'db> Place<'db> {
 
     #[must_use]
     pub(crate) fn with_qualifiers(self, qualifiers: TypeQualifiers) -> PlaceAndQualifiers<'db> {
-        PlaceAndQualifiers {
+        PlaceAndQualifiers::WithoutDeprecation {
             place: self,
             qualifiers,
-            deprecation: DeprecationPolicy::Inherit,
         }
     }
 
@@ -332,7 +331,7 @@ impl<'db> From<LookupResult<'db>> for PlaceAndQualifiers<'db> {
 }
 
 /// Possible ways in which a place lookup can (possibly or definitely) fail.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub(crate) enum LookupError<'db> {
     Undefined(TypeQualifiers),
     PossiblyUndefined(TypeAndQualifiers<'db>),
@@ -713,11 +712,31 @@ impl<'db> PlaceFromDeclarationsResult<'db> {
 /// that this comes with a [`CLASS_VAR`] type qualifier.
 ///
 /// [`CLASS_VAR`]: crate::types::TypeQualifiers::CLASS_VAR
-#[derive(Debug, Clone, Default, Copy, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
-pub(crate) struct PlaceAndQualifiers<'db> {
-    pub(crate) place: Place<'db>,
-    pub(crate) qualifiers: TypeQualifiers,
-    pub(crate) deprecation: DeprecationPolicy<'db>,
+#[derive(Debug, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+pub(crate) enum PlaceAndQualifiers<'db> {
+    /// The common case, stored inline to avoid an allocation.
+    WithoutDeprecation {
+        place: Place<'db>,
+        qualifiers: TypeQualifiers,
+    },
+    /// Non-default deprecation policies are rare, so store their payload out of line.
+    WithDeprecation(Box<DeprecatedPlaceAndQualifiers<'db>>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct DeprecatedPlaceAndQualifiers<'db> {
+    place: Place<'db>,
+    qualifiers: TypeQualifiers,
+    deprecation: DeprecationPolicy<'db>,
+}
+
+impl Default for PlaceAndQualifiers<'_> {
+    fn default() -> Self {
+        Self::WithoutDeprecation {
+            place: Place::Undefined,
+            qualifiers: TypeQualifiers::empty(),
+        }
+    }
 }
 
 impl<'db> PlaceAndQualifiers<'db> {
@@ -726,57 +745,108 @@ impl<'db> PlaceAndQualifiers<'db> {
     }
 
     pub(crate) fn is_undefined(&self) -> bool {
-        self.place.is_undefined()
+        self.place().is_undefined()
     }
 
     pub(crate) fn ignore_possibly_undefined(&self) -> Option<Type<'db>> {
-        self.place.ignore_possibly_undefined()
+        self.place().ignore_possibly_undefined()
+    }
+
+    pub(crate) fn place(&self) -> Place<'db> {
+        match self {
+            Self::WithoutDeprecation { place, .. } => *place,
+            Self::WithDeprecation(deprecated) => deprecated.place,
+        }
+    }
+
+    pub(crate) fn qualifiers(&self) -> TypeQualifiers {
+        match self {
+            Self::WithoutDeprecation { qualifiers, .. } => *qualifiers,
+            Self::WithDeprecation(deprecated) => deprecated.qualifiers,
+        }
+    }
+
+    pub(crate) fn deprecation_policy(&self) -> DeprecationPolicy<'db> {
+        match self {
+            Self::WithoutDeprecation { .. } => DeprecationPolicy::Inherit,
+            Self::WithDeprecation(deprecated) => deprecated.deprecation,
+        }
+    }
+
+    pub(crate) fn into_parts(self) -> (Place<'db>, TypeQualifiers, DeprecationPolicy<'db>) {
+        match self {
+            Self::WithoutDeprecation { place, qualifiers } => {
+                (place, qualifiers, DeprecationPolicy::Inherit)
+            }
+            Self::WithDeprecation(deprecated) => (
+                deprecated.place,
+                deprecated.qualifiers,
+                deprecated.deprecation,
+            ),
+        }
     }
 
     /// Returns `true` if the place has a `ClassVar` type qualifier.
     pub(crate) fn is_class_var(&self) -> bool {
-        self.qualifiers.contains(TypeQualifiers::CLASS_VAR)
+        self.qualifiers().contains(TypeQualifiers::CLASS_VAR)
     }
 
     /// Returns `true` if the place has a `InitVar` type qualifier.
     pub(crate) fn is_init_var(&self) -> bool {
-        self.qualifiers.contains(TypeQualifiers::INIT_VAR)
+        self.qualifiers().contains(TypeQualifiers::INIT_VAR)
     }
 
     /// Returns `true` if the place has a `Required` type qualifier.
     pub(crate) fn is_required(&self) -> bool {
-        self.qualifiers.contains(TypeQualifiers::REQUIRED)
+        self.qualifiers().contains(TypeQualifiers::REQUIRED)
     }
 
     /// Returns `true` if the place has a `NotRequired` type qualifier.
     pub(crate) fn is_not_required(&self) -> bool {
-        self.qualifiers.contains(TypeQualifiers::NOT_REQUIRED)
+        self.qualifiers().contains(TypeQualifiers::NOT_REQUIRED)
     }
 
     /// Returns `true` if the place has a `ReadOnly` type qualifier.
     pub(crate) fn is_read_only(&self) -> bool {
-        self.qualifiers.contains(TypeQualifiers::READ_ONLY)
+        self.qualifiers().contains(TypeQualifiers::READ_ONLY)
     }
 
     #[must_use]
-    pub(crate) fn with_deprecation_policy(mut self, deprecation: DeprecationPolicy<'db>) -> Self {
-        self.deprecation = deprecation;
-        self
+    pub(crate) fn with_deprecation_policy(self, deprecation: DeprecationPolicy<'db>) -> Self {
+        match (self, deprecation) {
+            (place @ Self::WithoutDeprecation { .. }, DeprecationPolicy::Inherit) => place,
+            (Self::WithoutDeprecation { place, qualifiers }, deprecation) => {
+                Self::WithDeprecation(Box::new(DeprecatedPlaceAndQualifiers {
+                    place,
+                    qualifiers,
+                    deprecation,
+                }))
+            }
+            (Self::WithDeprecation(deprecated), DeprecationPolicy::Inherit) => {
+                Self::WithoutDeprecation {
+                    place: deprecated.place,
+                    qualifiers: deprecated.qualifiers,
+                }
+            }
+            (Self::WithDeprecation(mut deprecated), deprecation) => {
+                deprecated.deprecation = deprecation;
+                Self::WithDeprecation(deprecated)
+            }
+        }
     }
 
     /// Returns `Some(…)` if the place is qualified with `typing.Final` without a specified type.
     pub(crate) fn is_bare_final(&self) -> Option<TypeQualifiers> {
-        match self {
-            PlaceAndQualifiers {
-                place, qualifiers, ..
-            } if (qualifiers.contains(TypeQualifiers::FINAL)
-                && place
-                    .ignore_possibly_undefined()
-                    .is_some_and(|ty| ty.is_unknown())) =>
-            {
-                Some(*qualifiers)
-            }
-            _ => None,
+        let place = self.place();
+        let qualifiers = self.qualifiers();
+        if qualifiers.contains(TypeQualifiers::FINAL)
+            && place
+                .ignore_possibly_undefined()
+                .is_some_and(|ty| ty.is_unknown())
+        {
+            Some(qualifiers)
+        } else {
+            None
         }
     }
 
@@ -785,10 +855,15 @@ impl<'db> PlaceAndQualifiers<'db> {
         self,
         f: impl FnOnce(Type<'db>) -> Type<'db>,
     ) -> PlaceAndQualifiers<'db> {
-        PlaceAndQualifiers {
-            place: self.place.map_type(f),
-            qualifiers: self.qualifiers,
-            deprecation: self.deprecation,
+        match self {
+            Self::WithoutDeprecation { place, qualifiers } => Self::WithoutDeprecation {
+                place: place.map_type(f),
+                qualifiers,
+            },
+            Self::WithDeprecation(mut deprecated) => {
+                deprecated.place = deprecated.place.map_type(f);
+                Self::WithDeprecation(deprecated)
+            }
         }
     }
 
@@ -799,12 +874,8 @@ impl<'db> PlaceAndQualifiers<'db> {
     /// For places whose public type differs from their raw stored type, this applies the
     /// public-type policy lazily during lookup.
     pub(crate) fn into_lookup_result(self, db: &'db dyn Db) -> LookupResult<'db> {
-        match self {
-            PlaceAndQualifiers {
-                place: Place::Defined(place),
-                qualifiers,
-                deprecation,
-            } => {
+        match self.into_parts() {
+            (Place::Defined(place), qualifiers, deprecation) => {
                 let ty = place.public_type_policy.apply_if_needed(db, place.ty);
                 let type_and_qualifiers = TypeAndQualifiers::new(ty, place.origin, qualifiers)
                     .with_deprecation_policy(deprecation);
@@ -815,11 +886,7 @@ impl<'db> PlaceAndQualifiers<'db> {
                     }
                 }
             }
-            PlaceAndQualifiers {
-                place: Place::Undefined,
-                qualifiers,
-                deprecation: _,
-            } => Err(LookupError::Undefined(qualifiers)),
+            (Place::Undefined, qualifiers, _) => Err(LookupError::Undefined(qualifiers)),
         }
     }
 
@@ -861,20 +928,24 @@ impl<'db> PlaceAndQualifiers<'db> {
     pub(crate) fn cycle_normalized(
         self,
         db: &'db dyn Db,
-        previous_place: Self,
+        previous: &Self,
         cycle: &salsa::Cycle,
     ) -> Self {
+        let (place, qualifiers, deprecation) = self.into_parts();
+        let previous_place = previous.place();
+        let previous_qualifiers = previous.qualifiers();
+        let previous_deprecation = previous.deprecation_policy();
         let qualifiers = if cycle.iteration() <= 1 {
-            self.qualifiers
+            qualifiers
         } else {
-            previous_place.qualifiers.union(self.qualifiers)
+            previous_qualifiers.union(qualifiers)
         };
         let deprecation = if cycle.iteration() <= 1 {
-            self.deprecation
+            deprecation
         } else {
-            merge_deprecation_policy(previous_place.deprecation, self.deprecation)
+            merge_deprecation_policy(previous_deprecation, deprecation)
         };
-        let place = match (previous_place.place, self.place) {
+        let place = match (previous_place, place) {
             // In fixed-point iteration of type inference, the member result must be monotonically
             // widened and not "oscillate". The type component is widened by unioning the previous
             // iteration into the current result; after the first couple iterations, the same
@@ -923,13 +994,15 @@ impl<'db> PlaceAndQualifiers<'db> {
             }
             (Place::Undefined, Place::Undefined) => Place::Undefined,
         };
-        PlaceAndQualifiers {
-            place,
-            qualifiers,
-            deprecation,
-        }
+        place
+            .with_qualifiers(qualifiers)
+            .with_deprecation_policy(deprecation)
     }
 }
+
+// Keep the common case at the same size as it was before adding place-level deprecation.
+#[cfg(all(not(debug_assertions), target_pointer_width = "64"))]
+static_assertions::assert_eq_size!(PlaceAndQualifiers<'_>, [u8; 24]);
 
 impl<'db> From<Place<'db>> for PlaceAndQualifiers<'db> {
     fn from(place: Place<'db>) -> Self {
@@ -940,7 +1013,7 @@ impl<'db> From<Place<'db>> for PlaceAndQualifiers<'db> {
 #[salsa::tracked(
     cycle_initial=|_, id, _, _, _, _| Place::bound(Type::divergent(id)).into(),
     cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, place: PlaceAndQualifiers<'db>, _, _, _, _| {
-        place.cycle_normalized(db, *previous, cycle)
+        place.cycle_normalized(db, previous, cycle)
     },
     heap_size=ruff_memory_usage::heap_size
 )]
@@ -980,20 +1053,19 @@ pub(crate) fn place_by_id<'db>(
             .with_deprecation_policy(inferred.deprecation);
     }
 
-    match declared {
+    match declared.into_parts() {
         // Handle bare `ClassVar` annotations by falling back to the union of `Unknown` and the
         // inferred type.
-        PlaceAndQualifiers {
-            place:
-                Place::Defined(DefinedPlace {
-                    ty: Type::Dynamic(DynamicType::Unknown),
-                    origin,
-                    definedness,
-                    ..
-                }),
+        (
+            Place::Defined(DefinedPlace {
+                ty: Type::Dynamic(DynamicType::Unknown),
+                origin,
+                definedness,
+                ..
+            }),
             qualifiers,
-            deprecation: _,
-        } if qualifiers.contains(TypeQualifiers::CLASS_VAR) => {
+            _,
+        ) if qualifiers.contains(TypeQualifiers::CLASS_VAR) => {
             let bindings = all_considered_bindings();
             let inferred = place_from_bindings_impl(db, bindings, requires_explicit_reexport);
             match inferred.place {
@@ -1020,27 +1092,27 @@ pub(crate) fn place_by_id<'db>(
             }
         }
         // Place is declared, trust the declared type
-        place_and_quals @ PlaceAndQualifiers {
-            place:
-                Place::Defined(DefinedPlace {
-                    definedness: Definedness::AlwaysDefined,
-                    ..
-                }),
-            qualifiers: _,
-            deprecation: _,
-        } => place_and_quals,
-        // Place is possibly declared
-        PlaceAndQualifiers {
-            place:
-                Place::Defined(DefinedPlace {
-                    ty: declared_ty,
-                    origin,
-                    definedness: Definedness::PossiblyUndefined,
-                    ..
-                }),
+        (
+            place @ Place::Defined(DefinedPlace {
+                definedness: Definedness::AlwaysDefined,
+                ..
+            }),
             qualifiers,
-            deprecation: declared_deprecation,
-        } => {
+            deprecation,
+        ) => place
+            .with_qualifiers(qualifiers)
+            .with_deprecation_policy(deprecation),
+        // Place is possibly declared
+        (
+            Place::Defined(DefinedPlace {
+                ty: declared_ty,
+                origin,
+                definedness: Definedness::PossiblyUndefined,
+                ..
+            }),
+            qualifiers,
+            declared_deprecation,
+        ) => {
             let bindings = all_considered_bindings();
             let boundness_analysis = bindings.boundness_analysis();
             let inferred = place_from_bindings_impl(db, bindings, requires_explicit_reexport);
@@ -1076,18 +1148,15 @@ pub(crate) fn place_by_id<'db>(
                 }),
             };
 
-            PlaceAndQualifiers {
-                place,
-                qualifiers,
-                deprecation: merge_deprecation_policy(declared_deprecation, inferred.deprecation),
-            }
+            place
+                .with_qualifiers(qualifiers)
+                .with_deprecation_policy(merge_deprecation_policy(
+                    declared_deprecation,
+                    inferred.deprecation,
+                ))
         }
         // Place is undeclared, infer the type from bindings
-        PlaceAndQualifiers {
-            place: Place::Undefined,
-            qualifiers: _,
-            deprecation: _,
-        } => {
+        (Place::Undefined, _, _) => {
             let bindings = all_considered_bindings();
             let boundness_analysis = bindings.boundness_analysis();
             let inferred = place_from_bindings_impl(db, bindings, requires_explicit_reexport);
@@ -1655,11 +1724,9 @@ pub(super) struct PlaceWithDefinition<'db> {
 
 impl<'db> PlaceWithDefinition<'db> {
     pub(super) fn into_place_and_qualifiers(self) -> PlaceAndQualifiers<'db> {
-        PlaceAndQualifiers {
-            place: self.place,
-            qualifiers: TypeQualifiers::empty(),
-            deprecation: self.deprecation,
-        }
+        self.place
+            .with_qualifiers(TypeQualifiers::empty())
+            .with_deprecation_policy(self.deprecation)
     }
 }
 
@@ -1769,7 +1836,7 @@ impl<'db> DeclaredTypeBuilder<'db> {
         }
     }
 
-    fn add(&mut self, element: TypeAndQualifiers<'db>, reachability: Truthiness) {
+    fn add(&mut self, element: &TypeAndQualifiers<'db>, reachability: Truthiness) {
         let element_ty = element.inner_type();
 
         if self.inner.add(element_ty, reachability) {
@@ -1876,10 +1943,10 @@ fn place_from_declarations_impl<'db>(
     if let Some((first, first_reachability)) = types.next() {
         let (declared, conflicting) = if let Some((second, second_reachability)) = types.next() {
             let mut builder = DeclaredTypeBuilder::new(db);
-            builder.add(first, first_reachability);
-            builder.add(second, second_reachability);
+            builder.add(&first, first_reachability);
+            builder.add(&second, second_reachability);
             for (element, reachability) in types {
-                builder.add(element, reachability);
+                builder.add(&element, reachability);
             }
             builder.build()
         } else {
@@ -2142,7 +2209,10 @@ pub(crate) mod implicit_globals {
             .filter_map(move |name| {
                 let place = module_type_implicit_global_symbol(db, name.as_str());
                 // Only include bound symbols
-                place.place.ignore_possibly_undefined().map(|ty| (name, ty))
+                place
+                    .place()
+                    .ignore_possibly_undefined()
+                    .map(|ty| (name, ty))
             })
     }
 
@@ -2233,6 +2303,13 @@ pub(crate) enum ConsideredDefinitions {
 mod tests {
     use super::*;
     use crate::db::tests::setup_db;
+
+    #[cfg(all(debug_assertions, target_pointer_width = "64"))]
+    #[test]
+    fn lookup_record_layout() {
+        assert_eq!(std::mem::size_of::<TypeAndQualifiers<'_>>(), 40);
+        assert_eq!(std::mem::size_of::<PlaceAndQualifiers<'_>>(), 48);
+    }
 
     #[test]
     fn test_symbol_or_fall_back_to() {
@@ -2342,19 +2419,19 @@ mod tests {
     #[test]
     fn implicit_builtin_globals() {
         let db = setup_db();
-        assert_bound_string_symbol(&db, builtins_symbol(&db, "__name__").place);
+        assert_bound_string_symbol(&db, builtins_symbol(&db, "__name__").place());
     }
 
     #[test]
     fn implicit_typing_globals() {
         let db = setup_db();
-        assert_bound_string_symbol(&db, typing_symbol(&db, "__name__").place);
+        assert_bound_string_symbol(&db, typing_symbol(&db, "__name__").place());
     }
 
     #[test]
     fn implicit_typing_extensions_globals() {
         let db = setup_db();
-        assert_bound_string_symbol(&db, typing_extensions_symbol(&db, "__name__").place);
+        assert_bound_string_symbol(&db, typing_extensions_symbol(&db, "__name__").place());
     }
 
     #[test]
@@ -2362,7 +2439,7 @@ mod tests {
         let db = setup_db();
         assert_bound_string_symbol(
             &db,
-            known_module_symbol(&db, KnownModule::Sys, "__name__").place,
+            known_module_symbol(&db, KnownModule::Sys, "__name__").place(),
         );
     }
 }

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -412,24 +412,16 @@ impl<'db> DeprecationBuilder<'db> {
 /// A suppressed deprecated binding can be joined with an inherited nondeprecated binding without
 /// re-enabling transitive deprecation. An inherited deprecated binding remains conservative,
 /// because that alternative has not already reported the warning.
-pub(crate) struct BindingDeprecationBuilder<'db> {
-    first: DeprecationPolicy<'db>,
-    has_candidate: bool,
-    all_same: bool,
-    has_suppress: bool,
-    can_suppress: bool,
-}
-
-impl Default for BindingDeprecationBuilder<'_> {
-    fn default() -> Self {
-        Self {
-            first: DeprecationPolicy::Inherit,
-            has_candidate: false,
-            all_same: true,
-            has_suppress: false,
-            can_suppress: true,
-        }
-    }
+#[derive(Default)]
+pub(crate) enum BindingDeprecationBuilder<'db> {
+    #[default]
+    Empty,
+    Uniform {
+        policy: DeprecationPolicy<'db>,
+        all_suppressible: bool,
+    },
+    MixedSuppressible,
+    MixedInherit,
 }
 
 impl<'db> BindingDeprecationBuilder<'db> {
@@ -438,24 +430,41 @@ impl<'db> BindingDeprecationBuilder<'db> {
         candidate: DeprecationPolicy<'db>,
         type_is_deprecated: bool,
     ) {
-        if self.has_candidate {
-            self.all_same &= candidate == self.first;
-        } else {
-            self.first = candidate;
-            self.has_candidate = true;
-        }
-        self.has_suppress |= candidate == DeprecationPolicy::Suppress;
-        self.can_suppress &= candidate == DeprecationPolicy::Suppress
+        let candidate_is_suppressible = candidate == DeprecationPolicy::Suppress
             || (candidate == DeprecationPolicy::Inherit && !type_is_deprecated);
+        *self = match std::mem::take(self) {
+            Self::Empty => Self::Uniform {
+                policy: candidate,
+                all_suppressible: candidate_is_suppressible,
+            },
+            Self::Uniform {
+                policy,
+                all_suppressible,
+            } if candidate == policy => Self::Uniform {
+                policy,
+                all_suppressible: all_suppressible && candidate_is_suppressible,
+            },
+            Self::Uniform {
+                policy,
+                all_suppressible,
+            } if all_suppressible
+                && candidate_is_suppressible
+                && (policy == DeprecationPolicy::Suppress
+                    || candidate == DeprecationPolicy::Suppress) =>
+            {
+                Self::MixedSuppressible
+            }
+            Self::Uniform { .. } => Self::MixedInherit,
+            Self::MixedSuppressible if candidate_is_suppressible => Self::MixedSuppressible,
+            Self::MixedSuppressible | Self::MixedInherit => Self::MixedInherit,
+        };
     }
 
     pub(crate) fn build_policy(self) -> DeprecationPolicy<'db> {
-        if self.all_same {
-            self.first
-        } else if self.has_suppress && self.can_suppress {
-            DeprecationPolicy::Suppress
-        } else {
-            DeprecationPolicy::Inherit
+        match self {
+            Self::Uniform { policy, .. } => policy,
+            Self::MixedSuppressible => DeprecationPolicy::Suppress,
+            Self::Empty | Self::MixedInherit => DeprecationPolicy::Inherit,
         }
     }
 }

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -10,8 +10,9 @@ use crate::dunder_all::dunder_all_names;
 use crate::reachability::{ReachabilityConstraintsExtension, evaluate_reachability};
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::{
-    DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers, TypeQualifiers,
-    UnionBuilder, UnionType, binding_type, inferred_declaration, is_discarded_dict_key_assignment,
+    DeprecatedInstance, DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers,
+    TypeQualifiers, UnionBuilder, UnionType, infer_definition_types, inferred_declaration,
+    is_discarded_dict_key_assignment,
 };
 use crate::{Db, FxIndexSet, FxOrderSet, Program};
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
@@ -242,6 +243,7 @@ impl<'db> Place<'db> {
         PlaceAndQualifiers {
             place: self,
             qualifiers,
+            deprecation: None,
         }
     }
 
@@ -303,14 +305,16 @@ impl<'db> From<LookupResult<'db>> for PlaceAndQualifiers<'db> {
                 DefinedPlace::new(type_and_qualifiers.inner_type())
                     .with_origin(type_and_qualifiers.origin()),
             )
-            .with_qualifiers(type_and_qualifiers.qualifiers()),
+            .with_qualifiers(type_and_qualifiers.qualifiers())
+            .with_deprecation(type_and_qualifiers.deprecation()),
             Err(LookupError::Undefined(qualifiers)) => Place::Undefined.with_qualifiers(qualifiers),
             Err(LookupError::PossiblyUndefined(type_and_qualifiers)) => Place::Defined(
                 DefinedPlace::new(type_and_qualifiers.inner_type())
                     .with_origin(type_and_qualifiers.origin())
                     .with_definedness(Definedness::PossiblyUndefined),
             )
-            .with_qualifiers(type_and_qualifiers.qualifiers()),
+            .with_qualifiers(type_and_qualifiers.qualifiers())
+            .with_deprecation(type_and_qualifiers.deprecation()),
         }
     }
 }
@@ -337,15 +341,50 @@ impl<'db> LookupError<'db> {
                 UnionType::from_two_elements(db, ty.inner_type(), ty2.inner_type()),
                 ty.origin().merge(ty2.origin()),
                 ty.qualifiers().union(ty2.qualifiers()),
-            )),
+            )
+            .with_deprecation(merge_deprecation(ty.deprecation(), ty2.deprecation()))),
             (LookupError::PossiblyUndefined(ty), Err(LookupError::PossiblyUndefined(ty2))) => {
-                Err(LookupError::PossiblyUndefined(TypeAndQualifiers::new(
-                    UnionType::from_two_elements(db, ty.inner_type(), ty2.inner_type()),
-                    ty.origin().merge(ty2.origin()),
-                    ty.qualifiers().union(ty2.qualifiers()),
-                )))
+                Err(LookupError::PossiblyUndefined(
+                    TypeAndQualifiers::new(
+                        UnionType::from_two_elements(db, ty.inner_type(), ty2.inner_type()),
+                        ty.origin().merge(ty2.origin()),
+                        ty.qualifiers().union(ty2.qualifiers()),
+                    )
+                    .with_deprecation(merge_deprecation(ty.deprecation(), ty2.deprecation())),
+                ))
             }
         }
+    }
+}
+
+/// Retain a binding deprecation only if both alternatives have the same message.
+pub(crate) fn merge_deprecation<'db>(
+    left: Option<DeprecatedInstance<'db>>,
+    right: Option<DeprecatedInstance<'db>>,
+) -> Option<DeprecatedInstance<'db>> {
+    (left == right).then_some(left).flatten()
+}
+
+/// Accumulates deprecation metadata across alternatives, retaining only a shared message.
+#[derive(Default)]
+pub(crate) struct DeprecationBuilder<'db> {
+    deprecation: Option<DeprecatedInstance<'db>>,
+    has_candidate: bool,
+}
+
+impl<'db> DeprecationBuilder<'db> {
+    /// Adds a viable alternative. `None` represents an alternative that is not deprecated.
+    pub(crate) fn add(&mut self, candidate: Option<DeprecatedInstance<'db>>) {
+        self.deprecation = if self.has_candidate {
+            merge_deprecation(self.deprecation, candidate)
+        } else {
+            self.has_candidate = true;
+            candidate
+        };
+    }
+
+    pub(crate) fn build(self) -> Option<DeprecatedInstance<'db>> {
+        self.deprecation
     }
 }
 
@@ -640,7 +679,7 @@ impl<'db> PlaceFromDeclarationsResult<'db> {
     }
 }
 
-/// A type with declaredness information, and a set of type qualifiers.
+/// A type with declaredness information, type qualifiers, and place-level metadata.
 ///
 /// This is used to represent the result of looking up the declared type. Consider this
 /// example:
@@ -658,6 +697,8 @@ impl<'db> PlaceFromDeclarationsResult<'db> {
 pub(crate) struct PlaceAndQualifiers<'db> {
     pub(crate) place: Place<'db>,
     pub(crate) qualifiers: TypeQualifiers,
+    /// Deprecation attached to the place rather than its inferred type.
+    pub(crate) deprecation: Option<DeprecatedInstance<'db>>,
 }
 
 impl<'db> PlaceAndQualifiers<'db> {
@@ -698,14 +739,21 @@ impl<'db> PlaceAndQualifiers<'db> {
         self.qualifiers.contains(TypeQualifiers::READ_ONLY)
     }
 
+    #[must_use]
+    pub(crate) fn with_deprecation(mut self, deprecation: Option<DeprecatedInstance<'db>>) -> Self {
+        self.deprecation = deprecation;
+        self
+    }
+
     /// Returns `Some(…)` if the place is qualified with `typing.Final` without a specified type.
     pub(crate) fn is_bare_final(&self) -> Option<TypeQualifiers> {
         match self {
-            PlaceAndQualifiers { place, qualifiers }
-                if (qualifiers.contains(TypeQualifiers::FINAL)
-                    && place
-                        .ignore_possibly_undefined()
-                        .is_some_and(|ty| ty.is_unknown())) =>
+            PlaceAndQualifiers {
+                place, qualifiers, ..
+            } if (qualifiers.contains(TypeQualifiers::FINAL)
+                && place
+                    .ignore_possibly_undefined()
+                    .is_some_and(|ty| ty.is_unknown())) =>
             {
                 Some(*qualifiers)
             }
@@ -721,6 +769,7 @@ impl<'db> PlaceAndQualifiers<'db> {
         PlaceAndQualifiers {
             place: self.place.map_type(f),
             qualifiers: self.qualifiers,
+            deprecation: self.deprecation,
         }
     }
 
@@ -735,9 +784,11 @@ impl<'db> PlaceAndQualifiers<'db> {
             PlaceAndQualifiers {
                 place: Place::Defined(place),
                 qualifiers,
+                deprecation,
             } => {
                 let ty = place.public_type_policy.apply_if_needed(db, place.ty);
-                let type_and_qualifiers = TypeAndQualifiers::new(ty, place.origin, qualifiers);
+                let type_and_qualifiers = TypeAndQualifiers::new(ty, place.origin, qualifiers)
+                    .with_deprecation(deprecation);
                 match place.definedness {
                     Definedness::AlwaysDefined => Ok(type_and_qualifiers),
                     Definedness::PossiblyUndefined => {
@@ -748,6 +799,7 @@ impl<'db> PlaceAndQualifiers<'db> {
             PlaceAndQualifiers {
                 place: Place::Undefined,
                 qualifiers,
+                deprecation: _,
             } => Err(LookupError::Undefined(qualifiers)),
         }
     }
@@ -798,6 +850,11 @@ impl<'db> PlaceAndQualifiers<'db> {
         } else {
             previous_place.qualifiers.union(self.qualifiers)
         };
+        let deprecation = if cycle.iteration() <= 1 {
+            self.deprecation
+        } else {
+            merge_deprecation(previous_place.deprecation, self.deprecation)
+        };
         let place = match (previous_place.place, self.place) {
             // In fixed-point iteration of type inference, the member result must be monotonically
             // widened and not "oscillate". The type component is widened by unioning the previous
@@ -847,7 +904,11 @@ impl<'db> PlaceAndQualifiers<'db> {
             }
             (Place::Undefined, Place::Undefined) => Place::Undefined,
         };
-        PlaceAndQualifiers { place, qualifiers }
+        PlaceAndQualifiers {
+            place,
+            qualifiers,
+            deprecation,
+        }
     }
 }
 
@@ -893,9 +954,11 @@ pub(crate) fn place_by_id<'db>(
     // inferred type, without unioning with `Unknown`, because it cannot be modified.
     if let Some(qualifiers) = declared.is_bare_final() {
         let bindings = all_considered_bindings();
-        return place_from_bindings_impl(db, bindings, requires_explicit_reexport)
+        let inferred = place_from_bindings_impl(db, bindings, requires_explicit_reexport);
+        return inferred
             .place
-            .with_qualifiers(qualifiers);
+            .with_qualifiers(qualifiers)
+            .with_deprecation(inferred.deprecation);
     }
 
     match declared {
@@ -910,21 +973,24 @@ pub(crate) fn place_by_id<'db>(
                     ..
                 }),
             qualifiers,
+            deprecation: _,
         } if qualifiers.contains(TypeQualifiers::CLASS_VAR) => {
             let bindings = all_considered_bindings();
-            match place_from_bindings_impl(db, bindings, requires_explicit_reexport).place {
+            let inferred = place_from_bindings_impl(db, bindings, requires_explicit_reexport);
+            match inferred.place {
                 Place::Defined(DefinedPlace {
-                    ty: inferred,
+                    ty: inferred_ty,
                     origin,
                     definedness: boundness,
                     ..
                 }) => Place::Defined(DefinedPlace {
-                    ty: UnionType::from_two_elements(db, Type::unknown(), inferred),
+                    ty: UnionType::from_two_elements(db, Type::unknown(), inferred_ty),
                     origin,
                     definedness: boundness,
                     public_type_policy: PublicTypePolicy::Raw,
                 })
-                .with_qualifiers(qualifiers),
+                .with_qualifiers(qualifiers)
+                .with_deprecation(inferred.deprecation),
                 Place::Undefined => Place::Defined(DefinedPlace {
                     ty: Type::unknown(),
                     origin,
@@ -942,6 +1008,7 @@ pub(crate) fn place_by_id<'db>(
                     ..
                 }),
             qualifiers: _,
+            deprecation: _,
         } => place_and_quals,
         // Place is possibly declared
         PlaceAndQualifiers {
@@ -953,6 +1020,7 @@ pub(crate) fn place_by_id<'db>(
                     ..
                 }),
             qualifiers,
+            deprecation: declared_deprecation,
         } => {
             let bindings = all_considered_bindings();
             let boundness_analysis = bindings.boundness_analysis();
@@ -989,22 +1057,28 @@ pub(crate) fn place_by_id<'db>(
                 }),
             };
 
-            PlaceAndQualifiers { place, qualifiers }
+            PlaceAndQualifiers {
+                place,
+                qualifiers,
+                deprecation: merge_deprecation(declared_deprecation, inferred.deprecation),
+            }
         }
         // Place is undeclared, infer the type from bindings
         PlaceAndQualifiers {
             place: Place::Undefined,
             qualifiers: _,
+            deprecation: _,
         } => {
             let bindings = all_considered_bindings();
             let boundness_analysis = bindings.boundness_analysis();
-            let mut inferred =
-                place_from_bindings_impl(db, bindings, requires_explicit_reexport).place;
+            let inferred = place_from_bindings_impl(db, bindings, requires_explicit_reexport);
+            let deprecation = inferred.deprecation;
+            let mut place = inferred.place;
 
             if boundness_analysis == BoundnessAnalysis::AssumeBound {
-                if let Place::Defined(defined) = inferred {
+                if let Place::Defined(defined) = place {
                     if defined.definedness == Definedness::PossiblyUndefined {
-                        inferred =
+                        place =
                             Place::Defined(defined.with_definedness(Definedness::AlwaysDefined));
                     }
                 }
@@ -1046,14 +1120,17 @@ pub(crate) fn place_by_id<'db>(
                 || scope_has_private_visibility
                 || in_stub_file
             {
-                inferred.into()
+                place
+                    .with_qualifiers(TypeQualifiers::empty())
+                    .with_deprecation(deprecation)
             } else {
                 // Public inferred types should expose a promoted view rather than their raw
                 // inferred literal form. The adjustment is applied lazily when converting to
                 // `LookupResult` via `into_lookup_result`.
-                inferred
+                place
                     .with_public_type_policy(PublicTypePolicy::Promote)
-                    .into()
+                    .with_qualifiers(TypeQualifiers::empty())
+                    .with_deprecation(deprecation)
             }
         }
     }
@@ -1361,6 +1438,7 @@ fn place_from_bindings_impl<'db>(
     let mut first_definition = None;
     // special handling for synthetic loop header definitions and nested bindings definitions
     let mut only_non_shadowing_bindings = true;
+    let mut deprecation = DeprecationBuilder::default();
 
     let mut types = bindings_with_constraints.filter_map(
         |BindingWithConstraints {
@@ -1471,7 +1549,13 @@ fn place_from_bindings_impl<'db>(
             }
 
             first_definition.get_or_insert(binding);
-            let binding_ty = binding_type(db, binding);
+            let inference = infer_definition_types(db, binding);
+            let binding_ty = inference.binding_type(binding);
+            let binding_deprecation = inference
+                .inferred_declaration(binding)
+                .declared()
+                .and_then(|declaration| declaration.deprecation());
+            deprecation.add(binding_deprecation);
             Some((
                 narrowing_constraint.narrow(db, binding_ty, binding.place(db)),
                 static_reachability,
@@ -1479,8 +1563,8 @@ fn place_from_bindings_impl<'db>(
         },
     );
 
-    let place = if let Some((first, first_reachability)) = types.next() {
-        let ty = if let Some((second, second_reachability)) = types.next() {
+    let ty = if let Some((first, first_reachability)) = types.next() {
+        Some(if let Some((second, second_reachability)) = types.next() {
             let mut builder = PublicTypeBuilder::new(db);
             builder.add(first, first_reachability);
             builder.add(second, second_reachability);
@@ -1492,8 +1576,12 @@ fn place_from_bindings_impl<'db>(
             builder.build()
         } else {
             first
-        };
+        })
+    } else {
+        None
+    };
 
+    let place = if let Some(ty) = ty {
         let boundness = match boundness_analysis {
             BoundnessAnalysis::AssumeBound => Definedness::AlwaysDefined,
             BoundnessAnalysis::BasedOnUnboundVisibility => match unbound_visibility() {
@@ -1525,16 +1613,31 @@ fn place_from_bindings_impl<'db>(
     } else {
         Place::Undefined
     };
+    let deprecation = if place.is_undefined() {
+        None
+    } else {
+        deprecation.build()
+    };
 
     PlaceWithDefinition {
         place,
         first_definition,
+        deprecation,
     }
 }
 
 pub(super) struct PlaceWithDefinition<'db> {
     pub(super) place: Place<'db>,
     pub(super) first_definition: Option<Definition<'db>>,
+    deprecation: Option<DeprecatedInstance<'db>>,
+}
+
+impl<'db> PlaceWithDefinition<'db> {
+    pub(super) fn into_place_and_qualifiers(self) -> PlaceAndQualifiers<'db> {
+        self.place
+            .with_qualifiers(TypeQualifiers::empty())
+            .with_deprecation(self.deprecation)
+    }
 }
 
 /// Accumulates types from multiple bindings or declarations, and eventually builds a
@@ -1627,6 +1730,7 @@ impl<'db> PublicTypeBuilder<'db> {
 struct DeclaredTypeBuilder<'db> {
     inner: PublicTypeBuilder<'db>,
     qualifiers: TypeQualifiers,
+    deprecation: DeprecationBuilder<'db>,
     first_type: Option<Type<'db>>,
     conflicting_types: FxOrderSet<Type<'db>>,
 }
@@ -1636,6 +1740,7 @@ impl<'db> DeclaredTypeBuilder<'db> {
         DeclaredTypeBuilder {
             inner: PublicTypeBuilder::new(db),
             qualifiers: TypeQualifiers::empty(),
+            deprecation: DeprecationBuilder::default(),
             first_type: None,
             conflicting_types: FxOrderSet::default(),
         }
@@ -1655,11 +1760,13 @@ impl<'db> DeclaredTypeBuilder<'db> {
         }
 
         self.qualifiers = self.qualifiers.union(element.qualifiers());
+        self.deprecation.add(element.deprecation());
     }
 
     fn build(mut self) -> DeclaredTypeAndConflictingTypes<'db> {
         let type_and_quals =
-            TypeAndQualifiers::new(self.inner.build(), TypeOrigin::Declared, self.qualifiers);
+            TypeAndQualifiers::new(self.inner.build(), TypeOrigin::Declared, self.qualifiers)
+                .with_deprecation(self.deprecation.build());
         if self.conflicting_types.is_empty() {
             (type_and_quals, None)
         } else {
@@ -1763,7 +1870,8 @@ fn place_from_declarations_impl<'db>(
                 .with_origin(TypeOrigin::Declared)
                 .with_definedness(boundness),
         )
-        .with_qualifiers(declared.qualifiers());
+        .with_qualifiers(declared.qualifiers())
+        .with_deprecation(declared.deprecation());
 
         if let Some(conflicting) = conflicting {
             PlaceFromDeclarationsResult::conflict(place_and_quals, conflicting, first_declaration)

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -433,15 +433,21 @@ impl<'db> LookupError<'db> {
         match (&self, &fallback) {
             (LookupError::Undefined(_), _) => fallback,
             (LookupError::PossiblyUndefined { .. }, Err(LookupError::Undefined(_))) => Err(self),
-            (LookupError::PossiblyUndefined(ty), Ok(ty2)) => Ok(TypeAndQualifiers::new(
-                UnionType::from_two_elements(db, ty.inner_type(), ty2.inner_type()),
-                ty.origin().merge(ty2.origin()),
-                ty.qualifiers().union(ty2.qualifiers()),
-            )
-            .with_deprecation_policy(merge_deprecation_policy(
-                ty.deprecation_policy(),
-                ty2.deprecation_policy(),
-            ))),
+            (LookupError::PossiblyUndefined(ty), Ok(ty2)) => {
+                let policy = DeprecationPolicy::from_alternatives(
+                    db,
+                    [
+                        (ty.inner_type(), ty.deprecation_policy()),
+                        (ty2.inner_type(), ty2.deprecation_policy()),
+                    ],
+                );
+                Ok(TypeAndQualifiers::new(
+                    UnionType::from_two_elements(db, ty.inner_type(), ty2.inner_type()),
+                    ty.origin().merge(ty2.origin()),
+                    ty.qualifiers().union(ty2.qualifiers()),
+                )
+                .with_deprecation_policy(policy))
+            }
             (LookupError::PossiblyUndefined(ty), Err(LookupError::PossiblyUndefined(ty2))) => {
                 Err(LookupError::PossiblyUndefined(
                     TypeAndQualifiers::new(
@@ -449,10 +455,15 @@ impl<'db> LookupError<'db> {
                         ty.origin().merge(ty2.origin()),
                         ty.qualifiers().union(ty2.qualifiers()),
                     )
-                    .with_deprecation_policy(merge_deprecation_policy(
-                        ty.deprecation_policy(),
-                        ty2.deprecation_policy(),
-                    )),
+                    .with_deprecation_policy(
+                        DeprecationPolicy::from_alternatives(
+                            db,
+                            [
+                                (ty.inner_type(), ty.deprecation_policy()),
+                                (ty2.inner_type(), ty2.deprecation_policy()),
+                            ],
+                        ),
+                    ),
                 ))
             }
         }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1221,7 +1221,7 @@ fn analyze_single(db: &dyn Db, predicate: &Predicate) -> Truthiness {
                 symbol.name(),
                 requires_explicit_reexport,
             )
-            .place
+            .place()
             {
                 Place::Defined(DefinedPlace {
                     definedness: Definedness::AlwaysDefined,

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -491,7 +491,7 @@ impl<'db> SemanticModel<'db> {
                         attr.attr.id.clone(),
                         crate::types::MemberLookupPolicy::default(),
                     )
-                    .qualifiers
+                    .qualifiers()
             }
             _ => TypeQualifiers::empty(),
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -47,7 +47,7 @@ pub(crate) use self::subclass_of::{SubclassOfInner, SubclassOfType};
 pub use crate::diagnostic::add_inferred_python_version_hint_to_diagnostic;
 use crate::place::{
     DefinedPlace, Definedness, DeprecationPolicy, Place, PlaceAndQualifiers, TypeOrigin,
-    builtins_module_scope, imported_symbol, known_module_symbol, merge_deprecation_policy,
+    builtins_module_scope, imported_symbol, known_module_symbol,
 };
 use crate::suppression::check_suppressions;
 use crate::types::bound_super::BoundSuperType;
@@ -3275,9 +3275,12 @@ impl<'db> Type<'db> {
                 public_type_policy: fallback_public_type_policy,
             })
             .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers))
-            .with_deprecation_policy(merge_deprecation_policy(
-                meta_attr_deprecation,
-                fallback_deprecation,
+            .with_deprecation_policy(DeprecationPolicy::from_alternatives(
+                db,
+                [
+                    (meta_attr_ty, meta_attr_deprecation),
+                    (fallback_ty, fallback_deprecation),
+                ],
             )),
 
             // `meta_attr` is *not* a data descriptor. This means that the `fallback` type has
@@ -3323,9 +3326,12 @@ impl<'db> Type<'db> {
                 public_type_policy: fallback_public_type_policy,
             })
             .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers))
-            .with_deprecation_policy(merge_deprecation_policy(
-                meta_attr_deprecation,
-                fallback_deprecation,
+            .with_deprecation_policy(DeprecationPolicy::from_alternatives(
+                db,
+                [
+                    (meta_attr_ty, meta_attr_deprecation),
+                    (fallback_ty, fallback_deprecation),
+                ],
             )),
 
             // If the attribute is not found on the meta-type, we simply return the fallback.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3074,19 +3074,20 @@ impl<'db> Type<'db> {
                 definedness: boundness,
                 public_type_policy,
             }) => (
-                union
-                    .map_with_boundness(db, |elem| {
-                        Place::Defined(DefinedPlace {
-                            ty: elem
-                                .try_call_dunder_get(db, instance, owner)
-                                .map_or(*elem, |(ty, _)| ty),
-                            origin,
-                            definedness: boundness,
-                            public_type_policy,
-                        })
+                union.map_with_boundness_and_qualifiers(db, |elem| {
+                    let elem_deprecation = deprecation.resolve_for_alternative_type(db, *elem);
+                    let mapped = elem
+                        .try_call_dunder_get(db, instance, owner)
+                        .map_or(*elem, |(ty, _)| ty);
+                    Place::Defined(DefinedPlace {
+                        ty: mapped,
+                        origin,
+                        definedness: boundness,
+                        public_type_policy,
                     })
                     .with_qualifiers(qualifiers)
-                    .with_deprecation_policy(deprecation),
+                    .with_deprecation_policy(elem_deprecation)
+                }),
                 // TODO: avoid the duplication here:
                 if union.elements(db).iter().all(|elem| {
                     elem.try_call_dunder_get(db, instance, owner)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -47,7 +47,7 @@ pub(crate) use self::subclass_of::{SubclassOfInner, SubclassOfType};
 pub use crate::diagnostic::add_inferred_python_version_hint_to_diagnostic;
 use crate::place::{
     DefinedPlace, Definedness, Place, PlaceAndQualifiers, TypeOrigin, builtins_module_scope,
-    imported_symbol, known_module_symbol,
+    imported_symbol, known_module_symbol, merge_deprecation,
 };
 use crate::suppression::check_suppressions;
 use crate::types::bound_super::BoundSuperType;
@@ -69,6 +69,7 @@ use crate::types::generics::{
     ApplySpecialization, InferableTypeVars, Specialization, bind_typevar,
 };
 use crate::types::infer::InferenceFlags;
+pub(crate) use crate::types::known_instance::DeprecatedInstance;
 use crate::types::known_instance::{
     InternedConstraintSet, InternedType, SentinelInstance, UnionTypeInstance,
 };
@@ -3030,6 +3031,7 @@ impl<'db> Type<'db> {
                     public_type_policy,
                 }),
             qualifiers,
+            deprecation,
         } = attribute
             && let Some(fallback) = ty.materialized_divergent_fallback()
         {
@@ -3041,7 +3043,8 @@ impl<'db> Type<'db> {
                     definedness,
                     public_type_policy,
                 })
-                .with_qualifiers(qualifiers),
+                .with_qualifiers(qualifiers)
+                .with_deprecation(deprecation),
                 instance,
                 owner,
             );
@@ -3063,6 +3066,7 @@ impl<'db> Type<'db> {
                         ..
                     }),
                 qualifiers: _,
+                ..
             } => (attribute, AttributeKind::DataDescriptor),
 
             PlaceAndQualifiers {
@@ -3074,6 +3078,7 @@ impl<'db> Type<'db> {
                         public_type_policy,
                     }),
                 qualifiers,
+                deprecation,
             } => (
                 union
                     .map_with_boundness(db, |elem| {
@@ -3086,7 +3091,8 @@ impl<'db> Type<'db> {
                             public_type_policy,
                         })
                     })
-                    .with_qualifiers(qualifiers),
+                    .with_qualifiers(qualifiers)
+                    .with_deprecation(deprecation),
                 // TODO: avoid the duplication here:
                 if union.elements(db).iter().all(|elem| {
                     elem.try_call_dunder_get(db, instance, owner)
@@ -3107,6 +3113,7 @@ impl<'db> Type<'db> {
                         public_type_policy,
                     }),
                 qualifiers,
+                deprecation,
             } => (
                 if intersection.positive(db).is_empty() {
                     attribute
@@ -3123,6 +3130,7 @@ impl<'db> Type<'db> {
                             })
                         })
                         .with_qualifiers(qualifiers)
+                        .with_deprecation(deprecation)
                 },
                 // TODO: Discover data descriptors in intersections.
                 AttributeKind::NormalOrNonDataDescriptor,
@@ -3137,6 +3145,7 @@ impl<'db> Type<'db> {
                         public_type_policy,
                     }),
                 qualifiers: _,
+                deprecation,
             } => {
                 if let Some((return_ty, attribute_kind)) =
                     attribute_ty.try_call_dunder_get(db, instance, owner)
@@ -3148,7 +3157,8 @@ impl<'db> Type<'db> {
                             definedness: boundness,
                             public_type_policy,
                         })
-                        .into(),
+                        .with_qualifiers(TypeQualifiers::empty())
+                        .with_deprecation(deprecation),
                         attribute_kind,
                     )
                 } else {
@@ -3228,6 +3238,7 @@ impl<'db> Type<'db> {
             PlaceAndQualifiers {
                 place: meta_attr,
                 qualifiers: meta_attr_qualifiers,
+                deprecation: meta_attr_deprecation,
             },
             meta_attr_kind,
         ) = Self::try_call_dunder_get_on_attribute(
@@ -3240,14 +3251,15 @@ impl<'db> Type<'db> {
         let PlaceAndQualifiers {
             place: fallback,
             qualifiers: fallback_qualifiers,
+            deprecation: fallback_deprecation,
         } = fallback;
 
         match (meta_attr, meta_attr_kind, fallback) {
             // The fallback type is unbound, so we can just return `meta_attr` unconditionally,
             // no matter if it's data descriptor, a non-data descriptor, or a normal attribute.
-            (meta_attr @ Place::Defined(_), _, Place::Undefined) => {
-                meta_attr.with_qualifiers(meta_attr_qualifiers)
-            }
+            (meta_attr @ Place::Defined(_), _, Place::Undefined) => meta_attr
+                .with_qualifiers(meta_attr_qualifiers)
+                .with_deprecation(meta_attr_deprecation),
 
             // `meta_attr` is the return type of a data descriptor and definitely bound, so we
             // return it.
@@ -3258,7 +3270,9 @@ impl<'db> Type<'db> {
                 }),
                 AttributeKind::DataDescriptor,
                 _,
-            ) => meta_attr.with_qualifiers(meta_attr_qualifiers),
+            ) => meta_attr
+                .with_qualifiers(meta_attr_qualifiers)
+                .with_deprecation(meta_attr_deprecation),
 
             // `meta_attr` is the return type of a data descriptor, but the attribute on the
             // meta-type is possibly-unbound. This means that we "fall through" to the next
@@ -3283,7 +3297,11 @@ impl<'db> Type<'db> {
                 definedness: fallback_boundness,
                 public_type_policy: fallback_public_type_policy,
             })
-            .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers)),
+            .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers))
+            .with_deprecation(merge_deprecation(
+                meta_attr_deprecation,
+                fallback_deprecation,
+            )),
 
             // `meta_attr` is *not* a data descriptor. This means that the `fallback` type has
             // now the highest priority. However, we only return the pure `fallback` type if the
@@ -3300,9 +3318,9 @@ impl<'db> Type<'db> {
                     definedness: Definedness::AlwaysDefined,
                     ..
                 }),
-            ) if policy == InstanceFallbackShadowsNonDataDescriptor::Yes => {
-                fallback.with_qualifiers(fallback_qualifiers)
-            }
+            ) if policy == InstanceFallbackShadowsNonDataDescriptor::Yes => fallback
+                .with_qualifiers(fallback_qualifiers)
+                .with_deprecation(fallback_deprecation),
 
             // `meta_attr` is *not* a data descriptor. The `fallback` symbol is either possibly
             // unbound or the policy argument is `No`. In both cases, the `fallback` type does
@@ -3327,10 +3345,16 @@ impl<'db> Type<'db> {
                 definedness: meta_attr_boundness.max(fallback_boundness),
                 public_type_policy: fallback_public_type_policy,
             })
-            .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers)),
+            .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers))
+            .with_deprecation(merge_deprecation(
+                meta_attr_deprecation,
+                fallback_deprecation,
+            )),
 
             // If the attribute is not found on the meta-type, we simply return the fallback.
-            (Place::Undefined, _, fallback) => fallback.with_qualifiers(fallback_qualifiers),
+            (Place::Undefined, _, fallback) => fallback
+                .with_qualifiers(fallback_qualifiers)
+                .with_deprecation(fallback_deprecation),
         }
     }
 
@@ -5155,6 +5179,7 @@ impl<'db> Type<'db> {
                         ..
                     }),
                 qualifiers: _,
+                ..
             } => member,
             member @ PlaceAndQualifiers {
                 place:
@@ -5163,12 +5188,14 @@ impl<'db> Type<'db> {
                         ..
                     }),
                 qualifiers: _,
+                ..
             } => member
                 .or_fall_back_to(db, custom_getattribute_result)
                 .or_fall_back_to(db, custom_getattr_result),
             PlaceAndQualifiers {
                 place: Place::Undefined,
                 qualifiers: _,
+                ..
             } => custom_getattribute_result().or_fall_back_to(db, custom_getattr_result),
         }
     }
@@ -7399,8 +7426,8 @@ impl TypeQualifiers {
 
 /// When inferring the type of an annotation expression, we can also encounter type qualifiers
 /// such as `ClassVar` or `Final`. These do not affect the inferred type itself, but rather
-/// control how a particular place can be accessed or modified. This struct holds a type and
-/// a set of type qualifiers.
+/// control how a particular place can be accessed or modified. This struct holds a type,
+/// qualifiers, and metadata attached to the place rather than the type.
 ///
 /// Example: `Annotated[ClassVar[tuple[int]], "metadata"]` would have type `tuple[int]` and the
 /// qualifier `ClassVar`.
@@ -7409,6 +7436,8 @@ pub(crate) struct TypeAndQualifiers<'db> {
     inner: Type<'db>,
     origin: TypeOrigin,
     qualifiers: TypeQualifiers,
+    /// Deprecation attached to the place rather than its inferred type.
+    deprecation: Option<DeprecatedInstance<'db>>,
 }
 
 impl<'db> TypeAndQualifiers<'db> {
@@ -7417,6 +7446,7 @@ impl<'db> TypeAndQualifiers<'db> {
             inner,
             origin,
             qualifiers,
+            deprecation: None,
         }
     }
 
@@ -7425,6 +7455,7 @@ impl<'db> TypeAndQualifiers<'db> {
             inner,
             origin: TypeOrigin::Declared,
             qualifiers: TypeQualifiers::empty(),
+            deprecation: None,
         }
     }
 
@@ -7448,6 +7479,16 @@ impl<'db> TypeAndQualifiers<'db> {
         self.qualifiers
     }
 
+    pub(crate) fn deprecation(&self) -> Option<DeprecatedInstance<'db>> {
+        self.deprecation
+    }
+
+    #[must_use]
+    pub(crate) fn with_deprecation(mut self, deprecation: Option<DeprecatedInstance<'db>>) -> Self {
+        self.deprecation = deprecation;
+        self
+    }
+
     pub(crate) fn map_type(
         &self,
         f: impl FnOnce(Type<'db>) -> Type<'db>,
@@ -7456,6 +7497,7 @@ impl<'db> TypeAndQualifiers<'db> {
             inner: f(self.inner),
             origin: self.origin,
             qualifiers: self.qualifiers,
+            deprecation: self.deprecation,
         }
     }
 }
@@ -7974,6 +8016,7 @@ impl<'db> ModuleLiteralType<'db> {
                         ..place
                     }),
                     qualifiers: TypeQualifiers::FROM_MODULE_GETATTR,
+                    deprecation: None,
                 };
             }
         }
@@ -8029,6 +8072,7 @@ impl<'db> ModuleLiteralType<'db> {
                         ..defined
                     }),
                     qualifiers: place_and_qualifiers.qualifiers,
+                    deprecation: place_and_qualifiers.deprecation,
                 };
             }
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -771,7 +771,7 @@ impl<'db> DataclassParams<'db> {
 
     fn from_flags(db: &'db dyn Db, flags: DataclassFlags) -> Self {
         let dataclasses_field = known_module_symbol(db, KnownModule::Dataclasses, "field")
-            .place
+            .place()
             .ignore_possibly_undefined()
             .unwrap_or_else(Type::unknown);
 
@@ -2616,7 +2616,7 @@ impl<'db> Type<'db> {
     #[salsa::tracked(
         cycle_initial=|_, id, _, _, _| Place::bound(Type::divergent(id)).into(),
         cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, member: PlaceAndQualifiers<'db>, _, _, _| {
-            member.cycle_normalized(db, *previous, cycle)
+            member.cycle_normalized(db, previous, cycle)
         },
         heap_size=ruff_memory_usage::heap_size
     )]
@@ -2679,7 +2679,7 @@ impl<'db> Type<'db> {
                     .to_class_literal(db)
                     .find_name_in_mro_with_policy(db, name.as_str(), policy)
                     .expect("`find_name_in_mro` should return `Some` for a class literal");
-                if !type_result.place.is_undefined() {
+                if !type_result.place().is_undefined() {
                     type_result
                 } else {
                     self.to_meta_type(db)
@@ -2728,16 +2728,12 @@ impl<'db> Type<'db> {
         // values populated by metaclass initialization, analogous to a declared instance
         // attribute initialized in `__init__`. An inherited declaration does not mask a value
         // that the metaclass stores directly on the newly constructed subclass.
-        let own_declaration_definedness = match own_class_attr {
-            Some(PlaceAndQualifiers {
-                place:
-                    Place::Defined(DefinedPlace {
-                        origin: TypeOrigin::Declared,
-                        definedness,
-                        ..
-                    }),
+        let own_declaration_definedness = match own_class_attr.map(|attr| attr.place()) {
+            Some(Place::Defined(DefinedPlace {
+                origin: TypeOrigin::Declared,
+                definedness,
                 ..
-            }) => Some(definedness),
+            })) => Some(definedness),
             _ => None,
         };
         if own_declaration_definedness == Some(Definedness::AlwaysDefined) {
@@ -2882,15 +2878,15 @@ impl<'db> Type<'db> {
     /// See also: [`Type::member`]
     fn static_member(&self, db: &'db dyn Db, name: &str) -> Place<'db> {
         if let Type::ModuleLiteral(module) = self {
-            module.static_member(db, name).place
-        } else if let place @ Place::Defined(_) = self.class_member(db, name.into()).place {
+            module.static_member(db, name).place()
+        } else if let place @ Place::Defined(_) = self.class_member(db, name.into()).place() {
             place
         } else if let Some(place @ Place::Defined(_)) =
-            self.find_name_in_mro(db, name).map(|inner| inner.place)
+            self.find_name_in_mro(db, name).map(|inner| inner.place())
         {
             place
         } else {
-            self.instance_member(db, name).place
+            self.instance_member(db, name).place()
         }
     }
 
@@ -2953,7 +2949,7 @@ impl<'db> Type<'db> {
                 _ => {}
             }
 
-            let descr_get = ty.class_member(db, "__get__".into()).place;
+            let descr_get = ty.class_member(db, "__get__".into()).place();
 
             if let Place::Defined(DefinedPlace {
                 ty: descr_get,
@@ -3022,17 +3018,16 @@ impl<'db> Type<'db> {
         instance: Option<Type<'db>>,
         owner: Type<'db>,
     ) -> (PlaceAndQualifiers<'db>, AttributeKind) {
-        if let PlaceAndQualifiers {
-            place:
-                Place::Defined(DefinedPlace {
-                    ty,
-                    origin,
-                    definedness,
-                    public_type_policy,
-                }),
-            qualifiers,
-            deprecation,
-        } = attribute
+        let place = attribute.place();
+        let qualifiers = attribute.qualifiers();
+        let deprecation = attribute.deprecation_policy();
+
+        if let Place::Defined(DefinedPlace {
+            ty,
+            origin,
+            definedness,
+            public_type_policy,
+        }) = place
             && let Some(fallback) = ty.materialized_divergent_fallback()
         {
             return Self::try_call_dunder_get_on_attribute(
@@ -3050,7 +3045,7 @@ impl<'db> Type<'db> {
             );
         }
 
-        match attribute {
+        match place {
             // This branch is not strictly needed, but it short-circuits the lookup of various dunder
             // methods and calls that would otherwise be made.
             //
@@ -3059,27 +3054,17 @@ impl<'db> Type<'db> {
             // data descriptors.
             //
             // The same is true for `Never`.
-            PlaceAndQualifiers {
-                place:
-                    Place::Defined(DefinedPlace {
-                        ty: Type::Dynamic(_) | Type::Divergent(_) | Type::Never,
-                        ..
-                    }),
-                qualifiers: _,
+            Place::Defined(DefinedPlace {
+                ty: Type::Dynamic(_) | Type::Divergent(_) | Type::Never,
                 ..
-            } => (attribute, AttributeKind::DataDescriptor),
+            }) => (attribute, AttributeKind::DataDescriptor),
 
-            PlaceAndQualifiers {
-                place:
-                    Place::Defined(DefinedPlace {
-                        ty: Type::Union(union),
-                        origin,
-                        definedness: boundness,
-                        public_type_policy,
-                    }),
-                qualifiers,
-                deprecation,
-            } => (
+            Place::Defined(DefinedPlace {
+                ty: Type::Union(union),
+                origin,
+                definedness: boundness,
+                public_type_policy,
+            }) => (
                 union
                     .map_with_boundness(db, |elem| {
                         Place::Defined(DefinedPlace {
@@ -3104,17 +3089,12 @@ impl<'db> Type<'db> {
                 },
             ),
 
-            attribute @ PlaceAndQualifiers {
-                place:
-                    Place::Defined(DefinedPlace {
-                        ty: Type::Intersection(intersection),
-                        origin,
-                        definedness,
-                        public_type_policy,
-                    }),
-                qualifiers,
-                deprecation,
-            } => (
+            Place::Defined(DefinedPlace {
+                ty: Type::Intersection(intersection),
+                origin,
+                definedness,
+                public_type_policy,
+            }) => (
                 if intersection.positive(db).is_empty() {
                     attribute
                 } else {
@@ -3136,17 +3116,12 @@ impl<'db> Type<'db> {
                 AttributeKind::NormalOrNonDataDescriptor,
             ),
 
-            PlaceAndQualifiers {
-                place:
-                    Place::Defined(DefinedPlace {
-                        ty: attribute_ty,
-                        origin,
-                        definedness: boundness,
-                        public_type_policy,
-                    }),
-                qualifiers: _,
-                deprecation,
-            } => {
+            Place::Defined(DefinedPlace {
+                ty: attribute_ty,
+                origin,
+                definedness: boundness,
+                public_type_policy,
+            }) => {
                 if let Some((return_ty, attribute_kind)) =
                     attribute_ty.try_call_dunder_get(db, instance, owner)
                 {
@@ -3166,7 +3141,7 @@ impl<'db> Type<'db> {
                 }
             }
 
-            _ => (attribute, AttributeKind::NormalOrNonDataDescriptor),
+            Place::Undefined => (attribute, AttributeKind::NormalOrNonDataDescriptor),
         }
     }
 
@@ -3203,10 +3178,13 @@ impl<'db> Type<'db> {
                 .iter_positive(db)
                 .any(|ty| ty.is_data_descriptor_impl(db, any_of_union)),
             _ => {
-                !self.class_member(db, "__set__".into()).place.is_undefined()
+                !self
+                    .class_member(db, "__set__".into())
+                    .place()
+                    .is_undefined()
                     || !self
                         .class_member(db, "__delete__".into())
-                        .place
+                        .place()
                         .is_undefined()
             }
         }
@@ -3234,25 +3212,15 @@ impl<'db> Type<'db> {
         policy: InstanceFallbackShadowsNonDataDescriptor,
         member_policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
-        let (
-            PlaceAndQualifiers {
-                place: meta_attr,
-                qualifiers: meta_attr_qualifiers,
-                deprecation: meta_attr_deprecation,
-            },
-            meta_attr_kind,
-        ) = Self::try_call_dunder_get_on_attribute(
+        let (meta_attr, meta_attr_kind) = Self::try_call_dunder_get_on_attribute(
             db,
             self.class_member_with_policy(db, name.into(), member_policy),
             Some(self),
             self.to_meta_type(db),
         );
+        let (meta_attr, meta_attr_qualifiers, meta_attr_deprecation) = meta_attr.into_parts();
 
-        let PlaceAndQualifiers {
-            place: fallback,
-            qualifiers: fallback_qualifiers,
-            deprecation: fallback_deprecation,
-        } = fallback;
+        let (fallback, fallback_qualifiers, fallback_deprecation) = fallback.into_parts();
 
         match (meta_attr, meta_attr_kind, fallback) {
             // The fallback type is unbound, so we can just return `meta_attr` unconditionally,
@@ -3381,7 +3349,7 @@ impl<'db> Type<'db> {
         #[salsa::tracked(
             cycle_initial=|_, id, _, _, _| Place::bound(Type::divergent(id)).into(),
             cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, member: PlaceAndQualifiers<'db>, _, _, _| {
-                member.cycle_normalized(db, *previous, cycle)
+                member.cycle_normalized(db, previous, cycle)
             },
             heap_size=ruff_memory_usage::heap_size
         )]
@@ -3730,7 +3698,7 @@ impl<'db> Type<'db> {
                         .into_functools_partial_instance(db)
                         .member_lookup_with_policy(db, name.clone(), policy);
                     if name_str == "func" {
-                        match nominal_lookup.place {
+                        match nominal_lookup.place() {
                             Place::Defined(DefinedPlace {
                                 origin,
                                 definedness,
@@ -3877,7 +3845,7 @@ impl<'db> Type<'db> {
                     let owner_attr = bound_super.find_name_in_mro_after_pivot(db, name_str, policy);
 
                     bound_super
-                        .try_call_dunder_get_on_attribute(db, owner_attr)
+                        .try_call_dunder_get_on_attribute(db, &owner_attr)
                         .unwrap_or(owner_attr)
                 }
             }
@@ -3956,7 +3924,7 @@ impl<'db> Type<'db> {
                 Name::new_static("__getitem__"),
                 MemberLookupPolicy::NO_INSTANCE_FALLBACK,
             )
-            .place
+            .place()
         {
             Place::Defined(DefinedPlace {
                 ty: getitem_method,
@@ -3980,7 +3948,7 @@ impl<'db> Type<'db> {
                 Name::new_static("keys"),
                 MemberLookupPolicy::NO_INSTANCE_FALLBACK,
             )
-            .place
+            .place()
         {
             Place::Defined(DefinedPlace {
                 ty: keys_method,
@@ -4284,7 +4252,7 @@ impl<'db> Type<'db> {
                         Name::new_static("__call__"),
                         MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                     )
-                    .place
+                    .place()
                 {
                     Place::Defined(DefinedPlace {
                         ty: dunder_callable,
@@ -4856,7 +4824,7 @@ impl<'db> Type<'db> {
             MemberLookupPolicy::NO_INSTANCE_FALLBACK | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
         );
 
-        let (new_bindings, has_any_new) = match new_method.as_ref().map(|method| method.place) {
+        let (new_bindings, has_any_new) = match new_method.as_ref().map(PlaceAndQualifiers::place) {
             Some(place) => match resolve_dunder_new_callable(db, self_type, place) {
                 Some((new_callable, definedness)) => {
                     let mut bindings =
@@ -4877,7 +4845,7 @@ impl<'db> Type<'db> {
         };
 
         // Only fall back to `object.__init__` when `__new__` is absent.
-        let init_bindings = match (&init_method_no_object.place, has_any_new) {
+        let init_bindings = match (init_method_no_object.place(), has_any_new) {
             (
                 Place::Defined(DefinedPlace {
                     ty: init_method,
@@ -4893,7 +4861,7 @@ impl<'db> Type<'db> {
                         ConstructorCallableKind::Init,
                     )
                     .with_constructed_instance_type(db, constructor_instance_ty);
-                if *definedness == Definedness::PossiblyUndefined {
+                if definedness == Definedness::PossiblyUndefined {
                     bindings.set_implicit_dunder_init_is_possibly_unbound();
                 }
                 Some(bindings)
@@ -4904,7 +4872,7 @@ impl<'db> Type<'db> {
                     "__init__".into(),
                     MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                 );
-                match init_method_with_object.place {
+                match init_method_with_object.place() {
                     Place::Defined(DefinedPlace {
                         ty: init_method,
                         definedness,
@@ -4962,7 +4930,7 @@ impl<'db> Type<'db> {
         let bindings = if let Place::Defined(DefinedPlace {
             ty: metaclass_call_method,
             ..
-        }) = metaclass_dunder_call.place
+        }) = metaclass_dunder_call.place()
         {
             let mut metaclass_bindings = metaclass_call_method
                 .bindings(db)
@@ -5060,7 +5028,7 @@ impl<'db> Type<'db> {
                 name.into(),
                 policy | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
             )
-            .place
+            .place()
         {
             Place::Defined(DefinedPlace {
                 ty: dunder_callable,
@@ -5099,7 +5067,7 @@ impl<'db> Type<'db> {
         argument_types: &CallArguments<'_, 'db>,
         tcx: TypeContext<'db>,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
-        match self.member(db, name).place {
+        match self.member(db, name).place() {
             Place::Defined(DefinedPlace {
                 ty: dunder_callable,
                 definedness: boundness,
@@ -5171,32 +5139,20 @@ impl<'db> Type<'db> {
             .into()
         };
 
-        match result {
-            member @ PlaceAndQualifiers {
-                place:
-                    Place::Defined(DefinedPlace {
-                        definedness: Definedness::AlwaysDefined,
-                        ..
-                    }),
-                qualifiers: _,
+        match result.place() {
+            Place::Defined(DefinedPlace {
+                definedness: Definedness::AlwaysDefined,
                 ..
-            } => member,
-            member @ PlaceAndQualifiers {
-                place:
-                    Place::Defined(DefinedPlace {
-                        definedness: Definedness::PossiblyUndefined,
-                        ..
-                    }),
-                qualifiers: _,
+            }) => result,
+            Place::Defined(DefinedPlace {
+                definedness: Definedness::PossiblyUndefined,
                 ..
-            } => member
+            }) => result
                 .or_fall_back_to(db, custom_getattribute_result)
                 .or_fall_back_to(db, custom_getattr_result),
-            PlaceAndQualifiers {
-                place: Place::Undefined,
-                qualifiers: _,
-                ..
-            } => custom_getattribute_result().or_fall_back_to(db, custom_getattr_result),
+            Place::Undefined => {
+                custom_getattribute_result().or_fall_back_to(db, custom_getattr_result)
+            }
         }
     }
 
@@ -6862,7 +6818,7 @@ impl<'db> UnionType<'db> {
                     name.into(),
                     policy | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                 )
-                .place
+                .place()
             {
                 Place::Defined(DefinedPlace {
                     ty,
@@ -7431,8 +7387,20 @@ impl TypeQualifiers {
 ///
 /// Example: `Annotated[ClassVar[tuple[int]], "metadata"]` would have type `tuple[int]` and the
 /// qualifier `ClassVar`.
-#[derive(Clone, Debug, Copy, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
-pub(crate) struct TypeAndQualifiers<'db> {
+#[derive(Clone, Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) enum TypeAndQualifiers<'db> {
+    /// The common case, stored inline to avoid an allocation.
+    WithoutDeprecation {
+        inner: Type<'db>,
+        origin: TypeOrigin,
+        qualifiers: TypeQualifiers,
+    },
+    /// Non-default deprecation policies are rare, so store their payload out of line.
+    WithDeprecation(Box<DeprecatedTypeAndQualifiers<'db>>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct DeprecatedTypeAndQualifiers<'db> {
     inner: Type<'db>,
     origin: TypeOrigin,
     qualifiers: TypeQualifiers,
@@ -7441,75 +7409,135 @@ pub(crate) struct TypeAndQualifiers<'db> {
 
 impl<'db> TypeAndQualifiers<'db> {
     pub(crate) fn new(inner: Type<'db>, origin: TypeOrigin, qualifiers: TypeQualifiers) -> Self {
-        Self {
+        Self::WithoutDeprecation {
             inner,
             origin,
             qualifiers,
-            deprecation: DeprecationPolicy::Inherit,
         }
     }
 
     pub(crate) fn declared(inner: Type<'db>) -> Self {
-        Self {
+        Self::WithoutDeprecation {
             inner,
             origin: TypeOrigin::Declared,
             qualifiers: TypeQualifiers::empty(),
-            deprecation: DeprecationPolicy::Inherit,
         }
     }
 
     /// Forget about type qualifiers and only return the inner type.
     pub(crate) fn inner_type(&self) -> Type<'db> {
-        self.inner
+        match self {
+            Self::WithoutDeprecation { inner, .. } => *inner,
+            Self::WithDeprecation(deprecated) => deprecated.inner,
+        }
     }
 
     pub(crate) fn origin(&self) -> TypeOrigin {
-        self.origin
+        match self {
+            Self::WithoutDeprecation { origin, .. } => *origin,
+            Self::WithDeprecation(deprecated) => deprecated.origin,
+        }
     }
 
     /// Return `self` with an additional qualifier added to the set of qualifiers.
     pub(crate) fn with_qualifier(mut self, qualifier: TypeQualifiers) -> Self {
-        self.qualifiers |= qualifier;
+        match &mut self {
+            Self::WithoutDeprecation { qualifiers, .. } => *qualifiers |= qualifier,
+            Self::WithDeprecation(deprecated) => deprecated.qualifiers |= qualifier,
+        }
         self
     }
 
     /// Return the set of type qualifiers.
     pub(crate) fn qualifiers(&self) -> TypeQualifiers {
-        self.qualifiers
+        match self {
+            Self::WithoutDeprecation { qualifiers, .. } => *qualifiers,
+            Self::WithDeprecation(deprecated) => deprecated.qualifiers,
+        }
     }
 
     pub(crate) fn deprecation_policy(&self) -> DeprecationPolicy<'db> {
-        self.deprecation
+        match self {
+            Self::WithoutDeprecation { .. } => DeprecationPolicy::Inherit,
+            Self::WithDeprecation(deprecated) => deprecated.deprecation,
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        Type<'db>,
+        TypeOrigin,
+        TypeQualifiers,
+        DeprecationPolicy<'db>,
+    ) {
+        match self {
+            Self::WithoutDeprecation {
+                inner,
+                origin,
+                qualifiers,
+            } => (inner, origin, qualifiers, DeprecationPolicy::Inherit),
+            Self::WithDeprecation(deprecated) => (
+                deprecated.inner,
+                deprecated.origin,
+                deprecated.qualifiers,
+                deprecated.deprecation,
+            ),
+        }
     }
 
     #[must_use]
-    pub(crate) fn with_deprecation(mut self, deprecation: Option<DeprecatedInstance<'db>>) -> Self {
-        self.deprecation =
-            deprecation.map_or(DeprecationPolicy::Inherit, DeprecationPolicy::Deprecated);
-        self
+    pub(crate) fn with_deprecation(self, deprecation: Option<DeprecatedInstance<'db>>) -> Self {
+        self.with_deprecation_policy(
+            deprecation.map_or(DeprecationPolicy::Inherit, DeprecationPolicy::Deprecated),
+        )
     }
 
     #[must_use]
-    pub(crate) fn with_deprecation_policy(mut self, deprecation: DeprecationPolicy<'db>) -> Self {
-        self.deprecation = deprecation;
-        self
+    pub(crate) fn with_deprecation_policy(self, deprecation: DeprecationPolicy<'db>) -> Self {
+        match (self, deprecation) {
+            (ty @ Self::WithoutDeprecation { .. }, DeprecationPolicy::Inherit) => ty,
+            (
+                Self::WithoutDeprecation {
+                    inner,
+                    origin,
+                    qualifiers,
+                },
+                deprecation,
+            ) => Self::WithDeprecation(Box::new(DeprecatedTypeAndQualifiers {
+                inner,
+                origin,
+                qualifiers,
+                deprecation,
+            })),
+            (Self::WithDeprecation(deprecated), DeprecationPolicy::Inherit) => {
+                Self::WithoutDeprecation {
+                    inner: deprecated.inner,
+                    origin: deprecated.origin,
+                    qualifiers: deprecated.qualifiers,
+                }
+            }
+            (Self::WithDeprecation(mut deprecated), deprecation) => {
+                deprecated.deprecation = deprecation;
+                Self::WithDeprecation(deprecated)
+            }
+        }
     }
 
     #[must_use]
-    pub(crate) fn suppress_type_deprecation(mut self) -> Self {
-        self.deprecation = DeprecationPolicy::Suppress;
+    pub(crate) fn suppress_type_deprecation(self) -> Self {
+        self.with_deprecation_policy(DeprecationPolicy::Suppress)
+    }
+
+    pub(crate) fn map_type(mut self, f: impl FnOnce(Type<'db>) -> Type<'db>) -> Self {
+        self.map_type_mut(f);
         self
     }
 
-    pub(crate) fn map_type(
-        &self,
-        f: impl FnOnce(Type<'db>) -> Type<'db>,
-    ) -> TypeAndQualifiers<'db> {
-        TypeAndQualifiers {
-            inner: f(self.inner),
-            origin: self.origin,
-            qualifiers: self.qualifiers,
-            deprecation: self.deprecation,
+    pub(crate) fn map_type_mut(&mut self, f: impl FnOnce(Type<'db>) -> Type<'db>) {
+        match self {
+            Self::WithoutDeprecation { inner, .. } => *inner = f(*inner),
+            Self::WithDeprecation(deprecated) => deprecated.inner = f(deprecated.inner),
         }
     }
 }
@@ -7743,7 +7771,7 @@ impl<'db> InvalidTypeExpression<'db> {
             let module_name_final_part = module.name(db).last_component();
             let Some(module_member_with_same_name) = ty
                 .member(db, module_name_final_part)
-                .place
+                .place()
                 .ignore_possibly_undefined()
             else {
                 return;
@@ -8016,20 +8044,17 @@ impl<'db> ModuleLiteralType<'db> {
         if let Some(file) = self.module(db).file(db) {
             let getattr_symbol = imported_symbol(db, Some(file), "__getattr__", None);
             // If we found a __getattr__ function, try to call it with the name argument
-            if let Place::Defined(place) = getattr_symbol.place
+            if let Place::Defined(place) = getattr_symbol.place()
                 && let Ok(outcome) = place.ty.try_call(
                     db,
                     &CallArguments::positional([Type::string_literal(db, name)]),
                 )
             {
-                return PlaceAndQualifiers {
-                    place: Place::Defined(DefinedPlace {
-                        ty: outcome.return_type(db),
-                        ..place
-                    }),
-                    qualifiers: TypeQualifiers::FROM_MODULE_GETATTR,
-                    deprecation: DeprecationPolicy::Inherit,
-                };
+                return Place::Defined(DefinedPlace {
+                    ty: outcome.return_type(db),
+                    ..place
+                })
+                .with_qualifiers(TypeQualifiers::FROM_MODULE_GETATTR);
             }
         }
 
@@ -8064,7 +8089,7 @@ impl<'db> ModuleLiteralType<'db> {
         let place_and_qualifiers = imported_symbol(db, self.module(db).file(db), name, None);
 
         // If the normal lookup failed, try to call the module's `__getattr__` function
-        if place_and_qualifiers.place.is_undefined() {
+        if place_and_qualifiers.place().is_undefined() {
             return self.try_module_getattr(db, name);
         }
 
@@ -8072,20 +8097,18 @@ impl<'db> ModuleLiteralType<'db> {
         // is `from typing import Callable as Callable`). The resolved type still carries the
         // definition-site variant (`SpecialFormType::TypingCallable`), so we recover the
         // import-path identity here while it's still observable.
-        if let Place::Defined(defined) = place_and_qualifiers.place
+        if let Place::Defined(defined) = place_and_qualifiers.place()
             && let Type::SpecialForm(special) = defined.ty
             && let Some(import_module) = self.module(db).known(db)
         {
             let rewrapped = special.rewrap_for_import_module(name, import_module);
             if rewrapped != special {
-                return PlaceAndQualifiers {
-                    place: Place::Defined(DefinedPlace {
-                        ty: Type::SpecialForm(rewrapped),
-                        ..defined
-                    }),
-                    qualifiers: place_and_qualifiers.qualifiers,
-                    deprecation: place_and_qualifiers.deprecation,
-                };
+                return Place::Defined(DefinedPlace {
+                    ty: Type::SpecialForm(rewrapped),
+                    ..defined
+                })
+                .with_qualifiers(place_and_qualifiers.qualifiers())
+                .with_deprecation_policy(place_and_qualifiers.deprecation_policy());
             }
         }
 
@@ -8368,6 +8391,10 @@ pub(super) fn determine_upper_bound<'db>(
 #[cfg(not(debug_assertions))]
 #[cfg(target_pointer_width = "64")]
 static_assertions::assert_eq_size!(Type, [u8; 16]);
+
+// Keep the common case at the same size as it was before adding place-level deprecation.
+#[cfg(all(not(debug_assertions), target_pointer_width = "64"))]
+static_assertions::assert_eq_size!(TypeAndQualifiers<'_>, [u8; 24]);
 
 // Make sure that `LiteralValueTypeInner` stays at 12 bytes.
 // The `LiteralFlags` byte must fit in the discriminant's padding.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1280,6 +1280,7 @@ impl<'db> Type<'db> {
     pub fn is_deprecated(&self, db: &'db dyn Db) -> bool {
         match self {
             Type::FunctionLiteral(f) => f.implementation_deprecated(db).is_some(),
+            Type::BoundMethod(bound) => bound.function(db).implementation_deprecated(db).is_some(),
             Type::ClassLiteral(c) => c.deprecated(db).is_some(),
             _ => false,
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7472,6 +7472,11 @@ impl<'db> TypeAndQualifiers<'db> {
         }
     }
 
+    pub(crate) fn resolved_deprecation_policy(&self, db: &'db dyn Db) -> DeprecationPolicy<'db> {
+        self.deprecation_policy()
+            .resolve_for_type(db, self.inner_type())
+    }
+
     pub(crate) fn into_parts(
         self,
     ) -> (

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -46,8 +46,8 @@ pub(crate) use self::signatures::Signature;
 pub(crate) use self::subclass_of::{SubclassOfInner, SubclassOfType};
 pub use crate::diagnostic::add_inferred_python_version_hint_to_diagnostic;
 use crate::place::{
-    DefinedPlace, Definedness, Place, PlaceAndQualifiers, TypeOrigin, builtins_module_scope,
-    imported_symbol, known_module_symbol, merge_deprecation,
+    DefinedPlace, Definedness, DeprecationPolicy, Place, PlaceAndQualifiers, TypeOrigin,
+    builtins_module_scope, imported_symbol, known_module_symbol, merge_deprecation_policy,
 };
 use crate::suppression::check_suppressions;
 use crate::types::bound_super::BoundSuperType;
@@ -3044,7 +3044,7 @@ impl<'db> Type<'db> {
                     public_type_policy,
                 })
                 .with_qualifiers(qualifiers)
-                .with_deprecation(deprecation),
+                .with_deprecation_policy(deprecation),
                 instance,
                 owner,
             );
@@ -3092,7 +3092,7 @@ impl<'db> Type<'db> {
                         })
                     })
                     .with_qualifiers(qualifiers)
-                    .with_deprecation(deprecation),
+                    .with_deprecation_policy(deprecation),
                 // TODO: avoid the duplication here:
                 if union.elements(db).iter().all(|elem| {
                     elem.try_call_dunder_get(db, instance, owner)
@@ -3130,7 +3130,7 @@ impl<'db> Type<'db> {
                             })
                         })
                         .with_qualifiers(qualifiers)
-                        .with_deprecation(deprecation)
+                        .with_deprecation_policy(deprecation)
                 },
                 // TODO: Discover data descriptors in intersections.
                 AttributeKind::NormalOrNonDataDescriptor,
@@ -3158,7 +3158,7 @@ impl<'db> Type<'db> {
                             public_type_policy,
                         })
                         .with_qualifiers(TypeQualifiers::empty())
-                        .with_deprecation(deprecation),
+                        .with_deprecation_policy(deprecation),
                         attribute_kind,
                     )
                 } else {
@@ -3259,7 +3259,7 @@ impl<'db> Type<'db> {
             // no matter if it's data descriptor, a non-data descriptor, or a normal attribute.
             (meta_attr @ Place::Defined(_), _, Place::Undefined) => meta_attr
                 .with_qualifiers(meta_attr_qualifiers)
-                .with_deprecation(meta_attr_deprecation),
+                .with_deprecation_policy(meta_attr_deprecation),
 
             // `meta_attr` is the return type of a data descriptor and definitely bound, so we
             // return it.
@@ -3272,7 +3272,7 @@ impl<'db> Type<'db> {
                 _,
             ) => meta_attr
                 .with_qualifiers(meta_attr_qualifiers)
-                .with_deprecation(meta_attr_deprecation),
+                .with_deprecation_policy(meta_attr_deprecation),
 
             // `meta_attr` is the return type of a data descriptor, but the attribute on the
             // meta-type is possibly-unbound. This means that we "fall through" to the next
@@ -3298,7 +3298,7 @@ impl<'db> Type<'db> {
                 public_type_policy: fallback_public_type_policy,
             })
             .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers))
-            .with_deprecation(merge_deprecation(
+            .with_deprecation_policy(merge_deprecation_policy(
                 meta_attr_deprecation,
                 fallback_deprecation,
             )),
@@ -3320,7 +3320,7 @@ impl<'db> Type<'db> {
                 }),
             ) if policy == InstanceFallbackShadowsNonDataDescriptor::Yes => fallback
                 .with_qualifiers(fallback_qualifiers)
-                .with_deprecation(fallback_deprecation),
+                .with_deprecation_policy(fallback_deprecation),
 
             // `meta_attr` is *not* a data descriptor. The `fallback` symbol is either possibly
             // unbound or the policy argument is `No`. In both cases, the `fallback` type does
@@ -3346,7 +3346,7 @@ impl<'db> Type<'db> {
                 public_type_policy: fallback_public_type_policy,
             })
             .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers))
-            .with_deprecation(merge_deprecation(
+            .with_deprecation_policy(merge_deprecation_policy(
                 meta_attr_deprecation,
                 fallback_deprecation,
             )),
@@ -3354,7 +3354,7 @@ impl<'db> Type<'db> {
             // If the attribute is not found on the meta-type, we simply return the fallback.
             (Place::Undefined, _, fallback) => fallback
                 .with_qualifiers(fallback_qualifiers)
-                .with_deprecation(fallback_deprecation),
+                .with_deprecation_policy(fallback_deprecation),
         }
     }
 
@@ -7436,8 +7436,7 @@ pub(crate) struct TypeAndQualifiers<'db> {
     inner: Type<'db>,
     origin: TypeOrigin,
     qualifiers: TypeQualifiers,
-    /// Deprecation attached to the place rather than its inferred type.
-    deprecation: Option<DeprecatedInstance<'db>>,
+    deprecation: DeprecationPolicy<'db>,
 }
 
 impl<'db> TypeAndQualifiers<'db> {
@@ -7446,7 +7445,7 @@ impl<'db> TypeAndQualifiers<'db> {
             inner,
             origin,
             qualifiers,
-            deprecation: None,
+            deprecation: DeprecationPolicy::Inherit,
         }
     }
 
@@ -7455,7 +7454,7 @@ impl<'db> TypeAndQualifiers<'db> {
             inner,
             origin: TypeOrigin::Declared,
             qualifiers: TypeQualifiers::empty(),
-            deprecation: None,
+            deprecation: DeprecationPolicy::Inherit,
         }
     }
 
@@ -7479,13 +7478,26 @@ impl<'db> TypeAndQualifiers<'db> {
         self.qualifiers
     }
 
-    pub(crate) fn deprecation(&self) -> Option<DeprecatedInstance<'db>> {
+    pub(crate) fn deprecation_policy(&self) -> DeprecationPolicy<'db> {
         self.deprecation
     }
 
     #[must_use]
     pub(crate) fn with_deprecation(mut self, deprecation: Option<DeprecatedInstance<'db>>) -> Self {
+        self.deprecation =
+            deprecation.map_or(DeprecationPolicy::Inherit, DeprecationPolicy::Deprecated);
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_deprecation_policy(mut self, deprecation: DeprecationPolicy<'db>) -> Self {
         self.deprecation = deprecation;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn suppress_type_deprecation(mut self) -> Self {
+        self.deprecation = DeprecationPolicy::Suppress;
         self
     }
 
@@ -8016,7 +8028,7 @@ impl<'db> ModuleLiteralType<'db> {
                         ..place
                     }),
                     qualifiers: TypeQualifiers::FROM_MODULE_GETATTR,
-                    deprecation: None,
+                    deprecation: DeprecationPolicy::Inherit,
                 };
             }
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1282,6 +1282,7 @@ impl<'db> Type<'db> {
             Type::FunctionLiteral(f) => f.implementation_deprecated(db).is_some(),
             Type::BoundMethod(bound) => bound.function(db).implementation_deprecated(db).is_some(),
             Type::ClassLiteral(c) => c.deprecated(db).is_some(),
+            Type::Union(union) => union.elements(db).iter().any(|ty| ty.is_deprecated(db)),
             _ => false,
         }
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1070,6 +1070,13 @@ impl<'db> Type<'db> {
         matches!(self, Type::Callable(..))
     }
 
+    pub(crate) fn is_definitely_callable(self, db: &'db dyn Db) -> bool {
+        !self.has_dynamic(db)
+            && !self.is_never()
+            && !self.is_divergent()
+            && self.bindings(db).is_definitely_callable()
+    }
+
     pub(crate) fn cycle_normalized(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -888,10 +888,10 @@ impl<'db> BoundSuperType<'db> {
     pub(super) fn try_call_dunder_get_on_attribute(
         self,
         db: &'db dyn Db,
-        attribute: PlaceAndQualifiers<'db>,
+        attribute: &PlaceAndQualifiers<'db>,
     ) -> Option<PlaceAndQualifiers<'db>> {
         let (instance, owner) = self.owner(db).descriptor_binding(db)?;
-        Some(Type::try_call_dunder_get_on_attribute(db, attribute, instance, owner).0)
+        Some(Type::try_call_dunder_get_on_attribute(db, attribute.clone(), instance, owner).0)
     }
 
     /// Similar to `Type::find_name_in_mro_with_policy`, but performs lookup starting *after* the
@@ -925,7 +925,7 @@ impl<'db> BoundSuperType<'db> {
         // typing._Generic in the typeshed, and we are hard-coding its signature. Ideally we would
         // look that up from the typeshed class, but that would require threading through the
         // static class literal through the SpecialForm and KnownInstance types that we create.
-        if result.place.is_undefined()
+        if result.place().is_undefined()
             && name == "__class_getitem__"
             && mro_after_pivot
                 .any(|superclass| matches!(superclass, ClassBase::Generic | ClassBase::Protocol))

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -69,11 +69,11 @@ impl<'db> Type<'db> {
         let right_class = right_ty.to_meta_type(db);
         if left_ty != right_ty && right_ty.is_subtype_of(db, left_ty) {
             let reflected_dunder = op.reflected_dunder();
-            let rhs_reflected = right_class.member(db, reflected_dunder).place;
+            let rhs_reflected = right_class.member(db, reflected_dunder).place();
             // TODO: if `rhs_reflected` is possibly unbound, we should union the two possible
             // Bindings together
             if !rhs_reflected.is_undefined()
-                && rhs_reflected != left_class.member(db, reflected_dunder).place
+                && rhs_reflected != left_class.member(db, reflected_dunder).place()
             {
                 return Ok(right_ty
                     .try_call_dunder_with_policy(

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -7715,7 +7715,7 @@ fn asynccontextmanager_return_type<'db>(db: &'db dyn Db, func_ty: Type<'db>) -> 
 
     let context_manager =
         known_module_symbol(db, KnownModule::Contextlib, "_AsyncGeneratorContextManager")
-            .place
+            .place()
             .ignore_possibly_undefined()?
             .as_class_literal()?;
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -205,6 +205,11 @@ impl<'db> CallableItem<'db> {
         self.callable().is_callable()
     }
 
+    fn is_definitely_callable(&self) -> bool {
+        let callable = self.callable();
+        callable.is_callable() && !callable.dunder_call_is_possibly_unbound
+    }
+
     fn callable_type(&self) -> Type<'db> {
         self.callable().callable_type
     }
@@ -369,6 +374,10 @@ impl<'db> BindingsElement<'db> {
     fn is_callable(&self) -> bool {
         self.items.iter().any(CallableItem::is_callable)
     }
+
+    fn is_definitely_callable(&self) -> bool {
+        self.items.iter().any(CallableItem::is_definitely_callable)
+    }
 }
 
 /// Binding information for a union of callables, where each union element may be an intersection.
@@ -402,6 +411,12 @@ pub(crate) struct Bindings<'db> {
 }
 
 impl<'db> Bindings<'db> {
+    pub(crate) fn is_definitely_callable(&self) -> bool {
+        self.elements
+            .iter()
+            .all(BindingsElement::is_definitely_callable)
+    }
+
     fn as_result(&self, db: &'db dyn Db) -> Result<(), CallErrorKind> {
         let mut all_ok = true;
         let mut any_binding_error = false;

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -117,7 +117,7 @@ impl<'db> Type<'db> {
                         Name::new_static("__call__"),
                         MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                     )
-                    .place;
+                    .place();
 
                 if let Place::Defined(place) = call_symbol
                     && place.is_definitely_defined()

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1162,7 +1162,7 @@ impl<'db> ClassType<'db> {
                     let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
                     !place_from_declarations(db, declarations)
                         .ignore_conflicting_declarations()
-                        .qualifiers
+                        .qualifiers()
                         .contains(TypeQualifiers::CLASS_VAR)
                 })
             });
@@ -1906,7 +1906,7 @@ impl<'db> ClassType<'db> {
                 MemberLookupPolicy::NO_INSTANCE_FALLBACK
                     | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
             )
-            .place;
+            .place();
 
         if let Place::Defined(DefinedPlace {
             ty: Type::BoundMethod(metaclass_dunder_call_function),
@@ -1974,7 +1974,7 @@ impl<'db> ClassType<'db> {
                 MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
                     | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
             )
-            .place;
+            .place();
 
         let correct_return_type = self_ty.to_instance(db).unwrap_or_else(Type::unknown);
 
@@ -2055,7 +2055,7 @@ impl<'db> ClassType<'db> {
                         "__new__".into(),
                         MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
                     )
-                    .place;
+                    .place();
 
                 if let Place::Defined(DefinedPlace {
                     ty: Type::FunctionLiteral(mut new_function),
@@ -2475,18 +2475,15 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                     return InstanceMemberResult::Done(PlaceAndQualifiers::unbound());
                 }
                 ClassBase::Class(class) => {
-                    if let member @ PlaceAndQualifiers {
-                        place:
-                            Place::Defined(DefinedPlace {
-                                ty,
-                                origin,
-                                definedness: boundness,
-                                ..
-                            }),
-                        qualifiers,
+                    let member = class.own_instance_member(db, name).inner;
+                    if let Place::Defined(DefinedPlace {
+                        ty,
+                        origin,
+                        definedness: boundness,
                         ..
-                    } = class.own_instance_member(db, name).inner
+                    }) = member.place()
                     {
+                        let qualifiers = member.qualifiers();
                         if boundness == Definedness::AlwaysDefined {
                             if origin.is_declared() {
                                 // We found a definitely-declared attribute. Discard possibly collected
@@ -2551,36 +2548,27 @@ pub(super) struct CompletedMemberLookup<'db> {
 impl<'db> CompletedMemberLookup<'db> {
     /// Finalize the lookup result by handling dynamic type intersection.
     pub(super) fn finalize(self, db: &'db dyn Db) -> PlaceAndQualifiers<'db> {
-        match (
-            PlaceAndQualifiers::from(self.lookup_result),
-            self.dynamic_type,
-        ) {
-            (symbol_and_qualifiers, None) => symbol_and_qualifiers,
+        let symbol_and_qualifiers = PlaceAndQualifiers::from(self.lookup_result);
+        let Some(dynamic) = self.dynamic_type else {
+            return symbol_and_qualifiers;
+        };
 
-            (
-                PlaceAndQualifiers {
-                    place: Place::Defined(DefinedPlace { ty, .. }),
-                    qualifiers,
-                    ..
-                },
-                Some(dynamic),
-            ) => Place::bound(IntersectionType::from_two_elements(db, ty, dynamic))
-                .with_qualifiers(qualifiers),
-
-            (
-                PlaceAndQualifiers {
-                    place: Place::Undefined,
-                    qualifiers,
-                    ..
-                },
-                Some(dynamic),
-            ) => Place::bound(dynamic).with_qualifiers(qualifiers),
+        let (place, qualifiers, deprecation) = symbol_and_qualifiers.into_parts();
+        match place {
+            Place::Defined(DefinedPlace { ty, .. }) => {
+                Place::bound(IntersectionType::from_two_elements(db, ty, dynamic))
+                    .with_qualifiers(qualifiers)
+                    .with_deprecation_policy(deprecation)
+            }
+            Place::Undefined => Place::bound(dynamic)
+                .with_qualifiers(qualifiers)
+                .with_deprecation_policy(deprecation),
         }
     }
 }
 
 /// Result of instance member lookup from MRO iteration.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum InstanceMemberResult<'db> {
     /// Found the member or exhausted the MRO
     Done(PlaceAndQualifiers<'db>),
@@ -2784,7 +2772,7 @@ impl SlotsKind {
         }) = base
             .own_class_member(db, base.inherited_generic_context(db), None, "__slots__")
             .inner
-            .place
+            .place()
         else {
             return Self::NotSpecified;
         };

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2484,6 +2484,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                                 ..
                             }),
                         qualifiers,
+                        ..
                     } = class.own_instance_member(db, name).inner
                     {
                         if boundness == Definedness::AlwaysDefined {
@@ -2560,6 +2561,7 @@ impl<'db> CompletedMemberLookup<'db> {
                 PlaceAndQualifiers {
                     place: Place::Defined(DefinedPlace { ty, .. }),
                     qualifiers,
+                    ..
                 },
                 Some(dynamic),
             ) => Place::bound(IntersectionType::from_two_elements(db, ty, dynamic))
@@ -2569,6 +2571,7 @@ impl<'db> CompletedMemberLookup<'db> {
                 PlaceAndQualifiers {
                     place: Place::Undefined,
                     qualifiers,
+                    ..
                 },
                 Some(dynamic),
             ) => Place::bound(dynamic).with_qualifiers(qualifiers),

--- a/crates/ty_python_semantic/src/types/class/enum_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/enum_literal.rs
@@ -225,7 +225,7 @@ impl<'db> DynamicEnumLiteral<'db> {
         db: &'db dyn Db,
         result: PlaceAndQualifiers<'db>,
     ) -> PlaceAndQualifiers<'db> {
-        if !self.has_known_members(db) && result.place.is_undefined() {
+        if !self.has_known_members(db) && result.place().is_undefined() {
             Place::bound(Type::unknown()).into()
         } else {
             result
@@ -265,7 +265,7 @@ impl<'db> DynamicEnumLiteral<'db> {
         }
         if let Some(mixin_class) = self.mixin_class(db) {
             let result = mixin_class.class_member(db, name, MemberLookupPolicy::default());
-            if !result.place.is_undefined() {
+            if !result.place().is_undefined() {
                 return result;
             }
         }
@@ -290,7 +290,7 @@ impl<'db> DynamicEnumLiteral<'db> {
     pub(crate) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         if let Some(mixin_class) = self.mixin_class(db) {
             let result = mixin_class.instance_member(db, name);
-            if !result.place.is_undefined() {
+            if !result.place().is_undefined() {
                 return result;
             }
         }

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -1042,7 +1042,7 @@ impl KnownClass {
         self,
         db: &dyn Db,
     ) -> Result<StaticClassLiteral<'_>, KnownClassLookupError<'_>> {
-        let symbol = known_module_symbol(db, self.canonical_module(db), self.name(db)).place;
+        let symbol = known_module_symbol(db, self.canonical_module(db), self.name(db)).place();
         match symbol {
             Place::Defined(DefinedPlace {
                 ty: Type::ClassLiteral(ClassLiteral::Static(class_literal)),

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -338,7 +338,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
 
         // If fields are unknown (dynamic) and the attribute wasn't found,
         // return `Any` instead of failing.
-        if !self.has_known_fields(db) && result.place.is_undefined() {
+        if !self.has_known_fields(db) && result.place().is_undefined() {
             return Place::bound(Type::any()).into();
         }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1132,7 +1132,7 @@ impl<'db> StaticClassLiteral<'db> {
         // undefined so the MRO falls through to parent classes.
         if member
             .inner
-            .place
+            .place()
             .raw_type()
             .is_some_and(|ty| ty.is_instance_of(db, KnownClass::KwOnly))
             && CodeGeneratorKind::from_static_class(db, self, None)
@@ -1144,7 +1144,7 @@ impl<'db> StaticClassLiteral<'db> {
         // For enum classes, `nonmember(value)` creates a non-member attribute.
         // At runtime, the enum metaclass unwraps the value, so accessing the attribute
         // returns the inner value, not the `nonmember` wrapper.
-        if let Some(ty) = member.inner.place.raw_type() {
+        if let Some(ty) = member.inner.place().raw_type() {
             if let Some(value_ty) = try_unwrap_nonmember_value(db, ty) {
                 if is_enum_class_by_inheritance(db, self) {
                     return Member::definitely_declared(value_ty);
@@ -1266,7 +1266,7 @@ impl<'db> StaticClassLiteral<'db> {
                     ty: dunder_set,
                     definedness: Definedness::AlwaysDefined,
                     ..
-                }) = dunder_set.place
+                }) = dunder_set.place()
                 {
                     // The descriptor handling below is guarded by this not-dynamic check, because
                     // dynamic types like `Any` are valid (data) descriptors: since they have all
@@ -1813,7 +1813,7 @@ impl<'db> StaticClassLiteral<'db> {
             let symbol = table.symbol(symbol_id);
             let name = symbol.name();
 
-            let Some(Type::FunctionLiteral(literal)) = attr.place.ignore_possibly_undefined()
+            let Some(Type::FunctionLiteral(literal)) = attr.place().ignore_possibly_undefined()
             else {
                 continue;
             };
@@ -1951,7 +1951,7 @@ impl<'db> StaticClassLiteral<'db> {
                 continue;
             }
 
-            if let Some(attr_ty) = attr.place.ignore_possibly_undefined() {
+            if let Some(attr_ty) = attr.place().ignore_possibly_undefined() {
                 let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
                 let mut default_ty = place_from_bindings(db, bindings)
                     .place
@@ -2197,8 +2197,9 @@ impl<'db> StaticClassLiteral<'db> {
                 let Some(annotation) = inferred_declaration(db, declaration).declared() else {
                     continue;
                 };
-                let annotation = Place::declared(annotation.inner).with_qualifiers(
-                    annotation.qualifiers | TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE,
+                let (annotation_ty, _, annotation_qualifiers, _) = annotation.into_parts();
+                let annotation = Place::declared(annotation_ty).with_qualifiers(
+                    annotation_qualifiers | TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE,
                 );
 
                 if let Some(all_qualifiers) = annotation.is_bare_final() {
@@ -2448,17 +2449,13 @@ impl<'db> StaticClassLiteral<'db> {
             let declared_and_qualifiers =
                 place_from_declarations(db, declarations).ignore_conflicting_declarations();
 
-            match declared_and_qualifiers {
-                PlaceAndQualifiers {
-                    place:
-                        mut declared @ Place::Defined(DefinedPlace {
-                            ty: declared_ty,
-                            definedness: declaredness,
-                            ..
-                        }),
-                    qualifiers,
+            let (mut declared, qualifiers, deprecation) = declared_and_qualifiers.into_parts();
+            match declared {
+                Place::Defined(DefinedPlace {
+                    ty: declared_ty,
+                    definedness: declaredness,
                     ..
-                } => {
+                }) => {
                     // For the purpose of finding instance attributes, ignore `ClassVar`
                     // declarations:
                     if qualifiers.contains(TypeQualifiers::CLASS_VAR) {
@@ -2502,7 +2499,9 @@ impl<'db> StaticClassLiteral<'db> {
                                 // attribute assignments in methods of the class,
                                 // we trust the declared type.
                                 Member {
-                                    inner: declared.with_qualifiers(qualifiers),
+                                    inner: declared
+                                        .with_qualifiers(qualifiers)
+                                        .with_deprecation_policy(deprecation),
                                 }
                             } else {
                                 Member {
@@ -2516,13 +2515,14 @@ impl<'db> StaticClassLiteral<'db> {
                                         definedness: declaredness,
                                         public_type_policy: PublicTypePolicy::Raw,
                                     })
-                                    .with_qualifiers(qualifiers),
+                                    .with_qualifiers(qualifiers)
+                                    .with_deprecation_policy(deprecation),
                                 }
                             }
                         } else if self.is_own_dataclass_instance_field(db, name)
                             && declared_ty
                                 .class_member(db, "__get__".into())
-                                .place
+                                .place()
                                 .is_undefined()
                         {
                             // For dataclass-like classes, declared fields are assigned
@@ -2535,7 +2535,9 @@ impl<'db> StaticClassLiteral<'db> {
                             // protocol in `member_lookup_with_policy` can resolve
                             // the attribute type through `__get__`.
                             Member {
-                                inner: declared.with_qualifiers(qualifiers),
+                                inner: declared
+                                    .with_qualifiers(qualifiers)
+                                    .with_deprecation_policy(deprecation),
                             }
                         } else {
                             // The symbol is declared and bound in the class body,
@@ -2555,7 +2557,9 @@ impl<'db> StaticClassLiteral<'db> {
 
                         if declaredness == Definedness::AlwaysDefined {
                             Member {
-                                inner: declared.with_qualifiers(qualifiers),
+                                inner: declared
+                                    .with_qualifiers(qualifiers)
+                                    .with_deprecation_policy(deprecation),
                             }
                         } else {
                             if let Some(implicit_ty) = Self::implicit_attribute(
@@ -2565,7 +2569,7 @@ impl<'db> StaticClassLiteral<'db> {
                                 MethodDecorator::None,
                             )
                             .inner
-                            .place
+                            .place()
                             .ignore_possibly_undefined()
                             {
                                 Member {
@@ -2579,22 +2583,21 @@ impl<'db> StaticClassLiteral<'db> {
                                         definedness: declaredness,
                                         public_type_policy: PublicTypePolicy::Raw,
                                     })
-                                    .with_qualifiers(qualifiers),
+                                    .with_qualifiers(qualifiers)
+                                    .with_deprecation_policy(deprecation),
                                 }
                             } else {
                                 Member {
-                                    inner: declared.with_qualifiers(qualifiers),
+                                    inner: declared
+                                        .with_qualifiers(qualifiers)
+                                        .with_deprecation_policy(deprecation),
                                 }
                             }
                         }
                     }
                 }
 
-                PlaceAndQualifiers {
-                    place: Place::Undefined,
-                    qualifiers: _,
-                    ..
-                } => {
+                Place::Undefined => {
                     // The attribute is not *declared* in the class body. It could still be declared/bound
                     // in a method.
 
@@ -2940,7 +2943,7 @@ impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
             .filter_map(|(name, place_and_qual)| {
                 place_and_qual.ignore_possibly_undefined().map(|ty| {
                     let variance = if place_and_qual
-                        .qualifiers
+                        .qualifiers()
                         // `CLASS_VAR || FINAL` is really `all()`, but
                         // we want to be robust against new qualifiers
                         .intersects(TypeQualifiers::CLASS_VAR | TypeQualifiers::FINAL)
@@ -3052,6 +3055,6 @@ fn implicit_attribute_cycle_recover<'db>(
 ) -> Member<'db> {
     let inner = member
         .inner
-        .cycle_normalized(db, previous_member.inner, cycle);
+        .cycle_normalized(db, &previous_member.inner, cycle);
     Member { inner }
 }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2457,6 +2457,7 @@ impl<'db> StaticClassLiteral<'db> {
                             ..
                         }),
                     qualifiers,
+                    ..
                 } => {
                     // For the purpose of finding instance attributes, ignore `ClassVar`
                     // declarations:
@@ -2592,6 +2593,7 @@ impl<'db> StaticClassLiteral<'db> {
                 PlaceAndQualifiers {
                     place: Place::Undefined,
                     qualifiers: _,
+                    ..
                 } => {
                     // The attribute is not *declared* in the class body. It could still be declared/bound
                     // in a method.

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -45,6 +45,8 @@ pub(crate) struct InferContext<'db, 'ast> {
     diagnostics: std::cell::RefCell<TypeCheckDiagnostics>,
     /// This field tracks various flags that control how type inference should behave in the current context.
     pub(crate) inference_flags: InferenceFlags,
+    /// The value expression of a PEP 613 alias during its first inference pass.
+    pub(crate) pep_613_alias_value_range: Option<TextRange>,
     bomb: DebugDropBomb,
 }
 
@@ -57,6 +59,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
             file: scope.file(db),
             diagnostics: std::cell::RefCell::new(TypeCheckDiagnostics::default()),
             inference_flags: InferenceFlags::empty(),
+            pep_613_alias_value_range: None,
             bomb: DebugDropBomb::new(
                 "`InferContext` needs to be explicitly consumed by calling `::finish` to prevent accidental loss of diagnostics.",
             ),
@@ -439,14 +442,17 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
     ) -> Option<LintDiagnosticGuardBuilder<'db, 'ctx>> {
         let lint_id = LintId::of(lint);
 
+        let in_pep_613_alias_first_pass = ctx
+            .inference_flags
+            .contains(InferenceFlags::IN_PEP_613_ALIAS_FIRST_PASS);
+
         // Suppress diagnostics that are emitted during the second, post-inference pass of
-        // inferring a PEP-613 type alias.
+        // inferring a PEP-613 type alias. A deprecation on the alias value itself is replayed,
+        // but nested deprecations in an invalid type form are not.
         if (lint_id == LintId::of(&INVALID_TYPE_FORM)
             || lint_id == LintId::of(&UNBOUND_TYPE_VARIABLE)
-            || lint_id == LintId::of(&DEPRECATED))
-            && ctx
-                .inference_flags
-                .contains(InferenceFlags::IN_PEP_613_ALIAS_FIRST_PASS)
+            || (lint_id == LintId::of(&DEPRECATED) && ctx.pep_613_alias_value_range == Some(range)))
+            && in_pep_613_alias_first_pass
         {
             return None;
         }

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -14,7 +14,7 @@ use super::{Type, TypeCheckDiagnostics, infer_definition_types};
 use crate::diagnostic::DiagnosticGuard;
 use crate::lint::LintSource;
 use crate::reachability::is_range_reachable;
-use crate::types::diagnostic::{INVALID_TYPE_FORM, UNBOUND_TYPE_VARIABLE};
+use crate::types::diagnostic::{DEPRECATED, INVALID_TYPE_FORM, UNBOUND_TYPE_VARIABLE};
 use crate::types::function::FunctionDecorators;
 use crate::types::infer::InferenceFlags;
 use crate::{
@@ -439,11 +439,11 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
     ) -> Option<LintDiagnosticGuardBuilder<'db, 'ctx>> {
         let lint_id = LintId::of(lint);
 
-        // Suppress all `invalid-type-form` errors during the first pass of
-        // inferring a PEP-613 type alias. These errors are emitted during the
-        // second pass, post-inference.
+        // Suppress diagnostics that are emitted during the second, post-inference pass of
+        // inferring a PEP-613 type alias.
         if (lint_id == LintId::of(&INVALID_TYPE_FORM)
-            || lint_id == LintId::of(&UNBOUND_TYPE_VARIABLE))
+            || lint_id == LintId::of(&UNBOUND_TYPE_VARIABLE)
+            || lint_id == LintId::of(&DEPRECATED))
             && ctx
                 .inference_flags
                 .contains(InferenceFlags::IN_PEP_613_ALIAS_FIRST_PASS)

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -6016,7 +6016,7 @@ pub(super) fn report_invalid_method_override<'db>(
 
     let class_member = |cls: ClassType<'db>| {
         cls.class_member(db, member, MemberLookupPolicy::default())
-            .place
+            .place()
     };
 
     if let Place::Defined(DefinedPlace {

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1211,7 +1211,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .write_str("method-wrapper")?;
                 f.write_str(" '")?;
                 if let Place::Defined(DefinedPlace { ty: member_ty, .. }) =
-                    class_ty.member(self.db, member_name).place
+                    class_ty.member(self.db, member_name).place()
                 {
                     f.with_type(member_ty).write_str(member_name)?;
                 } else {

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -683,7 +683,7 @@ pub(crate) fn enum_metadata<'db>(
                                 explicit_member_wrapper = true;
                                 Some(
                                     ty.member(db, "value")
-                                        .place
+                                        .place()
                                         .ignore_possibly_undefined()
                                         .unwrap_or(Type::unknown()),
                                 )
@@ -758,7 +758,7 @@ pub(crate) fn enum_metadata<'db>(
                                 "__get__".into(),
                                 MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                             )
-                            .place;
+                            .place();
 
                         match dunder_get {
                             Place::Undefined
@@ -1061,7 +1061,7 @@ pub(crate) fn try_unwrap_nonmember_value<'db>(db: &'db dyn Db, ty: Type<'db>) ->
         Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Nonmember) => {
             Some(
                 ty.member(db, "value")
-                    .place
+                    .place()
                     .ignore_possibly_undefined()
                     .unwrap_or(Type::unknown()),
             )

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -2660,7 +2660,7 @@ pub(crate) mod tests {
             };
 
             let function_definition = known_module_symbol(&db, module, function_name)
-                .place
+                .place()
                 .expect_type()
                 .expect_function_literal()
                 .definition(&db);

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -857,7 +857,7 @@ impl<'db> ScopeInference<'db> {
 }
 
 /// The result of inferring a declaration recorded by the semantic index.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+#[derive(Debug, Clone, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) enum InferredDeclaration<'db> {
     /// A valid declaration with an inferred declared type.
     Declared(TypeAndQualifiers<'db>),
@@ -926,11 +926,11 @@ impl<'db> DefinitionTypes<'db> {
         match (&*bindings, &*declarations) {
             ([], []) => Self::Empty,
             ([binding], []) => Self::Binding(Box::new(*binding)),
-            ([], [declaration]) => Self::Declaration(Box::new(*declaration)),
+            ([], [declaration]) => Self::Declaration(Box::new(declaration.clone())),
             ([(binding, binding_ty)], [(declaration, declaration_ty)])
                 if binding == declaration && *binding_ty == declaration_ty.inner_type() =>
             {
-                Self::BindingAndDeclaration(Box::new((*declaration, *declaration_ty)))
+                Self::BindingAndDeclaration(Box::new((*declaration, declaration_ty.clone())))
             }
             _ => Self::Other(Box::new(OtherDefinitionTypes {
                 bindings: bindings.into_boxed_slice(),
@@ -992,7 +992,7 @@ impl<'db> DefinitionTypes<'db> {
             }
             Self::Declaration(mut declaration) => {
                 let (definition, ty) = &mut *declaration;
-                *ty = Self::normalize_declaration(db, previous, cycle, *definition, *ty);
+                *ty = Self::normalize_declaration(db, previous, cycle, *definition, ty.clone());
                 Self::Declaration(declaration)
             }
             Self::BindingAndDeclaration(mut declaration) => {
@@ -1022,14 +1022,17 @@ impl<'db> DefinitionTypes<'db> {
                     *ty = Self::normalize_binding(db, previous, cycle, *definition, *ty);
                 }
                 for (definition, ty) in &mut other.declarations {
-                    *ty = Self::normalize_declaration(db, previous, cycle, *definition, *ty);
+                    *ty = Self::normalize_declaration(db, previous, cycle, *definition, ty.clone());
                 }
 
                 match (&*other.bindings, &*other.declarations) {
                     ([(binding, binding_ty)], [(declaration, declaration_ty)])
                         if binding == declaration && *binding_ty == declaration_ty.inner_type() =>
                     {
-                        Self::BindingAndDeclaration(Box::new((*declaration, *declaration_ty)))
+                        Self::BindingAndDeclaration(Box::new((
+                            *declaration,
+                            declaration_ty.clone(),
+                        )))
                     }
                     _ => Self::Other(other),
                 }
@@ -1053,10 +1056,10 @@ impl<'db> DefinitionTypes<'db> {
     ) -> impl ExactSizeIterator<Item = (Definition<'db>, TypeAndQualifiers<'db>)> {
         match self {
             Self::Declaration(declaration) | Self::BindingAndDeclaration(declaration) => {
-                Either::Left(std::iter::once(**declaration))
+                Either::Left(std::iter::once((declaration.0, declaration.1.clone())))
             }
-            Self::Other(other) => Either::Right(other.declarations.iter().copied()),
-            Self::Empty | Self::Binding(..) => Either::Right([].iter().copied()),
+            Self::Other(other) => Either::Right(other.declarations.iter().cloned()),
+            Self::Empty | Self::Binding(..) => Either::Right([].iter().cloned()),
         }
     }
 }
@@ -1528,12 +1531,11 @@ impl<'db> StatementInferenceInner<'db> {
                 .iter()
                 .find(|(previous_declaration, _)| previous_declaration == declaration)
             {
-                *declaration_ty = declaration_ty.map_type(|decl_ty| {
+                declaration_ty.map_type_mut(|decl_ty| {
                     decl_ty.cycle_normalized(db, previous_declaration.inner_type(), cycle)
                 });
             } else {
-                *declaration_ty =
-                    declaration_ty.map_type(|decl_ty| decl_ty.recursive_type_normalized(db, cycle));
+                declaration_ty.map_type_mut(|decl_ty| decl_ty.recursive_type_normalized(db, cycle));
             }
         }
 
@@ -1572,7 +1574,7 @@ impl<'db> StatementInferenceInner<'db> {
     fn declarations(
         &self,
     ) -> impl ExactSizeIterator<Item = (Definition<'db>, TypeAndQualifiers<'db>)> {
-        self.declarations.iter().copied()
+        self.declarations.iter().cloned()
     }
 
     pub(crate) fn fallback_type(&self) -> Option<Type<'db>> {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -56,11 +56,9 @@ pub(super) use ty_python_core::frozen::{FrozenMap, FrozenSet};
 use crate::types::diagnostic::TypeCheckDiagnostics;
 use crate::types::function::{FunctionDecorators, FunctionType};
 use crate::types::generics::Specialization;
-use crate::types::known_instance::DeprecatedInstance;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
-    ClassLiteral, KnownClass, KnownInstanceType, StaticClassLiteral, Type, TypeAndQualifiers,
-    TypeQualifiers,
+    ClassLiteral, KnownClass, StaticClassLiteral, Type, TypeAndQualifiers, TypeQualifiers,
 };
 use crate::{Db, FxIndexSet};
 
@@ -1092,9 +1090,6 @@ struct DefinitionInferenceExtra<'db> {
     /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
 
-    /// The `@deprecated` decorator attached to a decorated function's module-level binding.
-    binding_deprecation_decorator: Option<ExpressionNodeKey>,
-
     /// Whether synthesized dictionary-key assignments derived from the right-hand side should be
     /// discarded.
     discards_dict_key_assignments: bool,
@@ -1269,22 +1264,6 @@ impl<'db> DefinitionInference<'db> {
 
     pub(crate) fn undecorated_type(&self) -> Option<Type<'db>> {
         self.extra.as_ref().and_then(|extra| extra.undecorated_type)
-    }
-
-    pub(crate) fn binding_deprecation(
-        &self,
-        db: &'db dyn Db,
-        definition: Definition<'db>,
-    ) -> Option<DeprecatedInstance<'db>> {
-        let decorator = self
-            .extra
-            .as_ref()
-            .and_then(|extra| extra.binding_deprecation_decorator)?;
-        let decorator_ty = function_known_decorators(db, definition).expression_type(decorator)?;
-        let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) = decorator_ty else {
-            return None;
-        };
-        Some(deprecated)
     }
 
     pub(crate) fn function_type(&self, definition: Definition<'db>) -> Option<FunctionType<'db>> {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -56,9 +56,11 @@ pub(super) use ty_python_core::frozen::{FrozenMap, FrozenSet};
 use crate::types::diagnostic::TypeCheckDiagnostics;
 use crate::types::function::{FunctionDecorators, FunctionType};
 use crate::types::generics::Specialization;
+use crate::types::known_instance::DeprecatedInstance;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
-    ClassLiteral, KnownClass, StaticClassLiteral, Type, TypeAndQualifiers, TypeQualifiers,
+    ClassLiteral, KnownClass, KnownInstanceType, StaticClassLiteral, Type, TypeAndQualifiers,
+    TypeQualifiers,
 };
 use crate::{Db, FxIndexSet};
 
@@ -1090,6 +1092,9 @@ struct DefinitionInferenceExtra<'db> {
     /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
 
+    /// The `@deprecated` decorator attached to a decorated function's module-level binding.
+    binding_deprecation_decorator: Option<ExpressionNodeKey>,
+
     /// Whether synthesized dictionary-key assignments derived from the right-hand side should be
     /// discarded.
     discards_dict_key_assignments: bool,
@@ -1264,6 +1269,22 @@ impl<'db> DefinitionInference<'db> {
 
     pub(crate) fn undecorated_type(&self) -> Option<Type<'db>> {
         self.extra.as_ref().and_then(|extra| extra.undecorated_type)
+    }
+
+    pub(crate) fn binding_deprecation(
+        &self,
+        db: &'db dyn Db,
+        definition: Definition<'db>,
+    ) -> Option<DeprecatedInstance<'db>> {
+        let decorator = self
+            .extra
+            .as_ref()
+            .and_then(|extra| extra.binding_deprecation_decorator)?;
+        let decorator_ty = function_known_decorators(db, definition).expression_type(decorator)?;
+        let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) = decorator_ty else {
+            return None;
+        };
+        Some(deprecated)
     }
 
     pub(crate) fn function_type(&self, definition: Definition<'db>) -> Option<FunctionType<'db>> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11,6 +11,7 @@ use ruff_python_ast::{
     self as ast, AnyNodeRef, ArgOrKeyword, ArgumentsSourceOrder, ExprContext, HasNodeIndex,
     PythonVersion,
 };
+use ruff_python_ast::visitor::{self, Visitor};
 use ruff_python_stdlib::builtins::version_builtin_was_added;
 use ruff_python_stdlib::typing::as_pep_585_generic;
 use ruff_text_size::{Ranged, TextRange};
@@ -3564,13 +3565,32 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let target_ty =
             self.infer_assignment_definition_impl(assignment, definition, add.type_context());
         self.store_expression_type(target, target_ty);
-        self.suppress_transitive_deprecation(definition, target_ty);
+        self.suppress_transitive_deprecation(
+            definition,
+            target_ty,
+            assignment.value(self.module()),
+        );
         add.insert(self, target_ty);
     }
 
-    fn suppress_transitive_deprecation(&mut self, definition: Definition<'db>, ty: Type<'db>) {
-        if ty.is_deprecated(self.db()) {
+    fn suppress_transitive_deprecation(
+        &mut self,
+        definition: Definition<'db>,
+        ty: Type<'db>,
+        value: &'ast ast::Expr,
+    ) {
+        if ty.is_deprecated(self.db()) && self.expression_names_deprecated_symbol(value) {
             self.set_binding_deprecation_policy(definition, ty, DeprecationPolicy::Suppress);
+        }
+    }
+
+    fn expression_names_deprecated_symbol(&self, expression: &'ast ast::Expr) -> bool {
+        if let Some(standalone) = self.index.try_expression(expression) {
+            let inference =
+                infer_expression_types(self.db(), standalone, TypeContext::default());
+            DeprecatedReferenceVisitor::contains_in_inference(self.db(), inference, expression)
+        } else {
+            DeprecatedReferenceVisitor::contains_in_builder(self, expression)
         }
     }
 
@@ -4679,7 +4699,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             } else {
                 inferred_ty
             };
-            if inferred_ty.is_deprecated(self.db()) {
+            if inferred_ty.is_deprecated(self.db())
+                && self.expression_names_deprecated_symbol(value)
+            {
                 declared = declared.suppress_type_deprecation();
             }
 
@@ -7638,7 +7660,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let ty = self.infer_expression(value, add.type_context());
         self.store_expression_type(target, ty);
-        self.suppress_transitive_deprecation(definition, ty);
+        self.suppress_transitive_deprecation(definition, ty, value);
         add.insert(self, ty)
     }
 
@@ -11109,6 +11131,69 @@ impl<V> IntoIterator for VecSet<V> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+enum DeprecatedReferenceTypeSource<'builder, 'db, 'ast> {
+    Builder(&'builder TypeInferenceBuilder<'db, 'ast>),
+    Inference(&'builder ExpressionInference<'db>),
+}
+
+struct DeprecatedReferenceVisitor<'builder, 'db, 'ast> {
+    db: &'db dyn Db,
+    source: DeprecatedReferenceTypeSource<'builder, 'db, 'ast>,
+    found: bool,
+}
+
+impl<'builder, 'db, 'ast> DeprecatedReferenceVisitor<'builder, 'db, 'ast> {
+    fn contains_in_builder(
+        builder: &'builder TypeInferenceBuilder<'db, 'ast>,
+        expression: &'ast ast::Expr,
+    ) -> bool {
+        let mut visitor = Self {
+            db: builder.db(),
+            source: DeprecatedReferenceTypeSource::Builder(builder),
+            found: false,
+        };
+        visitor.visit_expr(expression);
+        visitor.found
+    }
+
+    fn contains_in_inference(
+        db: &'db dyn Db,
+        inference: &'builder ExpressionInference<'db>,
+        expression: &'ast ast::Expr,
+    ) -> bool {
+        let mut visitor = Self {
+            db,
+            source: DeprecatedReferenceTypeSource::Inference(inference),
+            found: false,
+        };
+        visitor.visit_expr(expression);
+        visitor.found
+    }
+
+    fn expression_type(&self, expression: &ast::Expr) -> Type<'db> {
+        match self.source {
+            DeprecatedReferenceTypeSource::Builder(builder) => {
+                builder.expression_type(expression)
+            }
+            DeprecatedReferenceTypeSource::Inference(inference) => {
+                inference.expression_type(expression)
+            }
+        }
+    }
+}
+
+impl<'ast> Visitor<'ast> for DeprecatedReferenceVisitor<'_, '_, 'ast> {
+    fn visit_expr(&mut self, expression: &'ast ast::Expr) {
+        if matches!(expression, ast::Expr::Name(_) | ast::Expr::Attribute(_))
+            && self.expression_type(expression).is_deprecated(self.db)
+        {
+            self.found = true;
+            return;
+        }
+        visitor::walk_expr(self, expression);
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11,7 +11,6 @@ use ruff_python_ast::{
     self as ast, AnyNodeRef, ArgOrKeyword, ArgumentsSourceOrder, ExprContext, HasNodeIndex,
     PythonVersion,
 };
-use ruff_python_ast::visitor::{self, Visitor};
 use ruff_python_stdlib::builtins::version_builtin_was_added;
 use ruff_python_stdlib::typing::as_pep_585_generic;
 use ruff_text_size::{Ranged, TextRange};
@@ -30,10 +29,10 @@ use super::{
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
-    BindingDeprecationBuilder, ConsideredDefinitions, DefinedPlace, Definedness,
-    DeprecationPolicy, LookupError, Place, PlaceAndQualifiers, RequiresExplicitReExport,
-    TypeOrigin, builtins_module_scope, builtins_symbol, class_body_implicit_symbol,
-    explicit_global_symbol, loop_header_reachability, module_type_implicit_global_declaration,
+    BindingDeprecationBuilder, ConsideredDefinitions, DefinedPlace, Definedness, DeprecationPolicy,
+    LookupError, Place, PlaceAndQualifiers, RequiresExplicitReExport, TypeOrigin,
+    builtins_module_scope, builtins_symbol, class_body_implicit_symbol, explicit_global_symbol,
+    loop_header_reachability, module_type_implicit_global_declaration,
     module_type_implicit_global_symbol, place_by_id, place_from_bindings, place_from_declarations,
     typing_extensions_symbol,
 };
@@ -3566,11 +3565,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let target_ty =
             self.infer_assignment_definition_impl(assignment, definition, add.type_context());
         self.store_expression_type(target, target_ty);
-        self.suppress_transitive_deprecation(
-            definition,
-            target_ty,
-            assignment.value(self.module()),
-        );
+        let deprecation = self.assignment_value_deprecation_policy(assignment);
+        self.suppress_transitive_deprecation(definition, target_ty, deprecation);
         add.insert(self, target_ty);
     }
 
@@ -3578,20 +3574,40 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         &mut self,
         definition: Definition<'db>,
         ty: Type<'db>,
-        value: &'ast ast::Expr,
+        deprecation: DeprecationPolicy<'db>,
     ) {
-        if ty.is_deprecated(self.db()) && self.expression_names_deprecated_symbol(value) {
+        if ty.is_deprecated(self.db()) && deprecation == DeprecationPolicy::Suppress {
             self.set_binding_deprecation_policy(definition, ty, DeprecationPolicy::Suppress);
         }
     }
 
-    fn expression_names_deprecated_symbol(&self, expression: &'ast ast::Expr) -> bool {
+    fn expression_deprecation_policy(&self, expression: &'ast ast::Expr) -> DeprecationPolicy<'db> {
         if let Some(standalone) = self.index.try_expression(expression) {
-            let inference =
-                infer_expression_types(self.db(), standalone, TypeContext::default());
-            DeprecatedReferenceVisitor::contains_in_inference(self.db(), inference, expression)
+            let inference = infer_expression_types(self.db(), standalone, TypeContext::default());
+            ExpressionDeprecationPolicy::from_inference(self.db(), inference).policy(expression)
         } else {
-            DeprecatedReferenceVisitor::contains_in_builder(self, expression)
+            ExpressionDeprecationPolicy::from_builder(self).policy(expression)
+        }
+    }
+
+    fn assignment_value_deprecation_policy(
+        &self,
+        assignment: &AssignmentDefinitionKind<'db>,
+    ) -> DeprecationPolicy<'db> {
+        match assignment.target_kind() {
+            TargetKind::Single => {
+                self.expression_deprecation_policy(assignment.value(self.module()))
+            }
+            TargetKind::Sequence(_, unpack) => {
+                let target = unpack.target(self.db(), self.module());
+                let value_expression = unpack.value(self.db()).expression();
+                let value = value_expression.node_ref(self.db()).node(self.module());
+                let inference =
+                    infer_expression_types(self.db(), value_expression, TypeContext::default());
+                let policy = ExpressionDeprecationPolicy::from_inference(self.db(), inference);
+                corresponding_unpack_value(target, value, assignment.target(self.module()))
+                    .map_or(DeprecationPolicy::Inherit, |value| policy.policy(value))
+            }
         }
     }
 
@@ -4701,7 +4717,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 inferred_ty
             };
             if inferred_ty.is_deprecated(self.db())
-                && self.expression_names_deprecated_symbol(value)
+                && self.expression_deprecation_policy(value) == DeprecationPolicy::Suppress
             {
                 declared = declared.suppress_type_deprecation();
             }
@@ -7661,7 +7677,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let ty = self.infer_expression(value, add.type_context());
         self.store_expression_type(target, ty);
-        self.suppress_transitive_deprecation(definition, ty, value);
+        let deprecation = self.expression_deprecation_policy(value);
+        self.suppress_transitive_deprecation(definition, ty, deprecation);
         add.insert(self, ty)
     }
 
@@ -11135,67 +11152,121 @@ impl<V> IntoIterator for VecSet<V> {
     }
 }
 
-enum DeprecatedReferenceTypeSource<'builder, 'db, 'ast> {
+enum ExpressionTypeSource<'builder, 'db, 'ast> {
     Builder(&'builder TypeInferenceBuilder<'db, 'ast>),
     Inference(&'builder ExpressionInference<'db>),
 }
 
-struct DeprecatedReferenceVisitor<'builder, 'db, 'ast> {
+struct ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
     db: &'db dyn Db,
-    source: DeprecatedReferenceTypeSource<'builder, 'db, 'ast>,
-    found: bool,
+    source: ExpressionTypeSource<'builder, 'db, 'ast>,
 }
 
-impl<'builder, 'db, 'ast> DeprecatedReferenceVisitor<'builder, 'db, 'ast> {
-    fn contains_in_builder(
-        builder: &'builder TypeInferenceBuilder<'db, 'ast>,
-        expression: &'ast ast::Expr,
-    ) -> bool {
-        let mut visitor = Self {
+impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
+    fn from_builder(builder: &'builder TypeInferenceBuilder<'db, 'ast>) -> Self {
+        Self {
             db: builder.db(),
-            source: DeprecatedReferenceTypeSource::Builder(builder),
-            found: false,
-        };
-        visitor.visit_expr(expression);
-        visitor.found
+            source: ExpressionTypeSource::Builder(builder),
+        }
     }
 
-    fn contains_in_inference(
-        db: &'db dyn Db,
-        inference: &'builder ExpressionInference<'db>,
-        expression: &'ast ast::Expr,
-    ) -> bool {
-        let mut visitor = Self {
+    fn from_inference(db: &'db dyn Db, inference: &'builder ExpressionInference<'db>) -> Self {
+        Self {
             db,
-            source: DeprecatedReferenceTypeSource::Inference(inference),
-            found: false,
-        };
-        visitor.visit_expr(expression);
-        visitor.found
+            source: ExpressionTypeSource::Inference(inference),
+        }
     }
 
     fn expression_type(&self, expression: &ast::Expr) -> Type<'db> {
         match self.source {
-            DeprecatedReferenceTypeSource::Builder(builder) => {
-                builder.expression_type(expression)
+            ExpressionTypeSource::Builder(builder) => builder.expression_type(expression),
+            ExpressionTypeSource::Inference(inference) => inference.expression_type(expression),
+        }
+    }
+
+    fn policy(&self, expression: &'ast ast::Expr) -> DeprecationPolicy<'db> {
+        if !self.expression_type(expression).is_deprecated(self.db) {
+            return DeprecationPolicy::Inherit;
+        }
+
+        match expression {
+            ast::Expr::Name(_) | ast::Expr::Attribute(_) => DeprecationPolicy::Suppress,
+            ast::Expr::If(ast::ExprIf { body, orelse, .. }) => {
+                let mut deprecation = BindingDeprecationBuilder::default();
+                deprecation.add_policy(
+                    self.policy(body),
+                    self.expression_type(body).is_deprecated(self.db),
+                );
+                deprecation.add_policy(
+                    self.policy(orelse),
+                    self.expression_type(orelse).is_deprecated(self.db),
+                );
+                deprecation.build_policy()
             }
-            DeprecatedReferenceTypeSource::Inference(inference) => {
-                inference.expression_type(expression)
+            ast::Expr::Named(ast::ExprNamed { value, .. }) => self.policy(value),
+            ast::Expr::Call(call)
+                if matches!(
+                    self.expression_type(&call.func),
+                    Type::FunctionLiteral(function)
+                        if function.is_known(self.db, KnownFunction::Cast)
+                ) =>
+            {
+                call.arguments
+                    .args
+                    .get(1)
+                    .map_or(DeprecationPolicy::Inherit, |value| self.policy(value))
             }
+            ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
+                let Some(elements) = sequence_elts(value) else {
+                    return DeprecationPolicy::Inherit;
+                };
+                let Some(index) = self.expression_type(slice).as_int_literal() else {
+                    return DeprecationPolicy::Inherit;
+                };
+                let Ok(len) = i64::try_from(elements.len()) else {
+                    return DeprecationPolicy::Inherit;
+                };
+                let index = if index < 0 { len + index } else { index };
+                usize::try_from(index)
+                    .ok()
+                    .and_then(|index| elements.get(index))
+                    .map_or(DeprecationPolicy::Inherit, |element| self.policy(element))
+            }
+            _ => DeprecationPolicy::Inherit,
         }
     }
 }
 
-impl<'ast> Visitor<'ast> for DeprecatedReferenceVisitor<'_, '_, 'ast> {
-    fn visit_expr(&mut self, expression: &'ast ast::Expr) {
-        if matches!(expression, ast::Expr::Name(_) | ast::Expr::Attribute(_))
-            && self.expression_type(expression).is_deprecated(self.db)
-        {
-            self.found = true;
-            return;
-        }
-        visitor::walk_expr(self, expression);
+fn sequence_elts(expression: &ast::Expr) -> Option<&[ast::Expr]> {
+    match expression {
+        ast::Expr::List(list) => Some(&list.elts),
+        ast::Expr::Tuple(tuple) => Some(&tuple.elts),
+        _ => None,
     }
+}
+
+fn corresponding_unpack_value<'ast>(
+    target: &'ast ast::Expr,
+    value: &'ast ast::Expr,
+    selected_target: &ast::Expr,
+) -> Option<&'ast ast::Expr> {
+    if target.node_index() == selected_target.node_index() {
+        return Some(value);
+    }
+
+    let target_elements = sequence_elts(target)?;
+    let value_elements = sequence_elts(value)?;
+    if target_elements.len() != value_elements.len()
+        || target_elements.iter().any(ast::Expr::is_starred_expr)
+        || value_elements.iter().any(ast::Expr::is_starred_expr)
+    {
+        return None;
+    }
+
+    target_elements
+        .iter()
+        .zip(value_elements)
+        .find_map(|(target, value)| corresponding_unpack_value(target, value, selected_target))
 }
 
 #[must_use]

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -29,12 +29,11 @@ use super::{
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
-    BindingDeprecationBuilder, ConsideredDefinitions, DefinedPlace, Definedness, DeprecationPolicy,
-    LookupError, Place, PlaceAndQualifiers, RequiresExplicitReExport, TypeOrigin,
-    builtins_module_scope, builtins_symbol, class_body_implicit_symbol, explicit_global_symbol,
-    loop_header_reachability, module_type_implicit_global_declaration,
-    module_type_implicit_global_symbol, place_by_id, place_from_bindings, place_from_declarations,
-    typing_extensions_symbol,
+    ConsideredDefinitions, DefinedPlace, Definedness, DeprecationPolicy, LookupError, Place,
+    PlaceAndQualifiers, RequiresExplicitReExport, TypeOrigin, builtins_module_scope,
+    builtins_symbol, class_body_implicit_symbol, explicit_global_symbol, loop_header_reachability,
+    module_type_implicit_global_declaration, module_type_implicit_global_symbol, place_by_id,
+    place_from_bindings, place_from_declarations, typing_extensions_symbol,
 };
 use crate::reachability::ReachabilityConstraintsExtension;
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
@@ -11208,6 +11207,49 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
     }
 
     fn policy(&self, expression: &'ast ast::Expr) -> DeprecationPolicy<'db> {
+        match expression {
+            ast::Expr::If(ast::ExprIf { body, orelse, .. }) => {
+                return DeprecationPolicy::from_alternatives(
+                    self.builder.db(),
+                    [
+                        (self.expression_type(body), self.policy(body)),
+                        (self.expression_type(orelse), self.policy(orelse)),
+                    ],
+                );
+            }
+            ast::Expr::Named(ast::ExprNamed { value, .. }) => return self.policy(value),
+            ast::Expr::Call(call)
+                if matches!(
+                    self.expression_type(&call.func),
+                    Type::FunctionLiteral(function)
+                        if function.is_known(self.builder.db(), KnownFunction::Cast)
+                ) =>
+            {
+                return call
+                    .arguments
+                    .args
+                    .get(1)
+                    .map_or(DeprecationPolicy::Inherit, |value| self.policy(value));
+            }
+            ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
+                let Some(elements) = sequence_elts(value) else {
+                    return DeprecationPolicy::Inherit;
+                };
+                let Some(index) = self.expression_type(slice).as_int_literal() else {
+                    return DeprecationPolicy::Inherit;
+                };
+                let Ok(len) = i64::try_from(elements.len()) else {
+                    return DeprecationPolicy::Inherit;
+                };
+                let index = if index < 0 { len + index } else { index };
+                return usize::try_from(index)
+                    .ok()
+                    .and_then(|index| elements.get(index))
+                    .map_or(DeprecationPolicy::Inherit, |element| self.policy(element));
+            }
+            _ => {}
+        }
+
         let expression_ty = self.expression_type(expression);
         let type_is_deprecated = expression_ty.is_deprecated(self.builder.db());
         if !type_is_deprecated
@@ -11250,48 +11292,6 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
                 } else {
                     DeprecationPolicy::Inherit
                 }
-            }
-            ast::Expr::If(ast::ExprIf { body, orelse, .. }) => {
-                let mut deprecation = BindingDeprecationBuilder::default();
-                deprecation.add_policy(
-                    self.policy(body),
-                    self.expression_type(body).is_deprecated(self.builder.db()),
-                );
-                deprecation.add_policy(
-                    self.policy(orelse),
-                    self.expression_type(orelse)
-                        .is_deprecated(self.builder.db()),
-                );
-                deprecation.build_policy()
-            }
-            ast::Expr::Named(ast::ExprNamed { value, .. }) => self.policy(value),
-            ast::Expr::Call(call)
-                if matches!(
-                    self.expression_type(&call.func),
-                    Type::FunctionLiteral(function)
-                        if function.is_known(self.builder.db(), KnownFunction::Cast)
-                ) =>
-            {
-                call.arguments
-                    .args
-                    .get(1)
-                    .map_or(DeprecationPolicy::Inherit, |value| self.policy(value))
-            }
-            ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
-                let Some(elements) = sequence_elts(value) else {
-                    return DeprecationPolicy::Inherit;
-                };
-                let Some(index) = self.expression_type(slice).as_int_literal() else {
-                    return DeprecationPolicy::Inherit;
-                };
-                let Ok(len) = i64::try_from(elements.len()) else {
-                    return DeprecationPolicy::Inherit;
-                };
-                let index = if index < 0 { len + index } else { index };
-                usize::try_from(index)
-                    .ok()
-                    .and_then(|index| elements.get(index))
-                    .map_or(DeprecationPolicy::Inherit, |element| self.policy(element))
             }
             _ => DeprecationPolicy::Inherit,
         }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -29,11 +29,12 @@ use super::{
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
-    ConsideredDefinitions, DefinedPlace, Definedness, DeprecationPolicy, LookupError, Place,
-    PlaceAndQualifiers, RequiresExplicitReExport, TypeOrigin, builtins_module_scope,
-    builtins_symbol, class_body_implicit_symbol, explicit_global_symbol, loop_header_reachability,
-    module_type_implicit_global_declaration, module_type_implicit_global_symbol, place_by_id,
-    place_from_bindings, place_from_declarations, typing_extensions_symbol,
+    ConsideredDefinitions, DefinedPlace, Definedness, DeprecationBuilder, DeprecationPolicy,
+    LookupError, Place, PlaceAndQualifiers, RequiresExplicitReExport, TypeOrigin,
+    builtins_module_scope, builtins_symbol, class_body_implicit_symbol, explicit_global_symbol,
+    loop_header_reachability, module_type_implicit_global_declaration,
+    module_type_implicit_global_symbol, place_by_id, place_from_bindings, place_from_declarations,
+    typing_extensions_symbol,
 };
 use crate::reachability::ReachabilityConstraintsExtension;
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
@@ -2105,17 +2106,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let place = loop_header_kind.place();
 
         let mut union = UnionBuilder::new(db).recursively_defined(RecursivelyDefined::Yes);
+        let mut deprecation = DeprecationBuilder::default();
 
         for reachable_binding in &loop_header.reachable_bindings {
-            let binding_ty = binding_type(db, reachable_binding.definition);
+            let inference = infer_definition_types(db, reachable_binding.definition);
+            let binding_ty = inference.binding_type(reachable_binding.definition);
             let narrowed_ty = use_def
                 .narrowing_evaluator(reachable_binding.narrowing_constraint)
                 .narrow(db, binding_ty, place);
 
             union.add_in_place(narrowed_ty);
+            deprecation.add_policy(
+                inference
+                    .inferred_declaration(reachable_binding.definition)
+                    .declared()
+                    .map_or(DeprecationPolicy::Inherit, |declaration| {
+                        declaration.deprecation_policy()
+                    }),
+            );
         }
 
-        self.bindings.insert(definition, union.build());
+        let ty = union.build();
+        self.bindings.insert(definition, ty);
+        self.set_binding_deprecation_policy(definition, ty, deprecation.build_policy());
     }
 
     fn infer_nested_bindings_definition(
@@ -2198,6 +2211,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let mut union = UnionBuilder::new(db).recursively_defined(RecursivelyDefined::Yes);
+        let mut deprecation = DeprecationBuilder::default();
         for declaration in visible_nested_declarations {
             assert!(
                 declaration.is_bound,
@@ -2208,16 +2222,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .symbol_id(&nested_bindings_kind.name)
                 .unwrap();
             let use_def = self.index.use_def_map(declaration.file_scope_id);
-            let Some(ty) =
+            let nested_place =
                 place_from_bindings(db, use_def.reachable_bindings(nested_symbol_id.into()))
-                    .place
-                    .raw_type()
-            else {
+                    .into_place_and_qualifiers();
+            let Some(ty) = nested_place.place().raw_type() else {
                 continue;
             };
             union.add_in_place(ty);
+            deprecation.add_policy(nested_place.deprecation_policy());
         }
-        self.bindings.insert(definition, union.build());
+        let ty = union.build();
+        self.bindings.insert(definition, ty);
+        self.set_binding_deprecation_policy(definition, ty, deprecation.build_policy());
     }
 
     fn infer_match_statement(&mut self, match_statement: &ast::StmtMatch) {
@@ -3552,10 +3568,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn suppress_transitive_deprecation(&mut self, definition: Definition<'db>, ty: Type<'db>) {
         if ty.is_deprecated(self.db()) {
+            self.set_binding_deprecation_policy(definition, ty, DeprecationPolicy::Suppress);
+        }
+    }
+
+    fn set_binding_deprecation_policy(
+        &mut self,
+        definition: Definition<'db>,
+        ty: Type<'db>,
+        policy: DeprecationPolicy<'db>,
+    ) {
+        if policy != DeprecationPolicy::Inherit {
             self.declarations.insert(
                 definition,
                 TypeAndQualifiers::new(ty, TypeOrigin::Inferred, TypeQualifiers::empty())
-                    .suppress_type_deprecation(),
+                    .with_deprecation_policy(policy),
             );
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3585,7 +3585,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) {
         let policy = match deprecation {
             DeprecationPolicy::Alternatives(_) => deprecation,
-            DeprecationPolicy::Suppress if ty.is_deprecated(self.db()) => {
+            DeprecationPolicy::Suppress
+                if ty.is_deprecated(self.db()) || matches!(ty, Type::Union(_)) =>
+            {
                 DeprecationPolicy::Suppress
             }
             _ => return,
@@ -11280,10 +11282,13 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
                 )
                 .0
                 .deprecation_policy();
-            if matches!(place_deprecation, DeprecationPolicy::Alternatives(_))
-                && place_deprecation.contains_deprecated(self.builder.db())
-            {
+            if matches!(place_deprecation, DeprecationPolicy::Alternatives(_)) {
                 return place_deprecation;
+            }
+            if place_deprecation == DeprecationPolicy::Suppress
+                && matches!(expression_ty, Type::Union(_))
+            {
+                return DeprecationPolicy::Suppress;
             }
         }
         let type_is_deprecated = expression_ty.is_deprecated(self.builder.db());

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2108,7 +2108,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let place = loop_header_kind.place();
 
         let mut union = UnionBuilder::new(db).recursively_defined(RecursivelyDefined::Yes);
-        let mut deprecation = BindingDeprecationBuilder::default();
+        let mut deprecation_alternatives = Vec::new();
 
         for reachable_binding in &loop_header.reachable_bindings {
             let inference = infer_definition_types(db, reachable_binding.definition);
@@ -2118,20 +2118,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .narrow(db, binding_ty, place);
 
             union.add_in_place(narrowed_ty);
-            deprecation.add_policy(
+            deprecation_alternatives.push((
+                narrowed_ty,
                 inference
                     .inferred_declaration(reachable_binding.definition)
                     .declared()
                     .map_or(DeprecationPolicy::Inherit, |declaration| {
                         declaration.deprecation_policy()
                     }),
-                narrowed_ty.is_deprecated(db),
-            );
+            ));
         }
 
         let ty = union.build();
         self.bindings.insert(definition, ty);
-        self.set_binding_deprecation_policy(definition, ty, deprecation.build_policy());
+        self.set_binding_deprecation_policy(
+            definition,
+            ty,
+            DeprecationPolicy::from_alternatives(db, deprecation_alternatives),
+        );
     }
 
     fn infer_nested_bindings_definition(
@@ -2214,7 +2218,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let mut union = UnionBuilder::new(db).recursively_defined(RecursivelyDefined::Yes);
-        let mut deprecation = BindingDeprecationBuilder::default();
+        let mut deprecation_alternatives = Vec::new();
         for declaration in visible_nested_declarations {
             assert!(
                 declaration.is_bound,
@@ -2232,11 +2236,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 continue;
             };
             union.add_in_place(ty);
-            deprecation.add_policy(nested_place.deprecation_policy(), ty.is_deprecated(db));
+            deprecation_alternatives.push((ty, nested_place.deprecation_policy()));
         }
         let ty = union.build();
         self.bindings.insert(definition, ty);
-        self.set_binding_deprecation_policy(definition, ty, deprecation.build_policy());
+        self.set_binding_deprecation_policy(
+            definition,
+            ty,
+            DeprecationPolicy::from_alternatives(db, deprecation_alternatives),
+        );
     }
 
     fn infer_match_statement(&mut self, match_statement: &ast::StmtMatch) {
@@ -9359,7 +9367,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         if let Some(ty) = place.place().ignore_possibly_undefined() {
-            match place.deprecation_policy() {
+            match place.deprecation_policy().resolve_for_type(db, ty) {
                 DeprecationPolicy::Deprecated(deprecated) if !ty.is_never() => {
                     if let Some(name) = match expr_ref {
                         ast::ExprRef::Name(name) => Some(name.id.as_str()),
@@ -9371,7 +9379,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         self.check_deprecated(expr_ref, ty);
                     }
                 }
-                DeprecationPolicy::Inherit => self.check_deprecated(expr_ref, ty),
+                DeprecationPolicy::Inherit | DeprecationPolicy::Alternatives(_) => {
+                    self.check_deprecated(expr_ref, ty);
+                }
                 DeprecationPolicy::Suppress | DeprecationPolicy::Deprecated(_) => {}
             }
         }
@@ -9806,11 +9816,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let deprecation = resolved_type.deprecation_policy();
         let resolved_type = resolved_type.inner_type();
 
-        match deprecation {
+        match deprecation.resolve_for_type(db, resolved_type) {
             DeprecationPolicy::Deprecated(deprecated) => {
                 self.report_deprecated_function(attr, attr.id.as_str(), deprecated);
             }
-            DeprecationPolicy::Inherit => self.check_deprecated(attr, resolved_type),
+            DeprecationPolicy::Inherit | DeprecationPolicy::Alternatives(_) => {
+                self.check_deprecated(attr, resolved_type);
+            }
             DeprecationPolicy::Suppress => {}
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -30,10 +30,10 @@ use super::{
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
-    ConsideredDefinitions, DefinedPlace, Definedness, DeprecationBuilder, DeprecationPolicy,
-    LookupError, Place, PlaceAndQualifiers, RequiresExplicitReExport, TypeOrigin,
-    builtins_module_scope, builtins_symbol, class_body_implicit_symbol, explicit_global_symbol,
-    loop_header_reachability, module_type_implicit_global_declaration,
+    BindingDeprecationBuilder, ConsideredDefinitions, DefinedPlace, Definedness,
+    DeprecationPolicy, LookupError, Place, PlaceAndQualifiers, RequiresExplicitReExport,
+    TypeOrigin, builtins_module_scope, builtins_symbol, class_body_implicit_symbol,
+    explicit_global_symbol, loop_header_reachability, module_type_implicit_global_declaration,
     module_type_implicit_global_symbol, place_by_id, place_from_bindings, place_from_declarations,
     typing_extensions_symbol,
 };
@@ -2109,7 +2109,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let place = loop_header_kind.place();
 
         let mut union = UnionBuilder::new(db).recursively_defined(RecursivelyDefined::Yes);
-        let mut deprecation = DeprecationBuilder::default();
+        let mut deprecation = BindingDeprecationBuilder::default();
 
         for reachable_binding in &loop_header.reachable_bindings {
             let inference = infer_definition_types(db, reachable_binding.definition);
@@ -2126,6 +2126,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .map_or(DeprecationPolicy::Inherit, |declaration| {
                         declaration.deprecation_policy()
                     }),
+                narrowed_ty.is_deprecated(db),
             );
         }
 
@@ -2214,7 +2215,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let mut union = UnionBuilder::new(db).recursively_defined(RecursivelyDefined::Yes);
-        let mut deprecation = DeprecationBuilder::default();
+        let mut deprecation = BindingDeprecationBuilder::default();
         for declaration in visible_nested_declarations {
             assert!(
                 declaration.is_bound,
@@ -2232,7 +2233,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 continue;
             };
             union.add_in_place(ty);
-            deprecation.add_policy(nested_place.deprecation_policy());
+            deprecation.add_policy(nested_place.deprecation_policy(), ty.is_deprecated(db));
         }
         let ty = union.build();
         self.bindings.insert(definition, ty);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11226,6 +11226,31 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
         }
     }
 
+    fn propagated_place_policy(
+        &self,
+        deprecation: DeprecationPolicy<'db>,
+        ty: Type<'db>,
+    ) -> Option<DeprecationPolicy<'db>> {
+        match deprecation {
+            DeprecationPolicy::Alternatives(_) => {
+                match deprecation.resolve_for_type(self.builder.db(), ty) {
+                    DeprecationPolicy::Deprecated(_) | DeprecationPolicy::Suppress => {
+                        Some(DeprecationPolicy::Suppress)
+                    }
+                    DeprecationPolicy::Inherit | DeprecationPolicy::Alternatives(_) => {
+                        Some(deprecation)
+                    }
+                }
+            }
+            DeprecationPolicy::Suppress if matches!(ty, Type::Union(_)) => {
+                Some(DeprecationPolicy::Suppress)
+            }
+            DeprecationPolicy::Inherit
+            | DeprecationPolicy::Suppress
+            | DeprecationPolicy::Deprecated(_) => None,
+        }
+    }
+
     fn policy(&self, expression: &'ast ast::Expr) -> DeprecationPolicy<'db> {
         match expression {
             ast::Expr::If(ast::ExprIf { body, orelse, .. }) => {
@@ -11284,13 +11309,10 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
                             .deprecation_policy()
                     })
                     .unwrap_or(DeprecationPolicy::Inherit);
-                if matches!(place_deprecation, DeprecationPolicy::Alternatives(_)) {
-                    return place_deprecation;
-                }
-                if place_deprecation == DeprecationPolicy::Suppress
-                    && matches!(expression_ty, Type::Union(_))
+                if let Some(propagated) =
+                    self.propagated_place_policy(place_deprecation, expression_ty)
                 {
-                    return DeprecationPolicy::Suppress;
+                    return propagated;
                 }
             }
             ast::Expr::Attribute(attribute) => {
@@ -11298,8 +11320,10 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
                     .expression_type(&attribute.value)
                     .member(self.builder.db(), &attribute.attr.id)
                     .deprecation_policy();
-                if matches!(place_deprecation, DeprecationPolicy::Alternatives(_)) {
-                    return place_deprecation;
+                if let Some(propagated) =
+                    self.propagated_place_policy(place_deprecation, expression_ty)
+                {
+                    return propagated;
                 }
             }
             _ => {}

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9025,6 +9025,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let binding_deprecation = if file_scope_id.is_global()
             && place_expr.as_symbol().is_some()
             && local_scope_place.is_definitely_bound()
+            && local_scope_place
+                .ignore_possibly_undefined()
+                .is_some_and(|ty| !ty.is_never())
             && let Some(use_id) = use_id
         {
             let mut bindings = use_def.bindings_at_use(use_id);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4672,7 +4672,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.add_declaration_with_binding(
                     target.into(),
                     definition,
-                    &DeclaredAndInferredType::AreTheSame(TypeAndQualifiers::declared(inferred_ty)),
+                    &DeclaredAndInferredType::AreTheSame(declared.map_type(|_| inferred_ty)),
                 );
             } else {
                 // Check for annotated enum members. The typing spec states that enum

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9367,7 +9367,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         if let Some(ty) = place.place().ignore_possibly_undefined() {
-            match place.deprecation_policy().resolve_for_type(db, ty) {
+            match place.deprecation_policy_for_type(db, ty) {
                 DeprecationPolicy::Deprecated(deprecated) if !ty.is_never() => {
                     if let Some(name) = match expr_ref {
                         ast::ExprRef::Name(name) => Some(name.id.as_str()),
@@ -9813,10 +9813,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             });
 
-        let deprecation = resolved_type.deprecation_policy();
+        let deprecation = resolved_type.resolved_deprecation_policy(db);
         let resolved_type = resolved_type.inner_type();
 
-        match deprecation.resolve_for_type(db, resolved_type) {
+        match deprecation {
             DeprecationPolicy::Deprecated(deprecated) => {
                 self.report_deprecated_function(attr, attr.id.as_str(), deprecated);
             }
@@ -11221,8 +11221,7 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
                                 ast::ExprRef::from(expression),
                             )
                             .0
-                            .deprecation_policy()
-                            .resolve_for_type(self.builder.db(), expression_ty)
+                            .deprecation_policy_for_type(self.builder.db(), expression_ty)
                     })
                     .unwrap_or(DeprecationPolicy::Inherit);
                 if place_deprecation != DeprecationPolicy::Inherit {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3574,19 +3574,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.infer_assignment_definition_impl(assignment, definition, add.type_context());
         self.store_expression_type(target, target_ty);
         let deprecation = self.assignment_value_deprecation_policy(assignment);
-        self.suppress_transitive_deprecation(definition, target_ty, deprecation);
+        self.set_assignment_deprecation_policy(definition, target_ty, deprecation);
         add.insert(self, target_ty);
     }
 
-    fn suppress_transitive_deprecation(
+    fn set_assignment_deprecation_policy(
         &mut self,
         definition: Definition<'db>,
         ty: Type<'db>,
         deprecation: DeprecationPolicy<'db>,
     ) {
-        if ty.is_deprecated(self.db()) && deprecation == DeprecationPolicy::Suppress {
-            self.set_binding_deprecation_policy(definition, ty, DeprecationPolicy::Suppress);
-        }
+        let policy = match deprecation {
+            DeprecationPolicy::Alternatives(_) => deprecation,
+            DeprecationPolicy::Suppress if ty.is_deprecated(self.db()) => {
+                DeprecationPolicy::Suppress
+            }
+            _ => return,
+        };
+        self.set_binding_deprecation_policy(definition, ty, policy);
     }
 
     fn expression_deprecation_policy(&self, expression: &'ast ast::Expr) -> DeprecationPolicy<'db> {
@@ -7689,7 +7694,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let ty = self.infer_expression(value, add.type_context());
         self.store_expression_type(target, ty);
         let deprecation = self.expression_deprecation_policy(value);
-        self.suppress_transitive_deprecation(definition, ty, deprecation);
+        self.set_assignment_deprecation_policy(definition, ty, deprecation);
         add.insert(self, ty)
     }
 
@@ -11204,11 +11209,27 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
 
     fn policy(&self, expression: &'ast ast::Expr) -> DeprecationPolicy<'db> {
         let expression_ty = self.expression_type(expression);
-        if !expression_ty.is_deprecated(self.builder.db()) {
+        let type_is_deprecated = expression_ty.is_deprecated(self.builder.db());
+        if !type_is_deprecated
+            && !matches!(
+                expression,
+                ast::Expr::Attribute(_) if matches!(expression_ty, Type::Union(_))
+            )
+        {
             return DeprecationPolicy::Inherit;
         }
 
         match expression {
+            ast::Expr::Attribute(attribute) if !type_is_deprecated => {
+                let deprecation = self
+                    .expression_type(&attribute.value)
+                    .member(self.builder.db(), &attribute.attr.id)
+                    .deprecation_policy();
+                match deprecation {
+                    DeprecationPolicy::Alternatives(_) => deprecation,
+                    _ => DeprecationPolicy::Inherit,
+                }
+            }
             ast::Expr::Name(_) | ast::Expr::Attribute(_) => {
                 if !matches!(expression_ty, Type::Union(_)) {
                     return DeprecationPolicy::Suppress;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4731,10 +4731,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             } else {
                 inferred_ty
             };
-            if inferred_ty.is_deprecated(self.db())
-                && self.expression_deprecation_policy(value) == DeprecationPolicy::Suppress
-            {
-                declared = declared.suppress_type_deprecation();
+            match self.expression_deprecation_policy(value) {
+                deprecation @ DeprecationPolicy::Alternatives(_) => {
+                    declared = declared.with_deprecation_policy(deprecation);
+                }
+                DeprecationPolicy::Suppress if inferred_ty.is_deprecated(self.db()) => {
+                    declared = declared.suppress_type_deprecation();
+                }
+                _ => {}
             }
 
             if is_pep_613_type_alias {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11297,7 +11297,7 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
                 let place_deprecation = PlaceExpr::try_from_expr(expression)
                     .map(|place_expr| {
                         self.builder
-                            .infer_place_load(
+                            .infer_place_load_without_deprecation_diagnostic(
                                 PlaceExprRef::from(&place_expr),
                                 ast::ExprRef::from(expression),
                             )

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3584,7 +3584,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn expression_deprecation_policy(&self, expression: &'ast ast::Expr) -> DeprecationPolicy<'db> {
         if let Some(standalone) = self.index.try_expression(expression) {
             let inference = infer_expression_types(self.db(), standalone, TypeContext::default());
-            ExpressionDeprecationPolicy::from_inference(self.db(), inference).policy(expression)
+            ExpressionDeprecationPolicy::from_inference(self, inference).policy(expression)
         } else {
             ExpressionDeprecationPolicy::from_builder(self).policy(expression)
         }
@@ -3604,7 +3604,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let value = value_expression.node_ref(self.db()).node(self.module());
                 let inference =
                     infer_expression_types(self.db(), value_expression, TypeContext::default());
-                let policy = ExpressionDeprecationPolicy::from_inference(self.db(), inference);
+                let policy = ExpressionDeprecationPolicy::from_inference(self, inference);
                 corresponding_unpack_value(target, value, assignment.target(self.module()))
                     .map_or(DeprecationPolicy::Inherit, |value| policy.policy(value))
             }
@@ -11158,21 +11158,24 @@ enum ExpressionTypeSource<'builder, 'db, 'ast> {
 }
 
 struct ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
-    db: &'db dyn Db,
+    builder: &'builder TypeInferenceBuilder<'db, 'ast>,
     source: ExpressionTypeSource<'builder, 'db, 'ast>,
 }
 
 impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
     fn from_builder(builder: &'builder TypeInferenceBuilder<'db, 'ast>) -> Self {
         Self {
-            db: builder.db(),
+            builder,
             source: ExpressionTypeSource::Builder(builder),
         }
     }
 
-    fn from_inference(db: &'db dyn Db, inference: &'builder ExpressionInference<'db>) -> Self {
+    fn from_inference(
+        builder: &'builder TypeInferenceBuilder<'db, 'ast>,
+        inference: &'builder ExpressionInference<'db>,
+    ) -> Self {
         Self {
-            db,
+            builder,
             source: ExpressionTypeSource::Inference(inference),
         }
     }
@@ -11185,21 +11188,43 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
     }
 
     fn policy(&self, expression: &'ast ast::Expr) -> DeprecationPolicy<'db> {
-        if !self.expression_type(expression).is_deprecated(self.db) {
+        let expression_ty = self.expression_type(expression);
+        if !expression_ty.is_deprecated(self.builder.db()) {
             return DeprecationPolicy::Inherit;
         }
 
         match expression {
-            ast::Expr::Name(_) | ast::Expr::Attribute(_) => DeprecationPolicy::Suppress,
+            ast::Expr::Name(_) | ast::Expr::Attribute(_) => {
+                if !matches!(expression_ty, Type::Union(_)) {
+                    return DeprecationPolicy::Suppress;
+                }
+                let place_deprecation = PlaceExpr::try_from_expr(expression)
+                    .map(|place_expr| {
+                        self.builder
+                            .infer_place_load(
+                                PlaceExprRef::from(&place_expr),
+                                ast::ExprRef::from(expression),
+                            )
+                            .0
+                            .deprecation_policy()
+                    })
+                    .unwrap_or(DeprecationPolicy::Inherit);
+                if place_deprecation != DeprecationPolicy::Inherit {
+                    DeprecationPolicy::Suppress
+                } else {
+                    DeprecationPolicy::Inherit
+                }
+            }
             ast::Expr::If(ast::ExprIf { body, orelse, .. }) => {
                 let mut deprecation = BindingDeprecationBuilder::default();
                 deprecation.add_policy(
                     self.policy(body),
-                    self.expression_type(body).is_deprecated(self.db),
+                    self.expression_type(body).is_deprecated(self.builder.db()),
                 );
                 deprecation.add_policy(
                     self.policy(orelse),
-                    self.expression_type(orelse).is_deprecated(self.db),
+                    self.expression_type(orelse)
+                        .is_deprecated(self.builder.db()),
                 );
                 deprecation.build_policy()
             }
@@ -11208,7 +11233,7 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
                 if matches!(
                     self.expression_type(&call.func),
                     Type::FunctionLiteral(function)
-                        if function.is_known(self.db, KnownFunction::Cast)
+                        if function.is_known(self.builder.db(), KnownFunction::Cast)
                 ) =>
             {
                 call.arguments

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -426,7 +426,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.expressions
             .extend(inference.expressions.iter().copied());
-        self.declarations.extend(inference.declarations());
+        if !matches!(self.region, InferenceRegion::Expression(..)) {
+            self.declarations.extend(inference.declarations());
+        }
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
             self.bindings.extend(inference.bindings());

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9095,6 +9095,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         place_expr: PlaceExprRef,
         expr_ref: ast::ExprRef,
     ) -> (PlaceAndQualifiers<'db>, Vec<(FileScopeId, ConstraintKey)>) {
+        let result = self.infer_place_load_without_deprecation_diagnostic(place_expr, expr_ref);
+        self.report_place_deprecation(expr_ref, &result.0);
+        result
+    }
+
+    fn infer_place_load_without_deprecation_diagnostic(
+        &self,
+        place_expr: PlaceExprRef,
+        expr_ref: ast::ExprRef,
+    ) -> (PlaceAndQualifiers<'db>, Vec<(FileScopeId, ConstraintKey)>) {
         let db = self.db();
         let scope = self.scope();
         let file_scope_id = scope.file_scope_id(db);
@@ -9374,27 +9384,31 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
         });
 
-        if let Some(ty) = place.place().ignore_possibly_undefined() {
-            match place.deprecation_policy_for_type(db, ty) {
-                DeprecationPolicy::Deprecated(deprecated) if !ty.is_never() => {
-                    if let Some(name) = match expr_ref {
-                        ast::ExprRef::Name(name) => Some(name.id.as_str()),
-                        ast::ExprRef::Attribute(attribute) => Some(attribute.attr.as_str()),
-                        _ => None,
-                    } {
-                        self.report_deprecated_function(expr_ref, name, deprecated);
-                    } else {
-                        self.check_deprecated(expr_ref, ty);
-                    }
-                }
-                DeprecationPolicy::Inherit | DeprecationPolicy::Alternatives(_) => {
+        (place, constraint_keys)
+    }
+
+    fn report_place_deprecation(&self, expr_ref: ast::ExprRef, place: &PlaceAndQualifiers<'db>) {
+        let db = self.db();
+        let Some(ty) = place.place().ignore_possibly_undefined() else {
+            return;
+        };
+        match place.deprecation_policy_for_type(db, ty) {
+            DeprecationPolicy::Deprecated(deprecated) if !ty.is_never() => {
+                if let Some(name) = match expr_ref {
+                    ast::ExprRef::Name(name) => Some(name.id.as_str()),
+                    ast::ExprRef::Attribute(attribute) => Some(attribute.attr.as_str()),
+                    _ => None,
+                } {
+                    self.report_deprecated_function(expr_ref, name, deprecated);
+                } else {
                     self.check_deprecated(expr_ref, ty);
                 }
-                DeprecationPolicy::Suppress | DeprecationPolicy::Deprecated(_) => {}
             }
+            DeprecationPolicy::Inherit | DeprecationPolicy::Alternatives(_) => {
+                self.check_deprecated(expr_ref, ty);
+            }
+            DeprecationPolicy::Suppress | DeprecationPolicy::Deprecated(_) => {}
         }
-
-        (place, constraint_keys)
     }
 
     pub(super) fn report_unresolved_reference(&self, expr_name_node: &ast::ExprName) {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4661,9 +4661,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // We defer the r.h.s. of PEP-613 `TypeAlias` assignments in stub files.
             let previous_deferred_state = self.deferred_state;
+            let previous_pep_613_alias_value_range = self.context.pep_613_alias_value_range;
 
             if is_pep_613_type_alias {
                 self.context.inference_flags |= InferenceFlags::IN_PEP_613_ALIAS_FIRST_PASS;
+                self.context.pep_613_alias_value_range = Some(value.range());
                 if self.in_stub() {
                     self.deferred_state = DeferredExpressionState::Deferred;
                 }
@@ -4701,6 +4703,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             self.typevar_binding_context = previous_typevar_binding_context;
             self.deferred_state = previous_deferred_state;
+            self.context.pep_613_alias_value_range = previous_pep_613_alias_value_range;
             self.dataclass_field_specifiers.clear();
             self.context
                 .inference_flags

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -29,9 +29,9 @@ use super::{
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
-    ConsideredDefinitions, DefinedPlace, Definedness, LookupError, Place, PlaceAndQualifiers,
-    RequiresExplicitReExport, TypeOrigin, builtins_module_scope, builtins_symbol,
-    class_body_implicit_symbol, explicit_global_symbol, loop_header_reachability,
+    ConsideredDefinitions, DefinedPlace, Definedness, DeprecationPolicy, LookupError, Place,
+    PlaceAndQualifiers, RequiresExplicitReExport, TypeOrigin, builtins_module_scope,
+    builtins_symbol, class_body_implicit_symbol, explicit_global_symbol, loop_header_reachability,
     module_type_implicit_global_declaration, module_type_implicit_global_symbol, place_by_id,
     place_from_bindings, place_from_declarations, typing_extensions_symbol,
 };
@@ -3575,6 +3575,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let target_ty =
             self.infer_assignment_definition_impl(assignment, definition, add.type_context());
         self.store_expression_type(target, target_ty);
+        if target_ty.is_deprecated(self.db()) {
+            self.declarations.insert(
+                definition,
+                TypeAndQualifiers::new(target_ty, TypeOrigin::Inferred, TypeQualifiers::empty())
+                    .suppress_type_deprecation(),
+            );
+        }
         add.insert(self, target_ty);
     }
 
@@ -4668,6 +4675,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             } else {
                 inferred_ty
             };
+            if inferred_ty.is_deprecated(self.db()) {
+                declared = declared.suppress_type_deprecation();
+            }
 
             if is_pep_613_type_alias {
                 let inferred_ty =
@@ -9296,17 +9306,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         if let Some(ty) = place.place.ignore_possibly_undefined() {
-            if !ty.is_never()
-                && let Some(deprecated) = place.deprecation
-                && let Some(name) = match expr_ref {
-                    ast::ExprRef::Name(name) => Some(name.id.as_str()),
-                    ast::ExprRef::Attribute(attribute) => Some(attribute.attr.as_str()),
-                    _ => None,
+            match place.deprecation {
+                DeprecationPolicy::Deprecated(deprecated) if !ty.is_never() => {
+                    if let Some(name) = match expr_ref {
+                        ast::ExprRef::Name(name) => Some(name.id.as_str()),
+                        ast::ExprRef::Attribute(attribute) => Some(attribute.attr.as_str()),
+                        _ => None,
+                    } {
+                        self.report_deprecated_function(expr_ref, name, deprecated);
+                    } else {
+                        self.check_deprecated(expr_ref, ty);
+                    }
                 }
-            {
-                self.report_deprecated_function(expr_ref, name, deprecated);
-            } else {
-                self.check_deprecated(expr_ref, ty);
+                DeprecationPolicy::Inherit => self.check_deprecated(expr_ref, ty),
+                DeprecationPolicy::Suppress | DeprecationPolicy::Deprecated(_) => {}
             }
         }
 
@@ -9737,13 +9750,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             });
 
-        let deprecation = resolved_type.deprecation();
+        let deprecation = resolved_type.deprecation_policy();
         let resolved_type = resolved_type.inner_type();
 
-        if let Some(deprecated) = deprecation {
-            self.report_deprecated_function(attr, attr.id.as_str(), deprecated);
-        } else {
-            self.check_deprecated(attr, resolved_type);
+        match deprecation {
+            DeprecationPolicy::Deprecated(deprecated) => {
+                self.report_deprecated_function(attr, attr.id.as_str(), deprecated);
+            }
+            DeprecationPolicy::Inherit => self.check_deprecated(attr, resolved_type),
+            DeprecationPolicy::Suppress => {}
         }
 
         // Even if we can obtain the attribute type based on the assignments, we still perform default type inference

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -77,10 +77,9 @@ use crate::types::infer::builder::paramspec_validation::validate_paramspec_compo
 use crate::types::infer::builder::typed_dict::TypedDictConstructorForm;
 use crate::types::infer::{
     StatementInference, StatementInferenceInner, StatementInferenceInnerExtra, TypeAndRange,
-    TypeExpressionFlags, infer_statement_types, nearest_enclosing_class,
+    TypeExpressionFlags, function_known_decorators, infer_statement_types, nearest_enclosing_class,
     nearest_enclosing_function, original_class_type,
 };
-use crate::types::known_instance::DeprecatedInstance;
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::newtype::NewType;
 use crate::types::set_theoretic::RecursivelyDefined;
@@ -326,9 +325,6 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
 
-    /// The `@deprecated` decorator attached to a decorated function's module-level binding.
-    binding_deprecation_decorator: Option<ExpressionNodeKey>,
-
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
     cycle_recovery: Option<Type<'db>>,
 
@@ -380,7 +376,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             typevar_binding_context: None,
             deferred: VecSet::default(),
             undecorated_type: None,
-            binding_deprecation_decorator: None,
             cycle_recovery: None,
             discards_dict_key_assignments: false,
             dataclass_field_specifiers: SmallVec::new(),
@@ -8749,22 +8744,43 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ty
     }
 
-    fn report_deprecated_function<T: Ranged>(
+    fn deprecated_function_binding(
         &self,
-        ranged: T,
-        name: &str,
-        deprecated: DeprecatedInstance,
-    ) {
-        let Some(builder) = self.context.report_lint(&diagnostic::DEPRECATED, ranged) else {
-            return;
+        definition: Definition<'db>,
+        ty: Type<'db>,
+    ) -> Option<FunctionType<'db>> {
+        fn is_function_type(db: &dyn Db, ty: Type) -> bool {
+            match ty {
+                Type::FunctionLiteral(_) | Type::BoundMethod(_) => true,
+                Type::Union(union) => union
+                    .elements(db)
+                    .iter()
+                    .all(|element| is_function_type(db, *element)),
+                _ => false,
+            }
+        }
+
+        if !is_function_type(self.db(), ty) {
+            return None;
+        }
+
+        let DefinitionKind::Function(function) = definition.kind(self.db()) else {
+            return None;
+        };
+        let function_ty = infer_definition_types(self.db(), definition).function_type(definition)?;
+        if ty == Type::FunctionLiteral(function_ty) {
+            return None;
+        }
+
+        let decorator = function.node(self.module()).decorator_list.first()?;
+        let Type::KnownInstance(KnownInstanceType::Deprecated(_)) =
+            function_known_decorators(self.db(), definition)
+                .expression_type(&decorator.expression)?
+        else {
+            return None;
         };
 
-        let mut diag =
-            builder.into_diagnostic(format_args!(r#"The function `{name}` is deprecated"#));
-        if let Some(message) = deprecated.message {
-            diag.set_primary_message(message.value(self.db()));
-        }
-        diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
+        Some(function_ty)
     }
 
     /// Check if the given type is `@deprecated`.
@@ -8804,7 +8820,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         };
 
-        self.report_deprecated_function(ranged, function.name(self.db()).as_str(), deprecated);
+        let Some(builder) = self
+            .context
+            .report_lint(&crate::types::diagnostic::DEPRECATED, ranged)
+        else {
+            return;
+        };
+
+        let func_name = function.name(self.db());
+        let mut diag =
+            builder.into_diagnostic(format_args!(r#"The function `{func_name}` is deprecated"#));
+        if let Some(message) = deprecated.message {
+            diag.set_primary_message(message.value(self.db()));
+        }
+        diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
 
     fn infer_name_load(&mut self, name_node: &ast::ExprName) -> Type<'db> {
@@ -9022,12 +9051,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             constraint_keys.push((file_scope_id, ConstraintKey::UseId(use_id)));
         }
 
-        let binding_deprecation = if file_scope_id.is_global()
+        let deprecated_function_binding = if file_scope_id.is_global()
             && place_expr.as_symbol().is_some()
             && local_scope_place.is_definitely_bound()
-            && local_scope_place
-                .ignore_possibly_undefined()
-                .is_some_and(|ty| !ty.is_never())
+            && let Some(ty) = local_scope_place.ignore_possibly_undefined()
             && let Some(use_id) = use_id
         {
             let mut bindings = use_def.bindings_at_use(use_id);
@@ -9035,10 +9062,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 bindings.next().map(|binding| binding.binding),
                 bindings.next(),
             ) {
-                (Some(DefinitionState::Defined(binding)), None)
-                    if binding.kind(db).is_function_def() =>
-                {
-                    infer_definition_types(db, binding).binding_deprecation(db, binding)
+                (Some(DefinitionState::Defined(binding)), None) => {
+                    self.deprecated_function_binding(binding, ty)
                 }
                 _ => None,
             }
@@ -9313,10 +9338,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         if let Some(ty) = place.place.ignore_possibly_undefined() {
-            if let Some(deprecated) = binding_deprecation
-                && let Some(symbol) = place_expr.as_symbol()
-            {
-                self.report_deprecated_function(expr_ref, symbol.name().as_str(), deprecated);
+            if let Some(function) = deprecated_function_binding {
+                self.check_deprecated(expr_ref, Type::FunctionLiteral(function));
             } else {
                 self.check_deprecated(expr_ref, ty);
             }
@@ -10228,7 +10251,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
-            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
 
             // builder only state
@@ -10310,7 +10332,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
-            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
 
             // builder only state
@@ -10418,7 +10439,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             collection_use_constraints: _,
             dataclass_field_specifiers: _,
             undecorated_type: _,
-            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10459,7 +10479,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred,
             cycle_recovery,
             undecorated_type,
-            binding_deprecation_decorator,
             discards_dict_key_assignments,
             called_functions,
 
@@ -10481,7 +10500,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             || !expected_types.is_empty()
             || cycle_recovery.is_some()
             || undecorated_type.is_some()
-            || binding_deprecation_decorator.is_some()
             || !deferred.is_empty()
             || !called_functions.is_empty()
             || !qualifiers.is_empty()
@@ -10503,7 +10521,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     deferred: deferred.into_boxed_slice(),
                     diagnostics,
                     undecorated_type,
-                    binding_deprecation_decorator,
                     discards_dict_key_assignments,
                     qualifiers: FrozenMap::from(qualifiers),
                 })
@@ -10555,7 +10572,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
-            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
 
             // Builder only state
@@ -10629,7 +10645,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred: _,
             called_functions: _,
             undecorated_type: _,
-            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
             qualifiers: _,
             type_expression_flags: _,
@@ -10674,7 +10689,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
-            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
 
             // builder only state

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11221,40 +11221,6 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
                     ],
                 );
             }
-            ast::Expr::BoolOp(ast::ExprBoolOp { op, values, .. }) => {
-                let db = self.builder.db();
-                let mut done = false;
-                return DeprecationPolicy::from_alternatives(
-                    db,
-                    values.iter().enumerate().map(|(index, value)| {
-                        let ty = self.expression_type(value);
-                        let is_last = index == values.len() - 1;
-                        let result_ty = if is_last {
-                            if done { Type::Never } else { ty }
-                        } else if done {
-                            Type::Never
-                        } else {
-                            match (ty.bool(db), op) {
-                                (Truthiness::AlwaysTrue, ast::BoolOp::And)
-                                | (Truthiness::AlwaysFalse, ast::BoolOp::Or) => Type::Never,
-                                (Truthiness::AlwaysFalse, ast::BoolOp::And)
-                                | (Truthiness::AlwaysTrue, ast::BoolOp::Or) => {
-                                    done = true;
-                                    ty
-                                }
-                                (Truthiness::Ambiguous, _) => IntersectionBuilder::new(db)
-                                    .add_positive(ty)
-                                    .add_negative(match op {
-                                        ast::BoolOp::And => Type::AlwaysTruthy,
-                                        ast::BoolOp::Or => Type::AlwaysFalsy,
-                                    })
-                                    .build(),
-                            }
-                        };
-                        (result_ty, self.policy(value))
-                    }),
-                );
-            }
             ast::Expr::Named(ast::ExprNamed { value, .. }) => return self.policy(value),
             ast::Expr::Call(call)
                 if matches!(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -77,7 +77,7 @@ use crate::types::infer::builder::paramspec_validation::validate_paramspec_compo
 use crate::types::infer::builder::typed_dict::TypedDictConstructorForm;
 use crate::types::infer::{
     StatementInference, StatementInferenceInner, StatementInferenceInnerExtra, TypeAndRange,
-    TypeExpressionFlags, function_known_decorators, infer_statement_types, nearest_enclosing_class,
+    TypeExpressionFlags, infer_statement_types, nearest_enclosing_class,
     nearest_enclosing_function, original_class_type,
 };
 use crate::types::known_instance::DeprecatedInstance;
@@ -1266,6 +1266,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let PlaceAndQualifiers {
             place: resolved_place,
             qualifiers,
+            ..
         } = place_and_quals;
 
         let declared_ty = if resolved_place.is_undefined() && !place.is_symbol() {
@@ -2705,6 +2706,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 PlaceAndQualifiers {
                                     place: Place::Defined(DefinedPlace { ty: attr_ty, .. }),
                                     qualifiers: _,
+                                    ..
                                 } => attr_ty.is_callable_type(),
                                 _ => false,
                             };
@@ -2766,6 +2768,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 ty: meta_attr_ty, ..
                             }),
                         qualifiers,
+                        ..
                     } => {
                         // Resolve `Self` type variables to the concrete instance type.
                         let meta_attr_ty = meta_attr_ty.bind_self_typevars(db, object_ty);
@@ -2837,6 +2840,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             ..
                                         }),
                                     qualifiers,
+                                    ..
                                 } = fallback_attr
                                 {
                                     // Bind `Self` via MRO matching.
@@ -2890,6 +2894,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     ..
                                 }),
                             qualifiers,
+                            ..
                         }) = fallback_attr
                         {
                             // Bind `Self` via MRO matching.
@@ -2975,6 +2980,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 ty: meta_attr_ty, ..
                             }),
                         qualifiers,
+                        ..
                     } => {
                         if emit_diagnostics
                             && self.invalid_assignment_to_final_attribute(
@@ -3091,6 +3097,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     ..
                                 }),
                             qualifiers,
+                            ..
                         }) = fallback_attr
                         {
                             let class_attr_ty =
@@ -8745,60 +8752,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ty
     }
 
-    fn deprecated_function_binding(
-        &self,
-        definition: Definition<'db>,
-    ) -> Option<DeprecatedInstance<'db>> {
-        fn is_replaced_function_type(
-            db: &dyn Db,
-            definition: Definition,
-            ty: Type,
-        ) -> Option<bool> {
-            match ty {
-                Type::FunctionLiteral(function) => {
-                    Some(!function.contains_definition(db, definition))
-                }
-                Type::BoundMethod(bound) => {
-                    Some(!bound.function(db).contains_definition(db, definition))
-                }
-                Type::Union(union) => {
-                    union
-                        .elements(db)
-                        .iter()
-                        .try_fold(false, |replaced, element| {
-                            Some(replaced || is_replaced_function_type(db, definition, *element)?)
-                        })
-                }
-                _ => None,
-            }
-        }
-
-        let DefinitionKind::Function(function) = definition.kind(self.db()) else {
-            return None;
-        };
-        let decorator_inference = function_known_decorators(self.db(), definition);
-        if decorator_inference
-            .known_decorators()
-            .contains(FunctionDecorators::OVERLOAD)
-        {
-            return None;
-        }
-
-        let definition_inference = infer_definition_types(self.db(), definition);
-        let binding_ty = definition_inference.binding_type(definition);
-        if is_replaced_function_type(self.db(), definition, binding_ty) != Some(true) {
-            return None;
-        }
-
-        let decorator = function.node(self.module()).decorator_list.first()?;
-        let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) =
-            decorator_inference.expression_type(&decorator.expression)?
-        else {
-            return None;
-        };
-        Some(deprecated)
-    }
-
     fn report_deprecated_function<T: Ranged>(
         &self,
         ranged: T,
@@ -8927,7 +8880,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         &self,
         expr: PlaceExprRef,
         expr_ref: ast::ExprRef,
-    ) -> (Place<'db>, Option<ScopedUseId>) {
+    ) -> (PlaceAndQualifiers<'db>, Option<ScopedUseId>) {
         let db = self.db();
         let scope = self.scope();
         let file_scope_id = scope.file_scope_id(db);
@@ -8937,13 +8890,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // If we're inferring types of deferred expressions, look them up from end-of-scope.
         if self.is_deferred() {
             let place = if let Some(place_id) = place_table.place_id(expr) {
-                place_from_bindings(db, use_def.reachable_bindings(place_id)).place
+                place_from_bindings(db, use_def.reachable_bindings(place_id))
+                    .into_place_and_qualifiers()
             } else {
                 assert!(
                     self.in_string_annotation(),
                     "Expected the place table to create a place for every valid PlaceExpr node"
                 );
-                Place::Undefined
+                Place::Undefined.into()
             };
             (place, None)
         } else {
@@ -8951,7 +8905,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .as_name_expr()
                 .is_some_and(|name| name.is_invalid())
             {
-                return (Place::Undefined, None);
+                return (Place::Undefined.into(), None);
             }
 
             // A named expression can show up here when resolving the parent place of something
@@ -8960,15 +8914,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let ast::ExprRef::Named(named) = expr_ref {
                 let place = if named.target.is_name_expr() {
                     let definition = self.index.expect_single_definition(named);
-                    Place::bound(binding_type(db, definition))
+                    Place::bound(binding_type(db, definition)).into()
                 } else {
-                    Place::Undefined
+                    Place::Undefined.into()
                 };
                 return (place, None);
             }
 
             let use_id = expr_ref.scoped_use_id(db, self.file());
-            let place = place_from_bindings(db, use_def.bindings_at_use(use_id)).place;
+            let place = place_from_bindings(db, use_def.bindings_at_use(use_id))
+                .into_place_and_qualifiers();
 
             (place, Some(use_id))
         }
@@ -9017,12 +8972,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     return Place::Undefined.into();
                 }
                 EnclosingSnapshotResult::FoundBindings(bindings) => {
-                    let mut place_and_qualifiers = place_from_bindings(db, bindings);
+                    let mut place_and_qualifiers =
+                        place_from_bindings(db, bindings).into_place_and_qualifiers();
                     if assume_bound && let Place::Defined(defined) = place_and_qualifiers.place {
                         place_and_qualifiers.place =
                             Place::Defined(defined.with_definedness(Definedness::AlwaysDefined));
                     }
-                    let place = place_and_qualifiers.place.map_type(|ty| {
+                    place_and_qualifiers = place_and_qualifiers.map_type(|ty| {
                         self.narrow_place_with_applicable_constraints(
                             place_expr,
                             ty,
@@ -9033,7 +8989,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         FileScopeId::global(),
                         ConstraintKey::NestedScope(current_scope_id),
                     ));
-                    return place.into();
+                    return place_and_qualifiers;
                 }
                 // There are no visible bindings / constraint here.
                 EnclosingSnapshotResult::NotFound => {
@@ -9064,7 +9020,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let scope = self.scope();
         let file_scope_id = scope.file_scope_id(db);
         let place_table = self.index.place_table(file_scope_id);
-        let use_def = self.index.use_def_map(file_scope_id);
 
         let mut constraint_keys = vec![];
         let (local_scope_place, use_id) = self.infer_local_place_load(place_expr, expr_ref);
@@ -9072,28 +9027,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             constraint_keys.push((file_scope_id, ConstraintKey::UseId(use_id)));
         }
 
-        let binding_deprecation = if file_scope_id.is_global()
-            && place_expr.as_symbol().is_some()
-            && local_scope_place.is_definitely_bound()
-            && let Some(ty) = local_scope_place.ignore_possibly_undefined()
-            && !ty.is_never()
-            && let Some(use_id) = use_id
-        {
-            let mut bindings = use_def.bindings_at_use(use_id);
-            match (
-                bindings.next().map(|binding| binding.binding),
-                bindings.next(),
-            ) {
-                (Some(DefinitionState::Defined(binding)), None) => {
-                    self.deprecated_function_binding(binding)
-                }
-                _ => None,
-            }
-        } else {
-            None
-        };
-
-        let place = PlaceAndQualifiers::from(local_scope_place).or_fall_back_to(db, || {
+        let place = local_scope_place.or_fall_back_to(db, || {
             let mut symbol_resolves_locally = false;
             if let Some(symbol) = place_expr.as_symbol()
                 && let Some(symbol_id) = place_table.symbol_id(symbol.name())
@@ -9140,7 +9074,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
                 let (parent_place, _use_id) = self.infer_local_place_load(parent_expr, expr_ref);
-                if let Place::Defined(_) = parent_place {
+                if let Place::Defined(_) = parent_place.place {
                     return Place::Undefined.into();
                 }
             }
@@ -9244,18 +9178,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             }
                         }
                         EnclosingSnapshotResult::FoundBindings(bindings) => {
-                            let place = place_from_bindings(db, bindings).place.map_type(|ty| {
-                                self.narrow_place_with_applicable_constraints(
-                                    place_expr,
-                                    ty,
-                                    &constraint_keys,
-                                )
-                            });
+                            let place = place_from_bindings(db, bindings)
+                                .into_place_and_qualifiers()
+                                .map_type(|ty| {
+                                    self.narrow_place_with_applicable_constraints(
+                                        place_expr,
+                                        ty,
+                                        &constraint_keys,
+                                    )
+                                });
                             constraint_keys.push((
                                 enclosing_scope_file_id,
                                 ConstraintKey::NestedScope(file_scope_id),
                             ));
-                            return place.into();
+                            return place;
                         }
                         // There are no visible bindings / constraint here.
                         // Don't fall back to non-eager place resolution.
@@ -9360,10 +9296,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         if let Some(ty) = place.place.ignore_possibly_undefined() {
-            if let Some(deprecated) = binding_deprecation
-                && let Some(symbol) = place_expr.as_symbol()
+            if !ty.is_never()
+                && let Some(deprecated) = place.deprecation
+                && let Some(name) = match expr_ref {
+                    ast::ExprRef::Name(name) => Some(name.id.as_str()),
+                    ast::ExprRef::Attribute(attribute) => Some(attribute.attr.as_str()),
+                    _ => None,
+                }
             {
-                self.report_deprecated_function(expr_ref, symbol.name().as_str(), deprecated);
+                self.report_deprecated_function(expr_ref, name, deprecated);
             } else {
                 self.check_deprecated(expr_ref, ty);
             }
@@ -9796,9 +9737,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             });
 
+        let deprecation = resolved_type.deprecation();
         let resolved_type = resolved_type.inner_type();
 
-        self.check_deprecated(attr, resolved_type);
+        if let Some(deprecated) = deprecation {
+            self.report_deprecated_function(attr, attr.id.as_str(), deprecated);
+        } else {
+            self.check_deprecated(attr, resolved_type);
+        }
 
         // Even if we can obtain the attribute type based on the assignments, we still perform default type inference
         // (to report errors).

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -80,6 +80,7 @@ use crate::types::infer::{
     TypeExpressionFlags, function_known_decorators, infer_statement_types, nearest_enclosing_class,
     nearest_enclosing_function, original_class_type,
 };
+use crate::types::known_instance::DeprecatedInstance;
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::newtype::NewType;
 use crate::types::set_theoretic::RecursivelyDefined;
@@ -8748,7 +8749,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         &self,
         definition: Definition<'db>,
         ty: Type<'db>,
-    ) -> Option<FunctionType<'db>> {
+    ) -> Option<DeprecatedInstance<'db>> {
         fn is_function_type(db: &dyn Db, ty: Type) -> bool {
             match ty {
                 Type::FunctionLiteral(_) | Type::BoundMethod(_) => true,
@@ -8773,14 +8774,31 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let decorator = function.node(self.module()).decorator_list.first()?;
-        let Type::KnownInstance(KnownInstanceType::Deprecated(_)) =
+        let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) =
             function_known_decorators(self.db(), definition)
                 .expression_type(&decorator.expression)?
         else {
             return None;
         };
+        Some(deprecated)
+    }
 
-        Some(function_ty)
+    fn report_deprecated_function<T: Ranged>(
+        &self,
+        ranged: T,
+        name: &str,
+        deprecated: DeprecatedInstance,
+    ) {
+        let Some(builder) = self.context.report_lint(&diagnostic::DEPRECATED, ranged) else {
+            return;
+        };
+
+        let mut diag =
+            builder.into_diagnostic(format_args!(r#"The function `{name}` is deprecated"#));
+        if let Some(message) = deprecated.message {
+            diag.set_primary_message(message.value(self.db()));
+        }
+        diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
 
     /// Check if the given type is `@deprecated`.
@@ -8820,20 +8838,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         };
 
-        let Some(builder) = self
-            .context
-            .report_lint(&crate::types::diagnostic::DEPRECATED, ranged)
-        else {
-            return;
-        };
-
-        let func_name = function.name(self.db());
-        let mut diag =
-            builder.into_diagnostic(format_args!(r#"The function `{func_name}` is deprecated"#));
-        if let Some(message) = deprecated.message {
-            diag.set_primary_message(message.value(self.db()));
-        }
-        diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
+        self.report_deprecated_function(ranged, function.name(self.db()).as_str(), deprecated);
     }
 
     fn infer_name_load(&mut self, name_node: &ast::ExprName) -> Type<'db> {
@@ -9051,7 +9056,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             constraint_keys.push((file_scope_id, ConstraintKey::UseId(use_id)));
         }
 
-        let deprecated_function_binding = if file_scope_id.is_global()
+        let binding_deprecation = if file_scope_id.is_global()
             && place_expr.as_symbol().is_some()
             && local_scope_place.is_definitely_bound()
             && let Some(ty) = local_scope_place.ignore_possibly_undefined()
@@ -9338,8 +9343,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         if let Some(ty) = place.place.ignore_possibly_undefined() {
-            if let Some(function) = deprecated_function_binding {
-                self.check_deprecated(expr_ref, Type::FunctionLiteral(function));
+            if let Some(deprecated) = binding_deprecation
+                && let Some(symbol) = place_expr.as_symbol()
+            {
+                self.report_deprecated_function(expr_ref, symbol.name().as_str(), deprecated);
             } else {
                 self.check_deprecated(expr_ref, ty);
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1249,7 +1249,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         // Fall back to implicit module globals for (possibly) unbound names
-        if !place_and_quals.place.is_definitely_bound()
+        if !place_and_quals.place().is_definitely_bound()
             && let PlaceExprRef::Symbol(symbol) = place
         {
             let symbol_id = place_id.expect_symbol();
@@ -1263,11 +1263,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        let PlaceAndQualifiers {
-            place: resolved_place,
-            qualifiers,
-            ..
-        } = place_and_quals;
+        let (resolved_place, qualifiers, _) = place_and_quals.into_parts();
 
         let declared_ty = if resolved_place.is_undefined() && !place.is_symbol() {
             self.fallback_member_declared_type(node)
@@ -1296,7 +1292,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ty,
                 definedness: Definedness::AlwaysDefined,
                 ..
-            }) = value_type.member(db, attr).place
+            }) = value_type.member(db, attr).place()
             {
                 // TODO: also consider qualifiers on the attribute
                 Some(ty)
@@ -1364,7 +1360,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     Place::Undefined.into()
                 }
             })
-            .place
+            .place()
             .ignore_possibly_undefined()
             .unwrap_or(Type::Never);
         let ty = if inferred_ty.is_assignable_to(self.db(), ty.inner_type()) {
@@ -1401,10 +1397,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .is_declaration()
         );
 
-        let (declared_ty, inferred_ty) = match *declared_and_inferred_ty {
-            DeclaredAndInferredType::AreTheSame(type_and_qualifiers) => {
-                (type_and_qualifiers, type_and_qualifiers.inner_type())
-            }
+        let (declared_ty, inferred_ty) = match declared_and_inferred_ty {
+            DeclaredAndInferredType::AreTheSame(type_and_qualifiers) => (
+                type_and_qualifiers.clone(),
+                type_and_qualifiers.inner_type(),
+            ),
             DeclaredAndInferredType::MightBeDifferent {
                 declared_ty,
                 inferred_ty,
@@ -1416,7 +1413,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     if let Some(module_type_implicit_declaration) = place
                         .as_symbol()
                         .map(|symbol| module_type_implicit_global_symbol(self.db(), symbol.name()))
-                        .and_then(|place| place.place.ignore_possibly_undefined())
+                        .and_then(|place| place.place().ignore_possibly_undefined())
                     {
                         let declared_type = declared_ty.inner_type();
                         if !declared_type
@@ -1439,17 +1436,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
                 let declared_type = declared_ty.inner_type();
                 if inferred_ty.is_assignable_to(self.db(), declared_type) {
-                    if !should_preserve_inferred_binding_type(inferred_ty)
+                    if !should_preserve_inferred_binding_type(*inferred_ty)
                         // TODO We currently can't distinguish here between "no declared type" and
                         // "declared types is `Unknown` (e.g. due to a bad annotation, missing
                         // import, etc.)". Ideally we would still prefer `Unknown` declared type,
                         // but use inferred type if there is no declared type.
                         && !matches!(declared_type, Type::Dynamic(DynamicType::Unknown))
-                        && declared_type.is_assignable_to(self.db(), inferred_ty)
+                        && declared_type.is_assignable_to(self.db(), *inferred_ty)
                     {
-                        (declared_ty, declared_type)
+                        (declared_ty.clone(), declared_type)
                     } else {
-                        (declared_ty, inferred_ty)
+                        (declared_ty.clone(), *inferred_ty)
                     }
                 } else {
                     self.discard_dict_key_assignments_for(definition);
@@ -1458,11 +1455,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         node,
                         definition,
                         declared_type,
-                        inferred_ty,
+                        *inferred_ty,
                     );
 
                     // if the assignment is invalid, fall back to assuming the annotation is correct
-                    (declared_ty, declared_type)
+                    (declared_ty.clone(), declared_type)
                 }
             }
         };
@@ -2698,21 +2695,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     if emit_diagnostics {
                         if let Some(builder) = self.context.report_lint(&INVALID_ASSIGNMENT, target)
                         {
-                            let is_setattr_synthesized = match object_ty.class_member_with_policy(
-                                db,
-                                "__setattr__".into(),
-                                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-                            ) {
-                                PlaceAndQualifiers {
-                                    place: Place::Defined(DefinedPlace { ty: attr_ty, .. }),
-                                    qualifiers: _,
-                                    ..
-                                } => attr_ty.is_callable_type(),
-                                _ => false,
+                            let is_setattr_synthesized = match object_ty
+                                .class_member_with_policy(
+                                    db,
+                                    "__setattr__".into(),
+                                    MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+                                )
+                                .place()
+                            {
+                                Place::Defined(DefinedPlace { ty: attr_ty, .. }) => {
+                                    attr_ty.is_callable_type()
+                                }
+                                Place::Undefined => false,
                             };
 
                             let member_exists =
-                                !object_ty.member(db, attribute).place.is_undefined();
+                                !object_ty.member(db, attribute).place().is_undefined();
 
                             let msg = if !member_exists {
                                 format!(
@@ -2748,8 +2746,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     return true;
                 };
 
-                match meta_attr {
-                    meta_attr @ PlaceAndQualifiers { .. } if meta_attr.is_class_var() => {
+                match (meta_attr.place(), meta_attr.qualifiers()) {
+                    _ if meta_attr.is_class_var() => {
                         if emit_diagnostics
                             && let Some(builder) =
                                 self.context.report_lint(&INVALID_ATTRIBUTE_ACCESS, target)
@@ -2762,14 +2760,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }
                         false
                     }
-                    PlaceAndQualifiers {
-                        place:
-                            Place::Defined(DefinedPlace {
-                                ty: meta_attr_ty, ..
-                            }),
+                    (
+                        Place::Defined(DefinedPlace {
+                            ty: meta_attr_ty, ..
+                        }),
                         qualifiers,
-                        ..
-                    } => {
+                    ) => {
                         // Resolve `Self` type variables to the concrete instance type.
                         let meta_attr_ty = meta_attr_ty.bind_self_typevars(db, object_ty);
 
@@ -2785,7 +2781,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             ty: meta_dunder_set,
                             ..
                         }) =
-                            meta_attr_ty.class_member(db, "__set__".into()).place
+                            meta_attr_ty.class_member(db, "__set__".into()).place()
                         {
                             // TODO: We could use the annotated parameter type of `__set__` as
                             // type context here.
@@ -2830,73 +2826,64 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             ensure_assignable_to(self, value_ty, write_ty)
                         };
 
-                        let assignable_to_instance_attribute =
-                            if let Some(fallback_attr) = fallback_attr {
-                                let (assignable, boundness) = if let PlaceAndQualifiers {
-                                    place:
-                                        Place::Defined(DefinedPlace {
-                                            ty: instance_attr_ty,
-                                            definedness: instance_attr_boundness,
-                                            ..
-                                        }),
-                                    qualifiers,
-                                    ..
-                                } = fallback_attr
-                                {
-                                    // Bind `Self` via MRO matching.
-                                    let instance_attr_ty =
-                                        instance_attr_ty.bind_self_typevars(db, object_ty);
-                                    let write_ty = effective_write_type(instance_attr_ty);
-                                    let value_ty = infer_value_ty
-                                        .infer_silent(self, TypeContext::new(Some(write_ty)));
-                                    if emit_diagnostics
-                                        && self.invalid_assignment_to_final_attribute(
-                                            object_ty, target, attribute, qualifiers,
-                                        )
-                                    {
-                                        return false;
-                                    }
-
-                                    (
-                                        ensure_assignable_to(self, value_ty, write_ty),
-                                        instance_attr_boundness,
+                        let assignable_to_instance_attribute = if let Some(fallback_attr) =
+                            fallback_attr
+                        {
+                            let qualifiers = fallback_attr.qualifiers();
+                            let (assignable, boundness) = if let Place::Defined(DefinedPlace {
+                                ty: instance_attr_ty,
+                                definedness: instance_attr_boundness,
+                                ..
+                            }) = fallback_attr.place()
+                            {
+                                // Bind `Self` via MRO matching.
+                                let instance_attr_ty =
+                                    instance_attr_ty.bind_self_typevars(db, object_ty);
+                                let write_ty = effective_write_type(instance_attr_ty);
+                                let value_ty = infer_value_ty
+                                    .infer_silent(self, TypeContext::new(Some(write_ty)));
+                                if emit_diagnostics
+                                    && self.invalid_assignment_to_final_attribute(
+                                        object_ty, target, attribute, qualifiers,
                                     )
-                                } else {
-                                    (true, Definedness::PossiblyUndefined)
-                                };
-
-                                if boundness == Definedness::PossiblyUndefined {
-                                    report_possibly_missing_attribute(
-                                        &self.context,
-                                        target,
-                                        attribute,
-                                        object_ty,
-                                    );
+                                {
+                                    return false;
                                 }
 
-                                assignable
+                                (
+                                    ensure_assignable_to(self, value_ty, write_ty),
+                                    instance_attr_boundness,
+                                )
                             } else {
-                                true
+                                (true, Definedness::PossiblyUndefined)
                             };
+
+                            if boundness == Definedness::PossiblyUndefined {
+                                report_possibly_missing_attribute(
+                                    &self.context,
+                                    target,
+                                    attribute,
+                                    object_ty,
+                                );
+                            }
+
+                            assignable
+                        } else {
+                            true
+                        };
 
                         assignable_to_meta_attr && assignable_to_instance_attribute
                     }
 
-                    PlaceAndQualifiers {
-                        place: Place::Undefined,
-                        ..
-                    } => {
-                        if let Some(PlaceAndQualifiers {
-                            place:
-                                Place::Defined(DefinedPlace {
-                                    ty: instance_attr_ty,
-                                    definedness: instance_attr_boundness,
-                                    ..
-                                }),
-                            qualifiers,
-                            ..
-                        }) = fallback_attr
+                    (Place::Undefined, _) => {
+                        if let Some(fallback_attr) = fallback_attr
+                            && let Place::Defined(DefinedPlace {
+                                ty: instance_attr_ty,
+                                definedness: instance_attr_boundness,
+                                ..
+                            }) = fallback_attr.place()
                         {
+                            let qualifiers = fallback_attr.qualifiers();
                             // Bind `Self` via MRO matching.
                             let instance_attr_ty =
                                 instance_attr_ty.bind_self_typevars(db, object_ty);
@@ -2973,15 +2960,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     return true;
                 };
 
-                match meta_attr {
-                    PlaceAndQualifiers {
-                        place:
-                            Place::Defined(DefinedPlace {
-                                ty: meta_attr_ty, ..
-                            }),
+                match (meta_attr.place(), meta_attr.qualifiers()) {
+                    (
+                        Place::Defined(DefinedPlace {
+                            ty: meta_attr_ty, ..
+                        }),
                         qualifiers,
-                        ..
-                    } => {
+                    ) => {
                         if emit_diagnostics
                             && self.invalid_assignment_to_final_attribute(
                                 object_ty, target, attribute, qualifiers,
@@ -3003,7 +2988,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             ty: meta_dunder_set,
                             ..
                         }) =
-                            meta_attr_ty.class_member(db, "__set__".into()).place
+                            meta_attr_ty.class_member(db, "__set__".into()).place()
                         {
                             // TODO: We could use the annotated parameter type of `__set__` as
                             // type context here.
@@ -3047,15 +3032,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         };
 
                         let assignable_to_class_attr = if let Some(fallback_attr) = fallback_attr {
-                            let (assignable, boundness) = if let PlaceAndQualifiers {
-                                place:
-                                    Place::Defined(DefinedPlace {
-                                        ty: class_attr_ty,
-                                        definedness: class_attr_boundness,
-                                        ..
-                                    }),
+                            let (assignable, boundness) = if let Place::Defined(DefinedPlace {
+                                ty: class_attr_ty,
+                                definedness: class_attr_boundness,
                                 ..
-                            } = fallback_attr
+                            }) = fallback_attr.place()
                             {
                                 let class_attr_ty =
                                     class_attr_ty.bind_self_typevars(db, class_attr_self_ty);
@@ -3085,21 +3066,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                         assignable_to_meta_attr && assignable_to_class_attr
                     }
-                    PlaceAndQualifiers {
-                        place: Place::Undefined,
-                        ..
-                    } => {
-                        if let Some(PlaceAndQualifiers {
-                            place:
-                                Place::Defined(DefinedPlace {
-                                    ty: class_attr_ty,
-                                    definedness: class_attr_boundness,
-                                    ..
-                                }),
-                            qualifiers,
-                            ..
-                        }) = fallback_attr
+                    (Place::Undefined, _) => {
+                        if let Some(fallback_attr) = fallback_attr
+                            && let Place::Defined(DefinedPlace {
+                                ty: class_attr_ty,
+                                definedness: class_attr_boundness,
+                                ..
+                            }) = fallback_attr.place()
                         {
+                            let qualifiers = fallback_attr.qualifiers();
                             let class_attr_ty =
                                 class_attr_ty.bind_self_typevars(db, class_attr_self_ty);
                             let value_ty =
@@ -3129,7 +3104,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 object_ty.to_instance(self.db()).is_some_and(|instance| {
                                     !instance
                                         .instance_member(self.db(), attribute)
-                                        .place
+                                        .place()
                                         .is_undefined()
                                 });
 
@@ -3174,7 +3149,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 } else {
                     module.static_member(db, attribute)
                 };
-                if let Place::Defined(DefinedPlace { ty: attr_ty, .. }) = sym.place {
+                if let Place::Defined(DefinedPlace { ty: attr_ty, .. }) = sym.place() {
                     let value_ty = infer_value_ty(self, TypeContext::new(Some(attr_ty)));
 
                     let assignable = value_ty.is_assignable_to(db, attr_ty);
@@ -3352,17 +3327,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     return false;
                 }
 
-                if let Some(PlaceAndQualifiers {
-                    place:
-                        Place::Defined(DefinedPlace {
-                            ty: attr_ty,
-                            definedness: Definedness::AlwaysDefined,
-                            ..
-                        }),
+                if let Some(Place::Defined(DefinedPlace {
+                    ty: attr_ty,
+                    definedness: Definedness::AlwaysDefined,
                     ..
-                }) = self
+                })) = self
                     .assignment_attribute_members(object_ty, attribute)
-                    .map(|(meta_attr, _)| meta_attr)
+                    .map(|(meta_attr, _)| meta_attr.place())
                 {
                     let attr_ty = attr_ty.bind_self_typevars(db, object_ty);
                     let delete_dunder_call_result = attr_ty.try_call_dunder(
@@ -3424,7 +3395,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
         let meta_attr = object_ty.class_member(db, attribute.into());
         let needs_fallback = matches!(
-            meta_attr.place,
+            meta_attr.place(),
             Place::Defined(DefinedPlace {
                 definedness: Definedness::PossiblyUndefined,
                 ..
@@ -4203,11 +4174,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 DeferredExpressionState::from(self.defer_annotations()),
             );
 
-            if !annotated.qualifiers.is_empty() {
+            if !annotated.qualifiers().is_empty() {
                 for qualifier in TypeQualifier::iter() {
                     if !qualifier.is_valid_for_non_name_targets()
                         && annotated
-                            .qualifiers
+                            .qualifiers()
                             .contains(TypeQualifiers::from(qualifier))
                         && let Some(builder) = self
                             .context
@@ -4320,7 +4291,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // looking up qualifiers from the object type (as `validate_final_attribute_assignment`
             // does for augmented assignments).
             if value.is_some()
-                && annotated.qualifiers.contains(TypeQualifiers::FINAL)
+                && annotated.qualifiers().contains(TypeQualifiers::FINAL)
                 && let ast::Expr::Attribute(attr_expr) = target.as_ref()
             {
                 let object_ty = self.expression_type(&attr_expr.value);
@@ -4328,7 +4299,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     object_ty,
                     attr_expr,
                     attr_expr.attr.id(),
-                    annotated.qualifiers,
+                    annotated.qualifiers(),
                 );
             }
 
@@ -4463,10 +4434,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let is_pep_613_type_alias = declared.inner_type().is_typealias_special_form();
 
-        if !declared.qualifiers.is_empty() {
+        if !declared.qualifiers().is_empty() {
             for qualifier in TypeQualifier::iter() {
                 if !declared
-                    .qualifiers
+                    .qualifiers()
                     .contains(TypeQualifiers::from(qualifier))
                 {
                     continue;
@@ -4599,7 +4570,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // otherwise, assigning something other than `False` is an error
                 report_invalid_type_checking_constant(&self.context, target.into());
             }
-            declared.inner = Type::bool_literal(true);
+            declared = declared.map_type(|_| Type::bool_literal(true));
         }
 
         // Handle various singletons.
@@ -4607,7 +4578,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && let Some(special_form) =
                 SpecialFormType::try_from_file_and_name(self.db(), self.file(), &name_expr.id)
         {
-            declared.inner = Type::SpecialForm(special_form);
+            declared = declared.map_type(|_| Type::SpecialForm(special_form));
         }
 
         // If the target of an assignment is not one of the place expressions we support,
@@ -4706,7 +4677,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     && !name_expr.id.starts_with("__")
                     && !matches!(name_expr.id.as_str(), "_ignore_" | "_value_" | "_name_")
                     // Not bare Final (bare Final is allowed on enum members)
-                    && !(declared.qualifiers.contains(TypeQualifiers::FINAL)
+                    && !(declared.qualifiers().contains(TypeQualifiers::FINAL)
                         && matches!(declared.inner_type(), Type::Dynamic(DynamicType::Unknown)))
                     // Value type would be an enum member at runtime (exclude callables,
                     // which are never members)
@@ -4755,8 +4726,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         "`TypeAlias` must be assigned a value in annotated assignments",
                     );
                 }
-                declared.inner = Type::unknown();
+                declared = declared.map_type(|_| Type::unknown());
             }
+            let declared_ty = declared.inner_type();
             if self.in_stub() {
                 self.add_declaration_with_binding(
                     target.into(),
@@ -4767,7 +4739,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.add_declaration(target.into(), definition, declared);
             }
 
-            self.store_expression_type(target, declared.inner_type());
+            self.store_expression_type(target, declared_ty);
         }
     }
 
@@ -5166,7 +5138,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
             if !module_type_implicit_global_symbol(self.db(), name)
-                .place
+                .place()
                 .is_undefined()
             {
                 // This name is an implicit global like `__file__` (but not a built-in like `int`).
@@ -5359,7 +5331,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
         match object
             .member_lookup_with_policy(db, name.into(), MemberLookupPolicy::NO_INSTANCE_FALLBACK)
-            .place
+            .place()
         {
             Place::Defined(DefinedPlace {
                 ty: dunder_callable,
@@ -8984,9 +8956,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 EnclosingSnapshotResult::FoundBindings(bindings) => {
                     let mut place_and_qualifiers =
                         place_from_bindings(db, bindings).into_place_and_qualifiers();
-                    if assume_bound && let Place::Defined(defined) = place_and_qualifiers.place {
-                        place_and_qualifiers.place =
-                            Place::Defined(defined.with_definedness(Definedness::AlwaysDefined));
+                    if assume_bound && let Place::Defined(defined) = place_and_qualifiers.place() {
+                        let qualifiers = place_and_qualifiers.qualifiers();
+                        let deprecation = place_and_qualifiers.deprecation_policy();
+                        place_and_qualifiers =
+                            Place::Defined(defined.with_definedness(Definedness::AlwaysDefined))
+                                .with_qualifiers(qualifiers)
+                                .with_deprecation_policy(deprecation);
                     }
                     place_and_qualifiers = place_and_qualifiers.map_type(|ty| {
                         self.narrow_place_with_applicable_constraints(
@@ -9084,7 +9060,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
                 let (parent_place, _use_id) = self.infer_local_place_load(parent_expr, expr_ref);
-                if let Place::Defined(_) = parent_place.place {
+                if let Place::Defined(_) = parent_place.place() {
                     return Place::Undefined.into();
                 }
             }
@@ -9280,7 +9256,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         && let Some(symbol) = place_expr.as_symbol()
                     {
                         let implicit = class_body_implicit_symbol(db, symbol.name());
-                        if implicit.place.is_definitely_bound() {
+                        if implicit.place().is_definitely_bound() {
                             return implicit.map_type(|ty| {
                                 self.narrow_place_with_applicable_constraints(
                                     place_expr,
@@ -9305,8 +9281,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
         });
 
-        if let Some(ty) = place.place.ignore_possibly_undefined() {
-            match place.deprecation {
+        if let Some(ty) = place.place().ignore_possibly_undefined() {
+            match place.deprecation_policy() {
                 DeprecationPolicy::Deprecated(deprecated) if !ty.is_never() => {
                     if let Some(name) = match expr_ref {
                         ast::ExprRef::Name(name) => Some(name.id.as_str()),
@@ -9396,11 +9372,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let attribute_exists = match MethodDecorator::try_from_fn_type(self.db(), function_type) {
             Some(MethodDecorator::ClassMethod) => !Type::instance(self.db(), class)
                 .class_member(self.db(), id.clone())
-                .place
+                .place()
                 .is_undefined(),
             Some(MethodDecorator::None) => !Type::instance(self.db(), class)
                 .member(self.db(), id)
-                .place
+                .place()
                 .is_undefined(),
             Some(MethodDecorator::StaticMethod) | None => false,
         };
@@ -9466,7 +9442,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 for element in union.elements(db) {
                     union_elements_missing_attribute(db, *element, attr_name, missing_types);
                 }
-            } else if ty.member(db, attr_name).place.is_undefined() {
+            } else if ty.member(db, attr_name).place().is_undefined() {
                 missing_types.insert(ty);
             }
         }
@@ -9500,7 +9476,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ty,
                 definedness: Definedness::AlwaysDefined,
                 ..
-            }) = resolved.place
+            }) = resolved.place()
             {
                 assigned_type = Some(ty);
             }
@@ -9577,7 +9553,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 self.scope(),
                                 self.typevar_binding_context,
                                 self.inference_flags()
-                            ) && !defined_type.member(db, attr_name).place.is_undefined()
+                            ) && !defined_type.member(db, attr_name).place().is_undefined()
                             {
                                 diag.help(format_args!(
                                     "Objects with type `{ty}` have a{maybe_n} `{attr_name}` \
@@ -9645,7 +9621,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         && KnownClass::FunctionType
                             .to_instance(db)
                             .member(db, attr_name)
-                            .place
+                            .place()
                             .is_definitely_bound()
                     {
                         diagnostic.help(format_args!(
@@ -11202,7 +11178,7 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
             // If the member is a data descriptor, the RHS value may differ from the value actually assigned.
             if value_ty
                 .class_member(db, attr.id.clone())
-                .place
+                .place()
                 .ignore_possibly_undefined()
                 .is_some_and(|ty| ty.may_be_data_descriptor(db))
             {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8768,6 +8768,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let DefinitionKind::Function(function) = definition.kind(self.db()) else {
             return None;
         };
+        let decorator_inference = function_known_decorators(self.db(), definition);
+        if decorator_inference
+            .known_decorators()
+            .contains(FunctionDecorators::OVERLOAD)
+        {
+            return None;
+        }
+
         let function_ty = infer_definition_types(self.db(), definition).function_type(definition)?;
         if ty == Type::FunctionLiteral(function_ty) {
             return None;
@@ -8775,8 +8783,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let decorator = function.node(self.module()).decorator_list.first()?;
         let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) =
-            function_known_decorators(self.db(), definition)
-                .expression_type(&decorator.expression)?
+            decorator_inference.expression_type(&decorator.expression)?
         else {
             return None;
         };

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -80,6 +80,7 @@ use crate::types::infer::{
     TypeExpressionFlags, infer_statement_types, nearest_enclosing_class,
     nearest_enclosing_function, original_class_type,
 };
+use crate::types::known_instance::DeprecatedInstance;
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::newtype::NewType;
 use crate::types::set_theoretic::RecursivelyDefined;
@@ -325,6 +326,9 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
 
+    /// The `@deprecated` decorator attached to a decorated function's module-level binding.
+    binding_deprecation_decorator: Option<ExpressionNodeKey>,
+
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
     cycle_recovery: Option<Type<'db>>,
 
@@ -376,6 +380,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             typevar_binding_context: None,
             deferred: VecSet::default(),
             undecorated_type: None,
+            binding_deprecation_decorator: None,
             cycle_recovery: None,
             discards_dict_key_assignments: false,
             dataclass_field_specifiers: SmallVec::new(),
@@ -8744,7 +8749,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ty
     }
 
-    /// Check if the given ty is `@deprecated` or not
+    fn report_deprecated_function<T: Ranged>(
+        &self,
+        ranged: T,
+        name: &str,
+        deprecated: DeprecatedInstance,
+    ) {
+        let Some(builder) = self.context.report_lint(&diagnostic::DEPRECATED, ranged) else {
+            return;
+        };
+
+        let mut diag =
+            builder.into_diagnostic(format_args!(r#"The function `{name}` is deprecated"#));
+        if let Some(message) = deprecated.message {
+            diag.set_primary_message(message.value(self.db()));
+        }
+        diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
+    }
+
+    /// Check if the given type is `@deprecated`.
     fn check_deprecated<T: Ranged>(&self, ranged: T, ty: Type) {
         // First handle classes
         if let Type::ClassLiteral(class_literal) = ty {
@@ -8781,20 +8804,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         };
 
-        let Some(builder) = self
-            .context
-            .report_lint(&crate::types::diagnostic::DEPRECATED, ranged)
-        else {
-            return;
-        };
-
-        let func_name = function.name(self.db());
-        let mut diag =
-            builder.into_diagnostic(format_args!(r#"The function `{func_name}` is deprecated"#));
-        if let Some(message) = deprecated.message {
-            diag.set_primary_message(message.value(self.db()));
-        }
-        diag.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
+        self.report_deprecated_function(ranged, function.name(self.db()).as_str(), deprecated);
     }
 
     fn infer_name_load(&mut self, name_node: &ast::ExprName) -> Type<'db> {
@@ -9004,12 +9014,34 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let scope = self.scope();
         let file_scope_id = scope.file_scope_id(db);
         let place_table = self.index.place_table(file_scope_id);
+        let use_def = self.index.use_def_map(file_scope_id);
 
         let mut constraint_keys = vec![];
         let (local_scope_place, use_id) = self.infer_local_place_load(place_expr, expr_ref);
         if let Some(use_id) = use_id {
             constraint_keys.push((file_scope_id, ConstraintKey::UseId(use_id)));
         }
+
+        let binding_deprecation = if file_scope_id.is_global()
+            && place_expr.as_symbol().is_some()
+            && local_scope_place.is_definitely_bound()
+            && let Some(use_id) = use_id
+        {
+            let mut bindings = use_def.bindings_at_use(use_id);
+            match (
+                bindings.next().map(|binding| binding.binding),
+                bindings.next(),
+            ) {
+                (Some(DefinitionState::Defined(binding)), None)
+                    if binding.kind(db).is_function_def() =>
+                {
+                    infer_definition_types(db, binding).binding_deprecation(db, binding)
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
 
         let place = PlaceAndQualifiers::from(local_scope_place).or_fall_back_to(db, || {
             let mut symbol_resolves_locally = false;
@@ -9278,7 +9310,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         if let Some(ty) = place.place.ignore_possibly_undefined() {
-            self.check_deprecated(expr_ref, ty);
+            if let Some(deprecated) = binding_deprecation
+                && let Some(symbol) = place_expr.as_symbol()
+            {
+                self.report_deprecated_function(expr_ref, symbol.name().as_str(), deprecated);
+            } else {
+                self.check_deprecated(expr_ref, ty);
+            }
         }
 
         (place, constraint_keys)
@@ -10187,6 +10225,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
+            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
 
             // builder only state
@@ -10268,6 +10307,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
+            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
 
             // builder only state
@@ -10375,6 +10415,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             collection_use_constraints: _,
             dataclass_field_specifiers: _,
             undecorated_type: _,
+            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10415,6 +10456,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred,
             cycle_recovery,
             undecorated_type,
+            binding_deprecation_decorator,
             discards_dict_key_assignments,
             called_functions,
 
@@ -10436,6 +10478,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             || !expected_types.is_empty()
             || cycle_recovery.is_some()
             || undecorated_type.is_some()
+            || binding_deprecation_decorator.is_some()
             || !deferred.is_empty()
             || !called_functions.is_empty()
             || !qualifiers.is_empty()
@@ -10457,6 +10500,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     deferred: deferred.into_boxed_slice(),
                     diagnostics,
                     undecorated_type,
+                    binding_deprecation_decorator,
                     discards_dict_key_assignments,
                     qualifiers: FrozenMap::from(qualifiers),
                 })
@@ -10508,6 +10552,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
+            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
 
             // Builder only state
@@ -10581,6 +10626,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred: _,
             called_functions: _,
             undecorated_type: _,
+            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
             qualifiers: _,
             type_expression_flags: _,
@@ -10625,6 +10671,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
+            binding_deprecation_decorator: _,
             discards_dict_key_assignments: _,
 
             // builder only state

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11222,6 +11222,7 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
                             )
                             .0
                             .deprecation_policy()
+                            .resolve_for_type(self.builder.db(), expression_ty)
                     })
                     .unwrap_or(DeprecationPolicy::Inherit);
                 if place_deprecation != DeprecationPolicy::Inherit {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3546,14 +3546,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let target_ty =
             self.infer_assignment_definition_impl(assignment, definition, add.type_context());
         self.store_expression_type(target, target_ty);
-        if target_ty.is_deprecated(self.db()) {
+        self.suppress_transitive_deprecation(definition, target_ty);
+        add.insert(self, target_ty);
+    }
+
+    fn suppress_transitive_deprecation(&mut self, definition: Definition<'db>, ty: Type<'db>) {
+        if ty.is_deprecated(self.db()) {
             self.declarations.insert(
                 definition,
-                TypeAndQualifiers::new(target_ty, TypeOrigin::Inferred, TypeQualifiers::empty())
+                TypeAndQualifiers::new(ty, TypeOrigin::Inferred, TypeQualifiers::empty())
                     .suppress_type_deprecation(),
             );
         }
-        add.insert(self, target_ty);
     }
 
     fn stub_placeholder_binding_type(&self, value: &ast::Expr) -> Option<Type<'db>> {
@@ -7605,6 +7609,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let ty = self.infer_expression(value, add.type_context());
         self.store_expression_type(target, ty);
+        self.suppress_transitive_deprecation(definition, ty);
         add.insert(self, ty)
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11271,47 +11271,45 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
         }
 
         let expression_ty = self.expression_type(expression);
-        if matches!(expression, ast::Expr::Name(_))
-            && let Some(place_expr) = PlaceExpr::try_from_expr(expression)
-        {
-            let place_deprecation = self
-                .builder
-                .infer_place_load_without_deprecation_diagnostic(
-                    PlaceExprRef::from(&place_expr),
-                    ast::ExprRef::from(expression),
-                )
-                .0
-                .deprecation_policy();
-            if matches!(place_deprecation, DeprecationPolicy::Alternatives(_)) {
-                return place_deprecation;
+        match expression {
+            ast::Expr::Name(_) => {
+                let place_deprecation = PlaceExpr::try_from_expr(expression)
+                    .map(|place_expr| {
+                        self.builder
+                            .infer_place_load_without_deprecation_diagnostic(
+                                PlaceExprRef::from(&place_expr),
+                                ast::ExprRef::from(expression),
+                            )
+                            .0
+                            .deprecation_policy()
+                    })
+                    .unwrap_or(DeprecationPolicy::Inherit);
+                if matches!(place_deprecation, DeprecationPolicy::Alternatives(_)) {
+                    return place_deprecation;
+                }
+                if place_deprecation == DeprecationPolicy::Suppress
+                    && matches!(expression_ty, Type::Union(_))
+                {
+                    return DeprecationPolicy::Suppress;
+                }
             }
-            if place_deprecation == DeprecationPolicy::Suppress
-                && matches!(expression_ty, Type::Union(_))
-            {
-                return DeprecationPolicy::Suppress;
+            ast::Expr::Attribute(attribute) => {
+                let place_deprecation = self
+                    .expression_type(&attribute.value)
+                    .member(self.builder.db(), &attribute.attr.id)
+                    .deprecation_policy();
+                if matches!(place_deprecation, DeprecationPolicy::Alternatives(_)) {
+                    return place_deprecation;
+                }
             }
+            _ => {}
         }
         let type_is_deprecated = expression_ty.is_deprecated(self.builder.db());
-        if !type_is_deprecated
-            && !matches!(
-                expression,
-                ast::Expr::Attribute(_) if matches!(expression_ty, Type::Union(_))
-            )
-        {
+        if !type_is_deprecated {
             return DeprecationPolicy::Inherit;
         }
 
         match expression {
-            ast::Expr::Attribute(attribute) if !type_is_deprecated => {
-                let deprecation = self
-                    .expression_type(&attribute.value)
-                    .member(self.builder.db(), &attribute.attr.id)
-                    .deprecation_policy();
-                match deprecation {
-                    DeprecationPolicy::Alternatives(_) => deprecation,
-                    _ => DeprecationPolicy::Inherit,
-                }
-            }
             ast::Expr::Name(_) | ast::Expr::Attribute(_) => {
                 if !matches!(expression_ty, Type::Union(_)) {
                     return DeprecationPolicy::Suppress;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11221,6 +11221,40 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
                     ],
                 );
             }
+            ast::Expr::BoolOp(ast::ExprBoolOp { op, values, .. }) => {
+                let db = self.builder.db();
+                let mut done = false;
+                return DeprecationPolicy::from_alternatives(
+                    db,
+                    values.iter().enumerate().map(|(index, value)| {
+                        let ty = self.expression_type(value);
+                        let is_last = index == values.len() - 1;
+                        let result_ty = if is_last {
+                            if done { Type::Never } else { ty }
+                        } else if done {
+                            Type::Never
+                        } else {
+                            match (ty.bool(db), op) {
+                                (Truthiness::AlwaysTrue, ast::BoolOp::And)
+                                | (Truthiness::AlwaysFalse, ast::BoolOp::Or) => Type::Never,
+                                (Truthiness::AlwaysFalse, ast::BoolOp::And)
+                                | (Truthiness::AlwaysTrue, ast::BoolOp::Or) => {
+                                    done = true;
+                                    ty
+                                }
+                                (Truthiness::Ambiguous, _) => IntersectionBuilder::new(db)
+                                    .add_positive(ty)
+                                    .add_negative(match op {
+                                        ast::BoolOp::And => Type::AlwaysTruthy,
+                                        ast::BoolOp::Or => Type::AlwaysFalsy,
+                                    })
+                                    .build(),
+                            }
+                        };
+                        (result_ty, self.policy(value))
+                    }),
+                );
+            }
             ast::Expr::Named(ast::ExprNamed { value, .. }) => return self.policy(value),
             ast::Expr::Call(call)
                 if matches!(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8748,21 +8748,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn deprecated_function_binding(
         &self,
         definition: Definition<'db>,
-        ty: Type<'db>,
     ) -> Option<DeprecatedInstance<'db>> {
-        fn is_function_type(db: &dyn Db, ty: Type) -> bool {
+        fn is_replaced_function_type(
+            db: &dyn Db,
+            definition: Definition,
+            ty: Type,
+        ) -> Option<bool> {
             match ty {
-                Type::FunctionLiteral(_) | Type::BoundMethod(_) => true,
-                Type::Union(union) => union
-                    .elements(db)
-                    .iter()
-                    .all(|element| is_function_type(db, *element)),
-                _ => false,
+                Type::FunctionLiteral(function) => {
+                    Some(!function.contains_definition(db, definition))
+                }
+                Type::BoundMethod(bound) => {
+                    Some(!bound.function(db).contains_definition(db, definition))
+                }
+                Type::Union(union) => {
+                    union
+                        .elements(db)
+                        .iter()
+                        .try_fold(false, |replaced, element| {
+                            Some(replaced || is_replaced_function_type(db, definition, *element)?)
+                        })
+                }
+                _ => None,
             }
-        }
-
-        if !is_function_type(self.db(), ty) {
-            return None;
         }
 
         let DefinitionKind::Function(function) = definition.kind(self.db()) else {
@@ -8776,8 +8784,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return None;
         }
 
-        let function_ty = infer_definition_types(self.db(), definition).function_type(definition)?;
-        if ty == Type::FunctionLiteral(function_ty) {
+        let definition_inference = infer_definition_types(self.db(), definition);
+        let binding_ty = definition_inference.binding_type(definition);
+        if is_replaced_function_type(self.db(), definition, binding_ty) != Some(true) {
             return None;
         }
 
@@ -9067,6 +9076,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && place_expr.as_symbol().is_some()
             && local_scope_place.is_definitely_bound()
             && let Some(ty) = local_scope_place.ignore_possibly_undefined()
+            && !ty.is_never()
             && let Some(use_id) = use_id
         {
             let mut bindings = use_def.bindings_at_use(use_id);
@@ -9075,7 +9085,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 bindings.next(),
             ) {
                 (Some(DefinitionState::Defined(binding)), None) => {
-                    self.deprecated_function_binding(binding, ty)
+                    self.deprecated_function_binding(binding)
                 }
                 _ => None,
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11269,6 +11269,23 @@ impl<'builder, 'db, 'ast> ExpressionDeprecationPolicy<'builder, 'db, 'ast> {
         }
 
         let expression_ty = self.expression_type(expression);
+        if matches!(expression, ast::Expr::Name(_))
+            && let Some(place_expr) = PlaceExpr::try_from_expr(expression)
+        {
+            let place_deprecation = self
+                .builder
+                .infer_place_load_without_deprecation_diagnostic(
+                    PlaceExprRef::from(&place_expr),
+                    ast::ExprRef::from(expression),
+                )
+                .0
+                .deprecation_policy();
+            if matches!(place_deprecation, DeprecationPolicy::Alternatives(_))
+                && place_deprecation.contains_deprecated(self.builder.db())
+            {
+                return place_deprecation;
+            }
+        }
         let type_is_deprecated = expression_ty.is_deprecated(self.builder.db());
         if !type_is_deprecated
             && !matches!(

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -225,10 +225,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 // not a dataclass, since Final already implies the semantics of ClassVar.
                                 let classvar_and_final = match qualifier {
                                     TypeQualifier::Final => type_and_qualifiers
-                                        .qualifiers
+                                        .qualifiers()
                                         .contains(TypeQualifiers::CLASS_VAR),
                                     TypeQualifier::ClassVar => type_and_qualifiers
-                                        .qualifiers
+                                        .qualifiers()
                                         .contains(TypeQualifiers::FINAL),
                                     _ => false,
                                 };
@@ -261,7 +261,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 if matches!(
                                     qualifier,
                                     TypeQualifier::Required | TypeQualifier::NotRequired
-                                ) && type_and_qualifiers.qualifiers.intersects(
+                                ) && type_and_qualifiers.qualifiers().intersects(
                                     TypeQualifiers::REQUIRED | TypeQualifiers::NOT_REQUIRED,
                                 ) && let Some(builder) =
                                     self.context.report_lint(&INVALID_TYPE_FORM, subscript)

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -636,7 +636,7 @@ impl ClassDecoratorUnknownResultPolicy {
                         Name::new_static("__call__"),
                         MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                     )
-                    .place;
+                    .place();
 
                 if let Place::Defined(place) = call_symbol
                     && place.is_definitely_defined()

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -74,7 +74,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             if !place_and_quals_result
                 .ignore_conflicting_declarations()
-                .qualifiers
+                .qualifiers()
                 .contains(TypeQualifiers::FINAL)
             {
                 continue;
@@ -317,14 +317,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             object_ty,
             target,
             attribute,
-            meta_attr.qualifiers,
+            meta_attr.qualifiers(),
         ) && let Some(fallback_attr) = fallback_attr
         {
             self.invalid_assignment_to_final_attribute(
                 object_ty,
                 target,
                 attribute,
-                fallback_attr.qualifiers,
+                fallback_attr.qualifiers(),
             );
         }
     }
@@ -346,14 +346,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             object_ty,
             target,
             attribute,
-            meta_attr.qualifiers,
+            meta_attr.qualifiers(),
             emit_diagnostics,
         ) || fallback_attr.is_some_and(|fallback_attr| {
             self.invalid_deletion_of_final_attribute(
                 object_ty,
                 target,
                 attribute,
-                fallback_attr.qualifiers,
+                fallback_attr.qualifiers(),
                 emit_diagnostics,
             )
         })

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -319,11 +319,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut decorator_types_and_nodes = Vec::with_capacity(decorator_list.len());
         let mut function_decorators = FunctionDecorators::empty();
         let mut deprecated = None;
-        let mut outermost_deprecation = None;
+        let mut binding_deprecation = None;
+        let mut outer_decorators_preserve_binding_deprecation = true;
         let mut dataclass_transformer_params = None;
         let mut final_decorator = None;
 
-        for (index, decorator) in decorator_list.iter().enumerate() {
+        for decorator in decorator_list {
             let decorator_type = decorator_inference
                 .as_ref()
                 .and_then(|decorator_inference| {
@@ -350,14 +351,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 },
                 Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) => {
                     deprecated = Some(deprecated_inst);
-                    if index == 0 {
-                        outermost_deprecation = Some(deprecated_inst);
+                    if binding_deprecation.is_none()
+                        && outer_decorators_preserve_binding_deprecation
+                    {
+                        binding_deprecation = Some(deprecated_inst);
                     }
                 }
                 Type::DataclassTransformer(params) => {
                     dataclass_transformer_params = Some(params);
                 }
                 _ => {}
+            }
+            if binding_deprecation.is_none() {
+                outer_decorators_preserve_binding_deprecation &=
+                    decorator_function_decorator == FunctionDecorators::STATICMETHOD;
             }
             if !decorator_function_decorator.is_empty() {
                 continue;
@@ -456,9 +463,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             inferred_ty = self.apply_decorator(*decorator_ty, inferred_ty, decorator_node);
         }
 
-        // An outermost `@deprecated` applies to the final decorator result. If that result is a
-        // supported callable that loses the original function, preserve it on the binding.
-        let deprecation = outermost_deprecation.filter(|_| {
+        // An outermost `@deprecated`, optionally wrapped by `@staticmethod`, applies to the final
+        // decorator result. If that result loses the original function, preserve it on the binding.
+        let deprecation = binding_deprecation.filter(|_| {
             !function_decorators.contains(FunctionDecorators::OVERLOAD)
                 && function_type_loses_definition(db, definition, inferred_ty) == Some(true)
         });

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -319,10 +319,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut decorator_types_and_nodes = Vec::with_capacity(decorator_list.len());
         let mut function_decorators = FunctionDecorators::empty();
         let mut deprecated = None;
+        let mut outermost_deprecation = None;
         let mut dataclass_transformer_params = None;
         let mut final_decorator = None;
 
-        for decorator in decorator_list {
+        for (index, decorator) in decorator_list.iter().enumerate() {
             let decorator_type = decorator_inference
                 .as_ref()
                 .and_then(|decorator_inference| {
@@ -349,6 +350,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 },
                 Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) => {
                     deprecated = Some(deprecated_inst);
+                    if index == 0 {
+                        outermost_deprecation = Some(deprecated_inst);
+                    }
                 }
                 Type::DataclassTransformer(params) => {
                     dataclass_transformer_params = Some(params);
@@ -452,25 +456,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             inferred_ty = self.apply_decorator(*decorator_ty, inferred_ty, decorator_node);
         }
 
-        // If decorators preserve the original function type, its function literal already carries
-        // the deprecation. If the inferred type loses that identity, attach it to the binding.
-        let deprecation = if function_decorators.contains(FunctionDecorators::OVERLOAD)
-            || function_type_loses_definition(db, definition, inferred_ty) != Some(true)
-        {
-            None
-        } else {
-            decorator_list.first().and_then(|decorator| {
-                match decorator_inference
-                    .as_ref()?
-                    .expression_type(&decorator.expression)?
-                {
-                    Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) => {
-                        Some(deprecated)
-                    }
-                    _ => None,
-                }
-            })
-        };
+        // An outermost `@deprecated` applies to the final decorator result. If that result is a
+        // supported callable that loses the original function, preserve it on the binding.
+        let deprecation = outermost_deprecation.filter(|_| {
+            !function_decorators.contains(FunctionDecorators::OVERLOAD)
+                && function_type_loses_definition(db, definition, inferred_ty) == Some(true)
+        });
 
         self.add_declaration_with_binding(
             function.into(),

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -456,16 +456,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .contains(FunctionDecorators::OVERLOAD)
             && definition.file_scope(db).is_global()
             && inferred_ty != function_ty
-            && inferred_ty.try_upcast_to_callable(db).is_some()
         {
             decorator_list.first().and_then(|decorator| {
                 let decorator_ty = decorator_inference
                     .as_ref()?
                     .expression_type(&decorator.expression)?;
-                matches!(
+                (matches!(
                     decorator_ty,
                     Type::KnownInstance(KnownInstanceType::Deprecated(_))
-                )
+                ) && inferred_ty.try_upcast_to_callable(db).is_some())
                 .then(|| ExpressionNodeKey::from(&decorator.expression))
             })
         } else {

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -1201,6 +1201,7 @@ fn function_type_loses_definition<'db>(
             .try_fold(false, |replaced, element| {
                 Some(replaced || function_type_loses_definition(db, definition, *element)?)
             }),
+        _ if ty.is_definitely_callable(db) => Some(true),
         _ => None,
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -32,7 +32,7 @@ use crate::{
     },
 };
 use ty_python_core::{
-    UseDefMap,
+    ExpressionNodeKey, UseDefMap,
     definition::{Definition, DefinitionKind},
     scope::NodeWithScopeRef,
 };
@@ -422,6 +422,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let mut inferred_ty = Type::FunctionLiteral(FunctionType::new(db, function_literal, None));
+        let function_ty = inferred_ty;
         if !decorator_list.is_empty() {
             self.undecorated_type = Some(inferred_ty);
         }
@@ -450,6 +451,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         for (decorator_ty, decorator_node) in decorator_types_and_nodes.iter().rev() {
             inferred_ty = self.apply_decorator(*decorator_ty, inferred_ty, decorator_node);
         }
+
+        let binding_deprecation_decorator = if !function_decorators
+            .contains(FunctionDecorators::OVERLOAD)
+            && definition.file_scope(db).is_global()
+            && inferred_ty != function_ty
+        {
+            decorator_list.first().and_then(|decorator| {
+                let decorator_ty = decorator_inference
+                    .as_ref()?
+                    .expression_type(&decorator.expression)?;
+                matches!(
+                    decorator_ty,
+                    Type::KnownInstance(KnownInstanceType::Deprecated(_))
+                )
+                .then(|| ExpressionNodeKey::from(&decorator.expression))
+            })
+        } else {
+            None
+        };
+        self.binding_deprecation_decorator = binding_deprecation_decorator;
 
         self.add_declaration_with_binding(
             function.into(),

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -456,6 +456,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .contains(FunctionDecorators::OVERLOAD)
             && definition.file_scope(db).is_global()
             && inferred_ty != function_ty
+            && inferred_ty.try_upcast_to_callable(db).is_some()
         {
             decorator_list.first().and_then(|decorator| {
                 let decorator_ty = decorator_inference

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -1,9 +1,10 @@
 use crate::{
     Db,
+    place::TypeOrigin,
     reachability::ReachabilityConstraintsExtension,
     types::{
         KnownClass, KnownInstanceType, ParamSpecAttrKind, SubclassOfInner, SubclassOfType, Type,
-        TypeContext, UnionType,
+        TypeAndQualifiers, TypeContext, TypeQualifiers, UnionType,
         diagnostic::{
             FINAL_ON_NON_METHOD, INVALID_PARAMETER_DEFAULT, INVALID_PARAMSPEC, INVALID_TYPE_FORM,
             USELESS_OVERLOAD_BODY, add_type_expression_reference_link,
@@ -451,10 +452,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             inferred_ty = self.apply_decorator(*decorator_ty, inferred_ty, decorator_node);
         }
 
+        // If decorators preserve the original function type, its function literal already carries
+        // the deprecation. If the inferred type loses that identity, attach it to the binding.
+        let deprecation = if function_decorators.contains(FunctionDecorators::OVERLOAD)
+            || function_type_loses_definition(db, definition, inferred_ty) != Some(true)
+        {
+            None
+        } else {
+            decorator_list.first().and_then(|decorator| {
+                match decorator_inference
+                    .as_ref()?
+                    .expression_type(&decorator.expression)?
+                {
+                    Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) => {
+                        Some(deprecated)
+                    }
+                    _ => None,
+                }
+            })
+        };
+
         self.add_declaration_with_binding(
             function.into(),
             definition,
-            &DeclaredAndInferredType::are_the_same_type(inferred_ty),
+            &DeclaredAndInferredType::AreTheSame(
+                TypeAndQualifiers::new(inferred_ty, TypeOrigin::Inferred, TypeQualifiers::empty())
+                    .with_deprecation(deprecation),
+            ),
         );
 
         if function_decorators.contains(FunctionDecorators::OVERLOAD) {
@@ -1168,5 +1192,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } else {
             Some(parameter_type)
         }
+    }
+}
+
+fn function_type_loses_definition<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+    ty: Type<'db>,
+) -> Option<bool> {
+    match ty {
+        Type::FunctionLiteral(function) => Some(!function.contains_definition(db, definition)),
+        Type::BoundMethod(bound) => Some(!bound.function(db).contains_definition(db, definition)),
+        Type::Callable(_) => Some(true),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .try_fold(false, |replaced, element| {
+                Some(replaced || function_type_loses_definition(db, definition, *element)?)
+            }),
+        _ => None,
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -32,7 +32,7 @@ use crate::{
     },
 };
 use ty_python_core::{
-    ExpressionNodeKey, UseDefMap,
+    UseDefMap,
     definition::{Definition, DefinitionKind},
     scope::NodeWithScopeRef,
 };
@@ -422,7 +422,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let mut inferred_ty = Type::FunctionLiteral(FunctionType::new(db, function_literal, None));
-        let function_ty = inferred_ty;
         if !decorator_list.is_empty() {
             self.undecorated_type = Some(inferred_ty);
         }
@@ -451,26 +450,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         for (decorator_ty, decorator_node) in decorator_types_and_nodes.iter().rev() {
             inferred_ty = self.apply_decorator(*decorator_ty, inferred_ty, decorator_node);
         }
-
-        let binding_deprecation_decorator = if !function_decorators
-            .contains(FunctionDecorators::OVERLOAD)
-            && definition.file_scope(db).is_global()
-            && inferred_ty != function_ty
-        {
-            decorator_list.first().and_then(|decorator| {
-                let decorator_ty = decorator_inference
-                    .as_ref()?
-                    .expression_type(&decorator.expression)?;
-                (matches!(
-                    decorator_ty,
-                    Type::KnownInstance(KnownInstanceType::Deprecated(_))
-                ) && inferred_ty.try_upcast_to_callable(db).is_some())
-                .then(|| ExpressionNodeKey::from(&decorator.expression))
-            })
-        } else {
-            None
-        };
-        self.binding_deprecation_decorator = binding_deprecation_decorator;
 
         self.add_declaration_with_binding(
             function.into(),

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -240,7 +240,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if definition.kind(db).as_star_import().is_none() {
                     // In the initial cycle, `declaration_types()` is empty, so no deprecation check is performed.
                     for ty in inferred.declaration_types() {
-                        self.check_deprecated(alias, ty.inner);
+                        if let Some(deprecated) = ty.deprecation() {
+                            self.report_deprecated_function(
+                                alias,
+                                alias.name.id.as_str(),
+                                deprecated,
+                            );
+                        } else {
+                            self.check_deprecated(alias, ty.inner);
+                        }
                     }
                 }
                 self.extend_definition(inferred);
@@ -371,6 +379,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ..
                     }),
                 qualifiers,
+                deprecation,
             } = module_ty.member(db, name)
             {
                 if &alias.name != "*" && boundness == Definedness::PossiblyUndefined {
@@ -386,7 +395,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
                 if qualifiers.contains(TypeQualifiers::FROM_MODULE_GETATTR) {
-                    from_module_getattr = Some((ty, qualifiers));
+                    from_module_getattr = Some((ty, qualifiers, deprecation));
                 } else {
                     self.add_declaration_with_binding(
                         alias.into(),
@@ -396,6 +405,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 inner: ty,
                                 origin: TypeOrigin::Declared,
                                 qualifiers,
+                                deprecation,
                             },
                             inferred_ty: ty,
                         },
@@ -443,7 +453,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // We've checked for a submodule, so now we can go ahead and use a type from module
         // `__getattr__`.
-        if let Some((ty, qualifiers)) = from_module_getattr {
+        if let Some((ty, qualifiers, deprecation)) = from_module_getattr {
             self.add_declaration_with_binding(
                 alias.into(),
                 definition,
@@ -452,6 +462,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         inner: ty,
                         origin: TypeOrigin::Declared,
                         qualifiers,
+                        deprecation,
                     },
                     inferred_ty: ty,
                 },

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -6,7 +6,7 @@ use ty_module_resolver::{
 
 use crate::{
     Program, TypeQualifiers, add_inferred_python_version_hint_to_diagnostic,
-    place::{DefinedPlace, Definedness, DeprecationPolicy, Place, PlaceAndQualifiers, TypeOrigin},
+    place::{DefinedPlace, Definedness, DeprecationPolicy, Place, TypeOrigin},
     types::{
         Type, TypeAndQualifiers,
         diagnostic::{
@@ -249,7 +249,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 );
                             }
                             DeprecationPolicy::Inherit => {
-                                self.check_deprecated(alias, ty.inner);
+                                self.check_deprecated(alias, ty.inner_type());
                             }
                             DeprecationPolicy::Suppress => {}
                         }
@@ -375,16 +375,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // First try loading the requested attribute from the module.
         if !skip_self_referential_member_lookup {
-            if let PlaceAndQualifiers {
-                place:
-                    Place::Defined(DefinedPlace {
-                        ty,
-                        definedness: boundness,
-                        ..
-                    }),
-                qualifiers,
-                deprecation,
-            } = module_ty.member(db, name)
+            let (place, qualifiers, deprecation) = module_ty.member(db, name).into_parts();
+            if let Place::Defined(DefinedPlace {
+                ty,
+                definedness: boundness,
+                ..
+            }) = place
             {
                 if &alias.name != "*" && boundness == Definedness::PossiblyUndefined {
                     // TODO: Consider loading _both_ the attribute and any submodule and unioning them
@@ -405,12 +401,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         alias.into(),
                         definition,
                         &DeclaredAndInferredType::MightBeDifferent {
-                            declared_ty: TypeAndQualifiers {
-                                inner: ty,
-                                origin: TypeOrigin::Declared,
+                            declared_ty: TypeAndQualifiers::new(
+                                ty,
+                                TypeOrigin::Declared,
                                 qualifiers,
-                                deprecation,
-                            },
+                            )
+                            .with_deprecation_policy(deprecation),
                             inferred_ty: ty,
                         },
                     );
@@ -462,12 +458,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 alias.into(),
                 definition,
                 &DeclaredAndInferredType::MightBeDifferent {
-                    declared_ty: TypeAndQualifiers {
-                        inner: ty,
-                        origin: TypeOrigin::Declared,
-                        qualifiers,
-                        deprecation,
-                    },
+                    declared_ty: TypeAndQualifiers::new(ty, TypeOrigin::Declared, qualifiers)
+                        .with_deprecation_policy(deprecation),
                     inferred_ty: ty,
                 },
             );

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -240,10 +240,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if definition.kind(db).as_star_import().is_none() {
                     // In the initial cycle, `declaration_types()` is empty, so no deprecation check is performed.
                     for ty in inferred.declaration_types() {
-                        match ty
-                            .deprecation_policy()
-                            .resolve_for_type(db, ty.inner_type())
-                        {
+                        match ty.resolved_deprecation_policy(db) {
                             DeprecationPolicy::Deprecated(deprecated) => {
                                 self.report_deprecated_function(
                                     alias,

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -6,7 +6,7 @@ use ty_module_resolver::{
 
 use crate::{
     Program, TypeQualifiers, add_inferred_python_version_hint_to_diagnostic,
-    place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, TypeOrigin},
+    place::{DefinedPlace, Definedness, DeprecationPolicy, Place, PlaceAndQualifiers, TypeOrigin},
     types::{
         Type, TypeAndQualifiers,
         diagnostic::{
@@ -240,14 +240,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if definition.kind(db).as_star_import().is_none() {
                     // In the initial cycle, `declaration_types()` is empty, so no deprecation check is performed.
                     for ty in inferred.declaration_types() {
-                        if let Some(deprecated) = ty.deprecation() {
-                            self.report_deprecated_function(
-                                alias,
-                                alias.name.id.as_str(),
-                                deprecated,
-                            );
-                        } else {
-                            self.check_deprecated(alias, ty.inner);
+                        match ty.deprecation_policy() {
+                            DeprecationPolicy::Deprecated(deprecated) => {
+                                self.report_deprecated_function(
+                                    alias,
+                                    alias.name.id.as_str(),
+                                    deprecated,
+                                );
+                            }
+                            DeprecationPolicy::Inherit => {
+                                self.check_deprecated(alias, ty.inner);
+                            }
+                            DeprecationPolicy::Suppress => {}
                         }
                     }
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -240,7 +240,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if definition.kind(db).as_star_import().is_none() {
                     // In the initial cycle, `declaration_types()` is empty, so no deprecation check is performed.
                     for ty in inferred.declaration_types() {
-                        match ty.deprecation_policy() {
+                        match ty
+                            .deprecation_policy()
+                            .resolve_for_type(db, ty.inner_type())
+                        {
                             DeprecationPolicy::Deprecated(deprecated) => {
                                 self.report_deprecated_function(
                                     alias,
@@ -248,7 +251,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     deprecated,
                                 );
                             }
-                            DeprecationPolicy::Inherit => {
+                            DeprecationPolicy::Inherit | DeprecationPolicy::Alternatives(_) => {
                                 self.check_deprecated(alias, ty.inner_type());
                             }
                             DeprecationPolicy::Suppress => {}

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/final_variable.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/final_variable.rs
@@ -33,7 +33,7 @@ pub(crate) fn check_final_without_value<'db>(
         let first_declaration = result.first_declaration;
         let (place_and_quals, _) = result.into_place_and_conflicting_declarations();
 
-        if !place_and_quals.qualifiers.contains(TypeQualifiers::FINAL) {
+        if !place_and_quals.qualifiers().contains(TypeQualifiers::FINAL) {
             continue;
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1071,7 +1071,9 @@ fn check_class_namespace_against_metaclass_members<'db>(
             ty: metaclass_member_ty,
             origin,
             ..
-        }) = metaclass_instance.instance_member(db, name.as_str()).place
+        }) = metaclass_instance
+            .instance_member(db, name.as_str())
+            .place()
         else {
             continue;
         };
@@ -1119,7 +1121,7 @@ fn check_class_namespace_against_metaclass_members<'db>(
         let Place::Defined(DefinedPlace {
             ty: class_declared_ty,
             ..
-        }) = result.ignore_conflicting_declarations().place
+        }) = result.ignore_conflicting_declarations().place()
         else {
             continue;
         };
@@ -1355,7 +1357,7 @@ fn check_class_final_without_value<'db>(
         let first_declaration = result.first_declaration;
         let (place_and_quals, _) = result.into_place_and_conflicting_declarations();
 
-        if !place_and_quals.qualifiers.contains(TypeQualifiers::FINAL) {
+        if !place_and_quals.qualifiers().contains(TypeQualifiers::FINAL) {
             continue;
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -171,7 +171,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     ty,
                     definedness: Definedness::AlwaysDefined,
                     ..
-                }) = place.place
+                }) = place.place()
                 {
                     // Even if we can obtain the subscript type based on the assignments, we still perform default type inference
                     // (to store the expression type and to report errors).
@@ -1253,7 +1253,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     "__setitem__".into(),
                     MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                 )
-                .place
+                .place()
             {
                 let mut identity_bindings = dunder_callable
                     .bindings(db)

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -547,7 +547,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         for qualifier in TypeQualifier::iter() {
             if !qualifier.is_valid_in_typeddict_field()
                 && annotation
-                    .qualifiers
+                    .qualifiers()
                     .contains(TypeQualifiers::from(qualifier))
                 && let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, value)
             {
@@ -572,7 +572,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         for qualifier in TypeQualifier::iter() {
             if qualifier != TypeQualifier::ReadOnly
                 && annotation
-                    .qualifiers
+                    .qualifiers()
                     .contains(TypeQualifiers::from(qualifier))
                 && let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, value)
             {

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -35,7 +35,7 @@ fn get_symbol<'db>(
         assert_eq!(scope.name(db, &module), *expected_scope_name);
     }
 
-    symbol(db, scope, symbol_name, ConsideredDefinitions::EndOfScope).place
+    symbol(db, scope, symbol_name, ConsideredDefinitions::EndOfScope).place()
 }
 
 #[track_caller]
@@ -191,7 +191,7 @@ fn pep695_type_params() {
         assert_eq!(var_ty.display(&db).to_string(), display);
 
         let expected_name_ty = format!(r#"Literal["{var}"]"#);
-        let name_ty = var_ty.member(&db, "__name__").place.expect_type();
+        let name_ty = var_ty.member(&db, "__name__").place().expect_type();
         assert_eq!(name_ty.display(&db).to_string(), expected_name_ty);
 
         let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = var_ty else {
@@ -304,7 +304,7 @@ fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
     ])?;
 
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
-    let x_ty = global_symbol(&db, a, "x").place.expect_type();
+    let x_ty = global_symbol(&db, a, "x").place().expect_type();
 
     assert_eq!(x_ty.display(&db).to_string(), "int");
 
@@ -313,7 +313,7 @@ fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
 
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
 
-    let x_ty_2 = global_symbol(&db, a, "x").place.expect_type();
+    let x_ty_2 = global_symbol(&db, a, "x").place().expect_type();
 
     assert_eq!(x_ty_2.display(&db).to_string(), "bool");
 
@@ -330,7 +330,7 @@ fn dependency_internal_symbol_change() -> anyhow::Result<()> {
     ])?;
 
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
-    let x_ty = global_symbol(&db, a, "x").place.expect_type();
+    let x_ty = global_symbol(&db, a, "x").place().expect_type();
 
     assert_eq!(x_ty.display(&db).to_string(), "int");
 
@@ -340,7 +340,7 @@ fn dependency_internal_symbol_change() -> anyhow::Result<()> {
 
     db.clear_salsa_events();
 
-    let x_ty_2 = global_symbol(&db, a, "x").place.expect_type();
+    let x_ty_2 = global_symbol(&db, a, "x").place().expect_type();
 
     assert_eq!(x_ty_2.display(&db).to_string(), "int");
 
@@ -366,7 +366,7 @@ fn dependency_unrelated_symbol() -> anyhow::Result<()> {
     ])?;
 
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
-    let x_ty = global_symbol(&db, a, "x").place.expect_type();
+    let x_ty = global_symbol(&db, a, "x").place().expect_type();
 
     assert_eq!(x_ty.display(&db).to_string(), "int");
 
@@ -376,7 +376,7 @@ fn dependency_unrelated_symbol() -> anyhow::Result<()> {
 
     db.clear_salsa_events();
 
-    let x_ty_2 = global_symbol(&db, a, "x").place.expect_type();
+    let x_ty_2 = global_symbol(&db, a, "x").place().expect_type();
 
     assert_eq!(x_ty_2.display(&db).to_string(), "int");
 
@@ -424,7 +424,7 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
     )?;
 
     let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
-    let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+    let attr_ty = global_symbol(&db, file_main, "x").place().expect_type();
     assert_eq!(attr_ty.display(&db).to_string(), "int | None");
 
     // Change the type of `attr` to `str | None`; this should trigger the type of `x` to be re-inferred
@@ -439,7 +439,7 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
-        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        let attr_ty = global_symbol(&db, file_main, "x").place().expect_type();
         assert_eq!(attr_ty.display(&db).to_string(), "str | None");
         db.take_salsa_events()
     };
@@ -463,7 +463,7 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
-        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        let attr_ty = global_symbol(&db, file_main, "x").place().expect_type();
         assert_eq!(attr_ty.display(&db).to_string(), "str | None");
         db.take_salsa_events()
     };
@@ -515,7 +515,7 @@ fn dependency_own_instance_member() -> anyhow::Result<()> {
     )?;
 
     let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
-    let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+    let attr_ty = global_symbol(&db, file_main, "x").place().expect_type();
     assert_eq!(attr_ty.display(&db).to_string(), "int | None");
 
     // Change the type of `attr` to `str | None`; this should trigger the type of `x` to be re-inferred
@@ -532,7 +532,7 @@ fn dependency_own_instance_member() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
-        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        let attr_ty = global_symbol(&db, file_main, "x").place().expect_type();
         assert_eq!(attr_ty.display(&db).to_string(), "str | None");
         db.take_salsa_events()
     };
@@ -558,7 +558,7 @@ fn dependency_own_instance_member() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
-        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        let attr_ty = global_symbol(&db, file_main, "x").place().expect_type();
         assert_eq!(attr_ty.display(&db).to_string(), "str | None");
         db.take_salsa_events()
     };
@@ -611,7 +611,7 @@ fn dependency_implicit_class_member() -> anyhow::Result<()> {
     )?;
 
     let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
-    let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+    let attr_ty = global_symbol(&db, file_main, "x").place().expect_type();
     assert_eq!(attr_ty.display(&db).to_string(), "int");
 
     // Change the type of `class_attr` to `str`; this should trigger the type of `x` to be re-inferred
@@ -630,7 +630,7 @@ fn dependency_implicit_class_member() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
-        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        let attr_ty = global_symbol(&db, file_main, "x").place().expect_type();
         assert_eq!(attr_ty.display(&db).to_string(), "str");
         db.take_salsa_events()
     };
@@ -658,7 +658,7 @@ fn dependency_implicit_class_member() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
-        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        let attr_ty = global_symbol(&db, file_main, "x").place().expect_type();
         assert_eq!(attr_ty.display(&db).to_string(), "str");
         db.take_salsa_events()
     };
@@ -697,7 +697,7 @@ fn call_type_doesnt_rerun_when_only_callee_changed() -> anyhow::Result<()> {
     )?;
 
     let bar = system_path_to_file(&db, "src/bar.py")?;
-    let a = global_symbol(&db, bar, "a").place;
+    let a = global_symbol(&db, bar, "a").place();
 
     assert_eq!(a.expect_type(), KnownClass::Int.to_instance(&db));
     let events = db.take_salsa_events();
@@ -725,7 +725,7 @@ fn call_type_doesnt_rerun_when_only_callee_changed() -> anyhow::Result<()> {
     )?;
     db.clear_salsa_events();
 
-    let a = global_symbol(&db, bar, "a").place;
+    let a = global_symbol(&db, bar, "a").place();
 
     assert_eq!(a.expect_type(), KnownClass::Int.to_instance(&db));
     let events = db.take_salsa_events();

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -43,7 +43,7 @@ pub(crate) fn all_end_of_scope_members<'db>(
             let first_reachable_definition = place_result.first_declaration?;
             let ty = place_result
                 .ignore_conflicting_declarations()
-                .place
+                .place()
                 .ignore_possibly_undefined()?;
             let symbol = table.symbol(symbol_id);
             let member = Member {
@@ -100,7 +100,7 @@ pub(crate) fn all_reachable_members<'db>(
                     .and_then(|first_reachable_definition| {
                         let ty = declaration_place_result
                             .ignore_conflicting_declarations()
-                            .place
+                            .place()
                             .ignore_possibly_undefined()?;
                         let member = Member {
                             name: symbol.name().clone(),
@@ -389,7 +389,7 @@ impl<'db> AllMembers<'db> {
                 for (symbol_id, _) in use_def_map.all_end_of_scope_symbol_declarations() {
                     let symbol_name = place_table.symbol(symbol_id).name();
                     let Place::Defined(DefinedPlace { ty, .. }) =
-                        imported_symbol(db, Some(file), symbol_name, None).place
+                        imported_symbol(db, Some(file), symbol_name, None).place()
                     else {
                         continue;
                     };
@@ -480,7 +480,7 @@ impl<'db> AllMembers<'db> {
             let parent_scope = parent.body_scope(db);
             for memberdef in all_end_of_scope_members(db, parent_scope) {
                 let result = ty.member(db, memberdef.member.name.as_str());
-                let Some(ty) = result.place.ignore_possibly_undefined() else {
+                let Some(ty) = result.place().ignore_possibly_undefined() else {
                     continue;
                 };
                 self.members.insert(Member {
@@ -527,7 +527,7 @@ impl<'db> AllMembers<'db> {
                     continue;
                 };
                 let result = ty.member(db, name);
-                let Some(ty) = result.place.ignore_possibly_undefined() else {
+                let Some(ty) = result.place().ignore_possibly_undefined() else {
                     continue;
                 };
                 self.members.insert(Member {
@@ -544,7 +544,7 @@ impl<'db> AllMembers<'db> {
         // method, but `instance_of_SomeClass.__delattr__` is.
         for memberdef in all_end_of_scope_members(db, class_body_scope) {
             let result = ty.member(db, memberdef.member.name.as_str());
-            let Some(ty) = result.place.ignore_possibly_undefined() else {
+            let Some(ty) = result.place().ignore_possibly_undefined() else {
                 continue;
             };
             self.members.insert(Member {
@@ -592,7 +592,7 @@ impl<'db> AllMembers<'db> {
                     if let Place::Defined(DefinedPlace {
                         ty: synthetic_member,
                         ..
-                    }) = ty.member(db, attr).place
+                    }) = ty.member(db, attr).place()
                     {
                         self.members.insert(Member {
                             name: Name::from(*attr),

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -60,6 +60,7 @@ pub(crate) fn all_end_of_scope_members<'db>(
                 let PlaceWithDefinition {
                     place,
                     first_definition,
+                    ..
                 } = place_from_bindings(db, bindings);
 
                 let first_reachable_definition = first_definition?;

--- a/crates/ty_python_semantic/src/types/member.rs
+++ b/crates/ty_python_semantic/src/types/member.rs
@@ -75,6 +75,7 @@ pub(super) fn class_member<'db>(db: &'db dyn Db, scope: ScopeId<'db>, name: &str
             if let PlaceAndQualifiers {
                 place: Place::Defined(DefinedPlace { ty, .. }),
                 qualifiers,
+                ..
             } = place_and_quals
             {
                 // Otherwise, we need to check if the symbol has bindings

--- a/crates/ty_python_semantic/src/types/member.rs
+++ b/crates/ty_python_semantic/src/types/member.rs
@@ -8,7 +8,7 @@ use ty_python_core::{place_table, scope::ScopeId, use_def_map};
 
 /// The return type of certain member-lookup operations. Contains information
 /// about the type, type qualifiers, boundness/declaredness.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, salsa::Update, get_size2::GetSize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize, Default)]
 pub(super) struct Member<'db> {
     /// Type, qualifiers, and boundness information of this member
     pub(super) inner: PlaceAndQualifiers<'db>,
@@ -29,17 +29,17 @@ impl<'db> Member<'db> {
 
     /// Returns the type qualifiers of this member.
     pub(super) fn qualifiers(&self) -> crate::types::TypeQualifiers {
-        self.inner.qualifiers
+        self.inner.qualifiers()
     }
 
     /// Returns `true` if the inner place is undefined (i.e. there is no such member).
     pub(super) fn is_undefined(&self) -> bool {
-        self.inner.place.is_undefined()
+        self.inner.is_undefined()
     }
 
     /// Returns the inner type, unless it is definitely undefined.
     pub(super) fn ignore_possibly_undefined(&self) -> Option<Type<'db>> {
-        self.inner.place.ignore_possibly_undefined()
+        self.inner.ignore_possibly_undefined()
     }
 
     /// Map a type transformation function over the type of this member.
@@ -72,12 +72,8 @@ pub(super) fn class_member<'db>(db: &'db dyn Db, scope: ScopeId<'db>, name: &str
                 };
             }
 
-            if let PlaceAndQualifiers {
-                place: Place::Defined(DefinedPlace { ty, .. }),
-                qualifiers,
-                ..
-            } = place_and_quals
-            {
+            let qualifiers = place_and_quals.qualifiers();
+            if let Place::Defined(DefinedPlace { ty, .. }) = place_and_quals.place() {
                 // Otherwise, we need to check if the symbol has bindings
                 let use_def = use_def_map(db, scope);
                 let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2547,7 +2547,7 @@ fn nominal_attribute_type<'db>(
     if resolved_ty.is_nominal_instance() {
         resolved_ty
             .member(db, attribute_name)
-            .place
+            .place()
             .ignore_possibly_undefined()
     } else {
         None

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -146,7 +146,7 @@ fn check_class_declaration<'db>(
     let Place::Defined(DefinedPlace {
         ty: type_on_subclass_instance,
         ..
-    }) = subclass_instance_member.place
+    }) = subclass_instance_member.place()
     else {
         return;
     };
@@ -374,7 +374,7 @@ fn check_class_declaration<'db>(
             let Place::Defined(DefinedPlace {
                 ty: superclass_type,
                 ..
-            }) = superclass_instance_member.place
+            }) = superclass_instance_member.place()
             else {
                 // If not defined on any superclass, no point in continuing to walk up the MRO
                 break;
@@ -481,8 +481,8 @@ fn check_class_declaration<'db>(
                     let subclass_kind = *subclass_variable_kind.get_or_insert_with(|| {
                         variable_kind(
                             db,
-                            class.own_class_member(db, None, &member.name).inner,
-                            subclass_instance_member,
+                            &class.own_class_member(db, None, &member.name).inner,
+                            &subclass_instance_member,
                         )
                     });
 
@@ -603,7 +603,7 @@ fn check_class_declaration<'db>(
             if !KnownClass::TypedDictFallback
                 .to_instance(db)
                 .member(db, &member.name)
-                .place
+                .place()
                 .is_undefined()
             {
                 subclass_overrides_superclass_declaration = true;
@@ -612,7 +612,7 @@ fn check_class_declaration<'db>(
             if !KnownClass::NamedTupleFallback
                 .to_instance(db)
                 .member(db, &member.name)
-                .place
+                .place()
                 .is_undefined()
             {
                 subclass_overrides_superclass_declaration = true;
@@ -683,8 +683,8 @@ fn superclass_variable_kind<'db>(
     db: &'db dyn Db,
     superclass_scope: ScopeId<'db>,
     superclass_symbol_id: Option<ScopedSymbolId>,
-    class_member: PlaceAndQualifiers<'db>,
-    instance_member: PlaceAndQualifiers<'db>,
+    class_member: &PlaceAndQualifiers<'db>,
+    instance_member: &PlaceAndQualifiers<'db>,
 ) -> Option<VariableKind> {
     // Method definitions and properties are not instance-variable declarations. Check the symbol
     // definition before class/instance member lookup can erase that distinction. For example,
@@ -698,7 +698,7 @@ fn superclass_variable_kind<'db>(
 
     // Final attributes have their own override rule and diagnostic. Treating them as class
     // variables here would report both diagnostics for the same override.
-    if class_member.qualifiers.contains(TypeQualifiers::FINAL) {
+    if class_member.qualifiers().contains(TypeQualifiers::FINAL) {
         return None;
     }
 
@@ -757,8 +757,8 @@ fn effective_superclass_variable_kind<'db>(
             db,
             superclass_scope,
             superclass_symbol_id,
-            superclass.own_class_member(db, None, &name).inner,
-            Type::instance(db, superclass).member(db, &name),
+            &superclass.own_class_member(db, None, &name).inner,
+            &Type::instance(db, superclass).member(db, &name),
         );
 
         if superclass_variable_kind == Some(VariableKind::Instance)
@@ -821,8 +821,8 @@ fn is_function_definition<'db>(
 /// Returns the variable kind for an attribute if it should participate in `ClassVar` override checks.
 fn variable_kind<'db>(
     db: &'db dyn Db,
-    class_member: PlaceAndQualifiers<'db>,
-    instance_member: PlaceAndQualifiers<'db>,
+    class_member: &PlaceAndQualifiers<'db>,
+    instance_member: &PlaceAndQualifiers<'db>,
 ) -> Option<VariableKind> {
     if class_member.is_class_var() || instance_member.is_class_var() {
         return Some(VariableKind::Class);
@@ -830,7 +830,7 @@ fn variable_kind<'db>(
 
     // A `Final` attribute behaves like a class variable, but final overrides are diagnosed by
     // `override-of-final-variable` instead of this rule.
-    if class_member.qualifiers.contains(TypeQualifiers::FINAL) {
+    if class_member.qualifiers().contains(TypeQualifiers::FINAL) {
         return None;
     }
 
@@ -847,7 +847,7 @@ fn variable_kind<'db>(
     //     def f(self) -> int: ...
     // ```
     if matches!(
-        class_member.place,
+        class_member.place(),
         Place::Defined(DefinedPlace {
             ty: Type::FunctionLiteral(_),
             ..
@@ -866,10 +866,10 @@ fn variable_kind<'db>(
         ty: class_member_ty,
         origin: TypeOrigin::Inferred,
         ..
-    }) = class_member.place
+    }) = class_member.place()
         && class_member_ty
             .class_member(db, "__get__".into())
-            .place
+            .place()
             .ignore_possibly_undefined()
             .is_some()
     {

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -164,14 +164,14 @@ impl Ty {
             Ty::EnumLiteral(name) => Type::enum_literal(EnumLiteralType::new(
                 db,
                 known_module_symbol(db, KnownModule::Uuid, "SafeUUID")
-                    .place
+                    .place()
                     .expect_type()
                     .expect_class_literal(),
                 Name::new(name),
             )),
             Ty::SingleMemberEnumLiteral => {
                 let ty = known_module_symbol(db, KnownModule::Dataclasses, "MISSING")
-                    .place
+                    .place()
                     .expect_type();
                 debug_assert!(
                     matches!(ty, Type::NominalInstance(instance) if is_single_member_enum(db, instance.class_literal(db)))
@@ -179,27 +179,27 @@ impl Ty {
                 ty
             }
             Ty::BuiltinInstance(s) => builtins_symbol(db, s)
-                .place
+                .place()
                 .expect_type()
                 .to_instance(db)
                 .unwrap(),
             Ty::AbcInstance(s) => known_module_symbol(db, KnownModule::Abc, s)
-                .place
+                .place()
                 .expect_type()
                 .to_instance(db)
                 .unwrap(),
             Ty::AbcClassLiteral(s) => known_module_symbol(db, KnownModule::Abc, s)
-                .place
+                .place()
                 .expect_type(),
             Ty::UnittestMockLiteral => known_module_symbol(db, KnownModule::UnittestMock, "Mock")
-                .place
+                .place()
                 .expect_type(),
             Ty::UnittestMockInstance => Ty::UnittestMockLiteral
                 .into_type(db)
                 .to_instance(db)
                 .unwrap(),
             Ty::TypingLiteral => Type::SpecialForm(SpecialFormType::Literal),
-            Ty::BuiltinClassLiteral(s) => builtins_symbol(db, s).place.expect_type(),
+            Ty::BuiltinClassLiteral(s) => builtins_symbol(db, s).place().expect_type(),
             Ty::KnownClassInstance(known_class) => known_class.to_instance(db),
             Ty::Union(tys) => {
                 UnionType::from_elements(db, tys.into_iter().map(|ty| ty.into_type(db)))
@@ -228,7 +228,7 @@ impl Ty {
             Ty::SubclassOfBuiltinClass(s) => SubclassOfType::from(
                 db,
                 builtins_symbol(db, s)
-                    .place
+                    .place()
                     .expect_type()
                     .expect_class_literal()
                     .default_specialization(db),
@@ -236,17 +236,17 @@ impl Ty {
             Ty::SubclassOfAbcClass(s) => SubclassOfType::from(
                 db,
                 known_module_symbol(db, KnownModule::Abc, s)
-                    .place
+                    .place()
                     .expect_type()
                     .expect_class_literal()
                     .default_specialization(db),
             ),
             Ty::AlwaysTruthy => Type::AlwaysTruthy,
             Ty::AlwaysFalsy => Type::AlwaysFalsy,
-            Ty::BuiltinsFunction(name) => builtins_symbol(db, name).place.expect_type(),
+            Ty::BuiltinsFunction(name) => builtins_symbol(db, name).place().expect_type(),
             Ty::BuiltinsBoundMethod { class, method } => {
-                let builtins_class = builtins_symbol(db, class).place.expect_type();
-                let function = builtins_class.member(db, method).place.expect_type();
+                let builtins_class = builtins_symbol(db, class).place().expect_type();
+                let function = builtins_class.member(db, method).place().expect_type();
 
                 create_bound_method(db, function, builtins_class)
             }
@@ -281,7 +281,7 @@ fn divergent(db: &TestDb, id_bits: u64, materialization: Option<MaterializationK
 fn newtype_instance<'db>(db: &'db dyn Db, name: &str) -> Type<'db> {
     let file = system_path_to_file(db, super::setup::PROPERTY_TEST_MODULE_PATH)
         .expect("Property-test module must exist");
-    let Place::Defined(DefinedPlace { ty, .. }) = global_symbol(db, file, name).place else {
+    let Place::Defined(DefinedPlace { ty, .. }) = global_symbol(db, file, name).place() else {
         panic!(
             "Expected a global symbol for `{name}` in the property test module, but it was not found"
         );

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -119,7 +119,6 @@ impl<'db> ProtocolClass<'db> {
                         )
                         .into_place_and_conflicting_declarations()
                         .0
-                        .place
                         .is_undefined()
                     });
 
@@ -323,11 +322,7 @@ impl<'db> ProtocolInterface<'db> {
 
     pub(super) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         self.member_by_name(db, name)
-            .map(|member| PlaceAndQualifiers {
-                place: Place::bound(member.ty()),
-                qualifiers: member.qualifiers(),
-                deprecation: crate::place::DeprecationPolicy::Inherit,
-            })
+            .map(|member| Place::bound(member.ty()).with_qualifiers(member.qualifiers()))
             .unwrap_or_else(|| Type::object().member(db, name))
     }
 
@@ -710,7 +705,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             InstanceFallbackShadowsNonDataDescriptor::No,
                             MemberLookupPolicy::default(),
                         )
-                        .place
+                        .place()
                     else {
                         self.provide_context(|| ErrorContext::ProtocolMemberNotDefined {
                             member_name: member.name.into(),
@@ -746,7 +741,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // TODO: consider the types of the attribute on `other` for property members
             ProtocolMemberKind::Property(_) => {
                 let is_defined = matches!(
-                    ty.member(db, member.name).place,
+                    ty.member(db, member.name).place(),
                     Place::Defined(DefinedPlace {
                         definedness: Definedness::AlwaysDefined,
                         ..
@@ -766,7 +761,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ty: attribute_type,
                     definedness: Definedness::AlwaysDefined,
                     ..
-                }) = ty.member(db, member.name).place
+                }) = ty.member(db, member.name).place()
                 else {
                     self.provide_context(|| ErrorContext::ProtocolMemberNotDefined {
                         member_name: member.name.into(),
@@ -1033,19 +1028,15 @@ fn cached_protocol_interface<'db>(
             let place_result = place_from_declarations(db, declarations);
             let first_declaration = place_result.first_declaration;
             let place = place_result.ignore_conflicting_declarations();
-            if let Some(new_type) = place.place.ignore_possibly_undefined() {
+            if let Some(new_type) = place.ignore_possibly_undefined() {
+                let qualifiers = place.qualifiers();
                 direct_members
                     .entry(symbol_id)
                     .and_modify(|(ty, quals, _, _)| {
                         *ty = new_type;
-                        *quals = place.qualifiers;
+                        *quals = qualifiers;
                     })
-                    .or_insert((
-                        new_type,
-                        place.qualifiers,
-                        first_declaration,
-                        BoundOnClass::No,
-                    ));
+                    .or_insert((new_type, qualifiers, first_declaration, BoundOnClass::No));
             }
         }
 
@@ -1160,7 +1151,7 @@ pub(super) fn has_all_protocol_members_defined<'db>(
         }
         _ => target_interface.members(db).all(|member| {
             matches!(
-                ty.member(db, member.name()).place,
+                ty.member(db, member.name()).place(),
                 Place::Defined(DefinedPlace {
                     definedness: Definedness::AlwaysDefined,
                     ..

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -326,6 +326,7 @@ impl<'db> ProtocolInterface<'db> {
             .map(|member| PlaceAndQualifiers {
                 place: Place::bound(member.ty()),
                 qualifiers: member.qualifiers(),
+                deprecation: None,
             })
             .unwrap_or_else(|| Type::object().member(db, name))
     }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -326,7 +326,7 @@ impl<'db> ProtocolInterface<'db> {
             .map(|member| PlaceAndQualifiers {
                 place: Place::bound(member.ty()),
                 qualifiers: member.qualifiers(),
-                deprecation: None,
+                deprecation: crate::place::DeprecationPolicy::Inherit,
             })
             .unwrap_or_else(|| Type::object().member(db, name))
     }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2342,7 +2342,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             .when_any(db, self.constraints, |member| {
                 other
                     .member(db, member.name())
-                    .place
+                    .place()
                     .ignore_possibly_undefined()
                     .when_none_or(db, self.constraints, |attribute_type| {
                         self.protocol_member_has_disjoint_type_from_ty(db, &member, attribute_type)
@@ -2736,7 +2736,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                         .interface(db)
                         .members(db)
                         .when_any(db, self.constraints, |member| {
-                            match other.member(db, member.name()).place {
+                            match other.member(db, member.name()).place() {
                                 Place::Defined(DefinedPlace {
                                     ty: attribute_type, ..
                                 }) => self.protocol_member_has_disjoint_type_from_ty(
@@ -3010,7 +3010,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                     Name::new_static("__call__"),
                     MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                 )
-                .place
+                .place()
                 .ignore_possibly_undefined()
                 .when_none_or(db, self.constraints, |dunder_call| {
                     self.as_relation_checker(TypeRelation::Assignability)

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -302,11 +302,7 @@ impl<'db> UnionType<'db> {
         let mut origin = TypeOrigin::Declared;
         let mut deprecation = DeprecationBuilder::default();
         for ty in self.elements(db) {
-            let PlaceAndQualifiers {
-                place: ty_member,
-                qualifiers: new_qualifiers,
-                deprecation: new_deprecation,
-            } = transform_fn(ty);
+            let (ty_member, new_qualifiers, new_deprecation) = transform_fn(ty).into_parts();
             qualifiers |= new_qualifiers;
             deprecation.add_policy(new_deprecation);
             match ty_member {
@@ -329,26 +325,24 @@ impl<'db> UnionType<'db> {
                 }
             }
         }
-        PlaceAndQualifiers {
-            place: if all_unbound {
-                Place::Undefined
-            } else {
-                Place::Defined(DefinedPlace {
-                    ty: builder
-                        .recursively_defined(self.recursively_defined(db))
-                        .build(),
-                    origin,
-                    definedness: if possibly_unbound {
-                        Definedness::PossiblyUndefined
-                    } else {
-                        Definedness::AlwaysDefined
-                    },
-                    public_type_policy: PublicTypePolicy::Raw,
-                })
-            },
-            qualifiers,
-            deprecation: deprecation.build_policy(),
-        }
+        (if all_unbound {
+            Place::Undefined
+        } else {
+            Place::Defined(DefinedPlace {
+                ty: builder
+                    .recursively_defined(self.recursively_defined(db))
+                    .build(),
+                origin,
+                definedness: if possibly_unbound {
+                    Definedness::PossiblyUndefined
+                } else {
+                    Definedness::AlwaysDefined
+                },
+                public_type_policy: PublicTypePolicy::Raw,
+            })
+        })
+        .with_qualifiers(qualifiers)
+        .with_deprecation_policy(deprecation.build_policy())
     }
 
     pub(crate) fn recursive_type_normalized_impl(
@@ -877,11 +871,7 @@ impl<'db> IntersectionType<'db> {
         let mut origin = TypeOrigin::Declared;
         let mut deprecation = DeprecationBuilder::default();
         for ty in self.positive_elements_or_object(db) {
-            let PlaceAndQualifiers {
-                place: member,
-                qualifiers: new_qualifiers,
-                deprecation: new_deprecation,
-            } = transform_fn(&ty);
+            let (member, new_qualifiers, new_deprecation) = transform_fn(&ty).into_parts();
             qualifiers |= new_qualifiers;
             match member {
                 Place::Undefined => {}
@@ -903,24 +893,22 @@ impl<'db> IntersectionType<'db> {
             }
         }
 
-        PlaceAndQualifiers {
-            place: if all_unbound {
-                Place::Undefined
-            } else {
-                Place::Defined(DefinedPlace {
-                    ty: builder.build(),
-                    origin,
-                    definedness: if any_definitely_bound {
-                        Definedness::AlwaysDefined
-                    } else {
-                        Definedness::PossiblyUndefined
-                    },
-                    public_type_policy: PublicTypePolicy::Raw,
-                })
-            },
-            qualifiers,
-            deprecation: deprecation.build_policy(),
-        }
+        (if all_unbound {
+            Place::Undefined
+        } else {
+            Place::Defined(DefinedPlace {
+                ty: builder.build(),
+                origin,
+                definedness: if any_definitely_bound {
+                    Definedness::AlwaysDefined
+                } else {
+                    Definedness::PossiblyUndefined
+                },
+                public_type_policy: PublicTypePolicy::Raw,
+            })
+        })
+        .with_qualifiers(qualifiers)
+        .with_deprecation_policy(deprecation.build_policy())
     }
 
     /// Return a version of this intersection type where any type variables in the positive elements

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -888,7 +888,9 @@ impl<'db> IntersectionType<'db> {
                         any_definitely_bound = true;
                     }
 
-                    deprecation.add_policy(new_deprecation);
+                    if new_deprecation != DeprecationPolicy::Inherit {
+                        deprecation.add_policy(new_deprecation);
+                    }
                     builder = builder.add_positive(ty_member);
                 }
             }

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -3,7 +3,8 @@ use itertools::Either;
 use std::convert::Infallible;
 
 use crate::place::{
-    DefinedPlace, Definedness, Place, PlaceAndQualifiers, PublicTypePolicy, TypeOrigin,
+    DefinedPlace, Definedness, DeprecationBuilder, Place, PlaceAndQualifiers, PublicTypePolicy,
+    TypeOrigin,
 };
 use crate::types::class::KnownClass;
 use crate::types::enums::EnumComplement;
@@ -299,12 +300,15 @@ impl<'db> UnionType<'db> {
         let mut all_unbound = true;
         let mut possibly_unbound = false;
         let mut origin = TypeOrigin::Declared;
+        let mut deprecation = DeprecationBuilder::default();
         for ty in self.elements(db) {
             let PlaceAndQualifiers {
                 place: ty_member,
                 qualifiers: new_qualifiers,
+                deprecation: new_deprecation,
             } = transform_fn(ty);
             qualifiers |= new_qualifiers;
+            deprecation.add(new_deprecation);
             match ty_member {
                 Place::Undefined => {
                     possibly_unbound = true;
@@ -343,6 +347,7 @@ impl<'db> UnionType<'db> {
                 })
             },
             qualifiers,
+            deprecation: deprecation.build(),
         }
     }
 
@@ -870,10 +875,12 @@ impl<'db> IntersectionType<'db> {
         let mut all_unbound = true;
         let mut any_definitely_bound = false;
         let mut origin = TypeOrigin::Declared;
+        let mut deprecation = DeprecationBuilder::default();
         for ty in self.positive_elements_or_object(db) {
             let PlaceAndQualifiers {
                 place: member,
                 qualifiers: new_qualifiers,
+                deprecation: new_deprecation,
             } = transform_fn(&ty);
             qualifiers |= new_qualifiers;
             match member {
@@ -890,6 +897,7 @@ impl<'db> IntersectionType<'db> {
                         any_definitely_bound = true;
                     }
 
+                    deprecation.add(new_deprecation);
                     builder = builder.add_positive(ty_member);
                 }
             }
@@ -911,6 +919,7 @@ impl<'db> IntersectionType<'db> {
                 })
             },
             qualifiers,
+            deprecation: deprecation.build(),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -308,7 +308,7 @@ impl<'db> UnionType<'db> {
                 deprecation: new_deprecation,
             } = transform_fn(ty);
             qualifiers |= new_qualifiers;
-            deprecation.add(new_deprecation);
+            deprecation.add_policy(new_deprecation);
             match ty_member {
                 Place::Undefined => {
                     possibly_unbound = true;
@@ -347,7 +347,7 @@ impl<'db> UnionType<'db> {
                 })
             },
             qualifiers,
-            deprecation: deprecation.build(),
+            deprecation: deprecation.build_policy(),
         }
     }
 
@@ -897,7 +897,7 @@ impl<'db> IntersectionType<'db> {
                         any_definitely_bound = true;
                     }
 
-                    deprecation.add(new_deprecation);
+                    deprecation.add_policy(new_deprecation);
                     builder = builder.add_positive(ty_member);
                 }
             }
@@ -919,7 +919,7 @@ impl<'db> IntersectionType<'db> {
                 })
             },
             qualifiers,
-            deprecation: deprecation.build(),
+            deprecation: deprecation.build_policy(),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -3,8 +3,8 @@ use itertools::Either;
 use std::convert::Infallible;
 
 use crate::place::{
-    DefinedPlace, Definedness, DeprecationBuilder, Place, PlaceAndQualifiers, PublicTypePolicy,
-    TypeOrigin,
+    DefinedPlace, Definedness, DeprecationBuilder, DeprecationPolicy, Place, PlaceAndQualifiers,
+    PublicTypePolicy, TypeOrigin,
 };
 use crate::types::class::KnownClass;
 use crate::types::enums::EnumComplement;
@@ -300,11 +300,10 @@ impl<'db> UnionType<'db> {
         let mut all_unbound = true;
         let mut possibly_unbound = false;
         let mut origin = TypeOrigin::Declared;
-        let mut deprecation = DeprecationBuilder::default();
+        let mut deprecation_alternatives = Vec::new();
         for ty in self.elements(db) {
             let (ty_member, new_qualifiers, new_deprecation) = transform_fn(ty).into_parts();
             qualifiers |= new_qualifiers;
-            deprecation.add_policy(new_deprecation);
             match ty_member {
                 Place::Undefined => {
                     possibly_unbound = true;
@@ -322,9 +321,11 @@ impl<'db> UnionType<'db> {
 
                     all_unbound = false;
                     builder = builder.add(ty_member);
+                    deprecation_alternatives.push((ty_member, new_deprecation));
                 }
             }
         }
+        let deprecation = DeprecationPolicy::from_alternatives(db, deprecation_alternatives);
         (if all_unbound {
             Place::Undefined
         } else {
@@ -342,7 +343,7 @@ impl<'db> UnionType<'db> {
             })
         })
         .with_qualifiers(qualifiers)
-        .with_deprecation_policy(deprecation.build_policy())
+        .with_deprecation_policy(deprecation)
     }
 
     pub(crate) fn recursive_type_normalized_impl(

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1852,7 +1852,7 @@ mod tests {
         db.write_dedented("/src/a.py", "type Alias = int").unwrap();
 
         let module = ruff_db::files::system_path_to_file(&db, "/src/a.py").unwrap();
-        let alias_ty = global_symbol(&db, module, "Alias").place.expect_type();
+        let alias_ty = global_symbol(&db, module, "Alias").place().expect_type();
         let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias))) =
             alias_ty
         else {
@@ -1932,7 +1932,7 @@ mod tests {
         let db = setup_db();
 
         let safe_uuid_class = known_module_symbol(&db, KnownModule::Uuid, "SafeUUID")
-            .place
+            .place()
             .ignore_possibly_undefined()
             .unwrap();
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -4316,7 +4316,7 @@ mod tests {
     fn get_function_f<'db>(db: &'db TestDb, file: &'static str) -> FunctionType<'db> {
         let module = ruff_db::files::system_path_to_file(db, file).unwrap();
         global_symbol(db, module, "f")
-            .place
+            .place()
             .expect_type()
             .expect_function_literal()
     }

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -30,9 +30,9 @@ fn typing_vs_typeshed_no_default() {
         .build()
         .unwrap();
 
-    let typing_no_default = typing_symbol(&db, "NoDefault").place.expect_type();
+    let typing_no_default = typing_symbol(&db, "NoDefault").place().expect_type();
     let typing_extensions_no_default = typing_extensions_symbol(&db, "NoDefault")
-        .place
+        .place()
         .expect_type();
 
     assert_eq!(typing_no_default.display(&db).to_string(), "NoDefault");
@@ -127,11 +127,11 @@ fn divergent_type() {
             .is_assignable_to(&db, bottom_div)
     );
     assert_eq!(
-        top_div.member(&db, "__str__").place.expect_type(),
-        Type::object().member(&db, "__str__").place.expect_type()
+        top_div.member(&db, "__str__").place().expect_type(),
+        Type::object().member(&db, "__str__").place().expect_type()
     );
     assert_eq!(
-        top_div.member(&db, "__class__").place.expect_type(),
+        top_div.member(&db, "__class__").place().expect_type(),
         Type::object().dunder_class(&db)
     );
     assert!(top_div.try_upcast_to_callable(&db).is_none());
@@ -284,7 +284,7 @@ fn type_alias_variance() {
 
     fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> PEP695TypeAliasType<'db> {
         let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
-        let ty = global_symbol(db, module, name).place.expect_type();
+        let ty = global_symbol(db, module, name).place().expect_type();
         let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
             type_alias,
         ))) = ty
@@ -440,7 +440,7 @@ fn eager_expansion() {
 
     fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> Type<'db> {
         let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
-        let ty = global_symbol(db, module, name).place.expect_type();
+        let ty = global_symbol(db, module, name).place().expect_type();
         let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
             type_alias,
         ))) = ty

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1268,7 +1268,7 @@ impl<'db> TypeVarConstraints<'db> {
                 deprecation: new_deprecation,
             } = transform_fn(ty);
             qualifiers |= new_qualifiers;
-            deprecation.add(new_deprecation);
+            deprecation.add_policy(new_deprecation);
             match ty_member {
                 Place::Undefined => {
                     possibly_unbound = true;
@@ -1305,7 +1305,7 @@ impl<'db> TypeVarConstraints<'db> {
                 })
             },
             qualifiers,
-            deprecation: deprecation.build(),
+            deprecation: deprecation.build_policy(),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -6,7 +6,10 @@ use rustc_hash::FxHashSet;
 
 use crate::{
     Db, TypeQualifiers,
-    place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, PublicTypePolicy, TypeOrigin},
+    place::{
+        DefinedPlace, Definedness, DeprecationBuilder, Place, PlaceAndQualifiers, PublicTypePolicy,
+        TypeOrigin,
+    },
     types::{
         ApplySpecialization, ApplyTypeMappingVisitor, CycleDetector, DynamicType, GenericContext,
         KnownClass, KnownInstanceType, MaterializationKind, Parameter, Parameters, Type,
@@ -1257,12 +1260,15 @@ impl<'db> TypeVarConstraints<'db> {
         let mut all_unbound = true;
         let mut possibly_unbound = false;
         let mut origin = TypeOrigin::Declared;
+        let mut deprecation = DeprecationBuilder::default();
         for ty in self.elements(db) {
             let PlaceAndQualifiers {
                 place: ty_member,
                 qualifiers: new_qualifiers,
+                deprecation: new_deprecation,
             } = transform_fn(ty);
             qualifiers |= new_qualifiers;
+            deprecation.add(new_deprecation);
             match ty_member {
                 Place::Undefined => {
                     possibly_unbound = true;
@@ -1299,6 +1305,7 @@ impl<'db> TypeVarConstraints<'db> {
                 })
             },
             qualifiers,
+            deprecation: deprecation.build(),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1262,11 +1262,7 @@ impl<'db> TypeVarConstraints<'db> {
         let mut origin = TypeOrigin::Declared;
         let mut deprecation = DeprecationBuilder::default();
         for ty in self.elements(db) {
-            let PlaceAndQualifiers {
-                place: ty_member,
-                qualifiers: new_qualifiers,
-                deprecation: new_deprecation,
-            } = transform_fn(ty);
+            let (ty_member, new_qualifiers, new_deprecation) = transform_fn(ty).into_parts();
             qualifiers |= new_qualifiers;
             deprecation.add_policy(new_deprecation);
             match ty_member {
@@ -1289,24 +1285,22 @@ impl<'db> TypeVarConstraints<'db> {
                 }
             }
         }
-        PlaceAndQualifiers {
-            place: if all_unbound {
-                Place::Undefined
-            } else {
-                Place::Defined(DefinedPlace {
-                    ty: builder.build(),
-                    origin,
-                    definedness: if possibly_unbound {
-                        Definedness::PossiblyUndefined
-                    } else {
-                        Definedness::AlwaysDefined
-                    },
-                    public_type_policy: PublicTypePolicy::Raw,
-                })
-            },
-            qualifiers,
-            deprecation: deprecation.build_policy(),
-        }
+        (if all_unbound {
+            Place::Undefined
+        } else {
+            Place::Defined(DefinedPlace {
+                ty: builder.build(),
+                origin,
+                definedness: if possibly_unbound {
+                    Definedness::PossiblyUndefined
+                } else {
+                    Definedness::AlwaysDefined
+                },
+                public_type_policy: PublicTypePolicy::Raw,
+            })
+        })
+        .with_qualifiers(qualifiers)
+        .with_deprecation_policy(deprecation.build_policy())
     }
 
     fn materialize_impl(

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashSet;
 use crate::{
     Db, TypeQualifiers,
     place::{
-        DefinedPlace, Definedness, DeprecationBuilder, Place, PlaceAndQualifiers, PublicTypePolicy,
+        DefinedPlace, Definedness, DeprecationPolicy, Place, PlaceAndQualifiers, PublicTypePolicy,
         TypeOrigin,
     },
     types::{
@@ -1260,11 +1260,10 @@ impl<'db> TypeVarConstraints<'db> {
         let mut all_unbound = true;
         let mut possibly_unbound = false;
         let mut origin = TypeOrigin::Declared;
-        let mut deprecation = DeprecationBuilder::default();
+        let mut deprecation_alternatives = Vec::new();
         for ty in self.elements(db) {
             let (ty_member, new_qualifiers, new_deprecation) = transform_fn(ty).into_parts();
             qualifiers |= new_qualifiers;
-            deprecation.add_policy(new_deprecation);
             match ty_member {
                 Place::Undefined => {
                     possibly_unbound = true;
@@ -1282,6 +1281,7 @@ impl<'db> TypeVarConstraints<'db> {
 
                     all_unbound = false;
                     builder = builder.add(ty_member);
+                    deprecation_alternatives.push((ty_member, new_deprecation));
                 }
             }
         }
@@ -1300,7 +1300,10 @@ impl<'db> TypeVarConstraints<'db> {
             })
         })
         .with_qualifiers(qualifiers)
-        .with_deprecation_policy(deprecation.build_policy())
+        .with_deprecation_policy(DeprecationPolicy::from_alternatives(
+            db,
+            deprecation_alternatives,
+        ))
     }
 
     fn materialize_impl(


### PR DESCRIPTION
## Summary

An outer `@deprecated` decorator applies after any inner decorators. We previously stored deprecation on the original function, so an inner decorator that _replaced_ that function caused the public binding to lose its warning.

So given something like:

```python
from collections.abc import Callable
from typing import Any, TypeVar
from typing_extensions import deprecated

R = TypeVar("R")

def replacement() -> str:
    return "replacement"

def replace_with(value: R) -> Callable[[Callable[...,
Any]], R]:
    def decorator(_function: Callable[..., Any]) -> R:
        return value
    return decorator

@deprecated("use replacement directly")
@replace_with(replacement)
def old() -> None:
    pass
```

Before, deprecation was associated with the function type, which was lost:

```python
old()          # No warning: its type is now `replacement`
replacement()  # No warning
```

Now, we retain deprecation separately on the binding:

```python
old()          # Warning: "use replacement directly"
replacement()  # No warning
```

There's a lot of churn here because the deprecation itself is stored on `PlaceAndQualifiers`, but we want to do so without increasing the struct size, so it's instead split into a small vs. large enum.

Closes https://github.com/astral-sh/ty/issues/3623.
