### PR TITLE
[ty] Fix anchor point for override diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -354,6 +354,110 @@ class DynamicParent(Any): ...
 class DynamicChild(DynamicParent):
     def method(self) -> int:
         return 1
+
+class SameFilePropertyParent:
+    @property
+    def prop(self) -> int:
+        return 1
+
+class SameFilePropertyChild(SameFilePropertyParent):
+    @SameFilePropertyParent.prop.deleter
+    def prop(self) -> None:  # error: [missing-override-decorator]
+        pass
+```
+
+`base_property.py`:
+
+```py
+# This padding makes the inherited getter's AST index larger than the entire child module's AST,
+# so attempting to resolve the getter in the (incorrect) context of the child module will induce a panic.
+# This reproduces the bug reported in astral-sh/ty#3653.
+_padding = (
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+)
+
+class BaseProperty:
+    @property
+    def prop(self) -> int:
+        return 1
+```
+
+`property_setter.py`:
+
+```py
+from typing_extensions import override
+
+from base_property import BaseProperty
+
+class MissingOverride(BaseProperty):
+    @BaseProperty.prop.setter
+    def prop(self, value: int) -> None:  # error: [missing-override-decorator]
+        pass
+
+class InvalidExplicitOverride:
+    @BaseProperty.prop.setter
+    @override
+    def prop(self, value: int) -> None:  # error: [invalid-explicit-override]
+        pass
 ```
 
 `stub.pyi`:

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -419,7 +419,7 @@ fn check_class_declaration<'db>(
                         let underlying_functions = extract_underlying_functions(
                             db,
                             own_class_member.ignore_possibly_undefined()?,
-                        )?;
+                        );
 
                         if underlying_functions.iter().any(|function| {
                             function.has_known_decorator(db, FunctionDecorators::FINAL)
@@ -1063,11 +1063,7 @@ fn check_explicit_overrides<'db>(
     class: ClassType<'db>,
 ) {
     let db = context.db();
-    let underlying_functions =
-        extract_overriding_functions(db, member.ty, &member.name, subclass_scope);
-    let Some(functions) = underlying_functions else {
-        return;
-    };
+    let functions = extract_overriding_functions(db, member.ty, &member.name, subclass_scope);
     let Some(decorated_function) = functions
         .iter()
         .find(|function| function.has_known_decorator(db, FunctionDecorators::OVERRIDE))
@@ -1182,7 +1178,7 @@ fn overriding_definition_without_decorator<'db>(
     subclass_scope: ScopeId<'db>,
     in_stub: bool,
 ) -> Option<OverloadLiteral<'db>> {
-    for function in extract_overriding_functions(db, ty, member_name, subclass_scope)? {
+    for function in extract_overriding_functions(db, ty, member_name, subclass_scope) {
         let definition = overriding_definition(db, function, in_stub);
         if !definition.has_known_decorator(db, FunctionDecorators::OVERRIDE) {
             return Some(definition);
@@ -1199,7 +1195,7 @@ fn extract_overriding_functions<'db>(
     ty: Type<'db>,
     member_name: &Name,
     subclass_scope: ScopeId<'db>,
-) -> Option<smallvec::SmallVec<[FunctionType<'db>; 1]>> {
+) -> smallvec::SmallVec<[FunctionType<'db>; 1]> {
     match ty {
         Type::PropertyInstance(property) => {
             let subclass_file = subclass_scope.file(db);
@@ -1215,9 +1211,7 @@ fn extract_overriding_functions<'db>(
             .into_iter()
             .flatten()
             {
-                let Some(accessor_functions) = extract_underlying_functions(db, accessor) else {
-                    continue;
-                };
+                let accessor_functions = extract_underlying_functions(db, accessor);
                 functions.extend(accessor_functions.into_iter().filter(|function| {
                     function.name(db) == member_name
                         && function.file(db) == subclass_file
@@ -1225,26 +1219,19 @@ fn extract_overriding_functions<'db>(
                 }));
             }
 
-            if functions.is_empty() {
-                None
-            } else {
-                Some(functions)
-            }
+            functions
         }
         Type::Union(union) => {
             let mut functions = smallvec::smallvec![];
             for member in union.elements(db) {
-                if let Some(mut member_functions) =
-                    extract_overriding_functions(db, *member, member_name, subclass_scope)
-                {
-                    functions.append(&mut member_functions);
-                }
+                functions.extend(extract_overriding_functions(
+                    db,
+                    *member,
+                    member_name,
+                    subclass_scope,
+                ));
             }
-            if functions.is_empty() {
-                None
-            } else {
-                Some(functions)
-            }
+            functions
         }
         _ => extract_underlying_functions(db, ty),
     }
@@ -1268,25 +1255,22 @@ fn overriding_definition<'db>(
 fn extract_underlying_functions<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
-) -> Option<smallvec::SmallVec<[FunctionType<'db>; 1]>> {
+) -> smallvec::SmallVec<[FunctionType<'db>; 1]> {
     match ty {
-        Type::FunctionLiteral(function) => Some(smallvec::smallvec_inline![function]),
-        Type::BoundMethod(method) => Some(smallvec::smallvec_inline![method.function(db)]),
-        Type::PropertyInstance(property) => extract_underlying_functions(db, property.getter(db)?),
+        Type::FunctionLiteral(function) => smallvec::smallvec_inline![function],
+        Type::BoundMethod(method) => smallvec::smallvec_inline![method.function(db)],
+        Type::PropertyInstance(property) => property.getter(db).map_or_else(
+            || smallvec::smallvec![],
+            |getter| extract_underlying_functions(db, getter),
+        ),
         Type::Union(union) => {
             let mut functions = smallvec::smallvec![];
             for member in union.elements(db) {
-                if let Some(mut member_functions) = extract_underlying_functions(db, *member) {
-                    functions.append(&mut member_functions);
-                }
+                functions.extend(extract_underlying_functions(db, *member));
             }
-            if functions.is_empty() {
-                None
-            } else {
-                Some(functions)
-            }
+            functions
         }
-        _ => None,
+        _ => smallvec::smallvec![],
     }
 }
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -623,7 +623,7 @@ fn check_class_declaration<'db>(
     if let Some(target) = missing_override_target
         && first_reachable_definition.kind(db).is_function_def()
     {
-        check_missing_overrides(context, member, target);
+        check_missing_overrides(context, member, class_scope, target);
     }
 
     if !subclass_overrides_superclass_declaration
@@ -632,7 +632,7 @@ fn check_class_declaration<'db>(
         // will always be a definition in the file currently being checked
         && first_reachable_definition.kind(db).is_function_def()
     {
-        check_explicit_overrides(context, member, class);
+        check_explicit_overrides(context, member, class_scope, class);
     }
 
     if let Some((superclass, superclass_method)) = overridden_final_method {
@@ -1059,10 +1059,12 @@ impl OverrideRulesConfig {
 fn check_explicit_overrides<'db>(
     context: &InferContext<'db, '_>,
     member: &Member<'db>,
+    subclass_scope: ScopeId<'db>,
     class: ClassType<'db>,
 ) {
     let db = context.db();
-    let underlying_functions = extract_underlying_functions(db, member.ty);
+    let underlying_functions =
+        extract_overriding_functions(db, member.ty, &member.name, subclass_scope);
     let Some(functions) = underlying_functions else {
         return;
     };
@@ -1127,13 +1129,18 @@ impl<'db> MissingOverrideTarget<'db> {
 fn check_missing_overrides<'db>(
     context: &InferContext<'db, '_>,
     member: &Member<'db>,
+    subclass_scope: ScopeId<'db>,
     target: MissingOverrideTarget<'db>,
 ) {
     let db = context.db();
 
-    let Some(undecorated_override) =
-        overriding_definition_without_decorator(db, member.ty, context.in_stub())
-    else {
+    let Some(undecorated_override) = overriding_definition_without_decorator(
+        db,
+        member.ty,
+        &member.name,
+        subclass_scope,
+        context.in_stub(),
+    ) else {
         return;
     };
 
@@ -1171,9 +1178,11 @@ fn check_missing_overrides<'db>(
 fn overriding_definition_without_decorator<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
+    member_name: &Name,
+    subclass_scope: ScopeId<'db>,
     in_stub: bool,
 ) -> Option<OverloadLiteral<'db>> {
-    for function in extract_underlying_functions(db, ty)? {
+    for function in extract_overriding_functions(db, ty, member_name, subclass_scope)? {
         let definition = overriding_definition(db, function, in_stub);
         if !definition.has_known_decorator(db, FunctionDecorators::OVERRIDE) {
             return Some(definition);
@@ -1181,6 +1190,64 @@ fn overriding_definition_without_decorator<'db>(
     }
 
     None
+}
+
+/// Extract functions that belong to the subclass member currently being checked.
+/// These functions are the appropriate anchor points for override diagnostics.
+fn extract_overriding_functions<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    member_name: &Name,
+    subclass_scope: ScopeId<'db>,
+) -> Option<smallvec::SmallVec<[FunctionType<'db>; 1]>> {
+    match ty {
+        Type::PropertyInstance(property) => {
+            let subclass_file = subclass_scope.file(db);
+            let mut functions = smallvec::smallvec![];
+
+            // A setter or deleter can reuse a getter from a different class or file. Diagnostics
+            // should only consider accessors defined by the subclass member under analysis.
+            for accessor in [
+                property.getter(db),
+                property.setter(db),
+                property.deleter(db),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                let Some(accessor_functions) = extract_underlying_functions(db, accessor) else {
+                    continue;
+                };
+                functions.extend(accessor_functions.into_iter().filter(|function| {
+                    function.name(db) == member_name
+                        && function.file(db) == subclass_file
+                        && function.definition(db).scope(db) == subclass_scope
+                }));
+            }
+
+            if functions.is_empty() {
+                None
+            } else {
+                Some(functions)
+            }
+        }
+        Type::Union(union) => {
+            let mut functions = smallvec::smallvec![];
+            for member in union.elements(db) {
+                if let Some(mut member_functions) =
+                    extract_overriding_functions(db, *member, member_name, subclass_scope)
+                {
+                    functions.append(&mut member_functions);
+                }
+            }
+            if functions.is_empty() {
+                None
+            } else {
+                Some(functions)
+            }
+        }
+        _ => extract_underlying_functions(db, ty),
+    }
 }
 
 fn overriding_definition<'db>(
@@ -1196,6 +1263,8 @@ fn overriding_definition<'db>(
     }
 }
 
+/// Extract callable functions represented by a type.
+/// These may be defined in files other than the one being checked.
 fn extract_underlying_functions<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This corrects the range to which we anchor diagnostics for `invalid-explicit-override` and `missing-override-decorator` errors. Both are now anchored to a definition in the file currently being checked (which is where the override occurs).

Previously, we handled this incorrectly for property instances in particular by assuming that [the getter was always the accessor to use as the diagnostic target](https://github.com/astral-sh/ruff/blob/5b9261aa2eb8b501612b1ecb33e8bde1ceb7387b/crates/ty_python_semantic/src/types/overrides.rs#L1206) (even if we were actually overriding a different accessor, such as the setter). Now, we correctly consider all property accessors and choose the override in the file being checked as the diagnostic target.

Closes https://github.com/astral-sh/ty/issues/3654.

## Test Plan

Please see included tests.
<!-- How was it tested? -->
