### PR TITLE
[ty] Correct Self binding for intersection refinements

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -459,6 +459,17 @@ def literal_refinement(value: LiteralEnum):
         reveal_type(value.other())  # revealed: LiteralEnum
         # error: [invalid-argument-type]
         accepts_literal_a(value.other())
+
+LiteralReceiver = TypeVar(
+    "LiteralReceiver",
+    Literal[LiteralEnum.A],
+    Literal[LiteralEnum.B],
+)
+
+def constrained_literal_refinement(value: LiteralReceiver) -> LiteralReceiver:
+    reveal_type(value.other())  # revealed: LiteralEnum
+    # error: [invalid-return-type]
+    return value.other()
 ```
 
 ## typing_extensions

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -489,17 +489,13 @@ def union_bounded_self[T: UnionSelfA | UnionSelfB](
     # error: [invalid-argument-type]
     reveal_type(value.copy_from(plain))  # revealed: T@union_bounded_self & UnionSelfExtra
 
-type DefaultdictSpec = None | int | Iterable[int] | dict[str, int]
-
-def is_mapping(value: object) -> bool:
-    return isinstance(value, dict)
+type DefaultdictSpec = Iterable[int] | dict[str, int]
 
 def copy_defaultdict(value: DefaultdictSpec) -> DefaultdictSpec:
-    if is_mapping(value) and isinstance(value, defaultdict):
-        copied = value.copy()
+    if isinstance(value, defaultdict):
         # revealed: (Iterable[int] & Top[defaultdict[Unknown, Unknown]]) | (dict[str, int] & Top[defaultdict[Unknown, Unknown]])
-        reveal_type(copied)
-        value = copied
+        reveal_type(value.copy())
+        value = value.copy()
     return value
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -19,6 +19,9 @@ class Shape:
         reveal_type(self)  # revealed: Self@set_scale
         return self
 
+    def make[T = Self](self) -> T:
+        raise NotImplementedError
+
     def nested_type(self: Self) -> list[Self]:
         return [self]
 
@@ -35,6 +38,7 @@ class Shape:
 
 reveal_type(Shape().nested_type())  # revealed: list[Shape]
 reveal_type(Shape().nested_func())  # revealed: Shape
+reveal_type(Shape().make())  # revealed: Shape
 
 class Circle(Shape):
     def set_scale(self: Self, scale: float) -> Self:

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -387,7 +387,8 @@ def _(value: Intersection[MethodAlias, MethodExtra]):
 ## Intersection receivers bind `Self` before inferring arguments
 
 ```py
-from typing import Protocol, Self, TypeVar
+from enum import Enum
+from typing import Literal, Protocol, Self, TypeVar, cast
 from ty_extensions import AlwaysTruthy, Intersection
 
 class Value:
@@ -444,6 +445,20 @@ def classmethod_intersection(
     # error: [invalid-argument-type]
     cls.copy_from(plain)
     reveal_type(cls.choose_default())  # revealed: ClassmethodValue & ClassmethodExtra
+
+class LiteralEnum(Enum):
+    A = 1
+    B = 2
+
+    def other(self) -> Self:
+        return cast(Self, LiteralEnum.B)
+
+def accepts_literal_a(value: Literal[LiteralEnum.A]) -> None: ...
+def literal_refinement(value: LiteralEnum):
+    if value is LiteralEnum.A:
+        reveal_type(value.other())  # revealed: LiteralEnum
+        # error: [invalid-argument-type]
+        accepts_literal_a(value.other())
 ```
 
 ## typing_extensions

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -375,12 +375,16 @@ class Value:
     def copy_from(self, other: Self) -> Self:
         raise NotImplementedError
 
+    def choose[T = Self](self) -> tuple[T, Self]:
+        raise NotImplementedError
+
 class Extra: ...
 
 def _(value: Intersection[Value, Extra], plain: Value):
     reveal_type(value.copy_from(value))  # revealed: Value & Extra
     # error: [invalid-argument-type]
     reveal_type(value.copy_from(plain))  # revealed: Value & Extra
+    reveal_type(value.choose())  # revealed: tuple[Value & Extra, Value & Extra]
 
 class MixedRefinementMarker(Protocol):
     marker: int

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -378,6 +378,9 @@ class Value:
     def choose[T = Self](self) -> tuple[T, Self]:
         raise NotImplementedError
 
+    def choose_default[T = Self](self) -> T:
+        raise NotImplementedError
+
 class Extra: ...
 
 def _(value: Intersection[Value, Extra], plain: Value):
@@ -385,6 +388,7 @@ def _(value: Intersection[Value, Extra], plain: Value):
     # error: [invalid-argument-type]
     reveal_type(value.copy_from(plain))  # revealed: Value & Extra
     reveal_type(value.choose())  # revealed: tuple[Value & Extra, Value & Extra]
+    reveal_type(value.choose_default())  # revealed: Value & Extra
 
 class MixedRefinementMarker(Protocol):
     marker: int

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -45,6 +45,15 @@ class Circle(Shape):
         reveal_type(self)  # revealed: Self@set_scale
         return self
 
+class ClassmethodBase:
+    @classmethod
+    def make[T = Self](cls) -> T:
+        raise NotImplementedError
+
+class ClassmethodSubclass(ClassmethodBase): ...
+
+reveal_type(ClassmethodSubclass.make())  # revealed: ClassmethodSubclass
+
 class Outer:
     class Inner:
         def foo(self: Self) -> Self:

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -12,7 +12,7 @@ python-version = "3.13"
 ## Methods
 
 ```py
-from typing import Self
+from typing import Callable, Self
 
 class Shape:
     def set_scale(self: Self, scale: float) -> Self:
@@ -58,6 +58,7 @@ class ClassmethodBase:
 class ClassmethodSubclass(ClassmethodBase): ...
 
 reveal_type(ClassmethodSubclass.make())  # revealed: ClassmethodSubclass
+classmethod_make: Callable[[], ClassmethodSubclass] = ClassmethodSubclass.make
 
 class Outer:
     class Inner:

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -470,6 +470,22 @@ def constrained_literal_refinement(value: LiteralReceiver) -> LiteralReceiver:
     reveal_type(value.other())  # revealed: LiteralEnum
     # error: [invalid-return-type]
     return value.other()
+
+class UnionSelfBase:
+    def copy_from(self, other: Self) -> Self:
+        raise NotImplementedError
+
+class UnionSelfA(UnionSelfBase): ...
+class UnionSelfB(UnionSelfBase): ...
+class UnionSelfExtra: ...
+
+def union_bounded_self[T: UnionSelfA | UnionSelfB](
+    value: Intersection[T, UnionSelfExtra],
+    plain: UnionSelfBase,
+):
+    reveal_type(value.copy_from(value))  # revealed: T@union_bounded_self & UnionSelfExtra
+    # error: [invalid-argument-type]
+    reveal_type(value.copy_from(plain))  # revealed: T@union_bounded_self & UnionSelfExtra
 ```
 
 ## typing_extensions

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -362,7 +362,7 @@ class MethodExtra:
     extra: int
 
 def _(value: Intersection[MethodAlias, MethodExtra]):
-    value.copy().extra  # error: [unresolved-attribute]
+    reveal_type(value.copy())  # revealed: Unknown
 ```
 
 ## Intersection receivers bind `Self` before inferring arguments

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -780,6 +780,7 @@ See also: <https://typing.python.org/en/latest/spec/generics.html#use-in-protoco
 
 ```py
 from typing import Self, Protocol
+from ty_extensions import Intersection
 
 class Copyable(Protocol):
     def copy(self) -> Self: ...
@@ -807,6 +808,14 @@ def copy_concrete(x: CopyableImpl) -> None:
 
 def copy_sub(x: SubCopyable) -> None:
     reveal_type(x.copy())  # revealed: SubCopyable
+
+def copy_tuple(x: Intersection[tuple[int, int], Copyable]) -> None:
+    copied = x.copy()
+    reveal_type(copied)  # revealed: tuple[object, ...] & Copyable
+
+    def accept_tuple(value: tuple[object, ...]) -> None: ...
+
+    accept_tuple(copied)
 ```
 
 ## Annotations

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -331,6 +331,73 @@ def f[U: Bar](x: Foo[U]):
     reveal_type(x.foo())  # revealed: U@f
 ```
 
+Intersection receivers must also preserve unrelated occurrences of `Self`:
+
+```py
+from typing import Self
+from ty_extensions import Intersection
+
+class Box[T]:
+    def __init__(self, value: T) -> None:
+        self.value = value
+
+class Owner:
+    def inspect(self: Self, value: Intersection[Box[Self], "Owner"]) -> None:
+        reveal_type(value.value)  # revealed: Self@inspect
+        value.value.value  # error: [unresolved-attribute]
+
+class ConcreteOwner(Owner): ...
+class Both(Box[ConcreteOwner], Owner): ...
+
+ConcreteOwner().inspect(Both(ConcreteOwner()))
+
+class MethodOwner:
+    def copy(self) -> Self:
+        return self
+
+class MethodAlias:
+    copy = MethodOwner.copy
+
+class MethodExtra:
+    extra: int
+
+def _(value: Intersection[MethodAlias, MethodExtra]):
+    value.copy().extra  # error: [unresolved-attribute]
+```
+
+## Intersection receivers bind `Self` before inferring arguments
+
+```py
+from typing import Protocol, Self, TypeVar
+from ty_extensions import AlwaysTruthy, Intersection
+
+class Value:
+    def copy_from(self, other: Self) -> Self:
+        raise NotImplementedError
+
+class Extra: ...
+
+def _(value: Intersection[Value, Extra], plain: Value):
+    reveal_type(value.copy_from(value))  # revealed: Value & Extra
+    # error: [invalid-argument-type]
+    reveal_type(value.copy_from(plain))  # revealed: Value & Extra
+
+class MixedRefinementMarker(Protocol):
+    marker: int
+
+MixedRefinement = TypeVar("MixedRefinement", Extra, MixedRefinementMarker)
+
+def mixed_refinement(value: Intersection[Value, MixedRefinement]):
+    # error: [invalid-argument-type]
+    value.copy_from(Value())
+
+MixedTruthinessRefinement = TypeVar("MixedTruthinessRefinement", Extra, AlwaysTruthy)
+
+def mixed_truthiness_refinement(value: Intersection[Value, MixedTruthinessRefinement]):
+    # error: [invalid-argument-type]
+    value.copy_from(Value())
+```
+
 ## typing_extensions
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -387,6 +387,8 @@ def _(value: Intersection[MethodAlias, MethodExtra]):
 ## Intersection receivers bind `Self` before inferring arguments
 
 ```py
+from collections import defaultdict
+from collections.abc import Iterable
 from enum import Enum
 from typing import Literal, Protocol, Self, TypeVar, cast
 from ty_extensions import AlwaysTruthy, Intersection
@@ -486,6 +488,19 @@ def union_bounded_self[T: UnionSelfA | UnionSelfB](
     reveal_type(value.copy_from(value))  # revealed: T@union_bounded_self & UnionSelfExtra
     # error: [invalid-argument-type]
     reveal_type(value.copy_from(plain))  # revealed: T@union_bounded_self & UnionSelfExtra
+
+type DefaultdictSpec = None | int | Iterable[int] | dict[str, int]
+
+def is_mapping(value: object) -> bool:
+    return isinstance(value, dict)
+
+def copy_defaultdict(value: DefaultdictSpec) -> DefaultdictSpec:
+    if is_mapping(value) and isinstance(value, defaultdict):
+        copied = value.copy()
+        # revealed: (Iterable[int] & Top[defaultdict[Unknown, Unknown]]) | (dict[str, int] & Top[defaultdict[Unknown, Unknown]])
+        reveal_type(copied)
+        value = copied
+    return value
 ```
 
 ## typing_extensions

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -423,6 +423,27 @@ MixedTruthinessRefinement = TypeVar("MixedTruthinessRefinement", Extra, AlwaysTr
 def mixed_truthiness_refinement(value: Intersection[Value, MixedTruthinessRefinement]):
     # error: [invalid-argument-type]
     value.copy_from(Value())
+
+class ClassmethodValue:
+    @classmethod
+    def copy_from(cls, other: Self) -> Self:
+        raise NotImplementedError
+
+    @classmethod
+    def choose_default[T = Self](cls) -> T:
+        raise NotImplementedError
+
+class ClassmethodExtra: ...
+
+def classmethod_intersection(
+    cls: Intersection[type[ClassmethodValue], type[ClassmethodExtra]],
+    both: Intersection[ClassmethodValue, ClassmethodExtra],
+    plain: ClassmethodValue,
+):
+    reveal_type(cls.copy_from(both))  # revealed: ClassmethodValue & ClassmethodExtra
+    # error: [invalid-argument-type]
+    cls.copy_from(plain)
+    reveal_type(cls.choose_default())  # revealed: ClassmethodValue & ClassmethodExtra
 ```
 
 ## typing_extensions

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -22,6 +22,9 @@ class Shape:
     def make[T = Self](self) -> T:
         raise NotImplementedError
 
+    def make_pair[U = Self, T = U](self) -> tuple[U, T]:
+        raise NotImplementedError
+
     def nested_type(self: Self) -> list[Self]:
         return [self]
 
@@ -44,6 +47,8 @@ class Circle(Shape):
     def set_scale(self: Self, scale: float) -> Self:
         reveal_type(self)  # revealed: Self@set_scale
         return self
+
+reveal_type(Circle().make_pair())  # revealed: tuple[Circle, Circle]
 
 class ClassmethodBase:
     @classmethod

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1928,6 +1928,12 @@ def _(value: Value):
         reveal_type(value.other)  # revealed: Value
         reveal_type(value.property)  # revealed: Value
 
+class Excluded: ...
+
+def _(value: Value):
+    if not isinstance(value, Excluded):
+        reveal_type(value.copy())  # revealed: Value & ~Excluded
+
 @runtime_checkable
 class VariableTruthProtocol(Protocol):
     def __bool__(self) -> bool: ...

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1882,6 +1882,183 @@ def _(a_and_b: Intersection[A, B]):
     reveal_type(a_and_b.method())  # revealed: A & B
 ```
 
+### `Self` binding excludes flow-only refinements
+
+```py
+from typing import Protocol, TypeVar, runtime_checkable
+from typing_extensions import Self, TypeIs
+from ty_extensions import AlwaysTruthy, Intersection
+
+class VariableTruth:
+    other: Self
+
+    def __bool__(self) -> bool:
+        return False
+
+    def copy(self) -> Self:
+        return self
+
+    @property
+    def property(self) -> Self:
+        return self
+
+def _(value: VariableTruth):
+    if value:
+        reveal_type(value.copy())  # revealed: VariableTruth
+        reveal_type(value.other)  # revealed: VariableTruth
+        reveal_type(value.property)  # revealed: VariableTruth
+
+@runtime_checkable
+class InstanceMarker(Protocol):
+    marker: int
+
+class Value:
+    other: Self
+
+    def copy(self) -> Self:
+        return self
+
+    @property
+    def property(self) -> Self:
+        return self
+
+def _(value: Value):
+    if isinstance(value, InstanceMarker):
+        reveal_type(value.copy())  # revealed: Value
+        reveal_type(value.other)  # revealed: Value
+        reveal_type(value.property)  # revealed: Value
+
+@runtime_checkable
+class VariableTruthProtocol(Protocol):
+    def __bool__(self) -> bool: ...
+    def copy(self) -> Self: ...
+
+def _(value: VariableTruthProtocol):
+    if value:
+        reveal_type(value.copy())  # revealed: VariableTruthProtocol
+
+class BaseProtocol(Protocol):
+    def copy(self) -> Self: ...
+
+class ChildProtocol(BaseProtocol, Protocol):
+    def __bool__(self) -> bool: ...
+
+def clone(value: ChildProtocol) -> ChildProtocol:
+    if value:
+        return value.copy()
+    return value
+
+class MyTuple(tuple[int, ...]):
+    def fresh(self) -> Self:
+        return type(self)((1, 2, 3))
+
+def takes_pair(value: tuple[int, int]): ...
+def takes_object_pair(value: tuple[object, object]): ...
+def _(value: tuple[int, int]):
+    if isinstance(value, MyTuple):
+        reveal_type(value.fresh())  # revealed: MyTuple
+        takes_pair(value.fresh())  # error: [invalid-argument-type]
+
+T = TypeVar("T", tuple[int, int], tuple[str, str])
+
+def _(value: Intersection[MyTuple, T]):
+    reveal_type(value.fresh())  # revealed: MyTuple
+    takes_object_pair(value.fresh())  # error: [invalid-argument-type]
+
+MixedTupleBound = TypeVar("MixedTupleBound", bound=tuple[int, int] | list[str])
+
+def _(value: Intersection[MyTuple, MixedTupleBound]):
+    reveal_type(value.fresh())  # revealed: MyTuple & MixedTupleBound@_
+    takes_pair(value.fresh())
+
+class TypeIsMarker(Protocol):
+    marker: int
+
+ProtocolBoundMarker = TypeVar("ProtocolBoundMarker", bound=TypeIsMarker)
+
+def protocol_bounded(value: Intersection[Value, ProtocolBoundMarker]):
+    reveal_type(value.other)  # revealed: Value
+    value.other.marker  # error: [unresolved-attribute]
+
+TruthinessBound = TypeVar("TruthinessBound", bound=AlwaysTruthy)
+
+def takes_truthy(value: AlwaysTruthy): ...
+def truthiness_bounded(value: Intersection[Value, TruthinessBound]):
+    reveal_type(value.copy())  # revealed: Value
+    takes_truthy(value.copy())  # error: [invalid-argument-type]
+
+def is_marker(value: object) -> TypeIs[TypeIsMarker]:
+    return hasattr(value, "marker")
+
+def _(value: Value):
+    if is_marker(value):
+        reveal_type(value.copy())  # revealed: Value
+        value.copy().marker  # error: [unresolved-attribute]
+
+    if hasattr(value, "synthesized_marker"):
+        reveal_type(value.copy())  # revealed: Value
+        value.copy().synthesized_marker  # error: [unresolved-attribute]
+
+class CopyableProtocol(Protocol):
+    other: Self
+
+    def copy(self) -> Self: ...
+    @property
+    def property(self) -> Self: ...
+
+class NominalCopyable: ...
+
+def _(value: Intersection[NominalCopyable, CopyableProtocol]):
+    value.copy().copy()
+
+def _(value: CopyableProtocol):
+    if is_marker(value):
+        reveal_type(value.copy())  # revealed: CopyableProtocol
+        reveal_type(value.other)  # revealed: CopyableProtocol
+        reveal_type(value.property)  # revealed: CopyableProtocol
+        value.copy().marker  # error: [unresolved-attribute]
+        value.other.marker  # error: [unresolved-attribute]
+        value.property.marker  # error: [unresolved-attribute]
+```
+
+### `Self` binding expands aliases around refinements
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, Self, TypeVar
+from ty_extensions import Intersection
+
+class AliasValue:
+    other: Self
+
+class AliasTuple(tuple[int, ...]):
+    def fresh(self) -> Self:
+        return type(self)((1, 2, 3))
+
+def takes_pair(value: tuple[int, int]): ...
+
+type PairAlias = tuple[int, int]
+AliasTupleBound = TypeVar("AliasTupleBound", bound=PairAlias)
+
+def _(value: Intersection[AliasTuple, AliasTupleBound]):
+    reveal_type(value.fresh())  # revealed: AliasTuple
+    takes_pair(value.fresh())  # error: [invalid-argument-type]
+
+class AliasMarker(Protocol):
+    marker: int
+
+type MarkerAlias = AliasMarker
+AliasProtocolBound = TypeVar("AliasProtocolBound", bound=MarkerAlias)
+
+def _(value: Intersection[AliasValue, AliasProtocolBound]):
+    reveal_type(value.other)  # revealed: AliasValue
+    value.other.marker  # error: [unresolved-attribute]
+```
+
 ### Descriptor binding uses the full intersection type
 
 ```py
@@ -1902,9 +2079,14 @@ class A:
     desc = Descriptor()
 
 class B: ...
+class Mixin: ...
 
 def _(a_and_b: Intersection[A, B]):
     reveal_type(a_and_b.desc)  # revealed: A & B
+
+def _(a: A):
+    if isinstance(a, Mixin):
+        reveal_type(a.desc)  # revealed: A & Mixin
 ```
 
 ### Negation types

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1438,6 +1438,23 @@ def _(y: type[typing.NamedTuple]):
 def _(z: typing.NamedTuple[int]): ...
 ```
 
+Value-level tuple refinements do not apply to another instance returned as `Self`:
+
+```py
+from typing import Literal
+from ty_extensions import Intersection
+
+def takes_literal_pair(value: tuple[Literal[1], Literal[2]]): ...
+def takes_tuple(value: tuple[object, ...]): ...
+def takes_named_tuple(value: typing.NamedTuple): ...
+def narrowed_named_tuple(value: Intersection[typing.NamedTuple, tuple[Literal[1], Literal[2]]]):
+    result = value._replace(x=3)
+    reveal_type(result)  # revealed: tuple[object, ...] & NamedTupleLike
+    takes_tuple(result)
+    takes_named_tuple(result)
+    takes_literal_pair(result)  # error: [invalid-argument-type]
+```
+
 NamedTuples are assignable to `NamedTupleLike`. The `NamedTupleLike._replace` method is typed with
 `(*args, **kwargs)`, which type checkers treat as equivalent to `...` (per the typing spec), making
 all NamedTuple implementations automatically compatible:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -424,7 +424,7 @@ class Answer(Enum):
 Answer.YES.is_yes_through_class_member()
 
 try:
-    reveal_type(Answer.MAYBE.assert_yes())  # revealed: Literal[Answer.MAYBE]
+    reveal_type(Answer.MAYBE.assert_yes())  # revealed: Answer
 except ValueError:
     pass
 ```

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -163,6 +163,31 @@ reveal_type(Base().narrowed)  # revealed: bound method Base.narrowed(x: int) -> 
 reveal_type(Child().narrowed)  # revealed: Overload[(x: int) -> int, (x: str) -> str]
 ```
 
+Flow narrowing of a bound receiver still participates in overload selection when another overload
+uses `Self`:
+
+```py
+from typing import Protocol, overload, runtime_checkable
+from typing_extensions import Self
+
+@runtime_checkable
+class Marker(Protocol):
+    marker: int
+
+class Value:
+    @overload
+    def select(self: Marker, value: int) -> str: ...
+    @overload
+    def select(self, value: str) -> Self: ...
+    def select(self, value: int | str) -> str | Self:
+        return self if isinstance(value, str) else ""
+
+def _(value: Value):
+    if isinstance(value, Marker):
+        reveal_type(value.select(1))  # revealed: str
+        reveal_type(value.select(""))  # revealed: Value
+```
+
 ## Specialized generic receivers
 
 An explicit receiver annotation can also select overloads based on a generic class specialization.

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -188,6 +188,42 @@ def _(value: Value):
         reveal_type(value.select(""))  # revealed: Value
 ```
 
+## Protocol overloads preserve `Self` owners during callable conversion
+
+`copyable.pyi`:
+
+```pyi
+from typing import Protocol, overload
+from typing_extensions import Self
+
+class Copyable(Protocol):
+    marker: int
+
+    @overload
+    def copy(self: "Copyable", value: int) -> int: ...
+    @overload
+    def copy(self, value: str) -> Self: ...
+```
+
+`main.py`:
+
+```py
+from typing import Callable
+from copyable import Copyable
+from ty_extensions import Intersection, RegularCallableTypeOf
+
+class Nominal:
+    copy = Copyable.copy
+
+def takes_copy(callback: Callable[[str], Copyable]) -> None: ...
+def _(value: Intersection[Nominal, Copyable]):
+    reveal_type(value.copy(""))  # revealed: Nominal & Copyable
+    copy: RegularCallableTypeOf[value.copy] = value.copy
+    # revealed: Overload[(value: int) -> int, (value: str) -> Nominal & Copyable]
+    reveal_type(copy)
+    takes_copy(copy)
+```
+
 ## Specialized generic receivers
 
 An explicit receiver annotation can also select overloads based on a generic class specialization.

--- a/crates/ty_python_semantic/resources/mdtest/properties.md
+++ b/crates/ty_python_semantic/resources/mdtest/properties.md
@@ -432,6 +432,43 @@ Alternatively, the above can also be written as a method call:
 reveal_type(attr_property.__get__(c, C))  # revealed: int
 ```
 
+The full receiver is used to match a getter with an explicit receiver annotation, while `Self` in
+the return type is bound to the receiver's runtime class:
+
+```py
+from typing import Protocol, runtime_checkable
+from typing_extensions import Self
+
+@runtime_checkable
+class Marker(Protocol):
+    marker: int
+
+class Value:
+    @property
+    def property(self: Marker) -> Self:
+        raise NotImplementedError
+
+def _(value: Value):
+    if isinstance(value, Marker):
+        reveal_type(value.property)  # revealed: Value
+        reveal_type(Value.property.__get__(value, Value))  # revealed: Value
+        reveal_type(type(Value.property).__get__(Value.property, value, Value))  # revealed: Value
+
+class SelfProperty:
+    @property
+    def value(self: Self) -> Self:
+        return self
+
+class Other: ...
+
+def _(other: Other):
+    # error: [call-non-callable]
+    reveal_type(SelfProperty.value.__get__(other, SelfProperty))  # revealed: Unknown
+    get = type(SelfProperty.value).__get__
+    # error: [call-non-callable]
+    reveal_type(get(SelfProperty.value, other, SelfProperty))  # revealed: Unknown
+```
+
 When we access `attr` on the class itself, the descriptor protocol is also invoked, but the instance
 argument is set to `None`. When `instance` is `None`, the call to `property.__get__` returns the
 property instance itself. So the following expressions are all equivalent

--- a/crates/ty_python_semantic/resources/mdtest/properties.md
+++ b/crates/ty_python_semantic/resources/mdtest/properties.md
@@ -689,3 +689,33 @@ static_assert(is_disjoint_from(TypeOf[both_a], TypeOf[both_d]))
 assert_equivalent_properties(get_equiv_a, get_equiv_b)
 assert_structural_property_relations(get_int, get_int, set_object, set_object)
 ```
+
+## Protocol-owned properties discard unrelated refinements
+
+`protocols.pyi`:
+
+```pyi
+from typing import Protocol
+from typing_extensions import Self
+
+class BaseProtocol(Protocol):
+    @property
+    def property(self) -> Self: ...
+
+class MarkerProtocol(Protocol):
+    marker: int
+```
+
+`main.py`:
+
+```py
+from protocols import BaseProtocol, MarkerProtocol
+from ty_extensions import Intersection
+
+class Impl:
+    pass
+
+def _(value: Intersection[Impl, BaseProtocol, MarkerProtocol]):
+    reveal_type(value.property)  # revealed: Impl & BaseProtocol
+    value.property.marker  # error: [unresolved-attribute]
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4171,20 +4171,21 @@ impl<'db> Type<'db> {
                 let intersection_self = needs_self_binding
                     && !function.is_classmethod(db)
                     && matches!(self_instance, Type::Intersection(_));
+                let self_binding_type = signatures.self_binding_type(db, self_instance);
                 CallableBinding::from_overloads(
                     self,
                     signatures.overloads.iter().map(|signature| {
                         if intersection_self && signature.needs_self_mapping(db, true) {
                             signature.apply_self(db, signature.self_binding_type(db, self_instance))
                         } else {
-                            signature.clone()
+                            signature.apply_self_to_generic_defaults(db, self_binding_type)
                         }
                     }),
                 )
                 .with_bound_type(if intersection_self || !needs_self_binding {
                     self_instance
                 } else {
-                    signatures.self_binding_type(db, self_instance)
+                    self_binding_type
                 })
                 .into()
             }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4172,13 +4172,21 @@ impl<'db> Type<'db> {
                     && !function.is_classmethod(db)
                     && matches!(self_instance, Type::Intersection(_));
                 let self_binding_type = signatures.self_binding_type(db, self_instance);
+                let generic_default_self_type = if function.is_classmethod(db) {
+                    signatures.self_binding_type(
+                        db,
+                        self_instance.to_instance(db).unwrap_or_else(Type::unknown),
+                    )
+                } else {
+                    self_binding_type
+                };
                 CallableBinding::from_overloads(
                     self,
                     signatures.overloads.iter().map(|signature| {
                         if intersection_self && signature.needs_self_mapping(db, true) {
                             signature.apply_self(db, signature.self_binding_type(db, self_instance))
                         } else {
-                            signature.apply_self_to_generic_defaults(db, self_binding_type)
+                            signature.apply_self_to_generic_defaults(db, generic_default_self_type)
                         }
                     }),
                 )

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1064,6 +1064,112 @@ impl<'db> Type<'db> {
         )
     }
 
+    /// Return the part of a receiver type that describes its runtime class for `Self` binding.
+    ///
+    /// Negative constraints and flow refinements describe the current value, but do not necessarily
+    /// apply to another instance returned as `Self`. When known, `self_typevar` identifies the
+    /// protocol that owns `Self`, so other structural constraints can be treated as refinements.
+    pub(crate) fn self_binding_type_for(
+        self,
+        db: &'db dyn Db,
+        self_typevar: Option<BoundTypeVarInstance<'db>>,
+    ) -> Self {
+        let Type::Intersection(intersection) = self else {
+            return self;
+        };
+
+        let owner = self_typevar
+            .and_then(|self_typevar| self_typevar_owner_class_literal(db, self_typevar));
+        let has_nominal_class_constraint = intersection.positive(db).iter().any(|positive| {
+            !matches!(positive, Type::ProtocolInstance(_)) && positive.nominal_class(db).is_some()
+        });
+        let has_named_tuple_like_constraint =
+            intersection
+                .positive(db)
+                .iter()
+                .any(|positive| match positive {
+                    Type::ProtocolInstance(ProtocolInstanceType {
+                        inner: Protocol::FromClass(class),
+                        ..
+                    }) => class.is_known(db, KnownClass::NamedTupleLike),
+                    _ => false,
+                });
+        let named_tuple_shape =
+            has_named_tuple_like_constraint.then(|| Type::homogeneous_tuple(db, Type::object()));
+        let mut builder = IntersectionBuilder::new(db);
+        if let Some(named_tuple_shape) = named_tuple_shape
+            && intersection.positive(db).iter().any(|positive| {
+                type_is_tuple_refinement(db, *positive) && *positive != named_tuple_shape
+            })
+        {
+            builder = builder.add_positive(named_tuple_shape);
+        }
+        for positive in intersection.positive(db) {
+            // `NamedTupleLike` is deliberately combined with a tuple type to describe
+            // `typing.NamedTuple`; unlike a user protocol, it is not a flow refinement.
+            let is_value_refinement = type_is_truthiness_refinement(db, *positive)
+                || (type_is_tuple_refinement(db, *positive)
+                    && named_tuple_shape != Some(*positive))
+                || matches!(
+                    positive,
+                    Type::ProtocolInstance(ProtocolInstanceType {
+                        inner: Protocol::Synthesized(_),
+                        ..
+                    })
+                )
+                || matches!(
+                    positive,
+                    Type::TypeVar(typevar)
+                        if has_nominal_class_constraint
+                            && typevar_is_protocol_refinement(db, *typevar, owner)
+                )
+                || matches!(
+                    positive,
+                    Type::ProtocolInstance(ProtocolInstanceType {
+                        inner: Protocol::FromClass(class),
+                        ..
+                    }) if ((owner.is_none() && has_nominal_class_constraint)
+                        || owner.is_some_and(|owner| {
+                            !class_mro_literals(db, class.class_literal(db)).contains(&owner)
+                        }))
+                        && !class.is_known(db, KnownClass::NamedTupleLike)
+                );
+            if !is_value_refinement {
+                builder = builder.add_positive(*positive);
+            }
+        }
+        builder.build()
+    }
+
+    pub(crate) fn needs_self_binding(self, db: &'db dyn Db) -> bool {
+        self.as_function_literal().is_some_and(|function| {
+            function
+                .signature(db)
+                .overloads
+                .iter()
+                .any(|signature| signature.needs_self_mapping(db, true))
+        })
+    }
+
+    /// Apply `Self` substitutions without binding or replacing the receiver parameter.
+    pub(crate) fn apply_self_binding(self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
+        match self {
+            Type::FunctionLiteral(function) => {
+                let self_type = function.signature(db).self_binding_type(db, self_type);
+                self.apply_type_mapping(
+                    db,
+                    &TypeMapping::BindSelf(SelfBinding::new(db, self_type, None)),
+                    TypeContext::default(),
+                )
+            }
+            Type::Callable(callable) if callable.is_function_like(db) => {
+                let self_type = callable.signatures(db).self_binding_type(db, self_type);
+                Type::Callable(callable.apply_self(db, self_type))
+            }
+            _ => self,
+        }
+    }
+
     /// Returns `true` if `self` is [`Type::Callable`].
     pub(crate) const fn is_callable_type(&self) -> bool {
         matches!(self, Type::Callable(..))
@@ -4057,10 +4163,29 @@ impl<'db> Type<'db> {
             }
 
             Type::BoundMethod(bound_method) => {
-                let signature = bound_method.function(db).signature(db);
-                CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
-                    .with_bound_type(bound_method.self_instance(db))
-                    .into()
+                let function = bound_method.function(db);
+                let signatures = function.signature(db);
+                let self_instance = bound_method.self_instance(db);
+                let needs_self_binding = Type::FunctionLiteral(function).needs_self_binding(db);
+                let intersection_self = needs_self_binding
+                    && !function.is_classmethod(db)
+                    && matches!(self_instance, Type::Intersection(_));
+                CallableBinding::from_overloads(
+                    self,
+                    signatures.overloads.iter().map(|signature| {
+                        if intersection_self && signature.needs_self_mapping(db, true) {
+                            signature.apply_self(db, signature.self_binding_type(db, self_instance))
+                        } else {
+                            signature.clone()
+                        }
+                    }),
+                )
+                .with_bound_type(if intersection_self || !needs_self_binding {
+                    self_instance
+                } else {
+                    signatures.self_binding_type(db, self_instance)
+                })
+                .into()
             }
 
             Type::KnownBoundMethod(method) => {
@@ -7069,6 +7194,90 @@ fn class_mro_literals<'db>(
         .collect()
 }
 
+fn typevar_is_protocol_refinement<'db>(
+    db: &'db dyn Db,
+    typevar: BoundTypeVarInstance<'db>,
+    owner: Option<ClassLiteral<'db>>,
+) -> bool {
+    let is_protocol_refinement = |ty: Type<'db>| match ty.resolve_type_alias(db) {
+        Type::ProtocolInstance(ProtocolInstanceType {
+            inner: Protocol::FromClass(class),
+            ..
+        }) => {
+            !class.is_known(db, KnownClass::NamedTupleLike)
+                && owner.is_none_or(|owner| {
+                    !class_mro_literals(db, class.class_literal(db)).contains(&owner)
+                })
+        }
+        _ => false,
+    };
+
+    typevar
+        .typevar(db)
+        .bound_or_constraints(db)
+        .is_some_and(|bound_or_constraints| match bound_or_constraints {
+            TypeVarBoundOrConstraints::Constraints(constraints) => constraints
+                .elements(db)
+                .iter()
+                .all(|constraint| is_protocol_refinement(*constraint)),
+            TypeVarBoundOrConstraints::UpperBound(Type::Union(union)) => union
+                .elements(db)
+                .iter()
+                .all(|bound| is_protocol_refinement(*bound)),
+            TypeVarBoundOrConstraints::UpperBound(bound) => is_protocol_refinement(bound),
+        })
+}
+
+fn type_is_tuple_refinement<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::NominalInstance(instance) => instance.own_tuple_spec(db).is_some(),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| type_is_tuple_refinement(db, *element)),
+        Type::TypeVar(typevar) => {
+            typevar
+                .typevar(db)
+                .bound_or_constraints(db)
+                .is_some_and(|bound_or_constraints| match bound_or_constraints {
+                    TypeVarBoundOrConstraints::Constraints(constraints) => constraints
+                        .elements(db)
+                        .iter()
+                        .all(|constraint| type_is_tuple_refinement(db, *constraint)),
+                    TypeVarBoundOrConstraints::UpperBound(bound) => {
+                        type_is_tuple_refinement(db, bound)
+                    }
+                })
+        }
+        _ => false,
+    }
+}
+
+fn type_is_truthiness_refinement<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::AlwaysTruthy | Type::AlwaysFalsy => true,
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| type_is_truthiness_refinement(db, *element)),
+        Type::TypeVar(typevar) => {
+            typevar
+                .typevar(db)
+                .bound_or_constraints(db)
+                .is_some_and(|bound_or_constraints| match bound_or_constraints {
+                    TypeVarBoundOrConstraints::Constraints(constraints) => constraints
+                        .elements(db)
+                        .iter()
+                        .all(|constraint| type_is_truthiness_refinement(db, *constraint)),
+                    TypeVarBoundOrConstraints::UpperBound(bound) => {
+                        type_is_truthiness_refinement(db, bound)
+                    }
+                })
+        }
+        _ => false,
+    }
+}
+
 /// Information needed to bind `Self` typevars to a concrete type.
 ///
 /// Uses MRO-based matching: a `Self` typevar is bound only if its owner class
@@ -7083,6 +7292,14 @@ pub struct SelfBinding<'db> {
 impl<'db> SelfBinding<'db> {
     pub(crate) fn self_type(&self) -> Type<'db> {
         self.ty
+    }
+
+    fn self_type_for(
+        &self,
+        db: &'db dyn Db,
+        bound_typevar: BoundTypeVarInstance<'db>,
+    ) -> Type<'db> {
+        self.ty.self_binding_type_for(db, Some(bound_typevar))
     }
 
     pub(crate) fn binding_context(&self) -> Option<BindingContext<'db>> {
@@ -7101,6 +7318,7 @@ impl<'db> SelfBinding<'db> {
                 self_typevar_owner_class_literal(db, typevar)
             }
             _ => self_type
+                .self_binding_type_for(db, None)
                 .nominal_class(db)
                 .map(|class| class.class_literal(db)),
         };
@@ -7118,19 +7336,53 @@ impl<'db> SelfBinding<'db> {
             return false;
         }
 
+        let owner_class = self_typevar_owner_class_literal(db, bound_typevar);
+        let intersection_inherits_from_owner = |owner_class| {
+            let Type::Intersection(intersection) = self.ty else {
+                return false;
+            };
+            intersection.positive(db).iter().any(|positive| {
+                positive.nominal_class(db).is_some_and(|class| {
+                    class_mro_literals(db, class.class_literal(db)).contains(&owner_class)
+                })
+            })
+        };
+
         // Fast path for the common method-signature case where the bound `Self`
-        // carries the same binding context as this mapping.
+        // carries the same binding context as this mapping. For intersection receivers, also
+        // verify that an element inherits from the method owner; attributes can alias methods
+        // from unrelated classes.
         if self.binding_context == Some(bound_typevar.binding_context(db)) {
-            return true;
+            return owner_class.is_none_or(|owner_class| {
+                !matches!(self.ty, Type::Intersection(_))
+                    || intersection_inherits_from_owner(owner_class)
+            });
         }
 
         // Check that the Self typevar's owner class is in the MRO of the self type's class.
-        // If we can't determine either class, conservatively don't bind.
-        self.class_literal.is_some_and(|class_literal| {
+        if self.class_literal.is_some_and(|class_literal| {
             let class_mro = class_mro_literals(db, class_literal);
-            self_typevar_owner_class_literal(db, bound_typevar)
-                .is_none_or(|owner_class| class_mro.contains(&owner_class))
-        })
+            owner_class.is_none_or(|owner_class| class_mro.contains(&owner_class))
+        }) {
+            return true;
+        }
+
+        // Context-free attribute binding must not replace a method-owned `Self`.
+        if self.binding_context.is_none()
+            && bound_typevar
+                .binding_context(db)
+                .definition()
+                .is_some_and(|definition| definition.kind(db).is_function_def())
+        {
+            return false;
+        }
+
+        // An intersection has no single nominal class, but a positive element can still inherit
+        // from the class or protocol that owns this `Self`.
+        let Some(owner_class) = owner_class else {
+            return false;
+        };
+        intersection_inherits_from_owner(owner_class)
     }
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1084,33 +1084,20 @@ impl<'db> Type<'db> {
         let has_nominal_class_constraint = intersection.positive(db).iter().any(|positive| {
             !matches!(positive, Type::ProtocolInstance(_)) && positive.nominal_class(db).is_some()
         });
-        let has_named_tuple_like_constraint =
-            intersection
-                .positive(db)
-                .iter()
-                .any(|positive| match positive {
-                    Type::ProtocolInstance(ProtocolInstanceType {
-                        inner: Protocol::FromClass(class),
-                        ..
-                    }) => class.is_known(db, KnownClass::NamedTupleLike),
-                    _ => false,
-                });
-        let named_tuple_shape =
-            has_named_tuple_like_constraint.then(|| Type::homogeneous_tuple(db, Type::object()));
+        let tuple_shape = Type::homogeneous_tuple(db, Type::object());
+        let has_tuple_refinement = intersection
+            .positive(db)
+            .iter()
+            .any(|positive| type_is_tuple_refinement(db, *positive) && *positive != tuple_shape);
         let mut builder = IntersectionBuilder::new(db);
-        if let Some(named_tuple_shape) = named_tuple_shape
-            && intersection.positive(db).iter().any(|positive| {
-                type_is_tuple_refinement(db, *positive) && *positive != named_tuple_shape
-            })
-        {
-            builder = builder.add_positive(named_tuple_shape);
+        if has_tuple_refinement {
+            builder = builder.add_positive(tuple_shape);
         }
         for positive in intersection.positive(db) {
             // `NamedTupleLike` is deliberately combined with a tuple type to describe
             // `typing.NamedTuple`; unlike a user protocol, it is not a flow refinement.
             let is_value_refinement = type_is_truthiness_refinement(db, *positive)
-                || (type_is_tuple_refinement(db, *positive)
-                    && named_tuple_shape != Some(*positive))
+                || (type_is_tuple_refinement(db, *positive) && tuple_shape != *positive)
                 || matches!(
                     positive,
                     Type::ProtocolInstance(ProtocolInstanceType {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1088,6 +1088,30 @@ impl<'db> Type<'db> {
         let has_nominal_class_constraint = intersection.positive(db).iter().any(|positive| {
             !matches!(positive, Type::ProtocolInstance(_)) && positive.nominal_class(db).is_some()
         });
+        // A generic protocol can constrain a nominal class's unknown type arguments. If the
+        // class's bottom materialization satisfies it, preserve it as a class constraint.
+        let protocol_is_nominal_class_constraint = |protocol: Type<'db>| {
+            if protocol.class_specialization(db).is_none() {
+                return false;
+            }
+
+            intersection.positive(db).iter().any(|positive| {
+                let Some(class) = positive.nominal_class(db) else {
+                    return false;
+                };
+                let Some(alias) = class.into_generic_alias() else {
+                    return false;
+                };
+                let bottom = GenericAlias::new(
+                    db,
+                    alias.origin(db),
+                    alias
+                        .specialization(db)
+                        .with_materialization_kind(db, Some(MaterializationKind::Bottom)),
+                );
+                Type::instance(db, bottom.into()).is_assignable_to(db, protocol)
+            })
+        };
         let tuple_shape = Type::homogeneous_tuple(db, Type::object());
         let has_tuple_refinement = intersection
             .positive(db)
@@ -1125,6 +1149,7 @@ impl<'db> Type<'db> {
                                 !class_mro_literals(db, class.class_literal(db)).contains(&owner)
                             }))
                             && !class.is_known(db, KnownClass::NamedTupleLike)
+                            && !protocol_is_nominal_class_constraint(*positive)
                 );
             if !is_value_refinement {
                 builder = builder

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7288,6 +7288,7 @@ pub struct SelfBinding<'db> {
     ty: Type<'db>,
     class_literal: Option<ClassLiteral<'db>>,
     binding_context: Option<BindingContext<'db>>,
+    unbound_method_self_to_unknown: bool,
 }
 
 impl<'db> SelfBinding<'db> {
@@ -7305,6 +7306,25 @@ impl<'db> SelfBinding<'db> {
 
     pub(crate) fn binding_context(&self) -> Option<BindingContext<'db>> {
         self.binding_context
+    }
+
+    fn unbound_self_type_for(
+        &self,
+        db: &'db dyn Db,
+        bound_typevar: BoundTypeVarInstance<'db>,
+    ) -> Option<Type<'db>> {
+        // A `Self` carried by the receiver is an unrelated specialization, but a method-owned
+        // `Self` that cannot bind to the receiver must not escape the bound signature.
+        (self.unbound_method_self_to_unknown
+            && self.binding_context == Some(bound_typevar.binding_context(db))
+            && bound_typevar
+                .binding_context(db)
+                .definition()
+                .is_some_and(|definition| definition.kind(db).is_function_def())
+            && !self
+                .ty
+                .references_typevar(db, bound_typevar.typevar(db).identity(db)))
+        .then(Type::unknown)
     }
 }
 
@@ -7328,7 +7348,13 @@ impl<'db> SelfBinding<'db> {
             ty: self_type,
             class_literal,
             binding_context,
+            unbound_method_self_to_unknown: false,
         }
+    }
+
+    pub(crate) fn with_unbound_method_self_fallback(mut self) -> Self {
+        self.unbound_method_self_to_unknown = true;
+        self
     }
 
     /// Returns whether `bound_typevar` should be replaced by this binding's concrete self type.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1075,6 +1075,10 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         self_typevar: Option<BoundTypeVarInstance<'db>>,
     ) -> Self {
+        if let Type::LiteralValue(literal) = self.resolve_type_alias(db) {
+            return literal.fallback_instance(db);
+        }
+
         let Type::Intersection(intersection) = self else {
             return self;
         };
@@ -1112,18 +1116,21 @@ impl<'db> Type<'db> {
                             && typevar_is_protocol_refinement(db, *typevar, owner)
                 )
                 || matches!(
-                    positive,
-                    Type::ProtocolInstance(ProtocolInstanceType {
-                        inner: Protocol::FromClass(class),
-                        ..
-                    }) if ((owner.is_none() && has_nominal_class_constraint)
-                        || owner.is_some_and(|owner| {
-                            !class_mro_literals(db, class.class_literal(db)).contains(&owner)
-                        }))
-                        && !class.is_known(db, KnownClass::NamedTupleLike)
+                        positive,
+                        Type::ProtocolInstance(ProtocolInstanceType {
+                            inner: Protocol::FromClass(class),
+                            ..
+                        }) if ((owner.is_none() && has_nominal_class_constraint)
+                            || owner.is_some_and(|owner| {
+                                !class_mro_literals(db, class.class_literal(db)).contains(&owner)
+                            }))
+                            && !class.is_known(db, KnownClass::NamedTupleLike)
                 );
             if !is_value_refinement {
-                builder = builder.add_positive(*positive);
+                builder = builder.add_positive(match positive.resolve_type_alias(db) {
+                    Type::LiteralValue(literal) => literal.fallback_instance(db),
+                    _ => *positive,
+                });
             }
         }
         for negative in intersection.negative(db) {
@@ -4174,11 +4181,12 @@ impl<'db> Type<'db> {
                 let signatures = function.signature(db);
                 let self_instance = bound_method.self_instance(db);
                 let typing_self_type = bound_method.typing_self_type(db);
-                let intersection_self = matches!(self_instance, Type::Intersection(_));
+                let prebind_self =
+                    matches!(self_instance, Type::Intersection(_) | Type::LiteralValue(_));
                 CallableBinding::from_overloads(
                     self,
                     signatures.overloads.iter().map(|signature| {
-                        if intersection_self {
+                        if prebind_self {
                             signature.apply_self_for_bound_call(db, typing_self_type)
                         } else {
                             signature.apply_self_to_generic_defaults(db, typing_self_type)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1161,12 +1161,7 @@ impl<'db> Type<'db> {
     pub(crate) fn apply_self_binding(self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
         match self {
             Type::FunctionLiteral(function) => {
-                let self_type = function.signature(db).self_binding_type(db, self_type);
-                self.apply_type_mapping(
-                    db,
-                    &TypeMapping::BindSelf(SelfBinding::new(db, self_type, None)),
-                    TypeContext::default(),
-                )
+                Type::FunctionLiteral(function.apply_self(db, self_type))
             }
             Type::Callable(callable) if callable.is_function_like(db) => {
                 let self_type = callable.signatures(db).self_binding_type(db, self_type);

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7325,6 +7325,7 @@ impl<'db> SelfBinding<'db> {
         // A `Self` carried by the receiver is an unrelated specialization, but a method-owned
         // `Self` that cannot bind to the receiver must not escape the bound signature.
         (self.unbound_method_self_to_unknown
+            && bound_typevar.typevar(db).is_self(db)
             && self.binding_context == Some(bound_typevar.binding_context(db))
             && bound_typevar
                 .binding_context(db)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1066,9 +1066,10 @@ impl<'db> Type<'db> {
 
     /// Return the part of a receiver type that describes its runtime class for `Self` binding.
     ///
-    /// Negative constraints and flow refinements describe the current value, but do not necessarily
-    /// apply to another instance returned as `Self`. When known, `self_typevar` identifies the
-    /// protocol that owns `Self`, so other structural constraints can be treated as refinements.
+    /// Value-level negative constraints and flow refinements describe the current value, but do not
+    /// necessarily apply to another instance returned as `Self`. Nominal exclusions describe the
+    /// receiver's runtime class and remain valid. When known, `self_typevar` identifies the protocol
+    /// that owns `Self`, so other structural constraints can be treated as refinements.
     pub(crate) fn self_binding_type_for(
         self,
         db: &'db dyn Db,
@@ -1136,6 +1137,11 @@ impl<'db> Type<'db> {
                 );
             if !is_value_refinement {
                 builder = builder.add_positive(*positive);
+            }
+        }
+        for negative in intersection.negative(db) {
+            if matches!(negative.resolve_type_alias(db), Type::NominalInstance(_)) {
+                builder = builder.add_negative(*negative);
             }
         }
         builder.build()

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1134,6 +1134,32 @@ impl<'db> Type<'db> {
         builder.build()
     }
 
+    fn classmethod_self_type(self, db: &'db dyn Db) -> Self {
+        let Type::Intersection(intersection) = self else {
+            return self.to_instance(db).unwrap_or_else(Type::unknown);
+        };
+
+        let mut builder = IntersectionBuilder::new(db);
+        let mut has_positive = false;
+        for positive in intersection.positive(db) {
+            if let Some(instance) = positive.to_instance(db) {
+                builder = builder.add_positive(instance);
+                has_positive = true;
+            }
+        }
+        for negative in intersection.negative(db) {
+            if let Some(instance) = negative.to_instance(db) {
+                builder = builder.add_negative(instance);
+            }
+        }
+
+        if has_positive {
+            builder.build()
+        } else {
+            Type::unknown()
+        }
+    }
+
     /// Apply `Self` substitutions without binding or replacing the receiver parameter.
     pub(crate) fn apply_self_binding(self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
         match self {
@@ -3897,6 +3923,7 @@ impl<'db> Type<'db> {
                 }
 
                 Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
+                    let receiver = receiver.unwrap_or(this);
                     let enum_class = match this {
                         Type::ClassLiteral(literal) => Some(literal),
                         Type::SubclassOf(subclass_of) => subclass_of
@@ -3919,18 +3946,21 @@ impl<'db> Type<'db> {
 
                     let class_attr_plain = this.class_object_member(db, name_str, policy);
 
-                    let self_instance = this
-                    .to_instance(db)
-                    .expect("`to_instance` always returns `Some` for `ClassLiteral`, `GenericAlias`, and `SubclassOf`");
+                    let self_instance = receiver.classmethod_self_type(db);
                     let class_attr_plain =
                         class_attr_plain.map_type(|ty| ty.bind_self_typevars(db, self_instance));
 
-                    let class_attr_fallback =
-                        Type::try_call_dunder_get_on_attribute(db, class_attr_plain, None, this).0;
+                    let class_attr_fallback = Type::try_call_dunder_get_on_attribute(
+                        db,
+                        class_attr_plain,
+                        None,
+                        receiver,
+                    )
+                    .0;
 
                     let result = this.invoke_descriptor_protocol(
                         db,
-                        this,
+                        receiver,
                         name_str,
                         class_attr_fallback,
                         InstanceFallbackShadowsNonDataDescriptor::Yes,
@@ -4144,8 +4174,7 @@ impl<'db> Type<'db> {
                 let signatures = function.signature(db);
                 let self_instance = bound_method.self_instance(db);
                 let typing_self_type = bound_method.typing_self_type(db);
-                let intersection_self =
-                    !function.is_classmethod(db) && matches!(self_instance, Type::Intersection(_));
+                let intersection_self = matches!(self_instance, Type::Intersection(_));
                 CallableBinding::from_overloads(
                     self,
                     signatures.overloads.iter().map(|signature| {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1091,26 +1091,19 @@ impl<'db> Type<'db> {
         // A generic protocol can constrain a nominal class's unknown type arguments. If the
         // class's bottom materialization satisfies it, preserve it as a class constraint.
         let protocol_is_nominal_class_constraint = |protocol: Type<'db>| {
-            if protocol.class_specialization(db).is_none() {
-                return false;
-            }
-
-            intersection.positive(db).iter().any(|positive| {
-                let Some(class) = positive.nominal_class(db) else {
-                    return false;
-                };
-                let Some(alias) = class.into_generic_alias() else {
-                    return false;
-                };
-                let bottom = GenericAlias::new(
-                    db,
-                    alias.origin(db),
-                    alias
-                        .specialization(db)
-                        .with_materialization_kind(db, Some(MaterializationKind::Bottom)),
-                );
-                Type::instance(db, bottom.into()).is_assignable_to(db, protocol)
-            })
+            protocol.is_specialized_generic(db)
+                && intersection.positive(db).iter().any(|positive| {
+                    let Some((class, specialization)) = positive.class_specialization(db) else {
+                        return false;
+                    };
+                    let bottom = GenericAlias::new(
+                        db,
+                        class,
+                        specialization
+                            .with_materialization_kind(db, Some(MaterializationKind::Bottom)),
+                    );
+                    Type::instance(db, bottom.into()).is_assignable_to(db, protocol)
+                })
         };
         let tuple_shape = Type::homogeneous_tuple(db, Type::object());
         let has_tuple_refinement = intersection

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1134,16 +1134,6 @@ impl<'db> Type<'db> {
         builder.build()
     }
 
-    pub(crate) fn needs_self_binding(self, db: &'db dyn Db) -> bool {
-        self.as_function_literal().is_some_and(|function| {
-            function
-                .signature(db)
-                .overloads
-                .iter()
-                .any(|signature| signature.needs_self_mapping(db, true))
-        })
-    }
-
     /// Apply `Self` substitutions without binding or replacing the receiver parameter.
     pub(crate) fn apply_self_binding(self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
         match self {
@@ -1151,7 +1141,6 @@ impl<'db> Type<'db> {
                 Type::FunctionLiteral(function.apply_self(db, self_type))
             }
             Type::Callable(callable) if callable.is_function_like(db) => {
-                let self_type = callable.signatures(db).self_binding_type(db, self_type);
                 Type::Callable(callable.apply_self(db, self_type))
             }
             _ => self,
@@ -4154,34 +4143,20 @@ impl<'db> Type<'db> {
                 let function = bound_method.function(db);
                 let signatures = function.signature(db);
                 let self_instance = bound_method.self_instance(db);
-                let needs_self_binding = Type::FunctionLiteral(function).needs_self_binding(db);
-                let intersection_self = needs_self_binding
-                    && !function.is_classmethod(db)
-                    && matches!(self_instance, Type::Intersection(_));
-                let self_binding_type = signatures.self_binding_type(db, self_instance);
-                let generic_default_self_type = if function.is_classmethod(db) {
-                    signatures.self_binding_type(
-                        db,
-                        self_instance.to_instance(db).unwrap_or_else(Type::unknown),
-                    )
-                } else {
-                    self_binding_type
-                };
+                let typing_self_type = bound_method.typing_self_type(db);
+                let intersection_self =
+                    !function.is_classmethod(db) && matches!(self_instance, Type::Intersection(_));
                 CallableBinding::from_overloads(
                     self,
                     signatures.overloads.iter().map(|signature| {
-                        if intersection_self && signature.needs_self_mapping(db, true) {
-                            signature.apply_self(db, signature.self_binding_type(db, self_instance))
+                        if intersection_self {
+                            signature.apply_self_for_bound_call(db, typing_self_type)
                         } else {
-                            signature.apply_self_to_generic_defaults(db, generic_default_self_type)
+                            signature.apply_self_to_generic_defaults(db, typing_self_type)
                         }
                     }),
                 )
-                .with_bound_type(if intersection_self || !needs_self_binding {
-                    self_instance
-                } else {
-                    self_binding_type
-                })
+                .with_bound_type(self_instance)
                 .into()
             }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1075,8 +1075,8 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         self_typevar: Option<BoundTypeVarInstance<'db>>,
     ) -> Self {
-        if let Type::LiteralValue(literal) = self.resolve_type_alias(db) {
-            return literal.fallback_instance(db);
+        if let Some(fallback) = literal_runtime_class_type(db, self) {
+            return fallback;
         }
 
         let Type::Intersection(intersection) = self else {
@@ -1127,10 +1127,8 @@ impl<'db> Type<'db> {
                             && !class.is_known(db, KnownClass::NamedTupleLike)
                 );
             if !is_value_refinement {
-                builder = builder.add_positive(match positive.resolve_type_alias(db) {
-                    Type::LiteralValue(literal) => literal.fallback_instance(db),
-                    _ => *positive,
-                });
+                builder = builder
+                    .add_positive(literal_runtime_class_type(db, *positive).unwrap_or(*positive));
             }
         }
         for negative in intersection.negative(db) {
@@ -4181,8 +4179,8 @@ impl<'db> Type<'db> {
                 let signatures = function.signature(db);
                 let self_instance = bound_method.self_instance(db);
                 let typing_self_type = bound_method.typing_self_type(db);
-                let prebind_self =
-                    matches!(self_instance, Type::Intersection(_) | Type::LiteralValue(_));
+                let prebind_self = matches!(self_instance, Type::Intersection(_))
+                    || literal_runtime_class_type(db, self_instance).is_some();
                 CallableBinding::from_overloads(
                     self,
                     signatures.overloads.iter().map(|signature| {
@@ -7284,6 +7282,30 @@ fn type_is_truthiness_refinement<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
                 })
         }
         _ => false,
+    }
+}
+
+fn literal_runtime_class_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
+    match ty.resolve_type_alias(db) {
+        Type::LiteralValue(literal) => Some(literal.fallback_instance(db)),
+        Type::Union(union) => UnionType::try_from_elements(
+            db,
+            union
+                .elements(db)
+                .iter()
+                .map(|element| literal_runtime_class_type(db, *element)),
+        ),
+        Type::TypeVar(typevar) => match typevar.typevar(db).bound_or_constraints(db)? {
+            TypeVarBoundOrConstraints::UpperBound(bound) => literal_runtime_class_type(db, bound),
+            TypeVarBoundOrConstraints::Constraints(constraints) => UnionType::try_from_elements(
+                db,
+                constraints
+                    .elements(db)
+                    .iter()
+                    .map(|constraint| literal_runtime_class_type(db, *constraint)),
+            ),
+        },
+        _ => None,
     }
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7387,9 +7387,7 @@ impl<'db> SelfBinding<'db> {
                 .references_typevar(db, bound_typevar.typevar(db).identity(db)))
         .then(Type::unknown)
     }
-}
 
-impl<'db> SelfBinding<'db> {
     pub(crate) fn new(
         db: &'db dyn Db,
         self_type: Type<'db>,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7309,6 +7309,36 @@ fn literal_runtime_class_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Typ
     }
 }
 
+fn type_inherits_from_owner<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    owner_class: ClassLiteral<'db>,
+) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| type_inherits_from_owner(db, *element, owner_class)),
+        Type::TypeVar(typevar) => {
+            typevar
+                .typevar(db)
+                .bound_or_constraints(db)
+                .is_some_and(|bound_or_constraints| match bound_or_constraints {
+                    TypeVarBoundOrConstraints::UpperBound(bound) => {
+                        type_inherits_from_owner(db, bound, owner_class)
+                    }
+                    TypeVarBoundOrConstraints::Constraints(constraints) => constraints
+                        .elements(db)
+                        .iter()
+                        .all(|constraint| type_inherits_from_owner(db, *constraint, owner_class)),
+                })
+        }
+        _ => ty.nominal_class(db).is_some_and(|class| {
+            class_mro_literals(db, class.class_literal(db)).contains(&owner_class)
+        }),
+    }
+}
+
 /// Information needed to bind `Self` typevars to a concrete type.
 ///
 /// Uses MRO-based matching: a `Self` typevar is bound only if its owner class
@@ -7399,11 +7429,10 @@ impl<'db> SelfBinding<'db> {
             let Type::Intersection(intersection) = self.ty else {
                 return false;
             };
-            intersection.positive(db).iter().any(|positive| {
-                positive.nominal_class(db).is_some_and(|class| {
-                    class_mro_literals(db, class.class_literal(db)).contains(&owner_class)
-                })
-            })
+            intersection
+                .positive(db)
+                .iter()
+                .any(|positive| type_inherits_from_owner(db, *positive, owner_class))
         };
 
         // Fast path for the common method-signature case where the bound `Self`

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2663,28 +2663,20 @@ fn call_property_getter<'db>(
     getter: Type<'db>,
     instance: Type<'db>,
 ) -> Option<Type<'db>> {
-    call_property_getter_with(db, getter, instance, |getter, instance| {
+    let call = |getter: Type<'db>| {
         getter
             .try_call(db, &CallArguments::positional([instance]))
             .ok()
             .map(|binding| binding.return_type(db))
-    })
-}
-
-fn call_property_getter_with<'db>(
-    db: &'db dyn Db,
-    getter: Type<'db>,
-    instance: Type<'db>,
-    mut call: impl FnMut(Type<'db>, Type<'db>) -> Option<Type<'db>>,
-) -> Option<Type<'db>> {
+    };
     // Validate the original receiver annotation before applying `Self` to compute the precise
     // return type.
-    let return_ty = call(getter, instance)?;
+    let return_ty = call(getter)?;
     let bound_getter = getter.apply_self_binding(db, instance);
     if bound_getter == getter {
         Some(return_ty)
     } else {
-        call(bound_getter, instance)
+        call(bound_getter)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1347,9 +1347,8 @@ impl<'db> Bindings<'db> {
                             }
                             [Some(Type::PropertyInstance(property)), Some(instance), ..] => {
                                 if let Some(getter) = property.getter(db) {
-                                    if let Ok(return_ty) = getter
-                                        .try_call(db, &CallArguments::positional([*instance]))
-                                        .map(|binding| binding.return_type(db))
+                                    if let Some(return_ty) =
+                                        call_property_getter(db, getter, *instance)
                                     {
                                         overload.set_return_type(return_ty);
                                     } else {
@@ -1376,9 +1375,8 @@ impl<'db> Bindings<'db> {
                             }
                             [Some(instance), ..] => {
                                 if let Some(getter) = property.getter(db) {
-                                    if let Ok(return_ty) = getter
-                                        .try_call(db, &CallArguments::positional([*instance]))
-                                        .map(|binding| binding.return_type(db))
+                                    if let Some(return_ty) =
+                                        call_property_getter(db, getter, *instance)
                                     {
                                         overload.set_return_type(return_ty);
                                     } else {
@@ -2657,6 +2655,36 @@ impl<'db> Bindings<'db> {
                 }
             }
         }
+    }
+}
+
+fn call_property_getter<'db>(
+    db: &'db dyn Db,
+    getter: Type<'db>,
+    instance: Type<'db>,
+) -> Option<Type<'db>> {
+    call_property_getter_with(db, getter, instance, |getter, instance| {
+        getter
+            .try_call(db, &CallArguments::positional([instance]))
+            .ok()
+            .map(|binding| binding.return_type(db))
+    })
+}
+
+fn call_property_getter_with<'db>(
+    db: &'db dyn Db,
+    getter: Type<'db>,
+    instance: Type<'db>,
+    mut call: impl FnMut(Type<'db>, Type<'db>) -> Option<Type<'db>>,
+) -> Option<Type<'db>> {
+    // Validate the original receiver annotation before applying `Self` to compute the precise
+    // return type.
+    let return_ty = call(getter, instance)?;
+    let bound_getter = getter.apply_self_binding(db, instance);
+    if bound_getter == getter {
+        Some(return_ty)
+    } else {
+        call(bound_getter, instance)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1047,6 +1047,22 @@ impl<'db> FunctionType<'db> {
         )
     }
 
+    pub(crate) fn apply_self(self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
+        let updated_signature = self.signature(db).apply_self(db, self_type);
+        let literal = self.literal(db);
+        let updated_implementation_signature = literal
+            .has_separate_implementation(db)
+            .then(|| self.last_definition_signature(db).apply_self(db, self_type));
+        Self::new(
+            db,
+            literal,
+            UpdatedFunctionSignatures::new(
+                Some(updated_signature),
+                updated_implementation_signature,
+            ),
+        )
+    }
+
     pub(crate) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -44,17 +44,14 @@ pub(super) fn walk_bound_method_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>
 
 #[salsa::tracked]
 impl<'db> BoundMethodType<'db> {
-    /// Returns the type that replaces any `typing.Self` annotations in the bound method signature.
-    /// This is normally the bound-instance type (the type of `self` or `cls`), but if the bound method is
-    /// a `@classmethod`, then it should be an instance of that bound-instance type.
+    /// Returns the receiver type used to replace `typing.Self` in the bound method signature.
+    /// For a `@classmethod`, this is the instance type corresponding to the bound class object.
     pub(crate) fn typing_self_type(self, db: &'db dyn Db) -> Type<'db> {
         let mut self_instance = self.self_instance(db);
         if self.function(db).is_classmethod(db) {
             self_instance = self_instance.to_instance(db).unwrap_or_else(Type::unknown);
         }
-        self.function(db)
-            .signature(db)
-            .self_binding_type(db, self_instance)
+        self_instance
     }
 
     pub(crate) fn map_self_type(

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -49,7 +49,7 @@ impl<'db> BoundMethodType<'db> {
     pub(crate) fn typing_self_type(self, db: &'db dyn Db) -> Type<'db> {
         let mut self_instance = self.self_instance(db);
         if self.function(db).is_classmethod(db) {
-            self_instance = self_instance.to_instance(db).unwrap_or_else(Type::unknown);
+            self_instance = self_instance.classmethod_self_type(db);
         }
         self_instance
     }

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -52,7 +52,9 @@ impl<'db> BoundMethodType<'db> {
         if self.function(db).is_classmethod(db) {
             self_instance = self_instance.to_instance(db).unwrap_or_else(Type::unknown);
         }
-        self_instance
+        self.function(db)
+            .signature(db)
+            .self_binding_type(db, self_instance)
     }
 
     pub(crate) fn map_self_type(

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1226,6 +1226,13 @@ impl<'db> Signature<'db> {
         // TODO: Expand type aliases here so `type Alias = Self` in parameters or returns
         // triggers binding when a method is accessed on a concrete receiver.
         self.return_ty.contains_self(db)
+            || self.generic_context.is_some_and(|generic_context| {
+                generic_context.variables(db).any(|typevar| {
+                    typevar
+                        .default_type(db)
+                        .is_some_and(|default| default.contains_self(db))
+                })
+            })
             || self
                 .parameters
                 .iter()

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -179,15 +179,6 @@ impl<'db> CallableSignature<'db> {
         self.overloads.iter()
     }
 
-    pub(crate) fn self_binding_type(&self, db: &'db dyn Db, self_type: Type<'db>) -> Type<'db> {
-        self.overloads
-            .iter()
-            .filter(|signature| signature.needs_self_mapping(db, false))
-            .map(|signature| signature.self_binding_type(db, self_type))
-            .find(|binding_type| *binding_type != self_type)
-            .unwrap_or(self_type)
-    }
-
     /// Returns the union of all overload return types, or `Unknown` if there are no overloads.
     pub(crate) fn overload_return_type_or_unknown(&self, db: &'db dyn Db) -> Type<'db> {
         match self.overloads.as_slice() {
@@ -520,6 +511,12 @@ pub struct Signature<'db> {
 
     /// Return type. If no annotation was provided, this is `Unknown`.
     pub(crate) return_ty: Type<'db>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SelfMappingComponents {
+    All,
+    GenericDefaults,
 }
 
 /// Whether one callable signature's parameters are compatible with another's.
@@ -923,15 +920,6 @@ impl<'db> Signature<'db> {
         self.definition
     }
 
-    pub(crate) fn self_binding_type(&self, db: &'db dyn Db, self_type: Type<'db>) -> Type<'db> {
-        let self_typevar = self.generic_context.and_then(|generic_context| {
-            generic_context
-                .variables(db)
-                .find(|typevar| typevar.typevar(db).is_self(db))
-        });
-        self_type.self_binding_type_for(db, self_typevar)
-    }
-
     pub(crate) fn bind_self(&self, db: &'db dyn Db, self_type: Option<Type<'db>>) -> Self {
         let mut parameters = self.parameters.iter().cloned().peekable();
         let removed_receiver = parameters.peek().is_some_and(Parameter::is_positional);
@@ -942,33 +930,25 @@ impl<'db> Signature<'db> {
             parameters.next();
         }
 
-        let mut parameters = Parameters::new(db, parameters);
-        let mut return_ty = self.return_ty;
-        let mut generic_context = self.generic_context;
         let binding_context = self.definition.map(BindingContext::Definition);
-        if let Some(self_type) = self_type
-            && self.needs_self_mapping(db, removed_receiver)
-        {
-            let self_mapping = TypeMapping::BindSelf(
+        let signature = Self {
+            generic_context: self.generic_context,
+            definition: self.definition,
+            parameters: Parameters::new(db, parameters),
+            return_ty: self.return_ty,
+        };
+        let mut signature = self_type.map_or(signature.clone(), |self_type| {
+            signature.apply_self_mapping(
+                db,
                 SelfBinding::new(db, self_type, binding_context)
                     .with_unbound_method_self_fallback(),
-            );
-            generic_context = self.map_self_in_generic_defaults(db, &self_mapping);
-            parameters = parameters.apply_type_mapping_impl(
-                db,
-                &self_mapping,
-                TypeContext::default(),
-                &ApplyTypeMappingVisitor::default(),
-            );
-            return_ty = return_ty.apply_type_mapping(db, &self_mapping, TypeContext::default());
-        }
-        Self {
-            generic_context: generic_context
-                .map(|generic_context| generic_context.remove_self(db, binding_context)),
-            definition: self.definition,
-            parameters,
-            return_ty,
-        }
+                SelfMappingComponents::All,
+            )
+        });
+        signature.generic_context = signature
+            .generic_context
+            .map(|generic_context| generic_context.remove_self(db, binding_context));
+        signature
     }
 
     /// Returns `true` if this signature's first parameter can accept the bound `self` type.
@@ -1044,49 +1024,77 @@ impl<'db> Signature<'db> {
             .is_some_and(|parameter| parameter.is_positional() && !parameter.inferred_annotation)
     }
 
-    pub(crate) fn apply_self_to_generic_defaults(
-        &self,
-        db: &'db dyn Db,
-        self_type: Type<'db>,
-    ) -> Self {
-        if !self.generic_defaults_contain_self(db) {
-            return self.clone();
-        }
-
-        let self_mapping = TypeMapping::BindSelf(
+    pub(crate) fn apply_self_for_bound_call(&self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
+        self.apply_self_mapping(
+            db,
             SelfBinding::new(
                 db,
                 self_type,
                 self.definition.map(BindingContext::Definition),
             )
             .with_unbound_method_self_fallback(),
-        );
-        Self {
-            generic_context: self.map_self_in_generic_defaults(db, &self_mapping),
-            ..self.clone()
-        }
+            SelfMappingComponents::All,
+        )
+    }
+
+    pub(crate) fn apply_self_to_generic_defaults(
+        &self,
+        db: &'db dyn Db,
+        self_type: Type<'db>,
+    ) -> Self {
+        self.apply_self_mapping(
+            db,
+            SelfBinding::new(
+                db,
+                self_type,
+                self.definition.map(BindingContext::Definition),
+            )
+            .with_unbound_method_self_fallback(),
+            SelfMappingComponents::GenericDefaults,
+        )
     }
 
     pub(crate) fn apply_self(&self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
-        if !self.needs_self_mapping(db, false) {
+        self.apply_self_mapping(
+            db,
+            SelfBinding::new(
+                db,
+                self_type,
+                self.definition.map(BindingContext::Definition),
+            ),
+            SelfMappingComponents::All,
+        )
+    }
+
+    fn apply_self_mapping(
+        &self,
+        db: &'db dyn Db,
+        self_binding: SelfBinding<'db>,
+        components: SelfMappingComponents,
+    ) -> Self {
+        let needs_mapping = match components {
+            SelfMappingComponents::All => self.needs_self_mapping(db),
+            SelfMappingComponents::GenericDefaults => self.generic_defaults_contain_self(db),
+        };
+        if !needs_mapping {
             return self.clone();
         }
 
-        let self_mapping = TypeMapping::BindSelf(SelfBinding::new(
-            db,
-            self_type,
-            self.definition.map(BindingContext::Definition),
-        ));
-        let parameters = self.parameters.apply_type_mapping_impl(
-            db,
-            &self_mapping,
-            TypeContext::default(),
-            &ApplyTypeMappingVisitor::default(),
-        );
-        let return_ty =
-            self.return_ty
-                .apply_type_mapping(db, &self_mapping, TypeContext::default());
+        let self_mapping = TypeMapping::BindSelf(self_binding);
         let generic_context = self.map_self_in_generic_defaults(db, &self_mapping);
+        let (parameters, return_ty) = match components {
+            SelfMappingComponents::All => (
+                self.parameters.apply_type_mapping_impl(
+                    db,
+                    &self_mapping,
+                    TypeContext::default(),
+                    &ApplyTypeMappingVisitor::default(),
+                ),
+                self.return_ty
+                    .apply_type_mapping(db, &self_mapping, TypeContext::default()),
+            ),
+            SelfMappingComponents::GenericDefaults => (self.parameters.clone(), self.return_ty),
+        };
         Self {
             generic_context,
             definition: self.definition,
@@ -1256,7 +1264,7 @@ impl<'db> Signature<'db> {
         ))
     }
 
-    pub(crate) fn needs_self_mapping(&self, db: &'db dyn Db, receiver_is_removed: bool) -> bool {
+    fn needs_self_mapping(&self, db: &'db dyn Db) -> bool {
         // TODO: Expand type aliases here so `type Alias = Self` in parameters or returns
         // triggers binding when a method is accessed on a concrete receiver.
         self.return_ty.contains_self(db)
@@ -1264,9 +1272,7 @@ impl<'db> Signature<'db> {
             || self
                 .parameters
                 .iter()
-                .enumerate()
-                .skip(usize::from(receiver_is_removed))
-                .any(|(_, parameter)| parameter.annotated_type().contains_self(db))
+                .any(|parameter| parameter.annotated_type().contains_self(db))
     }
 
     fn generic_defaults_contain_self(&self, db: &'db dyn Db) -> bool {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -948,8 +948,10 @@ impl<'db> Signature<'db> {
         if let Some(self_type) = self_type
             && self.needs_self_mapping(db, removed_receiver)
         {
-            let self_mapping =
-                TypeMapping::BindSelf(SelfBinding::new(db, self_type, binding_context));
+            let self_mapping = TypeMapping::BindSelf(
+                SelfBinding::new(db, self_type, binding_context)
+                    .with_unbound_method_self_fallback(),
+            );
             parameters = parameters.apply_type_mapping_impl(
                 db,
                 &self_mapping,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1059,8 +1059,16 @@ impl<'db> Signature<'db> {
         let return_ty =
             self.return_ty
                 .apply_type_mapping(db, &self_mapping, TypeContext::default());
+        let generic_context = self.generic_context.map(|generic_context| {
+            GenericContext::from_typevar_instances(
+                db,
+                generic_context
+                    .variables(db)
+                    .map(|typevar| typevar.apply_type_mapping_to_default(db, &self_mapping)),
+            )
+        });
         Self {
-            generic_context: self.generic_context,
+            generic_context,
             definition: self.definition,
             parameters,
             return_ty,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -182,6 +182,7 @@ impl<'db> CallableSignature<'db> {
     pub(crate) fn self_binding_type(&self, db: &'db dyn Db, self_type: Type<'db>) -> Type<'db> {
         self.overloads
             .iter()
+            .filter(|signature| signature.needs_self_mapping(db, false))
             .map(|signature| signature.self_binding_type(db, self_type))
             .find(|binding_type| *binding_type != self_type)
             .unwrap_or(self_type)

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -513,7 +513,7 @@ pub struct Signature<'db> {
     pub(crate) return_ty: Type<'db>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy)]
 enum SelfMappingComponents {
     All,
     GenericDefaults,
@@ -937,14 +937,16 @@ impl<'db> Signature<'db> {
             parameters: Parameters::new(db, parameters),
             return_ty: self.return_ty,
         };
-        let mut signature = self_type.map_or(signature.clone(), |self_type| {
+        let mut signature = if let Some(self_type) = self_type {
             signature.apply_self_mapping(
                 db,
                 SelfBinding::new(db, self_type, binding_context)
                     .with_unbound_method_self_fallback(),
                 SelfMappingComponents::All,
             )
-        });
+        } else {
+            signature
+        };
         signature.generic_context = signature
             .generic_context
             .map(|generic_context| generic_context.remove_self(db, binding_context));
@@ -1081,7 +1083,14 @@ impl<'db> Signature<'db> {
         }
 
         let self_mapping = TypeMapping::BindSelf(self_binding);
-        let generic_context = self.map_self_in_generic_defaults(db, &self_mapping);
+        let generic_context = self.generic_context.map(|generic_context| {
+            GenericContext::from_typevar_instances(
+                db,
+                generic_context
+                    .variables(db)
+                    .map(|typevar| typevar.apply_type_mapping_to_default(db, &self_mapping)),
+            )
+        });
         let (parameters, return_ty) = match components {
             SelfMappingComponents::All => (
                 self.parameters.apply_type_mapping_impl(
@@ -1101,21 +1110,6 @@ impl<'db> Signature<'db> {
             parameters,
             return_ty,
         }
-    }
-
-    fn map_self_in_generic_defaults(
-        &self,
-        db: &'db dyn Db,
-        self_mapping: &TypeMapping<'_, 'db>,
-    ) -> Option<GenericContext<'db>> {
-        self.generic_context.map(|generic_context| {
-            GenericContext::from_typevar_instances(
-                db,
-                generic_context
-                    .variables(db)
-                    .map(|typevar| typevar.apply_type_mapping_to_default(db, self_mapping)),
-            )
-        })
     }
 
     /// Returns this signature with the given specialization applied to parameters and return type.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -179,6 +179,14 @@ impl<'db> CallableSignature<'db> {
         self.overloads.iter()
     }
 
+    pub(crate) fn self_binding_type(&self, db: &'db dyn Db, self_type: Type<'db>) -> Type<'db> {
+        self.overloads
+            .iter()
+            .map(|signature| signature.self_binding_type(db, self_type))
+            .find(|binding_type| *binding_type != self_type)
+            .unwrap_or(self_type)
+    }
+
     /// Returns the union of all overload return types, or `Unknown` if there are no overloads.
     pub(crate) fn overload_return_type_or_unknown(&self, db: &'db dyn Db) -> Type<'db> {
         match self.overloads.as_slice() {
@@ -914,6 +922,15 @@ impl<'db> Signature<'db> {
         self.definition
     }
 
+    pub(crate) fn self_binding_type(&self, db: &'db dyn Db, self_type: Type<'db>) -> Type<'db> {
+        let self_typevar = self.generic_context.and_then(|generic_context| {
+            generic_context
+                .variables(db)
+                .find(|typevar| typevar.typevar(db).is_self(db))
+        });
+        self_type.self_binding_type_for(db, self_typevar)
+    }
+
     pub(crate) fn bind_self(&self, db: &'db dyn Db, self_type: Option<Type<'db>>) -> Self {
         let mut parameters = self.parameters.iter().cloned().peekable();
         let removed_receiver = parameters.peek().is_some_and(Parameter::is_positional);
@@ -1196,7 +1213,7 @@ impl<'db> Signature<'db> {
         ))
     }
 
-    fn needs_self_mapping(&self, db: &'db dyn Db, receiver_is_removed: bool) -> bool {
+    pub(crate) fn needs_self_mapping(&self, db: &'db dyn Db, receiver_is_removed: bool) -> bool {
         // TODO: Expand type aliases here so `type Alias = Self` in parameters or returns
         // triggers binding when a method is accessed on a concrete receiver.
         self.return_ty.contains_self(db)

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -944,6 +944,7 @@ impl<'db> Signature<'db> {
 
         let mut parameters = Parameters::new(db, parameters);
         let mut return_ty = self.return_ty;
+        let mut generic_context = self.generic_context;
         let binding_context = self.definition.map(BindingContext::Definition);
         if let Some(self_type) = self_type
             && self.needs_self_mapping(db, removed_receiver)
@@ -952,6 +953,7 @@ impl<'db> Signature<'db> {
                 SelfBinding::new(db, self_type, binding_context)
                     .with_unbound_method_self_fallback(),
             );
+            generic_context = self.map_self_in_generic_defaults(db, &self_mapping);
             parameters = parameters.apply_type_mapping_impl(
                 db,
                 &self_mapping,
@@ -961,8 +963,7 @@ impl<'db> Signature<'db> {
             return_ty = return_ty.apply_type_mapping(db, &self_mapping, TypeContext::default());
         }
         Self {
-            generic_context: self
-                .generic_context
+            generic_context: generic_context
                 .map(|generic_context| generic_context.remove_self(db, binding_context)),
             definition: self.definition,
             parameters,
@@ -1043,6 +1044,29 @@ impl<'db> Signature<'db> {
             .is_some_and(|parameter| parameter.is_positional() && !parameter.inferred_annotation)
     }
 
+    pub(crate) fn apply_self_to_generic_defaults(
+        &self,
+        db: &'db dyn Db,
+        self_type: Type<'db>,
+    ) -> Self {
+        if !self.generic_defaults_contain_self(db) {
+            return self.clone();
+        }
+
+        let self_mapping = TypeMapping::BindSelf(
+            SelfBinding::new(
+                db,
+                self_type,
+                self.definition.map(BindingContext::Definition),
+            )
+            .with_unbound_method_self_fallback(),
+        );
+        Self {
+            generic_context: self.map_self_in_generic_defaults(db, &self_mapping),
+            ..self.clone()
+        }
+    }
+
     pub(crate) fn apply_self(&self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
         if !self.needs_self_mapping(db, false) {
             return self.clone();
@@ -1062,20 +1086,28 @@ impl<'db> Signature<'db> {
         let return_ty =
             self.return_ty
                 .apply_type_mapping(db, &self_mapping, TypeContext::default());
-        let generic_context = self.generic_context.map(|generic_context| {
-            GenericContext::from_typevar_instances(
-                db,
-                generic_context
-                    .variables(db)
-                    .map(|typevar| typevar.apply_type_mapping_to_default(db, &self_mapping)),
-            )
-        });
+        let generic_context = self.map_self_in_generic_defaults(db, &self_mapping);
         Self {
             generic_context,
             definition: self.definition,
             parameters,
             return_ty,
         }
+    }
+
+    fn map_self_in_generic_defaults(
+        &self,
+        db: &'db dyn Db,
+        self_mapping: &TypeMapping<'_, 'db>,
+    ) -> Option<GenericContext<'db>> {
+        self.generic_context.map(|generic_context| {
+            GenericContext::from_typevar_instances(
+                db,
+                generic_context
+                    .variables(db)
+                    .map(|typevar| typevar.apply_type_mapping_to_default(db, self_mapping)),
+            )
+        })
     }
 
     /// Returns this signature with the given specialization applied to parameters and return type.
@@ -1228,19 +1260,23 @@ impl<'db> Signature<'db> {
         // TODO: Expand type aliases here so `type Alias = Self` in parameters or returns
         // triggers binding when a method is accessed on a concrete receiver.
         self.return_ty.contains_self(db)
-            || self.generic_context.is_some_and(|generic_context| {
-                generic_context.variables(db).any(|typevar| {
-                    typevar
-                        .default_type(db)
-                        .is_some_and(|default| default.contains_self(db))
-                })
-            })
+            || self.generic_defaults_contain_self(db)
             || self
                 .parameters
                 .iter()
                 .enumerate()
                 .skip(usize::from(receiver_is_removed))
                 .any(|(_, parameter)| parameter.annotated_type().contains_self(db))
+    }
+
+    fn generic_defaults_contain_self(&self, db: &'db dyn Db) -> bool {
+        self.generic_context.is_some_and(|generic_context| {
+            generic_context.variables(db).any(|typevar| {
+                typevar
+                    .default_type(db)
+                    .is_some_and(|default| default.contains_self(db))
+            })
+        })
     }
 
     fn inferable_typevars(&self, db: &'db dyn Db) -> InferableTypeVars<'db> {

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -918,7 +918,9 @@ impl<'db> BoundTypeVarInstance<'db> {
                 if binding.should_bind(db, self) {
                     binding.self_type_for(db, self)
                 } else {
-                    Type::TypeVar(self)
+                    binding
+                        .unbound_self_type_for(db, self)
+                        .unwrap_or(Type::TypeVar(self))
                 }
             }
             TypeMapping::ReplaceSelf { new_upper_bound } => {

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -888,7 +888,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                 .unwrap_or(Type::TypeVar(self)),
             TypeMapping::BindSelf(binding) => {
                 if binding.should_bind(db, self) {
-                    binding.self_type()
+                    binding.self_type_for(db, self)
                 } else {
                     Type::TypeVar(self)
                 }

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -819,6 +819,34 @@ impl<'db> BoundTypeVarInstance<'db> {
         )
     }
 
+    pub(crate) fn apply_type_mapping_to_default<'a>(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'a, 'db>,
+    ) -> Self {
+        let Some(default) = self.default_type(db) else {
+            return self;
+        };
+        let mapped_default = default.apply_type_mapping(db, type_mapping, TypeContext::default());
+        if mapped_default == default {
+            return self;
+        }
+
+        let typevar = TypeVarInstance::new(
+            db,
+            self.typevar(db).identity(db),
+            self.typevar(db)._bound_or_constraints(db),
+            self.typevar(db).explicit_variance(db),
+            Some(TypeVarDefaultEvaluation::Eager(mapped_default)),
+        );
+        Self::new(
+            db,
+            typevar,
+            self.binding_context(db),
+            self.paramspec_attr(db),
+        )
+    }
+
     pub(crate) fn variance_with_polarity(
         self,
         db: &'db dyn Db,


### PR DESCRIPTION
## Summary

When a method, property, or attribute returns `Self`, we bind it from the receiver type. For an intersection receiver, that type can mix runtime-class information with refinements that describe only the current value, such as truthiness, a literal value, an exact tuple shape, or a protocol learned through narrowing. Carrying all of those refinements into another `Self` instance is incorrect, while dropping the intersection entirely loses valid nominal constraints.

```py
from typing import Self
from ty_extensions import Intersection

class Value:
    def copy(self) -> Self:
        return self

class Extra: ...

def copy(value: Intersection[Value, Extra]):
    reveal_type(value.copy())  # before: Value; after: Value & Extra
```

Although `copy()` may return a different value, `Self` guarantees that it has the receiver's runtime type, so it still satisfies both nominal constraints.

We introduce an owner-aware projection for the receiver type used to bind `Self`. The projection preserves facts that remain true for another instance of the same runtime class, including nominal intersections and exclusions, relevant generic constraints, and tuple runtime-class information, while discarding value-only and unrelated structural refinements. We use the projected receiver consistently when binding methods, properties, attributes, overloads, aliases, and classmethods, and avoid exposing an unresolved method-scoped `Self` when an aliased method has an incompatible owner.

We also apply `Self` substitution to generic method defaults in both normal binding and prebinding paths. This covers defaults where `Self` is the only occurrence, dependent default chains, and classmethod defaults, so bound signatures retain concrete receiver types instead of leaking `Self` or degrading dependent parameters to `Unknown`.
