### PR TITLE
[ty] Avoid caching constant constraint relations

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -91,6 +91,7 @@ use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::ops::Range;
+use std::sync::OnceLock;
 
 use indexmap::map::Entry;
 use itertools::Itertools;
@@ -257,6 +258,15 @@ impl Default for OwnedConstraintSet<'_> {
 }
 
 impl<'db> OwnedConstraintSet<'db> {
+    pub(crate) fn always() -> &'static OwnedConstraintSet<'static> {
+        static ALWAYS: OnceLock<OwnedConstraintSet<'static>> = OnceLock::new();
+
+        ALWAYS.get_or_init(|| {
+            let builder = ConstraintSetBuilder::new();
+            builder.into_owned(|builder| ConstraintSet::always(builder))
+        })
+    }
+
     /// Loads this constraint set into a new builder, invokes a callback with that builder, and
     /// returns the result.
     ///

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -414,6 +414,34 @@ impl<'db> Type<'db> {
         )
     }
 
+    /// Returns whether constraint-set assignability is known to be unconditionally satisfied
+    /// before constructing the relation checker.
+    fn is_trivially_constraint_set_assignable_to(self, db: &'db dyn Db, target: Type<'db>) -> bool {
+        if self.materialized_divergent_fallback().is_none() && self == target {
+            return true;
+        }
+
+        // Type variables must be converted into constraints before applying the remaining
+        // relation shortcuts.
+        if self.is_type_var() || target.is_type_var() {
+            return false;
+        }
+
+        match (self, target) {
+            (Type::Never | Type::Dynamic(_), _) | (_, Type::Dynamic(_)) => true,
+            (_, Type::NominalInstance(target)) if target.is_object() => true,
+            (_, Type::Union(union)) => {
+                self.materialized_divergent_fallback().is_none()
+                    && union.elements(db).contains(&self)
+            }
+            (Type::Intersection(intersection), _) => {
+                target.materialized_divergent_fallback().is_none()
+                    && intersection.positive(db).contains(&target)
+            }
+            _ => false,
+        }
+    }
+
     /// Returns an _owned_ (i.e. salsa-cached) constraint set that describes when `self` is
     /// constraint-set assignable to `target`.
     pub(super) fn when_constraint_set_assignable_to_owned(
@@ -441,6 +469,10 @@ impl<'db> Type<'db> {
                     TypeRelation::ConstraintSetAssignability,
                 )
             })
+        }
+
+        if self.is_trivially_constraint_set_assignable_to(db, target) {
+            return OwnedConstraintSet::always();
         }
 
         when_constraint_set_assignable_to_owned_impl(db, self, target)


### PR DESCRIPTION
## Summary

`when_constraint_set_assignable_to_owned` currently creates and retains a Salsa query for every type pair, even when the relation is trivially and unconditionally satisfied.

This PR recognizes those cases before entering the tracked query and returns a shared `OwnedConstraintSet::always()`.
