### PR TITLE
[ty] better support for enum.property

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -4668,8 +4668,8 @@ Answer.<CURSOR>
                 NO :: Literal[Answer.NO]
                 YES :: Literal[Answer.YES]
                 mro :: bound method <class 'Answer'>.mro() -> list[type]
-                name :: Any
-                value :: Any
+                name :: property
+                value :: property
                 __annotations__ :: dict[str, Any]
                 __base__ :: type | None
                 __bases__ :: tuple[type, ...]

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -714,7 +714,7 @@ python-version = "3.11"
 
 ```py
 from enum import Enum, property as enum_property
-from typing import Any
+from typing import Any, assert_type
 from ty_extensions import enum_members
 
 class Answer(Enum):
@@ -725,8 +725,15 @@ class Answer(Enum):
     def some_property(self) -> str:
         return "property value"
 
+    def direct_property_getter(self) -> int:
+        return 1
+
+    direct_property = enum_property(fget=direct_property_getter)
+
 # revealed: tuple[Literal["YES"], Literal["NO"]]
 reveal_type(enum_members(Answer))
+assert_type(Answer.YES.some_property, str)
+assert_type(Answer.YES.direct_property, int)
 ```
 
 Enum attributes defined using `enum.property` take precedence over generated attributes.
@@ -741,8 +748,17 @@ class Choices(Enum):
     @enum_property
     def value(self) -> Any: ...
 
-# TODO: This should be `Any` - overridden by `@enum_property`
-reveal_type(Choices.A.value)  # revealed: Literal[1]
+reveal_type(Choices.A.value)  # revealed: Any
+
+class BaseChoices(Enum):
+    @enum_property
+    def value(self) -> str:
+        return "custom value"
+
+class InheritedChoices(BaseChoices):
+    A = 1
+
+reveal_type(InheritedChoices.A.value)  # revealed: str
 ```
 
 ### `types.DynamicClassAttribute`

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3626,8 +3626,14 @@ impl<'db> Type<'db> {
                 ),
 
                 Type::LiteralValue(literal)
-                    if literal.as_enum().is_some()
-                        && matches!(name_str, "name" | "_name_" | "value" | "_value_") =>
+                    if matches!(name_str, "name" | "_name_" | "value" | "_value_")
+                        && literal.as_enum().is_some_and(|enum_literal| {
+                            !enums::class_defines_property(
+                                db,
+                                enum_literal.enum_class(db),
+                                name_str,
+                            )
+                        }) =>
                 {
                     let enum_literal = literal.as_enum().unwrap();
                     let enum_class = enum_literal.enum_class(db);
@@ -3665,7 +3671,12 @@ impl<'db> Type<'db> {
 
                 Type::NominalInstance(instance)
                     if matches!(name_str, "name" | "_name_" | "value" | "_value_")
-                        && enum_metadata(db, instance.class_literal(db)).is_some() =>
+                        && enum_metadata(db, instance.class_literal(db)).is_some()
+                        && !enums::class_defines_property(
+                            db,
+                            instance.class_literal(db),
+                            name_str,
+                        ) =>
                 {
                     let class_literal = instance.class_literal(db);
                     let is_enum_subclass = Type::ClassLiteral(class_literal)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2636,10 +2636,7 @@ impl<'db> Bindings<'db> {
                             }
                         }
 
-                        known_class
-                            if known_class == Some(KnownClass::Property)
-                                || class.is_known(db, KnownClass::EnumProperty) =>
-                        {
+                        Some(KnownClass::Property | KnownClass::EnumProperty) => {
                             if let [getter, setter, deleter, ..] = overload.parameter_types() {
                                 let getter = getter.filter(|ty| !ty.is_none(db));
                                 let setter = setter.filter(|ty| !ty.is_none(db));

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -9,6 +9,7 @@
 //! `ty_python_semantic::types::call::bind`.
 
 mod constructor;
+mod enum_property;
 
 use std::borrow::Cow;
 use std::collections::HashSet;
@@ -1198,33 +1199,6 @@ impl<'db> Bindings<'db> {
                 // TODO: emit a diagnostic if we receive `bool`
                 default
             }
-        };
-
-        let enum_property_instance = |overload: &Binding<'db>| {
-            let accessor = |parameter_index| {
-                call_arguments
-                    .iter()
-                    .zip(overload.argument_matches())
-                    .find_map(|((_, argument_types), argument_matches)| {
-                        argument_matches
-                            .parameters
-                            .iter()
-                            .find(|parameter| parameter.index == parameter_index)
-                            .map(|parameter| {
-                                parameter
-                                    .argument_type
-                                    .or_else(|| argument_types.get_default())
-                            })
-                    })
-                    .flatten()
-                    .filter(|ty| !ty.is_none(db))
-            };
-            Type::PropertyInstance(PropertyInstanceType::new(
-                db,
-                accessor(0),
-                accessor(1),
-                accessor(2),
-            ))
         };
 
         // Each special case listed here should have a corresponding clause in `Type::bindings`.
@@ -2636,7 +2610,7 @@ impl<'db> Bindings<'db> {
                             }
                         }
 
-                        Some(KnownClass::Property | KnownClass::EnumProperty) => {
+                        Some(KnownClass::Property) => {
                             if let [getter, setter, deleter, ..] = overload.parameter_types() {
                                 let getter = getter.filter(|ty| !ty.is_none(db));
                                 let setter = setter.filter(|ty| !ty.is_none(db));
@@ -2685,24 +2659,7 @@ impl<'db> Bindings<'db> {
             }
         }
 
-        for constructor in self.iter_constructor_items_mut() {
-            if constructor
-                .constructed_instance_type()
-                .is_instance_of(db, KnownClass::EnumProperty)
-            {
-                let property = {
-                    constructor
-                        .callable()
-                        .matching_overloads()
-                        .exactly_one()
-                        .ok()
-                        .map(|(_, overload)| enum_property_instance(overload))
-                };
-                if let Some(property) = property {
-                    constructor.set_constructed_instance_type(property);
-                }
-            }
-        }
+        self.evaluate_enum_property_calls(db, call_arguments);
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1200,6 +1200,33 @@ impl<'db> Bindings<'db> {
             }
         };
 
+        let enum_property_instance = |overload: &Binding<'db>| {
+            let accessor = |parameter_index| {
+                call_arguments
+                    .iter()
+                    .zip(overload.argument_matches())
+                    .find_map(|((_, argument_types), argument_matches)| {
+                        argument_matches
+                            .parameters
+                            .iter()
+                            .find(|parameter| parameter.index == parameter_index)
+                            .map(|parameter| {
+                                parameter
+                                    .argument_type
+                                    .or_else(|| argument_types.get_default())
+                            })
+                    })
+                    .flatten()
+                    .filter(|ty| !ty.is_none(db))
+            };
+            Type::PropertyInstance(PropertyInstanceType::new(
+                db,
+                accessor(0),
+                accessor(1),
+                accessor(2),
+            ))
+        };
+
         // Each special case listed here should have a corresponding clause in `Type::bindings`.
         for binding in self.iter_flat_mut() {
             let binding_type = binding.callable_type;
@@ -2609,7 +2636,10 @@ impl<'db> Bindings<'db> {
                             }
                         }
 
-                        Some(KnownClass::Property) => {
+                        known_class
+                            if known_class == Some(KnownClass::Property)
+                                || class.is_known(db, KnownClass::EnumProperty) =>
+                        {
                             if let [getter, setter, deleter, ..] = overload.parameter_types() {
                                 let getter = getter.filter(|ty| !ty.is_none(db));
                                 let setter = setter.filter(|ty| !ty.is_none(db));
@@ -2654,6 +2684,25 @@ impl<'db> Bindings<'db> {
 
                     // Not a special case
                     _ => {}
+                }
+            }
+        }
+
+        for constructor in self.iter_constructor_items_mut() {
+            if constructor
+                .constructed_instance_type()
+                .is_instance_of(db, KnownClass::EnumProperty)
+            {
+                let property = {
+                    constructor
+                        .callable()
+                        .matching_overloads()
+                        .exactly_one()
+                        .ok()
+                        .map(|(_, overload)| enum_property_instance(overload))
+                };
+                if let Some(property) = property {
+                    constructor.set_constructed_instance_type(property);
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/call/bind/enum_property.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/enum_property.rs
@@ -6,8 +6,8 @@ use crate::types::call::CallArguments;
 use crate::types::{KnownClass, PropertyInstanceType, Type};
 
 impl<'db> Bindings<'db> {
-    /// Updates both the callable return and the constructed instance, which are tracked separately
-    /// for constructor bindings.
+    /// Replaces constructed `enum.property` instances with the property type derived from their
+    /// accessor arguments.
     pub(super) fn evaluate_enum_property_calls(
         &mut self,
         db: &'db dyn Db,
@@ -22,21 +22,6 @@ impl<'db> Bindings<'db> {
                     deleter.filter(|ty| !ty.is_none(db)),
                 ))
             };
-
-        for binding in self.iter_flat_mut() {
-            if !matches!(
-                binding.callable_type,
-                Type::ClassLiteral(class) if class.is_known(db, KnownClass::EnumProperty)
-            ) {
-                continue;
-            }
-
-            for (_, overload) in binding.matching_overloads_mut() {
-                if let [getter, setter, deleter, ..] = overload.parameter_types() {
-                    overload.set_return_type(property_instance(*getter, *setter, *deleter));
-                }
-            }
-        }
 
         for constructor in self.iter_constructor_items_mut() {
             if !constructor

--- a/crates/ty_python_semantic/src/types/call/bind/enum_property.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/enum_property.rs
@@ -1,0 +1,73 @@
+use itertools::Itertools;
+
+use super::Bindings;
+use crate::db::Db;
+use crate::types::call::CallArguments;
+use crate::types::{KnownClass, PropertyInstanceType, Type};
+
+impl<'db> Bindings<'db> {
+    /// Updates both the callable return and the constructed instance, which are tracked separately
+    /// for constructor bindings.
+    pub(super) fn evaluate_enum_property_calls(
+        &mut self,
+        db: &'db dyn Db,
+        call_arguments: &CallArguments<'_, 'db>,
+    ) {
+        let property_instance =
+            |getter: Option<Type<'db>>, setter: Option<Type<'db>>, deleter: Option<Type<'db>>| {
+                Type::PropertyInstance(PropertyInstanceType::new(
+                    db,
+                    getter.filter(|ty| !ty.is_none(db)),
+                    setter.filter(|ty| !ty.is_none(db)),
+                    deleter.filter(|ty| !ty.is_none(db)),
+                ))
+            };
+
+        for binding in self.iter_flat_mut() {
+            if !matches!(
+                binding.callable_type,
+                Type::ClassLiteral(class) if class.is_known(db, KnownClass::EnumProperty)
+            ) {
+                continue;
+            }
+
+            for (_, overload) in binding.matching_overloads_mut() {
+                if let [getter, setter, deleter, ..] = overload.parameter_types() {
+                    overload.set_return_type(property_instance(*getter, *setter, *deleter));
+                }
+            }
+        }
+
+        for constructor in self.iter_constructor_items_mut() {
+            if !constructor
+                .constructed_instance_type()
+                .is_instance_of(db, KnownClass::EnumProperty)
+            {
+                continue;
+            }
+
+            let property = {
+                let Ok((_, overload)) = constructor.callable().matching_overloads().exactly_one()
+                else {
+                    continue;
+                };
+                let accessor = |parameter_index| {
+                    call_arguments
+                        .iter()
+                        .zip(overload.argument_matches())
+                        .find_map(|((_, argument_types), argument_matches)| {
+                            let parameter = argument_matches
+                                .parameters
+                                .iter()
+                                .find(|parameter| parameter.index == parameter_index)?;
+                            parameter
+                                .argument_type
+                                .or_else(|| argument_types.get_default())
+                        })
+                };
+                property_instance(accessor(0), accessor(1), accessor(2))
+            };
+            constructor.set_constructed_instance_type(property);
+        }
+    }
+}

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -63,6 +63,7 @@ pub enum KnownClass {
     NotImplementedError,
     // enum
     Enum,
+    EnumProperty,
     EnumType,
     Auto,
     Member,
@@ -231,6 +232,7 @@ impl KnownClass {
             | Self::Deque
             | Self::Float
             | Self::Enum
+            | Self::EnumProperty
             | Self::EnumType
             | Self::Auto
             | Self::Member
@@ -308,6 +310,7 @@ impl KnownClass {
             | KnownClass::Deprecated
             | KnownClass::Super
             | KnownClass::Enum
+            | KnownClass::EnumProperty
             | KnownClass::EnumType
             | KnownClass::Auto
             | KnownClass::Member
@@ -408,6 +411,7 @@ impl KnownClass {
             | KnownClass::Deprecated
             | KnownClass::Super
             | KnownClass::Enum
+            | KnownClass::EnumProperty
             | KnownClass::EnumType
             | KnownClass::Auto
             | KnownClass::Member
@@ -508,6 +512,7 @@ impl KnownClass {
             | KnownClass::Deprecated
             | KnownClass::Super
             | KnownClass::Enum
+            | KnownClass::EnumProperty
             | KnownClass::EnumType
             | KnownClass::Auto
             | KnownClass::Member
@@ -655,6 +660,7 @@ impl KnownClass {
             | Self::Deque
             | Self::OrderedDict
             | Self::Enum
+            | Self::EnumProperty
             | Self::EnumType
             | Self::Auto
             | Self::Member
@@ -719,6 +725,7 @@ impl KnownClass {
             | KnownClass::Classmethod
             | KnownClass::Super
             | KnownClass::Enum
+            | KnownClass::EnumProperty
             | KnownClass::EnumType
             | KnownClass::Auto
             | KnownClass::Member
@@ -850,6 +857,7 @@ impl KnownClass {
             Self::Deque => "deque",
             Self::OrderedDict => "OrderedDict",
             Self::Enum => "Enum",
+            Self::EnumProperty => "property",
             Self::EnumType => {
                 if Program::get(db).python_version(db) >= PythonVersion::PY311 {
                     "EnumType"
@@ -1181,6 +1189,7 @@ impl KnownClass {
             Self::VersionInfo => KnownModule::Sys,
             Self::ABCMeta => KnownModule::Abc,
             Self::Enum
+            | Self::EnumProperty
             | Self::EnumType
             | Self::Auto
             | Self::Member
@@ -1324,6 +1333,7 @@ impl KnownClass {
             | Self::TypeVarTuple
             | Self::Sentinel
             | Self::Enum
+            | Self::EnumProperty
             | Self::EnumType
             | Self::Auto
             | Self::Member
@@ -1429,6 +1439,7 @@ impl KnownClass {
             | Self::TypeVarTuple
             | Self::Sentinel
             | Self::Enum
+            | Self::EnumProperty
             | Self::EnumType
             | Self::Auto
             | Self::Member
@@ -1490,7 +1501,7 @@ impl KnownClass {
             "dict" => &[Self::Dict],
             "list" => &[Self::List],
             "slice" => &[Self::Slice],
-            "property" => &[Self::Property],
+            "property" => &[Self::Property, Self::EnumProperty],
             "BaseException" => &[Self::BaseException],
             "BaseExceptionGroup" => &[Self::BaseExceptionGroup],
             "Exception" => &[Self::Exception],
@@ -1620,6 +1631,7 @@ impl KnownClass {
             | Self::MethodType
             | Self::MethodWrapperType
             | Self::Enum
+            | Self::EnumProperty
             | Self::EnumType
             | Self::Auto
             | Self::Member
@@ -1965,9 +1977,10 @@ mod tests {
                         PythonVersion::PY311
                     }
                     KnownClass::GenericAlias => PythonVersion::PY39,
-                    KnownClass::Member | KnownClass::Nonmember | KnownClass::StrEnum => {
-                        PythonVersion::PY311
-                    }
+                    KnownClass::EnumProperty
+                    | KnownClass::Member
+                    | KnownClass::Nonmember
+                    | KnownClass::StrEnum => PythonVersion::PY311,
                     _ => PythonVersion::PY37,
                 };
                 (class, version_added)

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -59,6 +59,39 @@ pub(crate) struct EnumMetadata<'db> {
 
 impl get_size2::GetSize for EnumMetadata<'_> {}
 
+pub(super) fn class_defines_property<'db>(
+    db: &'db dyn Db,
+    class: ClassLiteral<'db>,
+    name: &str,
+) -> bool {
+    let Some(class) = Type::ClassLiteral(class).to_class_type(db) else {
+        return false;
+    };
+
+    for base in class.iter_mro(db) {
+        let ClassBase::Class(base) = base else {
+            continue;
+        };
+        if matches!(
+            base.known(db),
+            Some(
+                KnownClass::Enum
+                    | KnownClass::StrEnum
+                    | KnownClass::IntEnum
+                    | KnownClass::Flag
+                    | KnownClass::IntFlag
+            )
+        ) {
+            return false;
+        }
+        if let Some(member) = base.own_class_member(db, None, name).inner.place.raw_type() {
+            return member.is_property_instance();
+        }
+    }
+
+    false
+}
+
 /// Look up an instance member on the finite enum literals represented by a complement.
 ///
 /// The enum-owned `.name`/`.value` attributes can often be answered directly. Other members
@@ -106,7 +139,8 @@ fn special_member_for_enum_complement<'db>(
     complement: EnumComplement<'db>,
     name: &str,
 ) -> Option<PlaceAndQualifiers<'db>> {
-    if matches!(name, "name" | "_name_" | "value" | "_value_")
+    if !class_defines_property(db, complement.enum_class(db), name)
+        && matches!(name, "name" | "_name_" | "value" | "_value_")
         && complement.rest(db).iter().all(Type::is_dynamic)
         && let Some(member_ty) = complement.member_type(db, name)
     {

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -139,8 +139,8 @@ fn special_member_for_enum_complement<'db>(
     complement: EnumComplement<'db>,
     name: &str,
 ) -> Option<PlaceAndQualifiers<'db>> {
-    if !class_defines_property(db, complement.enum_class(db), name)
-        && matches!(name, "name" | "_name_" | "value" | "_value_")
+    if matches!(name, "name" | "_name_" | "value" | "_value_")
+        && !class_defines_property(db, complement.enum_class(db), name)
         && complement.rest(db).iter().all(Type::is_dynamic)
         && let Some(member_ty) = complement.member_type(db, name)
     {


### PR DESCRIPTION
## Summary
Treat `enum.property` as a known class with `property` like behavior so we get accurate types from its `__get__` method, instead of just `Any`.

Closes https://github.com/astral-sh/ty/issues/3681

## Testing
Added mdtests