### PR TITLE
[ty] Avoid caching trivial class-header queries

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -98,6 +98,14 @@ impl<'db> CodeGeneratorKind<'db> {
         class: StaticClassLiteral<'db>,
         specialization: Option<Specialization<'db>>,
     ) -> Option<Self> {
+        if class.dataclass_params(db).is_none()
+            && class.known(db).is_none()
+            && !class.has_explicit_bases(db)
+            && !class.has_explicit_metaclass(db)
+        {
+            return None;
+        }
+
         #[salsa::tracked(cycle_initial=|_, _, _, _| None,
             heap_size=ruff_memory_usage::heap_size
         )]

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -94,6 +94,12 @@ pub struct StaticClassLiteral<'db> {
 
     /// Whether this class has PEP 695 type parameters.
     pub(crate) has_type_params: bool,
+
+    /// Whether this class has any explicit base classes.
+    pub(crate) has_explicit_bases: bool,
+
+    /// Whether this class has an explicit `metaclass` keyword argument.
+    pub(crate) has_explicit_metaclass: bool,
 }
 
 // The Salsa heap is tracked separately.
@@ -161,6 +167,8 @@ impl<'db> StaticClassLiteral<'db> {
             self.total_ordering(db),
             self.has_decorators(db),
             self.has_type_params(db),
+            self.has_explicit_bases(db),
+            self.has_explicit_metaclass(db),
         )
     }
 
@@ -299,22 +307,33 @@ impl<'db> StaticClassLiteral<'db> {
         })
     }
 
-    #[salsa::tracked(
-        cycle_initial=|_, _, _| None,
-        heap_size=ruff_memory_usage::heap_size,
-    )]
     pub(crate) fn inherited_legacy_generic_context(
         self,
         db: &'db dyn Db,
     ) -> Option<GenericContext<'db>> {
-        GenericContext::from_base_classes(
-            db,
-            self.definition(db),
-            self.explicit_bases(db)
-                .iter()
-                .copied()
-                .filter(|ty| matches!(ty, Type::GenericAlias(_))),
-        )
+        #[salsa::tracked(
+            cycle_initial=|_, _, _| None,
+            heap_size=ruff_memory_usage::heap_size,
+        )]
+        fn inherited_legacy_generic_context_inner<'db>(
+            db: &'db dyn Db,
+            class: StaticClassLiteral<'db>,
+        ) -> Option<GenericContext<'db>> {
+            GenericContext::from_base_classes(
+                db,
+                class.definition(db),
+                class
+                    .explicit_bases(db)
+                    .iter()
+                    .copied()
+                    .filter(|ty| matches!(ty, Type::GenericAlias(_))),
+            )
+        }
+
+        if !self.has_explicit_bases(db) {
+            return None;
+        }
+        inherited_legacy_generic_context_inner(db, self)
     }
 
     /// Returns all of the typevars that are referenced in this class's base class list.
@@ -456,23 +475,33 @@ impl<'db> StaticClassLiteral<'db> {
     ///
     /// Were this not a salsa query, then the calling query
     /// would depend on the class's AST and rerun for every change in that file.
-    #[salsa::tracked(returns(deref), cycle_initial=explicit_bases_cycle_initial, cycle_fn=explicit_bases_cycle_fn, heap_size=ruff_memory_usage::heap_size)]
-    pub(crate) fn explicit_bases(self, db: &'db dyn Db) -> Box<[Type<'db>]> {
-        tracing::trace!(
-            "StaticClassLiteral::explicit_bases_query: {}",
-            self.name(db)
-        );
+    pub(crate) fn explicit_bases(self, db: &'db dyn Db) -> &'db [Type<'db>] {
+        #[salsa::tracked(returns(deref), cycle_initial=explicit_bases_cycle_initial, cycle_fn=explicit_bases_cycle_fn, heap_size=ruff_memory_usage::heap_size)]
+        fn explicit_bases_inner<'db>(
+            db: &'db dyn Db,
+            class: StaticClassLiteral<'db>,
+        ) -> Box<[Type<'db>]> {
+            tracing::trace!(
+                "StaticClassLiteral::explicit_bases_query: {}",
+                class.name(db)
+            );
 
-        let module = parsed_module(db, self.file(db)).load(db);
-        let class_stmt = self.node(db, &module);
+            let module = parsed_module(db, class.file(db)).load(db);
+            let class_stmt = class.node(db, &module);
 
-        let class_definition =
-            semantic_index(db, self.file(db)).expect_single_definition(class_stmt);
+            let class_definition =
+                semantic_index(db, class.file(db)).expect_single_definition(class_stmt);
 
-        expanded_class_base_entries(db, self.known(db), class_stmt, class_definition)
-            .into_iter()
-            .map(ExpandedClassBaseEntry::ty)
-            .collect()
+            expanded_class_base_entries(db, class.known(db), class_stmt, class_definition)
+                .into_iter()
+                .map(ExpandedClassBaseEntry::ty)
+                .collect()
+        }
+
+        if !self.has_explicit_bases(db) {
+            return &[];
+        }
+        explicit_bases_inner(db, self)
     }
 
     /// Return `Some()` if this class is known to be a [`DisjointBase`], or `None` if it is not.
@@ -659,13 +688,20 @@ impl<'db> StaticClassLiteral<'db> {
 
     /// Return `true` if this class constitutes a typed dict specification (inherits from
     /// `typing.TypedDict`, either directly or indirectly).
-    #[salsa::tracked(cycle_initial=|_, _, _| false, heap_size=ruff_memory_usage::heap_size)]
     pub fn is_typed_dict(self, db: &'db dyn Db) -> bool {
+        #[salsa::tracked(cycle_initial=|_, _, _| false, heap_size=ruff_memory_usage::heap_size)]
+        fn is_typed_dict_inner<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> bool {
+            class.iter_mro(db, None).contains(&ClassBase::TypedDict)
+        }
+
         if let Some(known) = self.known(db) {
             return known.is_typed_dict_subclass();
         }
 
-        self.iter_mro(db, None).contains(&ClassBase::TypedDict)
+        if !self.has_explicit_bases(db) {
+            return false;
+        }
+        is_typed_dict_inner(db, self)
     }
 
     /// Return `true` if this class is, or inherits from, a `NamedTuple` (inherits from
@@ -842,147 +878,160 @@ impl<'db> StaticClassLiteral<'db> {
     }
 
     /// Return the metaclass of this class, or an error if the metaclass cannot be inferred.
-    #[salsa::tracked(
-        cycle_initial=|_, _, _| Err(MetaclassError {
-            kind: MetaclassErrorKind::Cycle,
-        }),
-        heap_size=ruff_memory_usage::heap_size,
-    )]
-    pub(crate) fn try_metaclass(
+    pub(in crate::types) fn try_metaclass(
         self,
         db: &'db dyn Db,
     ) -> Result<(Type<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>> {
-        tracing::trace!("StaticClassLiteral::try_metaclass: {}", self.name(db));
+        #[salsa::tracked(
+            cycle_initial=|_, _, _| Err(MetaclassError {
+                kind: MetaclassErrorKind::Cycle,
+            }),
+            heap_size=ruff_memory_usage::heap_size,
+        )]
+        fn try_metaclass_inner<'db>(
+            db: &'db dyn Db,
+            class: StaticClassLiteral<'db>,
+        ) -> Result<(Type<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>> {
+            tracing::trace!("StaticClassLiteral::try_metaclass: {}", class.name(db));
 
-        // Identify the class's own metaclass (or take the first base class's metaclass).
-        let mut base_classes = self.fully_static_explicit_bases(db).peekable();
+            // Identify the class's own metaclass (or take the first base class's metaclass).
+            let mut base_classes = class.fully_static_explicit_bases(db).peekable();
 
-        if base_classes.peek().is_some() && self.inheritance_cycle(db).is_some() {
-            // We emit diagnostics for cyclic class definitions elsewhere.
-            // Avoid attempting to infer the metaclass if the class is cyclically defined.
-            return Ok((SubclassOfType::subclass_of_unknown(), None));
-        }
-
-        if self.try_mro(db, None).is_err_and(StaticMroError::is_cycle) {
-            return Ok((SubclassOfType::subclass_of_unknown(), None));
-        }
-
-        let module = parsed_module(db, self.file(db)).load(db);
-
-        let explicit_metaclass = self.explicit_metaclass(db, &module);
-
-        // Generic metaclasses parameterized by type variables are not supported.
-        // `metaclass=Meta[int]` is fine, but `metaclass=Meta[T]` is not.
-        // See: https://typing.python.org/en/latest/spec/generics.html#generic-metaclasses
-        if let Some(Type::GenericAlias(alias)) = explicit_metaclass {
-            let specialization_has_typevars = alias
-                .specialization(db)
-                .types(db)
-                .iter()
-                .any(|ty| ty.has_typevar_or_typevar_instance(db));
-            if specialization_has_typevars {
-                return Err(MetaclassError {
-                    kind: MetaclassErrorKind::GenericMetaclass,
-                });
+            if base_classes.peek().is_some() && class.inheritance_cycle(db).is_some() {
+                // We emit diagnostics for cyclic class definitions elsewhere.
+                // Avoid attempting to infer the metaclass if the class is cyclically defined.
+                return Ok((SubclassOfType::subclass_of_unknown(), None));
             }
-        }
 
-        let (metaclass, class_metaclass_was_from) = if let Some(metaclass) = explicit_metaclass {
-            (metaclass, self)
-        } else if let Some(base_class) = base_classes.next() {
-            // For dynamic classes, we can't get a StaticClassLiteral, so use self for tracking.
-            let base_class_literal = base_class
-                .static_class_literal(db)
-                .map(|(lit, _)| lit)
-                .unwrap_or(self);
-            (base_class.metaclass(db), base_class_literal)
-        } else {
-            (KnownClass::Type.to_class_literal(db), self)
-        };
-
-        let mut candidate = if let Some(metaclass_ty) = metaclass.to_class_type(db) {
-            MetaclassCandidate {
-                metaclass: metaclass_ty,
-                explicit_metaclass_of: class_metaclass_was_from,
+            if class.try_mro(db, None).is_err_and(StaticMroError::is_cycle) {
+                return Ok((SubclassOfType::subclass_of_unknown(), None));
             }
-        } else {
-            let name = Type::string_literal(db, self.name(db));
-            let bases = Type::heterogeneous_tuple(db, self.explicit_bases(db));
-            let namespace = KnownClass::Dict
-                .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
 
-            // TODO: Other keyword arguments?
-            let arguments = CallArguments::positional([name, bases, namespace]);
+            let module = parsed_module(db, class.file(db)).load(db);
 
-            let return_ty_result = match metaclass.try_call(db, &arguments) {
-                Ok(bindings) => Ok(bindings.return_type(db)),
+            let explicit_metaclass = class.explicit_metaclass(db, &module);
 
-                Err(CallError(CallErrorKind::NotCallable, bindings)) => Err(MetaclassError {
-                    kind: MetaclassErrorKind::NotCallable(bindings.callable_type()),
-                }),
-
-                // TODO we should also check for binding errors that would indicate the metaclass
-                // does not accept the right arguments
-                Err(CallError(CallErrorKind::BindingError, bindings)) => {
-                    Ok(bindings.return_type(db))
+            // Generic metaclasses parameterized by type variables are not supported.
+            // `metaclass=Meta[int]` is fine, but `metaclass=Meta[T]` is not.
+            // See: https://typing.python.org/en/latest/spec/generics.html#generic-metaclasses
+            if let Some(Type::GenericAlias(alias)) = explicit_metaclass {
+                let specialization_has_typevars = alias
+                    .specialization(db)
+                    .types(db)
+                    .iter()
+                    .any(|ty| ty.has_typevar_or_typevar_instance(db));
+                if specialization_has_typevars {
+                    return Err(MetaclassError {
+                        kind: MetaclassErrorKind::GenericMetaclass,
+                    });
                 }
+            }
 
-                Err(CallError(CallErrorKind::PossiblyNotCallable, _)) => Err(MetaclassError {
-                    kind: MetaclassErrorKind::PartlyNotCallable(metaclass),
-                }),
+            let (metaclass, class_metaclass_was_from) = if let Some(metaclass) = explicit_metaclass
+            {
+                (metaclass, class)
+            } else if let Some(base_class) = base_classes.next() {
+                // For dynamic classes, we can't get a StaticClassLiteral, so use this class for
+                // tracking.
+                let base_class_literal = base_class
+                    .static_class_literal(db)
+                    .map(|(lit, _)| lit)
+                    .unwrap_or(class);
+                (base_class.metaclass(db), base_class_literal)
+            } else {
+                (KnownClass::Type.to_class_literal(db), class)
             };
 
-            return return_ty_result.map(|ty| (ty.to_meta_type(db), None));
-        };
+            let mut candidate = if let Some(metaclass_ty) = metaclass.to_class_type(db) {
+                MetaclassCandidate {
+                    metaclass: metaclass_ty,
+                    explicit_metaclass_of: class_metaclass_was_from,
+                }
+            } else {
+                let name = Type::string_literal(db, class.name(db));
+                let bases = Type::heterogeneous_tuple(db, class.explicit_bases(db));
+                let namespace = KnownClass::Dict
+                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
 
-        // Reconcile all base classes' metaclasses with the candidate metaclass.
-        //
-        // See:
-        // - https://docs.python.org/3/reference/datamodel.html#determining-the-appropriate-metaclass
-        // - https://github.com/python/cpython/blob/83ba8c2bba834c0b92de669cac16fcda17485e0e/Objects/typeobject.c#L3629-L3663
-        for base_class in base_classes {
-            let metaclass = base_class.metaclass(db);
-            let Some(metaclass) = metaclass.to_class_type(db) else {
-                continue;
-            };
-            // For dynamic classes, we can't get a StaticClassLiteral, so use self for tracking.
-            let base_class_literal = base_class
-                .static_class_literal(db)
-                .map(|(lit, _)| lit)
-                .unwrap_or(self);
-            if metaclass.is_subclass_of(db, candidate.metaclass) {
-                candidate = MetaclassCandidate {
-                    metaclass,
-                    explicit_metaclass_of: base_class_literal,
+                // TODO: Other keyword arguments?
+                let arguments = CallArguments::positional([name, bases, namespace]);
+
+                let return_ty_result = match metaclass.try_call(db, &arguments) {
+                    Ok(bindings) => Ok(bindings.return_type(db)),
+
+                    Err(CallError(CallErrorKind::NotCallable, bindings)) => Err(MetaclassError {
+                        kind: MetaclassErrorKind::NotCallable(bindings.callable_type()),
+                    }),
+
+                    // TODO we should also check for binding errors that would indicate the metaclass
+                    // does not accept the right arguments
+                    Err(CallError(CallErrorKind::BindingError, bindings)) => {
+                        Ok(bindings.return_type(db))
+                    }
+
+                    Err(CallError(CallErrorKind::PossiblyNotCallable, _)) => Err(MetaclassError {
+                        kind: MetaclassErrorKind::PartlyNotCallable(metaclass),
+                    }),
                 };
-                continue;
-            }
-            if candidate.metaclass.is_subclass_of(db, metaclass) {
-                continue;
-            }
-            return Err(MetaclassError {
-                kind: MetaclassErrorKind::Conflict {
-                    candidate1: candidate,
-                    candidate2: MetaclassCandidate {
+
+                return return_ty_result.map(|ty| (ty.to_meta_type(db), None));
+            };
+
+            // Reconcile all base classes' metaclasses with the candidate metaclass.
+            //
+            // See:
+            // - https://docs.python.org/3/reference/datamodel.html#determining-the-appropriate-metaclass
+            // - https://github.com/python/cpython/blob/83ba8c2bba834c0b92de669cac16fcda17485e0e/Objects/typeobject.c#L3629-L3663
+            for base_class in base_classes {
+                let metaclass = base_class.metaclass(db);
+                let Some(metaclass) = metaclass.to_class_type(db) else {
+                    continue;
+                };
+                // For dynamic classes, we can't get a StaticClassLiteral, so use this class for
+                // tracking.
+                let base_class_literal = base_class
+                    .static_class_literal(db)
+                    .map(|(lit, _)| lit)
+                    .unwrap_or(class);
+                if metaclass.is_subclass_of(db, candidate.metaclass) {
+                    candidate = MetaclassCandidate {
                         metaclass,
                         explicit_metaclass_of: base_class_literal,
+                    };
+                    continue;
+                }
+                if candidate.metaclass.is_subclass_of(db, metaclass) {
+                    continue;
+                }
+                return Err(MetaclassError {
+                    kind: MetaclassErrorKind::Conflict {
+                        candidate1: candidate,
+                        candidate2: MetaclassCandidate {
+                            metaclass,
+                            explicit_metaclass_of: base_class_literal,
+                        },
+                        candidate1_is_base_class: explicit_metaclass.is_none(),
                     },
-                    candidate1_is_base_class: explicit_metaclass.is_none(),
-                },
-            });
+                });
+            }
+
+            let transform_info = candidate
+                .metaclass
+                .static_class_literal(db)
+                .and_then(|(metaclass_literal, specialization)| {
+                    metaclass_literal.inherited_dataclass_transformer_params(db, specialization)
+                })
+                .map(|params| MetaclassTransformInfo {
+                    params,
+                    from_explicit_metaclass: candidate.explicit_metaclass_of == class,
+                });
+            Ok((candidate.metaclass.into(), transform_info))
         }
 
-        let transform_info = candidate
-            .metaclass
-            .static_class_literal(db)
-            .and_then(|(metaclass_literal, specialization)| {
-                metaclass_literal.inherited_dataclass_transformer_params(db, specialization)
-            })
-            .map(|params| MetaclassTransformInfo {
-                params,
-                from_explicit_metaclass: candidate.explicit_metaclass_of == self,
-            });
-        Ok((candidate.metaclass.into(), transform_info))
+        if !self.has_explicit_bases(db) && !self.has_explicit_metaclass(db) {
+            return Ok((KnownClass::Type.to_class_literal(db), None));
+        }
+        try_metaclass_inner(db, self)
     }
 
     /// Returns the class member of this class named `name`.
@@ -2685,55 +2734,71 @@ impl<'db> StaticClassLiteral<'db> {
     ///
     /// A class definition like this will fail at runtime,
     /// but we must be resilient to it or we could panic.
-    #[salsa::tracked(cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
     pub(crate) fn inheritance_cycle(self, db: &'db dyn Db) -> Option<InheritanceCycle> {
-        /// Return `true` if the class is cyclically defined.
-        ///
-        /// Also, populates `visited_classes` with all base classes of `self`.
-        fn is_cyclically_defined_recursive<'db>(
+        #[salsa::tracked(cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+        fn inheritance_cycle_inner<'db>(
             db: &'db dyn Db,
             class: StaticClassLiteral<'db>,
-            classes_on_stack: &mut FxIndexSet<StaticClassLiteral<'db>>,
-            visited_classes: &mut FxIndexSet<StaticClassLiteral<'db>>,
-        ) -> bool {
-            let mut result = false;
-            for explicit_base in class.explicit_bases(db) {
-                let explicit_base_class_literal = match explicit_base {
-                    Type::ClassLiteral(class_literal) => class_literal.as_static(),
-                    Type::GenericAlias(generic_alias) => Some(generic_alias.origin(db)),
-                    _ => continue,
-                };
-                let Some(explicit_base_class_literal) = explicit_base_class_literal else {
-                    continue;
-                };
-                if !classes_on_stack.insert(explicit_base_class_literal) {
-                    return true;
-                }
+        ) -> Option<InheritanceCycle> {
+            /// Return `true` if the class is cyclically defined.
+            ///
+            /// Also, populates `visited_classes` with all base classes of `class`.
+            fn is_cyclically_defined_recursive<'db>(
+                db: &'db dyn Db,
+                class: StaticClassLiteral<'db>,
+                classes_on_stack: &mut FxIndexSet<StaticClassLiteral<'db>>,
+                visited_classes: &mut FxIndexSet<StaticClassLiteral<'db>>,
+            ) -> bool {
+                let mut result = false;
+                for explicit_base in class.explicit_bases(db) {
+                    let explicit_base_class_literal = match explicit_base {
+                        Type::ClassLiteral(class_literal) => class_literal.as_static(),
+                        Type::GenericAlias(generic_alias) => Some(generic_alias.origin(db)),
+                        _ => continue,
+                    };
+                    let Some(explicit_base_class_literal) = explicit_base_class_literal else {
+                        continue;
+                    };
+                    if !classes_on_stack.insert(explicit_base_class_literal) {
+                        return true;
+                    }
 
-                if visited_classes.insert(explicit_base_class_literal) {
-                    // If we find a cycle, keep searching to check if we can reach the starting class.
-                    result |= is_cyclically_defined_recursive(
-                        db,
-                        explicit_base_class_literal,
-                        classes_on_stack,
-                        visited_classes,
-                    );
+                    if visited_classes.insert(explicit_base_class_literal) {
+                        // If we find a cycle, keep searching to check if we can reach the starting
+                        // class.
+                        result |= is_cyclically_defined_recursive(
+                            db,
+                            explicit_base_class_literal,
+                            classes_on_stack,
+                            visited_classes,
+                        );
+                    }
+                    classes_on_stack.pop();
                 }
-                classes_on_stack.pop();
+                result
             }
-            result
+
+            tracing::trace!("Class::inheritance_cycle: {}", class.name(db));
+
+            let visited_classes = &mut FxIndexSet::default();
+            if !is_cyclically_defined_recursive(
+                db,
+                class,
+                &mut FxIndexSet::default(),
+                visited_classes,
+            ) {
+                None
+            } else if visited_classes.contains(&class) {
+                Some(InheritanceCycle::Participant)
+            } else {
+                Some(InheritanceCycle::Inherited)
+            }
         }
 
-        tracing::trace!("Class::inheritance_cycle: {}", self.name(db));
-
-        let visited_classes = &mut FxIndexSet::default();
-        if !is_cyclically_defined_recursive(db, self, &mut FxIndexSet::default(), visited_classes) {
-            None
-        } else if visited_classes.contains(&self) {
-            Some(InheritanceCycle::Participant)
-        } else {
-            Some(InheritanceCycle::Inherited)
+        if !self.has_explicit_bases(db) {
+            return None;
         }
+        inheritance_cycle_inner(db, self)
     }
 
     /// Returns a [`Span`] with the range of the class's header.

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -106,6 +106,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let mut dataclass_params = None;
         let mut dataclass_transformer_params = None;
         let mut total_ordering = false;
+        let has_explicit_bases = class_node
+            .arguments
+            .as_deref()
+            .is_some_and(|arguments| !arguments.args.is_empty());
+        let has_explicit_metaclass = class_node
+            .arguments
+            .as_deref()
+            .is_some_and(|arguments| arguments.find_keyword("metaclass").is_some());
         let infer_original_class_ty = |deprecated,
                                        type_check_only,
                                        dataclass_params,
@@ -131,6 +139,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     total_ordering,
                     !class_node.decorator_list.is_empty(),
                     class_node.type_params.is_some(),
+                    has_explicit_bases,
+                    has_explicit_metaclass,
                 )),
             }
         };


### PR DESCRIPTION
## Summary

`StaticClassLiteral` currently creates and retains Salsa queries for explicit bases, inherited generic contexts, `TypedDict` detection, metaclass resolution, inheritance-cycle detection, and code-generator classification even when a class header has no bases or explicit metaclass.

This records whether those syntax forms are present when constructing the class literal and returns the trivial result before entering the tracked query when they are absent. Classes with bases or explicit metaclasses continue through the existing tracked implementations.

On a large codebase, this reduced retained memory from 93.03 GB to 91.54 GB, saving 1.49 GB (1.60%) on top of the decorator and type-parameter fast paths from #25689, without a runtime regression.