### PR TITLE
[ty] Reuse expression cache for TypedDict union inference

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1248,6 +1248,62 @@ fn benchmark_pandas_tdd(criterion: &mut Criterion) {
     });
 }
 
+fn benchmark_recursive_typed_dict_union_contextual_inference(criterion: &mut Criterion) {
+    const NUM_BRANCHES: usize = 11;
+
+    setup_rayon();
+
+    // Regression benchmark for https://github.com/astral-sh/ty/issues/3663.
+    let mut code = "from typing import Literal, TypedDict\n\n".to_string();
+    for i in 0..NUM_BRANCHES {
+        writeln!(
+            &mut code,
+            "class Node{i}(TypedDict):\n    type: Literal['node-{i}']\n    children: list['Node']\n"
+        )
+        .ok();
+    }
+    code.push_str("class Leaf(TypedDict):\n    type: Literal['leaf']\n    text: str\n\n");
+    code.push_str("type Node = ");
+    for i in 0..NUM_BRANCHES {
+        if i > 0 {
+            code.push_str(" | ");
+        }
+        write!(&mut code, "Node{i}").ok();
+    }
+    code.push_str(
+        r#" | Leaf
+
+value: list[Node] = [
+    {"type": "node-0", "children": [
+        {"type": "node-1", "children": [
+            {"type": "node-2", "children": [{"type": "leaf", "text": "x"}]},
+            {"type": "node-3", "children": [{"type": "leaf", "text": "y"}]},
+        ]},
+        {"type": "node-4", "children": [
+            {"type": "node-5", "children": [{"type": "leaf", "text": "z"}]},
+            {"type": "node-6", "children": [{"type": "leaf", "text": "w"}]},
+        ]},
+    ]},
+]
+"#,
+    );
+
+    criterion.bench_function(
+        "ty_micro[recursive_typed_dict_union_contextual_inference]",
+        |b| {
+            b.iter_batched_ref(
+                || setup_micro_case(&code),
+                |case| {
+                    let Case { db, .. } = case;
+                    let result = db.check();
+                    assert_eq!(result.len(), 0);
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
 fn benchmark_pydantic_core_schema_dict(criterion: &mut Criterion) {
     const NUM_CORE_SCHEMA_VARIANTS: usize = 24;
 
@@ -1469,6 +1525,7 @@ criterion_group!(
     benchmark_literal_equality_fallthrough_guarded_any,
     benchmark_typeis_narrowing,
     benchmark_pandas_tdd,
+    benchmark_recursive_typed_dict_union_contextual_inference,
     benchmark_pydantic_core_schema_dict,
 );
 criterion_group!(project, anyio, attrs, hydra, datetype);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6604,6 +6604,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     let mut narrowed_tys = Vec::new();
                     let mut item_types = FxHashMap::default();
+                    // Reuse nested expressions that receive the same field context across candidates.
+                    let teardown = self.setup_expression_cache();
                     for typed_dict in typed_dicts {
                         // Disable diagnostics as we attempt to narrow to specific `TypedDict`
                         // elements of the union. Mixed unions like `TypedDict | dict[str, Any]`
@@ -6618,6 +6620,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }
 
                         item_types.clear();
+                    }
+                    if teardown {
+                        self.teardown_expression_cache();
                     }
 
                     // Successfully narrowed to a subset of typed dicts.


### PR DESCRIPTION
## Summary

When contextually checking a dictionary literal against a union of TypedDicts, we speculatively infer the literal once for each candidate. Recursive fields often give the same nested expression the same type context for every candidate, causing us to repeat the entire nested inference at every level...

This reuses our existing shared expression cache across the candidate checks. We already use the same mechanism during generic-call multi-inference.

The linked issue drops from roughly 1.5s to 0.03s locally.

Closes https://github.com/astral-sh/ty/issues/3663.
