### PR TITLE
[ty] Avoid AST load for callable description names

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -46,6 +46,7 @@ use crate::types::function::{
 use crate::types::generics::{
     GenericContext, InferableTypeVars, Specialization, SpecializationBuilder, SpecializationError,
 };
+use crate::types::infer::original_class_type;
 use crate::types::known_instance::FieldInstance;
 use crate::types::signatures::{
     CallableSignature, Parameter, ParameterForm, ParameterKind, Parameters, ParametersKind,
@@ -66,7 +67,6 @@ use crate::{DisplaySettings, FxOrderSet, Program};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
 use ruff_python_ast::{self as ast, AnyNodeRef, ArgOrKeyword, PythonVersion};
 use ty_module_resolver::KnownModule;
-use ty_python_core::scope::NodeWithScopeKind;
 use ty_python_core::{EvaluationMode, semantic_index};
 
 pub(crate) use self::constructor::ConstructorCallableKind;
@@ -6605,13 +6605,13 @@ impl<'db> CallableDescription<'db> {
             let file = function.file(db);
             let semantic_index = semantic_index(db, file);
             let enclosing_scope = semantic_index.scope(function.definition(db).file_scope(db));
-            match enclosing_scope.node() {
-                NodeWithScopeKind::Class(class) => Cow::Owned(format!(
-                    "{}.{}",
-                    class.node(&parsed_module(db, file).load(db)).name,
-                    function.name(db)
-                )),
-                _ => Cow::Borrowed(function.name(db)),
+            if let Some(class_node) = enclosing_scope.node().as_class()
+                && let Some(class) =
+                    original_class_type(db, semantic_index.expect_single_definition(class_node))
+            {
+                Cow::Owned(format!("{}.{}", class.name(db), function.name(db)))
+            } else {
+                Cow::Borrowed(function.name(db))
             }
         }
 


### PR DESCRIPTION
## Summary

`CallableDescription` loaded the parsed module only to read the enclosing class name when formatting `Class.method` for function and bound-method diagnostics.

This now recovers the enclosing class from the semantic index and formats the name from the original class type metadata, avoiding that direct AST node lookup while preserving the same display text.