### PR TITLE
[ty] Check implicit open TypedDict extra items

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1350,6 +1350,7 @@ def _(kwargs: dict[str, int]) -> None:
 
 f(**{"foo": 1})
 f(**dict(foo=1))
+# error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `object`"
 f(**Foo(a=1, b=2))
 ```
 
@@ -1456,10 +1457,42 @@ class Foo2(TypedDict):
 
 def f(**kwargs: int) -> None: ...
 
-# error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `str`"
+# snapshot: invalid-argument-type
+# snapshot: invalid-argument-type
 f(**Foo1(a=1, b="b"))
 # error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `str`"
+# error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `object`"
 f(**Foo2(a=1))
+```
+
+```snapshot
+error[invalid-argument-type]: Argument to function `f` is incorrect
+  --> src/mdtest_snippet.py:15:3
+   |
+15 | f(**Foo1(a=1, b="b"))
+   |   ^^^^^^^^^^^^^^^^^^ Expected `int`, found `object`
+   |
+info: Function defined here
+  --> src/mdtest_snippet.py:11:5
+   |
+11 | def f(**kwargs: int) -> None: ...
+   |     ^ ------------- Parameter declared here
+   |
+info: Possible extra items in the unpacked open `TypedDict` have type `object`
+
+
+error[invalid-argument-type]: Argument to function `f` is incorrect
+  --> src/mdtest_snippet.py:15:3
+   |
+15 | f(**Foo1(a=1, b="b"))
+   |   ^^^^^^^^^^^^^^^^^^ Expected `int`, found `str`
+   |
+info: Function defined here
+  --> src/mdtest_snippet.py:11:5
+   |
+11 | def f(**kwargs: int) -> None: ...
+   |     ^ ------------- Parameter declared here
+   |
 ```
 
 ### TypedDict union
@@ -1490,6 +1523,7 @@ def _(good: GoodA | GoodB, bad: BadA | BadB) -> None:
     needs_known_keys(**good)
 
     # error: [invalid-argument-type] "Argument to function `takes_int_kwargs` is incorrect: Expected `int`, found `str`"
+    # error: [invalid-argument-type] "Argument to function `takes_int_kwargs` is incorrect: Expected `int`, found `object`"
     takes_int_kwargs(**bad)
 ```
 
@@ -1659,7 +1693,7 @@ def _(kwargs: dict[str, int]) -> None:
     reveal_type(f(**kwargs))  # revealed: int
 ```
 
-For a `TypedDict`, the type variable should be specialized to the union of all value types.
+For an open `TypedDict`, the type variable must also account for hidden values of type `object`.
 
 ```py
 from typing import TypeVar
@@ -1674,7 +1708,7 @@ class Foo(TypedDict):
 def f(**kwargs: _T) -> _T:
     return kwargs["a"]
 
-reveal_type(f(**Foo(a=1, b="b")))  # revealed: int | str
+reveal_type(f(**Foo(a=1, b="b")))  # revealed: object
 ```
 
 ## Non-iterable variadic argument

--- a/crates/ty_python_semantic/resources/mdtest/call/function.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/function.md
@@ -1350,7 +1350,7 @@ def _(kwargs: dict[str, int]) -> None:
 
 f(**{"foo": 1})
 f(**dict(foo=1))
-# error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `object`"
+# error: [invalid-argument-type] "Argument to function `f` is incorrect: Possible extra items in unpacked open `TypedDict` have type `object`, expected `int`"
 f(**Foo(a=1, b=2))
 ```
 
@@ -1461,7 +1461,7 @@ def f(**kwargs: int) -> None: ...
 # snapshot: invalid-argument-type
 f(**Foo1(a=1, b="b"))
 # error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `str`"
-# error: [invalid-argument-type] "Argument to function `f` is incorrect: Expected `int`, found `object`"
+# error: [invalid-argument-type] "Argument to function `f` is incorrect: Possible extra items in unpacked open `TypedDict` have type `object`, expected `int`"
 f(**Foo2(a=1))
 ```
 
@@ -1470,7 +1470,7 @@ error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:15:3
    |
 15 | f(**Foo1(a=1, b="b"))
-   |   ^^^^^^^^^^^^^^^^^^ Expected `int`, found `object`
+   |   ^^^^^^^^^^^^^^^^^^ Expected `int`, found `str`
    |
 info: Function defined here
   --> src/mdtest_snippet.py:11:5
@@ -1478,14 +1478,13 @@ info: Function defined here
 11 | def f(**kwargs: int) -> None: ...
    |     ^ ------------- Parameter declared here
    |
-info: Possible extra items in the unpacked open `TypedDict` have type `object`
 
 
 error[invalid-argument-type]: Argument to function `f` is incorrect
   --> src/mdtest_snippet.py:15:3
    |
 15 | f(**Foo1(a=1, b="b"))
-   |   ^^^^^^^^^^^^^^^^^^ Expected `int`, found `str`
+   |   ^^^^^^^^^^^^^^^^^^ Possible extra items in unpacked open `TypedDict` have type `object`, expected `int`
    |
 info: Function defined here
   --> src/mdtest_snippet.py:11:5
@@ -1523,7 +1522,7 @@ def _(good: GoodA | GoodB, bad: BadA | BadB) -> None:
     needs_known_keys(**good)
 
     # error: [invalid-argument-type] "Argument to function `takes_int_kwargs` is incorrect: Expected `int`, found `str`"
-    # error: [invalid-argument-type] "Argument to function `takes_int_kwargs` is incorrect: Expected `int`, found `object`"
+    # error: [invalid-argument-type] "Argument to function `takes_int_kwargs` is incorrect: Possible extra items in unpacked open `TypedDict` have type `object`, expected `int`"
     takes_int_kwargs(**bad)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -709,6 +709,25 @@ p = partial(f, **kwargs)
 reveal_type(p)  # revealed: partial[bool]
 ```
 
+Known items are still checked against their corresponding parameters, even when the partial
+signature cannot be represented precisely.
+
+```py
+from functools import partial
+from typing import TypedDict
+
+class MyKwargs(TypedDict):
+    b: int
+
+def f(*, b: str) -> bool:
+    return True
+
+kwargs: MyKwargs = {"b": 1}
+# error: [invalid-argument-type] "Argument to class `partial` is incorrect: Expected `str`, found `int`"
+p = partial(f, **kwargs)
+reveal_type(p)  # revealed: partial[bool]
+```
+
 ### Kwargs splat with closed TypedDict
 
 A closed `TypedDict` has no hidden extra items, so we should still be able to normalize it to a

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -709,6 +709,27 @@ p = partial(f, **kwargs)
 reveal_type(p)  # revealed: partial[bool]
 ```
 
+### Kwargs splat with closed TypedDict
+
+A closed `TypedDict` has no hidden extra items, so we should still be able to normalize it to a
+precise partial signature.
+
+```py
+from functools import partial
+from typing_extensions import TypedDict
+
+class MyKwargs(TypedDict, closed=True):
+    b: str
+
+def f(a: int, b: str) -> bool:
+    return True
+
+kwargs: MyKwargs = {"b": "hello"}
+p = partial(f, **kwargs)
+# TODO: should be `partial[(a: int, *, b: str = ...) -> bool]`
+reveal_type(p)  # revealed: partial[bool]
+```
+
 ### Kwargs splat with union of TypedDicts
 
 ```py
@@ -729,6 +750,27 @@ def make(kwargs: KwargsA | KwargsB) -> None:
     reveal_type(p)  # revealed: partial[bool]
 ```
 
+### Kwargs splat with union of closed TypedDicts
+
+```py
+from functools import partial
+from typing_extensions import TypedDict
+
+class KwargsA(TypedDict, closed=True):
+    b: str
+
+class KwargsB(TypedDict, closed=True):
+    b: str
+
+def f(*, b: str) -> bool:
+    return True
+
+def make(kwargs: KwargsA | KwargsB) -> None:
+    p = partial(f, **kwargs)
+    # TODO: should be `partial[(*, b: str = ...) -> bool]`
+    reveal_type(p)  # revealed: partial[bool]
+```
+
 ### Mixed keywords and kwargs splat
 
 ```py
@@ -743,6 +785,24 @@ def f(a: int, b: str, c: float) -> bool:
 
 kwargs: MyKwargs = {"c": 3.14}
 p = partial(f, b="hello", **kwargs)
+reveal_type(p)  # revealed: partial[bool]
+```
+
+### Mixed keywords and closed TypedDict splat
+
+```py
+from functools import partial
+from typing_extensions import TypedDict
+
+class MyKwargs(TypedDict, closed=True):
+    c: float
+
+def f(a: int, b: str, c: float) -> bool:
+    return True
+
+kwargs: MyKwargs = {"c": 3.14}
+p = partial(f, b="hello", **kwargs)
+# TODO: should be `partial[(a: int, *, b: str = "hello", c: int | float = ...) -> bool]`
 reveal_type(p)  # revealed: partial[bool]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -691,6 +691,9 @@ reveal_type(p)  # revealed: partial[bool]
 
 ### Kwargs splat with TypedDict
 
+An open `TypedDict` may contain hidden extra items, so it cannot be normalized to a precise partial
+signature.
+
 ```py
 from functools import partial
 from typing import TypedDict
@@ -703,7 +706,7 @@ def f(a: int, b: str) -> bool:
 
 kwargs: MyKwargs = {"b": "hello"}
 p = partial(f, **kwargs)
-reveal_type(p)  # revealed: partial[(a: int, *, b: str = ...) -> bool]
+reveal_type(p)  # revealed: partial[bool]
 ```
 
 ### Kwargs splat with union of TypedDicts
@@ -723,7 +726,7 @@ def f(*, b: str) -> bool:
 
 def make(kwargs: KwargsA | KwargsB) -> None:
     p = partial(f, **kwargs)
-    reveal_type(p)  # revealed: partial[(*, b: str = ...) -> bool]
+    reveal_type(p)  # revealed: partial[bool]
 ```
 
 ### Mixed keywords and kwargs splat
@@ -740,7 +743,7 @@ def f(a: int, b: str, c: float) -> bool:
 
 kwargs: MyKwargs = {"c": 3.14}
 p = partial(f, b="hello", **kwargs)
-reveal_type(p)  # revealed: partial[(a: int, *, b: str = "hello", c: int | float = ...) -> bool]
+reveal_type(p)  # revealed: partial[bool]
 ```
 
 ### Fallback for kwargs splat with dict

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -8,6 +8,7 @@ use rustc_hash::FxHashMap;
 use crate::Db;
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::tuple::Tuple;
+use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_value_type;
 use crate::types::{KnownClass, Type, TypeContext};
 
 /// Maximum number of expanded types that can be generated from a single tuple's
@@ -280,32 +281,40 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         }
     }
 
-    /// Returns the `functools.partial(...)` bound-argument slice when argument expansion is
-    /// concrete enough for partial-application analysis.
-    pub(crate) fn functools_partial_bound_arguments(&self, db: &'db dyn Db) -> Option<Self> {
+    /// Returns the `functools.partial(...)` bound-argument slice and whether it is concrete enough
+    /// to synthesize a precise partial signature.
+    pub(crate) fn functools_partial_bound_arguments(
+        &self,
+        db: &'db dyn Db,
+    ) -> Option<(Self, bool)> {
         let bound_call_arguments = self.start_from(1);
+        let mut can_synthesize_signature = true;
 
-        // We only handle variadics and keyword-maps that can be normalized to concrete argument
-        // positions for overload matching.
-        if bound_call_arguments.iter().any(|(argument, argument_ty)| {
+        for (argument, argument_ty) in bound_call_arguments.iter() {
             let argument_ty = argument_ty.get_default().unwrap_or_else(Type::unknown);
             match argument {
-                Argument::Variadic => !matches!(
-                    argument_ty
-                        .as_nominal_instance()
-                        .and_then(|nominal| nominal.tuple_spec(db)),
-                    Some(spec) if spec.as_fixed_length().is_some()
-                ),
-                // Keyword splats cannot be normalized to concrete partial arguments. Mappings
-                // may have arbitrary keys, and ordinary `TypedDict`s are implicitly open.
-                Argument::Keywords => true,
-                Argument::Positional | Argument::Synthetic | Argument::Keyword(_) => false,
+                Argument::Variadic => {
+                    if !matches!(
+                        argument_ty
+                            .as_nominal_instance()
+                            .and_then(|nominal| nominal.tuple_spec(db)),
+                        Some(spec) if spec.as_fixed_length().is_some()
+                    ) {
+                        return None;
+                    }
+                }
+                Argument::Keywords => {
+                    // Known `TypedDict` items can still be checked against their target
+                    // parameters, even though possible hidden items prevent us from synthesizing
+                    // a precise partial signature.
+                    extract_unpacked_typed_dict_keys_from_value_type(db, argument_ty)?;
+                    can_synthesize_signature = false;
+                }
+                Argument::Positional | Argument::Synthetic | Argument::Keyword(_) => {}
             }
-        }) {
-            return None;
         }
 
-        Some(bound_call_arguments)
+        Some((bound_call_arguments, can_synthesize_signature))
     }
 
     /// Returns an iterator on performing [argument type expansion].

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -8,7 +8,6 @@ use rustc_hash::FxHashMap;
 use crate::Db;
 use crate::types::enums::{enum_member_literals, enum_metadata};
 use crate::types::tuple::Tuple;
-use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_value_type;
 use crate::types::{KnownClass, Type, TypeContext};
 
 /// Maximum number of expanded types that can be generated from a single tuple's
@@ -297,13 +296,9 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                         .and_then(|nominal| nominal.tuple_spec(db)),
                     Some(spec) if spec.as_fixed_length().is_some()
                 ),
-                // Optional TypedDict keys may be absent at runtime, so we can only refine
-                // `partial(...)` when every expanded key is guaranteed to be present.
-                Argument::Keywords => {
-                    extract_unpacked_typed_dict_keys_from_value_type(db, argument_ty).is_none_or(
-                        |unpacked_keys| unpacked_keys.values().any(|key| !key.is_required),
-                    )
-                }
+                // Keyword splats cannot be normalized to concrete partial arguments. Mappings
+                // may have arbitrary keys, and ordinary `TypedDict`s are implicitly open.
+                Argument::Keywords => true,
                 Argument::Positional | Argument::Synthetic | Argument::Keyword(_) => false,
             }
         }) {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -5501,10 +5501,10 @@ pub struct MatchedArgument<'db> {
     /// types assigned to each matched parameter. This isn't necessarily the same as the number of
     /// types in the argument type which might not be a fixed-length iterable.
     ///
-    /// Another thing to note is that the way this is populated means that for any other argument
-    /// kind (synthetic, positional, keyword, keyword-variadic), this will be a single-element
-    /// vector containing `None`, since we don't know the type of the argument when this is
-    /// constructed. So, this field is populated only for variadic arguments.
+    /// For non-splatted arguments (synthetic, positional, and keyword), this will be a
+    /// single-element vector containing `None`, since we don't know the type of the argument when
+    /// this is constructed. Splatted positional and keyword arguments can both populate this field
+    /// with the type assigned to each matched parameter.
     ///
     /// For example, given a `*args` whose type is `tuple[A, B, C]` and the following parameters:
     /// - `(x, *args)`: the `types` field will only have two elements (`B`, `C`) since `A` has been

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1045,9 +1045,9 @@ impl<'db> Bindings<'db> {
         // its declared type.
         if let Some(binding) = self.single_element()
             && let Ok((_, overload)) = binding.matching_overloads().exactly_one()
-            && let [parameter_index] = *overload.argument_matches[argument_index].parameters
+            && let [parameter] = *overload.argument_matches[argument_index].parameters
         {
-            let declared_type = overload.signature.parameters()[parameter_index].annotated_type();
+            let declared_type = overload.signature.parameters()[parameter.index].annotated_type();
             return argument_types.get_for_declared_type(declared_type);
         }
 
@@ -3193,9 +3193,9 @@ impl<'db> CallableBinding<'db> {
             }
             let mut is_argument_assignable_to_any_overload = false;
             'overload: for overload in &self.overloads {
-                for parameter_index in &overload.argument_matches[argument_index].parameters {
+                for matched_parameter in &overload.argument_matches[argument_index].parameters {
                     let parameter_type =
-                        overload.signature.parameters()[*parameter_index].annotated_type();
+                        overload.signature.parameters()[matched_parameter.index].annotated_type();
                     let argument_type = argument_types.get_for_declared_type(parameter_type);
                     if argument_type
                         .when_assignable_to(
@@ -3440,21 +3440,19 @@ impl<'db> CallableBinding<'db> {
                     .iter()
                     .zip(arguments.iter_types())
                     .flat_map(move |(matched_argument, argument_types)| {
-                        matched_argument.iter().map(
-                            move |(parameter_index, variadic_argument_type)| {
-                                // TODO: For an unannotated `self` / `cls` parameter, the type should be
-                                // `typing.Self` / `type[typing.Self]`
-                                let parameter_type = overload.signature.parameters()
-                                    [parameter_index]
-                                    .annotated_type()
-                                    .apply_optional_specialization(db, overload.specialization);
-                                OverloadFilterSlot {
-                                    parameter: parameter_type,
-                                    argument: argument_types.get_for_declared_type(parameter_type),
-                                    variadic_argument: variadic_argument_type,
-                                }
-                            },
-                        )
+                        matched_argument.iter().map(move |matched_parameter| {
+                            // TODO: For an unannotated `self` / `cls` parameter, the type should be
+                            // `typing.Self` / `type[typing.Self]`
+                            let parameter_type = overload.signature.parameters()
+                                [matched_parameter.index]
+                                .annotated_type()
+                                .apply_optional_specialization(db, overload.specialization);
+                            OverloadFilterSlot {
+                                parameter: parameter_type,
+                                argument: argument_types.get_for_declared_type(parameter_type),
+                                variadic_argument: matched_parameter.argument_type,
+                            }
+                        })
                     })
                     .collect::<Vec<_>>();
                 (index, slots)
@@ -4134,6 +4132,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         argument_index: usize,
         argument: Argument<'a>,
         argument_type: Option<Type<'db>>,
+        provenance: InvalidArgumentTypeProvenance,
         parameter_index: usize,
         parameter: &Parameter<'db>,
         positional: bool,
@@ -4168,8 +4167,11 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             self.variadic_argument_matched_to_variadic_parameter = true;
         }
         let matched_argument = &mut self.argument_matches[argument_index];
-        matched_argument.parameters.push(parameter_index);
-        matched_argument.types.push(argument_type);
+        matched_argument.parameters.push(MatchedParameter {
+            index: parameter_index,
+            argument_type,
+            provenance,
+        });
         matched_argument.matched = true;
         self.parameter_info[parameter_index].matched = true;
     }
@@ -4199,6 +4201,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             argument_index,
             argument,
             argument_type,
+            InvalidArgumentTypeProvenance::Argument,
             parameter_index,
             parameter,
             !parameter.is_variadic(),
@@ -4240,6 +4243,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             argument_index,
             argument,
             argument_type,
+            InvalidArgumentTypeProvenance::Argument,
             parameter_index,
             parameter,
             false,
@@ -4519,6 +4523,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     argument_index,
                     Argument::Keywords,
                     Some(value_type),
+                    InvalidArgumentTypeProvenance::Argument,
                     parameter_index,
                     parameter,
                     false,
@@ -4541,6 +4546,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
             argument_index,
             Argument::Keywords,
             Some(Type::object()),
+            InvalidArgumentTypeProvenance::OpenTypedDictExtraItems,
             parameter_index,
             parameter,
             false,
@@ -4738,7 +4744,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 self.argument_matches[argument_index]
                     .parameters
                     .iter()
-                    .any(|parameter_index| *parameter_index >= prefix_len)
+                    .any(|parameter| parameter.index >= prefix_len)
                     .then_some((argument_index, adjusted_argument_index))
             })
             .collect()
@@ -4993,9 +4999,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         for (argument_index, adjusted_argument_index, _, argument_types) in
             self.enumerate_argument_types()
         {
-            for (parameter_index, variadic_argument_type) in
-                self.argument_matches[argument_index].iter()
-            {
+            for matched_parameter in self.argument_matches[argument_index].iter() {
+                let parameter_index = matched_parameter.index;
                 if self.is_gradual_variadic_parameter(parameter_index) {
                     continue;
                 }
@@ -5004,7 +5009,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 let argument_type = argument_types.get_for_declared_type(declared_type);
                 let specialization_result = builder.infer(
                     declared_type,
-                    variadic_argument_type.unwrap_or(argument_type),
+                    matched_parameter.argument_type.unwrap_or(argument_type),
                 );
 
                 if let Err(error) = specialization_result {
@@ -5024,7 +5029,6 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             })
     }
 
-    #[expect(clippy::too_many_arguments)]
     fn check_argument_type(
         &mut self,
         constraints: &ConstraintSetBuilder<'db>,
@@ -5032,9 +5036,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         adjusted_argument_index: Option<usize>,
         argument: Argument<'a>,
         mut argument_type: Type<'db>,
-        parameter_index: usize,
-        provenance: InvalidArgumentTypeProvenance,
+        matched_parameter: MatchedParameter<'db>,
     ) {
+        let parameter_index = matched_parameter.index;
         let parameters = self.signature.parameters();
         let parameter = &parameters[parameter_index];
         if self.is_gradual_variadic_parameter(parameter_index) {
@@ -5073,7 +5077,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 argument_index: adjusted_argument_index,
                 expected_ty,
                 provided_ty: argument_type,
-                provenance,
+                provenance: matched_parameter.provenance,
             });
         }
         // We still update the actual type of the parameter in this binding to match the argument,
@@ -5139,7 +5143,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         };
 
                         let Type::TypeVar(typevar) =
-                            self.signature.parameters()[*parameter_index].annotated_type()
+                            self.signature.parameters()[parameter_index.index].annotated_type()
                         else {
                             return false;
                         };
@@ -5172,7 +5176,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             if !matched_parameters.is_empty()
                 && matched_parameters
                     .iter()
-                    .all(|parameter_index| is_paramspec_component_parameter(*parameter_index))
+                    .all(|parameter| is_paramspec_component_parameter(parameter.index))
             {
                 continue;
             }
@@ -5196,13 +5200,14 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 ),
                 _ => {
                     // If the argument isn't splatted, just check its type directly.
-                    for parameter_index in &self.argument_matches[argument_index].parameters {
-                        if is_paramspec_component_parameter(*parameter_index) {
+                    for matched_parameter in self.argument_matches[argument_index].iter() {
+                        let parameter_index = matched_parameter.index;
+                        if is_paramspec_component_parameter(parameter_index) {
                             continue;
                         }
 
                         let declared_type =
-                            self.signature.parameters()[*parameter_index].annotated_type();
+                            self.signature.parameters()[parameter_index].annotated_type();
                         let argument_type = argument_types.get_for_declared_type(declared_type);
 
                         self.check_argument_type(
@@ -5211,8 +5216,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             adjusted_argument_index,
                             argument,
                             argument_type,
-                            *parameter_index,
-                            InvalidArgumentTypeProvenance::Argument,
+                            matched_parameter,
                         );
                     }
                 }
@@ -5345,9 +5349,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         argument: Argument<'a>,
         paramspec_component_start: Option<usize>,
     ) {
-        for (parameter_index, variadic_argument_type) in
-            self.argument_matches[argument_index].iter()
-        {
+        for matched_parameter in self.argument_matches[argument_index].iter() {
+            let parameter_index = matched_parameter.index;
             if paramspec_component_start.is_some_and(|start| parameter_index >= start) {
                 continue;
             }
@@ -5357,9 +5360,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 argument_index,
                 adjusted_argument_index,
                 argument,
-                variadic_argument_type.unwrap_or_else(Type::unknown),
-                parameter_index,
-                InvalidArgumentTypeProvenance::Argument,
+                matched_parameter
+                    .argument_type
+                    .unwrap_or_else(Type::unknown),
+                matched_parameter,
             );
         }
     }
@@ -5374,19 +5378,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         paramspec_component_start: Option<usize>,
     ) {
         if extract_unpacked_typed_dict_keys_from_value_type(self.db, argument_type).is_some() {
-            let open_extra_items_match_index = self.argument_matches[argument_index]
-                .parameters
-                .len()
-                .checked_sub(1)
-                .filter(|match_index| {
-                    let parameter_index =
-                        self.argument_matches[argument_index].parameters[*match_index];
-                    self.signature.parameters()[parameter_index].is_keyword_variadic()
-                });
-
-            for (match_index, (parameter_index, argument_type)) in
-                self.argument_matches[argument_index].iter().enumerate()
-            {
+            for matched_parameter in self.argument_matches[argument_index].iter() {
+                let parameter_index = matched_parameter.index;
                 if paramspec_component_start.is_some_and(|start| parameter_index >= start) {
                     continue;
                 }
@@ -5396,13 +5389,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     argument_index,
                     adjusted_argument_index,
                     argument,
-                    argument_type.unwrap_or_else(Type::unknown),
-                    parameter_index,
-                    if open_extra_items_match_index == Some(match_index) {
-                        InvalidArgumentTypeProvenance::OpenTypedDictExtraItems
-                    } else {
-                        InvalidArgumentTypeProvenance::Argument
-                    },
+                    matched_parameter
+                        .argument_type
+                        .unwrap_or_else(Type::unknown),
+                    matched_parameter,
                 );
             }
 
@@ -5432,15 +5422,16 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 None
             };
 
-        for parameter_index in &self.argument_matches[argument_index].parameters {
-            if paramspec_component_start.is_some_and(|start| *parameter_index >= start) {
+        for matched_parameter in self.argument_matches[argument_index].iter() {
+            let parameter_index = matched_parameter.index;
+            if paramspec_component_start.is_some_and(|start| parameter_index >= start) {
                 continue;
             }
 
             let value_type = if let Some(value_type) = value_type_paramspec {
                 value_type
             } else {
-                let parameter_name = self.signature.parameters()[*parameter_index]
+                let parameter_name = self.signature.parameters()[parameter_index]
                     .keyword_name()
                     .map(Name::as_str);
 
@@ -5455,8 +5446,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 adjusted_argument_index,
                 Argument::Keywords,
                 value_type,
-                *parameter_index,
-                InvalidArgumentTypeProvenance::Argument,
+                matched_parameter,
             );
         }
     }
@@ -5486,40 +5476,36 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 /// separately for each overload.
 #[derive(Clone, Debug, Default)]
 pub struct MatchedArgument<'db> {
-    /// The index of the parameter(s) that an argument was matched against. A splatted argument
-    /// might be matched against multiple parameters.
-    pub parameters: SmallVec<[usize; 1]>,
+    /// The parameters that an argument was matched against. A splatted argument might be matched
+    /// against multiple parameters.
+    pub parameters: SmallVec<[MatchedParameter<'db>; 1]>,
 
     /// Whether there were errors matching this argument. For a splatted argument, _all_ splatted
     /// elements must have been successfully matched. (That means that this can be `false` while
     /// the `parameters` field is non-empty.)
     pub matched: bool,
+}
 
-    /// The types of a variadic argument when it's unpacked.
+/// One parameter matched to an argument.
+#[derive(Clone, Copy, Debug)]
+pub struct MatchedParameter<'db> {
+    /// The index of the matched parameter.
+    pub index: usize,
+
+    /// The type contributed by an unpacked positional or keyword argument.
     ///
-    /// The length of this vector is always the same as the `parameters` vector i.e., these are the
-    /// types assigned to each matched parameter. This isn't necessarily the same as the number of
-    /// types in the argument type which might not be a fixed-length iterable.
-    ///
-    /// For non-splatted arguments (synthetic, positional, and keyword), this will be a
-    /// single-element vector containing `None`, since we don't know the type of the argument when
-    /// this is constructed. Splatted positional and keyword arguments can both populate this field
-    /// with the type assigned to each matched parameter.
-    ///
-    /// For example, given a `*args` whose type is `tuple[A, B, C]` and the following parameters:
-    /// - `(x, *args)`: the `types` field will only have two elements (`B`, `C`) since `A` has been
-    ///   matched with `x`.
-    /// - `(*args)`: the `types` field will have all the three elements (`A`, `B`, `C`)
-    types: SmallVec<[Option<Type<'db>>; 1]>,
+    /// This is `None` for non-splatted arguments because their type is not known when argument
+    /// matching runs.
+    argument_type: Option<Type<'db>>,
+
+    /// Why this parameter match exists.
+    provenance: InvalidArgumentTypeProvenance,
 }
 
 impl<'db> MatchedArgument<'db> {
-    /// Returns an iterator over the parameter indices and the corresponding argument type.
-    pub fn iter(&self) -> impl Iterator<Item = (usize, Option<Type<'db>>)> + '_ {
-        self.parameters
-            .iter()
-            .copied()
-            .zip(self.types.iter().copied())
+    /// Returns an iterator over the matched parameters.
+    fn iter(&self) -> impl Iterator<Item = MatchedParameter<'db>> + '_ {
+        self.parameters.iter().copied()
     }
 }
 
@@ -5748,7 +5734,7 @@ impl<'db> Binding<'db> {
                 argument_matches
                     .parameters
                     .iter()
-                    .any(|parameter_index| *parameter_index >= prefix_len)
+                    .any(|parameter| parameter.index >= prefix_len)
                     .then_some(matched_argument_index - bound_argument_offset)
             })
             .collect()
@@ -5856,7 +5842,7 @@ impl<'db> Binding<'db> {
             .matching_overloads()
             .exactly_one()
             .ok()?;
-        let [specialized_parameter_index] = specialized_overload
+        let [specialized_parameter] = specialized_overload
             .argument_matches()
             .get(sub_argument_index)?
             .parameters
@@ -5866,7 +5852,7 @@ impl<'db> Binding<'db> {
         };
 
         let parameter_type = specialized_overload.signature.parameters()
-            [*specialized_parameter_index]
+            [specialized_parameter.index]
             .annotated_type();
         // A context like `list[Unknown]` or `list[T@g]` is worse than no context here:
         // it can erase the concrete literal type that should later specialize the wrapped
@@ -5903,7 +5889,7 @@ impl<'db> Binding<'db> {
         argument_index: usize,
     ) -> Option<Type<'db>> {
         let (prefix, paramspec) = self.signature.parameters().as_paramspec_with_prefix()?;
-        let [parameter_index] = self
+        let [parameter] = self
             .matched_argument_for_call_argument(binding, argument_index)?
             .parameters
             .as_slice()
@@ -5911,11 +5897,11 @@ impl<'db> Binding<'db> {
             return None;
         };
 
-        if *parameter_index >= prefix.len() {
+        if parameter.index >= prefix.len() {
             return None;
         }
 
-        let parameter_type = self.signature.parameters()[*parameter_index].annotated_type();
+        let parameter_type = self.signature.parameters()[parameter.index].annotated_type();
         parameter_type
             .references_typevar(db, paramspec.typevar(db).identity(db))
             .then_some(parameter_type)
@@ -5942,11 +5928,11 @@ impl<'db> Binding<'db> {
         call_expression_tcx: TypeContext<'db>,
     ) -> Option<ArgumentTypeContext<'db>> {
         let argument_matches = self.matched_argument_for_call_argument(binding, argument_index)?;
-        let [parameter_index] = argument_matches.parameters.as_slice() else {
+        let [parameter] = argument_matches.parameters.as_slice() else {
             return None;
         };
 
-        let parameter = &self.signature.parameters()[*parameter_index];
+        let parameter = &self.signature.parameters()[parameter.index];
         let mut parameter_type = parameter.annotated_type();
         let original_parameter_type = parameter_type;
 
@@ -6299,7 +6285,8 @@ impl<'db> Binding<'db> {
         {
             match argument {
                 Argument::Positional | Argument::Synthetic | Argument::Variadic => {
-                    for (parameter_index, _) in argument_matches.iter() {
+                    for matched_parameter in argument_matches.iter() {
+                        let parameter_index = matched_parameter.index;
                         let parameter = &parameters[parameter_index];
                         if parameter.is_positional()
                             && parameter.annotated_type() != Type::Never
@@ -6311,7 +6298,8 @@ impl<'db> Binding<'db> {
                     }
                 }
                 Argument::Keyword(_) | Argument::Keywords => {
-                    for (parameter_index, matched_ty) in argument_matches.iter() {
+                    for matched_parameter in argument_matches.iter() {
+                        let parameter_index = matched_parameter.index;
                         if partial_application.is_positionally_bound(parameter_index) {
                             continue;
                         }
@@ -6327,7 +6315,7 @@ impl<'db> Binding<'db> {
                         partial_application.bind_by_keyword(
                             parameter_index,
                             (parameter.annotated_type() != Type::Never).then(|| {
-                                matched_ty.unwrap_or_else(|| {
+                                matched_parameter.argument_type.unwrap_or_else(|| {
                                     argument_ty.get_default().unwrap_or_else(Type::unknown)
                                 })
                             }),
@@ -6390,7 +6378,10 @@ impl<'db> Binding<'db> {
             .iter()
             .zip(&self.argument_matches)
             .filter(move |(_, argument_matches)| {
-                argument_matches.parameters.contains(&parameter_index)
+                argument_matches
+                    .parameters
+                    .iter()
+                    .any(|parameter| parameter.index == parameter_index)
             })
             .map(move |((argument, argument_types), _)| {
                 let declared_type = self.signature.parameters()[parameter_index].annotated_type();

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -802,11 +802,12 @@ impl<'db> Bindings<'db> {
         db: &'db dyn Db,
         wrapped_callable_ty: Type<'db>,
         call_arguments: &CallArguments<'a, 'db>,
-    ) -> Option<(CallArguments<'a, 'db>, Bindings<'db>)> {
+    ) -> Option<(CallArguments<'a, 'db>, Bindings<'db>, bool)> {
         // We can only infer bound-argument context from an actual callable.
         wrapped_callable_ty.try_upcast_to_callable(db)?;
 
-        let bound_call_arguments = call_arguments.functools_partial_bound_arguments(db)?;
+        let (bound_call_arguments, can_synthesize_signature) =
+            call_arguments.functools_partial_bound_arguments(db)?;
 
         let mut partial_bindings = wrapped_callable_ty
             .bindings(db)
@@ -819,7 +820,11 @@ impl<'db> Bindings<'db> {
                 downstream.clear_deferred_constructor_errors_for_partial_application();
             }
         }
-        Some((bound_call_arguments, partial_bindings))
+        Some((
+            bound_call_arguments,
+            partial_bindings,
+            can_synthesize_signature,
+        ))
     }
 
     /// Synthesizes the precise `functools.partial(...)` type for the already-matched bindings.
@@ -6233,10 +6238,11 @@ impl<'db> Binding<'db> {
             [Some(func_ty), ..] => *func_ty,
             _ => return None,
         };
-        let fallback_return_type =
+        let imprecise_return_type = self.return_ty;
+        let failed_synthesis_return_type =
             KnownClass::FunctoolsPartial.to_specialized_instance(db, &[Type::unknown()]);
 
-        let (bound_call_arguments, partial_bindings) =
+        let (bound_call_arguments, partial_bindings, can_synthesize_signature) =
             Bindings::functools_partial_matched_bindings(db, func_ty, call_arguments)?;
 
         // Reuse call-binding machinery to resolve which wrapped overloads are compatible with
@@ -6254,8 +6260,10 @@ impl<'db> Binding<'db> {
         let new_return_type =
             partial_bindings.functools_partial_type(db, func_ty, self, &bound_call_arguments);
 
-        Some(if new_return_type.is_never() {
-            fallback_return_type
+        Some(if !can_synthesize_signature {
+            imprecise_return_type
+        } else if new_return_type.is_never() {
+            failed_synthesis_return_type
         } else {
             new_return_type
         })

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -7035,9 +7035,19 @@ impl<'db> BindingError<'db> {
                         .map(|description| format!(" to {description}"))
                         .unwrap_or_default()
                 ));
-                diag.set_primary_message(format_args!(
-                    "Expected `{expected_ty_display}`, found `{provided_ty_display}`"
-                ));
+                if matches!(
+                    provenance,
+                    InvalidArgumentTypeProvenance::OpenTypedDictExtraItems
+                ) {
+                    diag.set_primary_message(format_args!(
+                        "Possible extra items in unpacked open `TypedDict` have type \
+                         `{provided_ty_display}`, expected `{expected_ty_display}`"
+                    ));
+                } else {
+                    diag.set_primary_message(format_args!(
+                        "Expected `{expected_ty_display}`, found `{provided_ty_display}`"
+                    ));
+                }
 
                 let error_context =
                     provided_ty.assignability_error_context(context.db(), *expected_ty);
@@ -7097,15 +7107,6 @@ impl<'db> BindingError<'db> {
 
                 if let Some(compound_diag) = compound_diag {
                     compound_diag.add_context(context.db(), &mut diag);
-                }
-
-                if matches!(
-                    provenance,
-                    InvalidArgumentTypeProvenance::OpenTypedDictExtraItems
-                ) {
-                    diag.info(
-                        "Possible extra items in the unpacked open `TypedDict` have type `object`",
-                    );
                 }
 
                 // If the type comes from first-party code, the user may have some control over

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4545,6 +4545,8 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
         self.assign_argument(
             argument_index,
             Argument::Keywords,
+            // TODO: Use the `TypedDict`'s extra-items type once PEP 728 is fully supported, and
+            // omit this match for closed `TypedDict`s.
             Some(Type::object()),
             InvalidArgumentTypeProvenance::OpenTypedDictExtraItems,
             parameter_index,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4482,6 +4482,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     name.as_str(),
                 );
             }
+            self.match_open_typed_dict_extra_items(argument_index);
         } else {
             for (parameter_index, parameter) in self.parameters.iter().enumerate() {
                 if self.parameter_info[parameter_index].matched && !parameter.is_keyword_variadic()
@@ -4520,6 +4521,26 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                 );
             }
         }
+    }
+
+    /// Match the possible hidden keyword arguments in an implicitly-open `TypedDict`.
+    ///
+    /// Hidden extra items can constrain an existing keyword-variadic parameter, but they should
+    /// not cause unknown-key errors when the destination has no `**kwargs`.
+    fn match_open_typed_dict_extra_items(&mut self, argument_index: usize) {
+        let Some((parameter_index, parameter)) = self.parameters.keyword_variadic() else {
+            return;
+        };
+
+        self.assign_argument(
+            argument_index,
+            Argument::Keywords,
+            Some(Type::object()),
+            parameter_index,
+            parameter,
+            false,
+            true,
+        );
     }
 
     fn finish(self) -> Box<[MatchedArgument<'db>]> {
@@ -4998,6 +5019,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             })
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn check_argument_type(
         &mut self,
         constraints: &ConstraintSetBuilder<'db>,
@@ -5006,6 +5028,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         argument: Argument<'a>,
         mut argument_type: Type<'db>,
         parameter_index: usize,
+        provenance: InvalidArgumentTypeProvenance,
     ) {
         let parameters = self.signature.parameters();
         let parameter = &parameters[parameter_index];
@@ -5045,6 +5068,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 argument_index: adjusted_argument_index,
                 expected_ty,
                 provided_ty: argument_type,
+                provenance,
             });
         }
         // We still update the actual type of the parameter in this binding to match the argument,
@@ -5183,6 +5207,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             argument,
                             argument_type,
                             *parameter_index,
+                            InvalidArgumentTypeProvenance::Argument,
                         );
                     }
                 }
@@ -5329,6 +5354,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 argument,
                 variadic_argument_type.unwrap_or_else(Type::unknown),
                 parameter_index,
+                InvalidArgumentTypeProvenance::Argument,
             );
         }
     }
@@ -5342,15 +5368,21 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         argument_type: Type<'db>,
         paramspec_component_start: Option<usize>,
     ) {
-        if let Some(unpacked_keys) =
-            extract_unpacked_typed_dict_keys_from_value_type(self.db, argument_type)
-        {
-            for (argument_type, parameter_index) in unpacked_keys
-                .values()
-                .map(|unpacked_key| unpacked_key.value_ty)
-                .zip(&self.argument_matches[argument_index].parameters)
+        if extract_unpacked_typed_dict_keys_from_value_type(self.db, argument_type).is_some() {
+            let open_extra_items_match_index = self.argument_matches[argument_index]
+                .parameters
+                .len()
+                .checked_sub(1)
+                .filter(|match_index| {
+                    let parameter_index =
+                        self.argument_matches[argument_index].parameters[*match_index];
+                    self.signature.parameters()[parameter_index].is_keyword_variadic()
+                });
+
+            for (match_index, (parameter_index, argument_type)) in
+                self.argument_matches[argument_index].iter().enumerate()
             {
-                if paramspec_component_start.is_some_and(|start| *parameter_index >= start) {
+                if paramspec_component_start.is_some_and(|start| parameter_index >= start) {
                     continue;
                 }
 
@@ -5359,8 +5391,13 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     argument_index,
                     adjusted_argument_index,
                     argument,
-                    argument_type,
-                    *parameter_index,
+                    argument_type.unwrap_or_else(Type::unknown),
+                    parameter_index,
+                    if open_extra_items_match_index == Some(match_index) {
+                        InvalidArgumentTypeProvenance::OpenTypedDictExtraItems
+                    } else {
+                        InvalidArgumentTypeProvenance::Argument
+                    },
                 );
             }
 
@@ -5414,6 +5451,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 Argument::Keywords,
                 value_type,
                 *parameter_index,
+                InvalidArgumentTypeProvenance::Argument,
             );
         }
     }
@@ -6696,6 +6734,12 @@ impl std::fmt::Display for ParameterContexts {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum InvalidArgumentTypeProvenance {
+    Argument,
+    OpenTypedDictExtraItems,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum BindingError<'db> {
     /// The type of an argument is not assignable to the annotated type of its corresponding
@@ -6705,6 +6749,7 @@ pub(crate) enum BindingError<'db> {
         argument_index: Option<usize>,
         expected_ty: Type<'db>,
         provided_ty: Type<'db>,
+        provenance: InvalidArgumentTypeProvenance,
     },
     /// The type of the keyword-variadic argument's key is not `str`.
     InvalidKeyType {
@@ -6940,6 +6985,7 @@ impl<'db> BindingError<'db> {
                 argument_index,
                 expected_ty,
                 provided_ty,
+                provenance,
             } => {
                 // Certain special forms in the typing module are aliases for classes
                 // elsewhere in the standard library. These special forms are not instances of `type`,
@@ -7052,6 +7098,15 @@ impl<'db> BindingError<'db> {
 
                 if let Some(compound_diag) = compound_diag {
                     compound_diag.add_context(context.db(), &mut diag);
+                }
+
+                if matches!(
+                    provenance,
+                    InvalidArgumentTypeProvenance::OpenTypedDictExtraItems
+                ) {
+                    diag.info(
+                        "Possible extra items in the unpacked open `TypedDict` have type `object`",
+                    );
                 }
 
                 // If the type comes from first-party code, the user may have some control over

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -615,9 +615,9 @@ impl<'db> CallSignatureDetails<'db> {
         let argument_to_displayed_parameter_mapping = argument_to_parameter_mapping
             .iter()
             .map(|mapping| {
-                mapping.parameters.iter().find_map(|parameter_index| {
+                mapping.parameters.iter().find_map(|parameter| {
                     parameter_to_displayed_parameter_mapping
-                        .get(*parameter_index)
+                        .get(parameter.index)
                         .copied()
                         .flatten()
                 })
@@ -873,9 +873,9 @@ fn argument_form_from_successful_binding(
 ) -> CallArgumentForm {
     if let Some(argument_match) = binding.argument_matches().get(argument_index)
         && argument_match.matched
-        && let [parameter_index] = argument_match.parameters.as_slice()
+        && let [parameter] = argument_match.parameters.as_slice()
     {
-        return match binding.signature.parameters()[*parameter_index].form {
+        return match binding.signature.parameters()[parameter.index].form {
             ParameterForm::Value => CallArgumentForm::Value,
             ParameterForm::Type => CallArgumentForm::Type,
         };
@@ -1221,11 +1221,11 @@ pub fn inlay_hint_call_argument_details<'db>(
             continue;
         }
 
-        let Some(param_index) = arg_mapping.parameters.first() else {
+        let Some(parameter) = arg_mapping.parameters.first() else {
             continue;
         };
 
-        let Some(param) = parameters.get(*param_index) else {
+        let Some(param) = parameters.get(parameter.index) else {
             continue;
         };
 


### PR DESCRIPTION
## Summary

Open `TypedDict` values can contain hidden extra items with value type `object`. This updates call binding to account for those possible values when a `**TypedDict` argument is matched against a keyword-variadic parameter, while continuing to ignore hidden items for callees without `**kwargs`.

This means calls like the following now reject the possible hidden extra items instead of only checking the declared keys:

```py
class Options(TypedDict):
    name: str

def accepts_ints(name: str, **kwargs: int) -> None: ...

accepts_ints(**Options(name="x"))  # Expected `int`, found `object`
```

The same implicit-open behavior also means `functools.partial(..., **typed_dict)` cannot be normalized to a precise reduced signature, because hidden extra items may bind additional keywords at runtime. We now fall back to the broad `partial[ReturnType]` form for those calls, matching Pyright for ordinary open `TypedDict`s.
