### PR TITLE
[ty] Clear reparsed ASTs after project check

### DIFF
--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -388,6 +388,16 @@ impl Project {
             });
         };
 
+        // A file can be reparsed by another worker after its own check task has already cleared it.
+        // Clear all non-open project files once more after the parallel check completes.
+        let open_files = self.open_files(db);
+        let checked_files = ProjectFiles::new(db, self);
+        for file in &checked_files {
+            if !open_files.contains(&file) {
+                parsed_module(db, file).clear();
+            }
+        }
+
         tracing::debug!(
             "Checking all files took {:.3}s",
             check_start.elapsed().as_secs_f64(),


### PR DESCRIPTION
## Summary
Project checking clears parsed ASTs for non-open files as each file's check task finishes. This only drops the reconstructible AST payload; the semantic index and other Salsa query results remain cached for incremental analysis.

During a parallel project check, another worker can still access a file's syntax after that file's own task has cleared it. In that case, we end up re-parsing the file and retaining the AST (since its cleanup already ran). I guess this is a race condition of sorts -- is it... avoidable?

Anyway, this change adds a final cleanup pass after the project check completes, clearing parsed modules for all non-open checked files. This primarily reduces idle retained memory for (e.g.) workspace diagnostics in the language server and `ty check --watch`.

I don't expect this to reduce peak memory during `ty check`, nor should it have much of an impact since we're about to exit anyway. But it still seems correct?