### PR TITLE
Respect diagnostic start and parent ranges and trailing comments in `ruff:ignore` suppressions

### DIFF
--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -1,0 +1,25 @@
+# Tests for `ruff:ignore` comments
+
+## End-of-line `ruff:ignore` range
+
+This is a regression test for <https://github.com/astral-sh/ruff/issues/25644>, where `ruff:ignore`
+comments behaved differently from `noqa` and `ty:ignore` comments when placed on the first line of a
+diagnostic range.
+
+```toml
+[lint]
+preview = true
+select = ["RUF015"]
+```
+
+```py
+suppressed = [  # noqa: RUF015
+    *range(10)
+][0]
+
+# TODO this shouldn't error
+# error: [unnecessary-iterable-allocation-for-first-element]
+not_suppressed = [  # ruff:ignore[RUF015]
+    *range(10)
+][0]
+```

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -17,8 +17,6 @@ suppressed = [  # noqa: RUF015
     *range(10)
 ][0]
 
-# TODO this shouldn't error
-# error: [unnecessary-iterable-allocation-for-first-element]
 not_suppressed = [  # ruff:ignore[RUF015]
     *range(10)
 ][0]

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -68,3 +68,18 @@ not_suppressed = [
 ][0]
 # ruff:enable[RUF015]
 ```
+
+## Make sure the code actually matches
+
+```toml
+[lint]
+preview = true
+select = ["RUF015"]
+```
+
+```py
+# error: [unnecessary-iterable-allocation-for-first-element]
+not_suppressed = [  # ruff:ignore[F401]
+    *range(10)
+][0]
+```

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -35,3 +35,36 @@ select = ["W292"]
 ```py
 suppressed = 1  # ruff:ignore[W292]
 ```
+
+## Block suppression boundaries
+
+A block suppression should not apply to a diagnostic that starts inside the disabled range but ends
+after the matching `ruff:enable` comment:
+
+```toml
+[lint]
+preview = true
+select = ["RUF015"]
+```
+
+```py
+# ruff:disable[RUF015]
+# error: [unnecessary-iterable-allocation-for-first-element]
+not_suppressed = [
+# ruff:enable[RUF015]
+    *range(10)
+][0]
+```
+
+This isn't _strictly_ a problem because the formatter will indent and invalidate the `ruff:enable`
+comment here, raising `RUF103`, but it seems better for this not to work regardless of formatting.
+
+This is how the comments should look instead:
+
+```py
+# ruff:disable[RUF015]
+not_suppressed = [
+    *range(10)
+][0]
+# ruff:enable[RUF015]
+```

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -2,7 +2,7 @@
 
 ## End-of-line `ruff:ignore` range
 
-This is a regression test for <https://github.com/astral-sh/ruff/issues/25644>, where `ruff:ignore`
+These are regression tests for <https://github.com/astral-sh/ruff/issues/25644>, where `ruff:ignore`
 comments behaved differently from `noqa` and `ty:ignore` comments when placed on the first line of a
 diagnostic range.
 
@@ -22,7 +22,25 @@ not_suppressed = [  # ruff:ignore[RUF015]
 ][0]
 ```
 
-## Empty diagnostic at end of file
+## Standalone `ruff:ignore` range
+
+This case also was previously not suppressed but will be now. The `B903` diagnostic covers the
+entire class definition.
+
+```toml
+[lint]
+preview = true
+select = ["B903"]
+```
+
+```py
+# ruff:ignore[B903]
+class Point:
+    def __init__(self, x: int):
+        self.x = x
+```
+
+## Empty diagnostic range at end of file
 
 Diagnostics with empty ranges should also be suppressible, as with `noqa`.
 

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -21,3 +21,17 @@ not_suppressed = [  # ruff:ignore[RUF015]
     *range(10)
 ][0]
 ```
+
+## Empty diagnostic at end of file
+
+Diagnostics with empty ranges should also be suppressible, as with `noqa`.
+
+```toml
+[lint]
+preview = true
+select = ["W292"]
+```
+
+```py
+suppressed = 1  # ruff:ignore[W292]
+```

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -101,3 +101,41 @@ not_suppressed = [  # ruff:ignore[F401]
     *range(10)
 ][0]
 ```
+
+## Own-line ignore covers trailing comments
+
+```toml
+[lint]
+preview = true
+select = [ "E" ]
+```
+
+```py
+# TODO:
+# ruff:ignore[E262]
+# error: [no-space-after-inline-comment]
+x = 1  #bad
+```
+
+## Respect parent suppression range
+
+```toml
+[lint]
+preview = true
+select = [ "F" ]
+```
+
+Some diagnostics have a "parent" range, which should also be accounted for when suppressing them
+with both `noqa` and `ruff:ignore`.
+
+```py
+from foo import (  # noqa: F401
+        bar
+)
+
+from foo import (  # ruff:ignore[F401]
+        # TODO:
+        # error: [unused-import]
+        baz
+)
+```

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -162,8 +162,6 @@ from foo import (  # noqa: F401
 )
 
 from foo import (  # ruff:ignore[F401]
-        # TODO:
-        # error: [unused-import]
         baz
 )
 ```

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -111,9 +111,7 @@ select = [ "E" ]
 ```
 
 ```py
-# TODO:
 # ruff:ignore[E262]
-# error: [no-space-after-inline-comment]
 x = 1  #bad
 ```
 

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -192,3 +192,27 @@ from sys import ( # ruff:ignore[F401]
     argv # ruff:ignore[F401]
 )
 ```
+
+## Trailing whitespace is included in the suppression range
+
+```toml
+[lint]
+preview = true
+select = [ "W291" ]
+```
+
+For both logical and non-logical newlines:
+
+<!-- fmt:off -->
+
+```py
+# ruff:ignore[W291]
+foo    
+
+values = [
+    # ruff:ignore[W291]
+    bar    
+]
+```
+
+<!-- fmt:on -->

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -165,3 +165,30 @@ from foo import (  # ruff:ignore[F401]
         baz
 )
 ```
+
+## Parent suppression range and unused comments
+
+```toml
+[lint]
+preview = true
+select = [ "F401", "RUF100" ]
+```
+
+For cases with both a parent and non-parent `noqa` comment, the parent is marked as used, while the
+non-parent, which falls later textually, is marked as unused.
+
+```py
+from math import ( # noqa: F401
+    # error: [unused-noqa]
+    cos # noqa: F401
+)
+```
+
+`ruff:ignore` should behave in the same way:
+
+```py
+from sys import ( # ruff:ignore[F401]
+    # error: [unused-noqa]
+    argv # ruff:ignore[F401]
+)
+```

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -115,6 +115,36 @@ select = [ "E" ]
 x = 1  #bad
 ```
 
+An ignore comment inside a multi-line statement only covers the next physical line, including its
+trailing comment:
+
+```py
+values = [
+    # ruff:ignore[E262]
+    1,  #bad
+    # error: [no-space-after-inline-comment]
+    2,  #bad
+]
+```
+
+An own-line ignore does not extend to a comment on the following line:
+
+```py
+# ruff:ignore[E265]
+x = 1
+# error: [no-space-after-block-comment]
+#bad
+```
+
+An own-line ignore above a multi-line statement covers a trailing comment on its final line:
+
+```py
+# ruff:ignore[E262]
+x = (
+    1
+)  #bad
+```
+
 ## Respect parent suppression range
 
 ```toml

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -95,6 +95,8 @@ preview = true
 select = ["RUF015"]
 ```
 
+This case tests that both the range and suppression code are checked.
+
 ```py
 # error: [unnecessary-iterable-allocation-for-first-element]
 not_suppressed = [  # ruff:ignore[F401]
@@ -109,6 +111,8 @@ not_suppressed = [  # ruff:ignore[F401]
 preview = true
 select = [ "E" ]
 ```
+
+This should be suppressed:
 
 ```py
 # ruff:ignore[E262]

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -239,7 +239,10 @@ impl Suppressions {
         for suppression in &self.valid {
             let suppression_code =
                 get_redirect_target(suppression.code.as_str()).unwrap_or(suppression.code.as_str());
-            if *code == suppression_code && suppression.range.contains(range.start()) {
+
+            // Note that `contains_inclusive` is used here for diagnostics with an empty range, such
+            // as missing-newline-at-end-of-file (W292) that would otherwise be unsuppressible.
+            if *code == suppression_code && suppression.range.contains_inclusive(range.start()) {
                 suppression.used.set(true);
                 return true;
             }

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -210,6 +210,17 @@ impl Suppressions {
     }
 
     /// Check if a diagnostic is suppressed by any known range suppressions
+    ///
+    /// A suppression applies for the given diagnostic if it contains the diagnostic's start offset.
+    /// This means the suppression is on the same line as the diagnostic's start, as in:
+    ///
+    /// ```python
+    /// suppressed = [  # ruff:disable[RUF015]
+    ///     *range(10)
+    /// ][0]
+    /// ```
+    ///
+    /// where the diagnostic starts at the `[`.
     pub(crate) fn check_diagnostic(&self, diagnostic: &Diagnostic) -> bool {
         if self.valid.is_empty() {
             return false;
@@ -228,7 +239,7 @@ impl Suppressions {
         for suppression in &self.valid {
             let suppression_code =
                 get_redirect_target(suppression.code.as_str()).unwrap_or(suppression.code.as_str());
-            if *code == suppression_code && suppression.range.contains_range(range) {
+            if *code == suppression_code && suppression.range.contains(range.start()) {
                 suppression.used.set(true);
                 return true;
             }

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -103,6 +103,17 @@ impl Suppression {
     fn codes(&self) -> &[TextRange] {
         &self.comments.first().codes
     }
+
+    /// Returns whether or not the suppression is a standalone `ruff:ignore` comment.
+    fn is_ignore(&self) -> bool {
+        matches!(
+            self.comments,
+            SuppressionComments::Single(SuppressionComment {
+                action: SuppressionAction::Ignore,
+                ..
+            })
+        )
+    }
 }
 
 #[derive(Debug)]
@@ -209,18 +220,38 @@ impl Suppressions {
         self.valid.is_empty() && self.invalid.is_empty() && self.errors.is_empty()
     }
 
-    /// Check if a diagnostic is suppressed by any known range suppressions
+    /// Check if a diagnostic is suppressed by any known range suppressions.
     ///
-    /// A suppression applies for the given diagnostic if it contains the diagnostic's start offset.
-    /// This means the suppression is on the same line as the diagnostic's start, as in:
+    /// A suppression applies for the given diagnostic if it fully contains the diagnostic's range.
+    /// For example, noting that the `RUF015` diagnostic spans from the opening `[` to the end of
+    /// the subscript expression:
     ///
-    /// ```python
-    /// suppressed = [  # ruff:disable[RUF015]
+    /// ```py
+    /// # ruff:disable[RUF015]
+    /// value = [
+    ///     *range(10)
+    /// ][0]
+    /// # ruff:enable[RUF015]
+    /// ```
+    ///
+    /// is suppressed, but
+    ///
+    /// ```py
+    /// # ruff:disable[RUF015]
+    /// value = [
+    /// # ruff:enable[RUF015]
     ///     *range(10)
     /// ][0]
     /// ```
     ///
-    /// where the diagnostic starts at the `[`.
+    /// is not. For `ruff:ignore`, this rule is augmented to check whether the diagnostic's start
+    /// offset is contained instead, meaning that this _will_ be suppressed:
+    ///
+    /// ```python
+    /// suppressed = [  # ruff:ignore[RUF015]
+    ///     *range(10)
+    /// ][0]
+    /// ```
     pub(crate) fn check_diagnostic(&self, diagnostic: &Diagnostic) -> bool {
         if self.valid.is_empty() {
             return false;
@@ -242,7 +273,11 @@ impl Suppressions {
 
             // Note that `contains_inclusive` is used here for diagnostics with an empty range, such
             // as missing-newline-at-end-of-file (W292) that would otherwise be unsuppressible.
-            if *code == suppression_code && suppression.range.contains_inclusive(range.start()) {
+            if *code == suppression_code
+                && (suppression.range.contains_range(range)
+                    || suppression.is_ignore()
+                        && suppression.range.contains_inclusive(range.start()))
+            {
                 suppression.used.set(true);
                 return true;
             }

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -271,15 +271,18 @@ impl Suppressions {
             let suppression_code =
                 get_redirect_target(suppression.code.as_str()).unwrap_or(suppression.code.as_str());
 
+            if *code != suppression_code {
+                continue;
+            }
+
             // Note that `contains_inclusive` is used here for diagnostics with an empty range, such
             // as missing-newline-at-end-of-file (W292) that would otherwise be unsuppressible.
-            if *code == suppression_code
-                && (suppression.range.contains_range(range)
-                    || diagnostic
-                        .parent()
-                        .is_some_and(|parent| suppression.range.contains_inclusive(parent))
-                    || suppression.is_ignore()
-                        && suppression.range.contains_inclusive(range.start()))
+            if suppression.range.contains_range(range)
+                || suppression.is_ignore()
+                    && (suppression.range.contains_inclusive(range.start())
+                        || diagnostic
+                            .parent()
+                            .is_some_and(|parent| suppression.range.contains_inclusive(parent)))
             {
                 suppression.used.set(true);
                 return true;

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -275,14 +275,12 @@ impl Suppressions {
                 continue;
             }
 
-            // Note that `contains_inclusive` is used here for diagnostics with an empty range, such
-            // as missing-newline-at-end-of-file (W292) that would otherwise be unsuppressible.
             if suppression.range.contains_range(range)
                 || suppression.is_ignore()
-                    && (suppression.range.contains_inclusive(range.start())
+                    && (suppression.range.contains(range.start())
                         || diagnostic
                             .parent()
-                            .is_some_and(|parent| suppression.range.contains_inclusive(parent)))
+                            .is_some_and(|parent| suppression.range.contains(parent)))
             {
                 suppression.used.set(true);
                 return true;

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -887,7 +887,10 @@ impl<'a> SuppressionsBuilder<'a> {
                 TokenKind::Newline => {
                     break;
                 }
-                TokenKind::Comment => {}
+                TokenKind::Comment => {
+                    // Extend the suppression range to include comments before the final newline.
+                    end = next_token.end();
+                }
                 TokenKind::NonLogicalNewline if is_inner_comment => {
                     if seen_nonlogical_newline && !is_blank_or_comment_only {
                         break;
@@ -2642,6 +2645,37 @@ def foo():
                 reason: "",
             },
         )
+        "##,
+        );
+    }
+
+    #[test]
+    fn trailing_comment_own_line_ignore() {
+        let source = "# ruff: ignore[some-thing]
+x = 1 # trailing";
+        let comment = Suppressions::debug(source);
+        assert_debug_snapshot!(
+            comment,
+            @r##"
+        Suppressions {
+            valid: [
+                Suppression {
+                    covered_source: "# ruff: ignore[some-thing]\nx = 1 # trailing",
+                    code: "some-thing",
+                    disable_comment: SuppressionComment {
+                        text: "# ruff: ignore[some-thing]",
+                        action: Ignore,
+                        codes: [
+                            "some-thing",
+                        ],
+                        reason: "",
+                    },
+                    enable_comment: None,
+                },
+            ],
+            invalid: [],
+            errors: [],
+        }
         "##,
         );
     }

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -276,7 +276,7 @@ impl Suppressions {
             }
 
             // For `ruff:ignore` comments, only require that the start of the diagnostic range (or
-            // its parent) is covered by the diagnostic. Range suppression comments must fully
+            // its parent) is covered by the suppression. Range suppression comments must fully
             // contain the diagnostic range.
             let suppressed = if suppression.is_ignore() {
                 suppression.range.contains(range.start())

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -275,13 +275,20 @@ impl Suppressions {
                 continue;
             }
 
-            if suppression.range.contains_range(range)
-                || suppression.is_ignore()
-                    && (suppression.range.contains(range.start())
-                        || diagnostic
-                            .parent()
-                            .is_some_and(|parent| suppression.range.contains(parent)))
-            {
+            // For `ruff:ignore` comments, only require that the start of the diagnostic range (or
+            // its parent) is covered by the diagnostic. Range suppression comments must fully
+            // contain the diagnostic range.
+            let suppressed = if suppression.is_ignore() {
+                suppression.range.contains(range.start())
+                    || range.is_empty() && suppression.range.end() == range.start()
+                    || diagnostic
+                        .parent()
+                        .is_some_and(|parent| suppression.range.contains(parent))
+            } else {
+                suppression.range.contains_range(range)
+            };
+
+            if suppressed {
                 suppression.used.set(true);
                 return true;
             }

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -896,13 +896,12 @@ impl<'a> SuppressionsBuilder<'a> {
         for next_token in after {
             match next_token.kind() {
                 TokenKind::Newline => {
+                    end = next_token.start();
                     break;
                 }
-                TokenKind::Comment => {
-                    // Extend the suppression range to include comments before the final newline.
-                    end = next_token.end();
-                }
+                TokenKind::Comment => {}
                 TokenKind::NonLogicalNewline if is_inner_comment => {
+                    end = next_token.start();
                     if seen_nonlogical_newline && !is_blank_or_comment_only {
                         break;
                     }

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -275,6 +275,9 @@ impl Suppressions {
             // as missing-newline-at-end-of-file (W292) that would otherwise be unsuppressible.
             if *code == suppression_code
                 && (suppression.range.contains_range(range)
+                    || diagnostic
+                        .parent()
+                        .is_some_and(|parent| suppression.range.contains_inclusive(parent))
                     || suppression.is_ignore()
                         && suppression.range.contains_inclusive(range.start()))
             {


### PR DESCRIPTION
Summary
--

Fixes #25644 by addressing the following cases:

```py
suppressed = [  # noqa: RUF015
    *range(10)
][0]

not_suppressed = [  # ruff:ignore[RUF015]
    *range(10)
][0]
```

`ruff:ignore` now properly suppresses `RUF015`, even though only the start of the diagnostic occurs within the suppression range. This is the case from #25644.

```py
from foo import (  # noqa: F401
        bar
)

from foo import (  # ruff:ignore[F401]
        baz
)
```

`ruff:ignore` now properly respects the `parent` range of a diagnostic and suppresses the unused import here, like `noqa`.


```py
# ruff:ignore[E262]
x = 1  #bad
```

`ruff:ignore` now properly suppresses `E262` here by extending its suppression range to include the full following line rather than skipping over the trailing comment. This case isn't directly related to `noqa` on its own, but it was another separate issue and pointed to a better solution to the other cases.

[Playground](https://play.ruff.rs/b877bf42-6fda-4e6a-9d6f-ac3e9e7a1934)

Test Plan
--

New mdtests based on the cases above