### PR TITLE
[ty] Preserve intersection receivers during attribute lookup

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1863,6 +1863,50 @@ def _(a_and_b: Intersection[type[A], type[B]]):
     a_and_b.x = R()
 ```
 
+For `Intersection[A, B]`, member lookup searches `A` and `B` separately to find the attribute. Once
+found, however, descriptors and `Self` must be bound using the full `A & B` receiver.
+
+### Method binding uses the full intersection type
+
+```py
+from typing_extensions import Self
+from ty_extensions import Intersection
+
+class A:
+    def method(self) -> Self:
+        return self
+
+class B: ...
+
+def _(a_and_b: Intersection[A, B]):
+    reveal_type(a_and_b.method())  # revealed: A & B
+```
+
+### Descriptor binding uses the full intersection type
+
+```py
+from typing import Any, TypeVar, overload
+from typing_extensions import Self
+from ty_extensions import Intersection
+
+T = TypeVar("T")
+
+class Descriptor:
+    @overload
+    def __get__(self, instance: None, owner: type, /) -> Self: ...
+    @overload
+    def __get__(self, instance: T, owner: type | None = None, /) -> T: ...
+    def __get__(self, instance: object, owner: type | None = None, /) -> Any: ...
+
+class A:
+    desc = Descriptor()
+
+class B: ...
+
+def _(a_and_b: Intersection[A, B]):
+    reveal_type(a_and_b.desc)  # revealed: A & B
+```
+
 ### Negation types
 
 Make sure that attributes accessible on `object` are also accessible on a negation type like `~P`,

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -1573,11 +1573,13 @@ reveal_type(p.__call__("hello"))  # revealed: bool
 
 ### Attribute access on partial results
 
-Standard `partial` attributes like `.func`, `.args`, and `.keywords` should be accessible:
+Standard `partial` attributes like `.func`, `.args`, and `.keywords` should be accessible. Runtime
+protocol narrowing can add a refinement to the concrete `partial` object, but attributes provided by
+`partial` must remain precise when looked up through that intersection.
 
 ```py
 from functools import partial
-from typing import Callable
+from typing import Protocol, runtime_checkable
 
 def f(a: int, b: str) -> bool:
     return True
@@ -1587,6 +1589,14 @@ reveal_type(p.func)  # revealed: def f(a: int, b: str) -> bool
 reveal_type(p.func(2, "hello"))  # revealed: bool
 reveal_type(p.args)  # revealed: tuple[Any, ...]
 reveal_type(p.keywords)  # revealed: dict[str, Any]
+
+@runtime_checkable
+class PartialMarker(Protocol):
+    def __call__(self, value: str) -> bool: ...
+
+if isinstance(p, PartialMarker):
+    reveal_type(p.args)  # revealed: tuple[Any, ...]
+    reveal_type(p.keywords)  # revealed: dict[str, Any]
 ```
 
 ### `partial.func` keeps the original callable type

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -100,6 +100,24 @@ methods, even though it is not available on `types.MethodType`:
 reveal_type(bound_method.__kwdefaults__)  # revealed: dict[str, Any] | None
 ```
 
+Bound-method attributes are resolved in two stages: first on `types.MethodType`, then, if absent, on
+the underlying function object. A protocol refinement of the bound method must not be used as the
+receiver for that underlying-function fallback:
+
+```py
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class ReturnsStr(Protocol):
+    def __call__(self, x: str) -> str: ...
+
+def narrowed_bound_method_attribute():
+    method = C().f
+    if isinstance(method, ReturnsStr):
+        reveal_type(method)  # revealed: (bound method C.f(x: int) -> str) & ReturnsStr
+        reveal_type(method.__globals__)  # revealed: dict[str, Any]
+```
+
 ## Basic method calls on class objects and instances
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -1343,7 +1343,7 @@ class Y(Base):
     pass
 
 def test(x: Intersection[X, Y]) -> None:
-    reveal_type(x.f)  # revealed: (bound method X.f() -> int) & (bound method Y.f() -> int)
+    reveal_type(x.f)  # revealed: bound method X & Y.f() -> int
     reveal_type(x.f())  # revealed: int
 
 # Example subclass that inhabits that intersection:

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1424,10 +1424,12 @@ satisfy:
 def expects_named_tuple(x: typing.NamedTuple):
     reveal_type(x)  # revealed: tuple[object, ...] & NamedTupleLike
     reveal_type(x._make)  # revealed: bound method type[NamedTupleLike]._make(iterable: Iterable[Any]) -> NamedTupleLike
-    reveal_type(x._replace)  # revealed: bound method NamedTupleLike._replace(...) -> NamedTupleLike
+    # revealed: bound method tuple[object, ...] & NamedTupleLike._replace(...) -> tuple[object, ...] & NamedTupleLike
+    reveal_type(x._replace)
     # revealed: Overload[(value: tuple[object, ...], /) -> tuple[object, ...], [_T](value: tuple[_T, ...], /) -> tuple[object, ...]]
     reveal_type(x.__add__)
-    reveal_type(x.__iter__)  # revealed: bound method tuple[object, ...].__iter__() -> Iterator[object]
+    # revealed: bound method tuple[object, ...] & NamedTupleLike.__iter__() -> Iterator[object]
+    reveal_type(x.__iter__)
 
 def _(y: type[typing.NamedTuple]):
     reveal_type(y)  # revealed: @Todo(unsupported type[X] special form)

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -517,6 +517,10 @@ def test() -> None:
 
 ## Truthiness narrowing of `NewType`s
 
+`NewType`s over `float` and `complex` use their concrete union base when looking up numeric
+attributes such as `real`. Truthiness adds `~AlwaysFalsy` to the outer `NewType`, but that
+refinement must not be forwarded as the receiver for this special union-base lookup.
+
 ```py
 from typing import NewType
 
@@ -532,6 +536,7 @@ def f(floaty: FloatNewType, complexy: ComplexNewType):
 
     if complexy:
         reveal_type(complexy)  # revealed: ComplexNewType & ~AlwaysFalsy
+        reveal_type(complexy.real)  # revealed: int | float
         expects_complex(complexy)  # fine
         expects_float(complexy)  # error: [invalid-argument-type]
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3219,6 +3219,7 @@ impl<'db> Type<'db> {
     fn invoke_descriptor_protocol(
         self,
         db: &'db dyn Db,
+        receiver: Type<'db>,
         name: &str,
         fallback: PlaceAndQualifiers<'db>,
         policy: InstanceFallbackShadowsNonDataDescriptor,
@@ -3233,7 +3234,7 @@ impl<'db> Type<'db> {
         ) = Self::try_call_dunder_get_on_attribute(
             db,
             self.class_member_with_policy(db, name.into(), member_policy),
-            Some(self),
+            Some(receiver),
             self.to_meta_type(db),
         );
 
@@ -3354,9 +3355,24 @@ impl<'db> Type<'db> {
         name: Name,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
+        self.member_lookup_with_policy_and_receiver(db, name, policy, None)
+    }
+
+    /// Perform member lookup while optionally binding descriptors and `Self` to a more precise
+    /// receiver than the type whose members are being searched.
+    ///
+    /// Intersection member lookup searches each positive element separately, but the resulting
+    /// attribute is still bound to the full intersection.
+    fn member_lookup_with_policy_and_receiver(
+        self,
+        db: &'db dyn Db,
+        name: Name,
+        policy: MemberLookupPolicy,
+        receiver: Option<Type<'db>>,
+    ) -> PlaceAndQualifiers<'db> {
         #[salsa::tracked(
-            cycle_initial=|_, id, _, _, _| Place::bound(Type::divergent(id)).into(),
-            cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, member: PlaceAndQualifiers<'db>, _, _, _| {
+            cycle_initial=|_, id, _, _, _, _| Place::bound(Type::divergent(id)).into(),
+            cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, member: PlaceAndQualifiers<'db>, _, _, _, _| {
                 member.cycle_normalized(db, *previous, cycle)
             },
             heap_size=ruff_memory_usage::heap_size
@@ -3366,25 +3382,37 @@ impl<'db> Type<'db> {
             this: Type<'db>,
             name: Name,
             policy: MemberLookupPolicy,
+            receiver: Option<Type<'db>>,
         ) -> PlaceAndQualifiers<'db> {
             tracing::trace!("member_lookup_with_policy: {}.{}", this.display(db), name);
             if let Some(fallback) = this.materialized_divergent_fallback() {
-                return fallback.member_lookup_with_policy(db, name, policy);
+                return fallback.member_lookup_with_policy_and_receiver(db, name, policy, receiver);
             }
 
             let name_str = name.as_str();
 
             match this {
                 Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
-                    elem.member_lookup_with_policy(db, name_str.into(), policy)
+                    elem.member_lookup_with_policy_and_receiver(
+                        db,
+                        name_str.into(),
+                        policy,
+                        receiver,
+                    )
                 }),
 
                 Type::Intersection(intersection) => {
                     if let Some(complement) = intersection.enum_complement(db) {
                         enums::member_lookup_for_enum_complement(db, complement, name_str, policy)
                     } else {
+                        let receiver = Some(receiver.unwrap_or(this));
                         intersection.map_with_boundness_and_qualifiers(db, |elem| {
-                            elem.member_lookup_with_policy(db, name_str.into(), policy)
+                            elem.member_lookup_with_policy_and_receiver(
+                                db,
+                                name_str.into(),
+                                policy,
+                                receiver,
+                            )
                         })
                     }
                 }
@@ -3521,7 +3549,12 @@ impl<'db> Type<'db> {
                     _ => {
                         KnownClass::MethodType
                             .to_instance(db)
-                            .member_lookup_with_policy(db, name.clone(), policy)
+                            .member_lookup_with_policy_and_receiver(
+                                db,
+                                name.clone(),
+                                policy,
+                                receiver,
+                            )
                             .or_fall_back_to(db, || {
                                 // If an attribute is not available on the bound method object,
                                 // it will be looked up on the underlying function object:
@@ -3533,13 +3566,13 @@ impl<'db> Type<'db> {
                 Type::KnownBoundMethod(method) => method
                     .class()
                     .to_instance(db)
-                    .member_lookup_with_policy(db, name, policy),
+                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
                 Type::WrapperDescriptor(_) => KnownClass::WrapperDescriptorType
                     .to_instance(db)
-                    .member_lookup_with_policy(db, name, policy),
+                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
                 Type::DataclassDecorator(_) => KnownClass::FunctionType
                     .to_instance(db)
-                    .member_lookup_with_policy(db, name, policy),
+                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
 
                 Type::Callable(_) | Type::DataclassTransformer(_) if name_str == "__call__" => {
                     Place::bound(this).into()
@@ -3548,12 +3581,11 @@ impl<'db> Type<'db> {
                 Type::Callable(callable) if callable.is_function_like(db) => {
                     KnownClass::FunctionType
                         .to_instance(db)
-                        .member_lookup_with_policy(db, name, policy)
+                        .member_lookup_with_policy_and_receiver(db, name, policy, receiver)
                 }
 
-                Type::Callable(_) | Type::DataclassTransformer(_) => {
-                    Type::object().member_lookup_with_policy(db, name, policy)
-                }
+                Type::Callable(_) | Type::DataclassTransformer(_) => Type::object()
+                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
 
                 Type::NominalInstance(instance)
                     if matches!(name.as_str(), "major" | "minor")
@@ -3625,10 +3657,11 @@ impl<'db> Type<'db> {
 
                 Type::TypeAlias(alias) => alias
                     .value_type(db)
-                    .member_lookup_with_policy(db, name, policy),
+                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
 
                 _ if policy.no_instance_fallback() => this.invoke_descriptor_protocol(
                     db,
+                    receiver.unwrap_or(this),
                     name_str,
                     Place::Undefined.into(),
                     InstanceFallbackShadowsNonDataDescriptor::No,
@@ -3741,6 +3774,8 @@ impl<'db> Type<'db> {
                 | Type::TypeGuard(..)
                 | Type::TypeForm(..)
                 | Type::TypedDict(_) => {
+                    let receiver = receiver.unwrap_or(this);
+
                     // Enum members can be accessed through enum instances and other enum members,
                     // e.g. `answer.YES` or `Answer.YES.NO`.
                     if let Some(enum_class) =
@@ -3760,6 +3795,7 @@ impl<'db> Type<'db> {
 
                     let result = this.invoke_descriptor_protocol(
                         db,
+                        receiver,
                         name_str,
                         fallback,
                         InstanceFallbackShadowsNonDataDescriptor::No,
@@ -3774,7 +3810,7 @@ impl<'db> Type<'db> {
 
                     let result = this.fallback_to_getattr(db, &name, result, policy);
 
-                    result.map_type(|ty| ty.bind_self_typevars(db, this))
+                    result.map_type(|ty| ty.bind_self_typevars(db, receiver))
                 }
 
                 Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
@@ -3811,6 +3847,7 @@ impl<'db> Type<'db> {
 
                     let result = this.invoke_descriptor_protocol(
                         db,
+                        this,
                         name_str,
                         class_attr_fallback,
                         InstanceFallbackShadowsNonDataDescriptor::Yes,
@@ -3869,7 +3906,7 @@ impl<'db> Type<'db> {
             }
         }
 
-        member_lookup_with_policy_inner(db, self, name, policy)
+        member_lookup_with_policy_inner(db, self, name, policy, receiver)
     }
 
     /// Return the type of `len()` on a type if it is known more precisely than `int`,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -704,6 +704,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     }) = ty
                         .invoke_descriptor_protocol(
                             db,
+                            ty,
                             member.name,
                             Place::Undefined.into(),
                             InstanceFallbackShadowsNonDataDescriptor::No,


### PR DESCRIPTION
## Summary

When looking up an attribute on an intersection, we search each positive element independently. We previously also used that individual element as the receiver when binding descriptors and `Self`, which meant we lost constraints:

```python
def f(value: Intersection[A, B]):
    reveal_type(value.method())  # A, previously
    reveal_type(value.descriptor)  # A, previously
```

This change separates (1) the type whose members are searched from (2) the receiver used to bind the resulting attribute. We continue searching each intersection element independently, but bind descriptors and Self using the full intersection:

```python
def f(value: Intersection[A, B]):
    reveal_type(value.method())  # A & B
    reveal_type(value.descriptor)  # A & B
```

Closes https://github.com/astral-sh/ty/issues/3565.

Closes https://github.com/astral-sh/ty/issues/3600.