### PR TITLE
[ty] Improve closed TypedDict precision

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5459,31 +5459,24 @@ class Closed(TypedDict, closed=True):
     age: int
 
 def _(closed: Closed) -> None:
-    # TODO: should be `dict_keys[Literal["name", "age"], str | int]`
-    reveal_type(closed.keys())  # revealed: dict_keys[str, object]
+    reveal_type(closed.keys())  # revealed: dict_keys[Literal["age", "name"], int | str]
 
-    # TODO: should be `dict_values[Literal["name", "age"], str | int]`
-    reveal_type(closed.values())  # revealed: dict_values[str, object]
+    reveal_type(closed.values())  # revealed: dict_values[Literal["age", "name"], int | str]
 
-    # TODO: should be `dict_items[Literal["name", "age"], str | int]`
-    reveal_type(closed.items())  # revealed: dict_items[str, object]
+    reveal_type(closed.items())  # revealed: dict_items[Literal["age", "name"], int | str]
 
     # iterating over the keys gives `Literal` types
     for key in closed:
-        # TODO: should be `Literal["name", "age"]`
-        reveal_type(key)  # revealed: str
+        reveal_type(key)  # revealed: Literal["age", "name"]
 
     for key in closed.keys():
-        # TODO: should be `Literal["name", "age"]`
-        reveal_type(key)  # revealed: str
+        reveal_type(key)  # revealed: Literal["age", "name"]
 
     for value in closed.values():
-        # TODO: should be `str | int
-        reveal_type(value)  # revealed: object
+        reveal_type(value)  # revealed: int | str
 
     for item in closed.items():
-        # TODO: should be `tuple[Literal["name"], str] | tuple[Literal["age"], int]`
-        reveal_type(item)  # revealed: tuple[str, object]
+        reveal_type(item)  # revealed: tuple[Literal["age", "name"], int | str]
 ```
 
 ### Iterating keys, values and items of an extra-items TypedDict
@@ -5549,17 +5542,29 @@ static_assert(is_equivalent_to(AliasedExtra, Closed))
 
 ### Empty closed TypedDict truthiness
 
-An empty `closed=True` TypedDict cannot contain any keys, so it is always empty and always falsy,
-but inferring that precisely is still TODO.
+An empty `closed=True` TypedDict cannot contain any keys, so it is always empty and always falsy.
 
 ```py
-from typing_extensions import TypedDict
+from typing_extensions import Never, NotRequired, TypedDict
 
 class Empty(TypedDict, closed=True): ...
+class EmptyByNever(TypedDict, extra_items=Never): ...
 
-def _(empty: Empty) -> None:
-    # TODO: should be `Literal[False]`
-    reveal_type(bool(empty))  # revealed: bool
+class OptionalClosed(TypedDict, closed=True):
+    value: NotRequired[int]
+
+class EmptyOpen(TypedDict): ...
+
+def _(
+    empty: Empty,
+    empty_by_never: EmptyByNever,
+    optional_closed: OptionalClosed,
+    empty_open: EmptyOpen,
+) -> None:
+    reveal_type(bool(empty))  # revealed: Literal[False]
+    reveal_type(bool(empty_by_never))  # revealed: Literal[False]
+    reveal_type(bool(optional_closed))  # revealed: bool
+    reveal_type(bool(empty_open))  # revealed: bool
 ```
 
 ### Closed TypedDict is structurally final but not nominally final
@@ -5612,9 +5617,8 @@ class Closed(TypedDict, closed=True):
     age: int
 
 def _(td: Closed, key: str) -> None:
-    # TODO: the error is correct, but this could validly be `str | int`
     # error: [invalid-key]
-    reveal_type(td[key])  # revealed: Unknown
+    reveal_type(td[key])  # revealed: int | str
 ```
 
 ### Subclass of extra-items TypedDict has the same extra-items type as its base

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5452,11 +5452,12 @@ Iterating over the keys produces a `Literal` type; iterating the values produces
 value types.
 
 ```py
-from typing_extensions import TypedDict
+from typing_extensions import Never, NotRequired, TypedDict
 
 class Closed(TypedDict, closed=True):
     name: str
     age: int
+    absent: NotRequired[Never]
 
 def _(closed: Closed) -> None:
     reveal_type(closed.keys())  # revealed: dict_keys[Literal["age", "name"], int | str]
@@ -5543,6 +5544,7 @@ static_assert(is_equivalent_to(AliasedExtra, Closed))
 ### Empty closed TypedDict truthiness
 
 An empty `closed=True` TypedDict cannot contain any keys, so it is always empty and always falsy.
+The same is true if all of its fields are `NotRequired[Never]`.
 
 ```py
 from typing_extensions import Never, NotRequired, TypedDict
@@ -5553,17 +5555,22 @@ class EmptyByNever(TypedDict, extra_items=Never): ...
 class OptionalClosed(TypedDict, closed=True):
     value: NotRequired[int]
 
+class ImpossibleOptionalClosed(TypedDict, closed=True):
+    value: NotRequired[Never]
+
 class EmptyOpen(TypedDict): ...
 
 def _(
     empty: Empty,
     empty_by_never: EmptyByNever,
     optional_closed: OptionalClosed,
+    impossible_optional_closed: ImpossibleOptionalClosed,
     empty_open: EmptyOpen,
 ) -> None:
     reveal_type(bool(empty))  # revealed: Literal[False]
     reveal_type(bool(empty_by_never))  # revealed: Literal[False]
     reveal_type(bool(optional_closed))  # revealed: bool
+    reveal_type(bool(impossible_optional_closed))  # revealed: Literal[False]
     reveal_type(bool(empty_open))  # revealed: bool
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -5477,6 +5477,7 @@ def _(closed: Closed) -> None:
         reveal_type(value)  # revealed: int | str
 
     for item in closed.items():
+        # TODO: should be `tuple[Literal["name"], str] | tuple[Literal["age"], int]`
         reveal_type(item)  # revealed: tuple[Literal["age", "name"], int | str]
 ```
 

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -219,8 +219,9 @@ impl<'db> Type<'db> {
             Type::TypedDict(td) => {
                 if td.items(db).values().any(TypedDictField::is_required) {
                     Truthiness::AlwaysTrue
+                } else if td.openness(db).is_closed() && td.items(db).is_empty() {
+                    Truthiness::AlwaysFalse
                 } else {
-                    // TODO: Empty closed TypedDicts can be inferred as always falsy.
                     Truthiness::Ambiguous
                 }
             }

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -219,7 +219,9 @@ impl<'db> Type<'db> {
             Type::TypedDict(td) => {
                 if td.items(db).values().any(TypedDictField::is_required) {
                     Truthiness::AlwaysTrue
-                } else if td.openness(db).is_closed() && td.items(db).is_empty() {
+                } else if td.openness(db).is_closed()
+                    && td.items(db).values().all(|field| !field.may_be_present(db))
+                {
                     Truthiness::AlwaysFalse
                 } else {
                     Truthiness::Ambiguous

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -58,13 +58,20 @@ pub(super) fn synthesize_typed_dict_method<'db>(
                 db, typed_dict, return_ty,
             ))
         }
-        "items" if typed_dict.explicit_extra_items(db).is_some() => Some(
+        "__iter__" if typed_dict.openness(db).is_closed() => {
+            let return_ty =
+                KnownClass::Iterator.to_specialized_instance(db, &[typed_dict.key_type(db)]);
+            Some(synthesize_typed_dict_no_argument_method(
+                db, typed_dict, return_ty,
+            ))
+        }
+        "items" if !typed_dict.openness(db).is_implicitly_open() => Some(
             synthesize_typed_dict_view_method(db, typed_dict, "dict_items"),
         ),
-        "keys" if typed_dict.explicit_extra_items(db).is_some() => Some(
+        "keys" if !typed_dict.openness(db).is_implicitly_open() => Some(
             synthesize_typed_dict_view_method(db, typed_dict, "dict_keys"),
         ),
-        "values" if typed_dict.explicit_extra_items(db).is_some() => Some(
+        "values" if !typed_dict.openness(db).is_implicitly_open() => Some(
             synthesize_typed_dict_view_method(db, typed_dict, "dict_values"),
         ),
         "__or__" | "__ror__" | "__ior__" => {
@@ -667,7 +674,7 @@ fn synthesize_typed_dict_no_argument_method<'db>(
     )
 }
 
-/// Synthesize `items`, `keys`, or `values` for a `TypedDict` with explicit extra items.
+/// Synthesize `items`, `keys`, or `values` for a closed or extra-items `TypedDict`.
 fn synthesize_typed_dict_view_method<'db>(
     db: &'db dyn Db,
     typed_dict: TypedDictType<'db>,
@@ -679,10 +686,8 @@ fn synthesize_typed_dict_view_method<'db>(
         .and_then(Type::as_class_literal)
         .map(|class| {
             class.apply_specialization(db, |generic_context| {
-                generic_context.specialize(
-                    db,
-                    &[KnownClass::Str.to_instance(db), typed_dict.value_type(db)],
-                )
+                generic_context
+                    .specialize(db, &[typed_dict.key_type(db), typed_dict.value_type(db)])
             })
         })
         .and_then(|class| Type::from(class).to_instance(db))

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -465,9 +465,9 @@ where
     ))
 }
 
-// `TypedDict` subscripts need custom handling because invalid keys should still
-// recover with `Unknown` while emitting `invalid-key`, which is not naturally
-// representable via synthesized `__getitem__` overloads alone.
+// `TypedDict` subscripts need custom handling because invalid keys should emit `invalid-key` while
+// recovering with the union of value types for non-literal string keys on closed `TypedDict`s and
+// `Unknown` otherwise. This is not naturally representable via synthesized `__getitem__` overloads.
 fn typed_dict_subscript<'db>(
     db: &'db dyn Db,
     typed_dict: TypedDictType<'db>,

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -490,8 +490,15 @@ fn typed_dict_subscript<'db>(
         {
             return Ok(typed_dict.value_type(db));
         }
+        let result_ty = if typed_dict.openness(db).is_closed()
+            && slice_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
+        {
+            typed_dict.value_type(db)
+        } else {
+            Type::unknown()
+        };
         return Err(SubscriptError::new(
-            Type::unknown(),
+            result_ty,
             SubscriptErrorKind::InvalidTypedDictKey {
                 typed_dict,
                 slice_ty,

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -333,6 +333,23 @@ impl<'db> TypedDictType<'db> {
         builder.build()
     }
 
+    /// Returns the type of keys that may be present in this `TypedDict`.
+    ///
+    /// A closed `TypedDict` has a finite set of literal keys. Open and extra-items `TypedDict`s may
+    /// contain arbitrary string keys.
+    pub(crate) fn key_type(self, db: &'db dyn Db) -> Type<'db> {
+        if !self.openness(db).is_closed() {
+            return KnownClass::Str.to_instance(db);
+        }
+
+        self.items(db)
+            .keys()
+            .fold(UnionBuilder::new(db), |builder, name| {
+                builder.add(Type::string_literal(db, name))
+            })
+            .build()
+    }
+
     /// Returns the field exposed by a literal key.
     ///
     /// Undeclared keys synthesize a field only for explicit extra items. Hidden items on an

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -343,8 +343,9 @@ impl<'db> TypedDictType<'db> {
         }
 
         self.items(db)
-            .keys()
-            .fold(UnionBuilder::new(db), |builder, name| {
+            .iter()
+            .filter(|(_, field)| field.may_be_present(db))
+            .fold(UnionBuilder::new(db), |builder, (name, _)| {
                 builder.add(Type::string_literal(db, name))
             })
             .build()
@@ -3000,6 +3001,11 @@ impl<'db> TypedDictField<'db> {
 
     pub(crate) const fn is_read_only(&self) -> bool {
         self.flags.contains(TypedDictFieldFlags::READ_ONLY)
+    }
+
+    /// Returns `false` for optional fields whose declared type is uninhabited.
+    pub(crate) fn may_be_present(&self, db: &'db dyn Db) -> bool {
+        self.is_required() || !self.declared_ty.resolve_type_alias(db).is_never()
     }
 
     pub(crate) const fn first_declaration(&self) -> Option<Definition<'db>> {


### PR DESCRIPTION
## Summary

This PR improves the types we infer once a TypedDict is known to be closed.

A closed TypedDict has a finite schema, so we now derive its key type from the union of declared string literals and its value type from the union of declared item types. These types specialize direct iteration and the synthesized `keys()`, `values()`, and `items()` methods.

```python
class Movie(TypedDict, closed=True):
    name: str
    year: int

reveal_type(movie.keys())  # dict_keys[Literal["name", "year"], str | int]
reveal_type(movie.values())  # dict_values[Literal["name", "year"], str | int]
```

An empty closed TypedDict is now always falsy, including the equivalent `extra_items=Never` form. Closed TypedDicts with optional items and ordinary open TypedDicts remain potentially truthy.

Indexing a closed TypedDict with a non-literal `str` continues to report `invalid-key`, but now recovers with the union of declared value types rather than `Unknown`.
