### PR TITLE
[ty] Remove loop-header precision caps

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -1603,15 +1603,13 @@ for _ in range(1_000_000):
         x = 2
 ```
 
-### Large reachability constraint graphs fall back to `Unknown`
+### Large reachability constraint graphs preserve exact loop-header types
 
 ```py
 def f(items, flags):
     x = 1
     for item in items:
-        # This example is just over the exact loop-header reachability cutoff. If it falls
-        # below the cutoff, this line reveals `Literal[1, 2]`.
-        reveal_type(x)  # revealed: Literal[1] | Unknown
+        reveal_type(x)  # revealed: Literal[1, 2]
         if flags[200]:
             x = 2
     for item0 in items:

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -18,9 +18,7 @@ use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::narrowing_constraints::ScopedNarrowingConstraint;
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::predicate::{Predicate, ScopedPredicateId};
-use ty_python_core::reachability_constraints::{
-    ReachabilityConstraints, ScopedReachabilityConstraintId,
-};
+use ty_python_core::reachability_constraints::ReachabilityConstraints;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{
     BindingWithConstraints, BindingWithConstraintsIterator, BoundnessAnalysis,
@@ -1218,10 +1216,6 @@ fn loop_header_reachability_impl<'db>(
     definition: Definition<'db>,
     is_cycle_initial: bool,
 ) -> LoopHeaderReachability<'db> {
-    // This cutoff was chosen by benchmarking real isort to keep loop analysis
-    // overhead minimal while preserving diagnostics.
-    const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 2048;
-
     let DefinitionKind::LoopHeader(loop_header_definition) = definition.kind(db) else {
         unreachable!("`loop_header_reachability` called with non-loop-header definition");
     };
@@ -1234,20 +1228,12 @@ fn loop_header_reachability_impl<'db>(
     let mut deleted_reachability = Truthiness::AlwaysFalse;
     let mut reachable_bindings = FxIndexSet::default();
     let live_bindings: Vec<_> = loop_header.bindings_for_place(place).collect();
-    let use_exact_reachability = use_def.reachability_constraints().used_interiors().len()
-        <= MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES;
 
     for live_binding in live_bindings {
         let reachability = if is_cycle_initial {
             Truthiness::Ambiguous
-        } else if use_exact_reachability {
-            evaluate_reachability(db, use_def, live_binding.reachability_constraint())
-        } else if live_binding.reachability_constraint()
-            == ScopedReachabilityConstraintId::ALWAYS_FALSE
-        {
-            Truthiness::AlwaysFalse
         } else {
-            Truthiness::Ambiguous
+            evaluate_reachability(db, use_def, live_binding.reachability_constraint())
         };
         // Skip unreachable bindings.
         if reachability.is_always_false() {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2083,25 +2083,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         loop_header_kind: &LoopHeaderDefinitionKind<'db>,
         definition: Definition<'db>,
     ) {
-        // This cutoff was chosen by benchmarking real isort to keep loop analysis
-        // overhead minimal while preserving diagnostics.
-        const MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES: usize = 4096;
-
         let db = self.db();
         let loop_header = loop_header_reachability(db, definition);
         let use_def = self
             .index
             .use_def_map(self.scope().file_scope_id(self.db()));
-
-        // Loop-header types are an approximation point for loop fixpoint analysis. Inferring the
-        // exact union of every visible loop-back binding can recursively force inference of large
-        // boolean expressions and explode on real-world loops.
-        if use_def.reachability_constraints().used_interiors().len()
-            > MAX_EXACT_LOOP_HEADER_REACHABILITY_NODES
-        {
-            self.bindings.insert(definition, Type::unknown());
-            return;
-        }
 
         let place = loop_header_kind.place();
 


### PR DESCRIPTION
This is a control PR for #25616. It removes the existing loop-header reachability and type-inference cutoffs without adding the bounded analysis, batching, or caching from that PR.

The goal is to compare the ecosystem and timing results and separate changes inherent to exact loop-header analysis from changes caused by the implementation in #25616.