### PR TITLE
Streamline ty ecosystem summary workflow

### DIFF
--- a/.agents/skills/minimizing-ty-ecosystem-changes/SKILL.md
+++ b/.agents/skills/minimizing-ty-ecosystem-changes/SKILL.md
@@ -5,117 +5,89 @@ description: Use when a user says "minimize this ty ecosystem change", "reproduc
 
 # Minimizing Ty Ecosystem Changes
 
-Use this skill when asked to reproduce a ty ecosystem change, investigate a behavior difference in a primer project, or minimize a reproducer from a ty ecosystem project.
+## Invariants
 
-## Building ty
+1. Use the exact Ruff revisions, PR config, dependency cutoff, mypy-primer revision, and project Python version from the Actions run.
+2. Reproduce the reported project difference before explaining it or writing a smaller example.
+3. Treat copied binaries and config as read-only, and verify every reduction against both binaries.
 
-If a primary agent supplies paths to a copied merge-base ty binary, copied PR ty binary, and copied PR ecosystem config that it freshly prepared at the start of the current task, reuse those artifacts as read-only inputs. Do not rebuild ty, switch refs in the Ruff checkout, or overwrite the supplied artifacts. Use a separate transient ecosystem-project directory from any concurrent subagents. If a supplied artifact is missing, stop and report that to the primary agent instead of mutating the Ruff checkout.
+Start each investigation from fresh artifacts. Do not trust retained memories, previous minimizations, current upstream project state, or the helper script's default lockfile.
 
-Otherwise, prepare the artifacts as follows.
+## Collect Exact-Run Metadata
 
-Build ty on both the PR branch and the PR's merge base by running `CARGO_PROFILE_PROFILING_DEBUG=line-tables-only cargo build --package ty --profile profiling` from the repository root on both refs, matching ecosystem CI. Copy each built executable to a stable path before checking out the other ref; otherwise, the second build overwrites `target/profiling/ty`.
+Run the bundled helper with the Actions run ID or URL and every affected mypy-primer project name:
 
-From the PR branch, also copy `.github/ty-ecosystem.toml` to a stable path before checking out another ref. Use that copied file for every comparison, matching ecosystem CI's behavior of reusing the PR config.
+```bash
+scripts/collect_ty_ecosystem_run_metadata.py \
+  <actions-run> <project-name>... \
+  --output target/ty-ecosystem-run.json
+```
 
-Before checking out another ref, inspect the working tree. If `git status --short` shows any staged, unstaged, or untracked changes, abort immediately and ask the user how to proceed.
+The manifest contains the analyzed Ruff revisions, Actions `EXCLUDE_NEWER`, ecosystem-analyzer and mypy-primer revisions, and each project's CI Python version. Stop if the helper cannot determine a unique value; never substitute a comment timestamp or local default.
 
-For example:
+## Prepare ty
+
+If a primary agent supplied freshly copied base and PR binaries plus the PR ecosystem config, verify the paths exist and reuse them. Do not rebuild, switch Ruff refs, or overwrite the shared artifacts.
+
+Otherwise, require a clean working tree, copy `.github/ty-ecosystem.toml` from the PR revision, and build ty on the manifest's merge base and PR revision:
+
+Fetch the PR revision explicitly because pull-request runs usually use a synthetic GitHub merge commit that a normal clone does not contain:
 
 ```bash
 set -euo pipefail
 
-if [[ -n "$(git status --short)" ]]; then
-    git status --short
-    echo "working tree is not clean; stop and ask the user how to proceed" >&2
-    exit 1
-fi
-
+test -z "$(git status --short)" || { git status --short; exit 1; }
+git fetch origin <pr-revision>
 mkdir -p target/ty-ecosystem-bins
-cp .github/ty-ecosystem.toml target/ty-ecosystem-bins/ty-ecosystem.toml
-export TY_CONFIG_FILE="$PWD/target/ty-ecosystem-bins/ty-ecosystem.toml"
 export CARGO_PROFILE_PROFILING_DEBUG=line-tables-only
 
 git checkout <merge-base>
 cargo build --package ty --profile profiling
 cp target/profiling/ty target/ty-ecosystem-bins/ty-base
 
-git checkout <pr-branch-or-sha>
+git checkout <pr-revision>
+cp .github/ty-ecosystem.toml target/ty-ecosystem-bins/ty-ecosystem.toml
 cargo build --package ty --profile profiling
 cp target/profiling/ty target/ty-ecosystem-bins/ty-pr
 ```
 
-On Windows, adapt the shell commands and executable paths as necessary.
+## Reproduce
 
-You should only need to build ty twice at the start of the investigation. Reuse the copied executables when determining if the behavior difference still reproduces.
-
-## Reproduce First
-
-From the repository root, export the ecosystem config that was copied from the PR branch, then use the following script to clone the ecosystem project, check out the relevant revision, and install its dependencies into `.venv`. Keep `TY_CONFIG_FILE` set when running ty comparisons; this applies the same rule configuration as ecosystem CI without overwriting the user's ty config. Shell exports may not persist between agent tool calls, so re-export `TY_CONFIG_FILE` in every new shell before invoking either ty binary. The examples below use the default artifact paths; substitute supplied artifact paths when a primary agent provides them.
-
-When preparing artifacts yourself, if `target/ty-ecosystem-bins/ty-ecosystem.toml` does not exist yet, check out the PR branch and copy `.github/ty-ecosystem.toml` from there before continuing. Do not copy `.github/ty-ecosystem.toml` while on the merge base, because ecosystem CI compares both binaries with the PR branch's config.
+Create a unique temporary directory for each project. Read its Python version and the pinned mypy-primer revision from the manifest, then bypass the adjacent script lockfile:
 
 ```bash
-set -euo pipefail
-
-export TY_CONFIG_FILE="$PWD/target/ty-ecosystem-bins/ty-ecosystem.toml"
-test -f "$TY_CONFIG_FILE" || { echo "missing $TY_CONFIG_FILE" >&2; exit 1; }
-uv run --no-project scripts/setup_primer_project.py <project-name> <some-temp-dir> --revision <report-revision> --exclude-newer <report-timestamp>
+uv run \
+  --python <project-python> \
+  --with "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@<mypy-primer-revision>" \
+  --no-project \
+  python scripts/setup_primer_project.py \
+  <project-name> <temporary-directory> \
+  --revision <report-project-revision> \
+  --exclude-newer <EXCLUDE_NEWER>
 ```
 
-ALWAYS confirm the behavior difference reproduces before minimizing or explaining it.
-ALWAYS use this script before attempting to reproduce the change.
-NEVER try to confirm the behaviour difference without first setting up the project's virtual environment using this script.
-
-When comparing the copied ty binaries, use the project-specific ty command printed by `setup_primer_project.py`. That command includes the project's mypy-primer metadata such as `paths` and any custom `ty_cmd`, matching ecosystem CI. Keep `TY_CONFIG_FILE` exported in the same shell that runs the comparison, and set `ty_binary` to each copied binary before running the printed command:
+Use absolute paths and re-export `TY_CONFIG_FILE` in every new shell before running either binary:
 
 ```bash
 export TY_CONFIG_FILE="$PWD/target/ty-ecosystem-bins/ty-ecosystem.toml"
-test -f "$TY_CONFIG_FILE" || { echo "missing $TY_CONFIG_FILE" >&2; exit 1; }
-
-project_dir="$PWD/<some-temp-dir>"
+test -f "$TY_CONFIG_FILE"
+project_dir="$PWD/<temporary-directory>"
 ty_base="$PWD/target/ty-ecosystem-bins/ty-base"
 ty_pr="$PWD/target/ty-ecosystem-bins/ty-pr"
 
 cd "$project_dir"
 ty_binary="$ty_base"
-<project-specific ty command printed by setup_primer_project.py>
+<project-specific command printed by setup_primer_project.py>
 ty_binary="$ty_pr"
-<project-specific ty command printed by setup_primer_project.py>
+<project-specific command printed by setup_primer_project.py>
 ```
 
-If the ecosystem report gives an exact project revision, pass it to the script with `--revision`. If the report gives a timestamp, pass it to the script with `--exclude-newer`. Do not install dependencies before checking out the report revision. Do not use current upstream or the current mypy-primer revision as evidence for a historical report when the report provides a pinned revision. If running `ecosystem-analyzer` directly, also pass the report timestamp as `--exclude-newer`, matching ecosystem CI.
+Confirm the detailed report's difference exactly, including duplicate diagnostics when present.
 
 ## Minimize
 
-When asked to minimize an ecosystem change, start from the reproduced project. Reduce the Python code until only the smallest code needed to demonstrate the behavior difference remains. DO NOT look at conversation or analysis in other PR comments: your analysis should start from a clean slate. Even if the cause looks obvious, DO NOT skip ahead to an explanation or a hand-written reproducer. Use a rigorous, systematic process and verify after each reduction that the behavior difference still reproduces.
+Reduce the reproduced project iteratively, using the base-versus-PR output as the oracle after every change. Prefer a single file, no third-party imports, and the least complex code that preserves the difference. For nontrivial reductions, follow [references/advanced-minimization.md](references/advanced-minimization.md).
 
-An ideal minimized reproducer:
+## Return
 
-- Is a single file that is as small as possible.
-- Has as few third-party imports as possible, ideally none.
-- Uses smaller third-party packages with fewer dependencies when third-party imports are unavoidable. For example, prefer an import from `numpy` over one from `pandas`.
-- Has as few first-party and standard-library imports as possible.
-- Keeps imports from modules with highly special-cased symbols only when they are necessary (such modules may include `typing`, `abc`, `enum`, `types`, or `typing_extensions`).
-- Uses an absolute minimum of "advanced"/complex typing or language features. For example, if the original code
-  uses a walrus operator, but the behavior difference still reproduces without it, remove the walrus operator. If the original code uses a `Protocol` from `typing_extensions`, but the behavior difference still reproduces without it, remove the `Protocol`.
-
-Use a systematic loop. You do not need to apply every tool in every iteration, but keep looping until none of the available minimization tools can reduce the reproducer further while preserving the behavior difference. Your clones of ecosystem projects and/or their dependencies should be treated as transient artifacts of the investigation: they should be deleted after the minimization is complete, and you SHOULD NOT ask for permission to modify them during the minimization process. If the user has asked for an ecosystem change to be minimized, ANY of the changes below should be understood as automatically having been approved by the user.
-
-Available minimization tools include:
-
-1. Remove files that are not needed for the difference.
-2. Strip imports, definitions, and statements from the remaining files.
-3. Cut and paste definitions from one file into another file to reduce first-party imports.
-4. Copy installed third-party dependency files from the project's `.venv` into the project as first-party files so that you can convert third-party imports into first-party imports. If you must clone a dependency instead, use the exact installed version rather than the dependency's current default branch.
-5. Inline the relevant parts of stdlib definitions from ty's vendored typeshed stubs into first-party code to reduce stdlib imports. ty's vendored typeshed stubs are the single source of truth for ty regarding the Python standard library, and they are found in `./crates/ty_vendored`.
-
-After applying a minimization tool, re-run the comparison between the PR branch and the PR's merge base.
-Keep a reduction only when the behavior difference still reproduces.
-
-DO NOT stop looping until no further reductions could be applied without making the behavior difference disappear.
-
-Before retaining the final reproducer, perform an import audit: attempt to delete every import, inline third-party definitions where possible, and explain why each surviving third-party import is necessary.
-
-If the minimized behavior change is a diagnostic change, the final minimized Python snippet MUST include the full diagnostic message and error code on both branches, as a comment above or on the relevant line of code.
-
-ANY reference to a line number in an external project MUST use a permalink in the form `[project file.py:123](permalink)`. Referring to an external line number without a permalink is unacceptable.
+Provide the original permalinked report entry, exact base and PR behavior, minimal code, full diagnostic messages and error codes, and the manifest/commands needed to reproduce it. When called from the summary workflow, return import-audit and reduction notes separately from report-ready Markdown.

--- a/.agents/skills/minimizing-ty-ecosystem-changes/references/advanced-minimization.md
+++ b/.agents/skills/minimizing-ty-ecosystem-changes/references/advanced-minimization.md
@@ -1,0 +1,26 @@
+# Advanced Minimization
+
+Use this reference after the reported difference reproduces against the copied base and PR binaries.
+
+## Target
+
+Prefer a single-file reproducer with no third-party imports, few definitions, and the least complex typing or language features that still demonstrate the difference. Keep special modules such as `typing`, `abc`, `enum`, `types`, and `typing_extensions` only when removing them changes the behavior.
+
+## Reduction Loop
+
+Work systematically from the reproduced project. Do not skip ahead to an explanation, hand-written reproducer, or a guessed subset of relevant code. Follow the stages below in order and exhaust each stage before advancing. Try one controlled reduction at a time, run both copied ty binaries after every change, and keep the reduction only if the original difference remains. After every successful reduction, restart at step 1 because it may make earlier reductions possible.
+
+1. Delete unrelated files.
+2. Remove imports, definitions, decorators, annotations, statements, and branches.
+3. Inline first-party definitions into the reproducer.
+4. For each required third-party dependency, copy the entire installed dependency into the source tree as first-party code, including every package directory and module it provides. Do this before attempting to minimize any part of the dependency. Adjust imports, verify that the difference still reproduces with the complete copy, and only then begin deleting files or definitions from it. Never start by copying only apparently relevant files or definitions. If cloning a dependency is unavoidable, use the exact installed revision or version and copy the complete dependency into the source tree before reducing it.
+5. Inline the relevant standard-library definitions from `crates/ty_vendored`, which is ty's source of truth for stdlib types.
+6. Replace complex constructs with simpler equivalents, such as removing a walrus expression or replacing a protocol when the difference survives.
+
+Repeat the full loop until an exhaustive pass through every stage finds no further reduction that preserves the difference. Do not stop merely because the likely cause is understood or the reproducer is already small.
+
+## Final Audit
+
+Attempt to remove every remaining import and inline every remaining third-party definition. Record why any surviving import is essential. Keep these notes as working evidence; the caller decides whether they belong in its final artifact.
+
+Delete transient project and dependency copies after the investigation.

--- a/.agents/skills/summarise-ecosystem-results/SKILL.md
+++ b/.agents/skills/summarise-ecosystem-results/SKILL.md
@@ -5,70 +5,23 @@ description: Use when a user says "summarise ecosystem results", "summarize this
 
 # Summarise Ecosystem Results
 
-Use this skill when asked to summarise ecosystem results for a Ruff PR with the `ty` label.
+## Priorities
 
-## Find the Report
+1. Reproduce every retained behavior with the exact environment used by the Actions run.
+2. Lead the report with analysis of diagnostic changes and clear minimized examples.
+3. Keep execution, audit, and traceability bookkeeping out of the report.
 
-Accept any of these inputs:
+## Deliverable
 
-- A PR number.
-- A GitHub PR URL.
-- A GitHub comment URL on a PR, such as `https://github.com/astral-sh/ruff/pull/25342#issuecomment-4525002693`.
-- A full detailed HTML ecosystem report URL.
+Create `PR_<number>_ECOSYSTEM_SUMMARY.md` at the repository root by adapting [assets/report-template.md](assets/report-template.md). The finished artifact must be GitHub-flavored Markdown suitable for a GitHub comment, with each prose paragraph and list item on one source line.
 
-Determine the PR number first. If the user gave only a PR number, open `https://github.com/astral-sh/ruff/pull/<number>`.
+Use the template's structure and omissions as the report contract. Remove all placeholders and HTML comments. Link external source locations with permalinks such as `[project file.py:123](permalink)`; never emit raw URLs.
 
-Find the ty ecosystem-results comment on the PR. Search PR comments for terms such as "ecosystem", "full report", "HTML report", and "detailed report". From that comment, open the linked full detailed HTML report.
+## Workflow
 
-Use the PR comment as the change list and the full detailed HTML report as the source of detailed evidence. When the report includes exact project revisions, use those revisions rather than current upstream checkouts.
+1. **Locate the evidence.** Normalize the input to a PR number, find the ty ecosystem-results comment, open the linked detailed HTML report, and identify the exact Actions run that produced it. Use the comment as the change list and the detailed report as evidence.
+2. **Reproduce from scratch.** Ignore retained memories and previous local artifacts. Load the `minimizing-ty-ecosystem-changes` skill, use its metadata helper and exact-run workflow, and reproduce each report entry before explaining or minimizing it.
+3. **Minimize and curate.** Retain the smallest clear reproducer for each distinct behavior change. Group entries only when the same base-to-PR behavior, explanation, and reproducer account for every entry in the group.
+4. **Write and verify.** Fill the report template, check every link and diagnostic, then run `uvx prek run --files PR_<number>_ECOSYSTEM_SUMMARY.md`. Present the Markdown file as the finished product.
 
-Start every summary from a clean slate. DO NOT trust retained memories of previous summaries or minimizations, and DO NOT trust local artifacts left by previous investigations. Independently rerun the current workflow, including reproduction and minimization, using fresh artifacts prepared at the start of the task.
-
-## Minimize in Parallel
-
-Before minimizing, load and apply the `minimizing-ty-ecosystem-changes` skill to each ecosystem change.
-
-Follow that skill's `Building ty` section once at the start of the task: build ty on the PR branch and the PR's merge base, then copy both executables and the PR branch's ecosystem config to stable paths. If delegating minimization work, the primary agent MUST prepare these fresh shared artifacts before spawning any subagents. It is safe for every subagent to use the same two copied executables and copied config concurrently: treat those artifacts as read-only inputs.
-
-If possible, use subagents to parallelize this work. Decide how to batch changes so the overall task finishes as quickly as possible while still allowing each subagent to work methodically. Reasonable batching strategies include grouping related changes by project, diagnostic code, suspected cause, or report section, while keeping large groups split enough to avoid one slow subagent blocking the whole task. DO NOT spawn more subagents than you can run in parallel.
-
-If subagents are not available, batch the minimization work manually and minimize the batches sequentially. Keep batches small enough that each pass can still be checked carefully.
-
-Give each subagent a self-contained assignment:
-
-- The PR number, PR URL, ecosystem comment URL, and detailed HTML report URL.
-- The exact ecosystem changes assigned to that subagent.
-- The requirement to use the `minimizing-ty-ecosystem-changes` process rigorously.
-- The exact paths to the fresh copied merge-base binary, PR binary, and PR ecosystem config prepared by the primary agent.
-- The requirement to reuse those shared artifacts as read-only inputs. Subagents MUST NOT rebuild ty, check out Ruff refs, or overwrite the shared artifacts.
-- The requirement to independently reproduce and minimize the assigned changes from the report using a fresh, uniquely named temporary project directory, without trusting retained memories or local project artifacts left by previous investigations.
-- The expected Markdown output format for each minimized change.
-
-Each subagent should proceed methodically through all assigned changes. If a subagent moves on to a new change and that change appears very similar to one it has already minimized, it may skip the new change without completing the full minimisation skill, but it must record why the skipped change appears to demonstrate the same behavior.
-
-## Collect Results
-
-After all subagents finish, collect their minimizations into one Markdown file at the repository root:
-
-```text
-PR_<number>_ECOSYSTEM_SUMMARY.md
-```
-
-Remove minimizations that appear to demonstrate the same behavior change. Prefer the smallest and clearest minimized reproducer, especially one that is single-file and has fewer imports.
-
-At the top of the file, add prose summarising the distinct behavior changes demonstrated by the retained minimizations. Then include the retained minimizations with enough detail for a reader to understand and reproduce them.
-
-For each retained minimization, include:
-
-- The original project and report entry.
-- The diagnostic or behavior change on `main` versus the PR.
-- The minimized code.
-- An import audit: attempt to delete every import, inline third-party definitions where possible, and explain why each surviving third-party import is necessary.
-
-If the minimized behavior change is a diagnostic change, the minimized Python snippet MUST include the full diagnostic message and error code on both branches, as a comment above or on the relevant line of code. Include duplicated diagnostics when relevant.
-
-At the bottom of the file, after the analysis and retained minimizations, add a verification section with the commands or comparison method used to verify each retained minimization.
-
-ANY reference to a line number in an external project MUST use a permalink in the form `[project file.py:123](permalink)`. Referring to an external line number without a permalink is unacceptable. The finished report should NEVER include "raw" URL links; it should ALWAYS use inline Markdown links with square brackets and parentheses.
-
-Present `PR_<number>_ECOSYSTEM_SUMMARY.md` as the finished product.
+When parallelizing step 2, read [references/subagent-handoff.md](references/subagent-handoff.md). Otherwise, keep batches small and work through them sequentially.

--- a/.agents/skills/summarise-ecosystem-results/assets/report-template.md
+++ b/.agents/skills/summarise-ecosystem-results/assets/report-template.md
@@ -1,0 +1,28 @@
+<!-- Replace every placeholder and remove all HTML comments before presenting the report. Keep each prose paragraph and list item on one source line. Do not add change-count tables, bot-update timestamps, reproduction-completeness bookkeeping, import-audit details, exhaustive traceability appendices, raw URLs, or artifact hashes. -->
+
+# PR #<number> ecosystem summary
+
+<Summarize the distinct diagnostic behavior changes and their significance. Lead with the analysis readers need; do not describe how the report was generated.>
+
+## <Distinct behavior change>
+
+**Report entries:** [<project file.py:line>](<permalink>)
+
+<Explain the exact behavior on the merge base and PR. Group additional entries here only when the same explanation and minimized reproducer account for all of them.>
+
+```python
+# Merge base: <every full diagnostic message and error code, including duplicates, or no diagnostic>
+# PR: <every full diagnostic message and error code, including duplicates, or no diagnostic>
+<minimal reproducer>
+```
+
+## Reproduction
+
+- Detailed report: [ecosystem-analyzer report](<report-url>)
+- Actions run: [run <id>](<run-url>)
+- Ruff comparison: `<merge-base>` to `<pr-revision>`
+- `ecosystem-analyzer`: `<revision>`
+- `mypy-primer`: `<revision>`
+- Project Python: `<project: version, ...>`
+- Dependency cutoff: `<EXCLUDE_NEWER>`
+- Comparison method: `<concise exact commands or method used to run both copied ty binaries>`

--- a/.agents/skills/summarise-ecosystem-results/references/subagent-handoff.md
+++ b/.agents/skills/summarise-ecosystem-results/references/subagent-handoff.md
@@ -1,0 +1,26 @@
+# Subagent Handoff
+
+Use this reference only when parallelizing reproduction and minimization.
+
+## Primary-Agent Responsibilities
+
+Prepare the copied base binary, PR binary, PR ecosystem config, and run-metadata manifest once. Treat them as read-only shared inputs. Batch related entries without creating more assignments than can run concurrently.
+
+## Assignment Checklist
+
+Give each subagent:
+
+- The PR, ecosystem comment, and detailed report links.
+- The exact report entries assigned to it.
+- The paths to the copied binaries, copied config, and metadata manifest.
+- The instruction to follow the `minimizing-ty-ecosystem-changes` skill using a unique temporary directory.
+- The instruction not to rebuild ty, switch Ruff refs, overwrite shared artifacts, trust previous local reproductions, or substitute current dependency metadata.
+
+## Required Return
+
+Request:
+
+- Report-ready GitHub-flavored Markdown describing the exact base-versus-PR behavior and minimized code.
+- Separate working notes covering reproduction, reductions, and the import audit.
+
+If a later entry has exactly the same behavior change and cause as an already minimized entry, the subagent may classify it as a duplicate instead of repeating the full minimization, but it must explain the match.

--- a/scripts/collect_ty_ecosystem_run_metadata.py
+++ b/scripts/collect_ty_ecosystem_run_metadata.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env -S uv run --script
+#
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+
+"""Collect the exact inputs used by a Ruff ty ecosystem-analyzer run."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+SHA = r"[0-9a-f]{40}"
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+class MetadataError(RuntimeError):
+    """Raised when historical run metadata is missing or inconsistent."""
+
+
+CommandRunner = Callable[[Sequence[str]], str]
+
+
+def run_command(command: Sequence[str]) -> str:
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or error.stdout.strip()
+        raise MetadataError(f"command failed: {' '.join(command)}\n{detail}") from error
+    return result.stdout
+
+
+def payloads(log: str) -> list[str]:
+    clean_log = ANSI_ESCAPE.sub("", log).replace("\ufeff", "")
+    result = []
+    for line in clean_log.splitlines():
+        columns = line.split("\t", 2)
+        payload = columns[-1]
+        if len(columns) == 3:
+            payload = re.sub(r"^\S+\s+", "", payload, count=1)
+        result.append(payload.strip())
+    return result
+
+
+def unique_value(log: str, pattern: str, label: str) -> str:
+    regex = re.compile(pattern)
+    values = {
+        match.group(1) for line in payloads(log) if (match := regex.fullmatch(line))
+    }
+    if not values:
+        raise MetadataError(f"could not find {label} in the Actions log")
+    if len(values) > 1:
+        rendered = ", ".join(sorted(values))
+        raise MetadataError(f"found conflicting {label} values: {rendered}")
+    return values.pop()
+
+
+def parse_build_log(log: str) -> tuple[str, str]:
+    merge_base = unique_value(log, rf"Merge base: ({SHA})", "merge base")
+    pr_revision = unique_value(log, rf"PR commit: ({SHA})", "PR revision")
+    return merge_base, pr_revision
+
+
+def parse_shard_log(log: str) -> tuple[str, str, str]:
+    exclude_newer = unique_value(
+        log,
+        r"EXCLUDE_NEWER: (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)",
+        "EXCLUDE_NEWER",
+    )
+    analyzer_revision = unique_value(
+        log,
+        rf"ECOSYSTEM_ANALYZER_COMMIT: ({SHA})",
+        "ecosystem-analyzer revision",
+    )
+    merge_base = unique_value(log, rf"MERGE_BASE: ({SHA})", "shard merge base")
+    return exclude_newer, analyzer_revision, merge_base
+
+
+def parse_minimum_python(source: str) -> tuple[int, int]:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "MINIMUM_PYTHON_VERSION"
+            for target in node.targets
+        ):
+            continue
+        value = ast.literal_eval(node.value)
+        if (
+            isinstance(value, tuple)
+            and len(value) == 2
+            and all(isinstance(part, int) for part in value)
+        ):
+            return value
+        break
+    raise MetadataError("could not parse ecosystem-analyzer MINIMUM_PYTHON_VERSION")
+
+
+def parse_mypy_primer_revision(pyproject: str) -> str:
+    project = tomllib.loads(pyproject).get("project")
+    dependencies = project.get("dependencies", []) if isinstance(project, dict) else []
+    revisions: set[str] = set()
+    for dependency in dependencies:
+        if not isinstance(dependency, str) or not dependency.startswith("mypy-primer "):
+            continue
+        if match := re.search(
+            rf"github\.com/hauntsaninja/mypy_primer(?:\.git)?(?:@|\?rev=)({SHA})",
+            dependency,
+        ):
+            revisions.add(match.group(1))
+    if len(revisions) != 1:
+        raise MetadataError("expected exactly one pinned mypy-primer revision")
+    return revisions.pop()
+
+
+def literal_keyword(call: ast.Call, name: str) -> Any:
+    for keyword in call.keywords:
+        if keyword.arg == name:
+            return ast.literal_eval(keyword.value)
+    return None
+
+
+def parse_project_versions(
+    source: str,
+    requested: Sequence[str],
+    baseline: tuple[int, int],
+) -> dict[str, str]:
+    projects: dict[str, tuple[int, int] | None] = {}
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name) or node.func.id != "Project":
+            continue
+        try:
+            location = literal_keyword(node, "location")
+            name_override = literal_keyword(node, "name_override")
+            minimum = literal_keyword(node, "min_python_version")
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(location, str):
+            continue
+        if name_override is not None and not isinstance(name_override, str):
+            raise MetadataError("mypy-primer project name_override is not a string")
+        if minimum is not None and (
+            not isinstance(minimum, tuple)
+            or len(minimum) != 2
+            or not all(isinstance(part, int) for part in minimum)
+        ):
+            raise MetadataError("mypy-primer min_python_version is not a version tuple")
+        name = name_override or location.rstrip("/").rsplit("/", 1)[-1]
+        if name in projects:
+            raise MetadataError(f"duplicate mypy-primer project name: {name}")
+        projects[name] = minimum
+
+    missing = sorted(set(requested) - projects.keys())
+    if missing:
+        raise MetadataError(f"unknown mypy-primer projects: {', '.join(missing)}")
+
+    return {
+        name: ".".join(str(part) for part in max(projects[name] or baseline, baseline))
+        for name in sorted(set(requested))
+    }
+
+
+def parse_run_reference(value: str) -> tuple[int, int | None]:
+    if value.isdigit():
+        return int(value), None
+    if match := re.search(r"/actions/runs/(\d+)(?:/attempts/(\d+))?(?:/|$)", value):
+        parsed_attempt = int(match.group(2)) if match.group(2) is not None else None
+        return int(match.group(1)), parsed_attempt
+    raise MetadataError(f"invalid Actions run ID or URL: {value}")
+
+
+def job_by_name(jobs: Sequence[dict[str, Any]], name: str) -> dict[str, Any]:
+    matches = [job for job in jobs if job.get("name") == name]
+    if len(matches) != 1:
+        raise MetadataError(f"expected exactly one {name!r} job")
+    return matches[0]
+
+
+def first_shard_job(jobs: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    matches: list[tuple[int, dict[str, Any]]] = []
+    for job in jobs:
+        if match := re.fullmatch(r"analyze-shards \((\d+)\)", str(job.get("name"))):
+            matches.append((int(match.group(1)), job))
+    if not matches:
+        raise MetadataError("could not find an analyze-shards job")
+    return min(matches, key=lambda item: item[0])[1]
+
+
+def collect_metadata(
+    run: str,
+    projects: Sequence[str],
+    *,
+    repo: str,
+    analyzer_repo: str,
+    attempt: int | None,
+    runner: CommandRunner = run_command,
+) -> dict[str, Any]:
+    run_id, url_attempt = parse_run_reference(run)
+    if attempt is not None and url_attempt is not None and attempt != url_attempt:
+        raise MetadataError(
+            f"Actions URL specifies attempt {url_attempt}, but --attempt specifies {attempt}"
+        )
+    requested_attempt = attempt if attempt is not None else url_attempt
+    view_command = [
+        "gh",
+        "run",
+        "view",
+        str(run_id),
+        "--repo",
+        repo,
+        "--json",
+        "attempt,databaseId,url,workflowName,status,conclusion,jobs",
+    ]
+    if requested_attempt is not None:
+        view_command.extend(["--attempt", str(requested_attempt)])
+    run_data = json.loads(runner(view_command))
+    selected_attempt = int(run_data["attempt"])
+    if run_data.get("workflowName") != "ty ecosystem-analyzer":
+        raise MetadataError("the run is not from the 'ty ecosystem-analyzer' workflow")
+    if run_data.get("status") != "completed":
+        raise MetadataError("the Actions run has not completed")
+
+    jobs = run_data.get("jobs")
+    if not isinstance(jobs, list):
+        raise MetadataError("the Actions run did not include job metadata")
+    build_job = job_by_name(jobs, "Build ty")
+    shard_job = first_shard_job(jobs)
+
+    def job_log(job: dict[str, Any]) -> str:
+        return runner(
+            [
+                "gh",
+                "run",
+                "view",
+                str(run_id),
+                "--repo",
+                repo,
+                "--attempt",
+                str(selected_attempt),
+                "--job",
+                str(job["databaseId"]),
+                "--log",
+            ]
+        )
+
+    merge_base, pr_revision = parse_build_log(job_log(build_job))
+    exclude_newer, analyzer_revision, shard_merge_base = parse_shard_log(
+        job_log(shard_job)
+    )
+    if shard_merge_base != merge_base:
+        raise MetadataError("build and shard logs disagree on the merge base")
+
+    def repository_file(repository: str, path: str, revision: str) -> str:
+        return runner(
+            [
+                "gh",
+                "api",
+                "--method",
+                "GET",
+                f"repos/{repository}/contents/{path}",
+                "-f",
+                f"ref={revision}",
+                "-H",
+                "Accept: application/vnd.github.raw+json",
+            ]
+        )
+
+    analyzer_pyproject = repository_file(
+        analyzer_repo, "pyproject.toml", analyzer_revision
+    )
+    analyzer_config = repository_file(
+        analyzer_repo,
+        "src/ecosystem_analyzer/config.py",
+        analyzer_revision,
+    )
+    minimum_python = parse_minimum_python(analyzer_config)
+    primer_revision = parse_mypy_primer_revision(analyzer_pyproject)
+    primer_projects = repository_file(
+        "hauntsaninja/mypy_primer",
+        "mypy_primer/projects.py",
+        primer_revision,
+    )
+
+    return {
+        "run": {
+            "attempt": selected_attempt,
+            "conclusion": run_data["conclusion"],
+            "id": int(run_data["databaseId"]),
+            "url": run_data["url"],
+        },
+        "ruff": {
+            "merge_base": merge_base,
+            "pr_revision": pr_revision,
+        },
+        "exclude_newer": exclude_newer,
+        "ecosystem_analyzer": {
+            "minimum_python": ".".join(str(part) for part in minimum_python),
+            "revision": analyzer_revision,
+        },
+        "mypy_primer": {"revision": primer_revision},
+        "project_python": parse_project_versions(
+            primer_projects, projects, minimum_python
+        ),
+    }
+
+
+def render_metadata(metadata: dict[str, Any]) -> str:
+    return json.dumps(metadata, indent=2, sort_keys=True) + "\n"
+
+
+def write_metadata(metadata: dict[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(render_metadata(metadata))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run", help="Actions run ID or URL")
+    parser.add_argument("projects", nargs="*", help="mypy-primer project names")
+    parser.add_argument("--repo", default="astral-sh/ruff")
+    parser.add_argument("--analyzer-repo", default="astral-sh/ecosystem-analyzer")
+    parser.add_argument("--attempt", type=int)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    try:
+        metadata = collect_metadata(
+            args.run,
+            args.projects,
+            repo=args.repo,
+            analyzer_repo=args.analyzer_repo,
+            attempt=args.attempt,
+        )
+    except (MetadataError, json.JSONDecodeError, KeyError, TypeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+
+    if args.output is None:
+        print(render_metadata(metadata), end="")
+    else:
+        write_metadata(metadata, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_primer_project.py
+++ b/scripts/setup_primer_project.py
@@ -5,18 +5,10 @@
 # dependencies = ["mypy-primer"]
 #
 # [tool.uv]
-# # The only direct dependency of this script is mypy-primer,
-# # and mypy-primer is a git dependency, so it is unaffected
-# # by the `exclude-newer` setting:
-# #
-# # > The --exclude-newer option is only applied to packages
-# # > that are read from a registry (as opposed to, e.g., Git dependencies).
-# # -- https://docs.astral.sh/uv/concepts/resolution/#reproducible-resolutions
-# #
-# # That's probably desirable: we usually want the latest
-# # version of mypy-primer anyway. But it's still worth setting
-# # `exclude-newer` here for any transitive dependencies of
-# # mypy-primer.
+# # This is the default for ad hoc use. Historical ecosystem reproduction must
+# # bypass the adjacent lock and select ecosystem-analyzer's exact mypy-primer
+# # revision and project Python version, as shown in the module docstring.
+# # `exclude-newer` still constrains mypy-primer's registry dependencies.
 # exclude-newer = "7 days"
 #
 # [tool.uv.sources]
@@ -25,7 +17,9 @@
 
 """Clone a mypy-primer project and set up a virtualenv with its dependencies installed.
 
-Usage: uv run --no-project scripts/setup_primer_project.py <project-name> [directory] [options]
+For ecosystem-report reproduction, always select the project's ecosystem-analyzer Python version and bypass the adjacent lock with the exact mypy-primer revision pinned by ecosystem-analyzer:
+
+uv run --python <version> --with "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@<mypy-primer-revision>" --no-project python scripts/setup_primer_project.py <project-name> [directory] [options]
 """
 
 from __future__ import annotations
@@ -157,7 +151,8 @@ def main() -> None:
     print(f"Activate the venv with: source {venv_dir}/bin/activate")
     print("\nProject-specific ty command:")
     print("  ty_binary=/path/to/ty")
-    print(f"  {get_ty_command(project, ty_binary='"$ty_binary"', venv_dir=venv_dir)}")
+    ty_command = get_ty_command(project, ty_binary='"$ty_binary"', venv_dir=venv_dir)
+    print(f"  {ty_command}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make the ecosystem-summary skill concise and output-focused, with an explicit report template and separate subagent guidance
- capture the exact historical Ruff, ecosystem-analyzer, mypy-primer, Python, and dependency-cutoff inputs from a GitHub Actions run
- move detailed minimization guidance into a reference and clarify how primer projects must be reproduced

## Test plan

- `./scripts/collect_ty_ecosystem_run_metadata.py --help`
- validate both updated skills with `quick_validate.py`
- `uvx prek run --files <all changed files>`
