### PR TITLE
[ty] Preserve deprecation on replacement functions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -38,6 +38,87 @@ MyClass.afunc()  # error: [deprecated] "use something else"
 MyClass().amethod()  # error: [deprecated] "don't use this!"
 ```
 
+## Function replacements
+
+An outer `@deprecated` decorator applies to the function returned by inner decorators.
+
+```py
+from collections.abc import Callable
+from typing import Any, TypeVar
+from typing_extensions import deprecated
+
+R = TypeVar("R")
+
+def replacement() -> str:
+    return "replacement"
+
+def replace_with(value: R) -> Callable[[Callable[..., Any]], R]:
+    def decorator(_function: Callable[..., Any]) -> R:
+        return value
+
+    return decorator
+
+@deprecated("use replacement directly")
+@replace_with(replacement)
+def old() -> None:
+    pass
+
+old()  # error: [deprecated] "use replacement directly"
+replacement()
+
+@replace_with(replacement)
+@deprecated("discarded by outer replacement")
+def replaced_after_deprecation() -> None:
+    pass
+
+replaced_after_deprecation()
+
+@deprecated("outer deprecation")
+@replace_with(replacement)
+@deprecated("inner deprecation")
+def multiply_deprecated() -> None:
+    pass
+
+multiply_deprecated()  # error: [deprecated] "outer deprecation"
+
+class StaticMethodReplacement:
+    @staticmethod
+    @deprecated("use replacement directly")
+    @replace_with(replacement)
+    def old() -> None:
+        pass
+
+StaticMethodReplacement.old()  # error: [deprecated] "use replacement directly"
+```
+
+`@deprecated` can also wrap other callable objects at runtime, but we currently only preserve the
+deprecation when an inner decorator returns a function literal.
+
+```py
+from collections.abc import Callable
+from typing import Any, TypeVar
+from typing_extensions import deprecated
+
+R = TypeVar("R")
+
+def replace_with(value: R) -> Callable[[Callable[..., Any]], R]:
+    def decorator(_function: Callable[..., Any]) -> R:
+        return value
+
+    return decorator
+
+class Replacement:
+    def __call__(self) -> str:
+        return "replacement"
+
+@deprecated("use Replacement directly")
+@replace_with(Replacement())
+def old() -> None:
+    pass
+
+old()  # TODO: error: [deprecated] "use Replacement directly"
+```
+
 ## Syntax
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -286,6 +286,19 @@ impl get_size2::GetSize for OverloadLiteral<'_> {}
 
 #[salsa::tracked]
 impl<'db> OverloadLiteral<'db> {
+    fn with_deprecated(self, db: &'db dyn Db, deprecated: DeprecatedInstance<'db>) -> Self {
+        Self::new(
+            db,
+            self.name(db).clone(),
+            self.known(db),
+            self.body_scope(db),
+            self.decorators(db),
+            Some(deprecated),
+            self.dataclass_transformer_params(db),
+            self.has_explicit_return_annotation(db),
+        )
+    }
+
     fn with_dataclass_transformer_params(
         self,
         db: &'db dyn Db,
@@ -1116,6 +1129,19 @@ impl<'db> FunctionType<'db> {
             .with_dataclass_transformer_params(db, params);
         let literal = FunctionLiteral { last_definition };
         Self::new(db, literal, None)
+    }
+
+    pub(crate) fn with_deprecated(
+        self,
+        db: &'db dyn Db,
+        deprecated: DeprecatedInstance<'db>,
+    ) -> Self {
+        // A decorator only applies to the specific overload that it is attached to, not to all
+        // previous overloads.
+        let literal = self.literal(db);
+        let last_definition = literal.last_definition.with_deprecated(db, deprecated);
+        let literal = FunctionLiteral { last_definition };
+        Self::new(db, literal, self.updated_signatures(db).cloned())
     }
 
     /// Returns the [`File`] in which this function is defined.

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -317,7 +317,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let mut decorator_types_and_nodes = Vec::with_capacity(decorator_list.len());
         let mut function_decorators = FunctionDecorators::empty();
-        let mut deprecated = None;
         let mut dataclass_transformer_params = None;
         let mut final_decorator = None;
 
@@ -346,9 +345,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                     _ => {}
                 },
-                Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) => {
-                    deprecated = Some(deprecated_inst);
-                }
                 Type::DataclassTransformer(params) => {
                     dataclass_transformer_params = Some(params);
                 }
@@ -413,7 +409,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             known_function,
             body_scope,
             function_decorators,
-            deprecated,
+            None,
             dataclass_transformer_params,
             function.returns.is_some(),
         );
@@ -448,7 +444,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         for (decorator_ty, decorator_node) in decorator_types_and_nodes.iter().rev() {
-            inferred_ty = self.apply_decorator(*decorator_ty, inferred_ty, decorator_node);
+            inferred_ty = if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) =
+                decorator_ty
+                && let Type::FunctionLiteral(function) = inferred_ty
+            {
+                Type::FunctionLiteral(function.with_deprecated(db, *deprecated))
+            } else {
+                self.apply_decorator(*decorator_ty, inferred_ty, decorator_node)
+            };
         }
 
         self.add_declaration_with_binding(


### PR DESCRIPTION
## Summary

An outer `@deprecated` decorator applies to the value returned by inner decorators. We currently record deprecation on the original function before applying decorators, so an inner decorator that replaces that function can cause the public binding to lose its warning.

```python
@deprecated("use replacement directly")
@replace_with(replacement)
def old() -> None:
    pass

old()          # Previously: no warning
replacement()  # No warning
```

This handles `@deprecated` in the post-decoration pass. When the current decorated value is another function literal, we copy that function type with the outer deprecation metadata. `old()` now warns while direct uses of `replacement()` remain unchanged.

This is a pared-down alternative to #25619, following [Doug's suggestion](https://github.com/astral-sh/ruff/pull/25619#issuecomment-4632505308). The original PR attached deprecation to place and binding metadata so it could survive decorator replacements whose returned value was not already deprecated. That required broad changes across place lookup and binding propagation, including special handling for aliases and synthetic bindings, and it introduced retained-memory and benchmark concerns. This version keeps the behavior local to function decorator inference and avoids changing the place representation or assignment semantics.

The narrower implementation deliberately preserves deprecation only when an inner decorator returns a function literal. Callable-instance replacements remain documented as a TODO.

Closes https://github.com/astral-sh/ty/issues/3623.
