### PR TITLE
[ty] Compact retained use-def bindings

### DIFF
--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -434,15 +434,14 @@ impl RetainedBindingsBuilder {
         }
     }
 
-    #[expect(clippy::cast_possible_truncation)]
     fn push(&mut self, bindings: &Bindings) -> InternedBindingsId {
         // Definition IDs are also 32-bit and a single scope cannot practically approach this
         // limit. Keeping offsets at the same width halves the retained range size.
-        debug_assert!(u32::try_from(self.live_bindings.len()).is_ok());
-        let start = self.live_bindings.len() as u32;
+        let start = u32::try_from(self.live_bindings.len())
+            .expect("Expected live-bindings length to fit into a u32");
         self.live_bindings.extend_from_slice(bindings.as_slice());
-        debug_assert!(u32::try_from(self.live_bindings.len()).is_ok());
-        let end = self.live_bindings.len() as u32;
+        let end = u32::try_from(self.live_bindings.len())
+            .expect("Expected live-bindings length to fit into a u32");
         self.ranges.push(start..end)
     }
 

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -446,15 +446,13 @@ impl RetainedBindingsBuilder {
     }
 
     fn finish(
-        mut self,
+        self,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) -> RetainedBindings {
         for binding in &self.live_bindings {
             reachability_constraints.mark_used(binding.reachability_constraint());
             reachability_constraints.mark_used(binding.narrowing_constraint());
         }
-        self.ranges.shrink_to_fit();
-        self.live_bindings.shrink_to_fit();
         RetainedBindings {
             ranges: self.ranges.into(),
             live_bindings: self.live_bindings.into_boxed_slice(),

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -240,6 +240,7 @@
 //! visits a `StmtIf` node.
 
 use std::collections::hash_map::Entry;
+use std::ops::Range;
 
 use ruff_index::{FrozenIndexVec, Idx, IndexSlice, IndexVec, newtype_index};
 use ruff_text_size::TextRange;
@@ -416,19 +417,13 @@ impl PlaceStateInterner {
 /// ranges into one contiguous array instead.
 #[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 struct RetainedBindings {
-    ranges: FrozenIndexVec<InternedBindingsId, RetainedBindingsRange>,
+    ranges: FrozenIndexVec<InternedBindingsId, Range<u32>>,
     live_bindings: Box<[LiveBinding]>,
 }
 
 struct RetainedBindingsBuilder {
-    ranges: IndexVec<InternedBindingsId, RetainedBindingsRange>,
+    ranges: IndexVec<InternedBindingsId, Range<u32>>,
     live_bindings: Vec<LiveBinding>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
-struct RetainedBindingsRange {
-    start: u32,
-    end: u32,
 }
 
 impl RetainedBindingsBuilder {
@@ -448,7 +443,7 @@ impl RetainedBindingsBuilder {
         self.live_bindings.extend_from_slice(bindings.as_slice());
         debug_assert!(u32::try_from(self.live_bindings.len()).is_ok());
         let end = self.live_bindings.len() as u32;
-        self.ranges.push(RetainedBindingsRange { start, end })
+        self.ranges.push(start..end)
     }
 
     fn finish(
@@ -470,7 +465,7 @@ impl RetainedBindingsBuilder {
 
 impl RetainedBindings {
     fn get(&self, id: InternedBindingsId) -> &[LiveBinding] {
-        let RetainedBindingsRange { start, end } = self.ranges[id];
+        let Range { start, end } = self.ranges[id];
         &self.live_bindings[start as usize..end as usize]
     }
 }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -293,7 +293,7 @@ impl InternedPlaceStateId {
 }
 
 struct PlaceStateInterner {
-    interned_bindings: IndexVec<InternedBindingsId, Bindings>,
+    interned_bindings: RetainedBindingsBuilder,
     interned_ids_by_bindings: FxHashMap<Bindings, InternedBindingsId>,
     interned_declarations: IndexVec<InternedDeclarationsId, Declarations>,
     interned_ids_by_declarations: FxHashMap<Declarations, InternedDeclarationsId>,
@@ -308,7 +308,7 @@ struct PlaceStateInterner {
 impl PlaceStateInterner {
     fn with_capacity(bindings: usize, declaration_map: usize, declarations: usize) -> Self {
         Self {
-            interned_bindings: IndexVec::with_capacity(bindings),
+            interned_bindings: RetainedBindingsBuilder::with_capacity(bindings),
             interned_ids_by_bindings: FxHashMap::with_capacity_and_hasher(bindings, FxBuildHasher),
             interned_declarations: IndexVec::with_capacity(declarations),
             interned_ids_by_declarations: FxHashMap::with_capacity_and_hasher(
@@ -327,7 +327,7 @@ impl PlaceStateInterner {
                 return interned_id;
             }
 
-            let interned_id = self.interned_bindings.push(bindings);
+            let interned_id = self.interned_bindings.push(&bindings);
             self.always_unbound_bindings = Some(interned_id);
             return interned_id;
         }
@@ -335,7 +335,7 @@ impl PlaceStateInterner {
         match self.interned_ids_by_bindings.entry(bindings) {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
-                let interned_id = self.interned_bindings.push(entry.key().clone());
+                let interned_id = self.interned_bindings.push(entry.key());
                 entry.insert(interned_id);
                 interned_id
             }
@@ -409,6 +409,72 @@ impl PlaceStateInterner {
     }
 }
 
+/// Compact, retained representation of the interned binding vectors for a scope.
+///
+/// The builder needs a `SmallVec` and an optional unbound constraint while constructing each
+/// binding state. Neither is needed after the semantic index is built, so the retained map stores
+/// ranges into one contiguous array instead.
+#[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+struct RetainedBindings {
+    ranges: FrozenIndexVec<InternedBindingsId, RetainedBindingsRange>,
+    live_bindings: Box<[LiveBinding]>,
+}
+
+struct RetainedBindingsBuilder {
+    ranges: IndexVec<InternedBindingsId, RetainedBindingsRange>,
+    live_bindings: Vec<LiveBinding>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+struct RetainedBindingsRange {
+    start: u32,
+    end: u32,
+}
+
+impl RetainedBindingsBuilder {
+    fn with_capacity(bindings: usize) -> Self {
+        Self {
+            ranges: IndexVec::with_capacity(bindings),
+            live_bindings: Vec::with_capacity(bindings),
+        }
+    }
+
+    #[expect(clippy::cast_possible_truncation)]
+    fn push(&mut self, bindings: &Bindings) -> InternedBindingsId {
+        // Definition IDs are also 32-bit and a single scope cannot practically approach this
+        // limit. Keeping offsets at the same width halves the retained range size.
+        debug_assert!(u32::try_from(self.live_bindings.len()).is_ok());
+        let start = self.live_bindings.len() as u32;
+        self.live_bindings.extend_from_slice(bindings.as_slice());
+        debug_assert!(u32::try_from(self.live_bindings.len()).is_ok());
+        let end = self.live_bindings.len() as u32;
+        self.ranges.push(RetainedBindingsRange { start, end })
+    }
+
+    fn finish(
+        mut self,
+        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+    ) -> RetainedBindings {
+        for binding in &self.live_bindings {
+            reachability_constraints.mark_used(binding.reachability_constraint());
+            reachability_constraints.mark_used(binding.narrowing_constraint());
+        }
+        self.ranges.shrink_to_fit();
+        self.live_bindings.shrink_to_fit();
+        RetainedBindings {
+            ranges: self.ranges.into(),
+            live_bindings: self.live_bindings.into_boxed_slice(),
+        }
+    }
+}
+
+impl RetainedBindings {
+    fn get(&self, id: InternedBindingsId) -> &[LiveBinding] {
+        let RetainedBindingsRange { start, end } = self.ranges[id];
+        &self.live_bindings[start as usize..end as usize]
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 struct RetainedPlaceStates<T> {
     end_of_scope: T,
@@ -446,7 +512,7 @@ pub struct UseDefMap<'db> {
     reachability_constraints: ReachabilityConstraints,
 
     /// Interned [`Bindings`] values.
-    interned_bindings: FrozenIndexVec<InternedBindingsId, Bindings>,
+    interned_bindings: RetainedBindings,
     /// Interned [`Declarations`] values.
     interned_declarations: FrozenIndexVec<InternedDeclarationsId, Declarations>,
 
@@ -577,7 +643,7 @@ impl<'db> UseDefMap<'db> {
     pub fn bindings_at_use(&self, use_id: ScopedUseId) -> BindingWithConstraintsIterator<'_, 'db> {
         let bindings_id = self.bindings_by_use[use_id];
         self.bindings_iterator(
-            &self.interned_bindings[bindings_id],
+            self.interned_bindings.get(bindings_id),
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -590,7 +656,10 @@ impl<'db> UseDefMap<'db> {
             .get(use_id)
             .map(|member_bindings| {
                 member_bindings.iter().map(|bindings| {
-                    self.bindings_iterator(bindings, BoundnessAnalysis::BasedOnUnboundVisibility)
+                    self.bindings_iterator(
+                        bindings.as_slice(),
+                        BoundnessAnalysis::BasedOnUnboundVisibility,
+                    )
                 })
             })
             .into_iter()
@@ -667,7 +736,7 @@ impl<'db> UseDefMap<'db> {
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.symbol_states[symbol].end_of_scope;
         self.bindings_iterator(
-            &self.interned_bindings[place_state_id.bindings_id()],
+            self.interned_bindings.get(place_state_id.bindings_id()),
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -678,7 +747,7 @@ impl<'db> UseDefMap<'db> {
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.member_states[member].end_of_scope;
         self.bindings_iterator(
-            &self.interned_bindings[place_state_id.bindings_id()],
+            self.interned_bindings.get(place_state_id.bindings_id()),
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -698,7 +767,7 @@ impl<'db> UseDefMap<'db> {
         symbol: ScopedSymbolId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.symbol_states[symbol].reachable;
-        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
+        let bindings = self.interned_bindings.get(place_state_id.bindings_id());
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -707,7 +776,7 @@ impl<'db> UseDefMap<'db> {
         member: ScopedMemberId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.member_states[member].reachable;
-        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
+        let bindings = self.interned_bindings.get(place_state_id.bindings_id());
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -728,12 +797,10 @@ impl<'db> UseDefMap<'db> {
                 EnclosingSnapshotResult::FoundConstraint(*constraint)
             }
             Some(InternedEnclosingSnapshotId::Bindings(bindings_id)) => {
-                EnclosingSnapshotResult::FoundBindings(
-                    self.bindings_iterator(
-                        &self.interned_bindings[*bindings_id],
-                        boundness_analysis,
-                    ),
-                )
+                EnclosingSnapshotResult::FoundBindings(self.bindings_iterator(
+                    self.interned_bindings.get(*bindings_id),
+                    boundness_analysis,
+                ))
             }
             None => EnclosingSnapshotResult::NotFound,
         }
@@ -745,7 +812,7 @@ impl<'db> UseDefMap<'db> {
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let bindings_id = self.definitions_by_definition[&definition].bindings;
         self.bindings_iterator(
-            &self.interned_bindings[bindings_id],
+            self.interned_bindings.get(bindings_id),
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -849,7 +916,7 @@ impl<'db> UseDefMap<'db> {
                     BoundnessAnalysis::AssumeBound,
                 );
                 let bindings = self.bindings_iterator(
-                    &self.interned_bindings[reachable.bindings_id()],
+                    self.interned_bindings.get(reachable.bindings_id()),
                     BoundnessAnalysis::AssumeBound,
                 );
                 (symbol_id, declarations, bindings)
@@ -859,7 +926,7 @@ impl<'db> UseDefMap<'db> {
 
     fn bindings_iterator<'map>(
         &'map self,
-        bindings: &'map Bindings,
+        bindings: &'map [LiveBinding],
         boundness_analysis: BoundnessAnalysis,
     ) -> BindingWithConstraintsIterator<'map, 'db> {
         BindingWithConstraintsIterator {
@@ -1897,19 +1964,16 @@ impl<'db> UseDefMapBuilder<'db> {
         let enclosing_snapshots =
             Self::intern_enclosing_snapshots(self.enclosing_snapshots, &mut place_state_interner);
         let PlaceStateInterner {
-            mut interned_bindings,
+            interned_bindings,
             mut interned_declarations,
             ..
         } = place_state_interner;
 
-        interned_bindings.shrink_to_fit();
         interned_declarations.shrink_to_fit();
 
         // We only walk the fields that are copied through to the UseDefMap when we finish building
         // it.
-        for bindings in &mut interned_bindings {
-            bindings.finish(&mut self.reachability_constraints);
-        }
+        let interned_bindings = interned_bindings.finish(&mut self.reachability_constraints);
         for declarations in &mut interned_declarations {
             declarations.finish(&mut self.reachability_constraints);
         }
@@ -1937,7 +2001,7 @@ impl<'db> UseDefMapBuilder<'db> {
             used_bindings: self.used_bindings.into(),
             predicates: self.predicates.build(),
             reachability_constraints: self.reachability_constraints.build(),
-            interned_bindings: interned_bindings.into(),
+            interned_bindings,
             interned_declarations: interned_declarations.into(),
             bindings_by_use: bindings_by_use.into(),
             multi_bindings_by_use,

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -240,7 +240,7 @@
 //! visits a `StmtIf` node.
 
 use std::collections::hash_map::Entry;
-use std::ops::Range;
+use std::ops::{Index, Range};
 
 use ruff_index::{FrozenIndexVec, Idx, IndexSlice, IndexVec, newtype_index};
 use ruff_text_size::TextRange;
@@ -460,9 +460,11 @@ impl RetainedBindingsBuilder {
     }
 }
 
-impl RetainedBindings {
-    fn get(&self, id: InternedBindingsId) -> &[LiveBinding] {
-        let Range { start, end } = self.ranges[id];
+impl Index<InternedBindingsId> for RetainedBindings {
+    type Output = [LiveBinding];
+
+    fn index(&self, index: InternedBindingsId) -> &Self::Output {
+        let Range { start, end } = self.ranges[index];
         &self.live_bindings[start as usize..end as usize]
     }
 }
@@ -635,7 +637,7 @@ impl<'db> UseDefMap<'db> {
     pub fn bindings_at_use(&self, use_id: ScopedUseId) -> BindingWithConstraintsIterator<'_, 'db> {
         let bindings_id = self.bindings_by_use[use_id];
         self.bindings_iterator(
-            self.interned_bindings.get(bindings_id),
+            &self.interned_bindings[bindings_id],
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -728,7 +730,7 @@ impl<'db> UseDefMap<'db> {
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.symbol_states[symbol].end_of_scope;
         self.bindings_iterator(
-            self.interned_bindings.get(place_state_id.bindings_id()),
+            &self.interned_bindings[place_state_id.bindings_id()],
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -739,7 +741,7 @@ impl<'db> UseDefMap<'db> {
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.member_states[member].end_of_scope;
         self.bindings_iterator(
-            self.interned_bindings.get(place_state_id.bindings_id()),
+            &self.interned_bindings[place_state_id.bindings_id()],
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -759,7 +761,7 @@ impl<'db> UseDefMap<'db> {
         symbol: ScopedSymbolId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.symbol_states[symbol].reachable;
-        let bindings = self.interned_bindings.get(place_state_id.bindings_id());
+        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -768,7 +770,7 @@ impl<'db> UseDefMap<'db> {
         member: ScopedMemberId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let place_state_id = self.member_states[member].reachable;
-        let bindings = self.interned_bindings.get(place_state_id.bindings_id());
+        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -789,10 +791,12 @@ impl<'db> UseDefMap<'db> {
                 EnclosingSnapshotResult::FoundConstraint(*constraint)
             }
             Some(InternedEnclosingSnapshotId::Bindings(bindings_id)) => {
-                EnclosingSnapshotResult::FoundBindings(self.bindings_iterator(
-                    self.interned_bindings.get(*bindings_id),
-                    boundness_analysis,
-                ))
+                EnclosingSnapshotResult::FoundBindings(
+                    self.bindings_iterator(
+                        &self.interned_bindings[*bindings_id],
+                        boundness_analysis,
+                    ),
+                )
             }
             None => EnclosingSnapshotResult::NotFound,
         }
@@ -804,7 +808,7 @@ impl<'db> UseDefMap<'db> {
     ) -> BindingWithConstraintsIterator<'_, 'db> {
         let bindings_id = self.definitions_by_definition[&definition].bindings;
         self.bindings_iterator(
-            self.interned_bindings.get(bindings_id),
+            &self.interned_bindings[bindings_id],
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -908,7 +912,7 @@ impl<'db> UseDefMap<'db> {
                     BoundnessAnalysis::AssumeBound,
                 );
                 let bindings = self.bindings_iterator(
-                    self.interned_bindings.get(reachable.bindings_id()),
+                    &self.interned_bindings[reachable.bindings_id()],
                     BoundnessAnalysis::AssumeBound,
                 );
                 (symbol_id, declarations, bindings)

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -237,16 +237,14 @@ pub(super) struct Bindings {
 
 impl Bindings {
     pub(super) fn is_always_unbound(&self) -> bool {
+        let [binding] = self.live_bindings.as_slice() else {
+            return false;
+        };
         self.unbound_narrowing_constraint.is_none()
-            && matches!(
-                self.live_bindings.as_slice(),
-                [LiveBinding {
-                    binding: ScopedDefinitionId::UNBOUND,
-                    narrowing_constraint: ScopedNarrowingConstraint::ALWAYS_TRUE,
-                    reachability_constraint: ScopedReachabilityConstraintId::ALWAYS_TRUE,
-                    can_be_shadowed: FutureDefinitions::ShadowThisOne,
-                }]
-            )
+            && binding.binding() == ScopedDefinitionId::UNBOUND
+            && binding.narrowing_constraint == ScopedNarrowingConstraint::ALWAYS_TRUE
+            && binding.reachability_constraint == ScopedReachabilityConstraintId::ALWAYS_TRUE
+            && binding.can_be_shadowed() == FutureDefinitions::ShadowThisOne
     }
 
     pub(super) fn unbound_narrowing_constraint(&self) -> ScopedNarrowingConstraint {
@@ -266,17 +264,65 @@ impl Bindings {
 /// One of the live bindings for a single place at some point in control flow.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
 pub struct LiveBinding {
-    binding: ScopedDefinitionId,
+    binding: PackedDefinitionId,
     narrowing_constraint: ScopedNarrowingConstraint,
     reachability_constraint: ScopedReachabilityConstraintId,
-    // TODO: This extra bit is responsible for 1% of our memory footprint in some projects. We
-    // could pack it into one of the fields above.
-    can_be_shadowed: FutureDefinitions,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+struct PackedDefinitionId(u32);
+
+impl PackedDefinitionId {
+    // Scope-local definition IDs cannot practically use the high bit, so retain the shadowing
+    // policy there instead of adding a byte plus padding to every `LiveBinding`.
+    const DONT_SHADOW: u32 = 1 << 31;
+    const DEFINITION_MASK: u32 = !Self::DONT_SHADOW;
+
+    fn new(binding: ScopedDefinitionId, can_be_shadowed: FutureDefinitions) -> Self {
+        let binding = binding.as_u32();
+        assert_eq!(
+            binding & Self::DONT_SHADOW,
+            0,
+            "scopes cannot contain more than 2^31 definitions"
+        );
+        Self(
+            binding
+                | match can_be_shadowed {
+                    FutureDefinitions::ShadowThisOne => 0,
+                    FutureDefinitions::DontShadowThisOne => Self::DONT_SHADOW,
+                },
+        )
+    }
+
+    const fn definition(self) -> ScopedDefinitionId {
+        ScopedDefinitionId::from_u32(self.0 & Self::DEFINITION_MASK)
+    }
+
+    const fn can_be_shadowed(self) -> FutureDefinitions {
+        if self.0 & Self::DONT_SHADOW == 0 {
+            FutureDefinitions::ShadowThisOne
+        } else {
+            FutureDefinitions::DontShadowThisOne
+        }
+    }
 }
 
 impl LiveBinding {
+    fn new(
+        binding: ScopedDefinitionId,
+        narrowing_constraint: ScopedNarrowingConstraint,
+        reachability_constraint: ScopedReachabilityConstraintId,
+        can_be_shadowed: FutureDefinitions,
+    ) -> Self {
+        Self {
+            binding: PackedDefinitionId::new(binding, can_be_shadowed),
+            narrowing_constraint,
+            reachability_constraint,
+        }
+    }
+
     pub const fn binding(&self) -> ScopedDefinitionId {
-        self.binding
+        self.binding.definition()
     }
 
     pub const fn narrowing_constraint(&self) -> ScopedNarrowingConstraint {
@@ -286,18 +332,24 @@ impl LiveBinding {
     pub const fn reachability_constraint(&self) -> ScopedReachabilityConstraintId {
         self.reachability_constraint
     }
+
+    const fn can_be_shadowed(&self) -> FutureDefinitions {
+        self.binding.can_be_shadowed()
+    }
 }
+
+static_assertions::assert_eq_size!(LiveBinding, [u32; 3]);
 
 pub(super) type LiveBindingsIterator<'a> = std::slice::Iter<'a, LiveBinding>;
 
 impl Bindings {
     pub(super) fn unbound(reachability_constraint: ScopedReachabilityConstraintId) -> Self {
-        let initial_binding = LiveBinding {
-            binding: ScopedDefinitionId::UNBOUND,
-            narrowing_constraint: ScopedNarrowingConstraint::ALWAYS_TRUE,
+        let initial_binding = LiveBinding::new(
+            ScopedDefinitionId::UNBOUND,
+            ScopedNarrowingConstraint::ALWAYS_TRUE,
             reachability_constraint,
-            can_be_shadowed: FutureDefinitions::ShadowThisOne,
-        };
+            FutureDefinitions::ShadowThisOne,
+        );
         Self {
             unbound_narrowing_constraint: None,
             live_bindings: smallvec![initial_binding],
@@ -316,21 +368,21 @@ impl Bindings {
     ) {
         // If we are in a class scope, and the unbound name binding was previously visible, but we will
         // now replace it, record the narrowing constraints on it:
-        if is_class_scope && is_place_name && self.live_bindings[0].binding.is_unbound() {
+        if is_class_scope && is_place_name && self.live_bindings[0].binding().is_unbound() {
             self.unbound_narrowing_constraint = Some(self.live_bindings[0].narrowing_constraint);
         }
         // If the new binding is a shadowing type, it replaces previous live bindings in this path
         // (unless they're marked as not shadowable), and has no constraints.
         if previous_definitions.are_shadowed() {
             self.live_bindings
-                .retain(|b| b.can_be_shadowed == FutureDefinitions::DontShadowThisOne);
+                .retain(|b| b.can_be_shadowed() == FutureDefinitions::DontShadowThisOne);
         }
-        self.live_bindings.push(LiveBinding {
+        self.live_bindings.push(LiveBinding::new(
             binding,
-            narrowing_constraint: ScopedNarrowingConstraint::ALWAYS_TRUE,
+            ScopedNarrowingConstraint::ALWAYS_TRUE,
             reachability_constraint,
             can_be_shadowed,
-        });
+        ));
     }
 
     /// Add given constraint to all live bindings.
@@ -362,6 +414,10 @@ impl Bindings {
         self.live_bindings.iter()
     }
 
+    pub(super) fn as_slice(&self) -> &[LiveBinding] {
+        &self.live_bindings
+    }
+
     pub(super) fn merge(
         &mut self,
         b: Self,
@@ -384,7 +440,7 @@ impl Bindings {
         // as-is.
         let a = a.live_bindings.into_iter();
         let b = b.live_bindings.into_iter();
-        for zipped in a.merge_join_by(b, |a, b| a.binding.cmp(&b.binding)) {
+        for zipped in a.merge_join_by(b, |a, b| a.binding().cmp(&b.binding())) {
             match zipped {
                 EitherOrBoth::Both(a, b) => {
                     // If the same definition is visible through both paths, we OR the narrowing
@@ -396,13 +452,13 @@ impl Bindings {
                     let reachability_constraint = reachability_constraints
                         .add_or_constraint(a.reachability_constraint, b.reachability_constraint);
 
-                    debug_assert_eq!(a.can_be_shadowed, b.can_be_shadowed);
-                    self.live_bindings.push(LiveBinding {
-                        binding: a.binding,
+                    debug_assert_eq!(a.can_be_shadowed(), b.can_be_shadowed());
+                    self.live_bindings.push(LiveBinding::new(
+                        a.binding(),
                         narrowing_constraint,
                         reachability_constraint,
-                        can_be_shadowed: a.can_be_shadowed,
-                    });
+                        a.can_be_shadowed(),
+                    ));
                 }
 
                 EitherOrBoth::Left(binding) | EitherOrBoth::Right(binding) => {
@@ -522,7 +578,7 @@ mod tests {
             .iter()
             .map(|live_binding| {
                 (
-                    live_binding.binding.as_u32(),
+                    live_binding.binding().as_u32(),
                     live_binding.narrowing_constraint,
                 )
             })
@@ -724,7 +780,7 @@ mod tests {
         let bindings: Vec<_> = sym3
             .bindings()
             .iter()
-            .map(|b| (b.binding.as_u32(), b.narrowing_constraint))
+            .map(|b| (b.binding().as_u32(), b.narrowing_constraint))
             .collect();
         assert_eq!(bindings.len(), 2);
         assert_eq!(bindings[0].0, 0); // unbound
@@ -737,7 +793,7 @@ mod tests {
         let bindings: Vec<_> = sym
             .bindings()
             .iter()
-            .map(|b| (b.binding.as_u32(), b.narrowing_constraint))
+            .map(|b| (b.binding().as_u32(), b.narrowing_constraint))
             .collect();
         assert_eq!(bindings.len(), 3);
         assert_eq!(bindings[0].0, 0); // unbound


### PR DESCRIPTION
## Summary

`UseDefMap` currently retains every interned binding state as a `SmallVec`, including builder-only capacity and an optional unbound constraint that are no longer needed after semantic indexing finishes.

This change packs the shadowing policy into the scope-local definition ID and stores retained binding states as ranges into one contiguous `LiveBinding` array. Binding construction and interning behavior remain unchanged, while each `LiveBinding` shrinks from 16 to 12 bytes and retained states no longer carry per-vector allocation metadata.

On a large codebase, this reduced retained memory by 2.96% without a wall-time regression.