### PR TITLE
[ty] dynamic class attributes are not instance attributes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1033,6 +1033,31 @@ class C1(metaclass=Meta1): ...
 reveal_type(C1.attr)  # revealed: Literal["metaclass value"]
 ```
 
+A dynamically-created metaclass can define methods with the same names as methods in the class it
+creates. These methods can have different roles; in particular, the metaclass's `__new__` creates
+the class object and its `__call__` creates instances, while the class's methods create and operate
+on instances of that class:
+
+```py
+class DynamicallyConstructed(
+    metaclass=type(
+        "DynamicMeta",
+        (type,),
+        {
+            "__new__": lambda mcls, name, bases, namespace: type.__new__(mcls, name, bases, namespace),
+            "__call__": lambda cls: type.__call__(cls),
+        },
+    )
+):
+    def __new__(cls):
+        return super().__new__(cls)
+
+    def __call__(self, value: int) -> int:
+        return value
+
+DynamicallyConstructed()(1)
+```
+
 Assignments in instance methods of a metaclass are also attributes on its class-object instances. In
 particular, a metaclass `__init__` assignment happens after the initial class namespace has been
 converted into a class object, so it shadows an attribute from that namespace:

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -127,6 +127,22 @@ foo = Foo()
 reveal_type(foo.custom_attr)  # revealed: Literal[42]
 ```
 
+Methods from the namespace dictionary use the descriptor protocol and can be overridden normally:
+
+```py
+def dynamic_method(self) -> int:
+    return 1
+
+DynamicBase = type("DynamicBase", (), {"method": dynamic_method})
+reveal_type(DynamicBase().method())  # revealed: int
+
+class Child(DynamicBase):
+    def method(self) -> str:
+        return "child"
+
+reveal_type(Child().method())  # revealed: str
+```
+
 When the namespace dict is not a literal (e.g., passed as a parameter), attribute access returns
 `Unknown` since we can't know what attributes might be defined:
 

--- a/crates/ty_python_semantic/resources/mdtest/call/type.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/type.md
@@ -127,7 +127,7 @@ foo = Foo()
 reveal_type(foo.custom_attr)  # revealed: Literal[42]
 ```
 
-Methods from the namespace dictionary use the descriptor protocol and can be overridden normally:
+Methods from the namespace dictionary use the descriptor protocol:
 
 ```py
 def dynamic_method(self) -> int:
@@ -135,12 +135,6 @@ def dynamic_method(self) -> int:
 
 DynamicBase = type("DynamicBase", (), {"method": dynamic_method})
 reveal_type(DynamicBase().method())  # revealed: int
-
-class Child(DynamicBase):
-    def method(self) -> str:
-        return "child"
-
-reveal_type(Child().method())  # revealed: str
 ```
 
 When the namespace dict is not a literal (e.g., passed as a parameter), attribute access returns

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -448,10 +448,9 @@ impl<'db> DynamicClassLiteral<'db> {
 
     /// Look up an instance member defined directly on this class (not inherited).
     ///
-    /// For dynamic classes, instance members are the same as class members
-    /// since they come from the namespace dict.
-    pub(super) fn own_instance_member(self, db: &'db dyn Db, name: &str) -> Member<'db> {
-        self.own_class_member(db, name)
+    /// Namespace entries are class attributes, not values stored directly on instances.
+    pub(super) fn own_instance_member(self, _db: &'db dyn Db, _name: &str) -> Member<'db> {
+        Member::unbound()
     }
 
     /// Try to compute the MRO for this dynamic class.

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -449,6 +449,7 @@ impl<'db> DynamicClassLiteral<'db> {
     /// Look up an instance member defined directly on this class (not inherited).
     ///
     /// Namespace entries are class attributes, not values stored directly on instances.
+    #[expect(clippy::unused_self)]
     pub(super) fn own_instance_member(self, _db: &'db dyn Db, _name: &str) -> Member<'db> {
         Member::unbound()
     }


### PR DESCRIPTION
## Summary

Values from a dynamic class namespace are class attributes, not direct instance members; treat them that way. This allows them to use the descriptor protocol, matching runtime behavior. It also avoids the members of a dynamically-created metaclass being treated as existing on the class using that metaclass.

Closes https://github.com/astral-sh/ty/issues/3671

## Testing

Added mdtests.