### PR TITLE
[ty] Avoid caching trivial overload query results

### DIFF
--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -781,6 +781,12 @@ impl<'db> FunctionLiteral<'db> {
             (overloads.into_boxed_slice(), implementation)
         }
 
+        if !self.last_definition.is_overload(db)
+            && self.last_definition.previous_overload(db).is_none()
+        {
+            return (&[], Some(self.last_definition));
+        }
+
         let (overloads, implementation) =
             overloads_and_implementation_inner(db, self.last_definition);
         (overloads.as_ref(), *implementation)


### PR DESCRIPTION
## Summary

An ordinary non-overloaded function always has an empty overload list with its last definition as the implementation.

This adds an untracked fast path before `overloads_and_implementation_inner`. Actual overload chains continue through the existing tracked computation.

On a representative package from a large Python codebase, retained `overloads_and_implementation_inner` memory fell by 99.76%.