### PR TITLE
[ty] Preserve literal promotion for mixed bounds

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -617,6 +617,14 @@ def h(x: TI) -> list[TI]:
     return [x]
 
 reveal_type(h(1))  # revealed: list[int]
+
+# An unrelated Literal union element should not prevent promotion when the
+# promoted type still satisfies another element of the upper bound.
+def i[T: Literal[1] | str](x: T) -> list[T]:
+    return [x]
+
+reveal_type(i("a"))  # revealed: list[str]
+reveal_type(i(1))  # revealed: list[Literal[1]]
 ```
 
 ## Literal annotations from declaration are respected

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5932,10 +5932,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Avoid promoting explicitly annotated literal values.
         if let Type::LiteralValue(literal) = ty
             && let Some(tcx) = tcx.annotation
-            && let Type::Union(_) | Type::LiteralValue(_) = tcx
+            && let literal_tcx @ (Type::Union(_) | Type::LiteralValue(_)) = tcx
                 .resolve_type_alias(self.db())
                 .filter_union(self.db(), |ty| ty.as_literal_value().is_some())
-            && ty.is_assignable_to(self.db(), tcx)
+            && ty.is_assignable_to(self.db(), literal_tcx)
         {
             ty = Type::LiteralValue(literal.to_unpromotable());
         }


### PR DESCRIPTION
## Summary

When inferring a literal against a union containing `Literal` and non-literal elements, we incorrectly preserved the literal whenever it matched any element of the union.

```python
def f[T: Literal[1] | str](x: T) -> list[T]: ...

reveal_type(f("a"))  # list[str]
reveal_type(f(1))    # list[Literal[1]]
```

We now mark a literal as unpromotable only when it matches the literal portion of the type context.

Closes https://github.com/astral-sh/ty/issues/3665.
