### PR TITLE
Match 5-character rule codes in ecosystem check

### DIFF
--- a/python/ruff-ecosystem/ruff_ecosystem/check.py
+++ b/python/ruff-ecosystem/ruff_ecosystem/check.py
@@ -49,7 +49,7 @@ CHECK_DIFF_LINE_RE = re.compile(
 # the severity. But should be good enough while we support both
 # the old and new rendering with severities.
 CHECK_DIAGNOSTIC_LINE_RE = re.compile(
-    r"^(?P<diff>[+-])? ?(?P<location>.*): (?:(?P<severity>[a-z]+)\[)?(?P<code>[A-Z]{1,4}[0-9]{3,4}|[a-z\-]+:)\]?(?P<fixable> \[\*\])? (?P<message>.*)"
+    r"^(?P<diff>[+-])? ?(?P<location>.*): (?:(?P<severity>[a-z]+)\[)?(?P<code>[A-Z]{1,5}[0-9]{3,4}|[a-z\-]+:)\]?(?P<fixable> \[\*\])? (?P<message>.*)"
 )
 
 PANIC_DIAGNOSTIC_LINE_RE = re.compile(r"^[^:]+: panic: Panicked at ")


### PR DESCRIPTION
Summary
--

I noticed while extending the regex to match human-readable names that it also didn't cover the
ASYNC rules, which have five letters in the rule code. For example, #24644 revealed no new
diagnostics in the ecosystem, but a local run on my cached ecosystem repos revealed many
diagnostics. This won't show up as a diff in CI on this PR but should help with ecosystem checks on
the ASYNC rules in the future.
