### PR TITLE
[ty] Avoid redundant sequence pattern intersections

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1193,6 +1193,54 @@ fn benchmark_literal_fallthrough(criterion: &mut Criterion, name: &str, code: &s
     });
 }
 
+/// Benchmarks sequence-pattern fallthrough for a tuple-expression subject.
+///
+/// This is based on a pattern in Kornia where a tuple expression is matched against many
+/// fixed-length sequence patterns:
+///
+/// ```python
+/// match (desired_type, channels):
+///     case (0, 1):
+///         pass
+///     case (0, 3):
+///         pass
+///     ...
+/// ```
+fn benchmark_sequence_match_tuple_subject(criterion: &mut Criterion) {
+    const NUM_MATCH_BRANCHES: usize = 40;
+
+    setup_rayon();
+
+    let mut code = r#"
+        def check_sequence_match_tuple_subject(kind: int, channels: int) -> None:
+            match (kind, channels):
+"#
+    .to_string();
+
+    for index in 0..NUM_MATCH_BRANCHES {
+        writeln!(
+            &mut code,
+            "                case ({}, {}):\n                    pass",
+            index / 4,
+            index % 4,
+        )
+        .ok();
+    }
+    code.push_str("                case _:\n                    pass\n");
+
+    criterion.bench_function("ty_micro[sequence_match_tuple_subject]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 /// Regression benchmark for <https://github.com/astral-sh/ty/issues/3120>.
 ///
 /// Sequential (`TypeIs`) narrowing on a large `Literal` union, combined with
@@ -1523,6 +1571,7 @@ criterion_group!(
     benchmark_literal_match_fallthrough,
     benchmark_literal_match_fallthrough_guarded_any,
     benchmark_literal_equality_fallthrough_guarded_any,
+    benchmark_sequence_match_tuple_subject,
     benchmark_typeis_narrowing,
     benchmark_pandas_tdd,
     benchmark_recursive_typed_dict_union_contextual_inference,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1193,54 +1193,6 @@ fn benchmark_literal_fallthrough(criterion: &mut Criterion, name: &str, code: &s
     });
 }
 
-/// Benchmarks sequence-pattern fallthrough for a tuple-expression subject.
-///
-/// This is based on a pattern in Kornia where a tuple expression is matched against many
-/// fixed-length sequence patterns:
-///
-/// ```python
-/// match (desired_type, channels):
-///     case (0, 1):
-///         pass
-///     case (0, 3):
-///         pass
-///     ...
-/// ```
-fn benchmark_sequence_match_tuple_subject(criterion: &mut Criterion) {
-    const NUM_MATCH_BRANCHES: usize = 40;
-
-    setup_rayon();
-
-    let mut code = r#"
-        def check_sequence_match_tuple_subject(kind: int, channels: int) -> None:
-            match (kind, channels):
-"#
-    .to_string();
-
-    for index in 0..NUM_MATCH_BRANCHES {
-        writeln!(
-            &mut code,
-            "                case ({}, {}):\n                    pass",
-            index / 4,
-            index % 4,
-        )
-        .ok();
-    }
-    code.push_str("                case _:\n                    pass\n");
-
-    criterion.bench_function("ty_micro[sequence_match_tuple_subject]", |b| {
-        b.iter_batched_ref(
-            || setup_micro_case(&code),
-            |case| {
-                let Case { db, .. } = case;
-                let result = db.check();
-                assert_eq!(result.len(), 0);
-            },
-            BatchSize::SmallInput,
-        );
-    });
-}
-
 /// Regression benchmark for <https://github.com/astral-sh/ty/issues/3120>.
 ///
 /// Sequential (`TypeIs`) narrowing on a large `Literal` union, combined with
@@ -1571,7 +1523,6 @@ criterion_group!(
     benchmark_literal_match_fallthrough,
     benchmark_literal_match_fallthrough_guarded_any,
     benchmark_literal_equality_fallthrough_guarded_any,
-    benchmark_sequence_match_tuple_subject,
     benchmark_typeis_narrowing,
     benchmark_pandas_tdd,
     benchmark_recursive_typed_dict_union_contextual_inference,

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -199,9 +199,9 @@ use crate::{
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
         CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, Type, TypeContext,
-        UnionType, definite_match_pattern_type, enum_metadata, infer_narrowing_constraints,
-        infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
-        singleton_pattern_type,
+        UnionType, definite_match_pattern_type, definite_sequence_pattern_constraint_type,
+        enum_metadata, infer_narrowing_constraints, infer_same_file_expression_type,
+        mapping_pattern_type, sequence_pattern_type_builder, singleton_pattern_type,
     },
 };
 use ruff_index::IndexSlice;
@@ -267,9 +267,18 @@ fn type_narrowed_by_pattern<'db>(
     predicate: PatternPredicate<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
+    let pattern_ty = match predicate.kind(db) {
+        PatternPredicateKind::Sequence(kind)
+            if subject_ty.is_subtype_of(db, sequence_pattern_type_builder(db).build()) =>
+        {
+            definite_sequence_pattern_constraint_type(db, kind)
+        }
+        kind => definite_match_pattern_type(db, kind),
+    };
+
     IntersectionBuilder::new(db)
         .add_positive(subject_ty)
-        .add_negative(definite_match_pattern_type(db, predicate.kind(db)))
+        .add_negative(pattern_ty)
         .build()
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -34,9 +34,9 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    definite_match_pattern_type, definite_sequence_pattern_type, exact_sequence_pattern_type,
-    mapping_pattern_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type,
+    definite_match_pattern_type, definite_sequence_pattern_constraint_type,
+    definite_sequence_pattern_type, exact_sequence_pattern_type, mapping_pattern_type,
+    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -95,8 +95,17 @@ pub(crate) fn exact_sequence_pattern_type<'db>(
     db: &'db dyn Db,
     element_types: impl ExactSizeIterator<Item = Type<'db>>,
 ) -> Type<'db> {
+    sequence_pattern_type_builder(db)
+        .add_positive(exact_sequence_pattern_protocol(db, element_types))
+        .build()
+}
+
+fn exact_sequence_pattern_protocol<'db>(
+    db: &'db dyn Db,
+    element_types: impl ExactSizeIterator<Item = Type<'db>>,
+) -> Type<'db> {
     let Ok(length) = i64::try_from(element_types.len()) else {
-        return sequence_pattern_type_builder(db).build();
+        return Type::object();
     };
 
     // `False == 0` and `True == 1`, so the protocol must accept both literals.
@@ -118,14 +127,10 @@ pub(crate) fn exact_sequence_pattern_type<'db>(
         )
     });
 
-    let protocol = Type::protocol_with_methods(
+    Type::protocol_with_methods(
         db,
         std::iter::once(("__len__", len_method)).chain(getitem_method),
-    );
-
-    sequence_pattern_type_builder(db)
-        .add_positive(protocol)
-        .build()
+    )
 }
 
 /// Build the structural type used for a sequence pattern containing `*rest`.
@@ -209,13 +214,12 @@ pub(crate) fn definite_match_pattern_type<'db>(
     }
 }
 
-/// Return the values that are guaranteed to match a sequence pattern.
-pub(crate) fn definite_sequence_pattern_type<'db>(
+pub(crate) fn definite_sequence_pattern_constraint_type<'db>(
     db: &'db dyn Db,
     kind: &SequencePatternPredicateKind<'db>,
 ) -> Type<'db> {
     if kind.is_irrefutable() {
-        return sequence_pattern_type_builder(db).build();
+        return Type::object();
     }
 
     if kind.is_exact_length() {
@@ -228,9 +232,19 @@ pub(crate) fn definite_sequence_pattern_type<'db>(
         if element_types.iter().any(Type::is_never) {
             Type::Never
         } else {
-            exact_sequence_pattern_type(db, element_types.into_iter())
+            exact_sequence_pattern_protocol(db, element_types.into_iter())
         }
     } else {
         Type::Never
     }
+}
+
+/// Return the values that are guaranteed to match a sequence pattern.
+pub(crate) fn definite_sequence_pattern_type<'db>(
+    db: &'db dyn Db,
+    kind: &SequencePatternPredicateKind<'db>,
+) -> Type<'db> {
+    sequence_pattern_type_builder(db)
+        .add_positive(definite_sequence_pattern_constraint_type(db, kind))
+        .build()
 }


### PR DESCRIPTION
## Summary

When a sequence-pattern subject is already known to be a sequence, intersecting each fallthrough branch with the negation of `Sequence[object] & <pattern constraint>` is redundant and expensive.

We now negate only the pattern-specific constraint in this case. This avoids repeatedly constructing and simplifying redundant sequence intersections, addressing the regression seen in Kornia when matching a tuple expression against many sequence patterns.

In a temporary 40-branch microbenchmark based on Kornia’s `match (desired_type, channels)` pattern, this reduced the median check time from 27.1 ms to 22.3 ms, an 18% improvement.