### PR TITLE
[ty] support specializing generic class from static/classmethod

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -335,6 +335,26 @@ C.f1(1)
 C().f1(1)
 C.f2(1)
 C().f2(1)
+
+class Box[T]:
+    @callable_identity
+    @classmethod
+    def make(cls, value: T) -> Box[T]:
+        raise NotImplementedError
+
+    @callable_identity
+    @staticmethod
+    def make_static(value: T) -> Box[T]:
+        raise NotImplementedError
+
+class Child[T](Box[T]): ...
+
+reveal_type(Box.make(1))  # revealed: Box[int]
+reveal_type(Box[int].make(1))  # revealed: Box[int]
+reveal_type(Child.make(1))  # revealed: Box[int]
+reveal_type(Box.make_static(1))  # revealed: Box[int]
+reveal_type(Box[int].make_static(1))  # revealed: Box[int]
+reveal_type(Child.make_static(1))  # revealed: Box[int]
 ```
 
 ## Types are not bound-method descriptors

--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -335,26 +335,6 @@ C.f1(1)
 C().f1(1)
 C.f2(1)
 C().f2(1)
-
-class Box[T]:
-    @callable_identity
-    @classmethod
-    def make(cls, value: T) -> Box[T]:
-        raise NotImplementedError
-
-    @callable_identity
-    @staticmethod
-    def make_static(value: T) -> Box[T]:
-        raise NotImplementedError
-
-class Child[T](Box[T]): ...
-
-reveal_type(Box.make(1))  # revealed: Box[int]
-reveal_type(Box[int].make(1))  # revealed: Box[int]
-reveal_type(Child.make(1))  # revealed: Box[int]
-reveal_type(Box.make_static(1))  # revealed: Box[int]
-reveal_type(Box[int].make_static(1))  # revealed: Box[int]
-reveal_type(Child.make_static(1))  # revealed: Box[int]
 ```
 
 ## Types are not bound-method descriptors

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -522,6 +522,22 @@ reveal_type(GenericFactory.make())  # revealed: GenericFactory[Unknown]
 
 def check_factory(value: GenericFactory[int]) -> None:
     reveal_type(GenericFactory.copy(value))  # revealed: GenericFactory[int]
+
+def flag() -> bool:
+    return True
+
+class ConditionalBox[T]:
+    if flag():
+        @classmethod
+        def from_value(cls, value: T) -> "ConditionalBox[T]":
+            raise NotImplementedError
+
+    else:
+        @classmethod
+        def from_value(cls, value: T) -> tuple[T]:
+            raise NotImplementedError
+
+reveal_type(ConditionalBox.from_value(1))  # revealed: ConditionalBox[int] | tuple[Literal[1]]
 ```
 
 The class type parameter can also be inferred through a specialized generic base class. This is a
@@ -1061,6 +1077,22 @@ class LegacyStaticBox(Generic[LegacyT]):
         raise NotImplementedError
 
 reveal_type(LegacyStaticBox.from_value(1))  # revealed: LegacyStaticBox[int]
+
+def flag() -> bool:
+    return True
+
+class ConditionalStaticBox[T]:
+    if flag():
+        @staticmethod
+        def from_value(value: T) -> "ConditionalStaticBox[T]":
+            raise NotImplementedError
+
+    else:
+        @staticmethod
+        def from_value(value: T) -> tuple[T]:
+            raise NotImplementedError
+
+reveal_type(ConditionalStaticBox.from_value(1))  # revealed: ConditionalStaticBox[int] | tuple[Literal[1]]
 ```
 
 ### Staticmethod assigned in class body

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -1069,6 +1069,8 @@ Assigning a `staticmethod(...)` object directly in the class body should preserv
 behavior of the wrapped function when accessed on both classes and instances.
 
 ```py
+from typing import Generic, TypeVar
+
 def foo(*args, **kwargs) -> None:
     print("foo", args, kwargs)
 
@@ -1087,6 +1089,18 @@ a.bar(x=10)
 A.bar()
 A.bar(5)
 A.bar(x=10)
+
+T = TypeVar("T")
+
+class Box(Generic[T]):
+    def from_value(value: T) -> "Box[T]":
+        raise NotImplementedError
+
+    make = staticmethod(from_value)
+
+reveal_type(Box.make(1))  # revealed: Box[int]
+reveal_type(Box[str].make("value"))  # revealed: Box[str]
+Box[str].make(1)  # error: [invalid-argument-type]
 ```
 
 ### Accessing the staticmethod as a static member

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -416,6 +416,183 @@ reveal_type(Derived.f(1))  # revealed: str
 reveal_type(Derived().f(1))  # revealed: str
 ```
 
+### Generic classmethod inference
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+Type parameters from a generic class are inferred when calling a classmethod on the non-specialized
+class:
+
+```py
+from typing import Generic, Self, TypeVar, overload
+
+class Box[T]:
+    @classmethod
+    def from_value(cls, value: T) -> Self:
+        return cls()
+
+    @classmethod
+    def from_value_explicit(cls, value: T) -> "Box[T]":
+        raise NotImplementedError
+
+class DerivedBox[T](Box[T]): ...
+
+def check(value: int) -> None:
+    reveal_type(Box.from_value(value))  # revealed: Box[int]
+    reveal_type(Box.from_value_explicit(value))  # revealed: Box[int]
+    reveal_type(DerivedBox.from_value(value))  # revealed: DerivedBox[int]
+
+reveal_type(Box[str].from_value("value"))  # revealed: Box[str]
+# revealed: bound method <class 'Box[str]'>.from_value(value: str) -> Box[str]
+reveal_type(Box[str].from_value)
+Box[str].from_value(1)  # error: [invalid-argument-type]
+
+class ReceiverBox[T]:
+    @classmethod
+    def pair[S](cls: "type[ReceiverBox[S]]", value: T, other: S) -> tuple[T, S]:
+        return value, other
+
+# The hidden `cls` argument requires `T` and `S` to agree.
+ReceiverBox.pair(1, "value")  # error: [invalid-argument-type]
+
+class ExplicitReceiverBox[T]:
+    @classmethod
+    def create(cls: "type[ExplicitReceiverBox[int]]") -> "ExplicitReceiverBox[T]":
+        raise NotImplementedError
+
+# TODO: Infer class type parameters from an explicit `cls` annotation.
+reveal_type(ExplicitReceiverBox.create())  # revealed: ExplicitReceiverBox[Unknown]
+
+class PartialReceiverBox[T, U]:
+    @classmethod
+    def create(cls: "type[PartialReceiverBox[T, int]]", value: T) -> "PartialReceiverBox[T, U]":
+        raise NotImplementedError
+
+# TODO: Infer `U` from the explicit `cls` annotation while inferring `T` from `value`.
+reveal_type(PartialReceiverBox.create("value"))  # revealed: PartialReceiverBox[str, Unknown]
+
+LegacyT = TypeVar("LegacyT")
+LegacyU = TypeVar("LegacyU")
+
+class LegacyBox(Generic[LegacyT]):
+    @classmethod
+    def from_value(cls, value: LegacyT) -> Self:
+        return cls()
+
+    @classmethod
+    def create_same(cls, value: LegacyT) -> "LegacyBox[LegacyT]":
+        raise NotImplementedError
+
+    @classmethod
+    def create_diff(cls, value: LegacyU) -> "LegacyBox[LegacyU]":
+        raise NotImplementedError
+
+def check_legacy(value: int) -> None:
+    reveal_type(LegacyBox.from_value(value))  # revealed: LegacyBox[int]
+    reveal_type(LegacyBox.create_same(value))  # revealed: LegacyBox[int]
+    reveal_type(LegacyBox.create_diff(value))  # revealed: LegacyBox[int]
+
+ConstrainedT = TypeVar("ConstrainedT", int, str)
+
+class Token(Generic[ConstrainedT]): ...
+
+class ConstrainedBox(Generic[ConstrainedT]):
+    @classmethod
+    def from_token(cls, *, token: Token[ConstrainedT]) -> "ConstrainedBox[ConstrainedT]":
+        raise NotImplementedError
+
+reveal_type(ConstrainedBox.from_token(token=Token[int]()))  # revealed: ConstrainedBox[int]
+reveal_type(ConstrainedBox.from_token(token=Token[str]()))  # revealed: ConstrainedBox[str]
+
+class Factory:
+    @classmethod
+    def make(cls) -> Self:
+        return cls()
+
+    @classmethod
+    def copy(cls, value: Self) -> Self:
+        return value
+
+class GenericFactory[T](Factory): ...
+
+reveal_type(GenericFactory.make())  # revealed: GenericFactory[Unknown]
+
+def check_factory(value: GenericFactory[int]) -> None:
+    reveal_type(GenericFactory.copy(value))  # revealed: GenericFactory[int]
+```
+
+The class type parameter can also be inferred through a specialized generic base class. This is a
+regression test for <https://github.com/astral-sh/ty/issues/3675>.
+
+```py
+class Inner[T]:
+    def kind(self) -> T:
+        raise NotImplementedError
+
+class Concrete(Inner[int]): ...
+
+class HasModel[X]:
+    @overload
+    @classmethod
+    def from_model(cls, model: list[X]) -> Self: ...
+    @overload
+    @classmethod
+    def from_model(cls, model: X) -> Self: ...
+    @classmethod
+    def from_model(cls, model: X | list[X]) -> Self:
+        raise NotImplementedError
+
+class Wrapper[T](HasModel[Inner[T]]): ...
+
+def want(wrapper: Wrapper[int]) -> None: ...
+
+obj = Concrete()
+reveal_type(Wrapper.from_model(obj))  # revealed: Wrapper[int]
+reveal_type(Wrapper[int].from_model(obj))  # revealed: Wrapper[int]
+want(Wrapper.from_model(obj))
+```
+
+### Type parameter defaults do not prevent method inference
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+Bare generic classes remain generic until a class or static method call is inferred, even when their
+type parameters have defaults. This is an intentional and potentially controversial policy choice:
+applying the default specialization before either call would make the calls below invalid rather
+than inferring `str`. See <https://github.com/astral-sh/ty/issues/541>.
+
+```py
+from typing import Self
+
+class DefaultBox[T = int]:
+    @classmethod
+    def from_value(cls, value: T) -> Self:
+        return cls()
+
+    @classmethod
+    def create(cls) -> Self:
+        return cls()
+
+    @staticmethod
+    def from_static_value(value: T) -> "DefaultBox[T]":
+        raise NotImplementedError
+
+    @staticmethod
+    def create_static() -> "DefaultBox[T]":
+        raise NotImplementedError
+
+reveal_type(DefaultBox.from_value("value"))  # revealed: DefaultBox[str]
+reveal_type(DefaultBox.from_static_value("value"))  # revealed: DefaultBox[str]
+reveal_type(DefaultBox.create())  # revealed: DefaultBox[int]
+reveal_type(DefaultBox.create_static())  # revealed: DefaultBox[int]
+```
+
 ### Accessing the classmethod as a static member
 
 Accessing a `@classmethod`-decorated function at runtime returns a `classmethod` object. We
@@ -828,6 +1005,64 @@ reveal_type(Derived.f(1))  # revealed: str
 reveal_type(Derived().f(1))  # revealed: str
 ```
 
+### Generic staticmethod inference
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+Like classmethods, staticmethods on a bare generic class are implicitly generic over the class type
+parameters that occur in their signature:
+
+```py
+from typing import Generic, TypeVar
+
+class StaticBox[T]:
+    @staticmethod
+    def from_value(value: T) -> "StaticBox[T]":
+        raise NotImplementedError
+
+    @staticmethod
+    def create[S](value: S) -> "StaticBox[S]":
+        raise NotImplementedError
+
+class DerivedStaticBox[T](StaticBox[T]): ...
+
+reveal_type(StaticBox.from_value(1))  # revealed: StaticBox[int]
+reveal_type(StaticBox.create(1))  # revealed: StaticBox[int]
+reveal_type(DerivedStaticBox.from_value(1))  # revealed: StaticBox[int]
+reveal_type(StaticBox[str].from_value("value"))  # revealed: StaticBox[str]
+StaticBox[str].from_value(1)  # error: [invalid-argument-type]
+
+class StaticBase[X]:
+    @staticmethod
+    def unwrap(value: X) -> X:
+        return value
+
+class StaticDerived[T](StaticBase[list[T]]): ...
+
+reveal_type(StaticDerived.unwrap([1]))  # revealed: list[int]
+
+class StaticAliasBox[T]:
+    type Values = list[T]
+
+    @staticmethod
+    def first(values: Values) -> T:
+        return values[0]
+
+reveal_type(StaticAliasBox.first([1]))  # revealed: int
+
+LegacyT = TypeVar("LegacyT")
+
+class LegacyStaticBox(Generic[LegacyT]):
+    @staticmethod
+    def from_value(value: LegacyT) -> "LegacyStaticBox[LegacyT]":
+        raise NotImplementedError
+
+reveal_type(LegacyStaticBox.from_value(1))  # revealed: LegacyStaticBox[int]
+```
+
 ### Staticmethod assigned in class body
 
 Assigning a `staticmethod(...)` object directly in the class body should preserve the callable
@@ -945,6 +1180,7 @@ reveal_type(D().ctx(5))  # revealed: _GeneratorContextManager[int, None, None]
 argument:
 
 ```py
+from typing import Generic, TypeVar
 from typing_extensions import Self
 
 reveal_type(object.__new__)  # revealed: def __new__[Self](cls) -> Self
@@ -959,6 +1195,13 @@ class X:
     def make_another(self) -> Self:
         reveal_type(self.__new__)  # revealed: def __new__[Self](cls) -> Self
         return self.__new__(type(self))
+
+T = TypeVar("T")
+
+class GenericNew(Generic[T]): ...
+
+# `__new__` uses constructor inference rather than inheriting the class context as a staticmethod.
+reveal_type(GenericNew.__new__)  # revealed: def __new__[Self](cls) -> Self
 ```
 
 ## Builtin functions and methods

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -446,8 +446,6 @@ def check(value: int) -> None:
     reveal_type(DerivedBox.from_value(value))  # revealed: DerivedBox[int]
 
 reveal_type(Box[str].from_value("value"))  # revealed: Box[str]
-# revealed: bound method <class 'Box[str]'>.from_value(value: str) -> Box[str]
-reveal_type(Box[str].from_value)
 Box[str].from_value(1)  # error: [invalid-argument-type]
 
 class ReceiverBox[T]:
@@ -576,12 +574,8 @@ class HasModel[X]:
 
 class Wrapper[T](HasModel[Inner[T]]): ...
 
-def want(wrapper: Wrapper[int]) -> None: ...
-
 obj = Concrete()
 reveal_type(Wrapper.from_model(obj))  # revealed: Wrapper[int]
-reveal_type(Wrapper[int].from_model(obj))  # revealed: Wrapper[int]
-want(Wrapper.from_model(obj))
 ```
 
 ### Type parameter defaults do not prevent method inference

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -507,6 +507,19 @@ class ConstrainedBox(Generic[ConstrainedT]):
 reveal_type(ConstrainedBox.from_token(token=Token[int]()))  # revealed: ConstrainedBox[int]
 reveal_type(ConstrainedBox.from_token(token=Token[str]()))  # revealed: ConstrainedBox[str]
 
+class OverloadedBox[T]:
+    @overload
+    @classmethod
+    def from_value(cls, value: list[T]) -> tuple[T, T]: ...
+    @overload
+    @classmethod
+    def from_value(cls, value: T) -> T: ...
+    @classmethod
+    def from_value(cls, value: T | list[T]) -> T | tuple[T, T]:
+        raise NotImplementedError
+
+reveal_type(OverloadedBox.from_value([1]))  # revealed: tuple[int, int]
+
 class Factory:
     @classmethod
     def make(cls) -> Self:
@@ -669,6 +682,19 @@ reveal_type(C.f1(1))  # revealed: str
 reveal_type(C().f1(1))  # revealed: str
 reveal_type(C.f2(1))  # revealed: str
 reveal_type(C().f2(1))  # revealed: str
+
+from typing import Callable
+
+def callable_identity[**P, R](func: Callable[P, R]) -> Callable[P, R]:
+    return func
+
+class DecoratedBox[T]:
+    @callable_identity
+    @classmethod
+    def make(cls, value: T) -> "DecoratedBox[T]":
+        raise NotImplementedError
+
+reveal_type(DecoratedBox.make(1))  # revealed: DecoratedBox[int]
 ```
 
 ### Classmethods with `Self` and callable-returning decorators
@@ -1193,6 +1219,19 @@ reveal_type(C.f1(1))  # revealed: str
 reveal_type(C().f1(1))  # revealed: str
 reveal_type(C.f2(1))  # revealed: str
 reveal_type(C().f2(1))  # revealed: str
+
+from collections.abc import Callable
+
+def callable_identity[**P, R](func: Callable[P, R]) -> Callable[P, R]:
+    return func
+
+class DecoratedStaticBox[T]:
+    @callable_identity
+    @staticmethod
+    def make(value: T) -> DecoratedStaticBox[T]:
+        raise NotImplementedError
+
+reveal_type(DecoratedStaticBox.make(1))  # revealed: DecoratedStaticBox[int]
 ```
 
 When a `@staticmethod` is decorated with `@contextmanager`, accessing it from an instance should not

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2939,8 +2939,16 @@ impl<'db> Type<'db> {
                         Some((ty, AttributeKind::NormalOrNonDataDescriptor))
                     } else {
                         let self_type = instance.unwrap_or_else(|| {
-                            // For classmethod-like callables, bind to the owner class.
-                            owner.to_instance(db).unwrap_or(owner)
+                            // Preserve a bare generic owner so call arguments can infer its
+                            // specialization after the classmethod-like callable is bound.
+                            if callable.is_classmethod_like(db)
+                                && let Type::ClassLiteral(class) = owner
+                                && class.generic_context(db).is_some()
+                            {
+                                Type::from(class.identity_specialization(db))
+                            } else {
+                                owner.to_instance(db).unwrap_or(owner)
+                            }
                         });
 
                         Some((

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2981,6 +2981,24 @@ impl<'db> Type<'db> {
                     // TODO: an error when calling `__get__` will lead to a `TypeError` or similar at runtime;
                     // we should emit a diagnostic here instead of silently ignoring the error.
                     .unwrap_or_else(|CallError(_, bindings)| bindings.return_type(db));
+                // Assignment-form staticmethods retain their wrapper until descriptor invocation,
+                // so propagate the bare owner's generic context to the unwrapped callable here.
+                let return_ty = if ty.is_instance_of(db, KnownClass::Staticmethod)
+                    && let Type::ClassLiteral(class) = owner
+                    && let Some(generic_context) = class.generic_context(db)
+                    && let Type::Callable(callable) = return_ty
+                {
+                    Type::Callable(CallableType::new(
+                        db,
+                        callable
+                            .signatures(db)
+                            .with_inherited_generic_context(db, generic_context),
+                        callable.kind(db),
+                        callable.provenance(db),
+                    ))
+                } else {
+                    return_ty
+                };
 
                 let descriptor_kind = if ty.is_data_descriptor(db) {
                     AttributeKind::DataDescriptor

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1064,6 +1064,31 @@ impl<'db> Type<'db> {
         )
     }
 
+    /// Adds an inherited generic context to callable elements of this type.
+    fn with_inherited_generic_context(
+        self,
+        db: &'db dyn Db,
+        generic_context: GenericContext<'db>,
+    ) -> Self {
+        match self {
+            Type::FunctionLiteral(function) => {
+                Type::FunctionLiteral(function.with_inherited_generic_context(db, generic_context))
+            }
+            Type::Callable(callable) => Type::Callable(CallableType::new(
+                db,
+                callable
+                    .signatures(db)
+                    .with_inherited_generic_context(db, generic_context),
+                callable.kind(db),
+                callable.provenance(db),
+            )),
+            Type::Union(union) => union.map(db, |element| {
+                element.with_inherited_generic_context(db, generic_context)
+            }),
+            _ => self,
+        }
+    }
+
     /// Returns `true` if `self` is [`Type::Callable`].
     pub(crate) const fn is_callable_type(&self) -> bool {
         matches!(self, Type::Callable(..))
@@ -2986,16 +3011,8 @@ impl<'db> Type<'db> {
                 let return_ty = if ty.is_instance_of(db, KnownClass::Staticmethod)
                     && let Type::ClassLiteral(class) = owner
                     && let Some(generic_context) = class.generic_context(db)
-                    && let Type::Callable(callable) = return_ty
                 {
-                    Type::Callable(CallableType::new(
-                        db,
-                        callable
-                            .signatures(db)
-                            .with_inherited_generic_context(db, generic_context),
-                        callable.kind(db),
-                        callable.provenance(db),
-                    ))
+                    return_ty.with_inherited_generic_context(db, generic_context)
                 } else {
                     return_ty
                 };

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4052,13 +4052,26 @@ impl<'db> Type<'db> {
                     CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
                         .with_bound_type(binding_self_type)
                         .into()
-                } else {
-                    // Replacing `Self` exposes the bare class's type variables directly to argument
-                    // inference while retaining the receiver for validation and inference.
+                } else if signature
+                    .overloads
+                    .iter()
+                    .any(Signature::has_explicit_positional_receiver_annotation)
+                {
+                    // Replacing `Self` exposes the bare class's type variables directly to
+                    // argument inference while retaining an explicit receiver for validation
+                    // and inference.
                     let signature = signature.apply_self(db, bound_method.typing_self_type(db));
                     CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
                         .with_bound_type(binding_self_type)
                         .into()
+                } else {
+                    // An implicit receiver does not constrain the call. Bind it before overload
+                    // resolution so it does not participate in overload precedence.
+                    CallableBinding::from_overloads(
+                        self,
+                        bound_method.bound_signatures(db).iter().cloned(),
+                    )
+                    .into()
                 }
             }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4021,9 +4021,19 @@ impl<'db> Type<'db> {
 
             Type::BoundMethod(bound_method) => {
                 let signature = bound_method.function(db).signature(db);
-                CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
-                    .with_bound_type(bound_method.self_instance(db))
-                    .into()
+                let binding_self_type = bound_method.binding_self_type(db);
+                if binding_self_type == bound_method.self_instance(db) {
+                    CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
+                        .with_bound_type(binding_self_type)
+                        .into()
+                } else {
+                    // Replacing `Self` exposes the bare class's type variables directly to argument
+                    // inference while retaining the receiver for validation and inference.
+                    let signature = signature.apply_self(db, bound_method.typing_self_type(db));
+                    CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
+                        .with_bound_type(binding_self_type)
+                        .into()
+                }
             }
 
             Type::KnownBoundMethod(method) => {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -984,7 +984,35 @@ impl<'db> StaticClassLiteral<'db> {
                     callable.is_classmethod_like(db)
                         || (name != "__new__" && callable.is_staticmethod_like(db))
                 }
+                Type::Union(union) => union
+                    .elements(db)
+                    .iter()
+                    .all(|element| is_class_or_static_method(db, name, *element)),
                 ty => name != "__new__" && ty.is_instance_of(db, KnownClass::Staticmethod),
+            }
+        }
+
+        fn with_inherited_generic_context<'d>(
+            db: &'d dyn Db,
+            ty: Type<'d>,
+            generic_context: GenericContext<'d>,
+        ) -> Type<'d> {
+            match ty {
+                Type::FunctionLiteral(function) => Type::FunctionLiteral(
+                    function.with_inherited_generic_context(db, generic_context),
+                ),
+                Type::Callable(callable) => Type::Callable(CallableType::new(
+                    db,
+                    callable
+                        .signatures(db)
+                        .with_inherited_generic_context(db, generic_context),
+                    callable.kind(db),
+                    callable.provenance(db),
+                )),
+                Type::Union(union) => union.map(db, |element| {
+                    with_inherited_generic_context(db, *element, generic_context)
+                }),
+                _ => ty,
             }
         }
 
@@ -1020,20 +1048,7 @@ impl<'db> StaticClassLiteral<'db> {
                     name,
                     policy,
                 )
-                .map_type(|ty| match ty {
-                    Type::FunctionLiteral(function) => Type::FunctionLiteral(
-                        function.with_inherited_generic_context(db, generic_context),
-                    ),
-                    Type::Callable(callable) => Type::Callable(CallableType::new(
-                        db,
-                        callable
-                            .signatures(db)
-                            .with_inherited_generic_context(db, generic_context),
-                        callable.kind(db),
-                        callable.provenance(db),
-                    )),
-                    _ => ty,
-                });
+                .map_type(|ty| with_inherited_generic_context(db, ty, generic_context));
         }
 
         // We generally treat dunder attributes with `Callable` types as function-like callables.

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -984,7 +984,7 @@ impl<'db> StaticClassLiteral<'db> {
                     callable.is_classmethod_like(db)
                         || (name != "__new__" && callable.is_staticmethod_like(db))
                 }
-                _ => false,
+                ty => name != "__new__" && ty.is_instance_of(db, KnownClass::Staticmethod),
             }
         }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -992,30 +992,6 @@ impl<'db> StaticClassLiteral<'db> {
             }
         }
 
-        fn with_inherited_generic_context<'d>(
-            db: &'d dyn Db,
-            ty: Type<'d>,
-            generic_context: GenericContext<'d>,
-        ) -> Type<'d> {
-            match ty {
-                Type::FunctionLiteral(function) => Type::FunctionLiteral(
-                    function.with_inherited_generic_context(db, generic_context),
-                ),
-                Type::Callable(callable) => Type::Callable(CallableType::new(
-                    db,
-                    callable
-                        .signatures(db)
-                        .with_inherited_generic_context(db, generic_context),
-                    callable.kind(db),
-                    callable.provenance(db),
-                )),
-                Type::Union(union) => union.map(db, |element| {
-                    with_inherited_generic_context(db, *element, generic_context)
-                }),
-                _ => ty,
-            }
-        }
-
         fn into_function_like_callable<'d>(db: &'d dyn Db, ty: Type<'d>) -> Type<'d> {
             match ty {
                 Type::Callable(callable_ty) => Type::Callable(CallableType::new(
@@ -1048,7 +1024,7 @@ impl<'db> StaticClassLiteral<'db> {
                     name,
                     policy,
                 )
-                .map_type(|ty| with_inherited_generic_context(db, ty, generic_context));
+                .map_type(|ty| ty.with_inherited_generic_context(db, generic_context));
         }
 
         // We generally treat dunder attributes with `Callable` types as function-like callables.

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -974,6 +974,20 @@ impl<'db> StaticClassLiteral<'db> {
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
+        fn is_class_or_static_method(db: &dyn Db, name: &str, ty: Type<'_>) -> bool {
+            match ty {
+                Type::FunctionLiteral(function) => {
+                    function.is_classmethod(db)
+                        || (name != "__new__" && function.is_staticmethod(db))
+                }
+                Type::Callable(callable) => {
+                    callable.is_classmethod_like(db)
+                        || (name != "__new__" && callable.is_staticmethod_like(db))
+                }
+                _ => false,
+            }
+        }
+
         fn into_function_like_callable<'d>(db: &'d dyn Db, ty: Type<'d>) -> Type<'d> {
             match ty {
                 Type::Callable(callable_ty) => Type::Callable(CallableType::new(
@@ -995,9 +1009,9 @@ impl<'db> StaticClassLiteral<'db> {
         // A class or static method on a bare generic class acts like a generic function: its
         // arguments can determine the specialization of the class on which it was accessed.
         if let Some(generic_context) = self.generic_context(db)
-            && member.ignore_possibly_undefined().is_some_and(|ty| {
-                matches!(ty, Type::FunctionLiteral(function) if function.is_classmethod(db) || (name != "__new__" && function.is_staticmethod(db)))
-            })
+            && member
+                .ignore_possibly_undefined()
+                .is_some_and(|ty| is_class_or_static_method(db, name, ty))
         {
             member = self
                 .class_member_inner(
@@ -1010,6 +1024,14 @@ impl<'db> StaticClassLiteral<'db> {
                     Type::FunctionLiteral(function) => Type::FunctionLiteral(
                         function.with_inherited_generic_context(db, generic_context),
                     ),
+                    Type::Callable(callable) => Type::Callable(CallableType::new(
+                        db,
+                        callable
+                            .signatures(db)
+                            .with_inherited_generic_context(db, generic_context),
+                        callable.kind(db),
+                        callable.provenance(db),
+                    )),
                     _ => ty,
                 });
         }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -992,6 +992,27 @@ impl<'db> StaticClassLiteral<'db> {
         }
 
         let mut member = self.class_member_inner(db, None, name, policy);
+        // A class or static method on a bare generic class acts like a generic function: its
+        // arguments can determine the specialization of the class on which it was accessed.
+        if let Some(generic_context) = self.generic_context(db)
+            && member.ignore_possibly_undefined().is_some_and(|ty| {
+                matches!(ty, Type::FunctionLiteral(function) if function.is_classmethod(db) || (name != "__new__" && function.is_staticmethod(db)))
+            })
+        {
+            member = self
+                .class_member_inner(
+                    db,
+                    Some(generic_context.identity_specialization(db)),
+                    name,
+                    policy,
+                )
+                .map_type(|ty| match ty {
+                    Type::FunctionLiteral(function) => Type::FunctionLiteral(
+                        function.with_inherited_generic_context(db, generic_context),
+                    ),
+                    _ => ty,
+                });
+        }
 
         // We generally treat dunder attributes with `Callable` types as function-like callables.
         // See `callables_as_descriptors.md` for more details.
@@ -1096,13 +1117,6 @@ impl<'db> StaticClassLiteral<'db> {
             // specially: they inherit the generic context of their class. That lets us treat them
             // as generic functions when constructing the class, and infer the specialization of
             // the class from the arguments that are passed in.
-            //
-            // We might decide to handle other class methods the same way, having them inherit the
-            // class's generic context, and performing type inference on calls to them to determine
-            // the specialization of the class. If we do that, we would update this to also apply
-            // to any method with a `@classmethod` decorator. (`__init__` would remain a special
-            // case, since it's an _instance_ method where we don't yet know the generic class's
-            // specialization.)
             match (inherited_generic_context, ty, specialization, name) {
                 (
                     Some(generic_context),

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -44,11 +44,37 @@ pub(super) fn walk_bound_method_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>
 
 #[salsa::tracked]
 impl<'db> BoundMethodType<'db> {
+    /// Returns the type used for the implicit `self` or `cls` argument when calling this method.
+    pub(crate) fn binding_self_type(self, db: &'db dyn Db) -> Type<'db> {
+        let self_instance = self.self_instance(db);
+        // The class generic context is attached during bare classmethod lookup. Requiring its
+        // presence on every overload avoids introducing free class type variables for bound
+        // methods created through other paths.
+        if self.function(db).is_classmethod(db)
+            && let Type::ClassLiteral(class) = self_instance
+            && let Some(class_generic_context) = class.generic_context(db)
+            && self
+                .function(db)
+                .signature(db)
+                .overloads
+                .iter()
+                .all(|signature| {
+                    signature
+                        .generic_context
+                        .is_some_and(|context| class_generic_context.is_subset_of(db, context))
+                })
+        {
+            Type::from(class.identity_specialization(db))
+        } else {
+            self_instance
+        }
+    }
+
     /// Returns the type that replaces any `typing.Self` annotations in the bound method signature.
     /// This is normally the bound-instance type (the type of `self` or `cls`), but if the bound method is
     /// a `@classmethod`, then it should be an instance of that bound-instance type.
     pub(crate) fn typing_self_type(self, db: &'db dyn Db) -> Type<'db> {
-        let mut self_instance = self.self_instance(db);
+        let mut self_instance = self.binding_self_type(db);
         if self.function(db).is_classmethod(db) {
             self_instance = self_instance.to_instance(db).unwrap_or_else(Type::unknown);
         }


### PR DESCRIPTION
## Summary

Infer generic class and method type parameters for bare generic classmethod and staticmethod calls, including inherited and legacy generic forms.

Closes https://github.com/astral-sh/ty/issues/541

## Testing

Added mdtests.

All ecosystem changes are expected. The egglog-python new diagnostic is a newly-revealed case of #3256, but that bug is orthogonal; it just shows up here because a callable goes from being non-generic to being generic.