### PR TITLE
Avoid PTH diagnostics for file descriptors

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH202.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH202.py
@@ -80,3 +80,18 @@ getsize(Path("filename").resolve())
 import pathlib
 
 os.path.getsize(pathlib.Path("filename"))
+
+
+fd: int = 1
+os.path.getsize(1)
+os.path.getsize(filename=fd)
+getsize(fd)
+getsize(filename=1)
+
+
+class AttrHolder:
+    fd: int = 1
+
+
+os.path.getsize(AttrHolder.fd)
+getsize(AttrHolder.fd)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH203.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH203.py
@@ -33,3 +33,18 @@ getatime(Path("filename").resolve())
 os.path.getatime(pathlib.Path("filename"))
 
 getatime(Path("dir") / "file.txt")
+
+
+fd: int = 1
+os.path.getatime(1)
+os.path.getatime(filename=fd)
+getatime(fd)
+getatime(filename=1)
+
+
+class AttrHolder:
+    fd: int = 1
+
+
+os.path.getatime(AttrHolder.fd)
+getatime(AttrHolder.fd)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH204.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH204.py
@@ -11,3 +11,18 @@ os.path.getmtime(Path("filename"))
 getmtime("filename")
 getmtime(b"filename")
 getmtime(Path("filename"))
+
+
+fd: int = 1
+os.path.getmtime(1)
+os.path.getmtime(filename=fd)
+getmtime(fd)
+getmtime(filename=1)
+
+
+class AttrHolder:
+    fd: int = 1
+
+
+os.path.getmtime(AttrHolder.fd)
+getmtime(AttrHolder.fd)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH205.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/PTH205.py
@@ -10,3 +10,18 @@ os.path.getctime(Path("filename"))
 getctime("filename")
 getctime(b"filename")
 getctime(Path("filename"))
+
+
+fd: int = 1
+os.path.getctime(1)
+os.path.getctime(filename=fd)
+getctime(fd)
+getctime(filename=1)
+
+
+class AttrHolder:
+    fd: int = 1
+
+
+os.path.getctime(AttrHolder.fd)
+getctime(AttrHolder.fd)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_use_pathlib/full_name.py
@@ -185,3 +185,24 @@ class _AttrHolder:
 
 os.chmod(_AttrHolder.fd, 0o644)    # Suppressed: resolved as `int`
 os.chmod(_AttrHolder.name, 0o644)  # Diagnostic + fix: resolved as `str`
+
+# `pathlib` does not support file descriptors for these `os.path` APIs.
+fd: int = 9
+os.path.exists(1)
+os.path.exists(path=fd)
+os.path.exists(_AttrHolder.fd)
+os.path.isdir(1)
+os.path.isdir(s=fd)
+os.path.isdir(_AttrHolder.fd)
+os.path.isfile(1)
+os.path.isfile(path=fd)
+os.path.isfile(_AttrHolder.fd)
+os.path.islink(1)
+os.path.islink(path=fd)
+os.path.islink(_AttrHolder.fd)
+os.path.samefile(1, p)
+os.path.samefile(p, 1)
+os.path.samefile(f1=fd, f2=p)
+os.path.samefile(f1=p, f2=fd)
+os.path.samefile(_AttrHolder.fd, p)
+os.path.samefile(p, _AttrHolder.fd)

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/helpers.rs
@@ -6,6 +6,12 @@ use crate::checkers::ast::Checker;
 use crate::importer::ImportRequest;
 use crate::{Applicability, Edit, Fix, Violation};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FileDescriptorHandling {
+    Ignore,
+    Suppress,
+}
+
 pub(crate) fn is_keyword_only_argument_non_default(arguments: &Arguments, name: &str) -> bool {
     arguments
         .find_keyword(name)
@@ -58,6 +64,7 @@ pub(crate) fn check_os_pathlib_single_arg_calls(
     fix_enabled: bool,
     violation: impl Violation,
     applicability: Applicability,
+    file_descriptor_handling: FileDescriptorHandling,
 ) {
     if call.arguments.len() != 1 {
         return;
@@ -66,6 +73,12 @@ pub(crate) fn check_os_pathlib_single_arg_calls(
     let Some(arg) = call.arguments.find_argument_value(fn_argument, 0) else {
         return;
     };
+
+    if file_descriptor_handling == FileDescriptorHandling::Suppress
+        && is_file_descriptor(arg, checker.semantic())
+    {
+        return;
+    }
 
     let arg_code = checker.locator().slice(arg.range());
     let range = call.range();

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_abspath.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_abspath.rs
@@ -5,7 +5,8 @@ use ruff_python_ast::ExprCall;
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_abspath_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    check_os_pathlib_single_arg_calls, has_unknown_keywords_or_starred_expr,
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+    has_unknown_keywords_or_starred_expr,
 };
 use crate::{FixAvailability, Violation};
 
@@ -90,5 +91,6 @@ pub(crate) fn os_path_abspath(checker: &Checker, call: &ExprCall, segments: &[&s
         is_fix_os_path_abspath_enabled(checker.settings()),
         OsPathAbspath,
         Applicability::Unsafe,
+        FileDescriptorHandling::Ignore,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_basename.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_basename.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_basename_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -83,5 +85,6 @@ pub(crate) fn os_path_basename(checker: &Checker, call: &ExprCall, segments: &[&
         is_fix_os_path_basename_enabled(checker.settings()),
         OsPathBasename,
         Applicability::Unsafe,
+        FileDescriptorHandling::Ignore,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_dirname.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_dirname.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_dirname_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -87,5 +89,6 @@ pub(crate) fn os_path_dirname(checker: &Checker, call: &ExprCall, segments: &[&s
         is_fix_os_path_dirname_enabled(checker.settings()),
         OsPathDirname,
         Applicability::Unsafe,
+        FileDescriptorHandling::Ignore,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_exists.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_exists.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_exists_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -74,5 +76,6 @@ pub(crate) fn os_path_exists(checker: &Checker, call: &ExprCall, segments: &[&st
         is_fix_os_path_exists_enabled(checker.settings()),
         OsPathExists,
         Applicability::Safe,
+        FileDescriptorHandling::Suppress,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_expanduser.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_expanduser.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_expanduser_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -81,5 +83,6 @@ pub(crate) fn os_path_expanduser(checker: &Checker, call: &ExprCall, segments: &
         is_fix_os_path_expanduser_enabled(checker.settings()),
         OsPathExpanduser,
         Applicability::Unsafe,
+        FileDescriptorHandling::Ignore,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getatime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getatime.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getatime_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -77,5 +79,6 @@ pub(crate) fn os_path_getatime(checker: &Checker, call: &ExprCall, segments: &[&
         is_fix_os_path_getatime_enabled(checker.settings()),
         OsPathGetatime,
         Applicability::Safe,
+        FileDescriptorHandling::Suppress,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getctime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getctime.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getctime_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -78,5 +80,6 @@ pub(crate) fn os_path_getctime(checker: &Checker, call: &ExprCall, segments: &[&
         is_fix_os_path_getctime_enabled(checker.settings()),
         OsPathGetctime,
         Applicability::Safe,
+        FileDescriptorHandling::Suppress,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getmtime.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getmtime.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getmtime_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -78,5 +80,6 @@ pub(crate) fn os_path_getmtime(checker: &Checker, call: &ExprCall, segments: &[&
         is_fix_os_path_getmtime_enabled(checker.settings()),
         OsPathGetmtime,
         Applicability::Safe,
+        FileDescriptorHandling::Suppress,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getsize.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_getsize.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_getsize_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -78,5 +80,6 @@ pub(crate) fn os_path_getsize(checker: &Checker, call: &ExprCall, segments: &[&s
         is_fix_os_path_getsize_enabled(checker.settings()),
         OsPathGetsize,
         Applicability::Safe,
+        FileDescriptorHandling::Suppress,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isabs.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isabs.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_isabs_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -73,5 +75,6 @@ pub(crate) fn os_path_isabs(checker: &Checker, call: &ExprCall, segments: &[&str
         is_fix_os_path_isabs_enabled(checker.settings()),
         OsPathIsabs,
         Applicability::Safe,
+        FileDescriptorHandling::Ignore,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isdir.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isdir.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_isdir_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -75,5 +77,6 @@ pub(crate) fn os_path_isdir(checker: &Checker, call: &ExprCall, segments: &[&str
         is_fix_os_path_isdir_enabled(checker.settings()),
         OsPathIsdir,
         Applicability::Safe,
+        FileDescriptorHandling::Suppress,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isfile.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_isfile.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_isfile_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -75,5 +77,6 @@ pub(crate) fn os_path_isfile(checker: &Checker, call: &ExprCall, segments: &[&st
         is_fix_os_path_isfile_enabled(checker.settings()),
         OsPathIsfile,
         Applicability::Safe,
+        FileDescriptorHandling::Suppress,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_islink.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_islink.rs
@@ -4,7 +4,9 @@ use ruff_python_ast::ExprCall;
 
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_islink_enabled;
-use crate::rules::flake8_use_pathlib::helpers::check_os_pathlib_single_arg_calls;
+use crate::rules::flake8_use_pathlib::helpers::{
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+};
 use crate::{FixAvailability, Violation};
 
 /// ## What it does
@@ -75,5 +77,6 @@ pub(crate) fn os_path_islink(checker: &Checker, call: &ExprCall, segments: &[&st
         is_fix_os_path_islink_enabled(checker.settings()),
         OsPathIslink,
         Applicability::Safe,
+        FileDescriptorHandling::Suppress,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_samefile.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_path_samefile.rs
@@ -5,7 +5,7 @@ use ruff_python_ast::ExprCall;
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_path_samefile_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    check_os_pathlib_two_arg_calls, has_unknown_keywords_or_starred_expr,
+    check_os_pathlib_two_arg_calls, has_unknown_keywords_or_starred_expr, is_file_descriptor,
 };
 use crate::{FixAvailability, Violation};
 
@@ -67,6 +67,18 @@ impl Violation for OsPathSamefile {
 /// PTH121
 pub(crate) fn os_path_samefile(checker: &Checker, call: &ExprCall, segments: &[&str]) {
     if segments != ["os", "path", "samefile"] {
+        return;
+    }
+
+    if call
+        .arguments
+        .find_argument_value("f1", 0)
+        .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+        || call
+            .arguments
+            .find_argument_value("f2", 1)
+            .is_some_and(|expr| is_file_descriptor(expr, checker.semantic()))
+    {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_readlink.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_readlink.rs
@@ -5,8 +5,8 @@ use ruff_python_ast::{ExprCall, PythonVersion};
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_readlink_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    check_os_pathlib_single_arg_calls, is_keyword_only_argument_non_default,
-    is_top_level_expression_in_statement,
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+    is_keyword_only_argument_non_default, is_top_level_expression_in_statement,
 };
 use crate::{FixAvailability, Violation};
 
@@ -101,5 +101,6 @@ pub(crate) fn os_readlink(checker: &Checker, call: &ExprCall, segments: &[&str])
         is_fix_os_readlink_enabled(checker.settings()),
         OsReadlink,
         applicability,
+        FileDescriptorHandling::Ignore,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_remove.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_remove.rs
@@ -5,7 +5,8 @@ use ruff_python_ast::ExprCall;
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_remove_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    check_os_pathlib_single_arg_calls, is_keyword_only_argument_non_default,
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+    is_keyword_only_argument_non_default,
 };
 use crate::{FixAvailability, Violation};
 
@@ -86,5 +87,6 @@ pub(crate) fn os_remove(checker: &Checker, call: &ExprCall, segments: &[&str]) {
         is_fix_os_remove_enabled(checker.settings()),
         OsRemove,
         Applicability::Safe,
+        FileDescriptorHandling::Ignore,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_rmdir.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_rmdir.rs
@@ -5,7 +5,8 @@ use ruff_python_ast::ExprCall;
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_rmdir_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    check_os_pathlib_single_arg_calls, is_keyword_only_argument_non_default,
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+    is_keyword_only_argument_non_default,
 };
 use crate::{FixAvailability, Violation};
 
@@ -86,5 +87,6 @@ pub(crate) fn os_rmdir(checker: &Checker, call: &ExprCall, segments: &[&str]) {
         is_fix_os_rmdir_enabled(checker.settings()),
         OsRmdir,
         Applicability::Safe,
+        FileDescriptorHandling::Ignore,
     );
 }

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_unlink.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_unlink.rs
@@ -5,7 +5,8 @@ use ruff_python_ast::ExprCall;
 use crate::checkers::ast::Checker;
 use crate::preview::is_fix_os_unlink_enabled;
 use crate::rules::flake8_use_pathlib::helpers::{
-    check_os_pathlib_single_arg_calls, is_keyword_only_argument_non_default,
+    FileDescriptorHandling, check_os_pathlib_single_arg_calls,
+    is_keyword_only_argument_non_default,
 };
 use crate::{FixAvailability, Violation};
 
@@ -86,5 +87,6 @@ pub(crate) fn os_unlink(checker: &Checker, call: &ExprCall, segments: &[&str]) {
         is_fix_os_unlink_enabled(checker.settings()),
         OsUnlink,
         Applicability::Safe,
+        FileDescriptorHandling::Ignore,
     );
 }


### PR DESCRIPTION
## Summary

Avoid emitting flake8-use-pathlib PTH diagnostics when the checked `os.path` API is called with a file descriptor, since `pathlib.Path` does not provide an equivalent replacement for those calls.

This covers the file-descriptor part of #17699 for:

- `os.path.exists`
- `os.path.isdir`
- `os.path.isfile`
- `os.path.islink`
- `os.path.getsize`
- `os.path.getatime`
- `os.path.getmtime`
- `os.path.getctime`
- `os.path.samefile`

It intentionally does not try to solve bytes-path handling; #24701 appears to cover that separately.

## Test plan

- `git diff --check ec763a^ ec763a`
- Parsed modified flake8-use-pathlib Python fixtures with `ast.parse`
- Static pass confirmed all `check_os_pathlib_single_arg_calls` call sites pass an explicit file-descriptor policy

Cargo/rustfmt are not available in this local environment, so I could not run the Ruff fixture snapshot tests locally.