### PR TITLE
Enable Clippy's `iter_over_hash_type` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,6 +258,7 @@ unnecessary_debug_formatting = "allow" # too many instances, the display also do
 needless_raw_string_hashes = "allow"
 # Disallowed restriction lints
 ignore_without_reason = "allow" # Too many exsisting instances, and there's no auto fix.
+iter_over_hash_type = "warn"
 print_stdout = "warn"
 print_stderr = "warn"
 dbg_macro = "warn"

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -160,6 +160,7 @@ impl FromIterator<(String, FixTable)> for FixMap {
 
 impl AddAssign for FixMap {
     fn add_assign(&mut self, rhs: Self) {
+        #[expect(clippy::iter_over_hash_type)]
         for (filename, fixed) in rhs.0 {
             if fixed.is_empty() {
                 continue;

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -160,7 +160,10 @@ impl FromIterator<(String, FixTable)> for FixMap {
 
 impl AddAssign for FixMap {
     fn add_assign(&mut self, rhs: Self) {
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "fix counts are merged independently for each filename"
+        )]
         for (filename, fixed) in rhs.0 {
             if fixed.is_empty() {
                 continue;

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -212,7 +212,10 @@ pub(crate) fn duplicate_exceptions(checker: &Checker, handlers: &[ExceptHandler]
                 }
             }
             Expr::Tuple(ast::ExprTuple { elts, .. }) => {
-                #[expect(clippy::iter_over_hash_type)]
+                #[expect(
+                    clippy::iter_over_hash_type,
+                    reason = "each distinct exception name updates independent set and map entries"
+                )]
                 for (name, expr) in duplicate_handler_exceptions(checker, type_, elts) {
                     if seen.contains(&name) {
                         duplicates.entry(name).or_default().push(expr);
@@ -226,7 +229,10 @@ pub(crate) fn duplicate_exceptions(checker: &Checker, handlers: &[ExceptHandler]
     }
 
     if checker.is_rule_enabled(Rule::DuplicateTryBlockException) {
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "iteration order does not affect the diagnostics produced"
+        )]
         for (name, exprs) in duplicates {
             for expr in exprs {
                 let is_star = checker

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -212,6 +212,7 @@ pub(crate) fn duplicate_exceptions(checker: &Checker, handlers: &[ExceptHandler]
                 }
             }
             Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+                #[expect(clippy::iter_over_hash_type)]
                 for (name, expr) in duplicate_handler_exceptions(checker, type_, elts) {
                     if seen.contains(&name) {
                         duplicates.entry(name).or_default().push(expr);
@@ -225,6 +226,7 @@ pub(crate) fn duplicate_exceptions(checker: &Checker, handlers: &[ExceptHandler]
     }
 
     if checker.is_rule_enabled(Rule::DuplicateTryBlockException) {
+        #[expect(clippy::iter_over_hash_type)]
         for (name, exprs) in duplicates {
             for expr in exprs {
                 let is_star = checker

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
@@ -63,7 +63,10 @@ pub(crate) fn loop_variable_overrides_iterator(checker: &Checker, target: &Expr,
         iter_finder.names
     };
 
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "iteration order does not affect the diagnostics produced"
+    )]
     for (name, expr) in target_names {
         if iter_names.contains_key(name) {
             checker.report_diagnostic(

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
@@ -63,6 +63,7 @@ pub(crate) fn loop_variable_overrides_iterator(checker: &Checker, target: &Expr,
         iter_finder.names
     };
 
+    #[expect(clippy::iter_over_hash_type)]
     for (name, expr) in target_names {
         if iter_names.contains_key(name) {
             checker.report_diagnostic(

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -96,6 +96,7 @@ pub(crate) fn unused_loop_control_variable(checker: &Checker, stmt_for: &ast::St
         finder.names
     };
 
+    #[expect(clippy::iter_over_hash_type)]
     for (name, expr) in control_names {
         // Ignore names that are already underscore-prefixed.
         if checker.settings().dummy_variable_rgx.is_match(name) {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -96,7 +96,10 @@ pub(crate) fn unused_loop_control_variable(checker: &Checker, stmt_for: &ast::St
         finder.names
     };
 
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "iteration order does not affect the diagnostics or fixes produced"
+    )]
     for (name, expr) in control_names {
         // Ignore names that are already underscore-prefixed.
         if checker.settings().dummy_variable_rgx.is_match(name) {

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -188,6 +188,7 @@ pub(crate) fn runtime_import_in_type_checking_block(checker: &Checker, scope: &S
         }
     }
 
+    #[expect(clippy::iter_over_hash_type)]
     for ((node_id, action), imports) in actions {
         match action {
             // Generate a diagnostic for every import, but share a fix across all imports within the same

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -188,7 +188,10 @@ pub(crate) fn runtime_import_in_type_checking_block(checker: &Checker, scope: &S
         }
     }
 
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "each statement group produces diagnostics and a fix independently"
+    )]
     for ((node_id, action), imports) in actions {
         match action {
             // Generate a diagnostic for every import, but share a fix across all imports within the same

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -396,6 +396,7 @@ pub(crate) fn typing_only_runtime_import(
 
     // Generate a diagnostic for every import, but share a fix across all imports within the same
     // statement (excluding those that are ignored).
+    #[expect(clippy::iter_over_hash_type)]
     for ((node_id, import_type), imports) in errors_by_statement {
         let fix = fix_imports(checker, node_id, &imports).ok();
 
@@ -423,6 +424,7 @@ pub(crate) fn typing_only_runtime_import(
 
     // Separately, generate a diagnostic for every _ignored_ import, to ensure that the
     // suppression comments aren't marked as unused.
+    #[expect(clippy::iter_over_hash_type)]
     for ((_, import_type), imports) in ignores_by_statement {
         for ImportBinding {
             import,

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -396,7 +396,10 @@ pub(crate) fn typing_only_runtime_import(
 
     // Generate a diagnostic for every import, but share a fix across all imports within the same
     // statement (excluding those that are ignored).
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "each statement group produces diagnostics and a fix independently"
+    )]
     for ((node_id, import_type), imports) in errors_by_statement {
         let fix = fix_imports(checker, node_id, &imports).ok();
 
@@ -424,7 +427,10 @@ pub(crate) fn typing_only_runtime_import(
 
     // Separately, generate a diagnostic for every _ignored_ import, to ensure that the
     // suppression comments aren't marked as unused.
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "each ignored statement group produces diagnostics independently"
+    )]
     for ((_, import_type), imports) in ignores_by_statement {
         for ImportBinding {
             import,

--- a/crates/ruff_linter/src/rules/isort/categorize.rs
+++ b/crates/ruff_linter/src/rules/isort/categorize.rs
@@ -199,6 +199,7 @@ pub(crate) fn categorize_imports<'a>(
 ) -> BTreeMap<&'a ImportSection, ImportBlock<'a>> {
     let mut block_by_type: BTreeMap<&ImportSection, ImportBlock> = BTreeMap::default();
     // Categorize `Stmt::Import`.
+    #[expect(clippy::iter_over_hash_type)]
     for (alias, comments) in block.import {
         let import_type = categorize(
             &alias.module_name(),
@@ -219,6 +220,7 @@ pub(crate) fn categorize_imports<'a>(
             .insert(alias, comments);
     }
     // Categorize `Stmt::ImportFrom` (without re-export).
+    #[expect(clippy::iter_over_hash_type)]
     for (import_from, aliases) in block.import_from {
         let classification = categorize(
             &import_from.module_name(),
@@ -239,6 +241,7 @@ pub(crate) fn categorize_imports<'a>(
             .insert(import_from, aliases);
     }
     // Categorize `Stmt::ImportFrom` (with re-export).
+    #[expect(clippy::iter_over_hash_type)]
     for ((import_from, alias), aliases) in block.import_from_as {
         let classification = categorize(
             &import_from.module_name(),
@@ -259,6 +262,7 @@ pub(crate) fn categorize_imports<'a>(
             .insert((import_from, alias), aliases);
     }
     // Categorize `Stmt::ImportFrom` (with star).
+    #[expect(clippy::iter_over_hash_type)]
     for (import_from, comments) in block.import_from_star {
         let classification = categorize(
             &import_from.module_name(),

--- a/crates/ruff_linter/src/rules/isort/categorize.rs
+++ b/crates/ruff_linter/src/rules/isort/categorize.rs
@@ -199,7 +199,10 @@ pub(crate) fn categorize_imports<'a>(
 ) -> BTreeMap<&'a ImportSection, ImportBlock<'a>> {
     let mut block_by_type: BTreeMap<&ImportSection, ImportBlock> = BTreeMap::default();
     // Categorize `Stmt::Import`.
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "categorization only moves entries between unordered import blocks"
+    )]
     for (alias, comments) in block.import {
         let import_type = categorize(
             &alias.module_name(),
@@ -220,7 +223,10 @@ pub(crate) fn categorize_imports<'a>(
             .insert(alias, comments);
     }
     // Categorize `Stmt::ImportFrom` (without re-export).
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "categorization only moves entries between unordered import blocks"
+    )]
     for (import_from, aliases) in block.import_from {
         let classification = categorize(
             &import_from.module_name(),
@@ -241,7 +247,10 @@ pub(crate) fn categorize_imports<'a>(
             .insert(import_from, aliases);
     }
     // Categorize `Stmt::ImportFrom` (with re-export).
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "categorization only moves entries between unordered import blocks"
+    )]
     for ((import_from, alias), aliases) in block.import_from_as {
         let classification = categorize(
             &import_from.module_name(),
@@ -262,7 +271,10 @@ pub(crate) fn categorize_imports<'a>(
             .insert((import_from, alias), aliases);
     }
     // Categorize `Stmt::ImportFrom` (with star).
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "categorization only moves entries between unordered import blocks"
+    )]
     for (import_from, comments) in block.import_from_star {
         let classification = categorize(
             &import_from.module_name(),

--- a/crates/ruff_linter/src/rules/isort/split.rs
+++ b/crates/ruff_linter/src/rules/isort/split.rs
@@ -36,21 +36,25 @@ pub(crate) fn split_by_forced_separate<'a>(
         import_from_as,
         import_from_star,
     } = block;
+    #[expect(clippy::iter_over_hash_type)]
     for (imp, comment_set) in import {
         blocks[find_block_index(forced_separate, &imp)]
             .import
             .insert(imp, comment_set);
     }
+    #[expect(clippy::iter_over_hash_type)]
     for (imp, val) in import_from {
         blocks[find_block_index(forced_separate, &imp)]
             .import_from
             .insert(imp, val);
     }
+    #[expect(clippy::iter_over_hash_type)]
     for ((imp, alias), val) in import_from_as {
         blocks[find_block_index(forced_separate, &imp)]
             .import_from_as
             .insert((imp, alias), val);
     }
+    #[expect(clippy::iter_over_hash_type)]
     for (imp, comment_set) in import_from_star {
         blocks[find_block_index(forced_separate, &imp)]
             .import_from_star

--- a/crates/ruff_linter/src/rules/isort/split.rs
+++ b/crates/ruff_linter/src/rules/isort/split.rs
@@ -36,25 +36,37 @@ pub(crate) fn split_by_forced_separate<'a>(
         import_from_as,
         import_from_star,
     } = block;
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "splitting only moves entries between unordered import blocks"
+    )]
     for (imp, comment_set) in import {
         blocks[find_block_index(forced_separate, &imp)]
             .import
             .insert(imp, comment_set);
     }
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "splitting only moves entries between unordered import blocks"
+    )]
     for (imp, val) in import_from {
         blocks[find_block_index(forced_separate, &imp)]
             .import_from
             .insert(imp, val);
     }
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "splitting only moves entries between unordered import blocks"
+    )]
     for ((imp, alias), val) in import_from_as {
         blocks[find_block_index(forced_separate, &imp)]
             .import_from_as
             .insert((imp, alias), val);
     }
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "splitting only moves entries between unordered import blocks"
+    )]
     for (imp, comment_set) in import_from_star {
         blocks[find_block_index(forced_separate, &imp)]
             .import_from_star

--- a/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
@@ -213,7 +213,10 @@ pub(crate) fn redefined_while_unused(checker: &Checker, scope_id: ScopeId, scope
 
     // Create a fix for each source statement.
     let mut fixes = FxHashMap::default();
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "each source statement gets an independent fix entry"
+    )]
     for entries in redefinitions.values() {
         let Some(source) = entries.iter().find_map(|info| info.runtime_import) else {
             continue;
@@ -257,7 +260,10 @@ pub(crate) fn redefined_while_unused(checker: &Checker, scope_id: ScopeId, scope
     }
 
     // Create diagnostics for each statement.
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "iteration order does not affect the diagnostics or fixes produced"
+    )]
     for entries in redefinitions.values() {
         for info in entries {
             let name = info.binding.name(checker.source());

--- a/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/redefined_while_unused.rs
@@ -213,6 +213,7 @@ pub(crate) fn redefined_while_unused(checker: &Checker, scope_id: ScopeId, scope
 
     // Create a fix for each source statement.
     let mut fixes = FxHashMap::default();
+    #[expect(clippy::iter_over_hash_type)]
     for entries in redefinitions.values() {
         let Some(source) = entries.iter().find_map(|info| info.runtime_import) else {
             continue;
@@ -256,6 +257,7 @@ pub(crate) fn redefined_while_unused(checker: &Checker, scope_id: ScopeId, scope
     }
 
     // Create diagnostics for each statement.
+    #[expect(clippy::iter_over_hash_type)]
     for entries in redefinitions.values() {
         for info in entries {
             let name = info.binding.name(checker.source());

--- a/crates/ruff_linter/src/rules/pylint/rules/redefined_slots_in_subclass.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/redefined_slots_in_subclass.rs
@@ -67,7 +67,10 @@ pub(crate) fn redefined_slots_in_subclass(checker: &Checker, class_def: &ast::St
         return;
     }
 
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "each slot is checked independently against the base classes"
+    )]
     for slot in class_slots {
         check_super_slots(checker, class_def, &slot);
     }

--- a/crates/ruff_linter/src/rules/pylint/rules/redefined_slots_in_subclass.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/redefined_slots_in_subclass.rs
@@ -67,6 +67,7 @@ pub(crate) fn redefined_slots_in_subclass(checker: &Checker, class_def: &ast::St
         return;
     }
 
+    #[expect(clippy::iter_over_hash_type)]
     for slot in class_slots {
         check_super_slots(checker, class_def, &slot);
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -165,7 +165,10 @@ pub(crate) fn unnecessary_future_import(checker: &Checker, scope: &Scope) {
         }
     }
 
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "each import statement produces an independent diagnostic and fix"
+    )]
     for (node_id, unused_aliases) in unused_imports {
         let mut diagnostic = checker.report_diagnostic(
             UnnecessaryFutureImport {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -165,6 +165,7 @@ pub(crate) fn unnecessary_future_import(checker: &Checker, scope: &Scope) {
         }
     }
 
+    #[expect(clippy::iter_over_hash_type)]
     for (node_id, unused_aliases) in unused_imports {
         let mut diagnostic = checker.report_diagnostic(
             UnnecessaryFutureImport {

--- a/crates/ruff_python_formatter/src/comments/map.rs
+++ b/crates/ruff_python_formatter/src/comments/map.rs
@@ -292,6 +292,7 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut builder = f.debug_map();
 
+        #[expect(clippy::iter_over_hash_type)]
         for (key, entry) in &self.index {
             builder.entry(&key, &LeadingDanglingTrailing::from_entry(entry, self));
         }

--- a/crates/ruff_python_formatter/src/comments/map.rs
+++ b/crates/ruff_python_formatter/src/comments/map.rs
@@ -292,7 +292,10 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut builder = f.debug_map();
 
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "Debug output intentionally reflects the map's unspecified order"
+        )]
         for (key, entry) in &self.index {
             builder.entry(&key, &LeadingDanglingTrailing::from_entry(entry, self));
         }

--- a/crates/ruff_python_parser/tests/generate_inline_tests.rs
+++ b/crates/ruff_python_parser/tests/generate_inline_tests.rs
@@ -109,8 +109,10 @@ fn install_tests(tests: &HashMap<String, Test>, target_dir: &str) -> Result<Test
     let existing = existing_tests(&tests_dir)?;
 
     let mut updated_files = vec![];
+    let mut sorted_tests = tests.iter().collect::<Vec<_>>();
+    sorted_tests.sort_unstable_by_key(|(name, _)| *name);
 
-    for (name, test) in tests {
+    for (name, test) in sorted_tests {
         let path = match existing.get(name) {
             Some(path) => path.clone(),
             None => tests_dir.join(name).with_extension("py"),
@@ -124,12 +126,15 @@ fn install_tests(tests: &HashMap<String, Test>, target_dir: &str) -> Result<Test
         updated_files.push(path);
     }
 
+    let mut unreferenced = existing
+        .into_iter()
+        .filter(|(name, _)| !tests.contains_key(name))
+        .map(|(_, path)| path)
+        .collect::<Vec<_>>();
+    unreferenced.sort_unstable();
+
     Ok(TestFiles {
-        unreferenced: existing
-            .into_iter()
-            .filter(|(name, _)| !tests.contains_key(name))
-            .map(|(_, path)| path)
-            .collect::<Vec<_>>(),
+        unreferenced,
         updated: updated_files,
     })
 }

--- a/crates/ruff_python_parser/tests/generate_inline_tests.rs
+++ b/crates/ruff_python_parser/tests/generate_inline_tests.rs
@@ -109,6 +109,7 @@ fn install_tests(tests: &HashMap<String, Test>, target_dir: &str) -> Result<Test
     let existing = existing_tests(&tests_dir)?;
 
     let mut updated_files = vec![];
+    // Sort so `TestFiles` reports generated files that need updating deterministically.
     let mut sorted_tests = tests.iter().collect::<Vec<_>>();
     sorted_tests.sort_unstable_by_key(|(name, _)| *name);
 

--- a/crates/ruff_python_semantic/src/analyze/type_inference.rs
+++ b/crates/ruff_python_semantic/src/analyze/type_inference.rs
@@ -49,6 +49,8 @@ impl ResolvedPythonType {
                 Self::Union(a)
             }
             (Self::Union(mut a), Self::Union(b)) => {
+                let mut b = b.into_iter().collect::<Vec<_>>();
+                b.sort_unstable();
                 for b_element in b {
                     // If `b_element` is a subtype of any of the types in `a`, then
                     // `b_element` is redundant.

--- a/crates/ruff_server/src/edit.rs
+++ b/crates/ruff_server/src/edit.rs
@@ -118,7 +118,10 @@ impl WorkspaceEditTracker {
         fixes: Fixes,
         version: DocumentVersion,
     ) -> crate::Result<()> {
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "edits for distinct document URIs are independent"
+        )]
         for (uri, edits) in fixes {
             self.set_edits_for_document(uri, version, edits)?;
         }

--- a/crates/ruff_server/src/edit.rs
+++ b/crates/ruff_server/src/edit.rs
@@ -118,6 +118,7 @@ impl WorkspaceEditTracker {
         fixes: Fixes,
         version: DocumentVersion,
     ) -> crate::Result<()> {
+        #[expect(clippy::iter_over_hash_type)]
         for (uri, edits) in fixes {
             self.set_edits_for_document(uri, version, edits)?;
         }

--- a/crates/ruff_server/src/server/api/diagnostics.rs
+++ b/crates/ruff_server/src/server/api/diagnostics.rs
@@ -22,7 +22,10 @@ pub(super) fn publish_diagnostics_for_document(
     snapshot: &DocumentSnapshot,
     client: &Client,
 ) -> crate::server::Result<()> {
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "diagnostic notifications for distinct document URIs are independent"
+    )]
     for (uri, diagnostics) in generate_diagnostics(snapshot) {
         client
             .send_notification::<lsp_types::PublishDiagnosticsNotification>(

--- a/crates/ruff_server/src/server/api/diagnostics.rs
+++ b/crates/ruff_server/src/server/api/diagnostics.rs
@@ -22,6 +22,7 @@ pub(super) fn publish_diagnostics_for_document(
     snapshot: &DocumentSnapshot,
     client: &Client,
 ) -> crate::server::Result<()> {
+    #[expect(clippy::iter_over_hash_type)]
     for (uri, diagnostics) in generate_diagnostics(snapshot) {
         client
             .send_notification::<lsp_types::PublishDiagnosticsNotification>(

--- a/crates/ruff_server/src/session/options.rs
+++ b/crates/ruff_server/src/session/options.rs
@@ -390,7 +390,10 @@ impl AllOptions {
     pub(crate) fn set_preview(&mut self, preview: bool) {
         self.global.set_preview(preview);
         if let Some(workspace_options) = self.workspace.as_mut() {
-            #[expect(clippy::iter_over_hash_type)]
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "the same preview value is applied independently to every workspace"
+            )]
             for options in workspace_options.values_mut() {
                 options.set_preview(preview);
             }
@@ -967,7 +970,10 @@ mod tests {
     fn assert_preview_all_options(all_options: &AllOptions, preview: bool) {
         assert_preview_client_options(all_options.global.client(), preview);
         if let Some(workspace_options) = all_options.workspace.as_ref() {
-            #[expect(clippy::iter_over_hash_type)]
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "each workspace is asserted independently"
+            )]
             for options in workspace_options.values() {
                 assert_preview_client_options(options, preview);
             }

--- a/crates/ruff_server/src/session/options.rs
+++ b/crates/ruff_server/src/session/options.rs
@@ -390,6 +390,7 @@ impl AllOptions {
     pub(crate) fn set_preview(&mut self, preview: bool) {
         self.global.set_preview(preview);
         if let Some(workspace_options) = self.workspace.as_mut() {
+            #[expect(clippy::iter_over_hash_type)]
             for options in workspace_options.values_mut() {
                 options.set_preview(preview);
             }
@@ -966,6 +967,7 @@ mod tests {
     fn assert_preview_all_options(all_options: &AllOptions, preview: bool) {
         assert_preview_client_options(all_options.global.client(), preview);
         if let Some(workspace_options) = all_options.workspace.as_ref() {
+            #[expect(clippy::iter_over_hash_type)]
             for options in workspace_options.values() {
                 assert_preview_client_options(options, preview);
             }

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -967,12 +967,18 @@ impl LintConfiguration {
                 docstring_overrides = docstring_override_updates;
             } else {
                 // Otherwise we apply the updates on top of the existing select_set.
-                #[expect(clippy::iter_over_hash_type)]
+                #[expect(
+                    clippy::iter_over_hash_type,
+                    reason = "each rule has one independent final enabled state"
+                )]
                 for (rule, enabled) in select_map_updates {
                     select_set.set(rule, enabled);
                 }
 
-                #[expect(clippy::iter_over_hash_type)]
+                #[expect(
+                    clippy::iter_over_hash_type,
+                    reason = "set insertion is independent of iteration order"
+                )]
                 for rule in docstring_override_updates {
                     docstring_overrides.insert(rule);
                 }
@@ -992,7 +998,10 @@ impl LintConfiguration {
                     carryover_unfixables = Some(&selection.unfixable);
                 }
             } else {
-                #[expect(clippy::iter_over_hash_type)]
+                #[expect(
+                    clippy::iter_over_hash_type,
+                    reason = "each rule has one independent final fixable state"
+                )]
                 for (rule, enabled) in fixable_map_updates {
                     fixable_set.set(rule, enabled);
                 }

--- a/crates/ruff_workspace/src/configuration.rs
+++ b/crates/ruff_workspace/src/configuration.rs
@@ -967,10 +967,12 @@ impl LintConfiguration {
                 docstring_overrides = docstring_override_updates;
             } else {
                 // Otherwise we apply the updates on top of the existing select_set.
+                #[expect(clippy::iter_over_hash_type)]
                 for (rule, enabled) in select_map_updates {
                     select_set.set(rule, enabled);
                 }
 
+                #[expect(clippy::iter_over_hash_type)]
                 for rule in docstring_override_updates {
                     docstring_overrides.insert(rule);
                 }
@@ -990,6 +992,7 @@ impl LintConfiguration {
                     carryover_unfixables = Some(&selection.unfixable);
                 }
             } else {
+                #[expect(clippy::iter_over_hash_type)]
                 for (rule, enabled) in fixable_map_updates {
                     fixable_set.set(rule, enabled);
                 }

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1734,8 +1734,10 @@ impl Flake8ImportConventionsOptions {
         }
 
         let mut normalized_aliases: FxHashMap<String, String> = FxHashMap::default();
-        let mut aliases = aliases.into_iter().collect::<Vec<_>>();
-        aliases.sort_unstable_by(|(module_a, _), (module_b, _)| module_a.cmp(module_b));
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "every invalid alias is rejected, regardless of which one is reported first"
+        )]
         for (module, alias) in aliases {
             let normalized_alias = alias.nfkc().collect::<String>();
             if normalized_alias == "__debug__" {

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -1734,6 +1734,8 @@ impl Flake8ImportConventionsOptions {
         }
 
         let mut normalized_aliases: FxHashMap<String, String> = FxHashMap::default();
+        let mut aliases = aliases.into_iter().collect::<Vec<_>>();
+        aliases.sort_unstable_by(|(module_a, _), (module_b, _)| module_a.cmp(module_b));
         for (module, alias) in aliases {
             let normalized_alias = alias.nfkc().collect::<String>();
             if normalized_alias == "__debug__" {
@@ -3019,7 +3021,9 @@ impl IsortOptions {
         let import_heading = self.import_heading.unwrap_or_default();
 
         // Verify that all sections listed in `import_heading` are defined in `sections`.
-        for section in import_heading.keys() {
+        let mut import_heading_sections = import_heading.keys().collect::<Vec<_>>();
+        import_heading_sections.sort_unstable();
+        for section in import_heading_sections {
             if let ImportSection::UserDefined(section_name) = section {
                 if !sections.contains_key(section_name) {
                     warn_user_once!("`import-heading` contains unknown section: `{:?}`", section,);

--- a/crates/ty_ide/src/all_symbols.rs
+++ b/crates/ty_ide/src/all_symbols.rs
@@ -403,6 +403,7 @@ mod merge {
                 let origin_module_name = origin.module().name(db);
                 let top = origin_module_name.first_component();
                 let mut min_reexport_len = None;
+                #[expect(clippy::iter_over_hash_type)]
                 for &reexport_index in &self.all_reexports {
                     let reexport = &mut self.reexport[reexport_index];
                     // Merge the kind from the original symbol into the
@@ -456,6 +457,7 @@ mod merge {
                 if origin_len > min_reexport_len {
                     self.origin_keep[origin_index] = false;
                 }
+                #[expect(clippy::iter_over_hash_type)]
                 for &reexport_index in &self.all_reexports {
                     let reexport = &self.reexport[reexport_index];
                     if reexport.module().name(db).components().count() > min_reexport_len {

--- a/crates/ty_ide/src/all_symbols.rs
+++ b/crates/ty_ide/src/all_symbols.rs
@@ -403,7 +403,10 @@ mod merge {
                 let origin_module_name = origin.module().name(db);
                 let top = origin_module_name.first_component();
                 let mut min_reexport_len = None;
-                #[expect(clippy::iter_over_hash_type)]
+                #[expect(
+                    clippy::iter_over_hash_type,
+                    reason = "each re-export update is independent and the minimum is commutative"
+                )]
                 for &reexport_index in &self.all_reexports {
                     let reexport = &mut self.reexport[reexport_index];
                     // Merge the kind from the original symbol into the
@@ -457,7 +460,10 @@ mod merge {
                 if origin_len > min_reexport_len {
                     self.origin_keep[origin_index] = false;
                 }
-                #[expect(clippy::iter_over_hash_type)]
+                #[expect(
+                    clippy::iter_over_hash_type,
+                    reason = "each re-export keep flag is updated independently"
+                )]
                 for &reexport_index in &self.all_reexports {
                     let reexport = &self.reexport[reexport_index];
                     if reexport.module().name(db).components().count() > min_reexport_len {

--- a/crates/ty_ide/src/workspace_symbols.rs
+++ b/crates/ty_ide/src/workspace_symbols.rs
@@ -27,7 +27,10 @@ pub fn workspace_symbols(db: &dyn Db, query: &str) -> Vec<WorkspaceSymbolInfo> {
 
         rayon::scope(move |s| {
             // For each file, extract symbols and add them to results
-            #[expect(clippy::iter_over_hash_type)]
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "Rayon task completion already makes result order unspecified"
+            )]
             for file in files.iter() {
                 let db = Db::dyn_clone(&*db);
                 s.spawn(move |_| {

--- a/crates/ty_ide/src/workspace_symbols.rs
+++ b/crates/ty_ide/src/workspace_symbols.rs
@@ -27,6 +27,7 @@ pub fn workspace_symbols(db: &dyn Db, query: &str) -> Vec<WorkspaceSymbolInfo> {
 
         rayon::scope(move |s| {
             // For each file, extract symbols and add them to results
+            #[expect(clippy::iter_over_hash_type)]
             for file in files.iter() {
                 let db = Db::dyn_clone(&*db);
                 s.spawn(move |_| {

--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -38,6 +38,7 @@ impl AstIds {
         let mut uses_map = FxHashMap::with_capacity_and_hasher(capacity, FxBuildHasher);
 
         for builder in builders {
+            #[expect(clippy::iter_over_hash_type)]
             for (key, use_id) in builder.uses_map {
                 let previous = uses_map.insert(key, use_id);
                 debug_assert!(previous.is_none());

--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -38,7 +38,10 @@ impl AstIds {
         let mut uses_map = FxHashMap::with_capacity_and_hasher(capacity, FxBuildHasher);
 
         for builder in builders {
-            #[expect(clippy::iter_over_hash_type)]
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "AST IDs have unique keys and are inserted independently"
+            )]
             for (key, use_id) in builder.uses_map {
                 let previous = uses_map.insert(key, use_id);
                 debug_assert!(previous.is_none());

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -646,6 +646,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         if !symbol.is_reassigned() {
             return;
         }
+        #[expect(clippy::iter_over_hash_type)]
         for (key, snapshot_id) in &self.enclosing_snapshots {
             if let Some(enclosing_symbol) = key.enclosing_place.as_symbol() {
                 let name = self.place_tables[key.enclosing_scope]
@@ -737,6 +738,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         let mut snapshots_to_mark = Vec::new();
 
+        #[expect(clippy::iter_over_hash_type)]
         for (&key, &snapshot_id) in &self.enclosing_snapshots {
             let ScopedPlaceId::Symbol(enclosing_symbol_id) = key.enclosing_place else {
                 continue;
@@ -903,6 +905,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     .is_module(),
                 "the last remaining scope should be the module scope",
             );
+            #[expect(clippy::iter_over_hash_type)]
             for (name, nested_declarations) in &nested_global_or_nonlocal_declarations {
                 for declaration in nested_declarations {
                     if matches!(declaration.kind, GlobalOrNonlocal::Nonlocal) {
@@ -923,6 +926,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // only respect the bindings within the popped scope, rather than in all the nested scopes
         // they've encountered so far.
         if !popped_scope_kind.is_module() {
+            #[expect(clippy::iter_over_hash_type)]
             for (name, declarations) in &nested_global_or_nonlocal_declarations {
                 self.current_scope_info_mut()
                     .nested_global_or_nonlocal_declarations
@@ -1585,6 +1589,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // Collect all the bindings within the loop that reached a loop back edge. Use the minimum
         // definition ID to filter out all the pre-loop bindings. The loop header doesn't shadow
         // them, so there's no need to duplicate them.
+        #[expect(clippy::iter_over_hash_type)]
         for place_id in loop_header_places {
             for live_binding in use_def.loop_back_bindings(*place_id) {
                 if live_binding.binding() >= loop_min_definition_id {
@@ -1593,6 +1598,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
         }
         // Mark the reachability and narrowing constraints as used.
+        #[expect(clippy::iter_over_hash_type)]
         for place_id in loop_header_places {
             for live_binding in loop_header.bindings_for_place(*place_id) {
                 use_def
@@ -1614,6 +1620,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         &mut self,
         nested_bindings: NestedGlobalOrNonlocalDeclarations,
     ) {
+        let mut nested_bindings = nested_bindings.into_iter().collect::<Vec<_>>();
+        nested_bindings.sort_unstable_by_key(|(name, _)| name.clone());
+
         for (name, mut declarations) in nested_bindings {
             // Filter down to only the declarations with `is_bound: true`. If there are none left,
             // skip synthesizing a definition for this symbol. (The reason we track these at all is

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -646,7 +646,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         if !symbol.is_reassigned() {
             return;
         }
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "each matching snapshot is updated independently"
+        )]
         for (key, snapshot_id) in &self.enclosing_snapshots {
             if let Some(enclosing_symbol) = key.enclosing_place.as_symbol() {
                 let name = self.place_tables[key.enclosing_scope]
@@ -738,7 +741,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         let mut snapshots_to_mark = Vec::new();
 
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "snapshot resolution is independent and marking bindings is idempotent"
+        )]
         for (&key, &snapshot_id) in &self.enclosing_snapshots {
             let ScopedPlaceId::Symbol(enclosing_symbol_id) = key.enclosing_place else {
                 continue;
@@ -905,7 +911,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     .is_module(),
                 "the last remaining scope should be the module scope",
             );
-            #[expect(clippy::iter_over_hash_type)]
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "iteration order does not affect the semantic errors produced"
+            )]
             for (name, nested_declarations) in &nested_global_or_nonlocal_declarations {
                 for declaration in nested_declarations {
                     if matches!(declaration.kind, GlobalOrNonlocal::Nonlocal) {
@@ -926,7 +935,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // only respect the bindings within the popped scope, rather than in all the nested scopes
         // they've encountered so far.
         if !popped_scope_kind.is_module() {
-            #[expect(clippy::iter_over_hash_type)]
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "declarations for distinct names are merged independently"
+            )]
             for (name, declarations) in &nested_global_or_nonlocal_declarations {
                 self.current_scope_info_mut()
                     .nested_global_or_nonlocal_declarations
@@ -1589,7 +1601,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // Collect all the bindings within the loop that reached a loop back edge. Use the minimum
         // definition ID to filter out all the pre-loop bindings. The loop header doesn't shadow
         // them, so there's no need to duplicate them.
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "bindings for distinct places are collected independently"
+        )]
         for place_id in loop_header_places {
             for live_binding in use_def.loop_back_bindings(*place_id) {
                 if live_binding.binding() >= loop_min_definition_id {
@@ -1598,7 +1613,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
         }
         // Mark the reachability and narrowing constraints as used.
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "marking reachability constraints as used is idempotent"
+        )]
         for place_id in loop_header_places {
             for live_binding in loop_header.bindings_for_place(*place_id) {
                 use_def

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1639,7 +1639,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         nested_bindings: NestedGlobalOrNonlocalDeclarations,
     ) {
         let mut nested_bindings = nested_bindings.into_iter().collect::<Vec<_>>();
-        nested_bindings.sort_unstable_by_key(|(name, _)| name.clone());
+        nested_bindings.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
 
         for (name, mut declarations) in nested_bindings {
             // Filter down to only the declarations with `is_bound: true`. If there are none left,

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -273,6 +273,7 @@ impl<'db> DefinitionsByNode<'db> {
         let mut non_single = FxHashMap::default();
         single.reserve(definitions_by_node.len());
 
+        #[expect(clippy::iter_over_hash_type)]
         for (key, definitions) in definitions_by_node {
             if definitions.len() == 1 {
                 single.insert(key, definitions[0]);

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -273,7 +273,10 @@ impl<'db> DefinitionsByNode<'db> {
         let mut non_single = FxHashMap::default();
         single.reserve(definitions_by_node.len());
 
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "each node is independently partitioned by definition count"
+        )]
         for (key, definitions) in definitions_by_node {
             if definitions.len() == 1 {
                 single.insert(key, definitions[0]);

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1388,6 +1388,7 @@ impl<'db> UseDefMapBuilder<'db> {
         constraint: ScopedNarrowingConstraint,
         places: &PossiblyNarrowedPlaces,
     ) {
+        #[expect(clippy::iter_over_hash_type)]
         for place in places {
             match place {
                 ScopedPlaceId::Symbol(symbol_id) => {
@@ -1485,6 +1486,7 @@ impl<'db> UseDefMapBuilder<'db> {
         self.symbol_states[symbol].merge(post_definition_state, &mut self.reachability_constraints);
 
         // And similarly for all associated members:
+        #[expect(clippy::iter_over_hash_type)]
         for (member_id, pre_definition_member_state) in pre_definition.associated_member_states {
             let mut post_definition_state = std::mem::replace(
                 &mut self.member_states[member_id],
@@ -2038,6 +2040,10 @@ impl<'db> UseDefMapBuilder<'db> {
     > {
         let mut interned_ids_by_definition =
             FxHashMap::with_capacity_and_hasher(definitions_by_definition.len(), FxBuildHasher);
+
+        let mut definitions_by_definition =
+            definitions_by_definition.into_iter().collect::<Vec<_>>();
+        definitions_by_definition.sort_unstable_by_key(|(definition, _)| *definition);
 
         for (
             definition,

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -2047,6 +2047,8 @@ impl<'db> UseDefMapBuilder<'db> {
         let mut interned_ids_by_definition =
             FxHashMap::with_capacity_and_hasher(definitions_by_definition.len(), FxBuildHasher);
 
+        // Keep the builder map hash-based because it is updated for every definition. We only need
+        // stable iteration here, where insertion order determines the generated interned IDs.
         let mut definitions_by_definition =
             definitions_by_definition.into_iter().collect::<Vec<_>>();
         definitions_by_definition.sort_unstable_by_key(|(definition, _)| *definition);

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1388,7 +1388,10 @@ impl<'db> UseDefMapBuilder<'db> {
         constraint: ScopedNarrowingConstraint,
         places: &PossiblyNarrowedPlaces,
     ) {
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "the same constraint is recorded independently for each place"
+        )]
         for place in places {
             match place {
                 ScopedPlaceId::Symbol(symbol_id) => {
@@ -1486,7 +1489,10 @@ impl<'db> UseDefMapBuilder<'db> {
         self.symbol_states[symbol].merge(post_definition_state, &mut self.reachability_constraints);
 
         // And similarly for all associated members:
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "associated member states are merged independently"
+        )]
         for (member_id, pre_definition_member_state) in pre_definition.associated_member_states {
             let mut post_definition_state = std::mem::replace(
                 &mut self.member_states[member_id],

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -638,6 +638,7 @@ impl SourceTexts {
 
     /// Revert all files with a tracked override back to their original source text.
     fn revert_all(self, db: &mut dyn Db) {
+        #[expect(clippy::iter_over_hash_type)]
         for (file, original) in self.originals {
             file.set_source_text_override(db).to(Some(original));
         }

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -638,7 +638,10 @@ impl SourceTexts {
 
     /// Revert all files with a tracked override back to their original source text.
     fn revert_all(self, db: &mut dyn Db) {
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "source text overrides for distinct files are independent"
+        )]
         for (file, original) in self.originals {
             file.set_source_text_override(db).to(Some(original));
         }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -420,7 +420,10 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
 
         let previous_coverage =
             enum_member_pattern_coverage(db, enum_class, previous_predicate.kind(db));
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "set removal is independent of iteration order"
+        )]
         for previous_name in previous_coverage.definitely_matched {
             remaining_names.remove(&previous_name);
         }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -420,6 +420,7 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
 
         let previous_coverage =
             enum_member_pattern_coverage(db, enum_class, previous_predicate.kind(db));
+        #[expect(clippy::iter_over_hash_type)]
         for previous_name in previous_coverage.definitely_matched {
             remaining_names.remove(&previous_name);
         }

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -181,7 +181,10 @@ impl<'db> SemanticModel<'db> {
         let builtin = module.is_known(self.db, KnownModule::Builtins);
 
         let mut completions = vec![];
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "completion order is determined later by relevance ranking"
+        )]
         for Member { name, ty } in all_members(self.db, ty) {
             completions.push(Completion {
                 name,

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -181,6 +181,7 @@ impl<'db> SemanticModel<'db> {
         let builtin = module.is_known(self.db, KnownModule::Builtins);
 
         let mut completions = vec![];
+        #[expect(clippy::iter_over_hash_type)]
         for Member { name, ty } in all_members(self.db, ty) {
             completions.push(Completion {
                 name,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -2426,6 +2426,7 @@ impl NodeId {
                 .is_always_satisfied(db, builder)
         };
 
+        #[expect(clippy::iter_over_hash_type)]
         for typevar in typevars {
             if typevar.is_inferable(db, inferable) {
                 // If the typevar is in inferable position, we need to verify that some valid
@@ -5687,6 +5688,7 @@ impl SequentMap {
                     }
                 };
 
+                #[expect(clippy::iter_over_hash_type)]
                 for (ante1, ante2) in &self.map.pair_impossibilities {
                     maybe_write_prefix(f)?;
                     write!(
@@ -5966,6 +5968,7 @@ impl PathAssignments {
 
         self.discover_constraint(db, builder, assignment.constraint());
 
+        #[expect(clippy::iter_over_hash_type)]
         for ante in &self.map.single_tautologies {
             if self.assignment_holds(ante.when_false()) {
                 // The sequent map says (ante1) is always true, and the current path asserts that
@@ -5985,6 +5988,7 @@ impl PathAssignments {
             }
         }
 
+        #[expect(clippy::iter_over_hash_type)]
         for (ante1, ante2) in &self.map.pair_impossibilities {
             if self.assignment_holds(ante1.when_true()) && self.assignment_holds(ante2.when_true())
             {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -2426,7 +2426,10 @@ impl NodeId {
                 .is_always_satisfied(db, builder)
         };
 
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "all type variables must pass the check regardless of order"
+        )]
         for typevar in typevars {
             if typevar.is_inferable(db, inferable) {
                 // If the typevar is in inferable position, we need to verify that some valid
@@ -5688,7 +5691,10 @@ impl SequentMap {
                     }
                 };
 
-                #[expect(clippy::iter_over_hash_type)]
+                #[expect(
+                    clippy::iter_over_hash_type,
+                    reason = "this debug-only formatter has no stable ordering contract"
+                )]
                 for (ante1, ante2) in &self.map.pair_impossibilities {
                     maybe_write_prefix(f)?;
                     write!(
@@ -5968,7 +5974,10 @@ impl PathAssignments {
 
         self.discover_constraint(db, builder, assignment.constraint());
 
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "any matching tautology yields the same conflict result"
+        )]
         for ante in &self.map.single_tautologies {
             if self.assignment_holds(ante.when_false()) {
                 // The sequent map says (ante1) is always true, and the current path asserts that
@@ -5988,7 +5997,10 @@ impl PathAssignments {
             }
         }
 
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "any matching impossibility yields the same conflict result"
+        )]
         for (ante1, ante2) in &self.map.pair_impossibilities {
             if self.assignment_holds(ante1.when_true()) && self.assignment_holds(ante2.when_true())
             {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -446,6 +446,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.type_expression_flags
                 .extend(extra.type_expression_flags.iter().copied());
 
+            #[expect(clippy::iter_over_hash_type)]
             for (collection_def, constraints) in &extra.collection_use_constraints {
                 self.collection_use_constraints
                     .entry(*collection_def)
@@ -512,6 +513,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.type_expression_flags
                 .extend(extra.type_expression_flags.iter().copied());
 
+            #[expect(clippy::iter_over_hash_type)]
             for (collection_def, constraints) in &extra.collection_use_constraints {
                 self.collection_use_constraints
                     .entry(*collection_def)
@@ -539,6 +541,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.type_expression_flags
                 .extend(extra.type_expression_flags.iter().copied());
 
+            #[expect(clippy::iter_over_hash_type)]
             for (collection_def, constraints) in &extra.collection_use_constraints {
                 self.collection_use_constraints
                     .entry(*collection_def)
@@ -6229,6 +6232,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn union_expected_types(&mut self, expected_types: &FxHashMap<ExpressionNodeKey, Type<'db>>) {
         let db = self.db();
+        #[expect(clippy::iter_over_hash_type)]
         for (expression, ty) in expected_types {
             self.expected_types
                 .entry(*expression)
@@ -10753,6 +10757,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .extend(bindings.iter().map(|(def, ty)| (*def, *ty)));
         }
 
+        #[expect(clippy::iter_over_hash_type)]
         for (collection_def, constraints) in &collection_use_constraints {
             self.collection_use_constraints
                 .entry(*collection_def)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -446,7 +446,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.type_expression_flags
                 .extend(extra.type_expression_flags.iter().copied());
 
-            #[expect(clippy::iter_over_hash_type)]
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "constraints for distinct collection definitions are merged independently"
+            )]
             for (collection_def, constraints) in &extra.collection_use_constraints {
                 self.collection_use_constraints
                     .entry(*collection_def)
@@ -513,7 +516,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.type_expression_flags
                 .extend(extra.type_expression_flags.iter().copied());
 
-            #[expect(clippy::iter_over_hash_type)]
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "constraints for distinct collection definitions are merged independently"
+            )]
             for (collection_def, constraints) in &extra.collection_use_constraints {
                 self.collection_use_constraints
                     .entry(*collection_def)
@@ -541,7 +547,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.type_expression_flags
                 .extend(extra.type_expression_flags.iter().copied());
 
-            #[expect(clippy::iter_over_hash_type)]
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "constraints for distinct collection definitions are merged independently"
+            )]
             for (collection_def, constraints) in &extra.collection_use_constraints {
                 self.collection_use_constraints
                     .entry(*collection_def)
@@ -6232,7 +6241,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn union_expected_types(&mut self, expected_types: &FxHashMap<ExpressionNodeKey, Type<'db>>) {
         let db = self.db();
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "expected types for distinct expressions are unioned independently"
+        )]
         for (expression, ty) in expected_types {
             self.expected_types
                 .entry(*expression)
@@ -10757,7 +10769,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .extend(bindings.iter().map(|(def, ty)| (*def, *ty)));
         }
 
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "constraints for distinct collection definitions are merged independently"
+        )]
         for (collection_def, constraints) in &collection_use_constraints {
             self.collection_use_constraints
                 .entry(*collection_def)

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1063,6 +1063,7 @@ fn check_class_namespace_against_metaclass_members<'db>(
         }
     }
 
+    #[expect(clippy::iter_over_hash_type)]
     for name in metaclass_instance_members {
         let Some(symbol_id) = table.symbol_id(name.as_str()) else {
             continue;

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1063,7 +1063,10 @@ fn check_class_namespace_against_metaclass_members<'db>(
         }
     }
 
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "each metaclass member is checked independently"
+    )]
     for name in metaclass_instance_members {
         let Some(symbol_id) = table.symbol_id(name.as_str()) else {
             continue;

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -624,7 +624,10 @@ fn merge_constraints_and<'db>(
     into: &mut NarrowingConstraints<'db>,
     from: NarrowingConstraints<'db>,
 ) {
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "constraints for distinct places are merged independently"
+    )]
     for (key, from_constraint) in from {
         match into.entry(key) {
             Entry::Occupied(mut entry) => {
@@ -653,7 +656,10 @@ fn merge_constraints_or<'db>(
     // For places that appear in `into` but not in `from`, widen to object
     into.retain(|key, _| from.contains_key(key));
 
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "constraints for distinct places are merged independently"
+    )]
     for (key, from_constraint) in from {
         match into.entry(key) {
             Entry::Occupied(mut entry) => {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -624,6 +624,7 @@ fn merge_constraints_and<'db>(
     into: &mut NarrowingConstraints<'db>,
     from: NarrowingConstraints<'db>,
 ) {
+    #[expect(clippy::iter_over_hash_type)]
     for (key, from_constraint) in from {
         match into.entry(key) {
             Entry::Occupied(mut entry) => {
@@ -652,6 +653,7 @@ fn merge_constraints_or<'db>(
     // For places that appear in `into` but not in `from`, widen to object
     into.retain(|key, _| from.contains_key(key));
 
+    #[expect(clippy::iter_over_hash_type)]
     for (key, from_constraint) in from {
         match into.entry(key) {
             Entry::Occupied(mut entry) => {

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -73,7 +73,10 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
     let own_class_members: FxHashSet<_> = all_end_of_scope_members(db, scope).collect();
     let enum_info = enum_metadata(db, class.into());
 
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "each class member is checked independently"
+    )]
     for member in own_class_members {
         check_class_declaration(
             context,

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -73,6 +73,7 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
     let own_class_members: FxHashSet<_> = all_end_of_scope_members(db, scope).collect();
     let enum_info = enum_metadata(db, class.into());
 
+    #[expect(clippy::iter_over_hash_type)]
     for member in own_class_members {
         check_class_declaration(
             context,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1049,7 +1049,10 @@ fn cached_protocol_interface<'db>(
             }
         }
 
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "direct members have unique names and the final map is ordered"
+        )]
         for (symbol_id, (ty, qualifiers, definition, bound_on_class)) in direct_members {
             let name = place_table.symbol(symbol_id).name();
             if excluded_from_proto_members(name) {

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -1049,6 +1049,7 @@ fn cached_protocol_interface<'db>(
             }
         }
 
+        #[expect(clippy::iter_over_hash_type)]
         for (symbol_id, (ty, qualifiers, definition, bound_on_class)) in direct_members {
             let name = place_table.symbol(symbol_id).name();
             if excluded_from_proto_members(name) {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3103,7 +3103,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // If there are still unmatched keyword parameters from `source`, then they should be
         // optional otherwise the subtype relation is invalid.
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "any required unmatched keyword parameter makes the relation invalid"
+        )]
         for (_, source_param) in source_keywords {
             if source_param.default_type().is_none() {
                 return self.never();

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3103,6 +3103,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         // If there are still unmatched keyword parameters from `source`, then they should be
         // optional otherwise the subtype relation is invalid.
+        #[expect(clippy::iter_over_hash_type)]
         for (_, source_param) in source_keywords {
             if source_param.default_type().is_none() {
                 return self.never();

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -225,6 +225,7 @@ pub(super) fn publish_diagnostics(document: &DocumentHandle, session: &Session, 
             publish_diagnostics_notification(document.uri().clone(), diagnostics);
         }
         LspDiagnostics::NotebookDocument(cell_diagnostics) => {
+            #[expect(clippy::iter_over_hash_type)]
             for (cell_uri, diagnostics) in cell_diagnostics {
                 publish_diagnostics_notification(cell_uri, diagnostics);
             }
@@ -305,6 +306,7 @@ pub(crate) fn publish_settings_diagnostics(
     let global_settings = session.global_settings();
 
     // Send the settings diagnostics!
+    #[expect(clippy::iter_over_hash_type)]
     for (uri, file_diagnostics) in diagnostics_by_uri {
         // Convert diagnostics to LSP format
         let lsp_diagnostics = file_diagnostics

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -225,7 +225,10 @@ pub(super) fn publish_diagnostics(document: &DocumentHandle, session: &Session, 
             publish_diagnostics_notification(document.uri().clone(), diagnostics);
         }
         LspDiagnostics::NotebookDocument(cell_diagnostics) => {
-            #[expect(clippy::iter_over_hash_type)]
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "diagnostic notifications for distinct cell URIs are independent"
+            )]
             for (cell_uri, diagnostics) in cell_diagnostics {
                 publish_diagnostics_notification(cell_uri, diagnostics);
             }
@@ -306,7 +309,10 @@ pub(crate) fn publish_settings_diagnostics(
     let global_settings = session.global_settings();
 
     // Send the settings diagnostics!
-    #[expect(clippy::iter_over_hash_type)]
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "diagnostic notifications for distinct document URIs are independent"
+    )]
     for (uri, file_diagnostics) in diagnostics_by_uri {
         // Convert diagnostics to LSP format
         let lsp_diagnostics = file_diagnostics

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -484,7 +484,10 @@ impl<'a> ResponseWriter<'a> {
 
         // Handle files that had diagnostics in previous request but no longer have any
         // Any remaining entries in previous_results are files that were fixed
-        #[expect(clippy::iter_over_hash_type)]
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "workspace diagnostic reports are independently identified by URI"
+        )]
         for (key, (previous_uri, previous_result_id)) in self.previous_result_ids {
             // This file had diagnostics before but doesn't now, so we need to report it as having no diagnostics
             let version = self

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -484,6 +484,7 @@ impl<'a> ResponseWriter<'a> {
 
         // Handle files that had diagnostics in previous request but no longer have any
         // Any remaining entries in previous_results are files that were fixed
+        #[expect(clippy::iter_over_hash_type)]
         for (key, (previous_uri, previous_result_id)) in self.previous_result_ids {
             // This file had diagnostics before but doesn't now, so we need to report it as having no diagnostics
             let version = self


### PR DESCRIPTION
## Summary

Stacks on #25726 and enables Clippy's `iter_over_hash_type` restriction lint across the workspace, so new hash-map and hash-set iterations must make their ordering assumptions explicit.

Most existing loops are order-independent and use a site-local `#[expect(clippy::iter_over_hash_type)]`. At the order-sensitive sites, this sorts before iteration. (In practice, that should stabilize some parser fixtures, configuration diagnostics, union normalization, etc.).

This lint is kind of annoying, but given how much we want to crack down on non-determinism in ty, it seems worthwhile to enable IMO.
