### PR TITLE
[ty] Avoid retaining simple specialized MROs

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -704,6 +704,68 @@ class Sub(Intermediate[T], Base): ...
 reveal_mro(Sub)
 ```
 
+## Specializing generic ancestors
+
+Specializing a generic class also specializes type variables used by indirect ancestors:
+
+```py
+from typing import Generic, TypeVar
+from ty_extensions import reveal_mro
+
+T = TypeVar("T")
+U = TypeVar("U")
+V = TypeVar("V")
+
+class A(Generic[T]): ...
+class B(A[list[U]], Generic[U]): ...
+class C(B[V], Generic[V]): ...
+
+reveal_mro(C[int])  # revealed: (<class 'C[int]'>, <class 'B[int]'>, <class 'A[list[int]]'>, typing.Generic, <class 'object'>)
+reveal_mro(C[str])  # revealed: (<class 'C[str]'>, <class 'B[str]'>, <class 'A[list[str]]'>, typing.Generic, <class 'object'>)
+```
+
+Specialization can change both the entries in an MRO and their C3 ordering. When an MRO contains
+multiple aliases of the same generic class, it must be recomputed rather than produced by
+substituting type variables in an existing MRO:
+
+```py
+from typing import Generic, TypeVar
+from ty_extensions import reveal_mro
+
+T = TypeVar("T")
+
+class GenericBase(Generic[T]): ...
+class Left(GenericBase[T]): ...
+class Combined(Left, GenericBase[T]): ...  # error: [missing-type-argument]
+class Outer(Combined, object): ...  # error: [missing-type-argument]
+
+# revealed: (<class 'Combined[int]'>, <class 'Left[Unknown]'>, <class 'GenericBase[Unknown]'>, <class 'GenericBase[int]'>, typing.Generic, <class 'object'>)
+reveal_mro(Combined[int])
+
+# revealed: (<class 'Outer'>, <class 'Combined[Unknown]'>, <class 'Left[Unknown]'>, <class 'GenericBase[Unknown]'>, typing.Generic, <class 'object'>)
+reveal_mro(Outer)
+```
+
+```py
+from typing import Generic, TypeVar
+from ty_extensions import reveal_mro
+
+T = TypeVar("T")
+
+class PredictionModel(Generic[T]): ...
+class RegressionModel(PredictionModel[T]): ...
+class JavaPredictionModel(PredictionModel[T]): ...
+class JavaRegressionModel(RegressionModel, JavaPredictionModel[T]): ...  # error: [missing-type-argument]
+class DecisionTreeModel(JavaPredictionModel[T]): ...
+
+# error: 16 [missing-type-argument]
+# error: 37 [missing-type-argument]
+class Combined(JavaRegressionModel, DecisionTreeModel): ...
+
+# revealed: (<class 'Combined'>, <class 'JavaRegressionModel[Unknown]'>, <class 'RegressionModel[Unknown]'>, <class 'DecisionTreeModel[Unknown]'>, <class 'JavaPredictionModel[Unknown]'>, <class 'PredictionModel[Unknown]'>, typing.Generic, <class 'object'>)
+reveal_mro(Combined)
+```
+
 ## Unresolvable MROs involving generics have the original bases reported in the error message, not the resolved bases
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -44,7 +44,7 @@ use crate::{
         infer_expression_type, inferred_declaration,
         known_instance::DeprecatedInstance,
         member::{Member, class_member},
-        mro::{Mro, MroIterator},
+        mro::{Mro, MroIterator, MroTemplate},
         signatures::CallableSignature,
         tuple::{FixedLengthTuple, Tuple},
         typed_dict::{TypedDictParams, typed_dict_params_from_class_def},
@@ -655,6 +655,28 @@ impl<'db> StaticClassLiteral<'db> {
     ) -> Result<Mro<'db>, StaticMroError<'db>> {
         tracing::trace!("StaticClassLiteral::try_mro: {}", self.name(db));
         Mro::of_static_class(db, self, specialization)
+    }
+
+    /// Return an MRO template that maps the class's type variables to themselves.
+    #[salsa::tracked(
+        returns(as_ref),
+        cycle_initial=|db, _, self_: StaticClassLiteral<'db>| {
+            Err(StaticMroError::cycle(db, self_.identity_specialization(db)))
+        },
+        heap_size=ruff_memory_usage::heap_size
+    )]
+    pub(crate) fn try_mro_template(
+        self,
+        db: &'db dyn Db,
+    ) -> Result<MroTemplate<'db>, StaticMroError<'db>> {
+        tracing::trace!("StaticClassLiteral::try_mro_template: {}", self.name(db));
+        Mro::of_static_class(
+            db,
+            self,
+            self.generic_context(db)
+                .map(|generic_context| generic_context.identity_specialization(db)),
+        )
+        .map(MroTemplate::new)
     }
 
     /// Iterate over the [method resolution order] ("MRO") of the class.

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -1,11 +1,10 @@
 use crate::types::class::CodeGeneratorKind;
-use crate::types::generics::{ApplySpecialization, Specialization};
+use crate::types::generics::Specialization;
 use crate::types::mro::MroIterator;
 use crate::types::tuple::TupleType;
 use crate::types::{
-    ApplyTypeMappingVisitor, ClassLiteral, ClassType, DivergentType, DynamicType, KnownClass,
-    KnownInstanceType, MaterializationKind, SpecialFormType, StaticMroError, Type, TypeContext,
-    TypeMapping, todo_type,
+    ClassLiteral, ClassType, DivergentType, DynamicType, GenericAlias, KnownClass,
+    KnownInstanceType, SpecialFormType, StaticMroError, Type, todo_type,
 };
 use crate::{Db, DisplaySettings};
 
@@ -309,18 +308,26 @@ impl<'db> ClassBase<'db> {
         }
     }
 
-    fn apply_type_mapping_impl<'a>(
+    pub(crate) fn apply_optional_specialization(
         self,
         db: &'db dyn Db,
-        type_mapping: &TypeMapping<'a, 'db>,
-        tcx: TypeContext<'db>,
-        visitor: &ApplyTypeMappingVisitor<'db>,
+        specialization: Option<Specialization<'db>>,
     ) -> Self {
+        let Some(specialization) = specialization else {
+            return self;
+        };
         match self {
-            Self::Class(class) => {
-                Self::Class(class.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+            Self::Class(ClassType::Generic(alias)) => {
+                Self::Class(ClassType::Generic(GenericAlias::new(
+                    db,
+                    alias.origin(db),
+                    alias
+                        .specialization(db)
+                        .apply_specialization(db, specialization),
+                )))
             }
-            Self::Dynamic(_)
+            Self::Class(ClassType::NonGeneric(_))
+            | Self::Dynamic(_)
             | Self::Divergent(_)
             | Self::Generic
             | Self::Protocol
@@ -328,42 +335,10 @@ impl<'db> ClassBase<'db> {
         }
     }
 
-    pub(crate) fn apply_optional_specialization(
-        self,
-        db: &'db dyn Db,
-        specialization: Option<Specialization<'db>>,
-    ) -> Self {
-        if let Some(specialization) = specialization {
-            let new_self = self.apply_type_mapping_impl(
-                db,
-                &TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
-                    specialization,
-                )),
-                TypeContext::default(),
-                &ApplyTypeMappingVisitor::default(),
-            );
-            match specialization.materialization_kind(db) {
-                None => new_self,
-                Some(materialization_kind) => new_self.materialize(db, materialization_kind),
-            }
-        } else {
-            self
-        }
-    }
-
-    fn materialize(self, db: &'db dyn Db, kind: MaterializationKind) -> Self {
-        self.apply_type_mapping_impl(
-            db,
-            &TypeMapping::Materialize(kind),
-            TypeContext::default(),
-            &ApplyTypeMappingVisitor::default(),
-        )
-    }
-
     pub(super) fn has_cyclic_mro(self, db: &'db dyn Db) -> bool {
         match self {
             ClassBase::Class(class) => {
-                let Some((class_literal, specialization)) = class.static_class_literal(db) else {
+                let ClassLiteral::Static(class_literal) = class.class_literal(db) else {
                     // Dynamic classes can't have cyclic MRO since their bases must
                     // already exist at creation time. Unlike statement classes, we do not
                     // permit dynamic classes to have forward references in their
@@ -371,7 +346,7 @@ impl<'db> ClassBase<'db> {
                     return false;
                 };
                 class_literal
-                    .try_mro(db, specialization)
+                    .try_mro(db, None)
                     .is_err_and(StaticMroError::is_cycle)
             }
             ClassBase::Dynamic(_)

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -37,6 +37,18 @@ use itertools::Itertools;
 pub(crate) struct Mro<'db>(Box<[ClassBase<'db>]>);
 
 impl<'db> Mro<'db> {
+    /// Return whether this MRO can be specialized lazily without a meaningful runtime cost.
+    fn can_specialize_lazily(&self) -> bool {
+        // Specialization can only change the C3 ordering if multiple aliases have the same origin.
+        // Even with distinct origins, repeatedly specializing several aliases is slower than
+        // loading the specialization-specific MRO, so keep the lazy path to at most one alias.
+        self.iter()
+            .filter(|base| matches!(base, ClassBase::Class(ClassType::Generic(_))))
+            .take(2)
+            .count()
+            <= 1
+    }
+
     /// Attempt to resolve the MRO of a given class. Because we derive the MRO from the list of
     /// base classes in the class definition, this operation is performed on a [class
     /// literal][StaticClassLiteral], not a [class type][ClassType]. (You can _also_ get the MRO of a
@@ -46,8 +58,7 @@ impl<'db> Mro<'db> {
     /// In the event that a possible list of bases would (or could) lead to a `TypeError` being
     /// raised at runtime due to an unresolvable MRO, we infer the MRO of the class as being `[<the
     /// class in question>, Unknown, object]`. This seems most likely to reduce the possibility of
-    /// cascading errors elsewhere. (For a generic class, the first entry in this fallback MRO uses
-    /// the default specialization of the class's type variables.)
+    /// cascading errors elsewhere.
     ///
     /// (We emit a diagnostic warning about the runtime `TypeError` in
     /// [`super::infer::infer_scope_types`].)
@@ -516,6 +527,22 @@ impl<'db> Mro<'db> {
     }
 }
 
+#[derive(PartialEq, Eq, Clone, Debug, salsa::Update, get_size2::GetSize)]
+pub(super) struct MroTemplate<'db> {
+    mro: Mro<'db>,
+    can_specialize_lazily: bool,
+}
+
+impl<'db> MroTemplate<'db> {
+    pub(super) fn new(mro: Mro<'db>) -> Self {
+        let can_specialize_lazily = mro.can_specialize_lazily();
+        Self {
+            mro,
+            can_specialize_lazily,
+        }
+    }
+}
+
 impl<'db, const N: usize> From<[ClassBase<'db>; N]> for Mro<'db> {
     fn from(value: [ClassBase<'db>; N]) -> Self {
         Self(Box::from(value))
@@ -567,7 +594,7 @@ pub(crate) struct MroIterator<'db> {
     /// The class whose MRO we're iterating over
     class: ClassLiteral<'db>,
 
-    /// The specialization to apply to each MRO element, if any
+    /// The specialization to use when computing the MRO, if any.
     specialization: Option<Specialization<'db>>,
 
     /// Whether or not we've already yielded the first element of the MRO
@@ -578,7 +605,69 @@ pub(crate) struct MroIterator<'db> {
     /// The full MRO is expensive to materialize, so this field is `None`
     /// unless we actually *need* to iterate past the first element of the MRO,
     /// at which point it is lazily materialized.
-    subsequent_elements: Option<std::slice::Iter<'db, ClassBase<'db>>>,
+    subsequent_elements: Option<MroElements<'db>>,
+}
+
+#[derive(Clone)]
+enum MroElements<'db> {
+    Cached(std::slice::Iter<'db, ClassBase<'db>>),
+    Template {
+        elements: std::slice::Iter<'db, ClassBase<'db>>,
+        db: &'db dyn Db,
+        specialization: Specialization<'db>,
+    },
+}
+
+impl<'db> MroElements<'db> {
+    fn cached(mro: &'db Mro<'db>) -> Self {
+        let mut elements = mro.iter();
+        elements.next();
+        Self::Cached(elements)
+    }
+
+    fn template(mro: &'db Mro<'db>, db: &'db dyn Db, specialization: Specialization<'db>) -> Self {
+        let mut elements = mro.iter();
+        elements.next();
+        Self::Template {
+            elements,
+            db,
+            specialization,
+        }
+    }
+}
+
+impl<'db> Iterator for MroElements<'db> {
+    type Item = ClassBase<'db>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Cached(elements) => elements.next().copied(),
+            Self::Template {
+                elements,
+                db,
+                specialization,
+            } => elements
+                .next()
+                .copied()
+                .map(|base| base.apply_optional_specialization(*db, Some(*specialization))),
+        }
+    }
+}
+
+impl DoubleEndedIterator for MroElements<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Cached(elements) => elements.next_back().copied(),
+            Self::Template {
+                elements,
+                db,
+                specialization,
+            } => elements
+                .next_back()
+                .copied()
+                .map(|base| base.apply_optional_specialization(*db, Some(*specialization))),
+        }
+    }
 }
 
 impl<'db> MroIterator<'db> {
@@ -618,42 +707,50 @@ impl<'db> MroIterator<'db> {
 
     /// Materialize the full MRO of the class.
     /// Return an iterator over that MRO which skips the first element of the MRO.
-    fn full_mro_except_first_element(&mut self) -> &mut std::slice::Iter<'db, ClassBase<'db>> {
+    fn full_mro_except_first_element(&mut self) -> &mut MroElements<'db> {
         self.subsequent_elements
             .get_or_insert_with(|| match self.class {
                 ClassLiteral::Static(literal) => {
-                    let mut full_mro_iter = match literal.try_mro(self.db, self.specialization) {
-                        Ok(mro) => mro.iter(),
-                        Err(error) => error.fallback_mro().iter(),
-                    };
-                    full_mro_iter.next();
-                    full_mro_iter
+                    if let Some(specialization) = self.specialization {
+                        match literal.try_mro_template(self.db) {
+                            Ok(template) if template.can_specialize_lazily => {
+                                MroElements::template(&template.mro, self.db, specialization)
+                            }
+                            Ok(_) | Err(_) => {
+                                let mro = match literal.try_mro(self.db, Some(specialization)) {
+                                    Ok(mro) => mro,
+                                    Err(error) => error.fallback_mro(),
+                                };
+                                MroElements::cached(mro)
+                            }
+                        }
+                    } else {
+                        let mro = match literal.try_mro(self.db, None) {
+                            Ok(mro) => mro,
+                            Err(error) => error.fallback_mro(),
+                        };
+                        MroElements::cached(mro)
+                    }
                 }
                 ClassLiteral::Dynamic(literal) => {
-                    let mut full_mro_iter = match literal.try_mro(self.db) {
-                        Ok(mro) => mro.iter(),
-                        Err(error) => error.fallback_mro().iter(),
+                    let mro = match literal.try_mro(self.db) {
+                        Ok(mro) => mro,
+                        Err(error) => error.fallback_mro(),
                     };
-                    full_mro_iter.next();
-                    full_mro_iter
+                    MroElements::cached(mro)
                 }
                 ClassLiteral::DynamicNamedTuple(literal) => {
-                    let mut full_mro_iter = literal.mro(self.db).iter();
-                    full_mro_iter.next();
-                    full_mro_iter
+                    MroElements::cached(literal.mro(self.db))
                 }
                 ClassLiteral::DynamicTypedDict(literal) => {
-                    let mut full_mro_iter = literal.mro(self.db).iter();
-                    full_mro_iter.next();
-                    full_mro_iter
+                    MroElements::cached(literal.mro(self.db))
                 }
                 ClassLiteral::DynamicEnum(literal) => {
-                    let mut full_mro_iter = match literal.try_mro(self.db) {
-                        Ok(mro) => mro.iter(),
-                        Err(error) => error.fallback_mro().iter(),
+                    let mro = match literal.try_mro(self.db) {
+                        Ok(mro) => mro,
+                        Err(error) => error.fallback_mro(),
                     };
-                    full_mro_iter.next();
-                    full_mro_iter
+                    MroElements::cached(mro)
                 }
             })
     }
@@ -667,7 +764,7 @@ impl<'db> Iterator for MroIterator<'db> {
             self.first_element_yielded = true;
             return Some(self.first_element());
         }
-        self.full_mro_except_first_element().next().copied()
+        self.full_mro_except_first_element().next()
     }
 }
 
@@ -677,7 +774,6 @@ impl DoubleEndedIterator for MroIterator<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.full_mro_except_first_element()
             .next_back()
-            .copied()
             .or_else(|| {
                 if self.first_element_yielded {
                     None


### PR DESCRIPTION
## Summary

`StaticClassLiteral::try_mro` currently retains a separate Salsa result for every specialization of a generic class, even though most specialized MROs differ only in their type arguments.

This adds one identity-specialized MRO template per generic class. If that template contains at most one inherited generic alias, applying a specialization cannot change any equality comparison observed by C3 and the iterator can cheaply specialize the cached template as it yields the alias. Longer MROs, repeated generic origins, and templates that are not resolvable fall back to the existing specialization-specific tracked query.

The fallback is required for correctness because specialization can make previously distinct aliases equal and change the C3 linearization. Apache Spark has a hierarchy where the specialized MRO must place `DecisionTreeModel` before `JavaPredictionModel[Unknown]`; blindly preserving the identity-specialized order produced a false `inconsistent-mro` diagnostic.

Applying a specialization to an MRO entry composes the interned `Specialization` values directly instead of invoking the general type-mapping visitor for the entire `ClassBase`. The Spark, SymPy, and Home Assistant diagnostic outputs are byte-for-byte identical to the base revision at the ecosystem revisions used by CI.
