### PR TITLE
Preserve whitespace for Quarto cell option comments

### DIFF
--- a/crates/ruff/tests/cli/format.rs
+++ b/crates/ruff/tests/cli/format.rs
@@ -2514,6 +2514,44 @@ fn markdown_formatting_stdin() -> Result<()> {
 }
 
 #[test]
+fn markdown_formatting_quarto_cell_option() -> Result<()> {
+    let test = CliTest::with_files([
+        ("ruff.toml", r#"extension = {qmd="markdown"}"#),
+        (
+            "test.qmd",
+            r#"```{python}
+#| echo: true
+print( 'hello' )
+```
+"#,
+        ),
+    ])?;
+
+    assert_cmd_snapshot!(
+        test.format_command().args(["--preview", "--diff", "test.qmd"]),
+        @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    --- test.qmd
+    +++ test.qmd
+    @@ -1,4 +1,4 @@
+     ```{python}
+     #| echo: true
+    -print( 'hello' )
+    +print("hello")
+     ```
+
+
+    ----- stderr -----
+    1 file would be reformatted
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
 fn format_mapped_extension_files() -> Result<()> {
     let test = CliTest::with_files([
         (

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/comment_prefixes.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/comment_prefixes.py
@@ -1,0 +1,8 @@
+# Comments are normalized by inserting a single leading space after the `#`,
+# unless they start with one of a few special characters. Those are preserved
+# verbatim so that tooling relying on a specific prefix keeps working.
+
+#! shebang-style comments are left as-is
+#: Sphinx-style comments are left as-is
+#' pweave-style comments are left as-is
+#| Quarto cell options are left as-is

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -292,7 +292,7 @@ impl Format<PyFormatContext<'_>> for FormatDanglingOpenParenthesisComments<'_> {
 
 /// Formats the content of the passed comment.
 ///
-/// * Adds a whitespace between `#` and the comment text except if the first character is a `#`, `:`, `'`, or `!`
+/// * Adds a whitespace between `#` and the comment text except if the first character is a `#`, `:`, `'`, `!`, or `|`
 /// * Replaces non breaking whitespaces with regular whitespaces except if in front of a `types:` comment
 pub(crate) const fn format_comment(comment: &SourceComment) -> FormatComment<'_> {
     FormatComment { comment }

--- a/crates/ruff_python_formatter/src/comments/format.rs
+++ b/crates/ruff_python_formatter/src/comments/format.rs
@@ -491,7 +491,7 @@ fn normalize_comment<'a>(
     // Fast path for correctly formatted comments: if the comment starts with a space, or any
     // of the allowed characters, then it's included verbatim (apart for trimming any trailing
     // whitespace).
-    if content.starts_with([' ', '!', ':', '#', '\'']) {
+    if content.starts_with([' ', '!', ':', '#', '\'', '|']) {
         return Ok(Cow::Borrowed(trimmed));
     }
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@comment_prefixes.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@comment_prefixes.py.snap
@@ -1,0 +1,27 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/comment_prefixes.py
+---
+## Input
+```python
+# Comments are normalized by inserting a single leading space after the `#`,
+# unless they start with one of a few special characters. Those are preserved
+# verbatim so that tooling relying on a specific prefix keeps working.
+
+#! shebang-style comments are left as-is
+#: Sphinx-style comments are left as-is
+#' pweave-style comments are left as-is
+#| Quarto cell options are left as-is
+```
+
+## Output
+```python
+# Comments are normalized by inserting a single leading space after the `#`,
+# unless they start with one of a few special characters. Those are preserved
+# verbatim so that tooling relying on a specific prefix keeps working.
+
+#! shebang-style comments are left as-is
+#: Sphinx-style comments are left as-is
+#' pweave-style comments are left as-is
+#| Quarto cell options are left as-is
+```


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Part of https://github.com/astral-sh/ruff/issues/6140, which is nicely summarized into 2 parts here https://github.com/astral-sh/ruff/issues/6140#issuecomment-2542241472

I saw that you all now support formatting markdown files (https://github.com/astral-sh/ruff/pull/22470) and can support `.qmd` via some user configuration (https://github.com/astral-sh/ruff/pull/23218, https://github.com/astral-sh/ruff/pull/23384, https://github.com/astral-sh/ruff/pull/23572).

Since ruff can now directly format a `.qmd`, I thought it would be nice if this bug was fixed:

With `ruff.toml` of:

```toml
extension = { qmd = "markdown" }
```

`test.qmd`:

``````
This is my qmd


```{python}
#| echo: true

1 + 1
```
``````

A call to `ruff format test.qmd --preview` results in

``````
This is my qmd


```{python}
# | echo: true

1 + 1
```
``````

Note how the special quarto code cell directive `#|` became `# |`.

Note this would diverge from black's behavior. There was a request to change this in black, but it was closed https://github.com/psf/black/issues/3557. But I'm hoping that the fact that ruff can support qmds directly may make this compelling enough for ruff to diverge?

## Test Plan

Added a new snapshot test file.

Note the the black compatibility file `comments.py` does exist already, but it did not feel appropriate to add this there.
