### PR TITLE
[ty] Factor and cache projected narrowing transforms

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1215,6 +1215,65 @@ fn benchmark_typeis_narrowing(criterion: &mut Criterion) {
     });
 }
 
+/// Regression benchmark for repeated loads under a long `TypeIs` `elif` chain.
+///
+/// Each branch adds one negative narrowing constraint to `source`. Without caching the projected
+/// transform, every load rebuilds the accumulated intersection.
+fn benchmark_typeis_elif_narrowing(criterion: &mut Criterion) {
+    const NUM_CLASSES: usize = 40;
+    const LOADS_PER_BRANCH: usize = 10;
+
+    setup_rayon();
+
+    let mut code = r#"
+from typing import TypeVar
+from typing_extensions import TypeIs
+
+T = TypeVar("T")
+
+class Source: ...
+"#
+    .to_string();
+
+    for i in 0..NUM_CLASSES {
+        writeln!(&mut code, "class C{i}(Source): ...").ok();
+    }
+
+    code.push_str(
+        r#"
+def istype(value: object, cls: type[T]) -> TypeIs[T]:
+    raise NotImplementedError
+
+def consume(value: object) -> None: ...
+
+def check(source: Source) -> None:
+"#,
+    );
+
+    for i in 0..NUM_CLASSES {
+        if i == 0 {
+            writeln!(&mut code, "    if istype(source, C{i}):").ok();
+        } else {
+            writeln!(&mut code, "    elif istype(source, C{i}):").ok();
+        }
+        for _ in 0..LOADS_PER_BRANCH {
+            code.push_str("        consume(source)\n");
+        }
+    }
+
+    criterion.bench_function("ty_micro[typeis_elif_narrowing]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 fn benchmark_pandas_tdd(criterion: &mut Criterion) {
     setup_rayon();
 
@@ -1524,6 +1583,7 @@ criterion_group!(
     benchmark_literal_match_fallthrough_guarded_any,
     benchmark_literal_equality_fallthrough_guarded_any,
     benchmark_typeis_narrowing,
+    benchmark_typeis_elif_narrowing,
     benchmark_pandas_tdd,
     benchmark_recursive_typed_dict_union_contextual_inference,
     benchmark_pydantic_core_schema_dict,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/type_guards.md
@@ -554,3 +554,35 @@ def f():
     else:
         reveal_type(y)  # revealed: int | str
 ```
+
+## Repeated `TypeIs` `elif` narrowing
+
+Each later branch retains the negative constraints from all earlier predicates.
+
+```py
+from typing_extensions import TypeIs
+from typing import TypeVar
+
+T = TypeVar("T")
+
+class Source: ...
+class A(Source): ...
+class B(Source): ...
+class C(Source): ...
+class D(Source): ...
+
+def istype(value: object, cls: type[T]) -> TypeIs[T]:
+    return type(value) is cls
+
+def check(source: Source) -> None:
+    if istype(source, A):
+        reveal_type(source)  # revealed: A
+    elif istype(source, B):
+        reveal_type(source)  # revealed: B & ~A
+    elif istype(source, C):
+        reveal_type(source)  # revealed: C & ~A & ~B
+    elif istype(source, D):
+        reveal_type(source)  # revealed: D & ~A & ~B & ~C
+    else:
+        reveal_type(source)  # revealed: Source & ~A & ~B & ~C & ~D
+```

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -198,10 +198,10 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, Type, TypeContext,
-        UnionType, definite_match_pattern_type, enum_metadata, infer_narrowing_constraints,
-        infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
-        singleton_pattern_type,
+        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, NarrowingTransform,
+        Type, TypeContext, UnionType, definite_match_pattern_type, enum_metadata,
+        infer_narrowing_constraints, infer_same_file_expression_type, mapping_pattern_type,
+        sequence_pattern_type_builder, singleton_pattern_type,
     },
 };
 use ruff_index::IndexSlice;
@@ -496,15 +496,10 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
 
 /// AND a new optional narrowing constraint with an accumulated one.
 fn accumulate_constraint<'db>(
-    accumulated: Option<NarrowingConstraint<'db>>,
+    accumulated: NarrowingTransform<'db>,
     new: Option<NarrowingConstraint<'db>>,
-) -> Option<NarrowingConstraint<'db>> {
-    match (accumulated, new) {
-        (Some(acc), Some(new_c)) => Some(new_c.merge_constraint_and(acc)),
-        (None, Some(new_c)) => Some(new_c),
-        (Some(acc), None) => Some(acc),
-        (None, None) => None,
-    }
+) -> NarrowingTransform<'db> {
+    NarrowingTransform::from_constraint(new).then(accumulated)
 }
 
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
@@ -566,7 +561,7 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
             joins: projector.graph.joins(projected_root),
             join_cache: FxHashMap::default(),
         };
-        context.narrow(projected_root, None)
+        context.narrow(projected_root, NarrowingTransform::identity())
     }
 
     /// Analyze the statically known reachability for a given constraint.
@@ -592,19 +587,6 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
                 Truthiness::AlwaysFalse => id = node.if_false(),
             }
         }
-    }
-}
-
-fn apply_accumulated_narrowing<'db>(
-    db: &'db dyn Db,
-    base_ty: Type<'db>,
-    accumulated: Option<NarrowingConstraint<'db>>,
-) -> Type<'db> {
-    match accumulated {
-        Some(constraint) => NarrowingConstraint::intersection(base_ty)
-            .merge_constraint_and(constraint)
-            .evaluate_constraint_type(db),
-        None => base_ty,
     }
 }
 
@@ -879,7 +861,7 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
             return *cached;
         }
 
-        let result = self.narrow_uncached(id, None);
+        let result = self.narrow_uncached(id, NarrowingTransform::identity());
         self.join_cache.insert(id, result);
         result
     }
@@ -888,13 +870,13 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
     fn narrow(
         &mut self,
         id: ProjectedNarrowingNodeId,
-        accumulated: Option<NarrowingConstraint<'db>>,
+        accumulated: NarrowingTransform<'db>,
     ) -> Type<'db> {
         if self.is_join(id) {
             // Preserve replacement narrowing order at a join: evaluate the shared suffix once,
             // then apply the incoming prefix constraint to its narrowed type.
             let suffix_ty = self.narrow_join(id);
-            return apply_accumulated_narrowing(self.db, suffix_ty, accumulated);
+            return accumulated.apply(self.db, suffix_ty);
         }
 
         self.narrow_uncached(id, accumulated)
@@ -904,14 +886,14 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
     fn narrow_uncached(
         &mut self,
         id: ProjectedNarrowingNodeId,
-        accumulated: Option<NarrowingConstraint<'db>>,
+        accumulated: NarrowingTransform<'db>,
     ) -> Type<'db> {
         if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
             return Type::Never;
         }
 
         if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
-            apply_accumulated_narrowing(self.db, self.base_ty, accumulated)
+            accumulated.apply(self.db, self.base_ty)
         } else {
             let node = self.graph.node(id);
             let (pos_constraint, neg_constraint) =

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -198,7 +198,7 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingTransform,
+        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, NarrowingTransform,
         NarrowingTransformBuilder, PredicateNarrowingConstraints, Type, TypeContext, UnionType,
         definite_match_pattern_type, enum_metadata, infer_narrowing_constraints,
         infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
@@ -499,6 +499,19 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
 
 const MIN_CACHED_PROJECTED_NODES: usize = 30;
 
+/// AND a new optional narrowing constraint with an accumulated one.
+fn accumulate_constraint<'db>(
+    accumulated: Option<NarrowingConstraint<'db>>,
+    new: Option<NarrowingConstraint<'db>>,
+) -> Option<NarrowingConstraint<'db>> {
+    match (accumulated, new) {
+        (Some(accumulated), Some(new)) => Some(new.merge_constraint_and(accumulated)),
+        (None, Some(new)) => Some(new),
+        (Some(accumulated), None) => Some(accumulated),
+        (None, None) => None,
+    }
+}
+
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
         PredicateNode::Expression(expression) => expression.scope(db),
@@ -524,6 +537,28 @@ fn large_projected_narrowing_transform<'db>(
     let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
     let root = projector.project(id);
     projected_narrowing_transform(db, &projector.graph, root)
+}
+
+#[salsa::tracked(
+    cycle_initial = |_, id, _, _, _, _| Type::divergent(id),
+    cycle_fn = |db, cycle, previous: &Type<'db>, result: Type<'db>, _, _, _, _| {
+        result.cycle_normalized(db, *previous, cycle)
+    },
+    heap_size = ruff_memory_usage::heap_size
+)]
+fn type_narrowed_by_large_replacement_constraint<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    id: ScopedReachabilityConstraintId,
+    base_ty: Type<'db>,
+    place: ScopedPlaceId,
+) -> Type<'db> {
+    let use_def = use_def_map(db, scope);
+    let constraints = use_def.reachability_constraints();
+    let predicates = use_def.predicates();
+    let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
+    let root = projector.project(id);
+    projected_narrowing_type(db, &projector.graph, root, base_ty)
 }
 
 #[salsa::tracked(
@@ -596,6 +631,19 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         let mut projector = NarrowingProjector::new(db, self, predicates, place);
         let projected_root = projector.project(id);
 
+        if projector.graph.has_replacement_narrowing() {
+            // Replacement constraints are order-sensitive and cannot use complementary branch
+            // factoring. Keep them on the direct evaluator, caching only large final results.
+            if projector.graph.nodes.len() >= MIN_CACHED_PROJECTED_NODES {
+                let node = self.get_interior_node(id);
+                let scope = predicate_scope(db, predicates[node.atom()]);
+                return type_narrowed_by_large_replacement_constraint(
+                    db, scope, id, base_ty, place,
+                );
+            }
+            return projected_narrowing_type(db, &projector.graph, projected_root, base_ty);
+        }
+
         let transform = if projector.graph.nodes.len() >= MIN_CACHED_PROJECTED_NODES {
             let node = self.get_interior_node(id);
             let scope = predicate_scope(db, predicates[node.atom()]);
@@ -632,6 +680,19 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
     }
 }
 
+fn apply_accumulated_narrowing<'db>(
+    db: &'db dyn Db,
+    base_ty: Type<'db>,
+    accumulated: Option<NarrowingConstraint<'db>>,
+) -> Type<'db> {
+    match accumulated {
+        Some(constraint) => NarrowingConstraint::intersection(base_ty)
+            .merge_constraint_and(constraint)
+            .evaluate_constraint_type(db),
+        None => base_ty,
+    }
+}
+
 /// Identifier for a node in a projected narrowing graph.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct ProjectedNarrowingNodeId(usize);
@@ -641,6 +702,10 @@ impl ProjectedNarrowingNodeId {
     const ALWAYS_TRUE: Self = Self(usize::MAX);
     /// Terminal node for paths that are statically unreachable.
     const ALWAYS_FALSE: Self = Self(usize::MAX - 1);
+
+    fn is_terminal(self) -> bool {
+        self == Self::ALWAYS_TRUE || self == Self::ALWAYS_FALSE
+    }
 }
 
 /// Interior node in a projected narrowing graph.
@@ -681,6 +746,50 @@ impl ProjectedNarrowingGraph<'_> {
         self.nodes.push(node);
         self.node_cache.insert(node, id);
         id
+    }
+
+    fn has_replacement_narrowing(&self) -> bool {
+        self.predicate_constraints_cache
+            .values()
+            .any(|constraints| {
+                constraints
+                    .positive
+                    .as_ref()
+                    .is_some_and(NarrowingConstraint::has_replacement)
+                    || constraints
+                        .negative
+                        .as_ref()
+                        .is_some_and(NarrowingConstraint::has_replacement)
+            })
+    }
+
+    /// Returns the projected nodes that join multiple incoming paths.
+    ///
+    /// Projection interns equivalent subgraphs into a DAG. Caching each join lets narrowing
+    /// evaluate a shared suffix once and apply each incoming prefix constraint afterward.
+    fn joins(&self, root: ProjectedNarrowingNodeId) -> Vec<bool> {
+        let mut referenced = vec![false; self.nodes.len()];
+        let mut joins = vec![false; self.nodes.len()];
+        let mut visited = vec![false; self.nodes.len()];
+        let mut pending = vec![root];
+
+        while let Some(id) = pending.pop() {
+            if id.is_terminal() || std::mem::replace(&mut visited[id.0], true) {
+                continue;
+            }
+
+            let node = self.node(id);
+            for next in [node.if_true, node.if_false] {
+                if !next.is_terminal() {
+                    if std::mem::replace(&mut referenced[next.0], true) {
+                        joins[next.0] = true;
+                    }
+                    pending.push(next);
+                }
+            }
+        }
+
+        joins
     }
 
     /// Fold the graph bottom-up, evaluating each shared subgraph once.
@@ -894,6 +1003,101 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
 
         self.project_cache.insert(id, projected);
         projected
+    }
+}
+
+fn projected_narrowing_type<'db>(
+    db: &'db dyn Db,
+    graph: &ProjectedNarrowingGraph<'db>,
+    root: ProjectedNarrowingNodeId,
+    base_ty: Type<'db>,
+) -> Type<'db> {
+    let mut context = ProjectedNarrowingContext {
+        db,
+        base_ty,
+        graph,
+        joins: graph.joins(root),
+        join_cache: FxHashMap::default(),
+    };
+    context.narrow(root, None)
+}
+
+/// Evaluates narrowed types over a projected narrowing graph.
+struct ProjectedNarrowingContext<'a, 'db> {
+    db: &'db dyn Db,
+    base_ty: Type<'db>,
+    graph: &'a ProjectedNarrowingGraph<'db>,
+    /// Marks join boundaries in the projected DAG.
+    joins: Vec<bool>,
+    /// Caches each join's narrowed suffix type from its boundary.
+    join_cache: FxHashMap<ProjectedNarrowingNodeId, Type<'db>>,
+}
+
+impl<'db> ProjectedNarrowingContext<'_, 'db> {
+    fn is_join(&self, id: ProjectedNarrowingNodeId) -> bool {
+        !id.is_terminal() && self.joins[id.0]
+    }
+
+    /// Evaluates one projected join from its boundary and caches its narrowed suffix type.
+    fn narrow_join(&mut self, id: ProjectedNarrowingNodeId) -> Type<'db> {
+        if let Some(cached) = self.join_cache.get(&id) {
+            return *cached;
+        }
+
+        let result = self.narrow_uncached(id, None);
+        self.join_cache.insert(id, result);
+        result
+    }
+
+    /// Recursively evaluates a projected path while accumulating narrowing constraints.
+    fn narrow(
+        &mut self,
+        id: ProjectedNarrowingNodeId,
+        accumulated: Option<NarrowingConstraint<'db>>,
+    ) -> Type<'db> {
+        if self.is_join(id) {
+            // Preserve replacement narrowing order at a join: evaluate the shared suffix once,
+            // then apply the incoming prefix constraint to its narrowed type.
+            let suffix_ty = self.narrow_join(id);
+            return apply_accumulated_narrowing(self.db, suffix_ty, accumulated);
+        }
+
+        self.narrow_uncached(id, accumulated)
+    }
+
+    /// Recursively evaluates an unshared projected path while accumulating narrowing constraints.
+    fn narrow_uncached(
+        &mut self,
+        id: ProjectedNarrowingNodeId,
+        accumulated: Option<NarrowingConstraint<'db>>,
+    ) -> Type<'db> {
+        if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+            return Type::Never;
+        }
+
+        if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
+            apply_accumulated_narrowing(self.db, self.base_ty, accumulated)
+        } else {
+            let node = self.graph.node(id);
+            let constraints = self.graph.predicate_constraints_cache[&node.atom].clone();
+
+            if node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                let false_accumulated = accumulate_constraint(accumulated, constraints.negative);
+                self.narrow(node.if_false, false_accumulated)
+            } else if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                let true_accumulated = accumulate_constraint(accumulated, constraints.positive);
+                self.narrow(node.if_true, true_accumulated)
+            } else {
+                let true_accumulated =
+                    accumulate_constraint(accumulated.clone(), constraints.positive);
+                let true_ty = self.narrow(node.if_true, true_accumulated);
+
+                let false_accumulated = accumulate_constraint(accumulated, constraints.negative);
+                let false_ty = self.narrow(node.if_false, false_accumulated);
+
+                UnionType::from_two_elements(self.db, true_ty, false_ty)
+            }
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -219,6 +219,8 @@ use ty_python_core::{
         ScopedPredicateId,
     },
     reachability_constraints::{ReachabilityConstraints, ScopedReachabilityConstraintId},
+    scope::ScopeId,
+    use_def_map,
 };
 
 /// Narrow `subject_ty` by all preceding unguarded match patterns.
@@ -494,12 +496,33 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
     }
 }
 
-/// AND a new optional narrowing constraint with an accumulated one.
-fn accumulate_constraint<'db>(
-    accumulated: NarrowingTransform<'db>,
-    new: Option<NarrowingConstraint<'db>>,
+const MIN_CACHED_PROJECTED_NODES: usize = 30;
+
+fn predicate_scope<'db>(db: &'db dyn Db, predicate: Predicate<'db>) -> ScopeId<'db> {
+    match predicate.node {
+        PredicateNode::Expression(expression) => expression.scope(db),
+        PredicateNode::IsNonTerminalCall(call) => call.callable.scope(db),
+        PredicateNode::Pattern(pattern) => pattern.scope(db),
+        PredicateNode::StarImportPlaceholder(star_import) => star_import.scope(db),
+    }
+}
+
+#[salsa::tracked(
+    cycle_initial = |_, _, _, _, _| NarrowingTransform::identity(),
+    heap_size = ruff_memory_usage::heap_size
+)]
+fn large_projected_narrowing_transform<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    id: ScopedReachabilityConstraintId,
+    place: ScopedPlaceId,
 ) -> NarrowingTransform<'db> {
-    NarrowingTransform::from_constraint(new).then(accumulated)
+    let use_def = use_def_map(db, scope);
+    let constraints = use_def.reachability_constraints();
+    let predicates = use_def.predicates();
+    let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
+    let root = projector.project(id);
+    ProjectedNarrowingContext::new(&projector.graph).transform(root)
 }
 
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
@@ -554,14 +577,15 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
     ) -> Type<'db> {
         let mut projector = NarrowingProjector::new(db, self, predicates, place);
         let projected_root = projector.project(id);
-        let mut context = ProjectedNarrowingContext {
-            db,
-            base_ty,
-            graph: &projector.graph,
-            joins: projector.graph.joins(projected_root),
-            join_cache: FxHashMap::default(),
+
+        let transform = if projector.graph.nodes.len() >= MIN_CACHED_PROJECTED_NODES {
+            let node = self.get_interior_node(id);
+            let scope = predicate_scope(db, predicates[node.atom()]);
+            large_projected_narrowing_transform(db, scope, id, place)
+        } else {
+            ProjectedNarrowingContext::new(&projector.graph).transform(projected_root)
         };
-        context.narrow(projected_root, NarrowingTransform::identity())
+        transform.apply(db, base_ty)
     }
 
     /// Analyze the statically known reachability for a given constraint.
@@ -599,10 +623,6 @@ impl ProjectedNarrowingNodeId {
     const ALWAYS_TRUE: Self = Self(usize::MAX);
     /// Terminal node for paths that are statically unreachable.
     const ALWAYS_FALSE: Self = Self(usize::MAX - 1);
-
-    fn is_terminal(self) -> bool {
-        self == Self::ALWAYS_TRUE || self == Self::ALWAYS_FALSE
-    }
 }
 
 /// Interior node in a projected narrowing graph.
@@ -649,35 +669,6 @@ impl ProjectedNarrowingGraph<'_> {
         self.nodes.push(node);
         self.node_cache.insert(node, id);
         id
-    }
-
-    /// Returns the projected nodes that join multiple incoming paths.
-    ///
-    /// Projection interns equivalent subgraphs into a DAG. Caching each join lets narrowing
-    /// evaluate a shared suffix once and apply each incoming prefix constraint afterward.
-    fn joins(&self, root: ProjectedNarrowingNodeId) -> Vec<bool> {
-        let mut referenced = vec![false; self.nodes.len()];
-        let mut joins = vec![false; self.nodes.len()];
-        let mut visited = vec![false; self.nodes.len()];
-        let mut pending = vec![root];
-
-        while let Some(id) = pending.pop() {
-            if id.is_terminal() || std::mem::replace(&mut visited[id.0], true) {
-                continue;
-            }
-
-            let node = self.node(id);
-            for next in [node.if_true, node.if_false] {
-                if !next.is_terminal() {
-                    if std::mem::replace(&mut referenced[next.0], true) {
-                        joins[next.0] = true;
-                    }
-                    pending.push(next);
-                }
-            }
-        }
-
-        joins
     }
 
     /// Constructs the canonical disjunction of two projected subgraphs.
@@ -839,82 +830,44 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     }
 }
 
-/// Evaluates narrowed types over a projected narrowing graph.
+/// Builds narrowing transforms over a projected narrowing graph.
 struct ProjectedNarrowingContext<'a, 'db> {
-    db: &'db dyn Db,
-    base_ty: Type<'db>,
     graph: &'a ProjectedNarrowingGraph<'db>,
-    /// Marks join boundaries in the projected DAG.
-    joins: Vec<bool>,
-    /// Caches each join's narrowed suffix type from its boundary.
-    join_cache: FxHashMap<ProjectedNarrowingNodeId, Type<'db>>,
+    transform_cache: Vec<Option<NarrowingTransform<'db>>>,
 }
 
-impl<'db> ProjectedNarrowingContext<'_, 'db> {
-    fn is_join(&self, id: ProjectedNarrowingNodeId) -> bool {
-        !id.is_terminal() && self.joins[id.0]
+impl<'a, 'db> ProjectedNarrowingContext<'a, 'db> {
+    fn new(graph: &'a ProjectedNarrowingGraph<'db>) -> Self {
+        ProjectedNarrowingContext {
+            graph,
+            transform_cache: vec![None; graph.nodes.len()],
+        }
     }
 
-    /// Evaluates one projected join from its boundary and caches its narrowed suffix type.
-    fn narrow_join(&mut self, id: ProjectedNarrowingNodeId) -> Type<'db> {
-        if let Some(cached) = self.join_cache.get(&id) {
-            return *cached;
-        }
-
-        let result = self.narrow_uncached(id, NarrowingTransform::identity());
-        self.join_cache.insert(id, result);
-        result
-    }
-
-    /// Recursively evaluates a projected path while accumulating narrowing constraints.
-    fn narrow(
-        &mut self,
-        id: ProjectedNarrowingNodeId,
-        accumulated: NarrowingTransform<'db>,
-    ) -> Type<'db> {
-        if self.is_join(id) {
-            // Preserve replacement narrowing order at a join: evaluate the shared suffix once,
-            // then apply the incoming prefix constraint to its narrowed type.
-            let suffix_ty = self.narrow_join(id);
-            return accumulated.apply(self.db, suffix_ty);
-        }
-
-        self.narrow_uncached(id, accumulated)
-    }
-
-    /// Recursively evaluates an unshared projected path while accumulating narrowing constraints.
-    fn narrow_uncached(
-        &mut self,
-        id: ProjectedNarrowingNodeId,
-        accumulated: NarrowingTransform<'db>,
-    ) -> Type<'db> {
-        if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-            return Type::Never;
-        }
-
+    /// Build the transform for a projected node, reusing shared subgraphs.
+    fn transform(&mut self, id: ProjectedNarrowingNodeId) -> NarrowingTransform<'db> {
         if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
-            accumulated.apply(self.db, self.base_ty)
-        } else {
-            let node = self.graph.node(id);
-            let (pos_constraint, neg_constraint) =
-                self.graph.predicate_constraints_cache[&node.atom].clone();
-
-            if node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
-                self.narrow(node.if_false, false_accumulated)
-            } else if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-                let true_accumulated = accumulate_constraint(accumulated, pos_constraint);
-                self.narrow(node.if_true, true_accumulated)
-            } else {
-                let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
-                let true_ty = self.narrow(node.if_true, true_accumulated);
-
-                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
-                let false_ty = self.narrow(node.if_false, false_accumulated);
-
-                UnionType::from_two_elements(self.db, true_ty, false_ty)
-            }
+            return NarrowingTransform::identity();
         }
+        if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+            return NarrowingTransform::unreachable();
+        }
+
+        if let Some(cached) = &self.transform_cache[id.0] {
+            return cached.clone();
+        }
+
+        let node = self.graph.node(id);
+        let (positive, negative) = self.graph.predicate_constraints_cache[&node.atom].clone();
+        let if_true = self
+            .transform(node.if_true)
+            .then(NarrowingTransform::from_constraint(positive));
+        let if_false = self
+            .transform(node.if_false)
+            .then(NarrowingTransform::from_constraint(negative));
+        let result = if_true.join(if_false);
+        self.transform_cache[id.0] = Some(result.clone());
+        result
     }
 }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -523,7 +523,7 @@ fn large_projected_narrowing_transform<'db>(
     let predicates = use_def.predicates();
     let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
     let root = projector.project(id);
-    projected_narrowing_transform(db, &projector.graph, root)
+    projected_narrowing_transform(&projector.graph, root)
 }
 
 #[salsa::tracked(
@@ -601,7 +601,7 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
             let scope = predicate_scope(db, predicates[node.atom()]);
             return type_narrowed_by_large_projected_constraint(db, scope, id, base_ty, place);
         } else {
-            projected_narrowing_transform(db, &projector.graph, projected_root)
+            projected_narrowing_transform(&projector.graph, projected_root)
         };
         transform.apply(db, base_ty)
     }
@@ -899,7 +899,6 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
 
 /// Builds a narrowing transform over a projected narrowing graph.
 fn projected_narrowing_transform<'db>(
-    db: &'db dyn Db,
     graph: &ProjectedNarrowingGraph<'db>,
     root: ProjectedNarrowingNodeId,
 ) -> NarrowingTransform<'db> {
@@ -909,7 +908,7 @@ fn projected_narrowing_transform<'db>(
     let root = graph.fold(root, identity, unreachable, |node, if_true, if_false| {
         let constraints = graph.predicate_constraints_cache[&node.atom].clone();
         if let Some(complementary) = constraints.complementary {
-            builder.branch(db, complementary, if_true, if_false)
+            builder.branch(complementary, if_true, if_false)
         } else {
             let positive = builder.constraint(constraints.positive);
             let negative = builder.constraint(constraints.negative);

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -199,10 +199,10 @@ use crate::{
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
         CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingTransform,
-        NarrowingTransformBuilder, NarrowingTransformId, PredicateNarrowingConstraints, Type,
-        TypeContext, UnionType, definite_match_pattern_type, enum_metadata,
-        infer_narrowing_constraints, infer_same_file_expression_type, mapping_pattern_type,
-        sequence_pattern_type_builder, singleton_pattern_type,
+        NarrowingTransformBuilder, PredicateNarrowingConstraints, Type, TypeContext, UnionType,
+        definite_match_pattern_type, enum_metadata, infer_narrowing_constraints,
+        infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
+        singleton_pattern_type,
     },
 };
 use ruff_index::IndexSlice;
@@ -523,7 +523,7 @@ fn large_projected_narrowing_transform<'db>(
     let predicates = use_def.predicates();
     let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
     let root = projector.project(id);
-    ProjectedNarrowingContext::new(db, &projector.graph).build(root)
+    projected_narrowing_transform(db, &projector.graph, root)
 }
 
 #[salsa::tracked(
@@ -601,7 +601,7 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
             let scope = predicate_scope(db, predicates[node.atom()]);
             return type_narrowed_by_large_projected_constraint(db, scope, id, base_ty, place);
         } else {
-            ProjectedNarrowingContext::new(db, &projector.graph).build(projected_root)
+            projected_narrowing_transform(db, &projector.graph, projected_root)
         };
         transform.apply(db, base_ty)
     }
@@ -681,6 +681,64 @@ impl ProjectedNarrowingGraph<'_> {
         self.nodes.push(node);
         self.node_cache.insert(node, id);
         id
+    }
+
+    /// Fold the graph bottom-up, evaluating each shared subgraph once.
+    fn fold<T: Copy>(
+        &self,
+        root: ProjectedNarrowingNodeId,
+        if_true_terminal: T,
+        if_false_terminal: T,
+        mut fold_node: impl FnMut(ProjectedNarrowingNode, T, T) -> T,
+    ) -> T {
+        fn fold_inner<T: Copy>(
+            graph: &ProjectedNarrowingGraph<'_>,
+            id: ProjectedNarrowingNodeId,
+            if_true_terminal: T,
+            if_false_terminal: T,
+            cache: &mut [Option<T>],
+            fold_node: &mut impl FnMut(ProjectedNarrowingNode, T, T) -> T,
+        ) -> T {
+            if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
+                return if_true_terminal;
+            }
+            if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                return if_false_terminal;
+            }
+            if let Some(cached) = cache[id.0] {
+                return cached;
+            }
+
+            let node = graph.node(id);
+            let if_true = fold_inner(
+                graph,
+                node.if_true,
+                if_true_terminal,
+                if_false_terminal,
+                cache,
+                fold_node,
+            );
+            let if_false = fold_inner(
+                graph,
+                node.if_false,
+                if_true_terminal,
+                if_false_terminal,
+                cache,
+                fold_node,
+            );
+            let result = fold_node(node, if_true, if_false);
+            cache[id.0] = Some(result);
+            result
+        }
+
+        fold_inner(
+            self,
+            root,
+            if_true_terminal,
+            if_false_terminal,
+            &mut vec![None; self.nodes.len()],
+            &mut fold_node,
+        )
     }
 
     /// Constructs the canonical disjunction of two projected subgraphs.
@@ -839,59 +897,28 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     }
 }
 
-/// Builds narrowing transforms over a projected narrowing graph.
-struct ProjectedNarrowingContext<'a, 'db> {
+/// Builds a narrowing transform over a projected narrowing graph.
+fn projected_narrowing_transform<'db>(
     db: &'db dyn Db,
-    graph: &'a ProjectedNarrowingGraph<'db>,
-    builder: NarrowingTransformBuilder<'db>,
-    transform_cache: Vec<Option<NarrowingTransformId>>,
-}
-
-impl<'a, 'db> ProjectedNarrowingContext<'a, 'db> {
-    fn new(db: &'db dyn Db, graph: &'a ProjectedNarrowingGraph<'db>) -> Self {
-        ProjectedNarrowingContext {
-            db,
-            graph,
-            builder: NarrowingTransformBuilder::default(),
-            transform_cache: vec![None; graph.nodes.len()],
-        }
-    }
-
-    fn build(mut self, root: ProjectedNarrowingNodeId) -> NarrowingTransform<'db> {
-        let root = self.transform(root);
-        self.builder.build(root)
-    }
-
-    /// Build the transform for a projected node, reusing shared subgraphs.
-    fn transform(&mut self, id: ProjectedNarrowingNodeId) -> NarrowingTransformId {
-        if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
-            return self.builder.identity();
-        }
-        if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-            return self.builder.unreachable();
-        }
-
-        if let Some(cached) = self.transform_cache[id.0] {
-            return cached;
-        }
-
-        let node = self.graph.node(id);
-        let constraints = self.graph.predicate_constraints_cache[&node.atom].clone();
-        let if_true = self.transform(node.if_true);
-        let if_false = self.transform(node.if_false);
-        let result = if let Some(complementary) = constraints.complementary {
-            self.builder
-                .branch(self.db, complementary, if_true, if_false)
+    graph: &ProjectedNarrowingGraph<'db>,
+    root: ProjectedNarrowingNodeId,
+) -> NarrowingTransform<'db> {
+    let mut builder = NarrowingTransformBuilder::default();
+    let identity = NarrowingTransformBuilder::identity();
+    let unreachable = NarrowingTransformBuilder::unreachable();
+    let root = graph.fold(root, identity, unreachable, |node, if_true, if_false| {
+        let constraints = graph.predicate_constraints_cache[&node.atom].clone();
+        if let Some(complementary) = constraints.complementary {
+            builder.branch(db, complementary, if_true, if_false)
         } else {
-            let positive = self.builder.from_constraint(constraints.positive);
-            let negative = self.builder.from_constraint(constraints.negative);
-            let if_true = self.builder.then(if_true, positive);
-            let if_false = self.builder.then(if_false, negative);
-            self.builder.join(if_true, if_false)
-        };
-        self.transform_cache[id.0] = Some(result);
-        result
-    }
+            let positive = builder.constraint(constraints.positive);
+            let negative = builder.constraint(constraints.negative);
+            let if_true = builder.then(if_true, positive);
+            let if_false = builder.then(if_false, negative);
+            builder.join(if_true, if_false)
+        }
+    });
+    builder.build(root)
 }
 
 fn analyze_single_pattern_predicate_kind<'db>(

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -198,8 +198,9 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, NarrowingTransform,
-        Type, TypeContext, UnionType, definite_match_pattern_type, enum_metadata,
+        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingTransform,
+        NarrowingTransformBuilder, NarrowingTransformId, PredicateNarrowingConstraints, Type,
+        TypeContext, UnionType, definite_match_pattern_type, enum_metadata,
         infer_narrowing_constraints, infer_same_file_expression_type, mapping_pattern_type,
         sequence_pattern_type_builder, singleton_pattern_type,
     },
@@ -522,7 +523,24 @@ fn large_projected_narrowing_transform<'db>(
     let predicates = use_def.predicates();
     let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
     let root = projector.project(id);
-    ProjectedNarrowingContext::new(&projector.graph).transform(root)
+    ProjectedNarrowingContext::new(db, &projector.graph).build(root)
+}
+
+#[salsa::tracked(
+    cycle_initial = |_, id, _, _, _, _| Type::divergent(id),
+    cycle_fn = |db, cycle, previous: &Type<'db>, result: Type<'db>, _, _, _, _| {
+        result.cycle_normalized(db, *previous, cycle)
+    },
+    heap_size = ruff_memory_usage::heap_size
+)]
+fn type_narrowed_by_large_projected_constraint<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    id: ScopedReachabilityConstraintId,
+    base_ty: Type<'db>,
+    place: ScopedPlaceId,
+) -> Type<'db> {
+    large_projected_narrowing_transform(db, scope, id, place).apply(db, base_ty)
 }
 
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
@@ -581,9 +599,9 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         let transform = if projector.graph.nodes.len() >= MIN_CACHED_PROJECTED_NODES {
             let node = self.get_interior_node(id);
             let scope = predicate_scope(db, predicates[node.atom()]);
-            large_projected_narrowing_transform(db, scope, id, place)
+            return type_narrowed_by_large_projected_constraint(db, scope, id, base_ty, place);
         } else {
-            ProjectedNarrowingContext::new(&projector.graph).transform(projected_root)
+            ProjectedNarrowingContext::new(db, &projector.graph).build(projected_root)
         };
         transform.apply(db, base_ty)
     }
@@ -640,13 +658,7 @@ struct ProjectedNarrowingGraph<'db> {
     node_cache: FxHashMap<ProjectedNarrowingNode, ProjectedNarrowingNodeId>,
     or_cache:
         FxHashMap<(ProjectedNarrowingNodeId, ProjectedNarrowingNodeId), ProjectedNarrowingNodeId>,
-    predicate_constraints_cache: FxHashMap<
-        ScopedPredicateId,
-        (
-            Option<NarrowingConstraint<'db>>,
-            Option<NarrowingConstraint<'db>>,
-        ),
-    >,
+    predicate_constraints_cache: FxHashMap<ScopedPredicateId, PredicateNarrowingConstraints<'db>>,
 }
 
 impl ProjectedNarrowingGraph<'_> {
@@ -768,10 +780,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     fn predicate_constraints(
         &mut self,
         predicate_id: ScopedPredicateId,
-    ) -> (
-        Option<NarrowingConstraint<'db>>,
-        Option<NarrowingConstraint<'db>>,
-    ) {
+    ) -> PredicateNarrowingConstraints<'db> {
         if let Some(cached) = self.graph.predicate_constraints_cache.get(&predicate_id) {
             return cached.clone();
         }
@@ -810,9 +819,9 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                 } else {
                     let if_true = self.project(node.if_true());
                     let if_false = self.project(node.if_false());
-                    let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom());
+                    let constraints = self.predicate_constraints(node.atom());
 
-                    if pos_constraint.is_none() && neg_constraint.is_none() {
+                    if constraints.positive.is_none() && constraints.negative.is_none() {
                         self.graph.or(if_true, if_false)
                     } else {
                         self.graph.add_node(ProjectedNarrowingNode {
@@ -832,41 +841,55 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
 
 /// Builds narrowing transforms over a projected narrowing graph.
 struct ProjectedNarrowingContext<'a, 'db> {
+    db: &'db dyn Db,
     graph: &'a ProjectedNarrowingGraph<'db>,
-    transform_cache: Vec<Option<NarrowingTransform<'db>>>,
+    builder: NarrowingTransformBuilder<'db>,
+    transform_cache: Vec<Option<NarrowingTransformId>>,
 }
 
 impl<'a, 'db> ProjectedNarrowingContext<'a, 'db> {
-    fn new(graph: &'a ProjectedNarrowingGraph<'db>) -> Self {
+    fn new(db: &'db dyn Db, graph: &'a ProjectedNarrowingGraph<'db>) -> Self {
         ProjectedNarrowingContext {
+            db,
             graph,
+            builder: NarrowingTransformBuilder::default(),
             transform_cache: vec![None; graph.nodes.len()],
         }
     }
 
+    fn build(mut self, root: ProjectedNarrowingNodeId) -> NarrowingTransform<'db> {
+        let root = self.transform(root);
+        self.builder.build(root)
+    }
+
     /// Build the transform for a projected node, reusing shared subgraphs.
-    fn transform(&mut self, id: ProjectedNarrowingNodeId) -> NarrowingTransform<'db> {
+    fn transform(&mut self, id: ProjectedNarrowingNodeId) -> NarrowingTransformId {
         if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
-            return NarrowingTransform::identity();
+            return self.builder.identity();
         }
         if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-            return NarrowingTransform::unreachable();
+            return self.builder.unreachable();
         }
 
-        if let Some(cached) = &self.transform_cache[id.0] {
-            return cached.clone();
+        if let Some(cached) = self.transform_cache[id.0] {
+            return cached;
         }
 
         let node = self.graph.node(id);
-        let (positive, negative) = self.graph.predicate_constraints_cache[&node.atom].clone();
-        let if_true = self
-            .transform(node.if_true)
-            .then(NarrowingTransform::from_constraint(positive));
-        let if_false = self
-            .transform(node.if_false)
-            .then(NarrowingTransform::from_constraint(negative));
-        let result = if_true.join(if_false);
-        self.transform_cache[id.0] = Some(result.clone());
+        let constraints = self.graph.predicate_constraints_cache[&node.atom].clone();
+        let if_true = self.transform(node.if_true);
+        let if_false = self.transform(node.if_false);
+        let result = if let Some(complementary) = constraints.complementary {
+            self.builder
+                .branch(self.db, complementary, if_true, if_false)
+        } else {
+            let positive = self.builder.from_constraint(constraints.positive);
+            let negative = self.builder.from_constraint(constraints.negative);
+            let if_true = self.builder.then(if_true, positive);
+            let if_false = self.builder.then(if_false, negative);
+            self.builder.join(if_true, if_false)
+        };
+        self.transform_cache[id.0] = Some(result);
         result
     }
 }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -198,7 +198,7 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingTransform,
+        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, NarrowingTransform,
         NarrowingTransformBuilder, PredicateNarrowingConstraints, Type, TypeContext, UnionType,
         definite_match_pattern_type, enum_metadata, infer_narrowing_constraints,
         infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
@@ -499,6 +499,19 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
 
 const MIN_CACHED_PROJECTED_NODES: usize = 30;
 
+/// AND a new optional narrowing constraint with an accumulated one.
+fn accumulate_constraint<'db>(
+    accumulated: Option<NarrowingConstraint<'db>>,
+    new: Option<NarrowingConstraint<'db>>,
+) -> Option<NarrowingConstraint<'db>> {
+    match (accumulated, new) {
+        (Some(accumulated), Some(new)) => Some(new.merge_constraint_and(accumulated)),
+        (None, Some(new)) => Some(new),
+        (Some(accumulated), None) => Some(accumulated),
+        (None, None) => None,
+    }
+}
+
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
         PredicateNode::Expression(expression) => expression.scope(db),
@@ -523,7 +536,7 @@ fn large_projected_narrowing_transform<'db>(
     let predicates = use_def.predicates();
     let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
     let root = projector.project(id);
-    projected_narrowing_transform(&projector.graph, root)
+    projected_narrowing_transform(db, &projector.graph, root)
 }
 
 #[salsa::tracked(
@@ -533,7 +546,29 @@ fn large_projected_narrowing_transform<'db>(
     },
     heap_size = ruff_memory_usage::heap_size
 )]
-fn type_narrowed_by_large_projected_constraint<'db>(
+fn type_narrowed_by_large_replacement_constraint<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    id: ScopedReachabilityConstraintId,
+    base_ty: Type<'db>,
+    place: ScopedPlaceId,
+) -> Type<'db> {
+    let use_def = use_def_map(db, scope);
+    let constraints = use_def.reachability_constraints();
+    let predicates = use_def.predicates();
+    let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
+    let root = projector.project(id);
+    projected_narrowing_type(db, &projector.graph, root, base_ty)
+}
+
+#[salsa::tracked(
+    cycle_initial = |_, id, _, _, _, _| Type::divergent(id),
+    cycle_fn = |db, cycle, previous: &Type<'db>, result: Type<'db>, _, _, _, _| {
+        result.cycle_normalized(db, *previous, cycle)
+    },
+    heap_size = ruff_memory_usage::heap_size
+)]
+fn type_narrowed_by_large_projected_transform<'db>(
     db: &'db dyn Db,
     scope: ScopeId<'db>,
     id: ScopedReachabilityConstraintId,
@@ -596,12 +631,25 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         let mut projector = NarrowingProjector::new(db, self, predicates, place);
         let projected_root = projector.project(id);
 
+        if projector.graph.has_replacement_narrowing() {
+            // Replacement constraints are order-sensitive and cannot use complementary branch
+            // factoring. Keep them on the direct evaluator, caching only large final results.
+            if projector.graph.nodes.len() >= MIN_CACHED_PROJECTED_NODES {
+                let node = self.get_interior_node(id);
+                let scope = predicate_scope(db, predicates[node.atom()]);
+                return type_narrowed_by_large_replacement_constraint(
+                    db, scope, id, base_ty, place,
+                );
+            }
+            return projected_narrowing_type(db, &projector.graph, projected_root, base_ty);
+        }
+
         let transform = if projector.graph.nodes.len() >= MIN_CACHED_PROJECTED_NODES {
             let node = self.get_interior_node(id);
             let scope = predicate_scope(db, predicates[node.atom()]);
-            return type_narrowed_by_large_projected_constraint(db, scope, id, base_ty, place);
+            return type_narrowed_by_large_projected_transform(db, scope, id, base_ty, place);
         } else {
-            projected_narrowing_transform(&projector.graph, projected_root)
+            projected_narrowing_transform(db, &projector.graph, projected_root)
         };
         transform.apply(db, base_ty)
     }
@@ -632,6 +680,19 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
     }
 }
 
+fn apply_accumulated_narrowing<'db>(
+    db: &'db dyn Db,
+    base_ty: Type<'db>,
+    accumulated: Option<NarrowingConstraint<'db>>,
+) -> Type<'db> {
+    match accumulated {
+        Some(constraint) => NarrowingConstraint::intersection(base_ty)
+            .merge_constraint_and(constraint)
+            .evaluate_constraint_type(db),
+        None => base_ty,
+    }
+}
+
 /// Identifier for a node in a projected narrowing graph.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct ProjectedNarrowingNodeId(usize);
@@ -641,6 +702,10 @@ impl ProjectedNarrowingNodeId {
     const ALWAYS_TRUE: Self = Self(usize::MAX);
     /// Terminal node for paths that are statically unreachable.
     const ALWAYS_FALSE: Self = Self(usize::MAX - 1);
+
+    fn is_terminal(self) -> bool {
+        self == Self::ALWAYS_TRUE || self == Self::ALWAYS_FALSE
+    }
 }
 
 /// Interior node in a projected narrowing graph.
@@ -681,6 +746,50 @@ impl ProjectedNarrowingGraph<'_> {
         self.nodes.push(node);
         self.node_cache.insert(node, id);
         id
+    }
+
+    fn has_replacement_narrowing(&self) -> bool {
+        self.predicate_constraints_cache
+            .values()
+            .any(|constraints| {
+                constraints
+                    .positive
+                    .as_ref()
+                    .is_some_and(NarrowingConstraint::has_replacement)
+                    || constraints
+                        .negative
+                        .as_ref()
+                        .is_some_and(NarrowingConstraint::has_replacement)
+            })
+    }
+
+    /// Returns the projected nodes that join multiple incoming paths.
+    ///
+    /// Projection interns equivalent subgraphs into a DAG. Caching each join lets narrowing
+    /// evaluate a shared suffix once and apply each incoming prefix constraint afterward.
+    fn joins(&self, root: ProjectedNarrowingNodeId) -> Vec<bool> {
+        let mut referenced = vec![false; self.nodes.len()];
+        let mut joins = vec![false; self.nodes.len()];
+        let mut visited = vec![false; self.nodes.len()];
+        let mut pending = vec![root];
+
+        while let Some(id) = pending.pop() {
+            if id.is_terminal() || std::mem::replace(&mut visited[id.0], true) {
+                continue;
+            }
+
+            let node = self.node(id);
+            for next in [node.if_true, node.if_false] {
+                if !next.is_terminal() {
+                    if std::mem::replace(&mut referenced[next.0], true) {
+                        joins[next.0] = true;
+                    }
+                    pending.push(next);
+                }
+            }
+        }
+
+        joins
     }
 
     /// Fold the graph bottom-up, evaluating each shared subgraph once.
@@ -897,8 +1006,104 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     }
 }
 
+fn projected_narrowing_type<'db>(
+    db: &'db dyn Db,
+    graph: &ProjectedNarrowingGraph<'db>,
+    root: ProjectedNarrowingNodeId,
+    base_ty: Type<'db>,
+) -> Type<'db> {
+    let mut context = ProjectedNarrowingContext {
+        db,
+        base_ty,
+        graph,
+        joins: graph.joins(root),
+        join_cache: FxHashMap::default(),
+    };
+    context.narrow(root, None)
+}
+
+/// Evaluates narrowed types over a projected narrowing graph.
+struct ProjectedNarrowingContext<'a, 'db> {
+    db: &'db dyn Db,
+    base_ty: Type<'db>,
+    graph: &'a ProjectedNarrowingGraph<'db>,
+    /// Marks join boundaries in the projected DAG.
+    joins: Vec<bool>,
+    /// Caches each join's narrowed suffix type from its boundary.
+    join_cache: FxHashMap<ProjectedNarrowingNodeId, Type<'db>>,
+}
+
+impl<'db> ProjectedNarrowingContext<'_, 'db> {
+    fn is_join(&self, id: ProjectedNarrowingNodeId) -> bool {
+        !id.is_terminal() && self.joins[id.0]
+    }
+
+    /// Evaluates one projected join from its boundary and caches its narrowed suffix type.
+    fn narrow_join(&mut self, id: ProjectedNarrowingNodeId) -> Type<'db> {
+        if let Some(cached) = self.join_cache.get(&id) {
+            return *cached;
+        }
+
+        let result = self.narrow_uncached(id, None);
+        self.join_cache.insert(id, result);
+        result
+    }
+
+    /// Recursively evaluates a projected path while accumulating narrowing constraints.
+    fn narrow(
+        &mut self,
+        id: ProjectedNarrowingNodeId,
+        accumulated: Option<NarrowingConstraint<'db>>,
+    ) -> Type<'db> {
+        if self.is_join(id) {
+            // Preserve replacement narrowing order at a join: evaluate the shared suffix once,
+            // then apply the incoming prefix constraint to its narrowed type.
+            let suffix_ty = self.narrow_join(id);
+            return apply_accumulated_narrowing(self.db, suffix_ty, accumulated);
+        }
+
+        self.narrow_uncached(id, accumulated)
+    }
+
+    /// Recursively evaluates an unshared projected path while accumulating narrowing constraints.
+    fn narrow_uncached(
+        &mut self,
+        id: ProjectedNarrowingNodeId,
+        accumulated: Option<NarrowingConstraint<'db>>,
+    ) -> Type<'db> {
+        if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+            return Type::Never;
+        }
+
+        if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
+            apply_accumulated_narrowing(self.db, self.base_ty, accumulated)
+        } else {
+            let node = self.graph.node(id);
+            let constraints = self.graph.predicate_constraints_cache[&node.atom].clone();
+
+            if node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                let false_accumulated = accumulate_constraint(accumulated, constraints.negative);
+                self.narrow(node.if_false, false_accumulated)
+            } else if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                let true_accumulated = accumulate_constraint(accumulated, constraints.positive);
+                self.narrow(node.if_true, true_accumulated)
+            } else {
+                let true_accumulated =
+                    accumulate_constraint(accumulated.clone(), constraints.positive);
+                let true_ty = self.narrow(node.if_true, true_accumulated);
+
+                let false_accumulated = accumulate_constraint(accumulated, constraints.negative);
+                let false_ty = self.narrow(node.if_false, false_accumulated);
+
+                UnionType::from_two_elements(self.db, true_ty, false_ty)
+            }
+        }
+    }
+}
+
 /// Builds a narrowing transform over a projected narrowing graph.
 fn projected_narrowing_transform<'db>(
+    db: &'db dyn Db,
     graph: &ProjectedNarrowingGraph<'db>,
     root: ProjectedNarrowingNodeId,
 ) -> NarrowingTransform<'db> {
@@ -907,7 +1112,7 @@ fn projected_narrowing_transform<'db>(
     let unreachable = NarrowingTransformBuilder::unreachable();
     let root = graph.fold(root, identity, unreachable, |node, if_true, if_false| {
         let constraints = graph.predicate_constraints_cache[&node.atom].clone();
-        if let Some(complementary) = constraints.complementary {
+        if let Some(complementary) = constraints.complementary(db) {
             builder.branch(complementary, if_true, if_false)
         } else {
             let positive = builder.constraint(constraints.positive);

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -198,7 +198,7 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, NarrowingTransform,
+        CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingTransform,
         NarrowingTransformBuilder, PredicateNarrowingConstraints, Type, TypeContext, UnionType,
         definite_match_pattern_type, enum_metadata, infer_narrowing_constraints,
         infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
@@ -499,19 +499,6 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
 
 const MIN_CACHED_PROJECTED_NODES: usize = 30;
 
-/// AND a new optional narrowing constraint with an accumulated one.
-fn accumulate_constraint<'db>(
-    accumulated: Option<NarrowingConstraint<'db>>,
-    new: Option<NarrowingConstraint<'db>>,
-) -> Option<NarrowingConstraint<'db>> {
-    match (accumulated, new) {
-        (Some(accumulated), Some(new)) => Some(new.merge_constraint_and(accumulated)),
-        (None, Some(new)) => Some(new),
-        (Some(accumulated), None) => Some(accumulated),
-        (None, None) => None,
-    }
-}
-
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
         PredicateNode::Expression(expression) => expression.scope(db),
@@ -537,28 +524,6 @@ fn large_projected_narrowing_transform<'db>(
     let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
     let root = projector.project(id);
     projected_narrowing_transform(db, &projector.graph, root)
-}
-
-#[salsa::tracked(
-    cycle_initial = |_, id, _, _, _, _| Type::divergent(id),
-    cycle_fn = |db, cycle, previous: &Type<'db>, result: Type<'db>, _, _, _, _| {
-        result.cycle_normalized(db, *previous, cycle)
-    },
-    heap_size = ruff_memory_usage::heap_size
-)]
-fn type_narrowed_by_large_replacement_constraint<'db>(
-    db: &'db dyn Db,
-    scope: ScopeId<'db>,
-    id: ScopedReachabilityConstraintId,
-    base_ty: Type<'db>,
-    place: ScopedPlaceId,
-) -> Type<'db> {
-    let use_def = use_def_map(db, scope);
-    let constraints = use_def.reachability_constraints();
-    let predicates = use_def.predicates();
-    let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
-    let root = projector.project(id);
-    projected_narrowing_type(db, &projector.graph, root, base_ty)
 }
 
 #[salsa::tracked(
@@ -631,19 +596,6 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         let mut projector = NarrowingProjector::new(db, self, predicates, place);
         let projected_root = projector.project(id);
 
-        if projector.graph.has_replacement_narrowing() {
-            // Replacement constraints are order-sensitive and cannot use complementary branch
-            // factoring. Keep them on the direct evaluator, caching only large final results.
-            if projector.graph.nodes.len() >= MIN_CACHED_PROJECTED_NODES {
-                let node = self.get_interior_node(id);
-                let scope = predicate_scope(db, predicates[node.atom()]);
-                return type_narrowed_by_large_replacement_constraint(
-                    db, scope, id, base_ty, place,
-                );
-            }
-            return projected_narrowing_type(db, &projector.graph, projected_root, base_ty);
-        }
-
         let transform = if projector.graph.nodes.len() >= MIN_CACHED_PROJECTED_NODES {
             let node = self.get_interior_node(id);
             let scope = predicate_scope(db, predicates[node.atom()]);
@@ -680,19 +632,6 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
     }
 }
 
-fn apply_accumulated_narrowing<'db>(
-    db: &'db dyn Db,
-    base_ty: Type<'db>,
-    accumulated: Option<NarrowingConstraint<'db>>,
-) -> Type<'db> {
-    match accumulated {
-        Some(constraint) => NarrowingConstraint::intersection(base_ty)
-            .merge_constraint_and(constraint)
-            .evaluate_constraint_type(db),
-        None => base_ty,
-    }
-}
-
 /// Identifier for a node in a projected narrowing graph.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct ProjectedNarrowingNodeId(usize);
@@ -702,10 +641,6 @@ impl ProjectedNarrowingNodeId {
     const ALWAYS_TRUE: Self = Self(usize::MAX);
     /// Terminal node for paths that are statically unreachable.
     const ALWAYS_FALSE: Self = Self(usize::MAX - 1);
-
-    fn is_terminal(self) -> bool {
-        self == Self::ALWAYS_TRUE || self == Self::ALWAYS_FALSE
-    }
 }
 
 /// Interior node in a projected narrowing graph.
@@ -746,50 +681,6 @@ impl ProjectedNarrowingGraph<'_> {
         self.nodes.push(node);
         self.node_cache.insert(node, id);
         id
-    }
-
-    fn has_replacement_narrowing(&self) -> bool {
-        self.predicate_constraints_cache
-            .values()
-            .any(|constraints| {
-                constraints
-                    .positive
-                    .as_ref()
-                    .is_some_and(NarrowingConstraint::has_replacement)
-                    || constraints
-                        .negative
-                        .as_ref()
-                        .is_some_and(NarrowingConstraint::has_replacement)
-            })
-    }
-
-    /// Returns the projected nodes that join multiple incoming paths.
-    ///
-    /// Projection interns equivalent subgraphs into a DAG. Caching each join lets narrowing
-    /// evaluate a shared suffix once and apply each incoming prefix constraint afterward.
-    fn joins(&self, root: ProjectedNarrowingNodeId) -> Vec<bool> {
-        let mut referenced = vec![false; self.nodes.len()];
-        let mut joins = vec![false; self.nodes.len()];
-        let mut visited = vec![false; self.nodes.len()];
-        let mut pending = vec![root];
-
-        while let Some(id) = pending.pop() {
-            if id.is_terminal() || std::mem::replace(&mut visited[id.0], true) {
-                continue;
-            }
-
-            let node = self.node(id);
-            for next in [node.if_true, node.if_false] {
-                if !next.is_terminal() {
-                    if std::mem::replace(&mut referenced[next.0], true) {
-                        joins[next.0] = true;
-                    }
-                    pending.push(next);
-                }
-            }
-        }
-
-        joins
     }
 
     /// Fold the graph bottom-up, evaluating each shared subgraph once.
@@ -1003,101 +894,6 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
 
         self.project_cache.insert(id, projected);
         projected
-    }
-}
-
-fn projected_narrowing_type<'db>(
-    db: &'db dyn Db,
-    graph: &ProjectedNarrowingGraph<'db>,
-    root: ProjectedNarrowingNodeId,
-    base_ty: Type<'db>,
-) -> Type<'db> {
-    let mut context = ProjectedNarrowingContext {
-        db,
-        base_ty,
-        graph,
-        joins: graph.joins(root),
-        join_cache: FxHashMap::default(),
-    };
-    context.narrow(root, None)
-}
-
-/// Evaluates narrowed types over a projected narrowing graph.
-struct ProjectedNarrowingContext<'a, 'db> {
-    db: &'db dyn Db,
-    base_ty: Type<'db>,
-    graph: &'a ProjectedNarrowingGraph<'db>,
-    /// Marks join boundaries in the projected DAG.
-    joins: Vec<bool>,
-    /// Caches each join's narrowed suffix type from its boundary.
-    join_cache: FxHashMap<ProjectedNarrowingNodeId, Type<'db>>,
-}
-
-impl<'db> ProjectedNarrowingContext<'_, 'db> {
-    fn is_join(&self, id: ProjectedNarrowingNodeId) -> bool {
-        !id.is_terminal() && self.joins[id.0]
-    }
-
-    /// Evaluates one projected join from its boundary and caches its narrowed suffix type.
-    fn narrow_join(&mut self, id: ProjectedNarrowingNodeId) -> Type<'db> {
-        if let Some(cached) = self.join_cache.get(&id) {
-            return *cached;
-        }
-
-        let result = self.narrow_uncached(id, None);
-        self.join_cache.insert(id, result);
-        result
-    }
-
-    /// Recursively evaluates a projected path while accumulating narrowing constraints.
-    fn narrow(
-        &mut self,
-        id: ProjectedNarrowingNodeId,
-        accumulated: Option<NarrowingConstraint<'db>>,
-    ) -> Type<'db> {
-        if self.is_join(id) {
-            // Preserve replacement narrowing order at a join: evaluate the shared suffix once,
-            // then apply the incoming prefix constraint to its narrowed type.
-            let suffix_ty = self.narrow_join(id);
-            return apply_accumulated_narrowing(self.db, suffix_ty, accumulated);
-        }
-
-        self.narrow_uncached(id, accumulated)
-    }
-
-    /// Recursively evaluates an unshared projected path while accumulating narrowing constraints.
-    fn narrow_uncached(
-        &mut self,
-        id: ProjectedNarrowingNodeId,
-        accumulated: Option<NarrowingConstraint<'db>>,
-    ) -> Type<'db> {
-        if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-            return Type::Never;
-        }
-
-        if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
-            apply_accumulated_narrowing(self.db, self.base_ty, accumulated)
-        } else {
-            let node = self.graph.node(id);
-            let constraints = self.graph.predicate_constraints_cache[&node.atom].clone();
-
-            if node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-                let false_accumulated = accumulate_constraint(accumulated, constraints.negative);
-                self.narrow(node.if_false, false_accumulated)
-            } else if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-                let true_accumulated = accumulate_constraint(accumulated, constraints.positive);
-                self.narrow(node.if_true, true_accumulated)
-            } else {
-                let true_accumulated =
-                    accumulate_constraint(accumulated.clone(), constraints.positive);
-                let true_ty = self.narrow(node.if_true, true_accumulated);
-
-                let false_accumulated = accumulate_constraint(accumulated, constraints.negative);
-                let false_ty = self.narrow(node.if_false, false_accumulated);
-
-                UnionType::from_two_elements(self.db, true_ty, false_ty)
-            }
-        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -79,7 +79,9 @@ use crate::types::known_instance::{
 };
 pub use crate::types::method::{BoundMethodType, KnownBoundMethodType, WrapperDescriptorKind};
 use crate::types::mro::{MroIterator, StaticMroError};
-pub(crate) use crate::types::narrow::{NarrowingConstraint, infer_narrowing_constraints};
+pub(crate) use crate::types::narrow::{
+    NarrowingConstraint, NarrowingTransform, infer_narrowing_constraints,
+};
 use crate::types::newtype::NewType;
 pub(crate) use crate::types::signatures::{Parameter, Parameters};
 use crate::types::signatures::{ParameterForm, walk_signature};

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -80,8 +80,8 @@ use crate::types::known_instance::{
 pub use crate::types::method::{BoundMethodType, KnownBoundMethodType, WrapperDescriptorKind};
 use crate::types::mro::{MroIterator, StaticMroError};
 pub(crate) use crate::types::narrow::{
-    NarrowingTransform, NarrowingTransformBuilder, NarrowingTransformId,
-    PredicateNarrowingConstraints, infer_narrowing_constraints,
+    NarrowingTransform, NarrowingTransformBuilder, PredicateNarrowingConstraints,
+    infer_narrowing_constraints,
 };
 use crate::types::newtype::NewType;
 pub(crate) use crate::types::signatures::{Parameter, Parameters};

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -80,8 +80,8 @@ use crate::types::known_instance::{
 pub use crate::types::method::{BoundMethodType, KnownBoundMethodType, WrapperDescriptorKind};
 use crate::types::mro::{MroIterator, StaticMroError};
 pub(crate) use crate::types::narrow::{
-    NarrowingTransform, NarrowingTransformBuilder, PredicateNarrowingConstraints,
-    infer_narrowing_constraints,
+    NarrowingConstraint, NarrowingTransform, NarrowingTransformBuilder,
+    PredicateNarrowingConstraints, infer_narrowing_constraints,
 };
 use crate::types::newtype::NewType;
 pub(crate) use crate::types::signatures::{Parameter, Parameters};

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -80,8 +80,8 @@ use crate::types::known_instance::{
 pub use crate::types::method::{BoundMethodType, KnownBoundMethodType, WrapperDescriptorKind};
 use crate::types::mro::{MroIterator, StaticMroError};
 pub(crate) use crate::types::narrow::{
-    NarrowingConstraint, NarrowingTransform, NarrowingTransformBuilder,
-    PredicateNarrowingConstraints, infer_narrowing_constraints,
+    NarrowingTransform, NarrowingTransformBuilder, PredicateNarrowingConstraints,
+    infer_narrowing_constraints,
 };
 use crate::types::newtype::NewType;
 pub(crate) use crate::types::signatures::{Parameter, Parameters};

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -80,7 +80,8 @@ use crate::types::known_instance::{
 pub use crate::types::method::{BoundMethodType, KnownBoundMethodType, WrapperDescriptorKind};
 use crate::types::mro::{MroIterator, StaticMroError};
 pub(crate) use crate::types::narrow::{
-    NarrowingConstraint, NarrowingTransform, infer_narrowing_constraints,
+    NarrowingTransform, NarrowingTransformBuilder, NarrowingTransformId,
+    PredicateNarrowingConstraints, infer_narrowing_constraints,
 };
 use crate::types::newtype::NewType;
 pub(crate) use crate::types::signatures::{Parameter, Parameters};

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -635,10 +635,6 @@ impl<'db> NarrowingConstraint<'db> {
 
         self.replacement_disjuncts.is_empty().then_some(*conjunct)
     }
-
-    pub(crate) fn has_replacement(&self) -> bool {
-        !self.replacement_disjuncts.is_empty()
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -904,12 +904,18 @@ pub(crate) struct NarrowingTransformBuilder<'db> {
     cache: FxHashMap<NarrowingTransformNode<'db>, NarrowingTransformId>,
     conditions: Vec<NarrowingConditionNode<'db>>,
     condition_cache: FxHashMap<NarrowingConditionNode<'db>, NarrowingConditionId>,
-    branch_specs: FxHashMap<NarrowingTransformId, NarrowingBranchSpec>,
+    branch_specs: FxHashMap<NarrowingTransformId, NarrowingBranchSpec<'db>>,
 }
 
 #[derive(Clone, Copy)]
-struct NarrowingBranchSpec {
-    condition: NarrowingConditionId,
+enum NarrowingBranchCondition<'db> {
+    Atom(ComplementaryNarrowing<'db>),
+    Node(NarrowingConditionId),
+}
+
+#[derive(Clone, Copy)]
+struct NarrowingBranchSpec<'db> {
+    condition: NarrowingBranchCondition<'db>,
     if_true: NarrowingTransformId,
     if_false: NarrowingTransformId,
     branches: usize,
@@ -1003,16 +1009,16 @@ impl<'db> NarrowingTransformBuilder<'db> {
         }
 
         let atomic_condition = condition;
-        let condition = self.add_condition(NarrowingConditionNode::Atom(condition));
         let spec = if let Some(nested) = self.branch_specs.get(&if_false).copied()
             && if_true != Self::unreachable()
             && if_true == nested.if_true
         {
             NarrowingBranchSpec {
-                condition: self.add_condition(NarrowingConditionNode::Or {
-                    left: nested.condition,
-                    right: condition,
-                }),
+                condition: NarrowingBranchCondition::Node(self.combine_condition(
+                    nested.condition,
+                    condition,
+                    true,
+                )),
                 if_true,
                 if_false: nested.if_false,
                 branches: nested.branches + 1,
@@ -1022,17 +1028,18 @@ impl<'db> NarrowingTransformBuilder<'db> {
             && if_false == nested.if_false
         {
             NarrowingBranchSpec {
-                condition: self.add_condition(NarrowingConditionNode::And {
-                    left: nested.condition,
-                    right: condition,
-                }),
+                condition: NarrowingBranchCondition::Node(self.combine_condition(
+                    nested.condition,
+                    condition,
+                    false,
+                )),
                 if_true: nested.if_true,
                 if_false,
                 branches: nested.branches + 1,
             }
         } else {
             NarrowingBranchSpec {
-                condition,
+                condition: NarrowingBranchCondition::Atom(condition),
                 if_true,
                 if_false,
                 branches: 1,
@@ -1040,8 +1047,9 @@ impl<'db> NarrowingTransformBuilder<'db> {
         };
 
         let result = if spec.branches >= Self::MIN_REPEATED_BRANCHES {
+            let condition = self.condition_id(spec.condition);
             self.add_node(NarrowingTransformNode::Branch {
-                condition: spec.condition,
+                condition,
                 if_true: spec.if_true,
                 if_false: spec.if_false,
             })
@@ -1199,6 +1207,31 @@ impl<'db> NarrowingTransformBuilder<'db> {
         self.conditions.push(node);
         self.condition_cache.insert(node, id);
         id
+    }
+
+    fn condition_id(&mut self, condition: NarrowingBranchCondition<'db>) -> NarrowingConditionId {
+        match condition {
+            NarrowingBranchCondition::Atom(condition) => {
+                self.add_condition(NarrowingConditionNode::Atom(condition))
+            }
+            NarrowingBranchCondition::Node(id) => id,
+        }
+    }
+
+    fn combine_condition(
+        &mut self,
+        left: NarrowingBranchCondition<'db>,
+        right: ComplementaryNarrowing<'db>,
+        is_or: bool,
+    ) -> NarrowingConditionId {
+        let left = self.condition_id(left);
+        let right = self.add_condition(NarrowingConditionNode::Atom(right));
+        let node = if is_or {
+            NarrowingConditionNode::Or { left, right }
+        } else {
+            NarrowingConditionNode::And { left, right }
+        };
+        self.add_condition(node)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -146,6 +146,76 @@ fn has_finite_single_valued_union_alternatives<'db>(db: &'db dyn Db, ty: Type<'d
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct ComplementaryNarrowing<'db> {
+    positive: Type<'db>,
+    negative: Type<'db>,
+}
+
+impl<'db> ComplementaryNarrowing<'db> {
+    fn from_constraints(
+        db: &'db dyn Db,
+        positive: &NarrowingConstraint<'db>,
+        negative: &NarrowingConstraint<'db>,
+    ) -> Option<Self> {
+        fn is_direct_negation<'db>(db: &'db dyn Db, ty: Type<'db>, negated: Type<'db>) -> bool {
+            let Type::Intersection(intersection) = negated else {
+                return false;
+            };
+            intersection.positive(db).is_empty()
+                && intersection.negative(db).len() == 1
+                && intersection.negative(db).contains(&ty)
+        }
+
+        let positive = positive.single_intersection_type()?;
+        let negative = negative.single_intersection_type()?;
+        (is_direct_negation(db, positive, negative) || is_direct_negation(db, negative, positive))
+            .then_some(Self { positive, negative })
+    }
+
+    pub(crate) fn positive(self) -> Type<'db> {
+        self.positive
+    }
+
+    pub(crate) fn negative(self) -> Type<'db> {
+        self.negative
+    }
+
+    fn swapped(self) -> Self {
+        Self {
+            positive: self.negative,
+            negative: self.positive,
+        }
+    }
+
+    pub(crate) fn or(self, db: &'db dyn Db, other: Self) -> Self {
+        Self {
+            positive: UnionType::from_two_elements(db, self.positive, other.positive),
+            negative: IntersectionBuilder::new(db)
+                .add_positive(self.negative)
+                .add_positive(other.negative)
+                .build(),
+        }
+    }
+
+    pub(crate) fn and(self, db: &'db dyn Db, other: Self) -> Self {
+        Self {
+            positive: IntersectionBuilder::new(db)
+                .add_positive(self.positive)
+                .add_positive(other.positive)
+                .build(),
+            negative: UnionType::from_two_elements(db, self.negative, other.negative),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PredicateNarrowingConstraints<'db> {
+    pub(crate) positive: Option<NarrowingConstraint<'db>>,
+    pub(crate) negative: Option<NarrowingConstraint<'db>>,
+    pub(crate) complementary: Option<ComplementaryNarrowing<'db>>,
+}
+
 /// Return the type constraints that `test` would place on `symbol` if true and false.
 ///
 /// For example, if we have this code:
@@ -166,11 +236,8 @@ pub(crate) fn infer_narrowing_constraints<'db>(
     db: &'db dyn Db,
     predicate: Predicate<'db>,
     place: ScopedPlaceId,
-) -> (
-    Option<NarrowingConstraint<'db>>,
-    Option<NarrowingConstraint<'db>>,
-) {
-    let constraints = match predicate.node {
+) -> PredicateNarrowingConstraints<'db> {
+    let (positive, negative) = match predicate.node {
         PredicateNode::Expression(expression) => {
             let constraints = all_narrowing_constraints_for_expression(db, expression);
             (
@@ -189,11 +256,26 @@ pub(crate) fn infer_narrowing_constraints<'db>(
             (None, None)
         }
     };
+    let complementary =
+        positive
+            .as_ref()
+            .zip(negative.as_ref())
+            .and_then(|(positive, negative)| {
+                ComplementaryNarrowing::from_constraints(db, positive, negative)
+            });
 
     if predicate.is_positive {
-        constraints
+        PredicateNarrowingConstraints {
+            positive,
+            negative,
+            complementary,
+        }
     } else {
-        (constraints.1, constraints.0)
+        PredicateNarrowingConstraints {
+            positive: negative,
+            negative: positive,
+            complementary: complementary.map(ComplementaryNarrowing::swapped),
+        }
     }
 }
 
@@ -558,21 +640,6 @@ impl<'db> NarrowingConstraint<'db> {
         }
     }
 
-    /// Merge two constraints with OR semantics.
-    fn merge_constraint_or(mut self, other: Self) -> Self {
-        for disjunct in other.intersection_disjuncts {
-            if !self.intersection_disjuncts.contains(&disjunct) {
-                self.intersection_disjuncts.push(disjunct);
-            }
-        }
-        for disjunct in other.replacement_disjuncts {
-            if !self.replacement_disjuncts.contains(&disjunct) {
-                self.replacement_disjuncts.push(disjunct);
-            }
-        }
-        self
-    }
-
     /// Evaluate the type this effectively constrains to
     ///
     /// Forgets whether each constraint originated from a `replacement` disjunct or not
@@ -587,90 +654,287 @@ impl<'db> NarrowingConstraint<'db> {
         }
         union.build()
     }
+
+    fn single_intersection_type(&self) -> Option<Type<'db>> {
+        let [disjunct] = &*self.intersection_disjuncts else {
+            return None;
+        };
+        let [conjunct] = &*disjunct.conjuncts else {
+            return None;
+        };
+
+        self.replacement_disjuncts.is_empty().then_some(*conjunct)
+    }
 }
 
-/// A narrowing operation that can be applied to a previously known type.
-///
-/// A transform with no constraint is the identity transform.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct NarrowingTransformId(usize);
+
+impl NarrowingTransformId {
+    const IDENTITY: Self = Self(0);
+    const UNREACHABLE: Self = Self(1);
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+enum NarrowingTransformNode<'db> {
+    Identity,
+    Unreachable,
+    Constraint(NarrowingConstraint<'db>),
+    Then {
+        earlier: NarrowingTransformId,
+        later: NarrowingTransformId,
+    },
+    Join {
+        left: NarrowingTransformId,
+        right: NarrowingTransformId,
+    },
+    Branch {
+        condition: ComplementaryNarrowing<'db>,
+        if_true: NarrowingTransformId,
+        if_false: NarrowingTransformId,
+    },
+}
+
+/// A factorized narrowing operation that can be applied to a previously known type.
+#[derive(Clone, Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct NarrowingTransform<'db> {
-    reachable: bool,
-    constraint: Option<NarrowingConstraint<'db>>,
+    nodes: Box<[NarrowingTransformNode<'db>]>,
+    root: NarrowingTransformId,
 }
 
 impl<'db> NarrowingTransform<'db> {
     pub(crate) fn identity() -> Self {
-        Self {
-            reachable: true,
-            constraint: None,
-        }
+        NarrowingTransformBuilder::default().build(NarrowingTransformId::IDENTITY)
     }
 
-    pub(crate) fn unreachable() -> Self {
-        Self {
-            reachable: false,
-            constraint: None,
-        }
+    pub(crate) fn apply(&self, db: &'db dyn Db, base_ty: Type<'db>) -> Type<'db> {
+        self.apply_node(
+            db,
+            self.root,
+            base_ty,
+            base_ty,
+            &mut vec![None; self.nodes.len()],
+        )
     }
 
-    pub(crate) fn from_constraint(constraint: Option<NarrowingConstraint<'db>>) -> Self {
+    fn apply_node(
+        &self,
+        db: &'db dyn Db,
+        id: NarrowingTransformId,
+        base_ty: Type<'db>,
+        original_base_ty: Type<'db>,
+        cache: &mut [Option<Type<'db>>],
+    ) -> Type<'db> {
+        if base_ty == original_base_ty
+            && let Some(cached) = cache[id.0]
+        {
+            return cached;
+        }
+
+        let result = match &self.nodes[id.0] {
+            NarrowingTransformNode::Identity => base_ty,
+            NarrowingTransformNode::Unreachable => Type::Never,
+            NarrowingTransformNode::Constraint(constraint) => {
+                NarrowingConstraint::intersection(base_ty)
+                    .merge_constraint_and(constraint.clone())
+                    .evaluate_constraint_type(db)
+            }
+            NarrowingTransformNode::Then { earlier, later } => {
+                let earlier = self.apply_node(db, *earlier, base_ty, original_base_ty, cache);
+                self.apply_node(db, *later, earlier, original_base_ty, cache)
+            }
+            NarrowingTransformNode::Join { left, right } => UnionType::from_two_elements(
+                db,
+                self.apply_node(db, *left, base_ty, original_base_ty, cache),
+                self.apply_node(db, *right, base_ty, original_base_ty, cache),
+            ),
+            NarrowingTransformNode::Branch {
+                condition,
+                if_true,
+                if_false,
+            } => {
+                let if_true = IntersectionBuilder::new(db)
+                    .add_positive(self.apply_node(db, *if_true, base_ty, original_base_ty, cache))
+                    .add_positive(condition.positive())
+                    .build();
+                let if_false = IntersectionBuilder::new(db)
+                    .add_positive(self.apply_node(db, *if_false, base_ty, original_base_ty, cache))
+                    .add_positive(condition.negative())
+                    .build();
+                UnionType::from_two_elements(db, if_true, if_false)
+            }
+        };
+        if base_ty == original_base_ty {
+            cache[id.0] = Some(result);
+        }
+        result
+    }
+}
+
+pub(crate) struct NarrowingTransformBuilder<'db> {
+    nodes: Vec<NarrowingTransformNode<'db>>,
+    cache: FxHashMap<NarrowingTransformNode<'db>, NarrowingTransformId>,
+    branch_specs: FxHashMap<NarrowingTransformId, NarrowingBranchSpec<'db>>,
+}
+
+#[derive(Clone, Copy)]
+struct NarrowingBranchSpec<'db> {
+    condition: ComplementaryNarrowing<'db>,
+    if_true: NarrowingTransformId,
+    if_false: NarrowingTransformId,
+    branches: usize,
+}
+
+impl Default for NarrowingTransformBuilder<'_> {
+    fn default() -> Self {
+        let nodes = vec![
+            NarrowingTransformNode::Identity,
+            NarrowingTransformNode::Unreachable,
+        ];
+        let cache = nodes
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(index, node)| (node, NarrowingTransformId(index)))
+            .collect();
         Self {
-            reachable: true,
-            constraint,
+            nodes,
+            cache,
+            branch_specs: FxHashMap::default(),
+        }
+    }
+}
+
+impl<'db> NarrowingTransformBuilder<'db> {
+    // Compact only long chains: applying the identity below normalizes equivalent
+    // intersections, which would otherwise change the displayed type of short flows.
+    const MIN_REPEATED_BRANCHES: usize = 4;
+
+    pub(crate) fn identity() -> NarrowingTransformId {
+        NarrowingTransformId::IDENTITY
+    }
+
+    pub(crate) fn unreachable() -> NarrowingTransformId {
+        NarrowingTransformId::UNREACHABLE
+    }
+
+    pub(crate) fn constraint(
+        &mut self,
+        constraint: Option<NarrowingConstraint<'db>>,
+    ) -> NarrowingTransformId {
+        match constraint {
+            Some(constraint) => self.add_node(NarrowingTransformNode::Constraint(constraint)),
+            None => Self::identity(),
         }
     }
 
     /// Compose this transform with one that occurs later in control flow.
-    pub(crate) fn then(self, later: Self) -> Self {
-        if !self.reachable || !later.reachable {
-            return Self::unreachable();
-        }
-
-        let constraint = match (self.constraint, later.constraint) {
-            (Some(earlier), Some(later)) => Some(earlier.merge_constraint_and(later)),
-            (Some(constraint), None) | (None, Some(constraint)) => Some(constraint),
-            (None, None) => None,
-        };
-        Self {
-            reachable: true,
-            constraint,
+    pub(crate) fn then(
+        &mut self,
+        earlier: NarrowingTransformId,
+        later: NarrowingTransformId,
+    ) -> NarrowingTransformId {
+        match (&self.nodes[earlier.0], &self.nodes[later.0]) {
+            (NarrowingTransformNode::Unreachable, _) | (_, NarrowingTransformNode::Unreachable) => {
+                Self::unreachable()
+            }
+            (NarrowingTransformNode::Identity, _) => later,
+            (_, NarrowingTransformNode::Identity) => earlier,
+            _ => self.add_node(NarrowingTransformNode::Then { earlier, later }),
         }
     }
 
     /// Join transforms from alternative control-flow paths.
-    pub(crate) fn join(self, other: Self) -> Self {
-        match (self.reachable, other.reachable) {
-            (false, false) => Self::unreachable(),
-            (true, false) => self,
-            (false, true) => other,
-            (true, true) => {
-                let constraint = match (self.constraint, other.constraint) {
-                    (Some(left), Some(right)) => Some(left.merge_constraint_or(right)),
-                    (Some(constraint), None) | (None, Some(constraint)) => Some(
-                        NarrowingConstraint::intersection(Type::object())
-                            .merge_constraint_or(constraint),
-                    ),
-                    (None, None) => None,
-                };
-                Self {
-                    reachable: true,
-                    constraint,
-                }
-            }
+    pub(crate) fn join(
+        &mut self,
+        left: NarrowingTransformId,
+        right: NarrowingTransformId,
+    ) -> NarrowingTransformId {
+        if left == right {
+            return left;
+        }
+        match (&self.nodes[left.0], &self.nodes[right.0]) {
+            (NarrowingTransformNode::Unreachable, _) => right,
+            (_, NarrowingTransformNode::Unreachable) => left,
+            _ => self.add_node(NarrowingTransformNode::Join { left, right }),
         }
     }
 
-    pub(crate) fn apply(self, db: &'db dyn Db, base_ty: Type<'db>) -> Type<'db> {
-        if !self.reachable {
-            return Type::Never;
+    pub(crate) fn branch(
+        &mut self,
+        db: &'db dyn Db,
+        condition: ComplementaryNarrowing<'db>,
+        if_true: NarrowingTransformId,
+        if_false: NarrowingTransformId,
+    ) -> NarrowingTransformId {
+        if if_true == if_false {
+            return if_true;
         }
 
-        match self.constraint {
-            Some(constraint) => NarrowingConstraint::intersection(base_ty)
-                .merge_constraint_and(constraint)
-                .evaluate_constraint_type(db),
-            None => base_ty,
+        let spec = if let Some(nested) = self.branch_specs.get(&if_false)
+            && if_true == nested.if_true
+        {
+            NarrowingBranchSpec {
+                condition: nested.condition.or(db, condition),
+                if_true,
+                if_false: nested.if_false,
+                branches: nested.branches + 1,
+            }
+        } else if let Some(nested) = self.branch_specs.get(&if_true)
+            && if_false == nested.if_false
+        {
+            NarrowingBranchSpec {
+                condition: nested.condition.and(db, condition),
+                if_true: nested.if_true,
+                if_false,
+                branches: nested.branches + 1,
+            }
+        } else {
+            NarrowingBranchSpec {
+                condition,
+                if_true,
+                if_false,
+                branches: 1,
+            }
+        };
+
+        let result = if spec.branches >= Self::MIN_REPEATED_BRANCHES {
+            self.add_node(NarrowingTransformNode::Branch {
+                condition: spec.condition,
+                if_true: spec.if_true,
+                if_false: spec.if_false,
+            })
+        } else {
+            let positive = self.constraint(Some(NarrowingConstraint::intersection(
+                condition.positive(),
+            )));
+            let negative = self.constraint(Some(NarrowingConstraint::intersection(
+                condition.negative(),
+            )));
+            let if_true = self.then(if_true, positive);
+            let if_false = self.then(if_false, negative);
+            self.join(if_true, if_false)
+        };
+        self.branch_specs.insert(result, spec);
+        result
+    }
+
+    pub(crate) fn build(mut self, root: NarrowingTransformId) -> NarrowingTransform<'db> {
+        self.nodes.shrink_to_fit();
+        NarrowingTransform {
+            nodes: self.nodes.into_boxed_slice(),
+            root,
         }
+    }
+
+    fn add_node(&mut self, node: NarrowingTransformNode<'db>) -> NarrowingTransformId {
+        if let Some(id) = self.cache.get(&node) {
+            return *id;
+        }
+        let id = NarrowingTransformId(self.nodes.len());
+        self.nodes.push(node.clone());
+        self.cache.insert(node, id);
+        id
     }
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -574,6 +574,43 @@ impl<'db> NarrowingConstraint<'db> {
     }
 }
 
+/// A narrowing operation that can be applied to a previously known type.
+///
+/// A transform with no constraint is the identity transform.
+#[derive(Clone, Debug)]
+pub(crate) struct NarrowingTransform<'db> {
+    constraint: Option<NarrowingConstraint<'db>>,
+}
+
+impl<'db> NarrowingTransform<'db> {
+    pub(crate) fn identity() -> Self {
+        Self { constraint: None }
+    }
+
+    pub(crate) fn from_constraint(constraint: Option<NarrowingConstraint<'db>>) -> Self {
+        Self { constraint }
+    }
+
+    /// Compose this transform with one that occurs later in control flow.
+    pub(crate) fn then(self, later: Self) -> Self {
+        let constraint = match (self.constraint, later.constraint) {
+            (Some(earlier), Some(later)) => Some(earlier.merge_constraint_and(later)),
+            (Some(constraint), None) | (None, Some(constraint)) => Some(constraint),
+            (None, None) => None,
+        };
+        Self { constraint }
+    }
+
+    pub(crate) fn apply(self, db: &'db dyn Db, base_ty: Type<'db>) -> Type<'db> {
+        match self.constraint {
+            Some(constraint) => NarrowingConstraint::intersection(base_ty)
+                .merge_constraint_and(constraint)
+                .evaluate_constraint_type(db),
+            None => base_ty,
+        }
+    }
+}
+
 impl<'db> From<Type<'db>> for NarrowingConstraint<'db> {
     fn from(constraint: Type<'db>) -> Self {
         Self::intersection(constraint)

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -944,9 +944,10 @@ impl Default for NarrowingTransformBuilder<'_> {
 }
 
 impl<'db> NarrowingTransformBuilder<'db> {
-    // Compact only long chains: applying the identity below normalizes equivalent
-    // intersections, which would otherwise change the displayed type of short flows.
-    const MIN_REPEATED_BRANCHES: usize = 4;
+    // Compact only long chains: medium chains do not amortize building and applying the
+    // condition DAG. Applying the identity below also normalizes equivalent intersections,
+    // which would otherwise change the displayed type of short flows.
+    const MIN_REPEATED_BRANCHES: usize = 8;
 
     pub(crate) fn identity() -> NarrowingTransformId {
         NarrowingTransformId::IDENTITY

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -558,6 +558,21 @@ impl<'db> NarrowingConstraint<'db> {
         }
     }
 
+    /// Merge two constraints with OR semantics.
+    fn merge_constraint_or(mut self, other: Self) -> Self {
+        for disjunct in other.intersection_disjuncts {
+            if !self.intersection_disjuncts.contains(&disjunct) {
+                self.intersection_disjuncts.push(disjunct);
+            }
+        }
+        for disjunct in other.replacement_disjuncts {
+            if !self.replacement_disjuncts.contains(&disjunct) {
+                self.replacement_disjuncts.push(disjunct);
+            }
+        }
+        self
+    }
+
     /// Evaluate the type this effectively constrains to
     ///
     /// Forgets whether each constraint originated from a `replacement` disjunct or not
@@ -577,31 +592,79 @@ impl<'db> NarrowingConstraint<'db> {
 /// A narrowing operation that can be applied to a previously known type.
 ///
 /// A transform with no constraint is the identity transform.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct NarrowingTransform<'db> {
+    reachable: bool,
     constraint: Option<NarrowingConstraint<'db>>,
 }
 
 impl<'db> NarrowingTransform<'db> {
     pub(crate) fn identity() -> Self {
-        Self { constraint: None }
+        Self {
+            reachable: true,
+            constraint: None,
+        }
+    }
+
+    pub(crate) fn unreachable() -> Self {
+        Self {
+            reachable: false,
+            constraint: None,
+        }
     }
 
     pub(crate) fn from_constraint(constraint: Option<NarrowingConstraint<'db>>) -> Self {
-        Self { constraint }
+        Self {
+            reachable: true,
+            constraint,
+        }
     }
 
     /// Compose this transform with one that occurs later in control flow.
     pub(crate) fn then(self, later: Self) -> Self {
+        if !self.reachable || !later.reachable {
+            return Self::unreachable();
+        }
+
         let constraint = match (self.constraint, later.constraint) {
             (Some(earlier), Some(later)) => Some(earlier.merge_constraint_and(later)),
             (Some(constraint), None) | (None, Some(constraint)) => Some(constraint),
             (None, None) => None,
         };
-        Self { constraint }
+        Self {
+            reachable: true,
+            constraint,
+        }
+    }
+
+    /// Join transforms from alternative control-flow paths.
+    pub(crate) fn join(self, other: Self) -> Self {
+        match (self.reachable, other.reachable) {
+            (false, false) => Self::unreachable(),
+            (true, false) => self,
+            (false, true) => other,
+            (true, true) => {
+                let constraint = match (self.constraint, other.constraint) {
+                    (Some(left), Some(right)) => Some(left.merge_constraint_or(right)),
+                    (Some(constraint), None) | (None, Some(constraint)) => Some(
+                        NarrowingConstraint::intersection(Type::object())
+                            .merge_constraint_or(constraint),
+                    ),
+                    (None, None) => None,
+                };
+                Self {
+                    reachable: true,
+                    constraint,
+                }
+            }
+        }
     }
 
     pub(crate) fn apply(self, db: &'db dyn Db, base_ty: Type<'db>) -> Type<'db> {
+        if !self.reachable {
+            return Type::Never;
+        }
+
         match self.constraint {
             Some(constraint) => NarrowingConstraint::intersection(base_ty)
                 .merge_constraint_and(constraint)

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -919,11 +919,74 @@ impl<'db> NarrowingTransformBuilder<'db> {
         result
     }
 
-    pub(crate) fn build(mut self, root: NarrowingTransformId) -> NarrowingTransform<'db> {
-        self.nodes.shrink_to_fit();
+    pub(crate) fn build(self, root: NarrowingTransformId) -> NarrowingTransform<'db> {
+        let mut reachable = vec![false; self.nodes.len()];
+        let mut pending = vec![root];
+        while let Some(id) = pending.pop() {
+            if std::mem::replace(&mut reachable[id.0], true) {
+                continue;
+            }
+            match self.nodes[id.0] {
+                NarrowingTransformNode::Identity
+                | NarrowingTransformNode::Unreachable
+                | NarrowingTransformNode::Constraint(_) => {}
+                NarrowingTransformNode::Then { earlier, later } => {
+                    pending.extend([earlier, later]);
+                }
+                NarrowingTransformNode::Join { left, right } => {
+                    pending.extend([left, right]);
+                }
+                NarrowingTransformNode::Branch {
+                    if_true, if_false, ..
+                } => {
+                    pending.extend([if_true, if_false]);
+                }
+            }
+        }
+
+        let mut remap = vec![NarrowingTransformId::UNREACHABLE; self.nodes.len()];
+        let mut nodes =
+            Vec::with_capacity(reachable.iter().filter(|reachable| **reachable).count());
+        for (index, node) in self.nodes.into_iter().enumerate() {
+            if !reachable[index] {
+                continue;
+            }
+
+            let new_id = NarrowingTransformId(nodes.len());
+            remap[index] = new_id;
+            let remap_child = |id: NarrowingTransformId| {
+                debug_assert!(id.0 < index && reachable[id.0]);
+                remap[id.0]
+            };
+            nodes.push(match node {
+                NarrowingTransformNode::Identity => NarrowingTransformNode::Identity,
+                NarrowingTransformNode::Unreachable => NarrowingTransformNode::Unreachable,
+                NarrowingTransformNode::Constraint(constraint) => {
+                    NarrowingTransformNode::Constraint(constraint)
+                }
+                NarrowingTransformNode::Then { earlier, later } => NarrowingTransformNode::Then {
+                    earlier: remap_child(earlier),
+                    later: remap_child(later),
+                },
+                NarrowingTransformNode::Join { left, right } => NarrowingTransformNode::Join {
+                    left: remap_child(left),
+                    right: remap_child(right),
+                },
+                NarrowingTransformNode::Branch {
+                    condition,
+                    if_true,
+                    if_false,
+                } => NarrowingTransformNode::Branch {
+                    condition,
+                    if_true: remap_child(if_true),
+                    if_false: remap_child(if_false),
+                },
+            });
+        }
+
         NarrowingTransform {
-            nodes: self.nodes.into_boxed_slice(),
-            root,
+            nodes: nodes.into_boxed_slice(),
+            root: remap[root.0],
         }
     }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -187,26 +187,6 @@ impl<'db> ComplementaryNarrowing<'db> {
             negative: self.positive,
         }
     }
-
-    pub(crate) fn or(self, db: &'db dyn Db, other: Self) -> Self {
-        Self {
-            positive: UnionType::from_two_elements(db, self.positive, other.positive),
-            negative: IntersectionBuilder::new(db)
-                .add_positive(self.negative)
-                .add_positive(other.negative)
-                .build(),
-        }
-    }
-
-    pub(crate) fn and(self, db: &'db dyn Db, other: Self) -> Self {
-        Self {
-            positive: IntersectionBuilder::new(db)
-                .add_positive(self.positive)
-                .add_positive(other.positive)
-                .build(),
-            negative: UnionType::from_two_elements(db, self.negative, other.negative),
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -675,6 +655,22 @@ impl NarrowingTransformId {
     const UNREACHABLE: Self = Self(1);
 }
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+struct NarrowingConditionId(usize);
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+enum NarrowingConditionNode<'db> {
+    Atom(ComplementaryNarrowing<'db>),
+    Or {
+        left: NarrowingConditionId,
+        right: NarrowingConditionId,
+    },
+    And {
+        left: NarrowingConditionId,
+        right: NarrowingConditionId,
+    },
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 enum NarrowingTransformNode<'db> {
     Identity,
@@ -689,7 +685,7 @@ enum NarrowingTransformNode<'db> {
         right: NarrowingTransformId,
     },
     Branch {
-        condition: ComplementaryNarrowing<'db>,
+        condition: NarrowingConditionId,
         if_true: NarrowingTransformId,
         if_false: NarrowingTransformId,
     },
@@ -699,6 +695,7 @@ enum NarrowingTransformNode<'db> {
 #[derive(Clone, Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct NarrowingTransform<'db> {
     nodes: Box<[NarrowingTransformNode<'db>]>,
+    conditions: Box<[NarrowingConditionNode<'db>]>,
     root: NarrowingTransformId,
 }
 
@@ -708,12 +705,14 @@ impl<'db> NarrowingTransform<'db> {
     }
 
     pub(crate) fn apply(&self, db: &'db dyn Db, base_ty: Type<'db>) -> Type<'db> {
+        let mut condition_cache = vec![None; self.conditions.len()];
         self.apply_node(
             db,
             self.root,
             base_ty,
             base_ty,
             &mut vec![None; self.nodes.len()],
+            &mut condition_cache,
         )
     }
 
@@ -724,6 +723,7 @@ impl<'db> NarrowingTransform<'db> {
         base_ty: Type<'db>,
         original_base_ty: Type<'db>,
         cache: &mut [Option<Type<'db>>],
+        condition_cache: &mut [Option<ComplementaryNarrowing<'db>>],
     ) -> Type<'db> {
         if base_ty == original_base_ty
             && let Some(cached) = cache[id.0]
@@ -735,30 +735,49 @@ impl<'db> NarrowingTransform<'db> {
             NarrowingTransformNode::Identity => base_ty,
             NarrowingTransformNode::Unreachable => Type::Never,
             NarrowingTransformNode::Constraint(constraint) => {
-                NarrowingConstraint::intersection(base_ty)
-                    .merge_constraint_and(constraint.clone())
-                    .evaluate_constraint_type(db)
+                apply_narrowing_constraint(db, base_ty, constraint.clone())
             }
-            NarrowingTransformNode::Then { earlier, later } => {
-                let earlier = self.apply_node(db, *earlier, base_ty, original_base_ty, cache);
-                self.apply_node(db, *later, earlier, original_base_ty, cache)
+            NarrowingTransformNode::Then { .. } => {
+                self.apply_sequence(db, id, base_ty, original_base_ty, cache, condition_cache)
             }
             NarrowingTransformNode::Join { left, right } => UnionType::from_two_elements(
                 db,
-                self.apply_node(db, *left, base_ty, original_base_ty, cache),
-                self.apply_node(db, *right, base_ty, original_base_ty, cache),
+                self.apply_node(db, *left, base_ty, original_base_ty, cache, condition_cache),
+                self.apply_node(
+                    db,
+                    *right,
+                    base_ty,
+                    original_base_ty,
+                    cache,
+                    condition_cache,
+                ),
             ),
             NarrowingTransformNode::Branch {
                 condition,
                 if_true,
                 if_false,
             } => {
+                let condition = self.apply_condition(db, *condition, condition_cache);
                 let if_true = IntersectionBuilder::new(db)
-                    .add_positive(self.apply_node(db, *if_true, base_ty, original_base_ty, cache))
+                    .add_positive(self.apply_node(
+                        db,
+                        *if_true,
+                        base_ty,
+                        original_base_ty,
+                        cache,
+                        condition_cache,
+                    ))
                     .add_positive(condition.positive())
                     .build();
                 let if_false = IntersectionBuilder::new(db)
-                    .add_positive(self.apply_node(db, *if_false, base_ty, original_base_ty, cache))
+                    .add_positive(self.apply_node(
+                        db,
+                        *if_false,
+                        base_ty,
+                        original_base_ty,
+                        cache,
+                        condition_cache,
+                    ))
                     .add_positive(condition.negative())
                     .build();
                 UnionType::from_two_elements(db, if_true, if_false)
@@ -769,17 +788,128 @@ impl<'db> NarrowingTransform<'db> {
         }
         result
     }
+
+    fn apply_sequence(
+        &self,
+        db: &'db dyn Db,
+        id: NarrowingTransformId,
+        base_ty: Type<'db>,
+        original_base_ty: Type<'db>,
+        cache: &mut [Option<Type<'db>>],
+        condition_cache: &mut [Option<ComplementaryNarrowing<'db>>],
+    ) -> Type<'db> {
+        let mut sequence = Vec::new();
+        let mut pending = vec![id];
+        while let Some(id) = pending.pop() {
+            if let NarrowingTransformNode::Then { earlier, later } = self.nodes[id.0] {
+                pending.extend([later, earlier]);
+            } else {
+                sequence.push(id);
+            }
+        }
+
+        let mut result = base_ty;
+        let mut accumulated: Option<NarrowingConstraint<'db>> = None;
+        for id in sequence {
+            if let NarrowingTransformNode::Constraint(constraint) = &self.nodes[id.0] {
+                accumulated = Some(match accumulated {
+                    Some(accumulated) => accumulated.merge_constraint_and(constraint.clone()),
+                    None => constraint.clone(),
+                });
+            } else {
+                if let Some(constraint) = accumulated.take() {
+                    result = apply_narrowing_constraint(db, result, constraint);
+                }
+                result = self.apply_node(db, id, result, original_base_ty, cache, condition_cache);
+            }
+        }
+        if let Some(constraint) = accumulated {
+            result = apply_narrowing_constraint(db, result, constraint);
+        }
+        result
+    }
+
+    fn apply_condition(
+        &self,
+        db: &'db dyn Db,
+        id: NarrowingConditionId,
+        cache: &mut [Option<ComplementaryNarrowing<'db>>],
+    ) -> ComplementaryNarrowing<'db> {
+        if let Some(cached) = cache[id.0] {
+            return cached;
+        }
+
+        let result = match self.conditions[id.0] {
+            NarrowingConditionNode::Atom(condition) => condition,
+            NarrowingConditionNode::Or { .. } => {
+                let mut positive = UnionBuilder::new(db);
+                let mut negative = IntersectionBuilder::new(db);
+                let mut pending = vec![id];
+                while let Some(id) = pending.pop() {
+                    match self.conditions[id.0] {
+                        NarrowingConditionNode::Or { left, right } if cache[id.0].is_none() => {
+                            pending.extend([left, right]);
+                        }
+                        _ => {
+                            let condition = self.apply_condition(db, id, cache);
+                            positive = positive.add(condition.positive());
+                            negative = negative.add_positive(condition.negative());
+                        }
+                    }
+                }
+                ComplementaryNarrowing {
+                    positive: positive.build(),
+                    negative: negative.build(),
+                }
+            }
+            NarrowingConditionNode::And { .. } => {
+                let mut positive = IntersectionBuilder::new(db);
+                let mut negative = UnionBuilder::new(db);
+                let mut pending = vec![id];
+                while let Some(id) = pending.pop() {
+                    match self.conditions[id.0] {
+                        NarrowingConditionNode::And { left, right } if cache[id.0].is_none() => {
+                            pending.extend([left, right]);
+                        }
+                        _ => {
+                            let condition = self.apply_condition(db, id, cache);
+                            positive = positive.add_positive(condition.positive());
+                            negative = negative.add(condition.negative());
+                        }
+                    }
+                }
+                ComplementaryNarrowing {
+                    positive: positive.build(),
+                    negative: negative.build(),
+                }
+            }
+        };
+        cache[id.0] = Some(result);
+        result
+    }
+}
+
+fn apply_narrowing_constraint<'db>(
+    db: &'db dyn Db,
+    base_ty: Type<'db>,
+    constraint: NarrowingConstraint<'db>,
+) -> Type<'db> {
+    NarrowingConstraint::intersection(base_ty)
+        .merge_constraint_and(constraint)
+        .evaluate_constraint_type(db)
 }
 
 pub(crate) struct NarrowingTransformBuilder<'db> {
     nodes: Vec<NarrowingTransformNode<'db>>,
     cache: FxHashMap<NarrowingTransformNode<'db>, NarrowingTransformId>,
-    branch_specs: FxHashMap<NarrowingTransformId, NarrowingBranchSpec<'db>>,
+    conditions: Vec<NarrowingConditionNode<'db>>,
+    condition_cache: FxHashMap<NarrowingConditionNode<'db>, NarrowingConditionId>,
+    branch_specs: FxHashMap<NarrowingTransformId, NarrowingBranchSpec>,
 }
 
 #[derive(Clone, Copy)]
-struct NarrowingBranchSpec<'db> {
-    condition: ComplementaryNarrowing<'db>,
+struct NarrowingBranchSpec {
+    condition: NarrowingConditionId,
     if_true: NarrowingTransformId,
     if_false: NarrowingTransformId,
     branches: usize,
@@ -800,6 +930,8 @@ impl Default for NarrowingTransformBuilder<'_> {
         Self {
             nodes,
             cache,
+            conditions: Vec::new(),
+            condition_cache: FxHashMap::default(),
             branch_specs: FxHashMap::default(),
         }
     }
@@ -862,7 +994,6 @@ impl<'db> NarrowingTransformBuilder<'db> {
 
     pub(crate) fn branch(
         &mut self,
-        db: &'db dyn Db,
         condition: ComplementaryNarrowing<'db>,
         if_true: NarrowingTransformId,
         if_false: NarrowingTransformId,
@@ -871,20 +1002,30 @@ impl<'db> NarrowingTransformBuilder<'db> {
             return if_true;
         }
 
-        let spec = if let Some(nested) = self.branch_specs.get(&if_false)
+        let atomic_condition = condition;
+        let condition = self.add_condition(NarrowingConditionNode::Atom(condition));
+        let spec = if let Some(nested) = self.branch_specs.get(&if_false).copied()
+            && if_true != Self::unreachable()
             && if_true == nested.if_true
         {
             NarrowingBranchSpec {
-                condition: nested.condition.or(db, condition),
+                condition: self.add_condition(NarrowingConditionNode::Or {
+                    left: nested.condition,
+                    right: condition,
+                }),
                 if_true,
                 if_false: nested.if_false,
                 branches: nested.branches + 1,
             }
-        } else if let Some(nested) = self.branch_specs.get(&if_true)
+        } else if let Some(nested) = self.branch_specs.get(&if_true).copied()
+            && if_false != Self::unreachable()
             && if_false == nested.if_false
         {
             NarrowingBranchSpec {
-                condition: nested.condition.and(db, condition),
+                condition: self.add_condition(NarrowingConditionNode::And {
+                    left: nested.condition,
+                    right: condition,
+                }),
                 if_true: nested.if_true,
                 if_false,
                 branches: nested.branches + 1,
@@ -906,10 +1047,10 @@ impl<'db> NarrowingTransformBuilder<'db> {
             })
         } else {
             let positive = self.constraint(Some(NarrowingConstraint::intersection(
-                condition.positive(),
+                atomic_condition.positive(),
             )));
             let negative = self.constraint(Some(NarrowingConstraint::intersection(
-                condition.negative(),
+                atomic_condition.negative(),
             )));
             let if_true = self.then(if_true, positive);
             let if_false = self.then(if_false, negative);
@@ -921,7 +1062,9 @@ impl<'db> NarrowingTransformBuilder<'db> {
 
     pub(crate) fn build(self, root: NarrowingTransformId) -> NarrowingTransform<'db> {
         let mut reachable = vec![false; self.nodes.len()];
+        let mut reachable_conditions = vec![false; self.conditions.len()];
         let mut pending = vec![root];
+        let mut pending_conditions = Vec::new();
         while let Some(id) = pending.pop() {
             if std::mem::replace(&mut reachable[id.0], true) {
                 continue;
@@ -937,11 +1080,58 @@ impl<'db> NarrowingTransformBuilder<'db> {
                     pending.extend([left, right]);
                 }
                 NarrowingTransformNode::Branch {
-                    if_true, if_false, ..
+                    condition,
+                    if_true,
+                    if_false,
                 } => {
                     pending.extend([if_true, if_false]);
+                    pending_conditions.push(condition);
                 }
             }
+        }
+
+        while let Some(id) = pending_conditions.pop() {
+            if std::mem::replace(&mut reachable_conditions[id.0], true) {
+                continue;
+            }
+            match self.conditions[id.0] {
+                NarrowingConditionNode::Atom(_) => {}
+                NarrowingConditionNode::Or { left, right }
+                | NarrowingConditionNode::And { left, right } => {
+                    pending_conditions.extend([left, right]);
+                }
+            }
+        }
+
+        let mut condition_remap = vec![NarrowingConditionId(usize::MAX); self.conditions.len()];
+        let mut conditions = Vec::with_capacity(
+            reachable_conditions
+                .iter()
+                .filter(|reachable| **reachable)
+                .count(),
+        );
+        for (index, condition) in self.conditions.into_iter().enumerate() {
+            if !reachable_conditions[index] {
+                continue;
+            }
+
+            let new_id = NarrowingConditionId(conditions.len());
+            condition_remap[index] = new_id;
+            let remap_child = |id: NarrowingConditionId| {
+                debug_assert!(id.0 < index && reachable_conditions[id.0]);
+                condition_remap[id.0]
+            };
+            conditions.push(match condition {
+                NarrowingConditionNode::Atom(condition) => NarrowingConditionNode::Atom(condition),
+                NarrowingConditionNode::Or { left, right } => NarrowingConditionNode::Or {
+                    left: remap_child(left),
+                    right: remap_child(right),
+                },
+                NarrowingConditionNode::And { left, right } => NarrowingConditionNode::And {
+                    left: remap_child(left),
+                    right: remap_child(right),
+                },
+            });
         }
 
         let mut remap = vec![NarrowingTransformId::UNREACHABLE; self.nodes.len()];
@@ -977,7 +1167,7 @@ impl<'db> NarrowingTransformBuilder<'db> {
                     if_true,
                     if_false,
                 } => NarrowingTransformNode::Branch {
-                    condition,
+                    condition: condition_remap[condition.0],
                     if_true: remap_child(if_true),
                     if_false: remap_child(if_false),
                 },
@@ -986,6 +1176,7 @@ impl<'db> NarrowingTransformBuilder<'db> {
 
         NarrowingTransform {
             nodes: nodes.into_boxed_slice(),
+            conditions: conditions.into_boxed_slice(),
             root: remap[root.0],
         }
     }
@@ -997,6 +1188,16 @@ impl<'db> NarrowingTransformBuilder<'db> {
         let id = NarrowingTransformId(self.nodes.len());
         self.nodes.push(node.clone());
         self.cache.insert(node, id);
+        id
+    }
+
+    fn add_condition(&mut self, node: NarrowingConditionNode<'db>) -> NarrowingConditionId {
+        if let Some(id) = self.condition_cache.get(&node) {
+            return *id;
+        }
+        let id = NarrowingConditionId(self.conditions.len());
+        self.conditions.push(node);
+        self.condition_cache.insert(node, id);
         id
     }
 }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -180,20 +180,23 @@ impl<'db> ComplementaryNarrowing<'db> {
     pub(crate) fn negative(self) -> Type<'db> {
         self.negative
     }
-
-    fn swapped(self) -> Self {
-        Self {
-            positive: self.negative,
-            negative: self.positive,
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct PredicateNarrowingConstraints<'db> {
     pub(crate) positive: Option<NarrowingConstraint<'db>>,
     pub(crate) negative: Option<NarrowingConstraint<'db>>,
-    pub(crate) complementary: Option<ComplementaryNarrowing<'db>>,
+}
+
+impl<'db> PredicateNarrowingConstraints<'db> {
+    pub(crate) fn complementary(&self, db: &'db dyn Db) -> Option<ComplementaryNarrowing<'db>> {
+        self.positive
+            .as_ref()
+            .zip(self.negative.as_ref())
+            .and_then(|(positive, negative)| {
+                ComplementaryNarrowing::from_constraints(db, positive, negative)
+            })
+    }
 }
 
 /// Return the type constraints that `test` would place on `symbol` if true and false.
@@ -236,25 +239,12 @@ pub(crate) fn infer_narrowing_constraints<'db>(
             (None, None)
         }
     };
-    let complementary =
-        positive
-            .as_ref()
-            .zip(negative.as_ref())
-            .and_then(|(positive, negative)| {
-                ComplementaryNarrowing::from_constraints(db, positive, negative)
-            });
-
     if predicate.is_positive {
-        PredicateNarrowingConstraints {
-            positive,
-            negative,
-            complementary,
-        }
+        PredicateNarrowingConstraints { positive, negative }
     } else {
         PredicateNarrowingConstraints {
             positive: negative,
             negative: positive,
-            complementary: complementary.map(ComplementaryNarrowing::swapped),
         }
     }
 }
@@ -645,6 +635,10 @@ impl<'db> NarrowingConstraint<'db> {
 
         self.replacement_disjuncts.is_empty().then_some(*conjunct)
     }
+
+    pub(crate) fn has_replacement(&self) -> bool {
+        !self.replacement_disjuncts.is_empty()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
@@ -944,10 +938,9 @@ impl Default for NarrowingTransformBuilder<'_> {
 }
 
 impl<'db> NarrowingTransformBuilder<'db> {
-    // Compact only long chains: medium chains do not amortize building and applying the
-    // condition DAG. Applying the identity below also normalizes equivalent intersections,
-    // which would otherwise change the displayed type of short flows.
-    const MIN_REPEATED_BRANCHES: usize = 8;
+    // Compact only long chains: applying the identity below normalizes equivalent
+    // intersections, which would otherwise change the displayed type of short flows.
+    const MIN_REPEATED_BRANCHES: usize = 4;
 
     pub(crate) fn identity() -> NarrowingTransformId {
         NarrowingTransformId::IDENTITY

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -635,6 +635,10 @@ impl<'db> NarrowingConstraint<'db> {
 
         self.replacement_disjuncts.is_empty().then_some(*conjunct)
     }
+
+    pub(crate) fn has_replacement(&self) -> bool {
+        !self.replacement_disjuncts.is_empty()
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]


### PR DESCRIPTION
## Summary

Long `if`/`elif` chains accumulate a decision graph of positive and negative narrowing constraints. Evaluating that graph independently for every load repeatedly expands the same intersections and unions, especially when later branches retain all preceding `TypeIs` or `isinstance` exclusions.

This change models projected intersection narrowing as a base-independent transfer-function DAG. We fold the projected reachability graph bottom-up, hash-cons equivalent constraint, composition, join, and branch transforms, and apply the resulting transform with indexed caches for shared subgraphs. Large projected transforms are cached independently of the incoming type, while the final application is cached by scope, reachability constraint, base type, and place.

Sequential constraints and complementary Boolean conditions remain symbolic until application. We flatten each maximal composition or `and`/`or` region, merge it once, and normalize it once rather than constructing every growing prefix. Before storing a transform in Salsa, we compact both arenas to nodes reachable from the selected root.

For exact complementary intersection constraints represented as `T` and `~T`, the transform builder factors repeated branches that share a reachable anchor. For example, `(P1 & A) | (~P1 & ((P2 & A) | (~P2 & R)))` becomes `((P1 | P2) & A) | (~(P1 | P2) & R)`. We retain both sides of every predicate; no negative narrowing is omitted. Pure reachability filters with an unreachable anchor remain sequential constraints.

Replacement narrowing remains on a direct projected-DAG evaluator because its ordering semantics are encoded in `NarrowingConstraint`, and replacement constraints cannot participate in complementary branch factoring. The split is based on constraint kind rather than graph size: intersection-only graphs use transfer functions, while graphs containing replacement narrowing use direct evaluation. The projected-node threshold only decides whether to cache the transform or final narrowed type in Salsa.

Both evaluators operate over the same reduced projected graph. The graph exposes a reusable memoized bottom-up fold for transfer functions, while the direct evaluator identifies shared joins and caches narrowed suffixes so replacement narrowing does not repeatedly traverse the same subgraphs.

On PyTorch commit `29d6170e7c79f2c71943692985a1546fb2bed28c`, matched local runs remain roughly 2-3x faster than current `main`, and all 12,179 diagnostics are byte-for-byte identical. We also tested routing replacement narrowing through the transfer-function evaluator, but repeated apply/revert measurements showed a consistent real-project wall-time regression, so this PR retains the direct path for replacement constraints.
