### PR TITLE
[ty] Pull in salsa-rs/salsa#1109 (NEVER_CHANGE durability)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,8 +3690,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfc1e32b8d1a486e3a45a5480fb5dca7912f49262a8916a67378064da4fe1ab"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=01ff127e70ec9fb267ed5a47cc7059acb87d50b2#01ff127e70ec9fb267ed5a47cc7059acb87d50b2"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3717,14 +3716,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dad477a3e3a484a7c2311c1d25160fb270214981be24022de7de8a206a3300"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=01ff127e70ec9fb267ed5a47cc7059acb87d50b2#01ff127e70ec9fb267ed5a47cc7059acb87d50b2"
 
 [[package]]
 name = "salsa-macros"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943f70e101fb3bd599960e79e719e70d85142730e5b45f3269246086ed218562"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=01ff127e70ec9fb267ed5a47cc7059acb87d50b2#01ff127e70ec9fb267ed5a47cc7059acb87d50b2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,7 +3690,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=01ff127e70ec9fb267ed5a47cc7059acb87d50b2#01ff127e70ec9fb267ed5a47cc7059acb87d50b2"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=0b1d46c734722c9e128bbe582b14d2350778f99e#0b1d46c734722c9e128bbe582b14d2350778f99e"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3716,12 +3716,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=01ff127e70ec9fb267ed5a47cc7059acb87d50b2#01ff127e70ec9fb267ed5a47cc7059acb87d50b2"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=0b1d46c734722c9e128bbe582b14d2350778f99e#0b1d46c734722c9e128bbe582b14d2350778f99e"
 
 [[package]]
 name = "salsa-macros"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=01ff127e70ec9fb267ed5a47cc7059acb87d50b2#01ff127e70ec9fb267ed5a47cc7059acb87d50b2"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=0b1d46c734722c9e128bbe582b14d2350778f99e#0b1d46c734722c9e128bbe582b14d2350778f99e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,8 +158,8 @@ regex-automata = { version = "0.4.9" }
 regex-syntax = { version = "0.8.8" }
 rustc-hash = { version = "2.0.0" }
 rustc-stable-hash = { version = "0.1.2" }
-# When updating salsa, make sure to also update the version in `fuzz/Cargo.toml`
-salsa = { version = "0.27.0", default-features = false, features = [
+# When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "01ff127e70ec9fb267ed5a47cc7059acb87d50b2", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ regex-syntax = { version = "0.8.8" }
 rustc-hash = { version = "2.0.0" }
 rustc-stable-hash = { version = "0.1.2" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "01ff127e70ec9fb267ed5a47cc7059acb87d50b2", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "0b1d46c734722c9e128bbe582b14d2350778f99e", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -144,7 +144,7 @@ impl Files {
                 let file = File::builder(FilePath::Vendored(path.to_path_buf()))
                     .permissions(Some(0o444))
                     .revision(metadata.revision())
-                    .durability(Durability::HIGH)
+                    .durability(Durability::NEVER_CHANGE)
                     .new(db);
 
                 entry.insert(file);

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,7 +33,7 @@ ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { version = "0.27.0", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "01ff127e70ec9fb267ed5a47cc7059acb87d50b2", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,7 +33,7 @@ ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "01ff127e70ec9fb267ed5a47cc7059acb87d50b2", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "0b1d46c734722c9e128bbe582b14d2350778f99e", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",


### PR DESCRIPTION
## Summary

Pin Salsa to [salsa-rs/salsa#1109](https://github.com/salsa-rs/salsa/pull/1109).


What's interesting is that this not only helps with vendored files. It also helps with queries that operate on types. E.g. answering whether two types are redundant never changes. We don't need to read any inputs in that query. 

Changing the durability for `VendoredFile`'s doesn't give us that much, because `pased_module` reads `Program::python_version` which only has durability high :(

So this optimization works very much not because of the reason I thought it would
