### PR TITLE
[ty] fix cached_property with generic return type

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -328,6 +328,21 @@ class C:
     def f2(cls, x: int) -> str:
         return "a"
 
+class GenericC[T]:
+    @callable_identity
+    def instance_method(self) -> T:
+        raise NotImplementedError
+
+    @callable_identity
+    @staticmethod
+    def static_method(value: T) -> T:
+        return value
+
+    @callable_identity
+    @classmethod
+    def class_method(cls, value: T) -> T:
+        return value
+
 # error: [too-many-positional-arguments]
 # error: [invalid-argument-type]
 C.f1(C, 1)
@@ -335,6 +350,11 @@ C.f1(1)
 C().f1(1)
 C.f2(1)
 C().f2(1)
+
+generic = GenericC[str]()
+reveal_type(generic.instance_method())  # revealed: str
+reveal_type(GenericC[str].static_method("a"))  # revealed: str
+reveal_type(GenericC[str].class_method("a"))  # revealed: str
 ```
 
 ## Types are not bound-method descriptors

--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -179,6 +179,31 @@ class Foo:
 reveal_type(Foo().foo)  # revealed: str
 ```
 
+A cached property can refer to type variables from its enclosing class in its return type:
+
+```py
+from functools import cached_property
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class View(Generic[T]):
+    pass
+
+class Container(Generic[T]):
+    @cached_property
+    def items(self) -> View[T]:
+        return View()
+
+    @cached_property
+    def optional_items(self) -> list[T] | None:
+        return None
+
+container = Container[str]()
+reveal_type(container.items)  # revealed: View[str]
+reveal_type(container.optional_items)  # revealed: list[str] | None
+```
+
 ## Lambdas as decorators
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -28,6 +28,34 @@ reveal_type(generic_context(identity2))
 reveal_type(identity2(identity))
 ```
 
+Callable-owned type variables are abstracted away during inference rather than escaping into the
+caller's specialization. This also applies to generic callables returned by decorators, whose
+signatures no longer have source definitions:
+
+```py
+from typing import Callable, TypeVar, cast
+
+T_result = TypeVar("T_result")
+U_return = TypeVar("U_return")
+
+def get_result(fn: Callable[[], T_result]) -> T_result:
+    return fn()
+
+def generic() -> U_return:
+    return cast(U_return, 0)
+
+reveal_type(get_result(generic))  # revealed: Unknown
+
+def returns_generic(fn: Callable[..., object]) -> Callable[[], U_return]:
+    raise NotImplementedError
+
+@returns_generic
+def decorated() -> int:
+    raise NotImplementedError
+
+reveal_type(get_result(decorated))  # revealed: Unknown
+```
+
 Generic classes are another example, since you invoke the class to instantiate it:
 
 ```py
@@ -67,6 +95,48 @@ reveal_type(into_regular_callable(C))
 reveal_type(generic_context(into_regular_callable(C)))
 # revealed: C[int]
 reveal_type(into_regular_callable(C)(1))
+```
+
+## `ParamSpec` captures callable-owned type variables
+
+Callable-owned type variables are still abstracted away when a `ParamSpec` captures the callable's
+parameters:
+
+```py
+from typing import Callable, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+T = TypeVar("T")
+U = TypeVar("U")
+V = TypeVar("V")
+
+def get_result(fn: Callable[P, T]) -> T:
+    raise NotImplementedError
+
+def generic(x: U) -> U:
+    return x
+
+reveal_type(get_result(generic))  # revealed: Unknown
+
+def identity(fn: Callable[P, T]) -> Callable[P, T]:
+    return fn
+
+generic_callable = identity(generic)
+reveal_type(generic_callable)  # revealed: [U](x: U) -> U
+reveal_type(get_result(generic_callable))  # revealed: Unknown
+
+def generic_zero() -> U:
+    raise NotImplementedError
+
+def generic_with_mixed_result(value: U) -> tuple[U, V]:
+    raise NotImplementedError
+
+def invoke(fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
+    return fn(*args, **kwargs)
+
+reveal_type(invoke(generic_zero))  # revealed: Unknown
+reveal_type(invoke(generic, 1))  # revealed: Literal[1]
+reveal_type(invoke(generic_with_mixed_result, 1))  # revealed: tuple[Literal[1], Unknown]
 ```
 
 ## Naming a generic `Callable`: type aliases

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1,7 +1,7 @@
 use compact_str::ToCompactString;
 use itertools::Itertools;
 use ruff_diagnostics::{Edit, Fix};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use std::borrow::Cow;
 use std::cell::OnceCell;
@@ -82,6 +82,7 @@ use crate::types::special_form::TypeQualifier;
 use crate::types::tuple::TupleSpec;
 pub use crate::types::type_alias::TypeAliasType;
 pub(crate) use crate::types::typed_dict::TypedDictType;
+use crate::types::typevar::BoundTypeVarIdentity;
 use crate::types::typevar::TypeVarInstance;
 pub use crate::types::typevar::{
     BindingContext, BoundTypeVarInstance, ParamSpecAttrKind, TypeVarBoundOrConstraints, TypeVarKind,
@@ -5859,6 +5860,22 @@ impl<'db> Type<'db> {
         self.apply_type_mapping_impl(db, type_mapping, tcx, &ApplyTypeMappingVisitor::default())
     }
 
+    pub(crate) fn replace_escaping_typevars(
+        self,
+        db: &'db dyn Db,
+        typevars: &FxHashSet<BoundTypeVarIdentity<'db>>,
+    ) -> Type<'db> {
+        if typevars.is_empty() {
+            return self;
+        }
+
+        self.apply_type_mapping(
+            db,
+            &TypeMapping::ReplaceEscapingTypevars(typevars),
+            TypeContext::default(),
+        )
+    }
+
     fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
@@ -6122,6 +6139,7 @@ impl<'db> Type<'db> {
                 TypeMapping::ReplaceSelf { .. } |
                 TypeMapping::Materialize(_) |
                 TypeMapping::ReplaceParameterDefaults |
+                TypeMapping::ReplaceEscapingTypevars(_) |
                 TypeMapping::EagerExpansion |
                 TypeMapping::RescopeReturnCallables(_) |
                 TypeMapping::Promote(PromotionMode::Off, _) |
@@ -6137,6 +6155,7 @@ impl<'db> Type<'db> {
                 TypeMapping::ReplaceSelf { .. } |
                 TypeMapping::Promote(..) |
                 TypeMapping::ReplaceParameterDefaults |
+                TypeMapping::ReplaceEscapingTypevars(_) |
                 TypeMapping::EagerExpansion |
                 TypeMapping::RescopeReturnCallables(_) => self,
                 TypeMapping::Materialize(materialization_kind) => match materialization_kind {
@@ -7129,6 +7148,8 @@ pub enum TypeMapping<'a, 'db> {
     /// Replace default types in parameters of callables with `Unknown`. This is used to avoid infinite
     /// recursion when the type of the default value of a parameter depends on the callable itself.
     ReplaceParameterDefaults,
+    /// Replace callable-owned type variables that escape their generic callable with `Unknown`.
+    ReplaceEscapingTypevars(&'a FxHashSet<BoundTypeVarIdentity<'db>>),
     /// Apply eager expansion to the type.
     /// In the case of recursive type aliases, this will diverge, so that part will be replaced with `Divergent`.
     EagerExpansion,
@@ -7169,6 +7190,7 @@ impl<'db> TypeMapping<'_, 'db> {
             | TypeMapping::BindLegacyTypevars(_)
             | TypeMapping::Materialize(_)
             | TypeMapping::ReplaceParameterDefaults
+            | TypeMapping::ReplaceEscapingTypevars(_)
             | TypeMapping::EagerExpansion
             | TypeMapping::RescopeReturnCallables(_) => context,
             TypeMapping::BindSelf(binding) => {
@@ -7214,6 +7236,7 @@ impl<'db> TypeMapping<'_, 'db> {
             | TypeMapping::BindSelf(..)
             | TypeMapping::ReplaceSelf { .. }
             | TypeMapping::ReplaceParameterDefaults
+            | TypeMapping::ReplaceEscapingTypevars(_)
             | TypeMapping::EagerExpansion
             | TypeMapping::RescopeReturnCallables(_) => self.clone(),
         }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4619,6 +4619,7 @@ struct ArgumentTypeChecker<'a, 'db> {
 
     inferable_typevars: InferableTypeVars<'db>,
     specialization: Option<Specialization<'db>>,
+    potentially_escaping_callable_typevars: FxHashSet<BoundTypeVarIdentity<'db>>,
 
     /// Argument indices for which specialization inference has already produced a sufficiently
     /// precise argument mismatch. We can then silence `check_argument_type` for those arguments to
@@ -4697,6 +4698,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             errors,
             inferable_typevars: InferableTypeVars::None,
             specialization: None,
+            potentially_escaping_callable_typevars: FxHashSet::default(),
             constraint_set_errors: vec![false; arguments.len()],
         }
     }
@@ -4987,6 +4989,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let specialization = builder.build_with(generic_context, choose_solution);
 
         self.return_ty = self.return_ty.apply_specialization(self.db, specialization);
+        self.potentially_escaping_callable_typevars
+            .extend(builder.potentially_escaping_callable_typevars());
         self.specialization = Some(specialization);
     }
 
@@ -5311,6 +5315,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         match callable_binding.matching_overload_index() {
             MatchingOverloadIndex::None => {
                 if let [binding] = callable_binding.overloads() {
+                    self.return_ty = self
+                        .return_ty
+                        .apply_optional_specialization(self.db, binding.specialization);
                     // This is not an overloaded function, so we can propagate its errors to the
                     // outer bindings.
                     extend_errors(&binding.errors);
@@ -5326,9 +5333,11 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 }
             }
             MatchingOverloadIndex::Single(index) => {
-                // TODO: We should also update the specialization for the `ParamSpec` to reflect the
-                // matching overload here.
-                extend_errors(&callable_binding.overloads()[index].errors);
+                let binding = &callable_binding.overloads()[index];
+                self.return_ty = self
+                    .return_ty
+                    .apply_optional_specialization(self.db, binding.specialization);
+                extend_errors(&binding.errors);
             }
             MatchingOverloadIndex::Multiple(_) => {
                 if !matches!(
@@ -5454,7 +5463,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     }
 
     fn finish(
-        self,
+        mut self,
     ) -> (
         InferableTypeVars<'db>,
         Option<Specialization<'db>>,
@@ -5469,6 +5478,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                 *parameter_ty = Some(builder.build());
             }
         }
+
+        self.return_ty = self
+            .return_ty
+            .replace_escaping_typevars(self.db, &self.potentially_escaping_callable_typevars);
 
         (self.inferable_typevars, self.specialization, self.return_ty)
     }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -7,7 +7,7 @@ use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::types::callable::walk_callable_type;
+use crate::types::callable::{CallableTypeKind, walk_callable_type};
 use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::{
@@ -1826,6 +1826,7 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
     pending: ConstraintSet<'db, 'c>,
     types: FxHashMap<BoundTypeVarIdentity<'db>, UnionAccumulator<'db>>,
     paramspec_seen: FxHashSet<BoundTypeVarIdentity<'db>>,
+    potentially_escaping_callable_typevars: FxHashSet<BoundTypeVarIdentity<'db>>,
 }
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
@@ -1841,7 +1842,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             pending: ConstraintSet::from_bool(constraints, true),
             types: FxHashMap::default(),
             paramspec_seen: FxHashSet::default(),
+            potentially_escaping_callable_typevars: FxHashSet::default(),
         }
+    }
+
+    pub(crate) fn potentially_escaping_callable_typevars(
+        &self,
+    ) -> &FxHashSet<BoundTypeVarIdentity<'db>> {
+        &self.potentially_escaping_callable_typevars
     }
 
     /// Build a specialization, using a caller-provided hook to select the solution for each
@@ -2336,20 +2344,38 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let formal_is_single_paramspec = formal_signature.is_single_paramspec().is_some();
 
         for actual_callable in actual_callables.as_slice() {
+            let db = self.db;
+            let constraints = self.constraints;
+            let actual_signatures = actual_callable.signatures(db);
+            self.potentially_escaping_callable_typevars.extend(
+                actual_signatures
+                    .overloads
+                    .iter()
+                    .filter_map(|signature| signature.generic_context)
+                    .flat_map(|context| context.variables(db))
+                    .map(|typevar| typevar.identity(db)),
+            );
+            let preserve_source_transitive = matches!(
+                actual_callable.kind(db),
+                CallableTypeKind::FunctionLike
+                    | CallableTypeKind::StaticMethodLike
+                    | CallableTypeKind::ClassMethodLike
+            );
+
             if formal_is_single_paramspec {
-                let when = actual_callable
-                    .signatures(self.db)
-                    .when_constraint_set_assignable_to(self.db, formal_signature, self.constraints);
+                let when = actual_signatures.when_constraint_set_assignable_to(
+                    db,
+                    formal_signature,
+                    constraints,
+                    preserve_source_transitive,
+                );
                 self.add_type_mappings_from_constraint_set(when)?;
-                self.pending.intersect(self.db, self.constraints, when);
+                self.pending.intersect(db, constraints, when);
             } else {
                 // An overloaded actual callable is compatible with the formal signature if at
                 // least one of its overloads is. We collect type mappings from all satisfiable
                 // overloads, and only report an error if none of them are satisfiable.
-                let db = self.db;
-                let constraints = self.constraints;
-                let combined = actual_callable
-                    .signatures(db)
+                let combined = actual_signatures
                     .overloads
                     .iter()
                     .filter_map(|actual_signature| {
@@ -2357,6 +2383,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                             db,
                             formal_signature,
                             constraints,
+                            preserve_source_transitive,
                         );
                         self.add_type_mappings_from_constraint_set(when)
                             .ok()

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -370,6 +370,7 @@ impl<'db> KnownInstanceType<'db> {
                 | TypeMapping::ReplaceSelf { .. }
                 | TypeMapping::Materialize(_)
                 | TypeMapping::ReplaceParameterDefaults
+                | TypeMapping::ReplaceEscapingTypevars(_)
                 | TypeMapping::EagerExpansion
                 | TypeMapping::RescopeReturnCallables(_) => Type::KnownInstance(self),
             },

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -454,6 +454,7 @@ impl<'db> CallableSignature<'db> {
         db: &'db dyn Db,
         other: &Self,
         constraints: &'c ConstraintSetBuilder<'db>,
+        preserve_source_transitive: bool,
     ) -> ConstraintSet<'db, 'c> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
@@ -466,7 +467,12 @@ impl<'db> CallableSignature<'db> {
             &signature_relation_visitor,
             &materialization_visitor,
         );
-        checker.check_callable_signature_pair_inner(db, &self.overloads, &other.overloads)
+        checker.check_callable_signature_pair_inner(
+            db,
+            &self.overloads,
+            &other.overloads,
+            preserve_source_transitive,
+        )
     }
 }
 
@@ -817,6 +823,29 @@ impl<'db> Signature<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
+        let remaining: FxHashSet<BoundTypeVarIdentity<'db>>;
+        let nested_mapping;
+        let nested_visitor;
+        let (type_mapping, visitor) = if let TypeMapping::ReplaceEscapingTypevars(typevars) =
+            type_mapping
+            && let Some(generic_context) = self.generic_context
+        {
+            remaining = typevars
+                .iter()
+                .copied()
+                .filter(|typevar| !generic_context.contains(db, *typevar))
+                .collect();
+            if remaining.len() == typevars.len() {
+                (type_mapping, visitor)
+            } else {
+                nested_mapping = TypeMapping::ReplaceEscapingTypevars(&remaining);
+                nested_visitor = ApplyTypeMappingVisitor::default();
+                (&nested_mapping, &nested_visitor)
+            }
+        } else {
+            (type_mapping, visitor)
+        };
+
         Self {
             generic_context: self
                 .generic_context
@@ -1249,7 +1278,7 @@ impl<'db> Signature<'db> {
         );
 
         let is_consistent = checker
-            .check_signature_pair(db, &implementation, &overload)
+            .check_signature_pair(db, &implementation, &overload, false)
             .is_always_satisfied(db);
 
         if is_consistent {
@@ -1298,6 +1327,7 @@ impl<'db> Signature<'db> {
         db: &'db dyn Db,
         other: &CallableSignature<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
+        preserve_source_transitive: bool,
     ) -> ConstraintSet<'db, 'c> {
         // If this signature is a paramspec, bind it to the entire overloaded other callable.
         if let Some(self_bound_typevar) = self.parameters.as_paramspec()
@@ -1339,15 +1369,21 @@ impl<'db> Signature<'db> {
             .overloads
             .iter()
             .when_all(db, constraints, |other_signature| {
-                self.when_constraint_set_assignable_to(db, other_signature, constraints)
+                self.when_constraint_set_assignable_to_inner(
+                    db,
+                    other_signature,
+                    constraints,
+                    preserve_source_transitive,
+                )
             })
     }
 
-    fn when_constraint_set_assignable_to<'c>(
+    fn when_constraint_set_assignable_to_inner<'c>(
         &self,
         db: &'db dyn Db,
         other: &Self,
         constraints: &'c ConstraintSetBuilder<'db>,
+        preserve_source_transitive: bool,
     ) -> ConstraintSet<'db, 'c> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
@@ -1360,7 +1396,7 @@ impl<'db> Signature<'db> {
             &signature_relation_visitor,
             &materialization_visitor,
         );
-        checker.check_signature_pair(db, self, other)
+        checker.check_signature_pair(db, self, other, preserve_source_transitive)
     }
 
     /// Create a new signature with the given definition.
@@ -1516,7 +1552,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &CallableSignature<'db>,
         target: &CallableSignature<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        self.check_callable_signature_pair_inner(db, &source.overloads, &target.overloads)
+        self.check_callable_signature_pair_inner(db, &source.overloads, &target.overloads, false)
     }
 
     /// Implementation of subtyping and assignability between two, possible overloaded, callable
@@ -1526,6 +1562,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         db: &'db dyn Db,
         source_overloads: &[Signature<'db>],
         target_overloads: &[Signature<'db>],
+        preserve_source_transitive: bool,
     ) -> ConstraintSet<'db, 'c> {
         if self.relation.is_constraint_set_assignability() {
             // TODO: Oof, maybe ParamSpec needs to live at CallableSignature, not Signature?
@@ -1649,7 +1686,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 {
                     self.check_signature_pair_inner(db, source_signature, target_signature)
                 } else {
-                    self.check_signature_pair(db, source_signature, target_signature)
+                    self.check_signature_pair(
+                        db,
+                        source_signature,
+                        target_signature,
+                        preserve_source_transitive,
+                    )
                 }
             }
 
@@ -1673,6 +1715,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 db,
                                 std::slice::from_ref(self_signature),
                                 target_overloads,
+                                preserve_source_transitive,
                             )
                         })
                 })
@@ -1687,6 +1730,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             db,
                             source_overloads,
                             std::slice::from_ref(target_signature),
+                            preserve_source_transitive,
                         )
                     })
             }
@@ -1699,6 +1743,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         db,
                         source_overloads,
                         std::slice::from_ref(target_signature),
+                        preserve_source_transitive,
                     )
                 }),
         }
@@ -1710,6 +1755,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         db: &'db dyn Db,
         source: &Signature<'db>,
         target: &Signature<'db>,
+        preserve_source_transitive: bool,
     ) -> ConstraintSet<'db, 'c> {
         // If either signature is generic, their typevars should also be considered inferable when
         // checking whether one signature is a subtype/etc of the other, since we only need to find
@@ -1738,10 +1784,24 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // we produce, we reduce it back down to the inferable set that the caller asked about.
         // If we introduced new inferable typevars, those will be existentially quantified away
         // before returning.
+        let source_to_remove = if preserve_source_transitive {
+            // Function-like callables can reach additional typevars through a directly bound
+            // variable's bounds. Quantify the direct variables, but leave those transitive
+            // dependencies available to the caller's specialization inference.
+            Either::Left(
+                source
+                    .generic_context
+                    .into_iter()
+                    .flat_map(|context| context.variables(db))
+                    .map(|typevar| typevar.identity(db)),
+            )
+        } else {
+            Either::Right(source_inferable.iter(db))
+        };
         when.reduce_inferable(
             db,
             self.constraints,
-            source_inferable.iter(db).chain(target_inferable.iter(db)),
+            source_to_remove.chain(target_inferable.iter(db)),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -909,6 +909,13 @@ impl<'db> BoundTypeVarInstance<'db> {
             | TypeMapping::BindLegacyTypevars(_)
             | TypeMapping::EagerExpansion
             | TypeMapping::RescopeReturnCallables(_) => Type::TypeVar(self),
+            TypeMapping::ReplaceEscapingTypevars(typevars) => {
+                if typevars.contains(&self.identity(db)) {
+                    Type::unknown()
+                } else {
+                    Type::TypeVar(self)
+                }
+            }
             TypeMapping::Materialize(materialization_kind) => {
                 Type::TypeVar(self.materialize_impl(db, *materialization_kind, visitor))
             }


### PR DESCRIPTION
## Summary

We were existentially quantifying away all type variables found in a callable when checking it for assignability against another callable. This wrongly eliminated type variables from a surrounding context (e.g. a class) that should persist, meaning that we would (for example) lose a return type of a `cached_property` that was generic over a type variable from the class.

Distinguish the type variables so we can avoid this problem.

Closes https://github.com/astral-sh/ty/issues/3256.

## Testing

Added mdtests.