### PR TITLE
[ty] Fix hang with ambiguous overload and undefined name

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -3054,7 +3054,7 @@ class ManyCycles2:
         self.x3 = [1]
 
     def f1(self: "ManyCycles2"):
-        reveal_type(self.x3)  # revealed: list[int] | list[Divergent] | Unknown | list[Unknown]
+        reveal_type(self.x3)  # revealed: list[int] | list[Divergent] | Unknown
 
         self.x1 = [self.x2] + [self.x3]
         self.x2 = [self.x1] + [self.x3]

--- a/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
@@ -437,6 +437,16 @@ while random():
     reveal_type(y)  # revealed: Literal[1, 2]
 ```
 
+### Ambiguous overloads converge during loop fixpoint iteration
+
+Regression test for [#3677](https://github.com/astral-sh/ty/issues/3677). The ambiguous overload
+result from `list.__add__` must not discard the recursive type marker used for cycle recovery.
+
+```py
+while True:
+    x = [None] + [x]  # error: [possibly-unresolved-reference]
+```
+
 ### Tuple assignments are inferred correctly
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1197,7 +1197,15 @@ impl<'db> Type<'db> {
             // However, overload is an exception; as iterations progress, overload matching may become ambiguous, and a reversal of precision can occur.
             // This kind of precision degradation can be determined by whether the type contains `DynamicType::AmbiguousOverload`.
             if self_degraded_by_overload {
-                UnionType::from_elements_cycle_recovery(db, [previous, self])
+                // A bare cycle initial value would be removed from the union during recursive
+                // normalization, so keep it until a structured recursive type is available.
+                if previous.is_divergent()
+                    && matches!(self, Type::Dynamic(DynamicType::AmbiguousOverload))
+                {
+                    previous
+                } else {
+                    UnionType::from_elements_cycle_recovery(db, [previous, self])
+                }
             } else {
                 self
             }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1004,13 +1004,17 @@ impl<'db> DefinitionTypes<'db> {
 
     fn normalize_binding(
         db: &'db dyn Db,
-        previous: &DefinitionTypes<'db>,
+        previous: &DefinitionInference<'db>,
         cycle: &salsa::Cycle,
         owner: Definition<'db>,
         definition: Definition<'db>,
         ty: Type<'db>,
     ) -> Type<'db> {
-        if let Some(previous_ty) = previous.binding_type(owner, definition) {
+        if let Some(previous_ty) = previous
+            .types
+            .binding_type(owner, definition)
+            .or_else(|| previous.fallback_type())
+        {
             ty.cycle_normalized(db, previous_ty, cycle)
         } else {
             ty.recursive_type_normalized(db, cycle)
@@ -1019,14 +1023,16 @@ impl<'db> DefinitionTypes<'db> {
 
     fn normalize_declaration(
         db: &'db dyn Db,
-        previous: &DefinitionTypes<'db>,
+        previous: &DefinitionInference<'db>,
         cycle: &salsa::Cycle,
         owner: Definition<'db>,
         definition: Definition<'db>,
         ty: TypeAndQualifiers<'db>,
     ) -> TypeAndQualifiers<'db> {
-        if let Some(previous_ty) = previous.declaration_type(owner, definition) {
+        if let Some(previous_ty) = previous.types.declaration_type(owner, definition) {
             ty.map_type(|inner| inner.cycle_normalized(db, previous_ty.inner_type(), cycle))
+        } else if let Some(previous_fallback) = previous.fallback_type() {
+            ty.map_type(|inner| inner.cycle_normalized(db, previous_fallback, cycle))
         } else {
             ty.map_type(|inner| inner.recursive_type_normalized(db, cycle))
         }
@@ -1035,7 +1041,7 @@ impl<'db> DefinitionTypes<'db> {
     fn cycle_normalized(
         self,
         db: &'db dyn Db,
-        previous: &DefinitionTypes<'db>,
+        previous: &DefinitionInference<'db>,
         cycle: &salsa::Cycle,
         owner: Definition<'db>,
     ) -> Self {
@@ -1318,7 +1324,7 @@ impl<'db> DefinitionInference<'db> {
         }
         self.types = std::mem::take(&mut self.types).cycle_normalized(
             db,
-            &previous_inference.types,
+            previous_inference,
             cycle,
             definition,
         );


### PR DESCRIPTION
## Summary

- Thread `DefinitionInference` fallback types into cycle normalization so loop fixpoint iteration can still see the initial `Divergent` marker when no prior binding exists.
- Preserve a bare `Divergent` seed when an `AmbiguousOverload` result would otherwise normalize it away.

Closes https://github.com/astral-sh/ty/issues/3677.

## Testing

Added mdtest that hangs before this change.