### PR TITLE
[ty] Compact retained parser token streams

### DIFF
--- a/crates/mdtest/src/assertion.rs
+++ b/crates/mdtest/src/assertion.rs
@@ -34,8 +34,7 @@
 //! reveal_type(x)
 //! ```
 
-use ruff_db::parsed::ParsedModuleRef;
-use ruff_python_ast::token::Token;
+use ruff_python_ast::token::{Token, Tokens};
 use ruff_python_trivia::{CommentRanges, Cursor};
 use ruff_source_file::{LineIndex, OneIndexed};
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -49,14 +48,10 @@ pub(crate) struct InlineFileAssertions<'s> {
 }
 
 impl<'s> InlineFileAssertions<'s> {
-    pub(crate) fn from_file(
-        source: &'s str,
-        parsed: &ParsedModuleRef,
-        file_index: &LineIndex,
-    ) -> Self {
+    pub(crate) fn from_file(source: &'s str, tokens: &Tokens, file_index: &LineIndex) -> Self {
         let mut by_line = Vec::new();
         let mut file_assertions = UnparsedAssertionsIter {
-            tokens: parsed.tokens().iter(),
+            tokens: tokens.iter(),
             source,
         }
         .peekable();
@@ -499,7 +494,6 @@ mod tests {
     use super::*;
     use crate::tests::TestDb;
     use ruff_db::files::system_path_to_file;
-    use ruff_db::parsed::parsed_module;
     use ruff_db::source::line_index;
     use ruff_db::system::DbWithWritableSystem as _;
     use ruff_python_trivia::textwrap::dedent;
@@ -509,8 +503,8 @@ mod tests {
         let mut db = TestDb::setup();
         db.write_file("/src/test.py", source).unwrap();
         let file = system_path_to_file(&db, "/src/test.py").unwrap();
-        let parsed = parsed_module(&db, file).load(&db);
-        InlineFileAssertions::from_file(source, &parsed, &line_index(&db, file))
+        let tokens = ruff_db::parsed::parsed_module_full_tokens(&db, file);
+        InlineFileAssertions::from_file(source, tokens, &line_index(&db, file))
     }
 
     fn into_vec(assertions: InlineFileAssertions<'_>) -> Vec<LineAssertions<'_>> {

--- a/crates/mdtest/src/matcher.rs
+++ b/crates/mdtest/src/matcher.rs
@@ -11,7 +11,7 @@ use path_slash::PathExt;
 use ruff_db::Db;
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId};
 use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
+use ruff_db::parsed::parsed_module_full_tokens;
 use ruff_db::source::{SourceText, line_index, source_text};
 use ruff_source_file::{LineIndex, OneIndexed};
 use smallvec::SmallVec;
@@ -95,9 +95,9 @@ pub fn match_file(
     // Parse assertions from comments in the file, and get diagnostics from the file; both
     // ordered by line number.
     let source = source_text(db, file);
-    let parsed = parsed_module(db, file).load(db);
+    let tokens = parsed_module_full_tokens(db, file);
     let line_index = line_index(db, file);
-    let assertions = InlineFileAssertions::from_file(&source, &parsed, &line_index);
+    let assertions = InlineFileAssertions::from_file(&source, tokens, &line_index);
 
     // Sort diagnostics according to the line number of the starting offset of the token in which the diagnostic appears.
     //
@@ -108,10 +108,7 @@ pub fn match_file(
     // the diagnostic occurs (the string-literal) and use the token start as the basis for
     // the line number.
     let diagnostics = SortedDiagnostics::new(diagnostics, &|diagnostic_range| {
-        let token_start = parsed
-            .tokens()
-            .token_range(diagnostic_range.start())
-            .start();
+        let token_start = tokens.token_range(diagnostic_range.start()).start();
         line_index.line_index(token_start)
     });
 

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -6,6 +6,7 @@ use get_size2::GetSize;
 use ruff_python_ast::{
     AnyRootNodeRef, HasNodeIndex, ModExpression, ModModule, NodeIndex, NodeIndexError,
     StringLiteral,
+    token::{TokenKind, Tokens},
 };
 use ruff_python_parser::{
     ParseError, ParseErrorType, ParseOptions, Parsed, parse_string_annotation, parse_unchecked,
@@ -15,7 +16,10 @@ use crate::Db;
 use crate::files::File;
 use crate::source::source_text;
 
-/// Returns the parsed AST of `file`, including its token stream.
+/// Returns the parsed AST of `file`, including a compact token stream.
+///
+/// The retained tokens are sufficient for type checking, including suppression comments and
+/// parenthesized diagnostic ranges. Use [`parsed_module_full_tokens`] for arbitrary token access.
 ///
 /// The query uses Ruff's error-resilient parser. That means that the parser always succeeds to produce an
 /// AST even if the file contains syntax errors. The parse errors
@@ -39,7 +43,34 @@ pub fn parsed_module(db: &dyn Db, file: File) -> ParsedModule {
     ParsedModule::new(file, parsed)
 }
 
+/// Returns the complete token stream for `file`.
+///
+/// Most semantic analysis only needs the compact token stream stored by [`parsed_module`].
+/// Features that inspect arbitrary tokens, such as editor navigation and formatting, use this
+/// query instead.
+#[salsa::tracked(returns(ref), no_eq, heap_size=ruff_memory_usage::heap_size, lru=20)]
+pub fn parsed_module_full_tokens(db: &dyn Db, file: File) -> Tokens {
+    parse_module(db, file).into_tokens()
+}
+
 pub fn parsed_module_impl(db: &dyn Db, file: File) -> Parsed<ModModule> {
+    let mut parsed = parse_module(db, file);
+
+    parsed.retain_tokens_with_context(|token| {
+        matches!(
+            token.kind(),
+            TokenKind::Comment
+                | TokenKind::Newline
+                | TokenKind::NonLogicalNewline
+                | TokenKind::Lpar
+                | TokenKind::Rpar
+        )
+    });
+
+    parsed
+}
+
+fn parse_module(db: &dyn Db, file: File) -> Parsed<ModModule> {
     let source = source_text(db, file);
     let ty = file.source_type(db);
 
@@ -172,6 +203,11 @@ impl ParsedModuleRef {
     /// Returns a reference to the [`ParsedModule`] that this instance was loaded from.
     pub fn module(&self) -> &ParsedModule {
         &self.module
+    }
+
+    /// Returns the complete token stream for this module.
+    pub fn full_tokens<'db>(&self, db: &'db dyn Db) -> &'db Tokens {
+        parsed_module_full_tokens(db, self.module.file())
     }
 
     /// Returns a reference to the AST node at the given index.
@@ -495,6 +531,7 @@ mod tests {
     };
     use crate::tests::TestDb;
     use crate::vendored::{VendoredFileSystemBuilder, VendoredPath};
+    use ruff_python_ast::token::TokenKind;
     use zip::CompressionMethod;
 
     #[test]
@@ -509,6 +546,32 @@ mod tests {
         let parsed = parsed_module(&db, file).load(&db);
 
         assert!(parsed.has_valid_syntax());
+
+        Ok(())
+    }
+
+    #[test]
+    fn compact_tokens_retain_structural_context() -> crate::system::Result<()> {
+        let mut db = TestDb::new();
+        let path = "test.py";
+
+        db.write_file(path, "result = (left + right)  # comment\n")?;
+        let file = system_path_to_file(&db, path).unwrap();
+
+        let parsed = parsed_module(&db, file).load(&db);
+        let compact = parsed.tokens();
+        let full = parsed.full_tokens(&db);
+
+        assert!(compact.len() < full.len());
+        assert!(compact.iter().any(|token| token.kind() == TokenKind::Lpar));
+        assert!(compact.iter().any(|token| token.kind() == TokenKind::Rpar));
+        assert!(
+            compact
+                .iter()
+                .any(|token| token.kind() == TokenKind::Comment)
+        );
+        assert!(!compact.iter().any(|token| token.kind() == TokenKind::Plus));
+        assert!(full.iter().any(|token| token.kind() == TokenKind::Plus));
 
         Ok(())
     }

--- a/crates/ruff_python_ast/src/token/tokens.rs
+++ b/crates/ruff_python_ast/src/token/tokens.rs
@@ -16,6 +16,40 @@ impl Tokens {
         Tokens { raw: tokens }
     }
 
+    /// Retains matching tokens plus the first and last token in each non-matching run.
+    pub fn retain_with_context(&mut self, mut predicate: impl FnMut(&Token) -> bool) {
+        let tokens = std::mem::take(&mut self.raw);
+        let mut retained = Vec::with_capacity(tokens.len() / 4);
+        let mut first_skipped = None;
+        let mut last_skipped = None;
+
+        let flush_skipped =
+            |retained: &mut Vec<Token>, first: &mut Option<Token>, last: &mut Option<Token>| {
+                if let Some(first) = first.take() {
+                    retained.push(first);
+                    if let Some(last) = last.take()
+                        && last != first
+                    {
+                        retained.push(last);
+                    }
+                }
+            };
+
+        for token in tokens {
+            if predicate(&token) {
+                flush_skipped(&mut retained, &mut first_skipped, &mut last_skipped);
+                retained.push(token);
+            } else {
+                first_skipped.get_or_insert(token);
+                last_skipped = Some(token);
+            }
+        }
+        flush_skipped(&mut retained, &mut first_skipped, &mut last_skipped);
+
+        retained.shrink_to_fit();
+        self.raw = retained;
+    }
+
     /// Returns an iterator over all the tokens that provides context.
     pub fn iter_with_context(&self) -> TokenIterWithContext<'_> {
         TokenIterWithContext::new(&self.raw)
@@ -399,6 +433,38 @@ mod tests {
         let after = tokens.after(TextSize::new(8));
         assert_eq!(after.len(), 7);
         assert_eq!(after.first().unwrap().kind(), TokenKind::Rpar);
+    }
+
+    #[test]
+    fn retain_with_context_keeps_run_boundaries() {
+        let mut tokens = new_tokens(
+            [
+                TokenKind::Name,
+                TokenKind::Colon,
+                TokenKind::Name,
+                TokenKind::Equal,
+                TokenKind::Name,
+                TokenKind::Plus,
+                TokenKind::Name,
+                TokenKind::Newline,
+                TokenKind::Name,
+            ]
+            .into_iter()
+            .zip(0u32..)
+            .map(|(kind, index)| (kind, index..index + 1)),
+        );
+
+        tokens.retain_with_context(|token| token.kind() == TokenKind::Newline);
+
+        assert_eq!(
+            tokens.iter().map(Token::kind).collect::<Vec<_>>(),
+            [
+                TokenKind::Name,
+                TokenKind::Name,
+                TokenKind::Newline,
+                TokenKind::Name,
+            ]
+        );
     }
 
     #[test]

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -8,7 +8,7 @@ use tracing::Level;
 pub use range::format_range;
 use ruff_formatter::prelude::*;
 use ruff_formatter::{FormatError, Formatted, PrintError, Printed, SourceCode, format, write};
-use ruff_python_ast::{AnyNodeRef, Mod};
+use ruff_python_ast::{AnyNodeRef, Mod, token::Tokens};
 use ruff_python_parser::{ParseError, ParseOptions, Parsed, parse};
 use ruff_python_trivia::CommentRanges;
 use ruff_text_size::{Ranged, TextRange};
@@ -150,11 +150,18 @@ pub fn format_module_ast<'a>(
     source: &'a str,
     options: PyFormatOptions,
 ) -> FormatResult<Formatted<PyFormatContext<'a>>> {
-    format_node(parsed, comment_ranges, source, options)
+    format_node(
+        parsed.syntax(),
+        parsed.tokens(),
+        comment_ranges,
+        source,
+        options,
+    )
 }
 
 fn format_node<'a, N>(
-    parsed: &'a Parsed<N>,
+    syntax: &'a N,
+    tokens: &'a Tokens,
     comment_ranges: &'a CommentRanges,
     source: &'a str,
     options: PyFormatOptions,
@@ -164,11 +171,11 @@ where
     &'a N: Into<AnyNodeRef<'a>>,
 {
     let source_code = SourceCode::new(source);
-    let comments = Comments::from_ast(parsed.syntax(), source_code, comment_ranges);
+    let comments = Comments::from_ast(syntax, source_code, comment_ranges);
 
     let formatted = format!(
-        PyFormatContext::new(options, source, comments, parsed.tokens()),
-        [parsed.syntax().format()]
+        PyFormatContext::new(options, source, comments, tokens),
+        [syntax.format()]
     )?;
     formatted
         .context()
@@ -181,15 +188,16 @@ pub fn formatted_file(db: &dyn Db, file: File) -> Result<Option<String>, FormatM
     let options = db.format_options(file);
 
     let parsed = parsed_module(db, file).load(db);
+    let tokens = parsed.full_tokens(db);
 
     if let Some(first) = parsed.errors().first() {
         return Err(FormatModuleError::ParseError(first.clone()));
     }
 
-    let comment_ranges = CommentRanges::from(parsed.tokens());
+    let comment_ranges = CommentRanges::from(tokens);
     let source = source_text(db, file);
 
-    let formatted = format_node(&parsed, &comment_ranges, &source, options)?;
+    let formatted = format_node(parsed.syntax(), tokens, &comment_ranges, &source, options)?;
     let printed = formatted.print()?;
 
     if printed.as_code() == &*source {

--- a/crates/ruff_python_parser/src/lib.rs
+++ b/crates/ruff_python_parser/src/lib.rs
@@ -320,6 +320,14 @@ impl<T> Parsed<T> {
         &self.tokens
     }
 
+    /// Compacts the token stream while retaining context around matching tokens.
+    pub fn retain_tokens_with_context(
+        &mut self,
+        predicate: impl FnMut(&ruff_python_ast::token::Token) -> bool,
+    ) {
+        self.tokens.retain_with_context(predicate);
+    }
+
     /// Returns a list of syntax errors found during parsing.
     pub fn errors(&self) -> &[ParseError] {
         &self.errors
@@ -333,6 +341,11 @@ impl<T> Parsed<T> {
     /// Consumes the [`Parsed`] output and returns the contained syntax node.
     pub fn into_syntax(self) -> T {
         self.syntax
+    }
+
+    /// Consumes the [`Parsed`] output and returns the token stream.
+    pub fn into_tokens(self) -> Tokens {
+        self.tokens
     }
 
     /// Consumes the [`Parsed`] output and returns a list of syntax errors found during parsing.

--- a/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
@@ -168,6 +168,7 @@ fn call_sites_for_file(
 ) -> Vec<RawCallSite> {
     let parsed = parsed_module(db, file);
     let module = parsed.load(db);
+    let tokens = module.full_tokens(db);
     let model = SemanticModel::new(db, file);
     let mut sites = Vec::new();
 
@@ -175,7 +176,7 @@ fn call_sites_for_file(
         db,
         model: &model,
         module: &module,
-        tokens: module.tokens(),
+        tokens,
         target_definitions,
         target_role,
         needle,

--- a/crates/ty_ide/src/call_hierarchy/outgoing_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/outgoing_calls.rs
@@ -53,12 +53,13 @@ pub fn outgoing_calls(db: &dyn Db, file: File, offset: TextSize) -> Vec<Outgoing
         };
         let def_file = def.file(db);
         let parsed = parsed_module(db, def_file).load(db);
+        let tokens = parsed.full_tokens(db);
 
         let model = SemanticModel::new(db, def_file);
         let mut finder = OutgoingCallsFinder {
             db,
             model: &model,
-            tokens: parsed.tokens(),
+            tokens,
             by_callee: &mut groups,
             ancestors: Vec::new(),
         };

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -668,13 +668,13 @@ struct ContextNonImport<'m> {
 impl<'m> Context<'m> {
     /// Create a new context for finding completions.
     fn new(
-        db: &'_ dyn Db,
+        db: &'m dyn Db,
         file: File,
         parsed: &'m ParsedModuleRef,
         source: &'m SourceText,
         offset: TextSize,
     ) -> Option<Context<'m>> {
-        let cursor = ContextCursor::new(parsed, source, offset);
+        let cursor = ContextCursor::new(db, parsed, source, offset);
         if cursor.is_in_no_completions_place() {
             return None;
         }
@@ -742,6 +742,8 @@ impl<'m> Context<'m> {
 struct ContextCursor<'m> {
     /// The parsed module containing the cursor.
     parsed: &'m ParsedModuleRef,
+    /// The complete token stream for the parsed module.
+    tokens: &'m Tokens,
     /// The source code of the module containing the cursor.
     source: &'m SourceText,
     /// The typed text up to the cursor offset.
@@ -763,16 +765,19 @@ struct ContextCursor<'m> {
 impl<'m> ContextCursor<'m> {
     /// Returns information about the context of the cursor.
     fn new(
+        db: &'m dyn Db,
         parsed: &'m ParsedModuleRef,
         source: &'m SourceText,
         offset: TextSize,
     ) -> ContextCursor<'m> {
-        let tokens_before = tokens_start_before(parsed.tokens(), offset);
+        let tokens = parsed.full_tokens(db);
+        let tokens_before = tokens_start_before(tokens, offset);
         let Some(range) = ContextCursor::find_typed_text_range(tokens_before, offset) else {
             let range = TextRange::empty(offset);
             let covering_node = covering_node(parsed.syntax().into(), range);
             return ContextCursor {
                 parsed,
+                tokens,
                 source,
                 typed: None,
                 offset,
@@ -791,6 +796,7 @@ impl<'m> ContextCursor<'m> {
         let covering_node = covering_node(parsed.syntax().into(), range);
         ContextCursor {
             parsed,
+            tokens,
             source,
             typed: Some(text),
             offset,
@@ -879,8 +885,7 @@ impl<'m> ContextCursor<'m> {
     }
 
     fn next_token_is_open_parenthesis(&self) -> bool {
-        self.parsed
-            .tokens()
+        self.tokens
             .at_offset(self.offset)
             .last()
             .is_some_and(|token| token.kind() == TokenKind::Lpar)
@@ -1919,7 +1924,8 @@ fn add_unimported_completions<'db>(
     }
 
     let source = source_text(db, file);
-    let stylist = Stylist::from_tokens(parsed.tokens(), source.as_str());
+    let tokens = parsed.full_tokens(db);
+    let stylist = Stylist::from_tokens(tokens, source.as_str());
     let importer = Importer::new(db, &stylist, file, source.as_str(), parsed);
     let members = importer.members_in_scope_at(scoped.node, scoped.node.start());
 

--- a/crates/ty_ide/src/folding_range.rs
+++ b/crates/ty_ide/src/folding_range.rs
@@ -60,13 +60,14 @@ pub fn folding_ranges(
     range_filter: Option<TextRange>,
 ) -> Vec<FoldingRange> {
     let parsed = parsed_module(db, file).load(db);
+    let tokens = parsed.full_tokens(db);
     let source = source_text(db, file);
 
     let mut visitor = FoldingRangeVisitor {
         source: source.as_str(),
         ranges: vec![],
         active_block_fold_start_lines: vec![],
-        tokens: parsed.tokens(),
+        tokens,
         range_filter,
     };
     walk_node(&mut visitor, AnyNodeRef::from(parsed.syntax()));
@@ -76,8 +77,7 @@ pub fn folding_ranges(
     );
 
     // Add remaining ranges not covered by the AST visitor.
-    let own_line_comment_ranges: Vec<_> = parsed
-        .tokens()
+    let own_line_comment_ranges: Vec<_> = tokens
         .iter()
         .filter_map(|token| {
             if token.kind() == TokenKind::Comment

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -1341,7 +1341,12 @@ pub(crate) fn find_goto_target<'a>(
     parsed: &'a ParsedModuleRef,
     offset: TextSize,
 ) -> Option<GotoTarget<'a>> {
-    find_goto_target_impl(model, parsed.tokens(), parsed.syntax().into(), offset)
+    find_goto_target_impl(
+        model,
+        parsed.full_tokens(model.db()),
+        parsed.syntax().into(),
+        offset,
+    )
 }
 
 pub(crate) fn find_goto_target_impl<'a>(

--- a/crates/ty_ide/src/importer.rs
+++ b/crates/ty_ide/src/importer.rs
@@ -83,7 +83,7 @@ impl<'a> Importer<'a> {
             db,
             file,
             parsed,
-            tokens: parsed.tokens(),
+            tokens: parsed.full_tokens(db),
             source,
             stylist,
             imports,

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -292,9 +292,10 @@ pub fn inlay_hints(
     settings: &InlayHintSettings,
 ) -> Vec<InlayHint> {
     let ast = parsed_module(db, file).load(db);
+    let tokens = ast.full_tokens(db);
 
     let source = source_text(db, file);
-    let stylist = Stylist::from_tokens(ast.tokens(), source.as_str());
+    let stylist = Stylist::from_tokens(tokens, source.as_str());
     let importer = Importer::new(db, &stylist, file, source.as_str(), &ast);
 
     let mut visitor = InlayHintVisitor::new(db, file, importer, range, settings);

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -532,7 +532,7 @@ mod tests {
                     let source = source_text(&db, file);
                     let parsed = parsed_module(&db, file).load(&db);
                     let stylist =
-                        Stylist::from_tokens(parsed.tokens(), source.as_str()).into_owned();
+                        Stylist::from_tokens(parsed.full_tokens(&db), source.as_str()).into_owned();
                     cursor = Some(Cursor {
                         file,
                         offset,
@@ -679,7 +679,7 @@ mod tests {
                     let source = source_text(&db, file);
                     let parsed = parsed_module(&db, file).load(&db);
                     let stylist =
-                        Stylist::from_tokens(parsed.tokens(), source.as_str()).into_owned();
+                        Stylist::from_tokens(parsed.full_tokens(&db), source.as_str()).into_owned();
                     cursor = Some(Cursor {
                         file,
                         offset,

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -177,12 +177,13 @@ fn references_for_keyword_arguments_in_file(
 
     let parsed = ruff_db::parsed::parsed_module(db, file);
     let module = parsed.load(db);
+    let tokens = module.full_tokens(db);
     let model = SemanticModel::new(db, file);
     let mut references = Vec::new();
 
     let mut finder = KeywordArgumentReferencesFinder(LocalReferencesFinder {
         model: &model,
-        tokens: module.tokens(),
+        tokens,
         target_definitions,
         references: &mut references,
         mode,
@@ -236,6 +237,7 @@ fn references_for_file(
 ) -> Vec<ReferenceTarget> {
     let parsed = ruff_db::parsed::parsed_module(db, file);
     let module = parsed.load(db);
+    let tokens = module.full_tokens(db);
     let model = SemanticModel::new(db, file);
     let mut references = Vec::new();
 
@@ -244,7 +246,7 @@ fn references_for_file(
         target_definitions,
         references: &mut references,
         mode,
-        tokens: module.tokens(),
+        tokens,
         target_text,
         ancestors: Vec::new(),
     };

--- a/crates/ty_ide/src/signature_help.rs
+++ b/crates/ty_ide/src/signature_help.rs
@@ -77,7 +77,7 @@ pub fn signature_help(db: &dyn Db, file: File, offset: TextSize) -> Option<Signa
     let parsed = parsed_module(db, file).load(db);
 
     // Get the call expression at the given position.
-    let (call_expr, current_arg_index) = get_call_expr(&parsed, offset)?;
+    let (call_expr, current_arg_index) = get_call_expr(db, &parsed, offset)?;
 
     let model = SemanticModel::new(db, file);
 
@@ -108,15 +108,16 @@ pub fn signature_help(db: &dyn Db, file: File, offset: TextSize) -> Option<Signa
 
 /// Returns the innermost call expression that contains the specified offset
 /// and the index of the argument that the offset maps to.
-fn get_call_expr(
-    parsed: &ruff_db::parsed::ParsedModuleRef,
+fn get_call_expr<'a>(
+    db: &dyn Db,
+    parsed: &'a ruff_db::parsed::ParsedModuleRef,
     offset: TextSize,
-) -> Option<(&ast::ExprCall, usize)> {
+) -> Option<(&'a ast::ExprCall, usize)> {
     let root_node: AnyNodeRef = parsed.syntax().into();
 
     // Find the token under the cursor and use its offset to find the node
     let token = parsed
-        .tokens()
+        .full_tokens(db)
         .at_offset(offset)
         .max_by_key(|token| match token.kind() {
             TokenKind::Name

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -309,9 +309,9 @@ impl Workspace {
 
     /// Returns the token stream for `path` serialized as a string.
     pub fn tokens(&self, file_id: &FileHandle) -> Result<String, Error> {
-        let parsed = ruff_db::parsed::parsed_module(&self.db, file_id.file).load(&self.db);
+        let tokens = ruff_db::parsed::parsed_module_full_tokens(&self.db, file_id.file);
 
-        Ok(format!("{:#?}", parsed.tokens()))
+        Ok(format!("{tokens:#?}"))
     }
 
     #[wasm_bindgen(js_name = "sourceText")]


### PR DESCRIPTION
## Summary

`parsed_module` currently retains the complete lexer token stream alongside every cached AST, even though type checking only uses comments, line boundaries, parentheses, and nearby token boundaries for suppressions and diagnostic ranges.

This change compacts the retained stream to those structural tokens plus the first and last token from each discarded run. Features that need arbitrary tokens, including formatting and IDE navigation, use a separate full-token query with a smaller LRU. That query reparses the file on demand, but it was never invoked during the Home Assistant batch check.

On Home Assistant, retained memory fell from 3.23 GB to 3.17 GB, saving 62.1 MB (1.92%). Max RSS fell by 59.2 MB (1.38%), with identical diagnostics and no measurable runtime regression.
