### PR TITLE
[ty] Share code-generator classification across specializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -167,6 +167,29 @@ class CustomerModel(ModelBase):
 CustomerModel(id=1, name="Test")
 ```
 
+The dataclass-like behavior of a generic class does not depend on its specialization, but the types
+of its synthesized fields do:
+
+```py
+@dataclass_transform(kw_only_default=True)
+class ModelBase[T]: ...
+
+class GenericModel[T](ModelBase[T]):
+    value: T
+
+GenericModel[int](value=1)
+GenericModel[str](value="one")
+
+# error: [too-many-positional-arguments]
+GenericModel[int](1, value=1)
+
+# error: [invalid-argument-type]
+GenericModel[int](value="one")
+
+# error: [invalid-argument-type]
+GenericModel[str](value=1)
+```
+
 ## Arguments to `dataclass_transform`
 
 ### `eq_default`

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4774,7 +4774,7 @@ impl<'db> Type<'db> {
             })
         }
 
-        let (class_literal, class_specialization) = class.class_literal_and_specialization(db);
+        let class_literal = class.class_literal(db);
         let class_generic_context = class_literal.generic_context(db);
 
         // Keep bespoke constructor behavior for cases that don't map cleanly to `__new__`/`__init__`.
@@ -4795,7 +4795,7 @@ impl<'db> Type<'db> {
         // We don't want to use the synthesized binding for type inference, so here we just
         // return a permissive fallback binding.
         if class_literal.is_typed_dict(db)
-            || class::CodeGeneratorKind::TypedDict.matches(db, class_literal, class_specialization)
+            || class::CodeGeneratorKind::TypedDict.matches(db, class_literal)
         {
             return fallback_bindings();
         }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -77,15 +77,14 @@ pub(crate) enum CodeGeneratorKind<'db> {
 }
 
 impl<'db> CodeGeneratorKind<'db> {
-    pub(crate) fn from_class(
-        db: &'db dyn Db,
-        class: ClassLiteral<'db>,
-        specialization: Option<Specialization<'db>>,
-    ) -> Option<Self> {
+    /// Return the code-generation behavior for a class.
+    ///
+    /// This is invariant across generic specializations. Type arguments affect the types of
+    /// synthesized members, but not whether the class is dataclass-like, a `NamedTuple`, or a
+    /// `TypedDict`.
+    pub(crate) fn from_class(db: &'db dyn Db, class: ClassLiteral<'db>) -> Option<Self> {
         match class {
-            ClassLiteral::Static(static_class) => {
-                Self::from_static_class(db, static_class, specialization)
-            }
+            ClassLiteral::Static(static_class) => Self::from_static_class(db, static_class),
             ClassLiteral::Dynamic(dynamic_class) => Self::from_dynamic_class(db, dynamic_class),
             ClassLiteral::DynamicNamedTuple(_) => Some(Self::NamedTuple),
             ClassLiteral::DynamicTypedDict(_) => Some(Self::TypedDict),
@@ -93,11 +92,7 @@ impl<'db> CodeGeneratorKind<'db> {
         }
     }
 
-    fn from_static_class(
-        db: &'db dyn Db,
-        class: StaticClassLiteral<'db>,
-        specialization: Option<Specialization<'db>>,
-    ) -> Option<Self> {
+    fn from_static_class(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> Option<Self> {
         if class.dataclass_params(db).is_none()
             && class.known(db).is_none()
             && !class.has_explicit_bases(db)
@@ -106,13 +101,12 @@ impl<'db> CodeGeneratorKind<'db> {
             return None;
         }
 
-        #[salsa::tracked(cycle_initial=|_, _, _, _| None,
+        #[salsa::tracked(cycle_initial=|_, _, _| None,
             heap_size=ruff_memory_usage::heap_size
         )]
         fn code_generator_of_static_class<'db>(
             db: &'db dyn Db,
             class: StaticClassLiteral<'db>,
-            specialization: Option<Specialization<'db>>,
         ) -> Option<CodeGeneratorKind<'db>> {
             // If a class is directly decorated as a dataclass, it's a dataclass.
             // If a class' metaclass is a dataclass transformer, it's a dataclass.
@@ -135,7 +129,7 @@ impl<'db> CodeGeneratorKind<'db> {
                     )
                 })
                 && let Some(transformer_params) =
-                    class.iter_mro(db, specialization).skip(1).find_map(|base| {
+                    class.iter_mro(db, None).skip(1).find_map(|base| {
                         base.into_class().and_then(|class| {
                             class
                                 .static_class_literal(db)
@@ -156,7 +150,7 @@ impl<'db> CodeGeneratorKind<'db> {
             }
         }
 
-        code_generator_of_static_class(db, class, specialization)
+        code_generator_of_static_class(db, class)
     }
 
     fn from_dynamic_class(db: &'db dyn Db, class: DynamicClassLiteral<'db>) -> Option<Self> {
@@ -184,17 +178,9 @@ impl<'db> CodeGeneratorKind<'db> {
         code_generator_of_dynamic_class(db, class)
     }
 
-    pub(super) fn matches(
-        self,
-        db: &'db dyn Db,
-        class: ClassLiteral<'db>,
-        specialization: Option<Specialization<'db>>,
-    ) -> bool {
+    pub(super) fn matches(self, db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
         matches!(
-            (
-                CodeGeneratorKind::from_class(db, class, specialization),
-                self
-            ),
+            (CodeGeneratorKind::from_class(db, class), self),
             (Some(Self::DataclassLike(_)), Self::DataclassLike(_))
                 | (Some(Self::NamedTuple), Self::NamedTuple)
                 | (Some(Self::TypedDict), Self::TypedDict)

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -395,7 +395,7 @@ impl<'db> DynamicClassLiteral<'db> {
     ) -> PlaceAndQualifiers<'db> {
         // Check if this dynamic class is dataclass-like (via dataclass_transform inheritance).
         if matches!(
-            CodeGeneratorKind::from_class(db, self.into(), None),
+            CodeGeneratorKind::from_class(db, self.into()),
             Some(CodeGeneratorKind::DataclassLike(_))
         ) {
             if name == "__dataclass_fields__" {

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -1710,7 +1710,7 @@ impl KnownClass {
                         };
 
                         // Check if the enclosing class is a `NamedTuple`, which forbids the use of `super()`.
-                        if CodeGeneratorKind::NamedTuple.matches(db, enclosing_class.into(), None) {
+                        if CodeGeneratorKind::NamedTuple.matches(db, enclosing_class.into()) {
                             if let Some(builder) = context
                                 .report_lint(&SUPER_CALL_IN_NAMED_TUPLE_METHOD, call_expression)
                             {
@@ -1764,11 +1764,7 @@ impl KnownClass {
                     [Some(pivot_class_type), Some(owner_type)] => {
                         // Check if the enclosing class is a `NamedTuple`, which forbids the use of `super()`.
                         if let Some(enclosing_class) = nearest_enclosing_class(db, index, scope) {
-                            if CodeGeneratorKind::NamedTuple.matches(
-                                db,
-                                enclosing_class.into(),
-                                None,
-                            ) {
+                            if CodeGeneratorKind::NamedTuple.matches(db, enclosing_class.into()) {
                                 if let Some(builder) = context
                                     .report_lint(&SUPER_CALL_IN_NAMED_TUPLE_METHOD, call_expression)
                                 {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -136,7 +136,7 @@ impl<'db> StaticClassLiteral<'db> {
     /// `dataclass_transform` (function-based, metaclass-based, and base-class-based).
     pub(crate) fn is_dataclass_like(self, db: &'db dyn Db) -> bool {
         matches!(
-            CodeGeneratorKind::from_class(db, ClassLiteral::Static(self), None),
+            CodeGeneratorKind::from_class(db, ClassLiteral::Static(self)),
             Some(CodeGeneratorKind::DataclassLike(_))
         )
     }
@@ -804,7 +804,7 @@ impl<'db> StaticClassLiteral<'db> {
         }
 
         if let field_policy @ CodeGeneratorKind::DataclassLike(_) =
-            CodeGeneratorKind::from_class(db, self.into(), None)?
+            CodeGeneratorKind::from_class(db, self.into())?
         {
             // Otherwise, if this class is a dataclass-like class, determine its frozen status based on
             // dataclass params and dataclass transformer params.
@@ -1120,7 +1120,7 @@ impl<'db> StaticClassLiteral<'db> {
     ) -> Member<'db> {
         // Check if this class is dataclass-like (either via @dataclass or via dataclass_transform)
         if matches!(
-            CodeGeneratorKind::from_class(db, self.into(), specialization),
+            CodeGeneratorKind::from_class(db, self.into()),
             Some(CodeGeneratorKind::DataclassLike(_))
         ) {
             if name == "__dataclass_fields__" {
@@ -1143,7 +1143,7 @@ impl<'db> StaticClassLiteral<'db> {
             }
         }
 
-        if CodeGeneratorKind::NamedTuple.matches(db, self.into(), specialization) {
+        if CodeGeneratorKind::NamedTuple.matches(db, self.into()) {
             if let Some(field) = self
                 .own_fields(db, specialization, CodeGeneratorKind::NamedTuple)
                 .get(name)
@@ -1206,7 +1206,7 @@ impl<'db> StaticClassLiteral<'db> {
             .place
             .raw_type()
             .is_some_and(|ty| ty.is_instance_of(db, KnownClass::KwOnly))
-            && CodeGeneratorKind::from_static_class(db, self, None)
+            && CodeGeneratorKind::from_static_class(db, self)
                 .is_some_and(|policy| matches!(policy, CodeGeneratorKind::DataclassLike(_)))
         {
             return Member::unbound();
@@ -1299,7 +1299,7 @@ impl<'db> StaticClassLiteral<'db> {
             return Some(synthesized_setattr);
         }
 
-        let field_policy = CodeGeneratorKind::from_class(db, self.into(), specialization)?;
+        let field_policy = CodeGeneratorKind::from_class(db, self.into())?;
 
         let instance_ty =
             Type::instance(db, self.apply_optional_specialization(db, specialization));
@@ -1655,7 +1655,7 @@ impl<'db> StaticClassLiteral<'db> {
         db: &'db dyn Db,
         specialization: Option<Specialization<'db>>,
     ) -> Option<Type<'db>> {
-        if CodeGeneratorKind::from_static_class(db, self, specialization).is_some() {
+        if CodeGeneratorKind::from_static_class(db, self).is_some() {
             return None;
         }
 
@@ -1727,7 +1727,7 @@ impl<'db> StaticClassLiteral<'db> {
 
             if base_class.is_frozen_dataclass(db) == Some(true) {
                 let field_policy @ CodeGeneratorKind::DataclassLike(_) =
-                    CodeGeneratorKind::from_static_class(db, base_class, base_specialization)?
+                    CodeGeneratorKind::from_static_class(db, base_class)?
                 else {
                     return None;
                 };
@@ -1824,7 +1824,7 @@ impl<'db> StaticClassLiteral<'db> {
                 let class = superclass.into_class()?;
 
                 if let Some((class_literal, specialization)) = class.static_class_literal(db) {
-                    if field_policy.matches(db, class_literal.into(), specialization) {
+                    if field_policy.matches(db, class_literal.into()) {
                         return Some(FieldSource::Static(class_literal, specialization));
                     }
                 }
@@ -1872,7 +1872,7 @@ impl<'db> StaticClassLiteral<'db> {
 
     pub(crate) fn validate_members(self, context: &InferContext<'db, '_>) {
         let db = context.db();
-        let Some(field_policy) = CodeGeneratorKind::from_static_class(db, self, None) else {
+        let Some(field_policy) = CodeGeneratorKind::from_static_class(db, self) else {
             return;
         };
         let class_body_scope = self.body_scope(db);
@@ -2501,7 +2501,7 @@ impl<'db> StaticClassLiteral<'db> {
         // NamedTuple fields are modeled via synthesized descriptors on the class. Treating them
         // as instance attributes here causes inherited fields to leak through after a subclass
         // shadows the name with a normal class attribute.
-        if CodeGeneratorKind::NamedTuple.matches(db, self.into(), None)
+        if CodeGeneratorKind::NamedTuple.matches(db, self.into())
             && self
                 .own_fields(db, None, CodeGeneratorKind::NamedTuple)
                 .contains_key(name)
@@ -2547,9 +2547,9 @@ impl<'db> StaticClassLiteral<'db> {
 
                     // `KW_ONLY` sentinels are markers, not real instance attributes.
                     if declared_ty.is_instance_of(db, KnownClass::KwOnly)
-                        && CodeGeneratorKind::from_static_class(db, self, None).is_some_and(
-                            |policy| matches!(policy, CodeGeneratorKind::DataclassLike(_)),
-                        )
+                        && CodeGeneratorKind::from_static_class(db, self).is_some_and(|policy| {
+                            matches!(policy, CodeGeneratorKind::DataclassLike(_))
+                        })
                     {
                         return Member::unbound();
                     }
@@ -2686,7 +2686,7 @@ impl<'db> StaticClassLiteral<'db> {
     /// implicitly assigned in `__init__`, so they behave as instance attributes
     /// even though no explicit binding exists in the class body.
     fn is_own_dataclass_instance_field(self, db: &'db dyn Db, name: &str) -> bool {
-        let Some(field_policy) = CodeGeneratorKind::from_static_class(db, self, None) else {
+        let Some(field_policy) = CodeGeneratorKind::from_static_class(db, self) else {
             return false;
         };
         if !matches!(field_policy, CodeGeneratorKind::DataclassLike(_)) {
@@ -2713,7 +2713,7 @@ impl<'db> StaticClassLiteral<'db> {
         db: &'db dyn Db,
         name: &str,
     ) -> Option<Type<'db>> {
-        let field_policy = CodeGeneratorKind::from_static_class(db, self, None)?;
+        let field_policy = CodeGeneratorKind::from_static_class(db, self)?;
         if !matches!(field_policy, CodeGeneratorKind::DataclassLike(_)) {
             return None;
         }
@@ -2953,7 +2953,7 @@ impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
             .map(|class| class.variance_of(db, typevar));
 
         let default_attribute_variance = {
-            let is_namedtuple = CodeGeneratorKind::NamedTuple.matches(db, self.into(), None);
+            let is_namedtuple = CodeGeneratorKind::NamedTuple.matches(db, self.into());
             // Python 3.13 introduced a synthesized `__replace__` method on dataclasses which uses
             // their field types in contravariant position, thus meaning a frozen dataclass must
             // still be invariant in its field types. Other synthesized methods on dataclasses are
@@ -2962,7 +2962,7 @@ impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
             // methods, so we just look them up normally and don't hardcode this knowledge here.
             let is_frozen_dataclass_prior_to_313 = Program::get(db).python_version(db)
                 <= PythonVersion::PY312
-                && CodeGeneratorKind::from_static_class(db, self, None)
+                && CodeGeneratorKind::from_static_class(db, self)
                     .is_some_and(|kind| self.has_dataclass_param(db, kind, DataclassFlags::FROZEN));
 
             if is_namedtuple || is_frozen_dataclass_prior_to_313 {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -592,7 +592,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .map(|params| SmallVec::from(params.field_specifiers(db)))
                 .or_else(|| {
                     Some(SmallVec::from(
-                        CodeGeneratorKind::from_class(db, class_literal.into(), None)?
+                        CodeGeneratorKind::from_class(db, class_literal.into())?
                             .dataclass_transformer_params()?
                             .field_specifiers(db),
                     ))
@@ -4498,7 +4498,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let nearest_enclosing_class =
                     nearest_enclosing_class(self.db(), self.index, self.scope());
                 let class_kind = nearest_enclosing_class.and_then(|class| {
-                    CodeGeneratorKind::from_class(self.db(), ClassLiteral::Static(class), None)
+                    CodeGeneratorKind::from_class(self.db(), ClassLiteral::Static(class))
                 });
 
                 match class_kind {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -111,7 +111,7 @@ pub(crate) fn check_static_class_definitions<'db>(
         }
     }
 
-    let class_kind = CodeGeneratorKind::from_class(db, class.into(), None);
+    let class_kind = CodeGeneratorKind::from_class(db, class.into());
 
     // If it's a `NamedTuple` class, check that no field without a default value
     // appears after a field with a default value.
@@ -878,7 +878,7 @@ pub(crate) fn check_static_class_definitions<'db>(
     // Check that a dataclass does not have more than one `KW_ONLY`
     // and that required fields are defined before default fields.
     if let Some(field_policy @ CodeGeneratorKind::DataclassLike(_)) =
-        CodeGeneratorKind::from_class(db, class.into(), None)
+        CodeGeneratorKind::from_class(db, class.into())
     {
         let specialization = None;
 
@@ -1346,7 +1346,7 @@ fn check_class_final_without_value<'db>(
 
     // In dataclasses (and similar code-generated classes), Final fields without
     // defaults are initialized by the synthesized __init__, so they are valid.
-    if CodeGeneratorKind::from_class(db, class.into(), None).is_some() {
+    if CodeGeneratorKind::from_class(db, class.into()).is_some() {
         return;
     }
 

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -19,7 +19,6 @@ use crate::{
     types::{
         ClassBase, ClassLiteral, KnownClass, KnownInstanceType, StaticClassLiteral,
         SubclassOfInner, Type, TypeVarBoundOrConstraints, class::CodeGeneratorKind,
-        generics::Specialization,
     },
 };
 use ty_python_core::{
@@ -207,18 +206,13 @@ impl<'db> AllMembers<'db> {
 
             Type::NominalInstance(instance) => {
                 let class = instance.class(db);
-                if let Some((class_literal, specialization)) = class.static_class_literal(db) {
+                if let Some((class_literal, _)) = class.static_class_literal(db) {
                     self.extend_with_instance_members(db, ty, class_literal);
-                    self.extend_with_synthetic_members(
-                        db,
-                        ty,
-                        ClassLiteral::Static(class_literal),
-                        specialization,
-                    );
+                    self.extend_with_synthetic_members(db, ty, ClassLiteral::Static(class_literal));
                 } else {
                     // For dynamic classes, we can't enumerate instance members (requires body scope),
                     // but we can still add synthetic members for dataclass-like classes.
-                    self.extend_with_synthetic_members(db, ty, class.class_literal(db), None);
+                    self.extend_with_synthetic_members(db, ty, class.class_literal(db));
                 }
             }
 
@@ -240,19 +234,14 @@ impl<'db> AllMembers<'db> {
 
             Type::ClassLiteral(class_literal) => {
                 self.extend_with_class_members(db, ty, class_literal);
-                self.extend_with_synthetic_members(db, ty, class_literal, None);
+                self.extend_with_synthetic_members(db, ty, class_literal);
                 self.extend_with_metaclass_members(db, ty, class_literal.metaclass(db));
             }
 
             Type::GenericAlias(generic_alias) => {
                 let class_literal = generic_alias.origin(db);
                 self.extend_with_class_members(db, ty, ClassLiteral::Static(class_literal));
-                self.extend_with_synthetic_members(
-                    db,
-                    ty,
-                    ClassLiteral::Static(class_literal),
-                    None,
-                );
+                self.extend_with_synthetic_members(db, ty, ClassLiteral::Static(class_literal));
                 self.extend_with_metaclass_members(db, ty, class_literal.metaclass(db));
             }
 
@@ -262,9 +251,7 @@ impl<'db> AllMembers<'db> {
                 }
                 _ => {
                     if let Some(class_type) = subclass_of_type.subclass_of().into_class(db) {
-                        if let Some((class_literal, specialization)) =
-                            class_type.static_class_literal(db)
-                        {
+                        if let Some((class_literal, _)) = class_type.static_class_literal(db) {
                             self.extend_with_class_members(
                                 db,
                                 ty,
@@ -274,7 +261,6 @@ impl<'db> AllMembers<'db> {
                                 db,
                                 ty,
                                 ClassLiteral::Static(class_literal),
-                                specialization,
                             );
                             self.extend_with_metaclass_members(db, ty, class_literal.metaclass(db));
                         }
@@ -575,9 +561,8 @@ impl<'db> AllMembers<'db> {
         db: &'db dyn Db,
         ty: Type<'db>,
         class_literal: ClassLiteral<'db>,
-        specialization: Option<Specialization<'db>>,
     ) {
-        match CodeGeneratorKind::from_class(db, class_literal, specialization) {
+        match CodeGeneratorKind::from_class(db, class_literal) {
             Some(CodeGeneratorKind::NamedTuple) => {
                 if ty.is_nominal_instance() {
                     self.extend_with_type(db, KnownClass::NamedTupleFallback.to_instance(db));

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -99,8 +99,7 @@ fn conflicting_named_tuple_field_in_mro<'db>(
         let (superclass_literal, superclass_specialization) =
             superclass.class_literal_and_specialization(db);
 
-        if CodeGeneratorKind::NamedTuple.matches(db, superclass_literal, superclass_specialization)
-        {
+        if CodeGeneratorKind::NamedTuple.matches(db, superclass_literal) {
             match superclass_literal {
                 ClassLiteral::Static(superclass_literal) => {
                     if let Some(field) = superclass_literal
@@ -151,10 +150,10 @@ fn check_class_declaration<'db>(
         return;
     };
 
-    let Some((literal, specialization)) = class.static_class_literal(db) else {
+    let Some((literal, _)) = class.static_class_literal(db) else {
         return;
     };
-    let class_kind = CodeGeneratorKind::from_class(db, literal.into(), specialization);
+    let class_kind = CodeGeneratorKind::from_class(db, literal.into());
 
     // Check for prohibited `NamedTuple` attribute overrides.
     //
@@ -360,13 +359,9 @@ fn check_class_declaration<'db>(
                 {
                     continue;
                 }
-                method_kind = CodeGeneratorKind::from_class(
-                    db,
-                    superclass_literal.into(),
-                    superclass_specialization,
-                )
-                .map(MethodKind::Synthesized)
-                .unwrap_or_default();
+                method_kind = CodeGeneratorKind::from_class(db, superclass_literal.into())
+                    .map(MethodKind::Synthesized)
+                    .unwrap_or_default();
             }
 
             let superclass_instance_member =


### PR DESCRIPTION
## Summary

`CodeGeneratorKind::from_class` currently keys its retained Salsa query by both the class and its specialization, even though type arguments cannot change whether a class is dataclass-like, a `NamedTuple`, or a `TypedDict`. Generic classes therefore retain duplicate classification entries for each specialization.

This removes specialization from the classification query and evaluates inherited code-generator behavior through the unspecialized MRO. Synthesized field and member types continue to use their specialization at the existing call sites; the added generic `dataclass_transform` coverage verifies that `GenericModel[int]` and `GenericModel[str]` retain distinct constructor types.
