### PR TITLE
[ty] Cache projected narrowing DAGs incrementally

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1248,6 +1248,78 @@ fn benchmark_pandas_tdd(criterion: &mut Criterion) {
     });
 }
 
+fn projected_narrowing_conditional_attribute_bindings_code(
+    load_after_each_assignment: bool,
+) -> String {
+    const NUM_ASSIGNMENTS: usize = 60;
+    const NUM_FINAL_LOADS: usize = 200;
+
+    let mut code = "class Container:\n    value: int | None = None\n\n".to_string();
+    code.push_str("def check(container: Container, flags: list[bool]) -> None:\n");
+    for index in 0..NUM_ASSIGNMENTS {
+        writeln!(
+            &mut code,
+            "    if flags[{index}]:\n        container.value = {index}"
+        )
+        .ok();
+        if load_after_each_assignment {
+            code.push_str("    repr(container.value)\n");
+        }
+    }
+    if !load_after_each_assignment {
+        for _ in 0..NUM_FINAL_LOADS {
+            code.push_str("    repr(container.value)\n");
+        }
+    }
+
+    code
+}
+
+fn benchmark_projected_narrowing_attribute_bindings(
+    criterion: &mut Criterion,
+    name: &str,
+    load_after_each_assignment: bool,
+) {
+    setup_rayon();
+
+    let code = projected_narrowing_conditional_attribute_bindings_code(load_after_each_assignment);
+    criterion.bench_function(name, |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Benchmarks repeated reads from an attribute with many conditionally visible bindings.
+///
+/// The generated code first conditionally assigns `container.value` many times, then reads it
+/// repeatedly after the control-flow state has stabilized.
+fn benchmark_projected_narrowing_repeated_attribute_bindings(criterion: &mut Criterion) {
+    benchmark_projected_narrowing_attribute_bindings(
+        criterion,
+        "ty_micro[projected_narrowing_repeated_attribute_bindings]",
+        false,
+    );
+}
+
+/// Benchmarks reads interleaved with conditional assignments to the same attribute.
+///
+/// Each read sees one more possible binding than the previous read, so the projected narrowing
+/// roots overlap but are not identical.
+fn benchmark_projected_narrowing_progressive_attribute_bindings(criterion: &mut Criterion) {
+    benchmark_projected_narrowing_attribute_bindings(
+        criterion,
+        "ty_micro[projected_narrowing_progressive_attribute_bindings]",
+        true,
+    );
+}
+
 fn benchmark_recursive_typed_dict_union_contextual_inference(criterion: &mut Criterion) {
     const NUM_BRANCHES: usize = 11;
 
@@ -1525,6 +1597,8 @@ criterion_group!(
     benchmark_literal_equality_fallthrough_guarded_any,
     benchmark_typeis_narrowing,
     benchmark_pandas_tdd,
+    benchmark_projected_narrowing_repeated_attribute_bindings,
+    benchmark_projected_narrowing_progressive_attribute_bindings,
     benchmark_recursive_typed_dict_union_contextual_inference,
     benchmark_pydantic_core_schema_dict,
 );

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1320,6 +1320,41 @@ fn benchmark_projected_narrowing_progressive_attribute_bindings(criterion: &mut 
     );
 }
 
+/// Benchmarks reads interleaved with conditional assignments to a local variable.
+///
+/// This exercises the same overlapping-root pattern as the attribute benchmark, but the projected
+/// graphs are small enough that join-tracking overhead dominates.
+fn benchmark_projected_narrowing_progressive_local_bindings(criterion: &mut Criterion) {
+    const NUM_ASSIGNMENTS: usize = 80;
+
+    setup_rayon();
+
+    let mut code =
+        "def check(flags: list[bool]) -> None:\n    value: int | None = None\n".to_string();
+    for index in 0..NUM_ASSIGNMENTS {
+        writeln!(
+            &mut code,
+            "    if flags[{index}]:\n        value = {index}\n    repr(value)"
+        )
+        .ok();
+    }
+
+    criterion.bench_function(
+        "ty_micro[projected_narrowing_progressive_local_bindings]",
+        |b| {
+            b.iter_batched_ref(
+                || setup_micro_case(&code),
+                |case| {
+                    let Case { db, .. } = case;
+                    let result = db.check();
+                    assert_eq!(result.len(), 0);
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
 fn benchmark_recursive_typed_dict_union_contextual_inference(criterion: &mut Criterion) {
     const NUM_BRANCHES: usize = 11;
 
@@ -1599,6 +1634,7 @@ criterion_group!(
     benchmark_pandas_tdd,
     benchmark_projected_narrowing_repeated_attribute_bindings,
     benchmark_projected_narrowing_progressive_attribute_bindings,
+    benchmark_projected_narrowing_progressive_local_bindings,
     benchmark_recursive_typed_dict_union_contextual_inference,
     benchmark_pydantic_core_schema_dict,
 );

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -7,7 +7,9 @@ use ty_module_resolver::{
 };
 
 use crate::dunder_all::dunder_all_names;
-use crate::reachability::{ReachabilityConstraintsExtension, evaluate_reachability};
+use crate::reachability::{
+    ProjectedNarrowingCache, ReachabilityConstraintsExtension, evaluate_reachability,
+};
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::{
     DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers, TypeQualifiers,
@@ -581,6 +583,19 @@ pub(super) fn place_from_bindings<'db>(
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
 ) -> PlaceWithDefinition<'db> {
     place_from_bindings_impl(db, bindings_with_constraints, RequiresExplicitReExport::No)
+}
+
+pub(super) fn place_from_bindings_with_projected_narrowing_cache<'db>(
+    db: &'db dyn Db,
+    bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
+    projected_narrowing_cache: &ProjectedNarrowingCache<'db>,
+) -> PlaceWithDefinition<'db> {
+    place_from_bindings_impl_with_projected_narrowing_cache(
+        db,
+        bindings_with_constraints,
+        RequiresExplicitReExport::No,
+        Some(projected_narrowing_cache),
+    )
 }
 
 /// Build a declared type from a [`DeclarationsIterator`].
@@ -1330,6 +1345,20 @@ fn place_from_bindings_impl<'db>(
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
     requires_explicit_reexport: RequiresExplicitReExport,
 ) -> PlaceWithDefinition<'db> {
+    place_from_bindings_impl_with_projected_narrowing_cache(
+        db,
+        bindings_with_constraints,
+        requires_explicit_reexport,
+        None,
+    )
+}
+
+fn place_from_bindings_impl_with_projected_narrowing_cache<'db>(
+    db: &'db dyn Db,
+    bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
+    requires_explicit_reexport: RequiresExplicitReExport,
+    projected_narrowing_cache: Option<&ProjectedNarrowingCache<'db>>,
+) -> PlaceWithDefinition<'db> {
     let predicates = bindings_with_constraints.predicates();
     let reachability_constraints = bindings_with_constraints.reachability_constraints();
     let boundness_analysis = bindings_with_constraints.boundness_analysis();
@@ -1472,10 +1501,12 @@ fn place_from_bindings_impl<'db>(
 
             first_definition.get_or_insert(binding);
             let binding_ty = binding_type(db, binding);
-            Some((
-                narrowing_constraint.narrow(db, binding_ty, binding.place(db)),
-                static_reachability,
-            ))
+            let narrowed_ty = if let Some(cache) = projected_narrowing_cache {
+                narrowing_constraint.narrow_with_cache(db, binding_ty, binding.place(db), cache)
+            } else {
+                narrowing_constraint.narrow(db, binding_ty, binding.place(db))
+            };
+            Some((narrowed_ty, static_reachability))
         },
     );
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -193,6 +193,9 @@
 //! [Kleene]: <https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics>
 //! [bdd]: https://en.wikipedia.org/wiki/Binary_decision_diagram
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use crate::{
     Db,
     dunder_all::dunder_all_names,
@@ -219,6 +222,7 @@ use ty_python_core::{
         ScopedPredicateId,
     },
     reachability_constraints::{ReachabilityConstraints, ScopedReachabilityConstraintId},
+    scope::ScopeId,
 };
 
 /// Narrow `subject_ty` by all preceding unguarded match patterns.
@@ -507,6 +511,44 @@ fn accumulate_constraint<'db>(
     }
 }
 
+fn predicate_scope<'db>(db: &'db dyn Db, predicate: Predicate<'db>) -> ScopeId<'db> {
+    match predicate.node {
+        PredicateNode::Expression(expression) => expression.scope(db),
+        PredicateNode::IsNonTerminalCall(call) => call.callable.scope(db),
+        PredicateNode::Pattern(pattern) => pattern.scope(db),
+        PredicateNode::StarImportPlaceholder(star_import) => star_import.scope(db),
+    }
+}
+
+pub(crate) struct ProjectedNarrowingCache<'db> {
+    entries: RefCell<
+        FxHashMap<(ScopeId<'db>, ScopedPlaceId), Rc<RefCell<ProjectedNarrowingState<'db>>>>,
+    >,
+}
+
+impl<'db> ProjectedNarrowingCache<'db> {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: RefCell::new(FxHashMap::default()),
+        }
+    }
+
+    fn state(
+        &self,
+        scope: ScopeId<'db>,
+        place: ScopedPlaceId,
+    ) -> Rc<RefCell<ProjectedNarrowingState<'db>>> {
+        let key = (scope, place);
+        if let Some(state) = self.entries.borrow().get(&key) {
+            return Rc::clone(state);
+        }
+
+        let state = Rc::new(RefCell::new(ProjectedNarrowingState::default()));
+        self.entries.borrow_mut().insert(key, Rc::clone(&state));
+        state
+    }
+}
+
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
     /// Narrow a type by walking a TDD narrowing constraint.
     fn narrow_by_constraint(
@@ -516,6 +558,16 @@ pub(crate) trait ReachabilityConstraintsExtension<'db> {
         id: ScopedReachabilityConstraintId,
         base_ty: Type<'db>,
         place: ScopedPlaceId,
+    ) -> Type<'db>;
+
+    fn narrow_by_constraint_with_cache(
+        &self,
+        db: &'db dyn Db,
+        predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
+        id: ScopedReachabilityConstraintId,
+        base_ty: Type<'db>,
+        place: ScopedPlaceId,
+        cache: &ProjectedNarrowingCache<'db>,
     ) -> Type<'db>;
 
     /// Analyze the statically known reachability for a given constraint.
@@ -557,13 +609,57 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         base_ty: Type<'db>,
         place: ScopedPlaceId,
     ) -> Type<'db> {
-        let mut projector = NarrowingProjector::new(db, self, predicates, place);
-        let projected_root = projector.project(id);
+        let mut state = ProjectedNarrowingState::default();
+        let projected_root = {
+            let mut projector = NarrowingProjector::new(db, self, predicates, place, &mut state);
+            projector.project(id)
+        };
         let mut context = ProjectedNarrowingContext {
             db,
             base_ty,
-            graph: &projector.graph,
-            joins: projector.graph.joins(projected_root),
+            graph: &state.graph,
+            joins: ProjectedJoins::Dense(state.graph.joins(projected_root)),
+            join_cache: FxHashMap::default(),
+        };
+        context.narrow(projected_root, None)
+    }
+
+    fn narrow_by_constraint_with_cache(
+        &self,
+        db: &'db dyn Db,
+        predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
+        id: ScopedReachabilityConstraintId,
+        base_ty: Type<'db>,
+        place: ScopedPlaceId,
+        cache: &ProjectedNarrowingCache<'db>,
+    ) -> Type<'db> {
+        match id {
+            ScopedReachabilityConstraintId::ALWAYS_TRUE
+            | ScopedReachabilityConstraintId::AMBIGUOUS => return base_ty,
+            ScopedReachabilityConstraintId::ALWAYS_FALSE => return Type::Never,
+            _ => {}
+        }
+
+        let node = self.get_interior_node(id);
+        let scope = predicate_scope(db, predicates[node.atom()]);
+        let state = cache.state(scope, place);
+        let Ok(mut state_mut) = state.try_borrow_mut() else {
+            return self.narrow_by_constraint(db, predicates, id, base_ty, place);
+        };
+        let projected_root = {
+            let mut projector =
+                NarrowingProjector::new(db, self, predicates, place, &mut state_mut);
+            projector.project(id)
+        };
+        let joins = state_mut.graph.sparse_joins(projected_root);
+        drop(state_mut);
+
+        let state_ref = state.borrow();
+        let mut context = ProjectedNarrowingContext {
+            db,
+            base_ty,
+            graph: &state_ref.graph,
+            joins: ProjectedJoins::Sparse(joins),
             join_cache: FxHashMap::default(),
         };
         context.narrow(projected_root, None)
@@ -647,6 +743,12 @@ struct ProjectedNarrowingGraph<'db> {
     >,
 }
 
+#[derive(Default)]
+struct ProjectedNarrowingState<'db> {
+    project_cache: FxHashMap<ScopedReachabilityConstraintId, ProjectedNarrowingNodeId>,
+    graph: ProjectedNarrowingGraph<'db>,
+}
+
 impl ProjectedNarrowingGraph<'_> {
     /// Returns an interior projected node by ID.
     fn node(&self, id: ProjectedNarrowingNodeId) -> ProjectedNarrowingNode {
@@ -689,6 +791,31 @@ impl ProjectedNarrowingGraph<'_> {
                 if !next.is_terminal() {
                     if std::mem::replace(&mut referenced[next.0], true) {
                         joins[next.0] = true;
+                    }
+                    pending.push(next);
+                }
+            }
+        }
+
+        joins
+    }
+
+    fn sparse_joins(&self, root: ProjectedNarrowingNodeId) -> FxHashSet<ProjectedNarrowingNodeId> {
+        let mut referenced = FxHashSet::default();
+        let mut joins = FxHashSet::default();
+        let mut visited = FxHashSet::default();
+        let mut pending = vec![root];
+
+        while let Some(id) = pending.pop() {
+            if id.is_terminal() || !visited.insert(id) {
+                continue;
+            }
+
+            let node = self.node(id);
+            for next in [node.if_true, node.if_false] {
+                if !next.is_terminal() {
+                    if !referenced.insert(next) {
+                        joins.insert(next);
                     }
                     pending.push(next);
                 }
@@ -769,8 +896,7 @@ struct NarrowingProjector<'a, 'db> {
     constraints: &'a ReachabilityConstraints,
     predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
     place: ScopedPlaceId,
-    project_cache: FxHashMap<ScopedReachabilityConstraintId, ProjectedNarrowingNodeId>,
-    graph: ProjectedNarrowingGraph<'db>,
+    state: &'a mut ProjectedNarrowingState<'db>,
 }
 
 impl<'a, 'db> NarrowingProjector<'a, 'db> {
@@ -780,14 +906,14 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         constraints: &'a ReachabilityConstraints,
         predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
         place: ScopedPlaceId,
+        state: &'a mut ProjectedNarrowingState<'db>,
     ) -> Self {
         Self {
             db,
             constraints,
             predicates,
             place,
-            project_cache: FxHashMap::default(),
-            graph: ProjectedNarrowingGraph::default(),
+            state,
         }
     }
 
@@ -799,13 +925,19 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         Option<NarrowingConstraint<'db>>,
         Option<NarrowingConstraint<'db>>,
     ) {
-        if let Some(cached) = self.graph.predicate_constraints_cache.get(&predicate_id) {
+        if let Some(cached) = self
+            .state
+            .graph
+            .predicate_constraints_cache
+            .get(&predicate_id)
+        {
             return cached.clone();
         }
 
         let constraints =
             infer_narrowing_constraints(self.db, self.predicates[predicate_id], self.place);
-        self.graph
+        self.state
+            .graph
             .predicate_constraints_cache
             .insert(predicate_id, constraints.clone());
         constraints
@@ -815,7 +947,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     fn project(&mut self, id: ScopedReachabilityConstraintId) -> ProjectedNarrowingNodeId {
         type Id = ScopedReachabilityConstraintId;
 
-        if let Some(cached) = self.project_cache.get(&id) {
+        if let Some(cached) = self.state.project_cache.get(&id) {
             return *cached;
         }
 
@@ -840,9 +972,9 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                     let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom());
 
                     if pos_constraint.is_none() && neg_constraint.is_none() {
-                        self.graph.or(if_true, if_false)
+                        self.state.graph.or(if_true, if_false)
                     } else {
-                        self.graph.add_node(ProjectedNarrowingNode {
+                        self.state.graph.add_node(ProjectedNarrowingNode {
                             atom: node.atom(),
                             if_true,
                             if_false,
@@ -852,25 +984,39 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             }
         };
 
-        self.project_cache.insert(id, projected);
+        self.state.project_cache.insert(id, projected);
         projected
     }
 }
 
 /// Evaluates narrowed types over a projected narrowing graph.
+enum ProjectedJoins {
+    Dense(Vec<bool>),
+    Sparse(FxHashSet<ProjectedNarrowingNodeId>),
+}
+
+impl ProjectedJoins {
+    fn contains(&self, id: ProjectedNarrowingNodeId) -> bool {
+        match self {
+            ProjectedJoins::Dense(joins) => joins[id.0],
+            ProjectedJoins::Sparse(joins) => joins.contains(&id),
+        }
+    }
+}
+
 struct ProjectedNarrowingContext<'a, 'db> {
     db: &'db dyn Db,
     base_ty: Type<'db>,
     graph: &'a ProjectedNarrowingGraph<'db>,
     /// Marks join boundaries in the projected DAG.
-    joins: Vec<bool>,
+    joins: ProjectedJoins,
     /// Caches each join's narrowed suffix type from its boundary.
     join_cache: FxHashMap<ProjectedNarrowingNodeId, Type<'db>>,
 }
 
 impl<'db> ProjectedNarrowingContext<'_, 'db> {
     fn is_join(&self, id: ProjectedNarrowingNodeId) -> bool {
-        !id.is_terminal() && self.joins[id.0]
+        !id.is_terminal() && self.joins.contains(id)
     }
 
     /// Evaluates one projected join from its boundary and caches its narrowed suffix type.

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -619,7 +619,7 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
             db,
             base_ty,
             graph: &state.graph,
-            joins: ProjectedJoins::Dense(state.graph.joins(projected_root)),
+            joins: state.graph.joins(projected_root),
             join_cache: FxHashMap::default(),
         };
         context.narrow(projected_root, None)
@@ -652,7 +652,7 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
                 NarrowingProjector::new(db, self, predicates, place, &mut state_mut);
             projector.project(id)
         };
-        let joins = state_mut.graph.sparse_joins(projected_root);
+        let joins = state_mut.graph.joins(projected_root);
         drop(state_mut);
 
         let state_ref = state.borrow();
@@ -660,7 +660,7 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
             db,
             base_ty,
             graph: &state_ref.graph,
-            joins: ProjectedJoins::Sparse(joins),
+            joins,
             join_cache: FxHashMap::default(),
         };
         context.narrow(projected_root, None)
@@ -792,31 +792,6 @@ impl ProjectedNarrowingGraph<'_> {
                 if !next.is_terminal() {
                     if std::mem::replace(&mut referenced[next.0], true) {
                         joins[next.0] = true;
-                    }
-                    pending.push(next);
-                }
-            }
-        }
-
-        joins
-    }
-
-    fn sparse_joins(&self, root: ProjectedNarrowingNodeId) -> FxHashSet<ProjectedNarrowingNodeId> {
-        let mut referenced = FxHashSet::default();
-        let mut joins = FxHashSet::default();
-        let mut visited = FxHashSet::default();
-        let mut pending = vec![root];
-
-        while let Some(id) = pending.pop() {
-            if id.is_terminal() || !visited.insert(id) {
-                continue;
-            }
-
-            let node = self.node(id);
-            for next in [node.if_true, node.if_false] {
-                if !next.is_terminal() {
-                    if !referenced.insert(next) {
-                        joins.insert(next);
                     }
                     pending.push(next);
                 }
@@ -990,34 +965,19 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     }
 }
 
-/// Evaluates narrowed types over a projected narrowing graph.
-enum ProjectedJoins {
-    Dense(Vec<bool>),
-    Sparse(FxHashSet<ProjectedNarrowingNodeId>),
-}
-
-impl ProjectedJoins {
-    fn contains(&self, id: ProjectedNarrowingNodeId) -> bool {
-        match self {
-            ProjectedJoins::Dense(joins) => joins[id.0],
-            ProjectedJoins::Sparse(joins) => joins.contains(&id),
-        }
-    }
-}
-
 struct ProjectedNarrowingContext<'a, 'db> {
     db: &'db dyn Db,
     base_ty: Type<'db>,
     graph: &'a ProjectedNarrowingGraph<'db>,
     /// Marks join boundaries in the projected DAG.
-    joins: ProjectedJoins,
+    joins: Vec<bool>,
     /// Caches each join's narrowed suffix type from its boundary.
     join_cache: FxHashMap<ProjectedNarrowingNodeId, Type<'db>>,
 }
 
 impl<'db> ProjectedNarrowingContext<'_, 'db> {
     fn is_join(&self, id: ProjectedNarrowingNodeId) -> bool {
-        !id.is_terminal() && self.joins.contains(id)
+        !id.is_terminal() && self.joins[id.0]
     }
 
     /// Evaluates one projected join from its boundary and caches its narrowed suffix type.

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -520,10 +520,11 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: Predicate<'db>) -> ScopeId<'
     }
 }
 
+type ProjectedNarrowingCacheEntries<'db> =
+    FxHashMap<(ScopeId<'db>, ScopedPlaceId), Rc<RefCell<ProjectedNarrowingState<'db>>>>;
+
 pub(crate) struct ProjectedNarrowingCache<'db> {
-    entries: RefCell<
-        FxHashMap<(ScopeId<'db>, ScopedPlaceId), Rc<RefCell<ProjectedNarrowingState<'db>>>>,
-    >,
+    entries: RefCell<ProjectedNarrowingCacheEntries<'db>>,
 }
 
 impl<'db> ProjectedNarrowingCache<'db> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -33,9 +33,10 @@ use crate::place::{
     RequiresExplicitReExport, TypeOrigin, builtins_module_scope, builtins_symbol,
     class_body_implicit_symbol, explicit_global_symbol, loop_header_reachability,
     module_type_implicit_global_declaration, module_type_implicit_global_symbol, place_by_id,
-    place_from_bindings, place_from_declarations, typing_extensions_symbol,
+    place_from_bindings, place_from_bindings_with_projected_narrowing_cache,
+    place_from_declarations, typing_extensions_symbol,
 };
-use crate::reachability::ReachabilityConstraintsExtension;
+use crate::reachability::{ProjectedNarrowingCache, ReachabilityConstraintsExtension};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
 use crate::types::call::bind::MatchingOverloadIndex;
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
@@ -236,6 +237,9 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// An expression cache shared across builders during multi-inference.
     expression_cache: Option<Rc<RefCell<ExpressionCache<'db>>>>,
 
+    /// Projected narrowing graphs reused across local place loads and speculative inference.
+    projected_narrowing_cache: Rc<ProjectedNarrowingCache<'db>>,
+
     /// Type qualifiers (`Required`, `NotRequired`, etc.) for annotation expressions.
     /// Only populated for expressions that have non-empty qualifiers.
     qualifiers: FxHashMap<ExpressionNodeKey, TypeQualifiers>,
@@ -366,6 +370,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred_state: DeferredExpressionState::None,
             expressions: FxHashMap::default(),
             expression_cache: None,
+            projected_narrowing_cache: Rc::new(ProjectedNarrowingCache::new()),
             qualifiers: FxHashMap::default(),
             type_expression_flags: FxHashMap::default(),
             collection_use_constraints: FxHashMap::default(),
@@ -8783,9 +8788,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 if !is_discarded_dict_key_assignment(db, definition) =>
                             {
                                 let binding_ty = binding_type(db, definition);
-                                union = union.add(
-                                    binding.narrowing_constraint.narrow(db, binding_ty, place),
-                                );
+                                union = union.add(binding.narrowing_constraint.narrow_with_cache(
+                                    db,
+                                    binding_ty,
+                                    place,
+                                    &self.projected_narrowing_cache,
+                                ));
                             }
                             DefinitionState::Defined(_)
                             | DefinitionState::Undefined
@@ -8970,7 +8978,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             let use_id = expr_ref.scoped_use_id(db, self.file());
-            let place = place_from_bindings(db, use_def.bindings_at_use(use_id)).place;
+            let place = place_from_bindings_with_projected_narrowing_cache(
+                db,
+                use_def.bindings_at_use(use_id),
+                &self.projected_narrowing_cache,
+            )
+            .place;
 
             (place, Some(use_id))
         }
@@ -10253,6 +10266,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            projected_narrowing_cache: _,
             typevar_binding_context: _,
             deferred_state: _,
             called_functions: _,
@@ -10334,6 +10348,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            projected_narrowing_cache: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10428,6 +10443,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             bindings,
             called_functions,
             expression_cache: _,
+            projected_narrowing_cache: _,
             declarations: _,
             deferred: _,
             scope: _,
@@ -10482,6 +10498,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            projected_narrowing_cache: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10574,6 +10591,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Builder only state
             expression_cache: _,
+            projected_narrowing_cache: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10627,6 +10645,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred_state,
             typevar_binding_context,
             ref expression_cache,
+            ref projected_narrowing_cache,
             ref return_types_and_ranges,
             ref dataclass_field_specifiers,
 
@@ -10660,6 +10679,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         builder.context.inference_flags = self.inference_flags();
         builder.expression_cache.clone_from(expression_cache);
         builder
+            .projected_narrowing_cache
+            .clone_from(projected_narrowing_cache);
+        builder
             .return_types_and_ranges
             .clone_from(return_types_and_ranges);
         builder
@@ -10691,6 +10713,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            projected_narrowing_cache: _,
             typevar_binding_context: _,
             deferred_state: _,
             called_functions: _,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,5 +1,5 @@
 use crate::Db;
-use crate::reachability::ReachabilityConstraintsExtension;
+use crate::reachability::{ProjectedNarrowingCache, ReachabilityConstraintsExtension};
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
@@ -2746,6 +2746,14 @@ fn all_matching_tuple_elements_have_literal_types<'db>(
 
 pub(crate) trait NarrowingEvaluatorExtension<'db> {
     fn narrow(&self, db: &'db dyn Db, base_type: Type<'db>, place: ScopedPlaceId) -> Type<'db>;
+
+    fn narrow_with_cache(
+        &self,
+        db: &'db dyn Db,
+        base_type: Type<'db>,
+        place: ScopedPlaceId,
+        cache: &ProjectedNarrowingCache<'db>,
+    ) -> Type<'db>;
 }
 
 impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
@@ -2757,5 +2765,23 @@ impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
             base_type,
             place,
         )
+    }
+
+    fn narrow_with_cache(
+        &self,
+        db: &'db dyn Db,
+        base_type: Type<'db>,
+        place: ScopedPlaceId,
+        cache: &ProjectedNarrowingCache<'db>,
+    ) -> Type<'db> {
+        self.reachability_constraints()
+            .narrow_by_constraint_with_cache(
+                db,
+                self.predicates(),
+                self.constraint(),
+                base_type,
+                place,
+                cache,
+            )
     }
 }


### PR DESCRIPTION
## Summary

Each local place load currently projects its reachability constraint into a reduced narrowing graph from scratch. Repeated loads of the same place therefore rediscover the same relevant predicates, rebuild the same projected nodes, and recompute join boundaries for overlapping roots.

This change retains one projected narrowing state per scope and place for the lifetime of an inference builder. Later loads extend the existing projected DAG and reuse the projection, node, disjunction, and predicate-constraint caches. Evaluation computes join boundaries only for nodes reachable from the requested root. Speculative builders share the cache, while recursive re-entry falls back to the existing uncached path instead of borrowing partially constructed state.
