### PR TITLE
[ty] Compact retained definition maps

### DIFF
--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -1608,7 +1608,9 @@ pub struct NestedBindingsDefinitionKind {
     pub nested_declarations: SmallVec<[crate::builder::NestedDeclaration; 1]>,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, salsa::Update, get_size2::GetSize)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, salsa::Update, get_size2::GetSize,
+)]
 pub struct DefinitionNodeKey(NodeKey);
 
 impl DefinitionNodeKey {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -263,8 +263,8 @@ pub enum EnclosingSnapshotResult<'map, 'db> {
 
 #[derive(Debug, PartialEq, Eq, Update, get_size2::GetSize)]
 struct DefinitionsByNode<'db> {
-    single: FxHashMap<DefinitionNodeKey, Definition<'db>>,
-    non_single: FxHashMap<DefinitionNodeKey, Box<[Definition<'db>]>>,
+    single: FrozenMap<DefinitionNodeKey, Definition<'db>>,
+    non_single: FrozenMap<DefinitionNodeKey, Box<[Definition<'db>]>>,
 }
 
 impl<'db> DefinitionsByNode<'db> {
@@ -285,10 +285,10 @@ impl<'db> DefinitionsByNode<'db> {
             }
         }
 
-        single.shrink_to_fit();
-        non_single.shrink_to_fit();
-
-        Self { single, non_single }
+        Self {
+            single: FrozenMap::from(single),
+            non_single: FrozenMap::from(non_single),
+        }
     }
 
     fn get(&self, key: DefinitionNodeKey) -> Option<&[Definition<'db>]> {

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -249,6 +249,7 @@ use thin_vec::ThinVec;
 
 use crate::ast_ids::ScopedUseId;
 use crate::definition::{Definition, DefinitionState};
+use crate::frozen::FrozenMap;
 use crate::member::ScopedMemberId;
 use crate::narrowing_constraints::{
     ConstraintKey, NarrowingConstraints, NarrowingConstraintsBuilder, ScopedNarrowingConstraint,
@@ -543,7 +544,7 @@ pub struct UseDefMap<'db> {
     ///
     /// If we see a binding to a `Final`-qualified symbol, we also need the bindings to find
     /// previous bindings to that symbol. If there are any, the assignment is invalid.
-    definitions_by_definition: FxHashMap<
+    definitions_by_definition: FrozenMap<
         Definition<'db>,
         DefinitionsAtDefinition<InternedBindingsId, InternedDeclarationsId>,
     >,
@@ -2068,12 +2069,11 @@ impl<'db> UseDefMapBuilder<'db> {
             DefinitionsAtDefinition<Bindings, Declarations>,
         >,
         place_state_interner: &mut PlaceStateInterner,
-    ) -> FxHashMap<
+    ) -> FrozenMap<
         Definition<'db>,
         DefinitionsAtDefinition<InternedBindingsId, InternedDeclarationsId>,
     > {
-        let mut interned_ids_by_definition =
-            FxHashMap::with_capacity_and_hasher(definitions_by_definition.len(), FxBuildHasher);
+        let mut interned_ids_by_definition = Vec::with_capacity(definitions_by_definition.len());
 
         // Keep the builder map hash-based because it is updated for every definition. We only need
         // stable iteration here, where insertion order determines the generated interned IDs.
@@ -2092,16 +2092,16 @@ impl<'db> UseDefMapBuilder<'db> {
             let bindings = place_state_interner.intern_bindings(bindings);
             let declarations = declarations
                 .map(|declarations| place_state_interner.intern_declarations(declarations));
-            interned_ids_by_definition.insert(
+            interned_ids_by_definition.push((
                 definition,
                 DefinitionsAtDefinition {
                     bindings,
                     declarations,
                 },
-            );
+            ));
         }
 
-        interned_ids_by_definition
+        FrozenMap::from_entries(interned_ids_by_definition)
     }
 
     fn intern_bindings_by_use(


### PR DESCRIPTION
## Summary

`DefinitionsByNode` and `UseDefMap::definitions_by_definition` currently retain hash tables after semantic indexing has finished, even though the retained semantic index only needs deterministic keyed lookup.

This changes those retained maps to use the existing sorted `FrozenMap` representation. The builders continue to use hash maps while constructing the semantic index, then freeze the final entries into sorted slices before returning the cached value.

On the PyTorch memory benchmark, this reduced retained memory by 5.66 MB (0.40%).