### PR TITLE
[ty] Fix override diagnostics for decorated methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -133,10 +133,10 @@ class Invalid:
     def bad_settable_property(self, x: int) -> None: ...
     @lossy_decorator
     @override
-    def lossy(self): ...  # TODO: should emit `invalid-explicit-override` here
+    def lossy(self): ...  # error: [invalid-explicit-override]
     @override
     @lossy_decorator
-    def lossy2(self): ...  # TODO: should emit `invalid-explicit-override` here
+    def lossy2(self): ...  # error: [invalid-explicit-override]
 
 # TODO: all overrides in this class should cause us to emit *Liskov* violations,
 # but not `@override` violations
@@ -440,14 +440,25 @@ class BaseProperty:
     @property
     def prop(self) -> int:
         return 1
+
+    def method(self) -> int:
+        return 1
 ```
 
 `property_setter.py`:
 
 ```py
-from typing_extensions import override
+from typing_extensions import Callable, TypeVar, override
 
 from base_property import BaseProperty
+
+_T = TypeVar("_T")
+
+def wrap(f: _T) -> Callable[[object], _T]:
+    return lambda _: f
+
+def coinflip() -> bool:
+    return True
 
 class MissingOverride(BaseProperty):
     @BaseProperty.prop.setter
@@ -459,6 +470,39 @@ class InvalidExplicitOverride:
     @override
     def prop(self, value: int) -> None:  # error: [invalid-explicit-override]
         pass
+
+class WrappedMethod(BaseProperty):
+    @wrap(BaseProperty.method)
+    def method(self) -> int:  # error: [missing-override-decorator]
+        return 2
+
+class WrappedInvalidExplicitOverride:
+    @wrap(BaseProperty.method)
+    @override
+    def method(self) -> int:  # error: [invalid-explicit-override]
+        return 2
+
+class WrappedMethodWithOverrideBranch(BaseProperty):
+    if coinflip():
+        @wrap(BaseProperty.method)
+        def method(self) -> int:  # error: [missing-override-decorator]
+            return 2
+
+    else:
+        @override
+        def method(self) -> int:
+            return 3
+
+class WrappedInvalidExplicitOverrideWithUndecoratedBranch:
+    if coinflip():
+        @wrap(BaseProperty.method)
+        @override
+        def method(self) -> int:  # error: [invalid-explicit-override]
+            return 2
+
+    else:
+        def method(self) -> int:
+            return 3
 ```
 
 `stub.pyi`:
@@ -697,10 +741,13 @@ class Child(Parent):
 
 The typing spec states that for an overloaded method, `@override` should only be applied to the
 implementation function. However, we nonetheless respect the decorator in this situation, even
-though we also emit `invalid-overload` on these methods.
+though we may also emit `invalid-overload` on these methods.
 
 ```py
-from typing_extensions import override, overload
+from typing_extensions import Any, Callable, override, overload
+
+def lossy_decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+    return fn
 
 class Spam:
     @overload
@@ -732,6 +779,16 @@ class Spam:
     def baz(self, x: int) -> int: ...
     # error: [invalid-explicit-override]
     def baz(self, x: str | int) -> str | int:
+        return x
+
+    @overload
+    @override
+    def quux(self, x: str) -> str: ...
+    @overload
+    def quux(self, x: int) -> int: ...
+    @lossy_decorator
+    # error: [invalid-explicit-override]
+    def quux(self, x: str | int) -> str | int:
         return x
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/override.md_-_`typing.override`_-_Basics_(b7c220f8171f11f0).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/override.md_-_`typing.override`_-_Basics_(b7c220f8171f11f0).snap
@@ -137,10 +137,10 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/override.md
 122 |     def bad_settable_property(self, x: int) -> None: ...
 123 |     @lossy_decorator
 124 |     @override
-125 |     def lossy(self): ...  # TODO: should emit `invalid-explicit-override` here
+125 |     def lossy(self): ...  # error: [invalid-explicit-override]
 126 |     @override
 127 |     @lossy_decorator
-128 |     def lossy2(self): ...  # TODO: should emit `invalid-explicit-override` here
+128 |     def lossy2(self): ...  # error: [invalid-explicit-override]
 129 | 
 130 | # TODO: all overrides in this class should cause us to emit *Liskov* violations,
 131 | # but not `@override` violations
@@ -296,6 +296,33 @@ error[invalid-explicit-override]: Method `bad_settable_property` is decorated wi
     |         ^^^^^^^^^^^^^^^^^^^^^
     |
 info: No `bad_settable_property` definitions were found on any superclasses of `Invalid`
+
+```
+
+```
+error[invalid-explicit-override]: Method `lossy` is decorated with `@override` but does not override anything
+   --> src/mdtest_snippet.pyi:124:5
+    |
+124 |     @override
+    |     ---------
+125 |     def lossy(self): ...  # error: [invalid-explicit-override]
+    |         ^^^^^
+    |
+info: No `lossy` definitions were found on any superclasses of `Invalid`
+
+```
+
+```
+error[invalid-explicit-override]: Method `lossy2` is decorated with `@override` but does not override anything
+   --> src/mdtest_snippet.pyi:126:5
+    |
+126 |     @override
+    |     ---------
+127 |     @lossy_decorator
+128 |     def lossy2(self): ...  # error: [invalid-explicit-override]
+    |         ^^^^^^
+    |
+info: No `lossy2` definitions were found on any superclasses of `Invalid`
 
 ```
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -4,7 +4,11 @@
 //! [Liskov Substitution Principle]: https://en.wikipedia.org/wiki/Liskov_substitution_principle
 
 use bitflags::bitflags;
-use ruff_db::diagnostic::Annotation;
+use ruff_db::{
+    diagnostic::{Annotation, Span},
+    files::FileRange,
+    parsed::ParsedModuleRef,
+};
 use ruff_python_ast::name::Name;
 use ruff_python_stdlib::identifiers::is_mangled_private;
 use rustc_hash::FxHashSet;
@@ -13,6 +17,7 @@ use crate::{
     Db,
     lint::LintId,
     place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin},
+    reachability::ReachabilityConstraintsExtension,
     types::{
         CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, Parameter, Parameters,
         Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
@@ -29,6 +34,7 @@ use crate::{
         },
         enums::{EnumMetadata, enum_metadata},
         function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral},
+        infer::infer_definition_types,
         list_members::{Member, MemberWithDefinition, all_end_of_scope_members},
         tuple::Tuple,
     },
@@ -1063,32 +1069,20 @@ fn check_explicit_overrides<'db>(
     class: ClassType<'db>,
 ) {
     let db = context.db();
-    let functions = extract_overriding_functions(db, member.ty, &member.name, subclass_scope);
-    let Some(decorated_function) = functions
-        .iter()
-        .find(|function| function.has_known_decorator(db, FunctionDecorators::OVERRIDE))
+    let Some(definition) = invalid_explicit_override_definition(context, member, subclass_scope)
     else {
         return;
     };
-    let function_literal = if context.in_stub() {
-        decorated_function.first_overload_or_implementation(db)
-    } else {
-        decorated_function.literal(db).last_definition
-    };
 
-    let Some(builder) = context.report_lint(
-        &INVALID_EXPLICIT_OVERRIDE,
-        function_literal.focus_range(db, context.module()),
-    ) else {
+    let Some(builder) = context.report_lint(&INVALID_EXPLICIT_OVERRIDE, definition.focus_range)
+    else {
         return;
     };
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Method `{}` is decorated with `@override` but does not override anything",
         member.name
     ));
-    if let Some(decorator_span) =
-        function_literal.find_known_decorator_span(db, KnownFunction::Override)
-    {
+    if let Some(decorator_span) = definition.focus_override_decorator_span {
         diagnostic.annotate(Annotation::secondary(decorator_span));
     }
     diagnostic.info(format_args!(
@@ -1096,6 +1090,54 @@ fn check_explicit_overrides<'db>(
         member = &member.name,
         class = class.name(db)
     ));
+}
+
+/// Facts extracted for one local definition of the member under analysis.
+#[derive(Debug)]
+struct LocalOverrideDefinition {
+    /// Range to use as the primary diagnostic location.
+    ///
+    /// This is usually the function name. For an overloaded function, it points to the
+    /// implementation in a source file, or the first overload in a stub.
+    focus_range: FileRange,
+    /// Whether any overload or implementation in this local function has `@override`.
+    ///
+    /// `invalid-explicit-override` treats `@override` as explicit even when it appears on a
+    /// non-focused overload, for example on the first overload in a source file where the
+    /// diagnostic itself points at the implementation.
+    any_definition_has_override_decorator: bool,
+    /// Whether the definition selected as the diagnostic target has `@override`.
+    ///
+    /// `missing-override-decorator` uses this instead of `any_definition_has_override_decorator`
+    /// so that a misplaced `@override` on another overload still reports an error on the
+    /// implementation.
+    focus_definition_has_override_decorator: bool,
+    /// Span of the `@override` decorator on the focused definition, if present.
+    ///
+    /// This lets `invalid-explicit-override` underline the decorator separately from the function
+    /// name. It is absent when only a non-focused overload has `@override`.
+    focus_override_decorator_span: Option<Span>,
+}
+
+impl LocalOverrideDefinition {
+    fn from_function<'db>(
+        db: &'db dyn Db,
+        function: FunctionType<'db>,
+        in_stub: bool,
+        module: &ParsedModuleRef,
+    ) -> Self {
+        let focus_definition = overriding_definition(db, function, in_stub);
+
+        Self {
+            focus_range: focus_definition.focus_range(db, module),
+            any_definition_has_override_decorator: function
+                .has_known_decorator(db, FunctionDecorators::OVERRIDE),
+            focus_definition_has_override_decorator: focus_definition
+                .has_known_decorator(db, FunctionDecorators::OVERRIDE),
+            focus_override_decorator_span: focus_definition
+                .find_known_decorator_span(db, KnownFunction::Override),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1130,20 +1172,12 @@ fn check_missing_overrides<'db>(
 ) {
     let db = context.db();
 
-    let Some(undecorated_override) = overriding_definition_without_decorator(
-        db,
-        member.ty,
-        &member.name,
-        subclass_scope,
-        context.in_stub(),
-    ) else {
+    let Some(definition) = missing_override_definition(context, member, subclass_scope) else {
         return;
     };
 
-    let Some(builder) = context.report_lint(
-        &MISSING_OVERRIDE_DECORATOR,
-        undecorated_override.focus_range(db, context.module()),
-    ) else {
+    let Some(builder) = context.report_lint(&MISSING_OVERRIDE_DECORATOR, definition.focus_range)
+    else {
         return;
     };
 
@@ -1171,70 +1205,163 @@ fn check_missing_overrides<'db>(
     }
 }
 
-fn overriding_definition_without_decorator<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    member_name: &Name,
+fn invalid_explicit_override_definition<'db>(
+    context: &InferContext<'db, '_>,
+    member: &Member<'db>,
     subclass_scope: ScopeId<'db>,
-    in_stub: bool,
-) -> Option<OverloadLiteral<'db>> {
-    for function in extract_overriding_functions(db, ty, member_name, subclass_scope) {
-        let definition = overriding_definition(db, function, in_stub);
-        if !definition.has_known_decorator(db, FunctionDecorators::OVERRIDE) {
-            return Some(definition);
-        }
-    }
-
-    None
+) -> Option<LocalOverrideDefinition> {
+    extract_local_override_definitions(context, member, subclass_scope)
+        .into_iter()
+        .find(|definition| definition.any_definition_has_override_decorator)
 }
 
-/// Extract functions that belong to the subclass member currently being checked.
-/// These functions are the appropriate anchor points for override diagnostics.
-fn extract_overriding_functions<'db>(
+fn missing_override_definition<'db>(
+    context: &InferContext<'db, '_>,
+    member: &Member<'db>,
+    subclass_scope: ScopeId<'db>,
+) -> Option<LocalOverrideDefinition> {
+    extract_local_override_definitions(context, member, subclass_scope)
+        .into_iter()
+        .find(|definition| !definition.focus_definition_has_override_decorator)
+}
+
+/// Extract function definitions that can carry an `@override` decorator for the class member
+/// currently being checked.
+///
+/// Use functions recovered from the member type when possible, because this preserves overload and
+/// property accessor handling. If decorators replaced some subclass definitions with functions from
+/// another class or file, recover the local function type from the binding definition so overload
+/// metadata is still preserved.
+fn extract_local_override_definitions<'db>(
+    context: &InferContext<'db, '_>,
+    member: &Member<'db>,
+    subclass_scope: ScopeId<'db>,
+) -> smallvec::SmallVec<[LocalOverrideDefinition; 1]> {
+    let db = context.db();
+    let in_stub = context.in_stub();
+    let module = context.module();
+    let member_functions =
+        extract_member_functions_from_type(db, member.ty, &member.name, subclass_scope);
+    let mut candidates = smallvec::smallvec![];
+    let mut seen_function_types = smallvec::SmallVec::<[FunctionType<'db>; 1]>::new();
+
+    for definition in end_of_scope_function_definitions(db, subclass_scope, &member.name) {
+        let function = member_functions
+            .iter()
+            .copied()
+            .find(|function| function.contains_definition(db, definition))
+            .or_else(|| infer_definition_types(db, definition).function_type(definition));
+
+        let Some(function) = function else {
+            continue;
+        };
+
+        if seen_function_types.contains(&function) {
+            continue;
+        }
+        candidates.push(LocalOverrideDefinition::from_function(
+            db, function, in_stub, module,
+        ));
+        seen_function_types.push(function);
+    }
+
+    // A property with a setter can keep the getter in the member type even though the setter is the
+    // end-of-scope binding. Preserve any type-derived functions that the syntactic pass did not see.
+    for function in member_functions {
+        if !seen_function_types.contains(&function) {
+            candidates.push(LocalOverrideDefinition::from_function(
+                db, function, in_stub, module,
+            ));
+        }
+    }
+
+    candidates
+}
+
+/// Return reachable function definitions that bind `member_name` at the end of `subclass_scope`.
+fn end_of_scope_function_definitions<'db>(
+    db: &'db dyn Db,
+    subclass_scope: ScopeId<'db>,
+    member_name: &Name,
+) -> smallvec::SmallVec<[Definition<'db>; 1]> {
+    let table = place_table(db, subclass_scope);
+    let Some(symbol_id) = table.symbol_id(member_name) else {
+        return smallvec::smallvec![];
+    };
+
+    let use_def = use_def_map(db, subclass_scope);
+    let predicates = use_def.predicates();
+    let reachability_constraints = use_def.reachability_constraints();
+
+    use_def
+        .end_of_scope_symbol_bindings(symbol_id)
+        .filter_map(|binding| {
+            let definition = binding.binding.definition()?;
+            let reachability =
+                reachability_constraints.evaluate(db, predicates, binding.reachability_constraint);
+            if reachability.is_always_false() || !definition.kind(db).is_function_def() {
+                return None;
+            }
+
+            Some(definition)
+        })
+        .collect()
+}
+
+/// Extract functions represented by a member type that belong to the member currently being
+/// checked. Decorators can replace a function with a function from another class or file, so
+/// callers must not use unfiltered functions as diagnostic anchors.
+///
+/// The same is true for property accessors: a setter or deleter can reuse a getter defined by
+/// another class, but override diagnostics should only point at accessors defined by the subclass
+/// member under analysis.
+fn extract_member_functions_from_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
     member_name: &Name,
-    subclass_scope: ScopeId<'db>,
+    member_scope: ScopeId<'db>,
 ) -> smallvec::SmallVec<[FunctionType<'db>; 1]> {
-    match ty {
-        Type::PropertyInstance(property) => {
-            let subclass_file = subclass_scope.file(db);
-            let mut functions = smallvec::smallvec![];
+    let mut functions = smallvec::SmallVec::<[FunctionType<'db>; 1]>::new();
+    let mut types: smallvec::SmallVec<[Type<'db>; 1]> = smallvec::smallvec![ty];
+    let mut index = 0;
 
-            // A setter or deleter can reuse a getter from a different class or file. Diagnostics
-            // should only consider accessors defined by the subclass member under analysis.
-            for accessor in [
-                property.getter(db),
-                property.setter(db),
-                property.deleter(db),
-            ]
-            .into_iter()
-            .flatten()
-            {
-                let accessor_functions = extract_underlying_functions(db, accessor);
-                functions.extend(accessor_functions.into_iter().filter(|function| {
-                    function.name(db) == member_name
-                        && function.file(db) == subclass_file
-                        && function.definition(db).scope(db) == subclass_scope
-                }));
+    while let Some(ty) = types.get(index).copied() {
+        index += 1;
+        match ty {
+            Type::PropertyInstance(property) => {
+                for accessor in [
+                    property.getter(db),
+                    property.setter(db),
+                    property.deleter(db),
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    functions.extend(extract_underlying_functions(db, accessor));
+                }
             }
-
-            functions
-        }
-        Type::Union(union) => {
-            let mut functions = smallvec::smallvec![];
-            for member in union.elements(db) {
-                functions.extend(extract_overriding_functions(
-                    db,
-                    *member,
-                    member_name,
-                    subclass_scope,
-                ));
+            Type::Union(union) => {
+                types.extend(union.elements(db).iter().copied());
             }
-            functions
+            _ => functions.extend(extract_underlying_functions(db, ty)),
         }
-        _ => extract_underlying_functions(db, ty),
     }
+
+    functions
+        .into_iter()
+        .filter(|function| is_local_member_function(db, *function, member_name, member_scope))
+        .collect()
+}
+
+fn is_local_member_function<'db>(
+    db: &'db dyn Db,
+    function: FunctionType<'db>,
+    member_name: &Name,
+    member_scope: ScopeId<'db>,
+) -> bool {
+    function.file(db) == member_scope.file(db)
+        && function.definition(db).scope(db) == member_scope
+        && function.name(db) == member_name
 }
 
 fn overriding_definition<'db>(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This corrects `invalid-explicit-override` and `missing-override-decorator` diagnostics for decorated methods whose inferred member type no longer points at the local definition.

Previously, we could either miss the local `@override` marker entirely or anchor the diagnostic to a definition from outside the class being analyzed. An external definition is never the right target for these override diagnostics, so we now use type-derived functions only when they still belong to the member under analysis, and we supplement those candidates with reachable local function definitions recovered from the class body.

Tools differ on their handling of these diagnostics, but I think we've arrived at a reasonable place. The table below summarizes whether or not a tool emits an equivalent diagnostic (given the appropriate configuration) for each positive diagnostic expectation changed or added in this pull request:

| Changed test case                                                                                                                                                                                         | ty | pyrefly (`1.0.0`) | zuban (`0.8.0`) | mypy (`2.1.0`) | pyright (`1.1.410`)    |
| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- | ----------------- | --------------- | -------------- | ---------------------- |
| [`lossy` inner `@override`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L134-L136)                             | yes | yes               | yes             | yes            | no                     |
| [`lossy2` outer `@override`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L137-L139)                            | yes | yes               | yes             | yes            | no                     |
| [`WrappedMethod`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L474-L477)                                       | yes | no                | yes             | yes            | no                     |
| [`WrappedInvalidExplicitOverride`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L479-L482)                      | yes | no                | yes             | yes            | no                     |
| [`WrappedMethodWithOverrideBranch`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L485-L493)                     | yes | no                | yes             | yes            | ?[^redeclaration-only] |
| [`WrappedInvalidExplicitOverrideWithUndecoratedBranch`](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L496-L504) | yes | no                | yes             | yes            | ?[^redeclaration-only] |
| [`quux` overloaded `@override` with lossy implementation](https://github.com/astral-sh/ruff/blob/b1ed9f076837fe12a064bd2b35bd48bb0647edb8/crates/ty_python_semantic/resources/mdtest/override.md?plain=1#L784-L791) | yes | ?[^overload-placement-only] | yes | yes | ?[^overload-placement-only] |

[^redeclaration-only]: Pyright reported only a duplicate-definition diagnostic for this mixed-branch case (`reportRedeclaration`). That is not an equivalent override rule, but it may also obscure whether pyright would attempt the override-specific check after resolving the duplicate-definition problem.
[^overload-placement-only]: Pyrefly and Pyright reported only an overload-placement diagnostic for this case (`invalid-overload` / `reportInconsistentOverload`). That is not an equivalent override rule, but it may obscure whether they would attempt the override-specific check after resolving the overload-placement problem.

Closes https://github.com/astral-sh/ty/issues/3664.

## Test Plan

Please see included tests, both new and updated to remove some outstanding TODOs.
<!-- How was it tested? -->
