### PR TITLE
[ty] Render Google and NumPy docstrings as Markdown

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -8,10 +8,6 @@
 
 mod markdown;
 mod rest;
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired into reST rendering in a follow-up change")
-)]
 mod sections;
 
 use indexmap::IndexMap;
@@ -191,6 +187,13 @@ fn render_markdown(docstring: &str) -> String {
     // break out of it, even if they're writing python documentation about markdown
     // code fences and are showing off how you can use more than 3 backticks.
     const FENCE: &str = "```````````";
+
+    let docstring = if rest::may_contain_top_level_field_list(docstring) {
+        rest::Docstring::parse(docstring).render_markdown()
+    } else {
+        Cow::Borrowed(docstring)
+    };
+
     // TODO: there is a convention that `singletick` is for items that can
     // be looked up in-scope while ``multitick`` is for opaque inline code.
     // While rendering this we should make note of all the `singletick` locations
@@ -1972,12 +1975,14 @@ mod tests {
         assert_snapshot!(docstring.render_markdown(), @"
         This is a function description.<HB>
         <HB>
-        :param str param1: The first parameter description<HB>
-        :param int param2: The second parameter description<HB>
+        ## Parameters<HB>
+        `param1` (`str`): The first parameter description<HB>
+        `param2` (`int`): The second parameter description<HB>
         &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
-        :param param3: A parameter without type annotation<HB>
-        :returns: The return value description<HB>
-        :rtype: str
+        `param3`: A parameter without type annotation<HB>
+        <HB>
+        ## Returns<HB>
+        `str`: The return value description
         ");
     }
 
@@ -2041,8 +2046,9 @@ mod tests {
         Args:<HB>
         &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter<HB>
         <HB>
-        :param int param2: reST-style parameter<HB>
-        :param param3: Another reST-style parameter<HB>
+        ## Parameters<HB>
+        `param2` (`int`): reST-style parameter<HB>
+        `param3`: Another reST-style parameter<HB>
         <HB>
         Parameters<HB>
         ----------<HB>

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -9,6 +9,7 @@
 mod markdown;
 mod rest;
 mod sections;
+mod structured;
 
 use indexmap::IndexMap;
 use regex::Regex;
@@ -188,11 +189,13 @@ fn render_markdown(docstring: &str) -> String {
     // code fences and are showing off how you can use more than 3 backticks.
     const FENCE: &str = "```````````";
 
-    let docstring = if rest::may_contain_top_level_field_list(docstring) {
+    let rest_rendered = if rest::may_contain_top_level_field_list(docstring) {
         rest::Docstring::parse(docstring).render_markdown()
     } else {
         Cow::Borrowed(docstring)
     };
+    let docstring = structured::Docstring::parse(rest_rendered.as_ref(), structured::Style::Google)
+        .render_markdown();
 
     // TODO: there is a convention that `singletick` is for items that can
     // be looked up in-scope while ``multitick`` is for opaque inline code.
@@ -911,6 +914,318 @@ mod tests {
         "#);
     }
 
+    #[test]
+    fn google_sections_render_attributes_and_raises() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+Attributes:
+    name (str): Display name.
+    coords (tuple(int, int)): Coordinate pair.
+    callback (Callable(int, str)): Converts raw values.
+        if name:
+            return name
+
+Raises:
+    ValueError: If invalid."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Attributes<HB>
+        `name` (`str`): Display name.<HB>
+        `coords` (`tuple(int, int)`): Coordinate pair.<HB>
+        `callback` (`Callable(int, str)`): Converts raw values.<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;if name:<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return name<HB>
+        <HB>
+        ## Raises<HB>
+        `ValueError`: If invalid.
+        ");
+    }
+
+    #[test]
+    fn google_sections_render_single_first_line_section() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+Args:
+    value: Description.
+        ```python
+        Args:
+            nested: Still code.
+        Returns:
+            Still code.
+        ```
+    url (Literal[\"http://\"]): URL.
+
+    Examples:
+        Use it."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @r#"
+        ## Parameters<HB>
+        `value`: Description.<HB>
+        ```python
+            Args:
+                nested: Still code.
+            Returns:
+                Still code.
+        ```<HB>
+        `url` (`Literal["http://"]`): URL.<HB>
+        <HB>
+        Examples:<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;Use it.
+        "#);
+
+        let docstring = Docstring::new(
+            "\
+Args:
+    value: Description.
+Examples:
+    Use it."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Parameters<HB>
+        `value`: Description.<HB>
+        Examples:<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;Use it.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Args:
+    value: Description.
+```python
+example()
+```"
+            .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Parameters<HB>
+        `value`: Description.<HB>
+        ```python
+        example()
+        ```
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Args:
+    value: Description.
+```python
+example()
+```"
+            .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Summary.<HB>
+        <HB>
+        ## Parameters<HB>
+        `value`: Description.<HB>
+        ```python
+        example()
+        ```
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Args:
+    value: Description.
+>>> value
+42"
+            .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Summary.<HB>
+        <HB>
+        ## Parameters<HB>
+        `value`: Description.<HB>
+        ```````````python
+        >>> value
+        42
+        ```````````
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Args:
+    value: Description.
+
+.. code-block:: python
+
+    example()"
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Parameters<HB>
+        `value`: Description.<HB>
+          <HB>
+        ```````````python
+            example()
+        ```````````
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Args:
+    value: Description.
+
+Example::
+
+    example()"
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Parameters<HB>
+        `value`: Description.<HB>
+        Example:  <HB>
+        ```````````python
+            example()
+        ```````````
+        ");
+    }
+
+    #[test]
+    fn google_sections_preserve_items_without_names() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+Args:
+    : Missing name."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Args:<HB>
+        : Missing name.
+        ");
+    }
+
+    #[test]
+    fn google_sections_preserve_preamble_before_first_item() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Args:
+    Inputs are normalized first.
+    value: Description."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Summary.<HB>
+        <HB>
+        Args:<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;Inputs are normalized first.<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;value: Description.
+        ");
+    }
+
+    #[test]
+    fn google_sections_preserve_return_paragraph_breaks() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Returns:
+    Literal[\"http://\"]: First paragraph.
+
+    Second paragraph."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @r#"
+        Summary.<HB>
+        <HB>
+        ## Returns<HB>
+        `Literal["http://"]`: First paragraph.<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;Second paragraph.
+        "#);
+
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Returns:
+    On success: the created object.
+    https://example.com: more details."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Summary.<HB>
+        <HB>
+        ## Returns<HB>
+        On success: the created object.<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;https://example.com: more details.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Returns:
+    https://example.com: more details."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Returns<HB>
+        https://example.com: more details.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Returns:
+    s3://bucket/key: more details."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Returns<HB>
+        s3://bucket/key: more details.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Returns:
+    mailto:user@example.com"
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Returns<HB>
+        mailto:user@example.com
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Returns:
+    str:Description without whitespace."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Returns<HB>
+        `str`: Description without whitespace.
+        ");
+    }
+
     // A literal block where the `::`  with the paragraph
     // and should be erased
     #[test]
@@ -1266,8 +1581,8 @@ mod tests {
         assert_snapshot!(docstring.render_markdown(), @"
         My cool func...<HB>
         <HB>
-        Returns:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;Some details<HB>
+        ## Returns<HB>
+        Some details<HB>
         `````python
             x_y = thing_do();
             ``` # this should't close the fence!
@@ -1301,8 +1616,8 @@ mod tests {
         assert_snapshot!(docstring.render_markdown(), @"
         My cool func...<HB>
         <HB>
-        Returns:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;Some details<HB>
+        ## Returns<HB>
+        Some details<HB>
         ~~~~~~python
             x_y = thing_do();
             ~~~ # this should't close the fence!
@@ -1708,14 +2023,14 @@ mod tests {
         assert_snapshot!(docstring.render_markdown(), @"
         This is a function description.<HB>
         <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter description<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter description<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param3: A parameter without type annotation<HB>
+        ## Parameters<HB>
+        `param1` (`str`): The first parameter description<HB>
+        `param2` (`int`): The second parameter description<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
+        `param3`: A parameter without type annotation<HB>
         <HB>
-        Returns:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;str: The return value description
+        ## Returns<HB>
+        `str`: The return value description
         ");
     }
 
@@ -1919,9 +2234,9 @@ mod tests {
         assert_snapshot!(docstring.render_markdown(), @"
         This is a function description.<HB>
         <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): Another Google-style parameter<HB>
+        ## Parameters<HB>
+        `param1` (`str`): Google-style parameter<HB>
+        `param2` (`int`): Another Google-style parameter<HB>
         <HB>
         Parameters<HB>
         ----------<HB>
@@ -2043,8 +2358,8 @@ mod tests {
         assert_snapshot!(docstring.render_markdown(), @"
         This is a function description.<HB>
         <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter<HB>
+        ## Parameters<HB>
+        `param1` (`str`): Google-style parameter<HB>
         <HB>
         ## Parameters<HB>
         `param2` (`int`): reST-style parameter<HB>
@@ -2248,9 +2563,9 @@ mod tests {
         assert_snapshot!(docstring_windows.render_markdown(), @"
         This is a function description.<HB>
         <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter
+        ## Parameters<HB>
+        `param1` (`str`): The first parameter<HB>
+        `param2` (`int`): The second parameter
         ");
 
         assert_snapshot!(docstring_mac.render_plaintext(), @"
@@ -2264,9 +2579,9 @@ mod tests {
         assert_snapshot!(docstring_mac.render_markdown(), @"
         This is a function description.<HB>
         <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter
+        ## Parameters<HB>
+        `param1` (`str`): The first parameter<HB>
+        `param2` (`int`): The second parameter
         ");
 
         assert_snapshot!(docstring_unix.render_plaintext(), @"
@@ -2280,9 +2595,9 @@ mod tests {
         assert_snapshot!(docstring_unix.render_markdown(), @"
         This is a function description.<HB>
         <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter
+        ## Parameters<HB>
+        `param1` (`str`): The first parameter<HB>
+        `param2` (`int`): The second parameter
         ");
     }
 

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -194,8 +194,12 @@ fn render_markdown(docstring: &str) -> String {
     } else {
         Cow::Borrowed(docstring)
     };
-    let docstring = structured::Docstring::parse(rest_rendered.as_ref(), structured::Style::Google)
-        .render_markdown();
+    let google_rendered =
+        structured::Docstring::parse(rest_rendered.as_ref(), structured::Style::Google)
+            .render_markdown();
+    let docstring =
+        structured::Docstring::parse(google_rendered.as_ref(), structured::Style::Numpy)
+            .render_markdown();
 
     // TODO: there is a convention that `singletick` is for items that can
     // be looked up in-scope while ``multitick`` is for opaque inline code.
@@ -1226,6 +1230,242 @@ Returns:
         ");
     }
 
+    #[test]
+    fn structured_sections_preserve_doctest_closing_blanks() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+Args:
+    value: Example.
+        >>> value
+        1
+
+After."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Parameters<HB>
+        `value`: Example.<HB>
+        ```````````python
+            >>> value
+            1
+        ```````````<HB>
+        After.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Parameters
+----------
+value : int
+    Example.
+    >>> value
+    1
+
+Returns
+-------
+bool
+    Done."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Parameters<HB>
+        `value` (`int`): Example.<HB>
+        ```````````python
+            >>> value
+            1
+        ```````````<HB>
+        ## Returns<HB>
+        `bool`: Done.
+        ");
+    }
+
+    #[test]
+    fn numpy_sections_render_attributes_and_raises() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+Attributes
+----------
+name : str
+    Display name.
+
+Raises
+------
+ValueError
+    If invalid.
+TypeError : If wrong type.
+RuntimeError : If unavailable.
+    Retry later.
+This paragraph is not an exception."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Attributes<HB>
+        `name` (`str`): Display name.<HB>
+        <HB>
+        ## Raises<HB>
+        `ValueError`: If invalid.<HB>
+        `TypeError`: If wrong type.<HB>
+        `RuntimeError`: If unavailable.<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;Retry later.<HB>
+        This paragraph is not an exception.
+        ");
+    }
+
+    #[test]
+    fn numpy_sections_stop_before_following_paragraph() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+Parameters
+----------
+name : str
+    Display name.
+    if name:
+        return name
+This paragraph is not a parameter.
+
+Returns
+-------
+str
+    Display result.
+This paragraph is not a return."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Parameters<HB>
+        `name` (`str`): Display name.<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;if name:<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;return name<HB>
+        This paragraph is not a parameter.<HB>
+        <HB>
+        ## Returns<HB>
+        `str`: Display result.<HB>
+        This paragraph is not a return.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Returns
+-------
+str
+This paragraph is not a type-only return."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Returns<HB>
+        `str`<HB>
+        This paragraph is not a type-only return.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Returns
+-------
+The created object"
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Returns<HB>
+        -------<HB>
+        The created object
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Parameters
+    ----------
+name : str
+    Display name."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Parameters<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;----------<HB>
+        name : str<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;Display name.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Returns
+-------
+    The created object."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Returns<HB>
+        -------<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;The created object.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Returns
+-------
+    The created object"
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Returns<HB>
+        -------<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;The created object
+        ");
+    }
+
+    #[test]
+    fn numpy_sections_preserve_anonymous_return_paragraph_breaks() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Returns
+-------
+Literal[\"header : value\", \"http://\"]
+    First paragraph.
+
+    Second paragraph."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @r#"
+        Summary.<HB>
+        <HB>
+        ## Returns<HB>
+        `Literal["header : value", "http://"]`: First paragraph.<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;Second paragraph.
+        "#);
+
+        let docstring = Docstring::new(
+            "\
+Returns
+-------
+int
+    First value.
+str
+    Second value."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Returns<HB>
+        `int`: First value.<HB>
+        `str`: Second value.
+        ");
+    }
+
     // A literal block where the `::`  with the paragraph
     // and should be erased
     #[test]
@@ -1853,10 +2093,14 @@ Returns:
         let docstring = r#"
         This is a function description
 
-        >>> thing.do_thing()
-        wow it did the thing
-        >>> thing.do_other_thing()
-        it sure did the thing
+        >>> help(thing.do_thing)
+        Args:
+            value: from help output
+        >>> help(thing.do_other_thing)
+        Parameters
+        ----------
+        value : int
+            from help output
 
         As you can see it did the thing!
         "#;
@@ -1867,10 +2111,14 @@ Returns:
         This is a function description<HB>
         <HB>
         ```````````python
-        >>> thing.do_thing()
-        wow it did the thing
-        >>> thing.do_other_thing()
-        it sure did the thing
+        >>> help(thing.do_thing)
+        Args:
+            value: from help output
+        >>> help(thing.do_other_thing)
+        Parameters
+        ----------
+        value : int
+            from help output
         ```````````<HB>
         As you can see it did the thing!
         ");
@@ -2044,16 +2292,21 @@ Returns:
         ----------
         param1 : str
             The first parameter description
+
         param2 : int
             The second parameter description
             This is a continuation of param2 description.
+
         param3
             A parameter without type annotation
 
         Returns
         -------
-        str
+        result : str
             The return value description
+
+        warnings : list[str]
+            Warnings that were collected.
         "#;
 
         let docstring = Docstring::new(docstring.to_owned());
@@ -2080,35 +2333,35 @@ Returns:
         ----------
         param1 : str
             The first parameter description
+
         param2 : int
             The second parameter description
             This is a continuation of param2 description.
+
         param3
             A parameter without type annotation
 
         Returns
         -------
-        str
+        result : str
             The return value description
+
+        warnings : list[str]
+            Warnings that were collected.
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
         This is a function description.<HB>
         <HB>
-        Parameters<HB>
-        ----------<HB>
-        param1 : str<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;The first parameter description<HB>
-        param2 : int<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;The second parameter description<HB>
+        ## Parameters<HB>
+        `param1` (`str`): The first parameter description<HB>
+        `param2` (`int`): The second parameter description<HB>
         &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
-        param3<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;A parameter without type annotation<HB>
+        `param3`: A parameter without type annotation<HB>
         <HB>
-        Returns<HB>
-        -------<HB>
-        str<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;The return value description
+        ## Returns<HB>
+        `result` (`str`): The return value description<HB>
+        `warnings` (`list[str]`): Warnings that were collected.
         ");
     }
 
@@ -2238,10 +2491,8 @@ Returns:
         `param1` (`str`): Google-style parameter<HB>
         `param2` (`int`): Another Google-style parameter<HB>
         <HB>
-        Parameters<HB>
-        ----------<HB>
-        param3 : bool<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;NumPy-style parameter
+        ## Parameters<HB>
+        `param3` (`bool`): NumPy-style parameter
         ");
     }
 
@@ -2365,10 +2616,8 @@ Returns:
         `param2` (`int`): reST-style parameter<HB>
         `param3`: Another reST-style parameter<HB>
         <HB>
-        Parameters<HB>
-        ----------<HB>
-        param4 : bool<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;NumPy-style parameter
+        ## Parameters<HB>
+        `param4` (`bool`): NumPy-style parameter
         ");
     }
 
@@ -2433,20 +2682,14 @@ Returns:
         assert_snapshot!(docstring.render_markdown(), @"
         This is a function description.<HB>
         <HB>
-        Parameters<HB>
-        ----------<HB>
-        param1 : str<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;The first parameter description<HB>
-        param2 : int<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;The second parameter description<HB>
+        ## Parameters<HB>
+        `param1` (`str`): The first parameter description<HB>
+        `param2` (`int`): The second parameter description<HB>
         &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
-        param3<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;A parameter without type annotation<HB>
+        `param3`: A parameter without type annotation<HB>
         <HB>
-        Returns<HB>
-        -------<HB>
-        str<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;The return value description
+        ## Returns<HB>
+        `str`: The return value description
         ");
     }
 
@@ -2502,15 +2745,11 @@ Returns:
         assert_snapshot!(docstring.render_markdown(), @"
         This is a function description.<HB>
         <HB>
-        Parameters<HB>
-        ----------<HB>
-        param1 : str<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The first parameter description<HB>
-        param2 : int<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The second parameter description<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
-        param3<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A parameter without type annotation
+        ## Parameters<HB>
+        `param1` (`str`): The first parameter description<HB>
+        `param2` (`int`): The second parameter description<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
+        `param3`: A parameter without type annotation
         ");
     }
 

--- a/crates/ty_ide/src/docstring/rest.rs
+++ b/crates/ty_ide/src/docstring/rest.rs
@@ -199,7 +199,7 @@ impl FieldList {
             }
 
             let Some(field_list) = Self::parse(&mut lines) else {
-                preformatted_blocks.observe_non_field_line(line.text);
+                preformatted_blocks.observe_non_preformatted_line(line.text);
                 lines.next();
                 continue;
             };
@@ -505,7 +505,7 @@ impl TypedFieldRenderState {
 
 /// Recognizes preformatted blocks that may occur within a docstring (e.g. a markdown fence).
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-struct PreformattedBlockScanner<'a> {
+pub(super) struct PreformattedBlockScanner<'a> {
     active_markdown_fence: Option<markdown::MarkdownFence<'a>>,
     active_doctest: bool,
     preformatted_block_state: PreformattedBlockState,
@@ -517,9 +517,27 @@ struct PreformattedBlockScanner<'a> {
 const QUOTED_LITERAL_BLOCK_QUOTE_CHARACTERS: &str = r##"!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"##;
 
 impl<'a> PreformattedBlockScanner<'a> {
+    /// Returns whether the given line opens an accepted preformatted block.
+    pub(super) fn line_starts_preformatted_block(line: &'a str) -> bool {
+        let trimmed = line.trim_start_matches(' ');
+        trimmed.starts_with(">>>")
+            || markdown::MarkdownFence::find(line).is_some()
+            || Self::starts_preformatted_block(trimmed)
+    }
+
+    /// Returns whether the scanner is currently inside an accepted preformatted block.
+    pub(super) fn is_active(&self) -> bool {
+        self.active_markdown_fence.is_some()
+            || self.active_doctest
+            || matches!(
+                self.preformatted_block_state,
+                PreformattedBlockState::Active(_)
+            )
+    }
+
     /// Updates internal state to reflect the given line and returns whether or
     /// not the given line is contained within a preformatted block.
-    fn consume_preformatted_line(&mut self, line: &'a str) -> bool {
+    pub(super) fn consume_preformatted_line(&mut self, line: &'a str) -> bool {
         if let Some(fence) = self.active_markdown_fence {
             if fence.is_closed_by(line) {
                 self.active_markdown_fence = None;
@@ -613,7 +631,7 @@ impl<'a> PreformattedBlockScanner<'a> {
 
     /// Updates internal state that allows us to detect preformatted blocks introduced by reST
     /// syntax.
-    fn observe_non_field_line(&mut self, line: &str) {
+    pub(super) fn observe_non_preformatted_line(&mut self, line: &str) {
         if matches!(
             self.preformatted_block_state,
             PreformattedBlockState::Inactive

--- a/crates/ty_ide/src/docstring/rest.rs
+++ b/crates/ty_ide/src/docstring/rest.rs
@@ -1,22 +1,68 @@
+use std::borrow::Cow;
 use std::iter::{Enumerate, Peekable};
 
 use compact_str::{CompactString, ToCompactString};
 use ruff_python_trivia::leading_indentation;
 use ruff_source_file::{Line as SourceLine, UniversalNewlineIterator, UniversalNewlines};
 use ruff_text_size::{TextRange, TextSize};
+use rustc_hash::FxHashMap;
 
 use super::markdown;
+use super::sections::{DocstringItem, DocstringSectionKind, DocstringSections};
+
+/// Returns whether a normalized docstring may contain a top-level field list
+/// that markdown rendering would rewrite.
+pub(super) fn may_contain_top_level_field_list(raw: &str) -> bool {
+    let bytes = raw.as_bytes();
+    memchr::memchr_iter(b':', bytes).any(|colon| {
+        (colon == 0 || bytes[colon - 1] == b'\n')
+            && starts_renderable_field_header(&raw[colon + 1..])
+    })
+}
+
+fn starts_renderable_field_header(after_opening_colon: &str) -> bool {
+    let line = after_opening_colon
+        .split_once('\n')
+        .map_or(after_opening_colon, |(line, _)| line);
+
+    let Some(name_end) = line.find(|char: char| char == ':' || char.is_whitespace()) else {
+        return false;
+    };
+
+    let name = &line[..name_end];
+    matches!(
+        name,
+        "param"
+            | "parameter"
+            | "arg"
+            | "argument"
+            | "key"
+            | "keyword"
+            | "kwarg"
+            | "kwparam"
+            | "var"
+            | "ivar"
+            | "cvar"
+            | "return"
+            | "returns"
+            | "raises"
+            | "raise"
+            | "except"
+            | "exception"
+    ) && line[name_end..].contains(':')
+}
 
 /// Represents a parsed restructured text (reST) docstring.
-pub(super) struct Docstring {
+pub(super) struct Docstring<'a> {
+    raw: &'a str,
     field_lists: Vec<FieldList>,
 }
 
-impl Docstring {
+impl<'a> Docstring<'a> {
     /// Constructs a parsed representation from a raw docstring.
-    pub(super) fn parse(raw: &str) -> Self {
+    pub(super) fn parse(raw: &'a str) -> Self {
         let field_lists = FieldList::parse_all(raw);
-        Self { field_lists }
+        Self { raw, field_lists }
     }
 
     /// Returns the parameter documentation that we were able to recognize in a docstring.
@@ -46,6 +92,37 @@ impl Docstring {
         }
 
         parameters
+    }
+
+    /// Returns the original docstring when no supported field list is rendered.
+    pub(super) fn render_markdown(&self) -> Cow<'a, str> {
+        let mut output: Option<String> = None;
+        let mut rendered_through = TextSize::default();
+
+        for field_list in &self.field_lists {
+            if field_list.indent != TextSize::default()
+                || field_list.range.start() < rendered_through
+            {
+                continue;
+            }
+
+            let Some(markdown) = field_list.render_markdown() else {
+                continue;
+            };
+
+            let output = output.get_or_insert_with(String::new);
+            output.push_str(
+                &self.raw[rendered_through.to_usize()..field_list.range.start().to_usize()],
+            );
+            output.push_str(&markdown);
+            rendered_through = field_list.range.end();
+        }
+
+        let Some(mut output) = output else {
+            return Cow::Borrowed(self.raw);
+        };
+        output.push_str(&self.raw[rendered_through.to_usize()..]);
+        Cow::Owned(output)
     }
 }
 
@@ -238,6 +315,191 @@ impl FieldList {
 
         FieldHeader::indentation(non_blank_line.text) > indent
             || FieldHeader::at_indent(non_blank_line.text, indent).is_some()
+    }
+
+    fn render_markdown(&self) -> Option<String> {
+        let plan = FieldListRenderPlan::from_fields(&self.fields)?;
+        let markdown = plan.render(&self.fields);
+        (!markdown.is_empty()).then_some(markdown)
+    }
+}
+
+/// Validates a field list and stores cross-field metadata needed while rendering.
+struct FieldListRenderPlan<'a> {
+    parameter_types: FxHashMap<&'a str, &'a str>,
+    attribute_types: FxHashMap<&'a str, &'a str>,
+    return_type: Option<&'a str>,
+}
+
+impl<'a> FieldListRenderPlan<'a> {
+    fn from_fields(fields: &'a [Field]) -> Option<Self> {
+        let mut has_rendered_field = false;
+        let mut has_returns = false;
+        let mut has_return_type = false;
+        let mut parameters: FxHashMap<&'a str, TypedFieldRenderState> = FxHashMap::default();
+        let mut attributes: FxHashMap<&'a str, TypedFieldRenderState> = FxHashMap::default();
+        let mut parameter_types: FxHashMap<&'a str, &'a str> = FxHashMap::default();
+        let mut attribute_types: FxHashMap<&'a str, &'a str> = FxHashMap::default();
+        let mut return_type = None;
+
+        for field in fields {
+            match field {
+                Field::Parameter {
+                    lookup_name, ty, ..
+                } => {
+                    has_rendered_field = true;
+                    parameters
+                        .entry(lookup_name.as_str())
+                        .or_default()
+                        .record_field(ty.is_some());
+                }
+                Field::Attribute { name, ty, .. } => {
+                    has_rendered_field = true;
+                    attributes
+                        .entry(name.as_str())
+                        .or_default()
+                        .record_field(ty.is_some());
+                }
+                Field::Returns { .. } => {
+                    has_rendered_field = true;
+                    has_returns = true;
+                }
+                Field::Raises { .. } => {
+                    has_rendered_field = true;
+                }
+                Field::ParameterType { lookup_name, ty } => {
+                    if parameter_types
+                        .insert(lookup_name.as_str(), ty.as_str())
+                        .is_some()
+                    {
+                        return None;
+                    }
+                }
+                Field::AttributeType { name, ty } => {
+                    if attribute_types.insert(name.as_str(), ty.as_str()).is_some() {
+                        return None;
+                    }
+                }
+                Field::ReturnType { ty } => {
+                    if has_return_type {
+                        return None;
+                    }
+                    has_return_type = true;
+                    return_type = (!ty.is_empty()).then_some(ty.as_str());
+                }
+                Field::Metadata => {}
+                Field::Unknown { .. } => return None,
+            }
+        }
+
+        for lookup_name in parameter_types.keys() {
+            if !parameters
+                .get(*lookup_name)
+                .is_some_and(TypedFieldRenderState::accepts_separate_type)
+            {
+                return None;
+            }
+        }
+
+        for name in attribute_types.keys() {
+            if !attributes
+                .get(*name)
+                .is_some_and(TypedFieldRenderState::accepts_separate_type)
+            {
+                return None;
+            }
+        }
+
+        if !has_rendered_field || (has_return_type && !has_returns) {
+            return None;
+        }
+
+        Some(Self {
+            parameter_types,
+            attribute_types,
+            return_type,
+        })
+    }
+
+    fn render(&self, fields: &'a [Field]) -> String {
+        let mut sections = DocstringSections::default();
+        for field in fields {
+            match field {
+                Field::Parameter {
+                    display_name,
+                    lookup_name,
+                    ty,
+                    description,
+                } => sections.push(
+                    DocstringSectionKind::Parameters,
+                    DocstringItem::new(
+                        Some(display_name.as_str()),
+                        ty.as_deref().or_else(|| {
+                            self.parameter_types
+                                .get(lookup_name.as_str())
+                                .copied()
+                                .filter(|ty| !ty.is_empty())
+                        }),
+                        description.as_str(),
+                    ),
+                ),
+                Field::Attribute {
+                    name,
+                    ty,
+                    description,
+                } => sections.push(
+                    DocstringSectionKind::Attributes,
+                    DocstringItem::new(
+                        Some(name.as_str()),
+                        ty.as_deref().or_else(|| {
+                            self.attribute_types
+                                .get(name.as_str())
+                                .copied()
+                                .filter(|ty| !ty.is_empty())
+                        }),
+                        description.as_str(),
+                    ),
+                ),
+                Field::Returns { name, description } => sections.push(
+                    DocstringSectionKind::Returns,
+                    DocstringItem::new(name.as_deref(), self.return_type, description.as_str()),
+                ),
+                Field::Raises {
+                    exception,
+                    description,
+                } => sections.push(
+                    DocstringSectionKind::Raises,
+                    DocstringItem::new(exception.as_deref(), None, description.as_str()),
+                ),
+                Field::ParameterType { .. }
+                | Field::AttributeType { .. }
+                | Field::ReturnType { .. }
+                | Field::Metadata
+                | Field::Unknown { .. } => {}
+            }
+        }
+
+        sections.render_markdown()
+    }
+}
+
+#[derive(Default)]
+struct TypedFieldRenderState {
+    has_untyped_field: bool,
+    has_inline_typed_field: bool,
+}
+
+impl TypedFieldRenderState {
+    fn record_field(&mut self, has_inline_type: bool) {
+        if has_inline_type {
+            self.has_inline_typed_field = true;
+        } else {
+            self.has_untyped_field = true;
+        }
+    }
+
+    fn accepts_separate_type(&self) -> bool {
+        self.has_untyped_field && !self.has_inline_typed_field
     }
 }
 
@@ -837,7 +1099,7 @@ struct ParameterName<'a> {
 mod tests {
     use insta::{assert_debug_snapshot, assert_snapshot};
 
-    use super::Docstring;
+    use super::{Docstring, may_contain_top_level_field_list};
 
     #[test]
     fn parameter_documentation_extracts_rest_parameters() {
@@ -858,6 +1120,26 @@ mod tests {
           This is a continuation of param2 description.
         kwargs: Extra keyword arguments.
         ");
+    }
+
+    #[test]
+    fn field_list_precheck_detects_renderable_top_level_fields() {
+        assert!(may_contain_top_level_field_list(
+            "Summary.\n:param value: The value."
+        ));
+        assert!(may_contain_top_level_field_list(
+            ":type value: int\n:param value: The value."
+        ));
+        assert!(!may_contain_top_level_field_list(
+            "Summary: no field list here."
+        ));
+        assert!(!may_contain_top_level_field_list(
+            ":class:`Foo` instances are accepted.\n:meta private:"
+        ));
+        assert!(!may_contain_top_level_field_list(
+            "    :param value: Nested field lists are preserved."
+        ));
+        assert!(!may_contain_top_level_field_list(":rtype: str"));
     }
 
     #[test]
@@ -1183,6 +1465,276 @@ Section::
         let param_docs = parameter_documentation(docstring);
 
         assert_snapshot!(param_docs, @"real: Real parameter.");
+    }
+
+    #[test]
+    fn field_lists_render_supported_sections() {
+        let docstring = "\
+This is a function description.
+:class:`Foo` instances can be passed here.
+
+:param str param1: The first parameter description
+:meta private:
+:param param2: The second parameter description
+:type param2: int
+:kwparam retries: Retry attempts.
+:paramtype retries: int
+:param *args: Extra positional arguments.
+:type args: tuple[str, ...]
+:param **kwargs: Extra keyword arguments.
+:type **kwargs: dict[str, object]
+:var cache: Cached data.
+:vartype cache: dict[str,
+    object]
+:ivar state: Instance state.
+:var str title: Display title.
+:cvar VERSION: Package version.
+:vartype VERSION: str
+:returns baz: The return value description
+:rtype: dict[str,
+    int]
+:raises ValueError: If the value is invalid.
+:meta hide-value:
+:exception RuntimeError: If the system is unavailable.";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        This is a function description.
+        :class:`Foo` instances can be passed here.
+
+        ## Parameters
+        `param1` (`str`): The first parameter description
+        `param2` (`int`): The second parameter description
+        `retries` (`int`): Retry attempts.
+        `*args` (`tuple[str, ...]`): Extra positional arguments.
+        `**kwargs` (`dict[str, object]`): Extra keyword arguments.
+
+        ## Attributes
+        `cache` (`dict[str, object]`): Cached data.
+        `state`: Instance state.
+        `title` (`str`): Display title.
+        `VERSION` (`str`): Package version.
+
+        ## Returns
+        `baz` (`dict[str, int]`): The return value description
+
+        ## Raises
+        `ValueError`: If the value is invalid.
+        `RuntimeError`: If the system is unavailable.
+        ");
+    }
+
+    #[test]
+    fn field_lists_ignore_metadata_fields_when_rendering() {
+        let docstring = "\
+:meta private:
+:param value: The value to validate.
+:meta public:";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Parameters
+        `value`: The value to validate.
+        ");
+
+        let metadata_only = "\
+:meta private:
+:meta public:";
+        assert_eq!(
+            Docstring::parse(metadata_only).render_markdown(),
+            metadata_only
+        );
+    }
+
+    #[test]
+    fn field_lists_preserve_unrenderable_lists() {
+        let docstring = "\
+:param first: First parameter
+:meta private:
+:param second: Second parameter
+:type orphan: str
+:param **: Missing a parameter name.";
+
+        assert_eq!(Docstring::parse(docstring).render_markdown(), docstring);
+
+        assert_snapshot!(parameter_documentation(docstring), @"
+        first: First parameter
+        second: Second parameter
+        ");
+
+        for docstring in [
+            "\
+:param value: The value to validate.
+:rtype: str",
+            "\
+:param value: The value to validate.
+:type value: str
+:type value: int",
+            "\
+:param str value: The value to validate.
+:type value: int",
+            "\
+:var value: The value.
+:vartype orphan: str",
+            "\
+:var value: The value.
+:vartype value: str
+:vartype value: int",
+            "\
+:var str value: The value.
+:vartype value: int",
+            "\
+:returns:",
+            "\
+:raises:",
+            "\
+:meta private:
+:returns:
+:raises:",
+        ] {
+            assert_eq!(Docstring::parse(docstring).render_markdown(), docstring);
+        }
+    }
+
+    #[test]
+    fn field_lists_skip_empty_rendered_sections() {
+        let docstring = "\
+:param value: The value to validate.
+:returns:
+:raises:";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Parameters
+        `value`: The value to validate.
+        ");
+    }
+
+    #[test]
+    fn field_lists_render_return_type_without_name() {
+        let docstring = "\
+:returns: The return value description.
+:rtype: dict[str,
+    int]";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Returns
+        `dict[str, int]`: The return value description.
+        ");
+    }
+
+    #[test]
+    fn field_lists_render_sections_in_canonical_order() {
+        let docstring = "\
+:raises ValueError: If validation fails.
+:param value: The value to validate.
+:returns: The normalized value.
+:raises TypeError: If validation has the wrong type.";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Parameters
+        `value`: The value to validate.
+
+        ## Returns
+        The normalized value.
+
+        ## Raises
+        `ValueError`: If validation fails.
+        `TypeError`: If validation has the wrong type.
+        ");
+    }
+
+    #[test]
+    fn field_lists_render_list_descriptions_as_blocks() {
+        let docstring = "\
+:param value:
+    - First option.
+    - Second option.
+:param steps:
+    1. Validate the input.
+    2. Return the result.
+:param done: Whether work is done.";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Parameters
+        `value`:
+        - First option.
+        - Second option.
+
+        `steps`:
+        1. Validate the input.
+        2. Return the result.
+
+        `done`: Whether work is done.
+        ");
+    }
+
+    #[test]
+    fn field_lists_render_well_formed_lists_after_unrenderable_lists() {
+        let docstring = "\
+:param first: First parameter.
+
+Some prose between field lists.
+
+:meta private:
+
+More prose between field lists.
+
+:param second: Second parameter.";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Parameters
+        `first`: First parameter.
+
+        Some prose between field lists.
+
+        :meta private:
+
+        More prose between field lists.
+
+        ## Parameters
+        `second`: Second parameter.
+        ");
+    }
+
+    #[test]
+    fn field_lists_inside_code_examples_are_preserved() {
+        let docstring = "\
+Markdown input:
+
+```text
+:param sample: This is sample input
+```
+
+Doctest output:
+
+>>> print(\"field list\")
+:param sample: This is sample output
+
+Literal block::
+
+    :param sample: This is sample input
+
+:param real: Real parameter";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        Markdown input:
+
+        ```text
+        :param sample: This is sample input
+        ```
+
+        Doctest output:
+
+        >>> print(\"field list\")
+        :param sample: This is sample output
+
+        Literal block::
+
+            :param sample: This is sample input
+
+        ## Parameters
+        `real`: Real parameter
+        ");
+
+        assert_snapshot!(parameter_documentation(docstring), @"real: Real parameter");
     }
 
     fn parameter_documentation(docstring: &str) -> String {

--- a/crates/ty_ide/src/docstring/structured.rs
+++ b/crates/ty_ide/src/docstring/structured.rs
@@ -51,6 +51,7 @@ impl<'a> Docstring<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum Style {
     Google,
+    Numpy,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -117,7 +118,7 @@ fn parse_sections(raw: &str, style: Style) -> Vec<Section> {
         while let Some(line) = lines.get(body_end) {
             let previous_body = &lines[header.body_start..body_end];
             if line.text.trim().is_empty()
-                && !blank_line_continues_section(style, &lines[body_end..], header)
+                && !blank_line_continues_section(style, previous_body, &lines[body_end..], header)
             {
                 break;
             }
@@ -140,7 +141,9 @@ fn parse_sections(raw: &str, style: Style) -> Vec<Section> {
                 break;
             }
 
-            if !line.text.trim().is_empty() && !line_belongs_to_google_body(header, line.text) {
+            if !line.text.trim().is_empty()
+                && !line_belongs_to_body(style, line, previous_body, &lines[body_end + 1..], header)
+            {
                 break;
             }
 
@@ -151,7 +154,7 @@ fn parse_sections(raw: &str, style: Style) -> Vec<Section> {
             body_end += 1;
         }
 
-        if let Some(items) = parse_items(style, header.kind, &lines[header.body_start..body_end]) {
+        if let Some(items) = parse_items(style, header, &lines[header.body_start..body_end]) {
             sections.push(Section {
                 kind: header.kind,
                 indent: header.indent,
@@ -182,7 +185,12 @@ fn top_level_preformatted_block_follows_body(
         && PreformattedBlockScanner::line_starts_preformatted_block(line.text)
 }
 
-fn blank_line_continues_section(style: Style, lines: &[Line<'_>], header: Header) -> bool {
+fn blank_line_continues_section(
+    style: Style,
+    previous_lines: &[Line<'_>],
+    lines: &[Line<'_>],
+    header: Header,
+) -> bool {
     let Some((offset, non_blank_line)) = lines
         .iter()
         .enumerate()
@@ -195,7 +203,49 @@ fn blank_line_continues_section(style: Style, lines: &[Line<'_>], header: Header
         return false;
     }
 
-    line_belongs_to_google_body_after_blank(header, non_blank_line.text)
+    match style {
+        Style::Google => line_belongs_to_google_body_after_blank(header, non_blank_line.text),
+        Style::Numpy => {
+            line_belongs_to_numpy_body(header, non_blank_line, previous_lines, &lines[offset + 1..])
+        }
+    }
+}
+
+fn line_belongs_to_body(
+    style: Style,
+    line: &Line<'_>,
+    previous_lines: &[Line<'_>],
+    following_lines: &[Line<'_>],
+    header: Header,
+) -> bool {
+    match style {
+        Style::Google => line_belongs_to_google_body(header, line.text),
+        Style::Numpy => line_belongs_to_numpy_body(header, line, previous_lines, following_lines),
+    }
+}
+
+fn line_belongs_to_numpy_body(
+    header: Header,
+    line: &Line<'_>,
+    previous_lines: &[Line<'_>],
+    following_lines: &[Line<'_>],
+) -> bool {
+    let line_indent = indentation(line.text);
+    if line_indent > header.indent {
+        return true;
+    }
+
+    if line_indent != header.indent {
+        return false;
+    }
+
+    match header.kind {
+        SectionKind::Parameters | SectionKind::Attributes => {
+            numpy_named_item_starts(line, following_lines)
+        }
+        SectionKind::Raises => numpy_raise_item_starts(line, following_lines),
+        SectionKind::Returns => numpy_return_item_starts(line, previous_lines, following_lines),
+    }
 }
 
 fn line_belongs_to_google_body(header: Header, line: &str) -> bool {
@@ -252,6 +302,23 @@ fn parse_section_header(style: Style, lines: &[Line<'_>], index: usize) -> Optio
                 range_end: line.end,
             })
         }
+        Style::Numpy => {
+            let line = lines.get(index)?;
+            let underline = lines.get(index + 1)?;
+            let indent = indentation(line.text);
+            if indentation(underline.text) != indent || !is_numpy_underline(underline.text) {
+                return None;
+            }
+
+            let kind = parse_numpy_header(line.text)?;
+            Some(Header {
+                kind,
+                indent,
+                body_start: index + 2,
+                range_start: line.start,
+                range_end: underline.end,
+            })
+        }
     }
 }
 
@@ -301,6 +368,75 @@ fn normalized_google_section_name(name: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ")
         .to_ascii_lowercase()
+}
+
+fn parse_numpy_header(line: &str) -> Option<SectionKind> {
+    match line.trim().to_ascii_lowercase().as_str() {
+        "parameters" => Some(SectionKind::Parameters),
+        "attributes" => Some(SectionKind::Attributes),
+        "returns" | "return" => Some(SectionKind::Returns),
+        "raises" | "raise" => Some(SectionKind::Raises),
+        _ => None,
+    }
+}
+
+fn is_numpy_underline(line: &str) -> bool {
+    let line = line.trim();
+    line.len() >= 3 && line.chars().all(|char| char == '-')
+}
+
+fn numpy_named_item_starts(line: &Line<'_>, following_lines: &[Line<'_>]) -> bool {
+    let trimmed = line.text.trim();
+    if split_numpy_type_separator(trimmed).is_some() {
+        return true;
+    }
+
+    numpy_untyped_item_starts(trimmed, line, following_lines)
+}
+
+fn numpy_untyped_item_starts(trimmed: &str, line: &Line<'_>, following_lines: &[Line<'_>]) -> bool {
+    is_numpy_item_name(trimmed)
+        && following_lines
+            .iter()
+            .find(|line| !line.text.trim().is_empty())
+            .is_some_and(|next| indentation(next.text) > indentation(line.text))
+}
+
+fn split_numpy_type_separator(line: &str) -> Option<(&str, &str)> {
+    let (name, ty) = split_once_unbracketed_colon(line)?;
+    if !name.chars().last().is_some_and(char::is_whitespace) {
+        return None;
+    }
+
+    let name = name.trim();
+    let ty = ty.trim();
+    if !is_numpy_item_name(name) || ty.is_empty() {
+        return None;
+    }
+
+    Some((name, ty))
+}
+
+fn is_numpy_item_name(name: &str) -> bool {
+    name.split(',').all(|part| {
+        let part = part.trim();
+        let part = part
+            .strip_prefix("**")
+            .or_else(|| part.strip_prefix('*'))
+            .unwrap_or(part);
+
+        !part.is_empty() && part.split('.').all(is_numpy_name_part)
+    })
+}
+
+fn is_numpy_name_part(part: &str) -> bool {
+    let mut chars = part.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|char| char == '_' || char.is_ascii_alphanumeric())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -363,9 +499,10 @@ impl DescriptionLine {
     }
 }
 
-fn parse_items(style: Style, kind: SectionKind, body: &[Line<'_>]) -> Option<Vec<Item>> {
+fn parse_items(style: Style, header: Header, body: &[Line<'_>]) -> Option<Vec<Item>> {
     match style {
-        Style::Google => parse_google_items(kind, body),
+        Style::Google => parse_google_items(header.kind, body),
+        Style::Numpy => parse_numpy_items(header, body),
     }
 }
 
@@ -428,6 +565,16 @@ fn split_once_unbracketed_colon(line: &str) -> Option<(&str, &str)> {
     None
 }
 
+fn parse_numpy_items(header: Header, body: &[Line<'_>]) -> Option<Vec<Item>> {
+    match header.kind {
+        SectionKind::Parameters | SectionKind::Attributes => {
+            parse_named_items(body, parse_numpy_named_item)
+        }
+        SectionKind::Returns => parse_numpy_return_items(body, header.indent),
+        SectionKind::Raises => parse_named_items(body, parse_numpy_raise_item),
+    }
+}
+
 fn parse_named_items(
     body: &[Line<'_>],
     parse_item: fn(&str) -> Option<ItemBuilder>,
@@ -464,6 +611,100 @@ fn parse_named_items(
     (!items.is_empty()).then_some(items)
 }
 
+fn parse_numpy_named_item(line: &str) -> Option<ItemBuilder> {
+    let (name, ty) = split_numpy_type_separator(line).map_or_else(
+        || is_numpy_item_name(line.trim()).then_some((line.trim(), None)),
+        |(name, ty)| Some((name, Some(ty))),
+    )?;
+
+    Some(ItemBuilder {
+        display_name: Some(name.to_string()),
+        ty: ty.map(str::to_string),
+        description_lines: Vec::new(),
+    })
+}
+
+fn parse_numpy_return_items(body: &[Line<'_>], section_indent: usize) -> Option<Vec<Item>> {
+    let first = body.iter().find(|line| !line.text.trim().is_empty())?;
+    if indentation(first.text) != section_indent {
+        return None;
+    }
+
+    parse_named_items(body, parse_numpy_return_item)
+}
+
+fn numpy_return_item_starts(
+    line: &Line<'_>,
+    previous_lines: &[Line<'_>],
+    following_lines: &[Line<'_>],
+) -> bool {
+    let trimmed = line.text.trim();
+    parse_numpy_named_return_item(trimmed).is_some()
+        || (!previous_lines
+            .iter()
+            .any(|line| !line.text.trim().is_empty())
+            && is_numpy_anonymous_return_type(trimmed))
+        || (is_numpy_anonymous_return_type(trimmed)
+            && following_lines
+                .iter()
+                .find(|line| !line.text.trim().is_empty())
+                .is_some_and(|next| indentation(next.text) > indentation(line.text)))
+}
+
+fn is_numpy_anonymous_return_type(line: &str) -> bool {
+    !line.is_empty()
+        && !line.ends_with('.')
+        && !line.ends_with(':')
+        && is_structured_return_type(line)
+}
+
+fn parse_numpy_return_item(line: &str) -> Option<ItemBuilder> {
+    parse_numpy_named_return_item(line).or_else(|| {
+        is_numpy_anonymous_return_type(line).then(|| ItemBuilder {
+            display_name: None,
+            ty: Some(line.to_string()),
+            description_lines: Vec::new(),
+        })
+    })
+}
+
+fn parse_numpy_named_return_item(line: &str) -> Option<ItemBuilder> {
+    let (name, ty) = split_numpy_type_separator(line)?;
+
+    Some(ItemBuilder {
+        display_name: Some(name.to_string()),
+        ty: Some(ty.to_string()),
+        description_lines: Vec::new(),
+    })
+}
+
+fn numpy_raise_item_starts(line: &Line<'_>, following_lines: &[Line<'_>]) -> bool {
+    let trimmed = line.text.trim();
+    parse_numpy_raise_item(trimmed).is_some_and(|item| !item.description_lines.is_empty())
+        || numpy_untyped_item_starts(trimmed, line, following_lines)
+}
+
+fn parse_numpy_raise_item(line: &str) -> Option<ItemBuilder> {
+    let (name, description) = line
+        .split_once(':')
+        .map_or((line.trim(), None), |(name, description)| {
+            (name.trim(), Some(description.trim()))
+        });
+    if !is_numpy_item_name(name) {
+        return None;
+    }
+
+    Some(ItemBuilder {
+        display_name: Some(name.to_string()),
+        ty: None,
+        description_lines: description
+            .filter(|description| !description.is_empty())
+            .map(DescriptionLine::normalized)
+            .into_iter()
+            .collect(),
+    })
+}
+
 fn parse_google_return_item(body: &[Line<'_>]) -> Option<Vec<Item>> {
     let mut lines = body.iter().skip_while(|line| line.text.trim().is_empty());
     let first = lines.next()?;
@@ -489,7 +730,7 @@ fn split_google_return_type(line: &str) -> Option<(&str, &str)> {
 
     let description = description.trim();
 
-    if is_google_return_type(ty) {
+    if is_structured_return_type(ty) {
         Some((ty, description))
     } else {
         None
@@ -525,15 +766,15 @@ fn is_uri_scheme(scheme: &str) -> bool {
         && chars.all(|char| char.is_ascii_alphanumeric() || matches!(char, '+' | '-' | '.'))
 }
 
-fn is_google_return_type(ty: &str) -> bool {
-    if ty.is_empty() || !ty.chars().all(is_google_return_type_char) {
+fn is_structured_return_type(ty: &str) -> bool {
+    if ty.is_empty() || !ty.chars().all(is_structured_return_type_char) {
         return false;
     }
 
     !ty.chars().any(char::is_whitespace) || ty.contains('[') || ty.contains(',') || ty.contains('|')
 }
 
-fn is_google_return_type_char(ch: char) -> bool {
+fn is_structured_return_type_char(ch: char) -> bool {
     ch.is_ascii_alphanumeric() || "_.[](){},|\"':/ ".contains(ch)
 }
 

--- a/crates/ty_ide/src/docstring/structured.rs
+++ b/crates/ty_ide/src/docstring/structured.rs
@@ -1,0 +1,624 @@
+use std::borrow::Cow;
+use std::ops::Range;
+
+use ruff_python_trivia::leading_indentation;
+use ruff_source_file::UniversalNewlines;
+
+use super::rest::PreformattedBlockScanner;
+use super::sections::{DocstringItem, DocstringSectionKind, DocstringSections};
+
+pub(super) struct Docstring<'a> {
+    raw: &'a str,
+    sections: Vec<Section>,
+}
+
+impl<'a> Docstring<'a> {
+    pub(super) fn parse(raw: &'a str, style: Style) -> Self {
+        Self {
+            raw,
+            sections: parse_sections(raw, style),
+        }
+    }
+
+    pub(super) fn render_markdown(&self) -> Cow<'a, str> {
+        let mut output: Option<String> = None;
+        let mut rendered_through = 0;
+
+        for section in &self.sections {
+            if section.indent != 0 || section.range.start < rendered_through {
+                continue;
+            }
+
+            let markdown = section.render_markdown();
+            if markdown.is_empty() {
+                continue;
+            }
+
+            let output = output.get_or_insert_with(String::new);
+            output.push_str(&self.raw[rendered_through..section.range.start]);
+            output.push_str(&markdown);
+            rendered_through = section.range.end;
+        }
+
+        let Some(mut output) = output else {
+            return Cow::Borrowed(self.raw);
+        };
+        output.push_str(&self.raw[rendered_through..]);
+        Cow::Owned(output)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Style {
+    Google,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Line<'a> {
+    text: &'a str,
+    start: usize,
+    end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Section {
+    kind: SectionKind,
+    indent: usize,
+    range: Range<usize>,
+    items: Vec<Item>,
+}
+
+impl Section {
+    fn render_markdown(&self) -> String {
+        let mut sections = DocstringSections::default();
+        for item in &self.items {
+            sections.push(
+                self.kind.docstring_section_kind(),
+                DocstringItem::new(
+                    item.display_name.as_deref(),
+                    item.ty.as_deref(),
+                    item.description.as_str(),
+                ),
+            );
+        }
+        sections.render_markdown()
+    }
+}
+
+fn parse_sections(raw: &str, style: Style) -> Vec<Section> {
+    let lines = raw
+        .universal_newlines()
+        .map(|line| Line {
+            text: line.as_str(),
+            start: line.start().to_usize(),
+            end: line.end().to_usize(),
+        })
+        .collect::<Vec<_>>();
+
+    let mut sections = Vec::new();
+    let mut preformatted_blocks = PreformattedBlockScanner::default();
+    let mut index = 0;
+
+    while index < lines.len() {
+        if preformatted_blocks.consume_preformatted_line(lines[index].text) {
+            index += 1;
+            continue;
+        }
+
+        let Some(header) = parse_section_header(style, &lines, index) else {
+            preformatted_blocks.observe_non_preformatted_line(lines[index].text);
+            index += 1;
+            continue;
+        };
+
+        let mut body_end = header.body_start;
+        let mut range_end = header.range_end;
+        let mut body_preformatted_blocks = PreformattedBlockScanner::default();
+        while let Some(line) = lines.get(body_end) {
+            let previous_body = &lines[header.body_start..body_end];
+            if line.text.trim().is_empty()
+                && !blank_line_continues_section(style, &lines[body_end..], header)
+            {
+                break;
+            }
+
+            if body_preformatted_blocks.is_active()
+                && body_preformatted_blocks.consume_preformatted_line(line.text)
+            {
+                range_end = line.end;
+                body_end += 1;
+                continue;
+            }
+
+            if parse_section_header(style, &lines, body_end)
+                .is_some_and(|next| next.indent <= header.indent)
+            {
+                break;
+            }
+
+            if top_level_preformatted_block_follows_body(style, header, line, previous_body) {
+                break;
+            }
+
+            if !line.text.trim().is_empty() && !line_belongs_to_google_body(header, line.text) {
+                break;
+            }
+
+            if !body_preformatted_blocks.consume_preformatted_line(line.text) {
+                body_preformatted_blocks.observe_non_preformatted_line(line.text);
+            }
+            range_end = line.end;
+            body_end += 1;
+        }
+
+        if let Some(items) = parse_items(style, header.kind, &lines[header.body_start..body_end]) {
+            sections.push(Section {
+                kind: header.kind,
+                indent: header.indent,
+                range: header.range_start..range_end,
+                items,
+            });
+            index = body_end;
+        } else {
+            index += 1;
+        }
+    }
+
+    sections
+}
+
+fn top_level_preformatted_block_follows_body(
+    style: Style,
+    header: Header,
+    line: &Line<'_>,
+    previous_lines: &[Line<'_>],
+) -> bool {
+    matches!(style, Style::Google)
+        && header.range_start == 0
+        && indentation(line.text) == header.indent
+        && previous_lines
+            .iter()
+            .any(|line| !line.text.trim().is_empty())
+        && PreformattedBlockScanner::line_starts_preformatted_block(line.text)
+}
+
+fn blank_line_continues_section(style: Style, lines: &[Line<'_>], header: Header) -> bool {
+    let Some((offset, non_blank_line)) = lines
+        .iter()
+        .enumerate()
+        .find(|(_, line)| !line.text.trim().is_empty())
+    else {
+        return false;
+    };
+
+    if parse_section_header(style, lines, offset).is_some_and(|next| next.indent <= header.indent) {
+        return false;
+    }
+
+    line_belongs_to_google_body_after_blank(header, non_blank_line.text)
+}
+
+fn line_belongs_to_google_body(header: Header, line: &str) -> bool {
+    let line_indent = indentation(line);
+    if line_indent > header.indent {
+        return true;
+    }
+
+    // `documentation_trim` ignores the first docstring line when computing common
+    // indentation, so the body of a first-line section can be dedented to the
+    // header's column before structured parsing sees it.
+    header.range_start == 0
+        && line_indent == header.indent
+        && !is_google_section_like_header(line.trim())
+}
+
+fn line_belongs_to_google_body_after_blank(header: Header, line: &str) -> bool {
+    if !line_belongs_to_google_body(header, line) {
+        return false;
+    }
+
+    let line_indent = indentation(line);
+    if header.range_start != 0 || line_indent > header.indent {
+        return true;
+    }
+
+    match header.kind {
+        SectionKind::Parameters | SectionKind::Attributes | SectionKind::Raises => {
+            parse_google_named_item(line.trim()).is_some()
+        }
+        SectionKind::Returns => true,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Header {
+    kind: SectionKind,
+    indent: usize,
+    body_start: usize,
+    range_start: usize,
+    range_end: usize,
+}
+
+fn parse_section_header(style: Style, lines: &[Line<'_>], index: usize) -> Option<Header> {
+    match style {
+        Style::Google => {
+            let line = lines.get(index)?;
+            let (kind, indent) = parse_google_header(line.text)?;
+            Some(Header {
+                kind,
+                indent,
+                body_start: index + 1,
+                range_start: line.start,
+                range_end: line.end,
+            })
+        }
+    }
+}
+
+fn parse_google_header(line: &str) -> Option<(SectionKind, usize)> {
+    let name = line.trim().strip_suffix(':')?.trim();
+    let kind = match normalized_google_section_name(name).as_str() {
+        "args" | "arguments" | "parameters" | "keyword args" | "keyword arguments" => {
+            SectionKind::Parameters
+        }
+        "attributes" => SectionKind::Attributes,
+        "returns" | "return" => SectionKind::Returns,
+        "raises" | "raise" => SectionKind::Raises,
+        _ => return None,
+    };
+    Some((kind, indentation(line)))
+}
+
+fn is_google_section_like_header(line: &str) -> bool {
+    if parse_google_header(line).is_some() {
+        return true;
+    }
+
+    let Some(name) = line.strip_suffix(':') else {
+        return false;
+    };
+
+    matches!(
+        normalized_google_section_name(name).as_str(),
+        "example"
+            | "examples"
+            | "note"
+            | "notes"
+            | "other parameters"
+            | "references"
+            | "see also"
+            | "todo"
+            | "todos"
+            | "warning"
+            | "warnings"
+            | "yield"
+            | "yields"
+    )
+}
+
+fn normalized_google_section_name(name: &str) -> String {
+    name.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SectionKind {
+    Parameters,
+    Attributes,
+    Returns,
+    Raises,
+}
+
+impl SectionKind {
+    fn docstring_section_kind(self) -> DocstringSectionKind {
+        match self {
+            Self::Parameters => DocstringSectionKind::Parameters,
+            Self::Attributes => DocstringSectionKind::Attributes,
+            Self::Returns => DocstringSectionKind::Returns,
+            Self::Raises => DocstringSectionKind::Raises,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Item {
+    display_name: Option<String>,
+    ty: Option<String>,
+    description: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ItemBuilder {
+    display_name: Option<String>,
+    ty: Option<String>,
+    description_lines: Vec<DescriptionLine>,
+}
+
+impl ItemBuilder {
+    fn finish(self) -> Item {
+        Item {
+            display_name: self.display_name,
+            ty: self.ty,
+            description: normalize_description(self.description_lines),
+        }
+    }
+
+    fn push_description(&mut self, line: &str) {
+        self.description_lines
+            .push(DescriptionLine::Source(line.to_string()));
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DescriptionLine {
+    Normalized(String),
+    Source(String),
+}
+
+impl DescriptionLine {
+    fn normalized(line: &str) -> Self {
+        Self::Normalized(line.trim().to_string())
+    }
+}
+
+fn parse_items(style: Style, kind: SectionKind, body: &[Line<'_>]) -> Option<Vec<Item>> {
+    match style {
+        Style::Google => parse_google_items(kind, body),
+    }
+}
+
+fn parse_google_items(kind: SectionKind, body: &[Line<'_>]) -> Option<Vec<Item>> {
+    if kind == SectionKind::Returns {
+        return parse_google_return_item(body);
+    }
+
+    parse_named_items(body, parse_google_named_item)
+}
+
+fn parse_google_named_item(line: &str) -> Option<ItemBuilder> {
+    let (name, description) = split_once_unbracketed_colon(line)?;
+    let (name, ty) = parse_parenthesized_type(name.trim());
+    if name.is_empty() {
+        return None;
+    }
+
+    Some(ItemBuilder {
+        display_name: Some(name.to_string()),
+        ty: ty.map(str::to_string),
+        description_lines: vec![DescriptionLine::normalized(description)],
+    })
+}
+
+fn split_once_unbracketed_colon(line: &str) -> Option<(&str, &str)> {
+    let mut parentheses = 0usize;
+    let mut brackets = 0usize;
+    let mut braces = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (index, char) in line.char_indices() {
+        if let Some(quote_char) = quote {
+            if escaped {
+                escaped = false;
+            } else if char == '\\' {
+                escaped = true;
+            } else if char == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match char {
+            '\'' | '"' => quote = Some(char),
+            '(' => parentheses += 1,
+            ')' => parentheses = parentheses.saturating_sub(1),
+            '[' => brackets += 1,
+            ']' => brackets = brackets.saturating_sub(1),
+            '{' => braces += 1,
+            '}' => braces = braces.saturating_sub(1),
+            ':' if parentheses == 0 && brackets == 0 && braces == 0 => {
+                return Some((&line[..index], &line[index + ':'.len_utf8()..]));
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn parse_named_items(
+    body: &[Line<'_>],
+    parse_item: fn(&str) -> Option<ItemBuilder>,
+) -> Option<Vec<Item>> {
+    let mut items = Vec::new();
+    let mut current: Option<ItemBuilder> = None;
+    let mut item_indent = None;
+
+    for line in body {
+        let trimmed = line.text.trim();
+        if trimmed.is_empty() {
+            if let Some(current) = &mut current {
+                current.push_description("");
+            }
+            continue;
+        }
+
+        let starts_item = item_indent.is_none_or(|indent| indentation(line.text) == indent);
+        if starts_item && let Some(item) = parse_item(trimmed) {
+            if let Some(current) = current.replace(item) {
+                items.push(current.finish());
+            }
+            item_indent.get_or_insert_with(|| indentation(line.text));
+            continue;
+        }
+
+        let current = current.as_mut()?;
+        current.push_description(line.text);
+    }
+
+    if let Some(current) = current {
+        items.push(current.finish());
+    }
+    (!items.is_empty()).then_some(items)
+}
+
+fn parse_google_return_item(body: &[Line<'_>]) -> Option<Vec<Item>> {
+    let mut lines = body.iter().skip_while(|line| line.text.trim().is_empty());
+    let first = lines.next()?;
+    let first = first.text.trim();
+    let (ty, first_description) = split_google_return_type(first)
+        .map_or((None, first), |(ty, description)| (Some(ty), description));
+
+    let mut description_lines = vec![DescriptionLine::normalized(first_description)];
+    description_lines.extend(lines.map(|line| DescriptionLine::Source(line.text.to_string())));
+    Some(vec![Item {
+        display_name: None,
+        ty: ty.map(str::to_string),
+        description: normalize_description(description_lines),
+    }])
+}
+
+fn split_google_return_type(line: &str) -> Option<(&str, &str)> {
+    let (ty, description) = split_once_unbracketed_colon(line)?;
+    let ty = ty.trim();
+    if is_uri_scheme_prefix(ty, description) {
+        return None;
+    }
+
+    let description = description.trim();
+
+    if is_google_return_type(ty) {
+        Some((ty, description))
+    } else {
+        None
+    }
+}
+
+fn is_uri_scheme_prefix(ty: &str, description: &str) -> bool {
+    if !is_uri_scheme(ty) {
+        return false;
+    }
+
+    if description.starts_with("//") {
+        return true;
+    }
+
+    let Some(first) = description.chars().next() else {
+        return false;
+    };
+    if first.is_whitespace() {
+        return false;
+    }
+
+    matches!(first, '/' | '?' | '#' | '@' | ':')
+        || description
+            .chars()
+            .skip(1)
+            .any(|char| matches!(char, '/' | '?' | '#' | '@' | ':'))
+}
+
+fn is_uri_scheme(scheme: &str) -> bool {
+    let mut chars = scheme.chars();
+    chars.next().is_some_and(|char| char.is_ascii_alphabetic())
+        && chars.all(|char| char.is_ascii_alphanumeric() || matches!(char, '+' | '-' | '.'))
+}
+
+fn is_google_return_type(ty: &str) -> bool {
+    if ty.is_empty() || !ty.chars().all(is_google_return_type_char) {
+        return false;
+    }
+
+    !ty.chars().any(char::is_whitespace) || ty.contains('[') || ty.contains(',') || ty.contains('|')
+}
+
+fn is_google_return_type_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || "_.[](){},|\"':/ ".contains(ch)
+}
+
+fn parse_parenthesized_type(name: &str) -> (&str, Option<&str>) {
+    if !name.ends_with(')') {
+        return (name, None);
+    }
+
+    let mut depth = 0usize;
+    for (index, char) in name.char_indices().rev() {
+        match char {
+            ')' => depth += 1,
+            '(' => {
+                if depth == 0 {
+                    return (name, None);
+                }
+                depth -= 1;
+                if depth == 0 {
+                    let display_name = name[..index].trim();
+                    let ty = name[index + '('.len_utf8()..name.len() - ')'.len_utf8()].trim();
+                    return if display_name.is_empty() || ty.is_empty() {
+                        (name, None)
+                    } else {
+                        (display_name, Some(ty))
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+
+    (name, None)
+}
+
+fn normalize_description(lines: Vec<DescriptionLine>) -> String {
+    let dedent = lines
+        .iter()
+        .filter_map(|line| match line {
+            DescriptionLine::Source(line) if !line.trim().is_empty() => Some(indentation(line)),
+            DescriptionLine::Normalized(_) | DescriptionLine::Source(_) => None,
+        })
+        .min()
+        .unwrap_or(0);
+
+    let mut description = lines
+        .into_iter()
+        .map(|line| match line {
+            DescriptionLine::Normalized(line) => line,
+            DescriptionLine::Source(line) => {
+                strip_indentation(&line, dedent).trim_end().to_string()
+            }
+        })
+        .skip_while(String::is_empty)
+        .collect::<Vec<_>>();
+    while description.last().is_some_and(String::is_empty) {
+        description.pop();
+    }
+    description.join("\n")
+}
+
+fn strip_indentation(line: &str, width: usize) -> &str {
+    let mut indentation_width = 0;
+    for (index, char) in line.char_indices() {
+        let char_width = match char {
+            ' ' => 1,
+            '\t' => 8,
+            _ => return &line[index..],
+        };
+
+        if indentation_width + char_width > width {
+            return &line[index..];
+        }
+
+        indentation_width += char_width;
+        if indentation_width == width {
+            return &line[index + char.len_utf8()..];
+        }
+    }
+
+    ""
+}
+
+fn indentation(line: &str) -> usize {
+    leading_indentation(line)
+        .chars()
+        .map(|char| if char == '\t' { 8 } else { 1 })
+        .sum()
+}

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -495,9 +495,9 @@ mod tests {
         ---
         This is such a great func!!<HB>
         <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
+        ## Parameters<HB>
+        `a`: first for a reason<HB>
+        `b`: coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
           --> main.py:11:1
@@ -548,9 +548,9 @@ mod tests {
         ---
         This is such a great func!!<HB>
         <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
+        ## Parameters<HB>
+        `a`: first for a reason<HB>
+        `b`: coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
          --> main.py:2:5
@@ -1528,9 +1528,9 @@ mod tests {
         ---
         This is such a great func!!<HB>
         <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
+        ## Parameters<HB>
+        `a`: first for a reason<HB>
+        `b`: coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
           --> main.py:25:3


### PR DESCRIPTION
## Summary

Render supported Google and NumPy docstring sections as Markdown for hover and related IDE output. This routes docstrings through a narrow structured-docstring parser after the existing reST rendering pass, covering top-level Parameters/Attributes/Returns/Raises sections while leaving existing parameter-documentation extraction unchanged.

Closes https://github.com/astral-sh/ty/issues/1667

## Test Plan

Please see included tests.
