### PR TITLE
[ty] Content address the cache of vendored content that ships with ty

### DIFF
--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -343,8 +343,7 @@ impl HasNavigationTargets for TypeDefinition<'_> {
 
 /// Get the cache-relative path where vendored paths should be written to.
 pub fn relative_cached_vendored_root() -> SystemPathBuf {
-    // The vendored files are uniquely identified by the source commit.
-    SystemPathBuf::from(format!("vendored/typeshed/{}", ty_vendored::SOURCE_COMMIT))
+    SystemPathBuf::from(format!("vendored/typeshed/{}", ty_vendored::cache_key()))
 }
 
 /// Get the cached version of a vendored path in the cache, ensuring the file is written to disk.
@@ -413,12 +412,25 @@ mod tests {
     use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
     use ty_python_semantic::PythonVersionWithSource;
 
+    use crate::relative_cached_vendored_root;
+
     /// A way to create a simple single-file (named `main.py`) cursor test.
     ///
     /// Use cases that require multiple files with a `<CURSOR>` marker
     /// in a file other than `main.py` can use `CursorTest::builder()`.
     pub(super) fn cursor_test(source: &str) -> CursorTest {
         CursorTest::builder().source("main.py", source).build()
+    }
+
+    #[test]
+    fn cached_vendored_root_includes_content_hash() {
+        let cache_root = relative_cached_vendored_root();
+
+        assert_eq!(
+            cache_root.as_str(),
+            format!("vendored/typeshed/{}", ty_vendored::cache_key())
+        );
+        assert_eq!(ty_vendored::cache_key().len(), 16);
     }
 
     pub(super) struct CursorTest {

--- a/crates/ty_vendored/build.rs
+++ b/crates/ty_vendored/build.rs
@@ -3,9 +3,10 @@
 //!
 //! This script should be automatically run at build time
 //! whenever the script itself changes, or whenever any files
-//! in `crates/ty_vendored/vendor/typeshed` change.
+//! in `crates/ty_vendored/vendor/typeshed` or
+//! `crates/ty_vendored/ty_extensions` change.
 
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
 
@@ -16,15 +17,19 @@ use zip::write::{FileOptions, ZipWriter};
 
 const TYPESHED_SOURCE_DIR: &str = "vendor/typeshed";
 const TY_EXTENSIONS_STUBS: &str = "ty_extensions/ty_extensions.pyi";
+const TY_EXTENSIONS_ARCHIVE_PATH: &str = "stdlib/ty_extensions.pyi";
+const TY_EXTENSIONS_VERSION_ENTRY: &[u8] = b"ty_extensions: 3.0-\n";
 const TYPESHED_ZIP_LOCATION: &str = "/zipped_typeshed.zip";
+const VENDORED_CACHE_KEY_LOCATION: &str = "/vendored_cache_key.txt";
 
 /// Recursively zip the contents of the entire typeshed directory and patch typeshed
 /// on the fly to include the `ty_extensions` module.
 ///
 /// This routine is adapted from a recipe at
 /// <https://github.com/zip-rs/zip-old/blob/5d0f198124946b7be4e5969719a7f29f363118cd/examples/write_dir.rs>
-fn write_zipped_typeshed_to(writer: File) -> ZipResult<File> {
+fn write_zipped_typeshed_to(writer: File) -> ZipResult<u64> {
     let mut zip = ZipWriter::new(writer);
+    let mut content_hash = StableContentHasher::new();
 
     // Use deflated compression for WASM builds because compiling `zstd-sys` requires clang
     // [source](https://github.com/gyscos/zstd-rs/wiki/Compile-for-WASM) which complicates the build
@@ -45,45 +50,104 @@ fn write_zipped_typeshed_to(writer: File) -> ZipResult<File> {
         .compression_method(method)
         .unix_permissions(0o644);
 
-    for entry in walkdir::WalkDir::new(TYPESHED_SOURCE_DIR) {
+    for entry in walkdir::WalkDir::new(TYPESHED_SOURCE_DIR).sort_by_file_name() {
         let dir_entry = entry.unwrap();
-        let absolute_path = dir_entry.path();
-        let normalized_relative_path = absolute_path
+        let source_path = dir_entry.path();
+        let normalized_relative_path = source_path
             .strip_prefix(Path::new(TYPESHED_SOURCE_DIR))
             .unwrap()
             .to_slash()
             .expect("Unexpected non-utf8 typeshed path!");
 
-        // Write file or directory explicitly
-        // Some unzip tools unzip files with directory paths correctly, some do not!
-        if absolute_path.is_file() {
-            println!("adding file {absolute_path:?} as {normalized_relative_path:?} ...");
-            zip.start_file(&*normalized_relative_path, options)?;
-            let mut f = File::open(absolute_path)?;
-            std::io::copy(&mut f, &mut zip).unwrap();
+        if normalized_relative_path.is_empty() {
+            continue;
+        }
 
-            // Patch the VERSIONS file to make `ty_extensions` available
+        if source_path.is_file() {
+            println!("adding file {source_path:?} as {normalized_relative_path:?} ...");
+
+            let mut contents = fs::read(source_path)?;
             if normalized_relative_path == "stdlib/VERSIONS" {
-                writeln!(&mut zip, "ty_extensions: 3.0-")?;
+                contents.extend_from_slice(TY_EXTENSIONS_VERSION_ENTRY);
             }
-        } else if !normalized_relative_path.is_empty() {
-            // Only if not root! Avoids path spec / warning
-            // and mapname conversion failed error on unzip
-            println!("adding dir {absolute_path:?} as {normalized_relative_path:?} ...");
-            zip.add_directory(normalized_relative_path, options)?;
+
+            zip.start_file(&*normalized_relative_path, options)?;
+            zip.write_all(&contents)?;
+            content_hash.add_file(&normalized_relative_path, &contents);
+        } else {
+            // Write directories explicitly. Some unzip tools unzip files with directory
+            // paths correctly, and some do not.
+            let archive_path = format!("{normalized_relative_path}/");
+            println!("adding dir {archive_path:?} ...");
+            zip.add_directory(&archive_path, options)?;
+            content_hash.add_directory(&archive_path);
         }
     }
 
     // Patch typeshed and add the stubs for the `ty_extensions` module
-    println!("adding file {TY_EXTENSIONS_STUBS} as stdlib/ty_extensions.pyi ...");
-    zip.start_file("stdlib/ty_extensions.pyi", options)?;
-    let mut f = File::open(TY_EXTENSIONS_STUBS)?;
-    std::io::copy(&mut f, &mut zip).unwrap();
+    println!("adding file {TY_EXTENSIONS_STUBS} as {TY_EXTENSIONS_ARCHIVE_PATH} ...");
+    let ty_extensions = fs::read(TY_EXTENSIONS_STUBS)?;
+    zip.start_file(TY_EXTENSIONS_ARCHIVE_PATH, options)?;
+    zip.write_all(&ty_extensions)?;
+    content_hash.add_file(TY_EXTENSIONS_ARCHIVE_PATH, &ty_extensions);
 
-    zip.finish()
+    zip.finish()?;
+
+    Ok(content_hash.finish())
+}
+
+struct StableContentHasher {
+    hash: u64,
+}
+
+impl StableContentHasher {
+    fn new() -> Self {
+        let mut hasher = Self {
+            hash: 0xcbf2_9ce4_8422_2325,
+        };
+        hasher.update(b"ty-vendored-content-v1");
+        hasher
+    }
+
+    fn add_file(&mut self, path: &str, contents: &[u8]) {
+        self.update(b"file");
+        self.update_str(path);
+        self.update_len(contents.len());
+        self.update(contents);
+    }
+
+    fn add_directory(&mut self, path: &str) {
+        self.update(b"dir");
+        self.update_str(path);
+    }
+
+    fn finish(self) -> u64 {
+        self.hash
+    }
+
+    fn update_str(&mut self, value: &str) {
+        self.update_len(value.len());
+        self.update(value.as_bytes());
+    }
+
+    fn update_len(&mut self, len: usize) {
+        let len = u64::try_from(len).expect("vendored content length should fit in u64");
+        self.update(&len.to_le_bytes());
+    }
+
+    fn update(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.hash ^= u64::from(*byte);
+            self.hash = self.hash.wrapping_mul(0x0100_0000_01b3);
+        }
+    }
 }
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed={TYPESHED_SOURCE_DIR}");
+    println!("cargo:rerun-if-changed={TY_EXTENSIONS_STUBS}");
+
     assert!(
         Path::new(TYPESHED_SOURCE_DIR).is_dir(),
         "Where is typeshed?"
@@ -99,5 +163,12 @@ fn main() {
     let zipped_typeshed_location = format!("{out_dir}{TYPESHED_ZIP_LOCATION}");
 
     let zipped_typeshed_file = File::create(zipped_typeshed_location).unwrap();
-    write_zipped_typeshed_to(zipped_typeshed_file).unwrap();
+    let content_hash = write_zipped_typeshed_to(zipped_typeshed_file).unwrap();
+
+    let vendored_cache_key_location = format!("{out_dir}{VENDORED_CACHE_KEY_LOCATION}");
+    fs::write(
+        vendored_cache_key_location,
+        format!("{content_hash:016x}\n"),
+    )
+    .unwrap();
 }

--- a/crates/ty_vendored/src/lib.rs
+++ b/crates/ty_vendored/src/lib.rs
@@ -15,6 +15,20 @@ static_assertions::const_assert_eq!(SOURCE_COMMIT.len(), 40);
 // Luckily this crate will fail to build if this file isn't available at build time.
 static TYPESHED_ZIP_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/zipped_typeshed.zip"));
 
+// The file path here is hardcoded in this crate's `build.rs` script.
+// Luckily this crate will fail to build if this file isn't available at build time.
+const VENDORED_CACHE_KEY: &str =
+    include_str!(concat!(env!("OUT_DIR"), "/vendored_cache_key.txt")).trim_ascii_end();
+
+/// Returns the version key for the vendored stubs.
+///
+/// Ruff patches and adds custom files to the vendored typeshed archive. Those
+/// files can change independently from the upstream typeshed source commit, so
+/// include the final generated vendored content in the cache key.
+pub fn cache_key() -> &'static str {
+    VENDORED_CACHE_KEY
+}
+
 pub fn file_system() -> &'static VendoredFileSystem {
     static VENDORED_TYPESHED_STUBS: LazyLock<VendoredFileSystem> =
         LazyLock::new(|| VendoredFileSystem::new_static(TYPESHED_ZIP_BYTES).unwrap());
@@ -29,6 +43,9 @@ mod tests {
     use ruff_db::vendored::VendoredPath;
 
     use super::*;
+
+    const TY_EXTENSIONS_STUBS: &str = "ty_extensions/ty_extensions.pyi";
+    const TY_EXTENSIONS_ARCHIVE_PATH: &str = "stdlib/ty_extensions.pyi";
 
     #[test]
     fn typeshed_zip_created_at_build_time() {
@@ -46,6 +63,46 @@ mod tests {
             .unwrap();
 
         assert!(functools_module_stub_source.contains("def update_wrapper("));
+    }
+
+    #[test]
+    fn typeshed_zip_includes_build_time_patches() {
+        let mut typeshed_zip_archive =
+            zip::ZipArchive::new(io::Cursor::new(TYPESHED_ZIP_BYTES)).unwrap();
+
+        {
+            let mut versions = typeshed_zip_archive.by_name("stdlib/VERSIONS").unwrap();
+            let mut versions_source = String::new();
+            versions.read_to_string(&mut versions_source).unwrap();
+
+            assert!(
+                versions_source
+                    .lines()
+                    .any(|line| line == "ty_extensions: 3.0-")
+            );
+        }
+
+        {
+            let mut ty_extensions = typeshed_zip_archive
+                .by_name(TY_EXTENSIONS_ARCHIVE_PATH)
+                .unwrap();
+            let mut ty_extensions_source = Vec::new();
+            ty_extensions
+                .read_to_end(&mut ty_extensions_source)
+                .unwrap();
+
+            assert_eq!(
+                ty_extensions_source,
+                std::fs::read(TY_EXTENSIONS_STUBS).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn cache_key_includes_generated_vendored_content() {
+        let generated_content_hash = generated_vendored_content_hash();
+
+        assert_eq!(cache_key(), format!("{generated_content_hash:016x}"));
     }
 
     #[test]
@@ -104,5 +161,73 @@ mod tests {
             !empty_iterator,
             "Expected there to be at least one file or directory in the vendored typeshed stubs!"
         );
+    }
+
+    fn generated_vendored_content_hash() -> u64 {
+        let mut typeshed_zip_archive =
+            zip::ZipArchive::new(io::Cursor::new(TYPESHED_ZIP_BYTES)).unwrap();
+        let mut content_hash = StableContentHasher::new();
+
+        for index in 0..typeshed_zip_archive.len() {
+            let mut entry = typeshed_zip_archive.by_index(index).unwrap();
+            let archive_path = entry.name().to_string();
+
+            if entry.is_dir() {
+                content_hash.add_directory(&archive_path);
+            } else {
+                let mut contents = Vec::new();
+                entry.read_to_end(&mut contents).unwrap();
+                content_hash.add_file(&archive_path, &contents);
+            }
+        }
+
+        content_hash.finish()
+    }
+
+    struct StableContentHasher {
+        hash: u64,
+    }
+
+    impl StableContentHasher {
+        fn new() -> Self {
+            let mut hasher = Self {
+                hash: 0xcbf2_9ce4_8422_2325,
+            };
+            hasher.update(b"ty-vendored-content-v1");
+            hasher
+        }
+
+        fn add_file(&mut self, path: &str, contents: &[u8]) {
+            self.update(b"file");
+            self.update_str(path);
+            self.update_len(contents.len());
+            self.update(contents);
+        }
+
+        fn add_directory(&mut self, path: &str) {
+            self.update(b"dir");
+            self.update_str(path);
+        }
+
+        fn finish(self) -> u64 {
+            self.hash
+        }
+
+        fn update_str(&mut self, value: &str) {
+            self.update_len(value.len());
+            self.update(value.as_bytes());
+        }
+
+        fn update_len(&mut self, len: usize) {
+            let len = u64::try_from(len).expect("vendored content length should fit in u64");
+            self.update(&len.to_le_bytes());
+        }
+
+        fn update(&mut self, bytes: &[u8]) {
+            for byte in bytes {
+                self.hash ^= u64::from(*byte);
+                self.hash = self.hash.wrapping_mul(0x0100_0000_01b3);
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This generates the vendored content cache key from the final archive contents, including the ty_extensions overlay and build-time `VERSIONS` patch. Use that key for language server vendored file extraction so stale cached stubs are not reused when vendored content changes without a typeshed source commit bump.

Closes https://github.com/astral-sh/ty/issues/3669.

## Test Plan

Please see included tests.
<!-- How was it tested? -->
