### PR TITLE
[ty] Construct trivial constraint sets directly

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -91,7 +91,6 @@ use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::ops::Range;
-use std::sync::OnceLock;
 
 use indexmap::map::Entry;
 use itertools::Itertools;
@@ -258,13 +257,13 @@ impl Default for OwnedConstraintSet<'_> {
 }
 
 impl<'db> OwnedConstraintSet<'db> {
-    pub(crate) fn always() -> &'static OwnedConstraintSet<'static> {
-        static ALWAYS: OnceLock<OwnedConstraintSet<'static>> = OnceLock::new();
-
-        ALWAYS.get_or_init(|| {
-            let builder = ConstraintSetBuilder::new();
-            builder.into_owned(|builder| ConstraintSet::always(builder))
-        })
+    pub(crate) fn always() -> Self {
+        Self {
+            node: ALWAYS_TRUE,
+            constraints: IndexVec::default(),
+            typevars: IndexVec::default(),
+            nodes: IndexVec::default(),
+        }
     }
 
     /// Loads this constraint set into a new builder, invokes a callback with that builder, and
@@ -3217,8 +3216,8 @@ impl<'db> PathBounds<'db> {
                     let when_upper =
                         constraint_upper.when_constraint_set_assignable_to_owned(db, upper);
                     let when = builder
-                        .load(db, when_lower)
-                        .and(db, builder, || builder.load(db, when_upper));
+                        .load(db, &when_lower)
+                        .and(db, builder, || builder.load(db, &when_upper));
                     !when.is_never_satisfied(db)
                 });
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2312,13 +2312,13 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let spec = &[KnownClass::Str.to_instance(self.db), Type::object()];
         let mapping = KnownClass::Mapping.to_specialized_instance(self.db, spec);
         let mapping_when = mapping.when_constraint_set_assignable_to_owned(self.db, formal);
-        let mapping_when = self.constraints.load(self.db, mapping_when);
+        let mapping_when = self.constraints.load(self.db, &mapping_when);
         typed_dicts
             .into_iter()
             .all(|element| {
                 let element_when = self.constraints.load(
                     self.db,
-                    element.when_constraint_set_assignable_to_owned(self.db, formal),
+                    &element.when_constraint_set_assignable_to_owned(self.db, formal),
                 );
                 element_when
                     .iff(self.db, self.constraints, mapping_when)
@@ -2839,7 +2839,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         // eventually want this logic to be used for _all_ nominal instances
                         // (replacing the logic below).
                         let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
-                        let when = self.constraints.load(self.db, when);
+                        let when = self.constraints.load(self.db, &when);
                         // For protocol inference via constraint sets, we currently treat
                         // unsatisfiable results as "no inference" instead of an immediate
                         // specialization error. This matches the previous behavior (where
@@ -2904,7 +2904,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
             (formal @ Type::ProtocolInstance(_), actual @ Type::TypedDict(_)) => {
                 let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
-                let when = self.constraints.load(self.db, when);
+                let when = self.constraints.load(self.db, &when);
                 // For protocol inference via constraint sets, keep unsatisfiable results non-fatal
                 // for now, matching the protocol constraint-set path in the nominal-instance
                 // arm above.

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use itertools::Itertools;
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
@@ -448,7 +450,7 @@ impl<'db> Type<'db> {
         self,
         db: &'db dyn Db,
         target: Type<'db>,
-    ) -> &'db OwnedConstraintSet<'db> {
+    ) -> Cow<'db, OwnedConstraintSet<'db>> {
         #[salsa::tracked(
             returns(ref),
             cycle_initial=|_, _, _, _| OwnedConstraintSet::default(),
@@ -472,10 +474,12 @@ impl<'db> Type<'db> {
         }
 
         if self.is_trivially_constraint_set_assignable_to(db, target) {
-            return OwnedConstraintSet::always();
+            return Cow::Owned(OwnedConstraintSet::always());
         }
 
-        when_constraint_set_assignable_to_owned_impl(db, self, target)
+        Cow::Borrowed(when_constraint_set_assignable_to_owned_impl(
+            db, self, target,
+        ))
     }
 
     pub(super) fn when_constraint_set_assignable_to<'c>(


### PR DESCRIPTION
## Summary

`OwnedConstraintSet::always()` currently uses a `OnceLock` to retain a value that only contains the `ALWAYS_TRUE` node and empty arenas.

This constructs the value directly. `when_constraint_set_assignable_to_owned` now returns a `Cow`, so trivial relations can return the owned value while nontrivial relations continue to borrow the Salsa-cached result.

Follow-up to https://github.com/astral-sh/ruff/pull/25656#discussion_r3362972020.
