### PR TITLE
[ty] Bypass member lookup for module imports

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1565,13 +1565,6 @@ impl<'db> Type<'db> {
         ))
     }
 
-    pub(crate) const fn as_module_literal(self) -> Option<ModuleLiteralType<'db>> {
-        match self {
-            Type::ModuleLiteral(module) => Some(module),
-            _ => None,
-        }
-    }
-
     pub(crate) const fn is_union(self) -> bool {
         matches!(self, Type::Union(_))
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -8,7 +8,7 @@ use crate::{
     Program, TypeQualifiers, add_inferred_python_version_hint_to_diagnostic,
     place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, TypeOrigin},
     types::{
-        Type, TypeAndQualifiers,
+        ModuleLiteralType, Type, TypeAndQualifiers,
         diagnostic::{
             POSSIBLY_MISSING_IMPORT, UNRESOLVED_IMPORT,
             hint_if_stdlib_attribute_exists_on_other_versions,
@@ -335,7 +335,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         };
 
-        let module_ty = Type::module_literal(db, self.file(), module);
+        let module_literal = ModuleLiteralType::new(
+            db,
+            module,
+            module.kind(db).is_package().then_some(self.file()),
+        );
+        let module_ty = Type::ModuleLiteral(module_literal);
 
         let name = if let Some(star_import) = definition.kind(db).as_star_import() {
             self.index
@@ -352,9 +357,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         //
         // In nested scopes (e.g. function bodies), the module's global-scope definitions
         // are resolved independently, so there is no cycle risk and the lookup is safe.
-        let skip_self_referential_member_lookup = module_ty
-            .as_module_literal()
-            .is_some_and(|module| Some(self.file()) == module.module(db).file(db))
+        let skip_self_referential_member_lookup = Some(self.file())
+            == module_literal.module(db).file(db)
             && self.scope().file_scope_id(db).is_global();
 
         // Although it isn't the runtime semantics, we go to some trouble to prioritize a submodule
@@ -371,7 +375,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ..
                     }),
                 qualifiers,
-            } = module_ty.member(db, name)
+            } = module_literal.static_member(db, name)
             {
                 if &alias.name != "*" && boundness == Definedness::PossiblyUndefined {
                     // TODO: Consider loading _both_ the attribute and any submodule and unioning them


### PR DESCRIPTION
## Summary

`from module import name` import inference already knows that the left-hand side resolved to a module literal, but it still routed the final attribute lookup through the generic `Type::member` path. That path handles arbitrary receiver types and descriptor behavior before eventually reaching module lookup.

This constructs the `ModuleLiteralType` directly, reuses it for the existing self-referential global-import guard, and calls `ModuleLiteralType::static_member` when checking whether the imported module exports the requested name. Import semantics stay the same, while module import lookup avoids the generic member-lookup machinery.

The now-unused `Type::as_module_literal` helper is removed.