### PR TITLE
[ty] Simplify exact complementary cubes

### DIFF
--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -129,6 +129,79 @@ fn merge_truthiness_guarded_pair<'db>(
     }
 }
 
+fn simplify_complementary_cube_orientation<'db>(
+    db: &'db dyn Db,
+    positive_side: Type<'db>,
+    negative_side: Type<'db>,
+) -> Option<Type<'db>> {
+    let Type::Intersection(negative_intersection) = negative_side else {
+        return None;
+    };
+    let negative_positive = negative_intersection.positive(db);
+    let negative_negative = negative_intersection.negative(db);
+
+    let try_candidate = |candidate| {
+        if !negative_negative.contains(&candidate) {
+            return None;
+        }
+
+        let mut remainder = IntersectionBuilder::new(db);
+        match positive_side {
+            Type::Intersection(positive_intersection) => {
+                let positive_positive = positive_intersection.positive(db);
+                let positive_negative = positive_intersection.negative(db);
+
+                if positive_positive.len() != negative_positive.len() + 1
+                    || positive_negative.len() + 1 != negative_negative.len()
+                    || positive_positive.iter().any(|element| {
+                        *element != candidate && !negative_positive.contains(element)
+                    })
+                    || positive_negative
+                        .iter()
+                        .any(|element| !negative_negative.contains(element))
+                {
+                    return None;
+                }
+
+                for element in positive_positive {
+                    if *element != candidate {
+                        remainder = remainder.add_positive(*element);
+                    }
+                }
+                for element in positive_negative {
+                    remainder = remainder.add_negative(*element);
+                }
+            }
+            _ => {
+                if positive_side != candidate
+                    || !negative_positive.is_empty()
+                    || negative_negative.len() != 1
+                {
+                    return None;
+                }
+            }
+        }
+
+        // Boolean absorption is not representation-preserving for gradual types. For example,
+        // `(Any & ~None) | None` must not be widened to `Any`. Delay this recursive traversal
+        // until after the cheap shape checks because this function runs in the hot union loop.
+        if positive_side.has_dynamic(db) || negative_side.has_dynamic(db) {
+            return None;
+        }
+
+        Some(remainder.build())
+    };
+
+    match positive_side {
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .copied()
+            .find_map(try_candidate),
+        _ => try_candidate(positive_side),
+    }
+}
+
 /// Simplify two conjunctions containing opposite polarities of the same element.
 ///
 /// - `(R & P) | (R & ~P)` -> `R`
@@ -137,82 +210,11 @@ fn simplify_complementary_cubes<'db>(
     left: Type<'db>,
     right: Type<'db>,
 ) -> Option<Type<'db>> {
-    // Boolean absorption is not representation-preserving for gradual types. For example,
-    // `(Any & ~None) | None` must not be widened to `Any`.
-    if left.has_dynamic(db) || right.has_dynamic(db) {
-        return None;
-    }
-
-    fn try_orientation<'db>(
-        db: &'db dyn Db,
-        positive_side: Type<'db>,
-        negative_side: Type<'db>,
-    ) -> Option<Type<'db>> {
-        let Type::Intersection(negative_intersection) = negative_side else {
-            return None;
-        };
-        let negative_positive = negative_intersection.positive(db);
-        let negative_negative = negative_intersection.negative(db);
-
-        let try_candidate = |candidate| {
-            if !negative_negative.contains(&candidate) {
-                return None;
-            }
-
-            let mut remainder = IntersectionBuilder::new(db);
-            match positive_side {
-                Type::Intersection(positive_intersection) => {
-                    let positive_positive = positive_intersection.positive(db);
-                    let positive_negative = positive_intersection.negative(db);
-
-                    if positive_positive.len() != negative_positive.len() + 1
-                        || positive_negative.len() + 1 != negative_negative.len()
-                        || positive_positive.iter().any(|element| {
-                            *element != candidate && !negative_positive.contains(element)
-                        })
-                        || positive_negative
-                            .iter()
-                            .any(|element| !negative_negative.contains(element))
-                    {
-                        return None;
-                    }
-
-                    for element in positive_positive {
-                        if *element != candidate {
-                            remainder = remainder.add_positive(*element);
-                        }
-                    }
-                    for element in positive_negative {
-                        remainder = remainder.add_negative(*element);
-                    }
-                }
-                _ => {
-                    if positive_side != candidate
-                        || !negative_positive.is_empty()
-                        || negative_negative.len() != 1
-                    {
-                        return None;
-                    }
-                }
-            }
-            Some(remainder.build())
-        };
-
-        match positive_side {
-            Type::Intersection(intersection) => intersection
-                .positive(db)
-                .iter()
-                .copied()
-                .find_map(try_candidate),
-            _ => try_candidate(positive_side),
-        }
-    }
-
-    if let Some(reduction) = try_orientation(db, left, right) {
+    if let Some(reduction) = simplify_complementary_cube_orientation(db, left, right) {
         return Some(reduction);
     }
 
-    try_orientation(db, right, left)
+    simplify_complementary_cube_orientation(db, right, left)
 }
 
 /// Combine union elements that cover more of the same enum class.

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -129,6 +129,92 @@ fn merge_truthiness_guarded_pair<'db>(
     }
 }
 
+/// Simplify two conjunctions containing opposite polarities of the same element.
+///
+/// - `(R & P) | (R & ~P)` -> `R`
+fn simplify_complementary_cubes<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+) -> Option<Type<'db>> {
+    // Boolean absorption is not representation-preserving for gradual types. For example,
+    // `(Any & ~None) | None` must not be widened to `Any`.
+    if left.has_dynamic(db) || right.has_dynamic(db) {
+        return None;
+    }
+
+    fn try_orientation<'db>(
+        db: &'db dyn Db,
+        positive_side: Type<'db>,
+        negative_side: Type<'db>,
+    ) -> Option<Type<'db>> {
+        let Type::Intersection(negative_intersection) = negative_side else {
+            return None;
+        };
+        let negative_positive = negative_intersection.positive(db);
+        let negative_negative = negative_intersection.negative(db);
+
+        let try_candidate = |candidate| {
+            if !negative_negative.contains(&candidate) {
+                return None;
+            }
+
+            let mut remainder = IntersectionBuilder::new(db);
+            match positive_side {
+                Type::Intersection(positive_intersection) => {
+                    let positive_positive = positive_intersection.positive(db);
+                    let positive_negative = positive_intersection.negative(db);
+
+                    if positive_positive.len() != negative_positive.len() + 1
+                        || positive_negative.len() + 1 != negative_negative.len()
+                        || positive_positive.iter().any(|element| {
+                            *element != candidate && !negative_positive.contains(element)
+                        })
+                        || positive_negative
+                            .iter()
+                            .any(|element| !negative_negative.contains(element))
+                    {
+                        return None;
+                    }
+
+                    for element in positive_positive {
+                        if *element != candidate {
+                            remainder = remainder.add_positive(*element);
+                        }
+                    }
+                    for element in positive_negative {
+                        remainder = remainder.add_negative(*element);
+                    }
+                }
+                _ => {
+                    if positive_side != candidate
+                        || !negative_positive.is_empty()
+                        || negative_negative.len() != 1
+                    {
+                        return None;
+                    }
+                }
+            }
+            Some(remainder.build())
+        };
+
+        match positive_side {
+            Type::Intersection(intersection) => intersection
+                .positive(db)
+                .iter()
+                .copied()
+                .find_map(try_candidate),
+            _ => try_candidate(positive_side),
+        }
+    }
+
+    if let Some(reduction) = try_orientation(db, left, right) {
+        return Some(reduction);
+    }
+
+    try_orientation(db, right, left)
+}
+
 /// Combine union elements that cover more of the same enum class.
 ///
 /// Enum complements are intersections like `Color & ~Literal[Color.RED]`. When a union contains
@@ -928,6 +1014,12 @@ impl<'db> UnionBuilder<'db> {
                 to_remove.push(i);
                 ty = merged_type;
                 continue;
+            }
+
+            if let Some(replacement) = simplify_complementary_cubes(self.db, ty, element_type) {
+                self.elements.swap_remove(i);
+                self.add_in_place_impl(replacement, seen_aliases);
+                return;
             }
 
             if element_type
@@ -1776,6 +1868,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
 mod tests {
     use super::{
         IntersectionBuilder, MAX_NON_RECURSIVE_UNION_LITERALS, Type, UnionBuilder, UnionType,
+        simplify_complementary_cubes,
     };
 
     use crate::db::tests::{TestDb, setup_db};
@@ -1813,6 +1906,105 @@ mod tests {
         let union = UnionType::from_elements(&db, [t0, t1]).expect_union();
 
         assert_eq!(union.elements(&db), &[t0, t1]);
+    }
+
+    #[test]
+    fn simplify_complementary_cube_pair() {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/a.py",
+            "
+            class Predicate: ...
+            class Shared: ...
+            class Extra: ...
+            ",
+        )
+        .unwrap();
+        let module = ruff_db::files::system_path_to_file(&db, "/src/a.py").unwrap();
+        let instance = |name| {
+            global_symbol(&db, module, name)
+                .place
+                .expect_type()
+                .to_instance(&db)
+                .unwrap()
+        };
+        let predicate = instance("Predicate");
+        let shared = instance("Shared");
+        let extra = instance("Extra");
+
+        let positive = IntersectionBuilder::new(&db)
+            .add_positive(predicate)
+            .add_positive(shared)
+            .build();
+        let negative = IntersectionBuilder::new(&db)
+            .add_positive(shared)
+            .add_negative(predicate)
+            .build();
+
+        let replacement = simplify_complementary_cubes(&db, positive, negative).unwrap();
+        assert_eq!(replacement, shared);
+
+        let more_constrained_negative = IntersectionBuilder::new(&db)
+            .add_positive(shared)
+            .add_positive(extra)
+            .add_negative(predicate)
+            .build();
+        assert!(simplify_complementary_cubes(&db, positive, more_constrained_negative).is_none());
+        assert!(simplify_complementary_cubes(&db, more_constrained_negative, positive).is_none());
+    }
+
+    #[test]
+    fn does_not_simplify_non_comparable_complementary_cubes() {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/a.py",
+            "
+            class Predicate: ...
+            class Left: ...
+            class Right: ...
+            ",
+        )
+        .unwrap();
+        let module = ruff_db::files::system_path_to_file(&db, "/src/a.py").unwrap();
+        let instance = |name| {
+            global_symbol(&db, module, name)
+                .place
+                .expect_type()
+                .to_instance(&db)
+                .unwrap()
+        };
+        let predicate = instance("Predicate");
+        let left_remainder = instance("Left");
+        let right_remainder = instance("Right");
+
+        let left = IntersectionBuilder::new(&db)
+            .add_positive(predicate)
+            .add_positive(left_remainder)
+            .build();
+        let right = IntersectionBuilder::new(&db)
+            .add_positive(right_remainder)
+            .add_negative(predicate)
+            .build();
+
+        assert!(simplify_complementary_cubes(&db, left, right).is_none());
+    }
+
+    #[test]
+    fn does_not_simplify_gradual_complementary_cubes() {
+        let db = setup_db();
+        let predicate = KnownClass::Int.to_instance(&db);
+        let gradual = Type::any();
+
+        let positive = IntersectionBuilder::new(&db)
+            .add_positive(gradual)
+            .add_positive(predicate)
+            .build();
+        let negative = IntersectionBuilder::new(&db)
+            .add_positive(gradual)
+            .add_negative(predicate)
+            .build();
+
+        assert!(simplify_complementary_cubes(&db, positive, negative).is_none());
     }
 
     fn map_marker<'db>(ty: &Type<'db>, marker: Type<'db>, replacement: Type<'db>) -> Type<'db> {


### PR DESCRIPTION
## Summary

Projected narrowing evaluates the reachable paths for a place and unions the resulting types. For example, Meson contains this pattern:

```python
value = self.evaluate_statement(node.value)
if isinstance(value, MutableInterpreterObject):
    value = copy.deepcopy(value)
self.set_variable(var_name, value)
```

The join after the `if` previously retained a type equivalent to:

```text
None | (InterpreterObject & MutableInterpreterObject) | (InterpreterObject & ~MutableInterpreterObject)
```

The last two union elements cover all `InterpreterObject` values, so the result can be reduced to `None | InterpreterObject`.

This change recognizes that identity while building unions. It is not tied to the syntax of an `if` statement or to a specific shape of control-flow graph, and it does not add a new cache. It applies whenever two normalized union elements have the exact form `(R & P) | (R & ~P)`, where removing the positive and negative occurrences of `P` leaves identical positive and negative component sets on both sides.

The reduction can apply repeatedly, so a multi-condition result such as:

```text
(R & A & B) | (R & A & ~B) | (R & ~A)
```

first reduces to `(R & A) | (R & ~A)`, then to `R`. A chain of conditions is therefore covered when its projected paths normalize into complementary pairs; it does not need to mirror one particular sequence of `if` statements.

On PyTorch commit `29d6170e7c79f2c71943692985a1546fb2bed28c`, a matched nine-run benchmark of profiling builds against this PR's exact base reduced full-project wall time from `5.824 ± 0.245s` to `3.032 ± 0.148s` (48% lower, 1.92x faster) and user CPU from `23.142s` to `20.768s` (10% lower). The complete diagnostic output was byte-for-byte identical. These numbers are for this PR alone, without the projected-DAG factorization or cache from #25729.

We intentionally do not simplify pairs whose remaining constraints differ, for example `(R & P) | (R & Q & ~P)` or `(L & P) | (R & ~P)`. We also do not search for semantic equivalence through subtyping, and we skip pairs containing gradual types because boolean absorption is not representation-preserving for types such as `Any`. The matcher compares the normalized components first and only constructs the remainder after finding an exact match, avoiding normalization work for non-matching union pairs.
