### PR TITLE
[ty] Factor and cache repeated narrowing branches

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1215,6 +1215,65 @@ fn benchmark_typeis_narrowing(criterion: &mut Criterion) {
     });
 }
 
+/// Regression benchmark for repeated loads under a long `TypeIs` `elif` chain.
+///
+/// Each branch adds one negative narrowing constraint to `source`. Without compacting the repeated
+/// branches and caching large projected results, every load rebuilds the accumulated intersection.
+fn benchmark_typeis_elif_narrowing(criterion: &mut Criterion) {
+    const NUM_CLASSES: usize = 40;
+    const LOADS_PER_BRANCH: usize = 10;
+
+    setup_rayon();
+
+    let mut code = r#"
+from typing import TypeVar
+from typing_extensions import TypeIs
+
+T = TypeVar("T")
+
+class Source: ...
+"#
+    .to_string();
+
+    for i in 0..NUM_CLASSES {
+        writeln!(&mut code, "class C{i}(Source): ...").ok();
+    }
+
+    code.push_str(
+        r#"
+def istype(value: object, cls: type[T]) -> TypeIs[T]:
+    raise NotImplementedError
+
+def consume(value: object) -> None: ...
+
+def check(source: Source) -> None:
+"#,
+    );
+
+    for i in 0..NUM_CLASSES {
+        if i == 0 {
+            writeln!(&mut code, "    if istype(source, C{i}):").ok();
+        } else {
+            writeln!(&mut code, "    elif istype(source, C{i}):").ok();
+        }
+        for _ in 0..LOADS_PER_BRANCH {
+            code.push_str("        consume(source)\n");
+        }
+    }
+
+    criterion.bench_function("ty_micro[typeis_elif_narrowing]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 fn benchmark_pandas_tdd(criterion: &mut Criterion) {
     setup_rayon();
 
@@ -1524,6 +1583,7 @@ criterion_group!(
     benchmark_literal_match_fallthrough_guarded_any,
     benchmark_literal_equality_fallthrough_guarded_any,
     benchmark_typeis_narrowing,
+    benchmark_typeis_elif_narrowing,
     benchmark_pandas_tdd,
     benchmark_recursive_typed_dict_union_contextual_inference,
     benchmark_pydantic_core_schema_dict,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -554,3 +554,35 @@ def f():
     else:
         reveal_type(y)  # revealed: int | str
 ```
+
+## Repeated `TypeIs` `elif` narrowing
+
+Each later branch retains the negative constraints from all earlier predicates.
+
+```py
+from typing_extensions import TypeIs
+from typing import TypeVar
+
+T = TypeVar("T")
+
+class Source: ...
+class A(Source): ...
+class B(Source): ...
+class C(Source): ...
+class D(Source): ...
+
+def istype(value: object, cls: type[T]) -> TypeIs[T]:
+    return type(value) is cls
+
+def check(source: Source) -> None:
+    if istype(source, A):
+        reveal_type(source)  # revealed: A
+    elif istype(source, B):
+        reveal_type(source)  # revealed: B & ~A
+    elif istype(source, C):
+        reveal_type(source)  # revealed: C & ~A & ~B
+    elif istype(source, D):
+        reveal_type(source)  # revealed: D & ~A & ~B & ~C
+    else:
+        reveal_type(source)  # revealed: Source & ~A & ~B & ~C & ~D
+```

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -219,6 +219,8 @@ use ty_python_core::{
         ScopedPredicateId,
     },
     reachability_constraints::{ReachabilityConstraints, ScopedReachabilityConstraintId},
+    scope::ScopeId,
+    use_def_map,
 };
 
 /// Narrow `subject_ty` by all preceding unguarded match patterns.
@@ -507,6 +509,49 @@ fn accumulate_constraint<'db>(
     }
 }
 
+const MIN_CACHED_PROJECTED_NODES: usize = 30;
+const MIN_REPEATED_NARROWING_BRANCHES: usize = 4;
+
+fn predicate_scope<'db>(db: &'db dyn Db, predicate: Predicate<'db>) -> ScopeId<'db> {
+    match predicate.node {
+        PredicateNode::Expression(expression) => expression.scope(db),
+        PredicateNode::IsNonTerminalCall(call) => call.callable.scope(db),
+        PredicateNode::Pattern(pattern) => pattern.scope(db),
+        PredicateNode::StarImportPlaceholder(star_import) => star_import.scope(db),
+    }
+}
+
+/// Cache the final narrowed type for large projected graphs that are reused by many place loads.
+#[salsa::tracked(
+    cycle_initial = |_, id, _, _, _, _| Type::divergent(id),
+    cycle_fn = |db, cycle, previous: &Type<'db>, result: Type<'db>, _, _, _, _| {
+        result.cycle_normalized(db, *previous, cycle)
+    },
+    heap_size = ruff_memory_usage::heap_size
+)]
+fn type_narrowed_by_large_projected_constraint<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    id: ScopedReachabilityConstraintId,
+    base_ty: Type<'db>,
+    place: ScopedPlaceId,
+) -> Type<'db> {
+    let use_def = use_def_map(db, scope);
+    let constraints = use_def.reachability_constraints();
+    let predicates = use_def.predicates();
+    let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
+    let projected_root = projector.project(id);
+
+    let mut context = ProjectedNarrowingContext {
+        db,
+        base_ty,
+        graph: &projector.graph,
+        joins: projector.graph.joins(projected_root),
+        join_cache: FxHashMap::default(),
+    };
+    context.narrow(projected_root, None)
+}
+
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
     /// Narrow a type by walking a TDD narrowing constraint.
     fn narrow_by_constraint(
@@ -559,6 +604,13 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
     ) -> Type<'db> {
         let mut projector = NarrowingProjector::new(db, self, predicates, place);
         let projected_root = projector.project(id);
+
+        if projector.graph.nodes.len() >= MIN_CACHED_PROJECTED_NODES {
+            let node = self.get_interior_node(id);
+            let scope = predicate_scope(db, predicates[node.atom()]);
+            return type_narrowed_by_large_projected_constraint(db, scope, id, base_ty, place);
+        }
+
         let mut context = ProjectedNarrowingContext {
             db,
             base_ty,
@@ -884,6 +936,101 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
         result
     }
 
+    /// Find a chain where every predicate branch reaches the same anchor subgraph.
+    ///
+    /// For complementary predicates, a chain such as
+    /// `(P1 & A) | (~P1 & ((P2 & A) | (~P2 & R)))` is equivalent to
+    /// `((P1 | P2) & A) | (~(P1 | P2) & R)`.
+    fn repeated_branch_chain(
+        &self,
+        id: ProjectedNarrowingNodeId,
+        anchor_is_true: bool,
+    ) -> Option<(
+        ProjectedNarrowingNodeId,
+        ProjectedNarrowingNodeId,
+        Type<'db>,
+    )> {
+        let first = self.graph.node(id);
+        let anchor = if anchor_is_true {
+            first.if_true
+        } else {
+            first.if_false
+        };
+        if anchor == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+            return None;
+        }
+
+        let mut current = id;
+        let mut anchor_constraints = vec![];
+        while !current.is_terminal() {
+            let node = self.graph.node(current);
+            let (anchor_child, tail_child) = if anchor_is_true {
+                (node.if_true, node.if_false)
+            } else {
+                (node.if_false, node.if_true)
+            };
+            if anchor_child != anchor {
+                break;
+            }
+
+            let (positive, negative) = &self.graph.predicate_constraints_cache[&node.atom];
+            let (anchor_constraint, tail_constraint) = if anchor_is_true {
+                (positive.as_ref()?, negative.as_ref()?)
+            } else {
+                (negative.as_ref()?, positive.as_ref()?)
+            };
+            if !anchor_constraint.is_direct_complement_of(self.db, tail_constraint) {
+                break;
+            }
+            anchor_constraints.push(anchor_constraint.single_intersection_type()?);
+            current = tail_child;
+        }
+
+        (anchor_constraints.len() >= MIN_REPEATED_NARROWING_BRANCHES).then(|| {
+            (
+                anchor,
+                current,
+                UnionType::from_elements(self.db, anchor_constraints),
+            )
+        })
+    }
+
+    fn narrow_repeated_branch_chain(
+        &mut self,
+        id: ProjectedNarrowingNodeId,
+        accumulated: Option<NarrowingConstraint<'db>>,
+    ) -> Option<Type<'db>> {
+        // Replacement narrowing does not distribute over this rewrite.
+        if accumulated
+            .as_ref()
+            .is_some_and(|constraint| !constraint.is_intersection_only())
+        {
+            return None;
+        }
+
+        let (anchor, tail, anchor_constraint) = self
+            .repeated_branch_chain(id, true)
+            .or_else(|| self.repeated_branch_chain(id, false))?;
+        let tail_constraint = anchor_constraint.negate(self.db);
+
+        let anchor_ty = self.narrow(
+            anchor,
+            accumulate_constraint(
+                accumulated.clone(),
+                Some(NarrowingConstraint::intersection(anchor_constraint)),
+            ),
+        );
+        let tail_ty = self.narrow(
+            tail,
+            accumulate_constraint(
+                accumulated,
+                Some(NarrowingConstraint::intersection(tail_constraint)),
+            ),
+        );
+
+        Some(UnionType::from_two_elements(self.db, anchor_ty, tail_ty))
+    }
+
     /// Recursively evaluates a projected path while accumulating narrowing constraints.
     fn narrow(
         &mut self,
@@ -913,6 +1060,10 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
         if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
             apply_accumulated_narrowing(self.db, self.base_ty, accumulated)
         } else {
+            if let Some(narrowed) = self.narrow_repeated_branch_chain(id, accumulated.clone()) {
+                return narrowed;
+            }
+
             let node = self.graph.node(id);
             let (pos_constraint, neg_constraint) =
                 self.graph.predicate_constraints_cache[&node.atom].clone();

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -572,6 +572,40 @@ impl<'db> NarrowingConstraint<'db> {
         }
         union.build()
     }
+
+    pub(crate) fn is_intersection_only(&self) -> bool {
+        self.replacement_disjuncts.is_empty()
+    }
+
+    pub(crate) fn single_intersection_type(&self) -> Option<Type<'db>> {
+        let [disjunct] = &*self.intersection_disjuncts else {
+            return None;
+        };
+        let [conjunct] = &*disjunct.conjuncts else {
+            return None;
+        };
+
+        self.replacement_disjuncts.is_empty().then_some(*conjunct)
+    }
+
+    /// Return whether these are single intersection constraints represented as `T` and `~T`.
+    pub(crate) fn is_direct_complement_of(&self, db: &'db dyn Db, other: &Self) -> bool {
+        fn is_direct_negation<'db>(db: &'db dyn Db, ty: Type<'db>, negated: Type<'db>) -> bool {
+            let Type::Intersection(intersection) = negated else {
+                return false;
+            };
+            intersection.positive(db).is_empty()
+                && intersection.negative(db).len() == 1
+                && intersection.negative(db).contains(&ty)
+        }
+
+        self.single_intersection_type()
+            .zip(other.single_intersection_type())
+            .is_some_and(|(self_ty, other_ty)| {
+                is_direct_negation(db, self_ty, other_ty)
+                    || is_direct_negation(db, other_ty, self_ty)
+            })
+    }
 }
 
 impl<'db> From<Type<'db>> for NarrowingConstraint<'db> {


### PR DESCRIPTION
## Summary

Repeated loads under long narrowing conditions can evaluate and normalize the same projected reachability graph many times. For example:

```python
if (
    is_a(value)
    or is_b(value)
    or is_c(value)
    or is_d(value)
):
    consume(value)
    consume(value)
    consume(value)
```

After projection onto `value`, each predicate contributes a positive and negative narrowing constraint. The existing evaluator expands the reachable paths independently, producing the equivalent of:

```text
(A & R) | (~A & ((B & R) | (~B & ((C & R) | (~C & ((D & R) | (~D & F)))))))
```

This change recognizes linear projected-graph chains where at least four predicates have the same reachable continuation on the same side and each predicate contributes exact complementary constraints `T` and `~T`. It combines the predicates before evaluating the two continuations:

```text
((A | B | C | D) & R) | (~(A | B | C | D) & F)
```

The optimization is not specific to `istype`, function calls, or `TypeIs`. It runs after we infer narrowing constraints and project the reachability graph, so it can apply to any predicate form that produces the required exact `T` / `~T` intersection constraints. `TypeIs` is the motivating case because it naturally narrows both branches and PyTorch contains long chains with many repeated loads.

The rewrite is deliberately narrow. It does not factor replacement narrowing such as `TypeGuard`, compound or disjunctive constraints, predicates that are only semantically complementary, chains shorter than four predicates, alternating shared-branch shapes, or general diamond-shaped graphs. Those cases continue through the existing evaluator.

Separately, we cache the final narrowed type for any projected graph with at least 30 nodes, keyed by scope, reachability constraint, base type, and place. This cache is independent of the repeated-branch matcher: arbitrary large graph shapes can benefit when the same narrowing query is requested repeatedly, without retaining a Salsa entry for every intermediate prefix.

On PyTorch commit `29d6170e7c79f2c71943692985a1546fb2bed28c`, full-project checking improved from 7.1s to 3.3s wall time and from 24.5s to 21.2s user CPU, with all 12,179 diagnostics unchanged. Peak RSS fell from 3.31 GB to 3.08 GB, and the narrowing-heavy guard files improved from 5.1s to 2.0s.
