### PR TITLE
[ty] Infer annotated module declarations independently

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1128,6 +1128,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 AstNodeRef::new(self.module, alias.expression),
                 None,
                 ExpressionKind::Normal,
+                None,
             );
             self.alias_predicates.insert(
                 ExpressionNodeKey::from(leaf),
@@ -1251,11 +1252,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 self.add_dict_key_assignment_definitions(&node.targets, &node.value, assignment);
             }
             Some(CurrentAssignment::AnnAssign(ann_assign)) => {
-                self.add_standalone_type_expression(&ann_assign.annotation);
                 let assignment = self.add_definition(
                     place_id,
                     AnnotatedAssignmentDefinitionNodeRef { node: ann_assign },
                 );
+                self.add_standalone_annotation_expression(&ann_assign.annotation, assignment);
 
                 if let Some(value) = ann_assign.value.as_deref() {
                     self.add_dict_key_assignment_definitions(
@@ -2027,7 +2028,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     /// Record an expression that needs to be a Salsa ingredient, because we need to infer its type
     /// standalone (type narrowing tests, RHS of an assignment.)
     fn add_standalone_expression(&mut self, expression_node: &ast::Expr) -> Expression<'db> {
-        self.add_standalone_expression_impl(expression_node, ExpressionKind::Normal, None)
+        self.add_standalone_expression_impl(expression_node, ExpressionKind::Normal, None, None)
     }
 
     /// Record an expression that is immediately assigned to a target, and that needs to be a Salsa
@@ -2042,13 +2043,23 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             expression_node,
             ExpressionKind::Normal,
             Some(assigned_to),
+            None,
         )
     }
 
-    /// Same as [`SemanticIndexBuilder::add_standalone_expression`], but marks the expression as a
-    /// *type* expression, which makes sure that it will later be inferred as such.
-    fn add_standalone_type_expression(&mut self, expression_node: &ast::Expr) -> Expression<'db> {
-        self.add_standalone_expression_impl(expression_node, ExpressionKind::TypeExpression, None)
+    /// Same as [`SemanticIndexBuilder::add_standalone_expression`], but marks the expression as an
+    /// annotation expression so that inference preserves type qualifiers.
+    fn add_standalone_annotation_expression(
+        &mut self,
+        expression_node: &ast::Expr,
+        owner: Definition<'db>,
+    ) -> Expression<'db> {
+        self.add_standalone_expression_impl(
+            expression_node,
+            ExpressionKind::AnnotationExpression,
+            None,
+            Some(owner),
+        )
     }
 
     fn add_standalone_expression_impl(
@@ -2056,6 +2067,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         expression_node: &ast::Expr,
         expression_kind: ExpressionKind,
         assigned_to: Option<&ast::StmtAssign>,
+        annotation_owner: Option<Definition<'db>>,
     ) -> Expression<'db> {
         let expression = Expression::new(
             self.db,
@@ -2063,6 +2075,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             AstNodeRef::new(self.module, expression_node),
             assigned_to.map(|assigned_to| AstNodeRef::new(self.module, assigned_to)),
             expression_kind,
+            annotation_owner,
         );
         self.expressions_by_node
             .insert(expression_node.into(), expression);

--- a/crates/ty_python_core/src/expression.rs
+++ b/crates/ty_python_core/src/expression.rs
@@ -1,5 +1,6 @@
 use crate::ast_node_ref::AstNodeRef;
 use crate::db::Db;
+use crate::definition::Definition;
 use crate::scope::ScopeId;
 use ruff_db::files::File;
 use ruff_python_ast as ast;
@@ -12,7 +13,7 @@ use salsa;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub enum ExpressionKind {
     Normal,
-    TypeExpression,
+    AnnotationExpression,
 }
 
 /// An independently type-inferable expression.
@@ -55,8 +56,11 @@ pub struct Expression<'db> {
     #[tracked]
     pub assigned_to: Option<AstNodeRef<ast::StmtAssign>>,
 
-    /// Should this expression be inferred as a normal expression or a type expression?
+    /// Should this expression be inferred as a normal expression or an annotation expression?
     pub kind: ExpressionKind,
+
+    /// The definition whose declaration this annotation belongs to.
+    pub annotation_owner: Option<Definition<'db>>,
 }
 
 // The Salsa heap is tracked separately.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -15,6 +15,7 @@ use context::InferContext;
 use ruff_db::Instant;
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span};
 use ruff_db::files::File;
+use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
@@ -103,7 +104,7 @@ pub(crate) use literal::{
     BytesLiteralType, EnumLiteralType, LiteralValueType, LiteralValueTypeKind, StringLiteralType,
 };
 pub use special_form::SpecialFormType;
-use ty_python_core::definition::Definition;
+use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{Truthiness, place_table, semantic_index};
@@ -214,6 +215,40 @@ pub(crate) fn inferred_declaration<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> InferredDeclaration<'db> {
+    if let DefinitionKind::AnnotatedAssignment(assignment) = definition.kind(db) {
+        let file = definition.file(db);
+        let module = parsed_module(db, file).load(db);
+        let target = assignment.target(&module);
+
+        if definition.scope(db).file_scope_id(db).is_global()
+            && assignment.value(&module).is_some()
+            && let Some(name) = target.as_name_expr()
+        {
+            let annotation = assignment.annotation(&module);
+            let index = semantic_index(db, file);
+            let annotation_expression = index.expression(annotation);
+            let inference =
+                infer_expression_types(db, annotation_expression, TypeContext::default());
+            let mut declared = TypeAndQualifiers::declared(inference.expression_type(annotation))
+                .with_qualifier(inference.qualifiers(annotation));
+
+            // PEP 613 aliases derive their declaration from the right-hand side.
+            if !declared.inner_type().is_typealias_special_form() {
+                if name.id == "TYPE_CHECKING" {
+                    declared.inner = Type::bool_literal(true);
+                }
+
+                if let Some(special_form) =
+                    SpecialFormType::try_from_file_and_name(db, file, &name.id)
+                {
+                    declared.inner = Type::SpecialForm(special_form);
+                }
+
+                return InferredDeclaration::Declared(declared);
+            }
+        }
+    }
+
     let inference = infer_definition_types(db, definition);
     inference.inferred_declaration(definition)
 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1317,6 +1317,10 @@ struct ExpressionInferenceExtra<'db> {
 
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
     cycle_recovery: Option<Type<'db>>,
+
+    /// Type qualifiers (`Required`, `NotRequired`, etc.) for annotation expressions.
+    /// Only populated for expressions that have non-empty qualifiers.
+    qualifiers: FrozenMap<ExpressionNodeKey, TypeQualifiers>,
 }
 
 impl<'db> ExpressionInference<'db> {
@@ -1385,6 +1389,13 @@ impl<'db> ExpressionInference<'db> {
             .as_ref()?
             .collection_use_constraints
             .get(&collection_def)
+    }
+
+    pub(crate) fn qualifiers(&self, expression: impl Into<ExpressionNodeKey>) -> TypeQualifiers {
+        self.extra
+            .as_ref()
+            .and_then(|extra| extra.qualifiers.get(&expression.into()).copied())
+            .unwrap_or_default()
     }
 
     fn fallback_type(&self) -> Option<Type<'db>> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -397,8 +397,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             InferenceRegion::Definition(definition) | InferenceRegion::Deferred(definition) => {
                 Some(definition)
             }
+            InferenceRegion::Expression(expression, _) => expression.annotation_owner(self.db()),
             InferenceRegion::Statement(_)
-            | InferenceRegion::Expression(_, _)
             | InferenceRegion::FunctionDecorators(_)
             | InferenceRegion::Scope(_, _) => None,
         })
@@ -507,6 +507,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .extend(extra.string_annotations.iter().copied());
             self.expected_types
                 .extend(extra.expected_types.iter().copied());
+            self.qualifiers.extend(extra.qualifiers.iter().copied());
             self.type_expression_flags
                 .extend(extra.type_expression_flags.iter().copied());
 
@@ -1129,10 +1130,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ExpressionKind::Normal => {
                 self.infer_expression_impl(expression.node_ref(self.db()).node(self.module()), tcx);
             }
-            ExpressionKind::TypeExpression => {
-                self.infer_type_expression(expression.node_ref(self.db()).node(self.module()));
+            ExpressionKind::AnnotationExpression => {
+                self.infer_annotation_expression_allow_pep_613(
+                    expression.node_ref(self.db()).node(self.module()),
+                    DeferredExpressionState::from(self.defer_annotations()),
+                );
             }
         }
+    }
+
+    fn infer_standalone_annotation_expression(
+        &mut self,
+        annotation: &ast::Expr,
+        definition: Definition<'db>,
+    ) -> TypeAndQualifiers<'db> {
+        let expression = self.index.expression(annotation);
+        debug_assert_eq!(expression.annotation_owner(self.db()), Some(definition));
+
+        let inference = infer_expression_types(self.db(), expression, TypeContext::default());
+        let declared = TypeAndQualifiers::declared(inference.expression_type(annotation))
+            .with_qualifier(inference.qualifiers(annotation));
+        self.extend_expression(inference);
+        declared
     }
 
     /// Add a binding for the given definition.
@@ -4401,10 +4420,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         let annotation = assignment.annotation(self.module());
-        let mut declared = self.infer_annotation_expression_allow_pep_613(
-            annotation,
-            DeferredExpressionState::from(self.defer_annotations()),
-        );
+        let mut declared = if definition
+            .scope(self.db())
+            .file_scope_id(self.db())
+            .is_global()
+            && value.is_some()
+            && target.is_name_expr()
+        {
+            self.infer_standalone_annotation_expression(annotation, definition)
+        } else {
+            self.infer_annotation_expression_allow_pep_613(
+                annotation,
+                DeferredExpressionState::from(self.defer_annotations()),
+            )
+        };
 
         // P.args and P.kwargs are only valid as annotations on *args and **kwargs,
         // not as variable annotations. Check both resolved type and AST form.
@@ -10235,7 +10264,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let Self {
             context,
             expressions,
-            qualifiers: _,
+            qualifiers,
             type_expression_flags,
             mut collection_use_constraints,
             string_annotations,
@@ -10278,6 +10307,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 || !type_expression_flags.is_empty()
                 || !collection_use_constraints.is_empty()
                 || !expected_types.is_empty()
+                || !qualifiers.is_empty()
                 || cycle_recovery.is_some()
                 || !bindings.is_empty()
                 || !diagnostics.is_empty()).then(|| {
@@ -10297,7 +10327,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     bindings: bindings.into_boxed_slice(),
                     diagnostics,
                     cycle_recovery,
-                    collection_use_constraints
+                    collection_use_constraints,
+                    qualifiers: FrozenMap::from(qualifiers),
                 })
             });
 

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -321,6 +321,68 @@ fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
 }
 
 #[test]
+fn imported_annotated_assignment_doesnt_infer_value() -> anyhow::Result<()> {
+    let mut db = setup_db();
+
+    db.write_files([
+        ("/src/a.py", "from foo import x"),
+        ("/src/foo.py", r#"x: int = "not an int""#),
+    ])?;
+
+    let a = system_path_to_file(&db, "/src/a.py").unwrap();
+    let foo = system_path_to_file(&db, "/src/foo.py").unwrap();
+
+    db.clear_salsa_events();
+
+    let x_ty = global_symbol(&db, a, "x").place.expect_type();
+    assert_eq!(x_ty.display(&db).to_string(), "int");
+
+    let events = db.take_salsa_events();
+    assert_function_query_was_not_run(
+        &db,
+        infer_definition_types,
+        first_public_binding(&db, foo, "x"),
+        &events,
+    );
+    assert_file_diagnostics(
+        &db,
+        "/src/foo.py",
+        &[r#"Object of type `Literal["not an int"]` is not assignable to `int`"#],
+    );
+
+    Ok(())
+}
+
+#[test]
+fn imported_pep_613_alias_infers_value() -> anyhow::Result<()> {
+    let mut db = setup_db();
+
+    db.write_files([
+        ("/src/a.py", "from foo import Alias\nx: Alias = 1"),
+        (
+            "/src/foo.py",
+            "from typing import TypeAlias\nAlias: TypeAlias = int",
+        ),
+    ])?;
+
+    let foo = system_path_to_file(&db, "/src/foo.py").unwrap();
+
+    db.clear_salsa_events();
+
+    assert_file_diagnostics(&db, "/src/a.py", &[]);
+
+    let events = db.take_salsa_events();
+    assert_function_query_was_run(
+        &db,
+        infer_definition_types,
+        first_public_binding(&db, foo, "Alias"),
+        &events,
+    );
+
+    Ok(())
+}
+
+#[test]
 fn dependency_internal_symbol_change() -> anyhow::Result<()> {
     let mut db = setup_db();
 


### PR DESCRIPTION
## Summary

When an imported module attribute is backed by an annotated assignment, we currently infer the entire definition to answer its public declaration. This couples declaration lookup to the assignment's right-hand side even though the annotation already determines the declaration. In PyTorch, importing `op_db: list[OpInfo] = [...]` therefore enters the large initializer and its reachability graph.

This change indexes module-level annotated assignments' annotations as standalone annotation expressions and uses that query for public declaration lookup. Full definition inference still evaluates the value and reports assignment diagnostics when checking the defining module; annotation-only assignments, non-name targets, local assignments, and PEP 613 aliases continue through the existing definition query because their declarations cannot be recovered from the annotation alone.
