### PR TITLE
[ty] Avoid retaining missing descriptor lookups

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2883,8 +2883,30 @@ impl<'db> Type<'db> {
     /// that `self` represents: (1) a data descriptor or (2) a non-data descriptor / normal attribute.
     ///
     /// If `__get__` is not defined on the meta-type, this method returns `None`.
-    #[salsa::tracked(cycle_initial=|_, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
     pub(crate) fn try_call_dunder_get(
+        self,
+        db: &'db dyn Db,
+        instance: Option<Type<'db>>,
+        owner: Type<'db>,
+    ) -> Option<(Type<'db>, AttributeKind)> {
+        // Avoid retaining a query for every access context when the attribute's class has no
+        // `__get__`. The tracked class-member lookup preserves the dependency on that class.
+        if matches!(self, Type::NominalInstance(_) | Type::ClassLiteral(_)) {
+            let Place::Defined(DefinedPlace {
+                ty, definedness, ..
+            }) = self.class_member(db, "__get__".into()).place
+            else {
+                return None;
+            };
+
+            return self.try_call_dunder_get_resolved(db, instance, owner, ty, definedness);
+        }
+
+        self.try_call_dunder_get_inner(db, instance, owner)
+    }
+
+    #[salsa::tracked(cycle_initial=|_, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+    fn try_call_dunder_get_inner(
         self,
         db: &'db dyn Db,
         instance: Option<Type<'db>>,
@@ -2950,38 +2972,65 @@ impl<'db> Type<'db> {
             _ => {}
         }
 
-        let descr_get = self.class_member(db, "__get__".into()).place;
-
-        if let Place::Defined(DefinedPlace {
+        let Place::Defined(DefinedPlace {
             ty: descr_get,
             definedness: descr_get_boundness,
             ..
-        }) = descr_get
-        {
-            let instance_ty = instance.unwrap_or_else(|| Type::none(db));
-            let return_ty = descr_get
-                .try_call(db, &CallArguments::positional([self, instance_ty, owner]))
-                .map(|bindings| {
-                    if descr_get_boundness == Definedness::AlwaysDefined {
-                        bindings.return_type(db)
-                    } else {
-                        UnionType::from_two_elements(db, bindings.return_type(db), self)
-                    }
-                })
-                // TODO: an error when calling `__get__` will lead to a `TypeError` or similar at runtime;
-                // we should emit a diagnostic here instead of silently ignoring the error.
-                .unwrap_or_else(|CallError(_, bindings)| bindings.return_type(db));
+        }) = self.class_member(db, "__get__".into()).place
+        else {
+            return None;
+        };
 
-            let descriptor_kind = if self.is_data_descriptor(db) {
-                AttributeKind::DataDescriptor
-            } else {
-                AttributeKind::NormalOrNonDataDescriptor
-            };
+        Some(self.call_dunder_get(db, instance, owner, descr_get, descr_get_boundness))
+    }
 
-            Some((return_ty, descriptor_kind))
+    #[salsa::tracked(cycle_initial=|_, _, _, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+    fn try_call_dunder_get_resolved(
+        self,
+        db: &'db dyn Db,
+        instance: Option<Type<'db>>,
+        owner: Type<'db>,
+        descr_get: Type<'db>,
+        descr_get_boundness: Definedness,
+    ) -> Option<(Type<'db>, AttributeKind)> {
+        tracing::trace!(
+            "try_call_dunder_get: {}, {}, {}",
+            self.display(db),
+            instance.unwrap_or_else(|| Type::none(db)).display(db),
+            owner.display(db)
+        );
+        Some(self.call_dunder_get(db, instance, owner, descr_get, descr_get_boundness))
+    }
+
+    fn call_dunder_get(
+        self,
+        db: &'db dyn Db,
+        instance: Option<Type<'db>>,
+        owner: Type<'db>,
+        descr_get: Type<'db>,
+        descr_get_boundness: Definedness,
+    ) -> (Type<'db>, AttributeKind) {
+        let instance_ty = instance.unwrap_or_else(|| Type::none(db));
+        let return_ty = descr_get
+            .try_call(db, &CallArguments::positional([self, instance_ty, owner]))
+            .map(|bindings| {
+                if descr_get_boundness == Definedness::AlwaysDefined {
+                    bindings.return_type(db)
+                } else {
+                    UnionType::from_two_elements(db, bindings.return_type(db), self)
+                }
+            })
+            // TODO: an error when calling `__get__` will lead to a `TypeError` or similar at runtime;
+            // we should emit a diagnostic here instead of silently ignoring the error.
+            .unwrap_or_else(|CallError(_, bindings)| bindings.return_type(db));
+
+        let descriptor_kind = if self.is_data_descriptor(db) {
+            AttributeKind::DataDescriptor
         } else {
-            None
-        }
+            AttributeKind::NormalOrNonDataDescriptor
+        };
+
+        (return_ty, descriptor_kind)
     }
 
     /// Look up `__get__` on the meta-type of `attribute`, and call it with `attribute`, `instance`,

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -673,6 +673,93 @@ fn dependency_implicit_class_member() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn dependency_descriptor_method() -> anyhow::Result<()> {
+    fn x_rhs_expression(db: &TestDb) -> Expression<'_> {
+        let file_main = system_path_to_file(db, "/src/main.py").unwrap();
+        let ast = parsed_module(db, file_main).load(db);
+        let x_rhs_node = &ast.syntax().body[1].as_assign_stmt().unwrap().value;
+
+        semantic_index(db, file_main).expression(x_rhs_node.as_ref())
+    }
+
+    let mut db = setup_db();
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class Descriptor:
+            pass
+
+        class C:
+            attr = Descriptor()
+        "#,
+    )?;
+    db.write_dedented(
+        "/src/main.py",
+        r#"
+        from mod import C
+        x = y = C().attr
+        "#,
+    )?;
+
+    let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
+    let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+    assert_eq!(attr_ty.display(&db).to_string(), "Descriptor");
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class Descriptor:
+            # comment
+            pass
+
+        class C:
+            attr = Descriptor()
+        "#,
+    )?;
+
+    let events = {
+        db.clear_salsa_events();
+        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        assert_eq!(attr_ty.display(&db).to_string(), "Descriptor");
+        db.take_salsa_events()
+    };
+    assert_function_query_was_not_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(x_rhs_expression(&db)),
+        &events,
+    );
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class Descriptor:
+            def __get__(self, instance: object, owner: type) -> int:
+                return 42
+
+        class C:
+            attr = Descriptor()
+        "#,
+    )?;
+
+    let events = {
+        db.clear_salsa_events();
+        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        assert_eq!(attr_ty.display(&db).to_string(), "int");
+        db.take_salsa_events()
+    };
+    assert_function_query_was_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(x_rhs_expression(&db)),
+        &events,
+    );
+
+    Ok(())
+}
+
 /// Inferring the result of a call-expression shouldn't need to re-run after
 /// a trivial change to the function's file (e.g. by adding a docstring to the function).
 #[test]


### PR DESCRIPTION
## Summary

`try_call_dunder_get` currently retains a Salsa query for every `(attribute type, instance, owner)` combination, even when a nominal instance or class-literal attribute type does not define `__get__`. On the bounded `oaiproto` workload, 18,747 of the 29,347 retained entries were these missing probes.

This moves those `__get__` probes ahead of the context-specific tracked query and relies on the existing tracked class-member lookup for dependency isolation. If `__get__` remains absent after an unrelated edit, Salsa can validate the unchanged result without retaining a query for every access context; adding or removing `__get__` still invalidates consumers. When `__get__` is present, we pass the resolved descriptor into a tracked query and preserve the existing descriptor-call behavior.

For example, an ordinary value like this no longer retains a context-specific descriptor query:

```python
class Value:
    pass

class C:
    attr = Value()
```

A real descriptor is not skipped:

```python
class Descriptor:
    def __get__(self, instance: object, owner: type) -> int:
        return 42

class C:
    attr = Descriptor()
```

The shortcut is limited to nominal instances and class literals. Callables, unions and intersections, dynamic types, and the existing special cases continue through their existing handling.

On the same `oaiproto` workload, retained memory falls from 396,615,262 bytes to 391,988,374 bytes, a reduction of 4,626,888 bytes or 1.17%, with no regression in paired local runtime checks.
