### PR TITLE
[ty] Avoid caching missing implicit attributes

### DIFF
--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2084,7 +2084,8 @@ impl<'db> StaticClassLiteral<'db> {
         name: &str,
         target_method_decorator: MethodDecorator,
     ) -> Member<'db> {
-        // Avoid retaining tracked-query entries for names that no method can define.
+        // Keep the file-wide semantic-index dependency behind an equality-comparable tracked
+        // result, and avoid retaining tracked-query entries for names that no method can define.
         if implicit_attribute_names(db, class_body_scope)
             .binary_search_by(|candidate| candidate.as_str().cmp(name))
             .is_err()

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2084,6 +2084,18 @@ impl<'db> StaticClassLiteral<'db> {
         name: &str,
         target_method_decorator: MethodDecorator,
     ) -> Member<'db> {
+        // Avoid retaining tracked-query entries for names that no method can define.
+        let index = semantic_index(db, class_body_scope.file(db));
+        let has_attribute = attribute_scopes(db, class_body_scope).any(|function_scope_id| {
+            index
+                .place_table(function_scope_id)
+                .member_id_by_instance_attribute_name(name)
+                .is_some()
+        });
+        if !has_attribute {
+            return Member::unbound();
+        }
+
         Self::implicit_attribute_inner(
             db,
             class_body_scope,

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2084,8 +2084,8 @@ impl<'db> StaticClassLiteral<'db> {
         name: &str,
         target_method_decorator: MethodDecorator,
     ) -> Member<'db> {
-        // Keep the file-wide semantic-index dependency behind an equality-comparable tracked
-        // result, and avoid retaining tracked-query entries for names that no method can define.
+        // Collect names in a tracked query so unrelated edits can preserve dependent member
+        // lookups, and avoid retaining query entries for names that no method can define.
         if implicit_attribute_names(db, class_body_scope)
             .binary_search_by(|candidate| candidate.as_str().cmp(name))
             .is_err()

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2085,14 +2085,10 @@ impl<'db> StaticClassLiteral<'db> {
         target_method_decorator: MethodDecorator,
     ) -> Member<'db> {
         // Avoid retaining tracked-query entries for names that no method can define.
-        let index = semantic_index(db, class_body_scope.file(db));
-        let has_attribute = attribute_scopes(db, class_body_scope).any(|function_scope_id| {
-            index
-                .place_table(function_scope_id)
-                .member_id_by_instance_attribute_name(name)
-                .is_some()
-        });
-        if !has_attribute {
+        if implicit_attribute_names(db, class_body_scope)
+            .binary_search_by(|candidate| candidate.as_str().cmp(name))
+            .is_err()
+        {
             return Member::unbound();
         }
 
@@ -3021,6 +3017,25 @@ fn explicit_bases_cycle_fn<'db>(
         // unfortunate, but maybe only pathological programs can trigger such a thing.
         current
     }
+}
+
+#[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
+fn implicit_attribute_names<'db>(db: &'db dyn Db, class_body_scope: ScopeId<'db>) -> Box<[Name]> {
+    let index = semantic_index(db, class_body_scope.file(db));
+    let mut names = Vec::new();
+
+    for function_scope_id in attribute_scopes(db, class_body_scope) {
+        names.extend(
+            index
+                .place_table(function_scope_id)
+                .members()
+                .filter_map(|member| member.as_instance_attribute().map(Name::new)),
+        );
+    }
+
+    names.sort_unstable();
+    names.dedup();
+    names.into_boxed_slice()
 }
 
 fn implicit_attribute_cycle_recover<'db>(

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -7,7 +7,6 @@ use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::DbWithWritableSystem as _;
 use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
-use salsa::Database as _;
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::FileScopeId;
 use ty_python_core::{global_scope, place_table, semantic_index, use_def_map};
@@ -470,110 +469,6 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
     };
 
     assert_function_query_was_not_run(
-        &db,
-        infer_expression_types_impl,
-        InferExpression::Bare(x_rhs_expression(&db)),
-        &events,
-    );
-
-    Ok(())
-}
-
-#[test]
-fn dependency_missing_implicit_instance_attribute() -> anyhow::Result<()> {
-    fn x_rhs_expression(db: &TestDb) -> Expression<'_> {
-        let file_main = system_path_to_file(db, "/src/main.py").unwrap();
-        let ast = parsed_module(db, file_main).load(db);
-        let x_rhs_node = &ast.syntax().body[1].as_assign_stmt().unwrap().value;
-
-        let index = semantic_index(db, file_main);
-        index.expression(x_rhs_node.as_ref())
-    }
-
-    let mut db = setup_db();
-
-    db.write_dedented(
-        "/src/mod.py",
-        r#"
-        class C:
-            def f(self):
-                pass
-        "#,
-    )?;
-    db.write_dedented(
-        "/src/main.py",
-        r#"
-        from mod import C
-        x = y = C().attr
-        "#,
-    )?;
-
-    let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
-    let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-    assert_eq!(attr_ty.display(&db).to_string(), "Unknown");
-
-    db.write_dedented(
-        "/src/mod.py",
-        r#"
-        class C:
-            def f(self):
-                # a comment!
-                pass
-        "#,
-    )?;
-
-    let events = {
-        db.clear_salsa_events();
-        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-        assert_eq!(attr_ty.display(&db).to_string(), "Unknown");
-        db.take_salsa_events()
-    };
-
-    assert_function_query_was_not_run(
-        &db,
-        infer_expression_types_impl,
-        InferExpression::Bare(x_rhs_expression(&db)),
-        &events,
-    );
-    let executed_queries = events
-        .iter()
-        .filter_map(|event| {
-            let salsa::EventKind::WillExecute { database_key } = event.kind else {
-                return None;
-            };
-            Some(db.ingredient_debug_name(database_key.ingredient_index()))
-        })
-        .collect::<Vec<_>>();
-    assert!(
-        !executed_queries
-            .iter()
-            .any(|query| query.contains("member_lookup_with_policy")),
-        "{executed_queries:#?}"
-    );
-    assert!(
-        executed_queries
-            .iter()
-            .any(|query| query.contains("implicit_attribute_names")),
-        "{executed_queries:#?}"
-    );
-
-    db.write_dedented(
-        "/src/mod.py",
-        r#"
-        class C:
-            def f(self):
-                self.attr: int = 1
-        "#,
-    )?;
-
-    let events = {
-        db.clear_salsa_events();
-        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-        assert_eq!(attr_ty.display(&db).to_string(), "int");
-        db.take_salsa_events()
-    };
-
-    assert_function_query_was_run(
         &db,
         infer_expression_types_impl,
         InferExpression::Bare(x_rhs_expression(&db)),

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -7,6 +7,7 @@ use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::DbWithWritableSystem as _;
 use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
+use salsa::Database as _;
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::FileScopeId;
 use ty_python_core::{global_scope, place_table, semantic_index, use_def_map};
@@ -469,6 +470,110 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
     };
 
     assert_function_query_was_not_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(x_rhs_expression(&db)),
+        &events,
+    );
+
+    Ok(())
+}
+
+#[test]
+fn dependency_missing_implicit_instance_attribute() -> anyhow::Result<()> {
+    fn x_rhs_expression(db: &TestDb) -> Expression<'_> {
+        let file_main = system_path_to_file(db, "/src/main.py").unwrap();
+        let ast = parsed_module(db, file_main).load(db);
+        let x_rhs_node = &ast.syntax().body[1].as_assign_stmt().unwrap().value;
+
+        let index = semantic_index(db, file_main);
+        index.expression(x_rhs_node.as_ref())
+    }
+
+    let mut db = setup_db();
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class C:
+            def f(self):
+                pass
+        "#,
+    )?;
+    db.write_dedented(
+        "/src/main.py",
+        r#"
+        from mod import C
+        x = y = C().attr
+        "#,
+    )?;
+
+    let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
+    let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+    assert_eq!(attr_ty.display(&db).to_string(), "Unknown");
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class C:
+            def f(self):
+                # a comment!
+                pass
+        "#,
+    )?;
+
+    let events = {
+        db.clear_salsa_events();
+        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        assert_eq!(attr_ty.display(&db).to_string(), "Unknown");
+        db.take_salsa_events()
+    };
+
+    assert_function_query_was_not_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(x_rhs_expression(&db)),
+        &events,
+    );
+    let executed_queries = events
+        .iter()
+        .filter_map(|event| {
+            let salsa::EventKind::WillExecute { database_key } = event.kind else {
+                return None;
+            };
+            Some(db.ingredient_debug_name(database_key.ingredient_index()))
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        !executed_queries
+            .iter()
+            .any(|query| query.contains("member_lookup_with_policy")),
+        "{executed_queries:#?}"
+    );
+    assert!(
+        executed_queries
+            .iter()
+            .any(|query| query.contains("implicit_attribute_names")),
+        "{executed_queries:#?}"
+    );
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class C:
+            def f(self):
+                self.attr: int = 1
+        "#,
+    )?;
+
+    let events = {
+        db.clear_salsa_events();
+        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        assert_eq!(attr_ty.display(&db).to_string(), "int");
+        db.take_salsa_events()
+    };
+
+    assert_function_query_was_run(
         &db,
         infer_expression_types_impl,
         InferExpression::Bare(x_rhs_expression(&db)),


### PR DESCRIPTION
## Summary

Implicit attribute lookup currently retains a tracked query for every probed member name, including names that no method in the class can define. On large projects, these missing-name queries account for most of the retained implicit-attribute entries.

This change aggregates the implicit attribute names for each class in a tracked query. Its sorted result can be compared across revisions, so an unrelated edit that leaves the names unchanged does not invalidate dependent member lookups. For example:

```python
class C:
    def initialize(self):
        self.present: int = 1

C().present  # Included: a method defines this implicit attribute.
C().missing  # Not included: no method defines this name.
```

Included names continue through detailed implicit-attribute inference. Names that are _not_ included return an unbound member before we create an `implicit_attribute_inner` entry. (This only changes which queries we retain, not the inferred attribute behavior.)
