### PR TITLE
Fix typo in the message emitted by ruff when a user types `ruff: enable[<rules>]` or `ruff: disable[<rules>]` where `ruff: ignore[<rules>]` is expected

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/invalid_suppression_comment.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/invalid_suppression_comment.rs
@@ -38,7 +38,7 @@ impl AlwaysFixableViolation for InvalidSuppressionComment {
                 "unexpected indentation".to_string()
             }
             InvalidSuppressionCommentKind::Invalid(InvalidSuppressionKind::Trailing) => {
-                "trailing comments are only support for ruff:ignore suppressions".to_string()
+                "trailing comments are only supported for ruff:ignore suppressions".to_string()
             }
             InvalidSuppressionCommentKind::Invalid(InvalidSuppressionKind::Unmatched) => {
                 "no matching 'disable' comment".to_string()


### PR DESCRIPTION
## Summary

Closes #25698.

## Test Plan

No tests are required, since this is a tiny change.
