### PR TITLE
[`flake8-no-pep420`] Ignore top-level tests for INP001

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_no_pep420/test_fail_nested_tests/package/tests/test_foo.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_no_pep420/test_fail_nested_tests/package/tests/test_foo.py
@@ -1,0 +1,2 @@
+def test_foo():
+    pass

--- a/crates/ruff_linter/resources/test/fixtures/flake8_no_pep420/test_pass_top_level_tests/tests/test_foo.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_no_pep420/test_pass_top_level_tests/tests/test_foo.py
@@ -1,0 +1,2 @@
+def test_foo():
+    assert True

--- a/crates/ruff_linter/resources/test/fixtures/flake8_no_pep420/test_pass_top_level_tests/tests/unit/test_bar.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_no_pep420/test_pass_top_level_tests/tests/unit/test_bar.py
@@ -1,0 +1,2 @@
+def test_bar():
+    assert True

--- a/crates/ruff_linter/src/rules/flake8_no_pep420/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_no_pep420/mod.rs
@@ -15,6 +15,10 @@ mod tests {
     use crate::test::{test_path, test_resource_path};
 
     #[test_case(Path::new("test_fail_empty"), Path::new("example.py"))]
+    #[test_case(
+        Path::new("test_fail_nested_tests"),
+        Path::new("package/tests/test_foo.py")
+    )]
     #[test_case(Path::new("test_fail_nonempty"), Path::new("example.py"))]
     #[test_case(Path::new("test_ignored"), Path::new("example.py"))]
     #[test_case(Path::new("test_pass_init"), Path::new("example.py"))]
@@ -41,6 +45,26 @@ mod tests {
         )?;
         insta::with_settings!({filters => vec![(r"\\", "/")]}, {
             assert_diagnostics!(snapshot, diagnostics);
+        });
+        Ok(())
+    }
+
+    #[test_case(Path::new("tests/test_foo.py"))]
+    #[test_case(Path::new("tests/unit/test_bar.py"))]
+    fn top_level_tests(filename: &Path) -> Result<()> {
+        let project_root =
+            test_resource_path("fixtures/flake8_no_pep420/test_pass_top_level_tests");
+        let p = project_root.join(filename);
+        let diagnostics = test_path(
+            p.strip_prefix(test_resource_path("fixtures"))?,
+            &LinterSettings {
+                project_root: project_root.clone(),
+                src: vec![project_root.clone(), project_root.join("src")],
+                ..LinterSettings::for_rule(Rule::ImplicitNamespacePackage)
+            },
+        )?;
+        insta::with_settings!({filters => vec![(r"\\", "/")]}, {
+            assert_diagnostics!(format!("top_level_tests_{}", filename.display()), diagnostics);
         });
         Ok(())
     }

--- a/crates/ruff_linter/src/rules/flake8_no_pep420/rules/implicit_namespace_package.rs
+++ b/crates/ruff_linter/src/rules/flake8_no_pep420/rules/implicit_namespace_package.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::PySourceType;
@@ -82,6 +82,9 @@ pub(crate) fn implicit_namespace_package(
         && !path
             .parent()
             .is_some_and( |parent| src.iter().any(|src| src == parent))
+        // Ignore test files in the top-level `tests` directory, as recommended pytest layouts do
+        // not require `tests` to be a package.
+        && !is_top_level_tests_file(path, project_root)
         // Ignore files that contain a shebang.
         && comment_ranges
             .first().filter(|range| range.start() == TextSize::from(0))
@@ -115,4 +118,16 @@ pub(crate) fn implicit_namespace_package(
             }
         }
     }
+}
+
+fn is_top_level_tests_file(path: &Path, project_root: &Path) -> bool {
+    let Ok(relative) = path.strip_prefix(project_root) else {
+        return false;
+    };
+
+    let mut components = relative.components();
+    matches!(
+        components.next(),
+        Some(Component::Normal(component)) if component == "tests"
+    ) && components.next().is_some()
 }

--- a/crates/ruff_linter/src/rules/flake8_no_pep420/snapshots/ruff_linter__rules__flake8_no_pep420__tests__test_fail_nested_tests.snap
+++ b/crates/ruff_linter/src/rules/flake8_no_pep420/snapshots/ruff_linter__rules__flake8_no_pep420__tests__test_fail_nested_tests.snap
@@ -1,0 +1,5 @@
+---
+source: crates/ruff_linter/src/rules/flake8_no_pep420/mod.rs
+---
+INP001 File `./resources/test/fixtures/flake8_no_pep420/test_fail_nested_tests/package/tests/test_foo.py` is part of an implicit namespace package. Add an `__init__.py`.
+--> test_foo.py:1:1

--- a/crates/ruff_linter/src/rules/flake8_no_pep420/snapshots/ruff_linter__rules__flake8_no_pep420__tests__top_level_tests_tests__test_foo.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_no_pep420/snapshots/ruff_linter__rules__flake8_no_pep420__tests__top_level_tests_tests__test_foo.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/flake8_no_pep420/mod.rs
+---
+

--- a/crates/ruff_linter/src/rules/flake8_no_pep420/snapshots/ruff_linter__rules__flake8_no_pep420__tests__top_level_tests_tests__unit__test_bar.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_no_pep420/snapshots/ruff_linter__rules__flake8_no_pep420__tests__top_level_tests_tests__unit__test_bar.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/flake8_no_pep420/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Fixes #6474.

This skips `INP001` for Python files under a top-level `tests/` directory. The exemption is limited to `project_root/tests/**`; nested paths like `package/tests/test_foo.py` still report `INP001`.

## Test Plan

- `cargo fmt --check`
- `cargo test -p ruff_linter flake8_no_pep420 -- --nocapture`
- `cargo test -p ruff_linter package_detection -- --nocapture`
- `cargo run -p ruff -- check . --select INP001 --isolated --no-cache` from the top-level tests fixture
- `cargo run -p ruff -- check . --select INP001 --isolated --no-cache` from the nested tests fixture, expecting one `INP001`
- `uvx prek run --files <changed files>`
- `cargo clippy -p ruff_linter --all-targets --all-features -- -D warnings`
- `git diff --check`
