### PR TITLE
Stabilize generated rule code for incremental builds

### DIFF
--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -253,7 +253,11 @@ fn generate_rule_to_code(linter_to_rules: &BTreeMap<Ident, BTreeMap<String, Rule
 
     let mut rule_noqa_code_match_arms = quote!();
 
-    for (rule, codes) in rule_to_codes {
+    // Keep the proc-macro output stable so unchanged code can be reused incrementally.
+    for (rule, codes) in rule_to_codes
+        .into_iter()
+        .sorted_by_key(|(rule, _)| rule.to_token_stream().to_string())
+    {
         let rule_name = rule.segments.last().unwrap();
         assert_eq!(
             codes.len(),


### PR DESCRIPTION
## Summary

I found this while looking at some changes in `rust` itself. `map_codes` groups rules in a `HashMap` and previously emitted the `Rule::noqa_code` match arms in hash iteration order. Since that order is randomized between compiler processes, an unrelated edit could change the generated function and invalidate a `ruff_linter` codegen unit even when the rule mapping itself was unchanged!

On main, touching then rebuilding only reused 255 of 256 `ruff_linter` ThinLTO modules (and recompiled the module containing `Rule::noqa_code`); with this change, `rustc` reused all 256 modules. This can make incremental rebuilds ~10-15% faster!

Here's the output of `hyperfine --warmup 3 --runs 10 --prepare 'touch crates/ruff_linter/src/codes.rs' 'env CARGO_INCREMENTAL=1 CARGO_TARGET_DIR=... cargo build -p ruff_linter'`:

```
 Revision             Pass 1             Pass 2    Combined mean
━━━━━━━━━━  ━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━
 HEAD        2.667s ± 0.052s    2.597s ± 0.042s           2.632s
──────────  ─────────────────  ─────────────────  ───────────────
 HEAD^       3.093s ± 0.043s    3.038s ± 0.038s           3.066s
```
