### PR TITLE
[ty] Compact retained symbol lookups

### DIFF
--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -173,7 +173,10 @@ impl PlaceTable {
     /// Iterate over the "root" expressions of the place (e.g. `x.y.z`, `x.y`, `x` for `x.y.z[0]`).
     ///
     /// Note, this iterator may skip some parents if they are not defined in the current scope.
-    pub fn parents<'a>(&'a self, place_expr: impl Into<PlaceExprRef<'a>>) -> ParentPlaceIter<'a> {
+    pub fn parents<'a>(
+        &'a self,
+        place_expr: impl Into<PlaceExprRef<'a>>,
+    ) -> impl Iterator<Item = ScopedPlaceId> + 'a {
         match place_expr.into() {
             PlaceExprRef::Symbol(_) => ParentPlaceIter::for_symbol(),
             PlaceExprRef::Member(member) => {
@@ -484,28 +487,56 @@ impl From<FilePlaceId> for ScopedPlaceId {
     }
 }
 
-pub struct ParentPlaceIter<'a> {
-    state: Option<ParentPlaceIterState<'a>>,
+pub(crate) struct ParentPlaceIter<'a, S = SymbolTable, M = MemberTable> {
+    state: Option<ParentPlaceIterState<'a, S, M>>,
 }
 
-enum ParentPlaceIterState<'a> {
+trait SymbolLookup {
+    fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId>;
+}
+
+impl SymbolLookup for SymbolTable {
+    fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
+        SymbolTable::symbol_id(self, name)
+    }
+}
+
+impl SymbolLookup for SymbolTableBuilder {
+    fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
+        SymbolTableBuilder::symbol_id(self, name)
+    }
+}
+
+trait MemberLookup {
+    fn member_id<'a>(&self, member: impl Into<MemberExprRef<'a>>) -> Option<ScopedMemberId>;
+}
+
+impl MemberLookup for MemberTable {
+    fn member_id<'a>(&self, member: impl Into<MemberExprRef<'a>>) -> Option<ScopedMemberId> {
+        MemberTable::member_id(self, member)
+    }
+}
+
+impl MemberLookup for MemberTableBuilder {
+    fn member_id<'a>(&self, member: impl Into<MemberExprRef<'a>>) -> Option<ScopedMemberId> {
+        MemberTable::member_id(self, member)
+    }
+}
+
+enum ParentPlaceIterState<'a, S, M> {
     Symbol {
         symbol_name: &'a str,
-        symbols: &'a SymbolTable,
+        symbols: &'a S,
     },
     Member {
-        symbols: &'a SymbolTable,
-        members: &'a MemberTable,
+        symbols: &'a S,
+        members: &'a M,
         next_member: MemberExprRef<'a>,
     },
 }
 
-impl<'a> ParentPlaceIterState<'a> {
-    fn parent_state(
-        expression: &MemberExprRef<'a>,
-        symbols: &'a SymbolTable,
-        members: &'a MemberTable,
-    ) -> Self {
+impl<'a, S, M> ParentPlaceIterState<'a, S, M> {
+    fn parent_state(expression: &MemberExprRef<'a>, symbols: &'a S, members: &'a M) -> Self {
         match expression.parent() {
             Some(parent) => Self::Member {
                 next_member: parent,
@@ -520,15 +551,15 @@ impl<'a> ParentPlaceIterState<'a> {
     }
 }
 
-impl<'a> ParentPlaceIter<'a> {
+impl<'a, S, M> ParentPlaceIter<'a, S, M> {
     pub(super) fn for_symbol() -> Self {
         ParentPlaceIter { state: None }
     }
 
     pub(super) fn for_member(
         expression: &'a MemberExpr,
-        symbol_table: &'a SymbolTable,
-        member_table: &'a MemberTable,
+        symbol_table: &'a S,
+        member_table: &'a M,
     ) -> Self {
         let expr_ref = expression.as_ref();
         ParentPlaceIter {
@@ -541,7 +572,11 @@ impl<'a> ParentPlaceIter<'a> {
     }
 }
 
-impl Iterator for ParentPlaceIter<'_> {
+impl<S, M> Iterator for ParentPlaceIter<'_, S, M>
+where
+    S: SymbolLookup,
+    M: MemberLookup,
+{
     type Item = ScopedPlaceId;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -574,7 +609,12 @@ impl Iterator for ParentPlaceIter<'_> {
     }
 }
 
-impl FusedIterator for ParentPlaceIter<'_> {}
+impl<S, M> FusedIterator for ParentPlaceIter<'_, S, M>
+where
+    S: SymbolLookup,
+    M: MemberLookup,
+{
+}
 
 /// Builder for computing the conservative set of places that could possibly be narrowed.
 ///

--- a/crates/ty_python_core/src/symbol.rs
+++ b/crates/ty_python_core/src/symbol.rs
@@ -1,10 +1,9 @@
 use bitflags::bitflags;
 use hashbrown::hash_table::Entry;
-use ruff_index::{IndexVec, newtype_index};
+use ruff_index::{FrozenIndexVec, IndexVec, newtype_index};
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHasher;
 use std::hash::{Hash as _, Hasher as _};
-use std::ops::{Deref, DerefMut};
 
 /// Uniquely identifies a symbol in a given scope.
 #[newtype_index]
@@ -157,17 +156,17 @@ impl Symbol {
 /// The symbols of a given scope.
 ///
 /// Allows lookup by name and a symbol's ID.
-#[derive(Default, get_size2::GetSize)]
+#[derive(get_size2::GetSize)]
 pub(super) struct SymbolTable {
-    symbols: IndexVec<ScopedSymbolId, Symbol>,
+    symbols: FrozenIndexVec<ScopedSymbolId, Symbol>,
 
     /// Map from symbol name to its ID.
-    ///
-    /// Uses a hash table to avoid storing the name twice.
-    map: hashbrown::HashTable<ScopedSymbolId>,
+    symbols_by_name: Box<[ScopedSymbolId]>,
 }
 
 impl SymbolTable {
+    const LINEAR_LOOKUP_THRESHOLD: usize = 16;
+
     /// Look up a symbol by its ID.
     ///
     /// ## Panics
@@ -177,20 +176,19 @@ impl SymbolTable {
         &self.symbols[id]
     }
 
-    /// Look up a symbol by its ID, mutably.
-    ///
-    /// ## Panics
-    /// If the ID is not valid for this symbol table.
-    #[track_caller]
-    pub(crate) fn symbol_mut(&mut self, id: ScopedSymbolId) -> &mut Symbol {
-        &mut self.symbols[id]
-    }
-
     /// Look up the ID of a symbol by its name.
     pub(crate) fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
-        self.map
-            .find(Self::hash_name(name), |id| self.symbols[*id].name == name)
-            .copied()
+        if self.symbols_by_name.len() <= Self::LINEAR_LOOKUP_THRESHOLD {
+            self.symbols_by_name
+                .iter()
+                .find(|id| self.symbols[**id].name == name)
+                .copied()
+        } else {
+            self.symbols_by_name
+                .binary_search_by(|id| self.symbols[*id].name().as_str().cmp(name))
+                .ok()
+                .map(|index| self.symbols_by_name[index])
+        }
     }
 
     /// Iterate over the symbols in this symbol table.
@@ -222,17 +220,22 @@ impl std::fmt::Debug for SymbolTable {
 
 #[derive(Debug, Default)]
 pub(super) struct SymbolTableBuilder {
-    table: SymbolTable,
+    symbols: IndexVec<ScopedSymbolId, Symbol>,
+
+    /// Map from symbol name to its ID.
+    ///
+    /// Uses a hash table to avoid storing the name twice.
+    map: hashbrown::HashTable<ScopedSymbolId>,
 }
 
 impl SymbolTableBuilder {
     /// Add a new symbol to this scope or update the flags if a symbol with the same name already exists.
     pub(super) fn add(&mut self, mut symbol: Symbol) -> (ScopedSymbolId, bool) {
         let hash = SymbolTable::hash_name(symbol.name());
-        let entry = self.table.map.entry(
+        let entry = self.map.entry(
             hash,
-            |id| &self.table.symbols[*id].name == symbol.name(),
-            |id| SymbolTable::hash_name(&self.table.symbols[*id].name),
+            |id| &self.symbols[*id].name == symbol.name(),
+            |id| SymbolTable::hash_name(&self.symbols[*id].name),
         );
 
         match entry {
@@ -247,33 +250,48 @@ impl SymbolTableBuilder {
             }
             Entry::Vacant(entry) => {
                 symbol.name.shrink_to_fit();
-                let id = self.table.symbols.push(symbol);
+                let id = self.symbols.push(symbol);
                 entry.insert(id);
                 (id, true)
             }
         }
     }
 
+    #[track_caller]
+    pub(crate) fn symbol(&self, id: ScopedSymbolId) -> &Symbol {
+        &self.symbols[id]
+    }
+
+    #[track_caller]
+    pub(crate) fn symbol_mut(&mut self, id: ScopedSymbolId) -> &mut Symbol {
+        &mut self.symbols[id]
+    }
+
+    pub(crate) fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
+        self.map
+            .find(SymbolTable::hash_name(name), |id| {
+                self.symbols[*id].name == name
+            })
+            .copied()
+    }
+
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Symbol> {
+        self.symbols.iter()
+    }
+
     pub(super) fn build(self) -> SymbolTable {
-        let mut table = self.table;
-        table.symbols.shrink_to_fit();
-        table
-            .map
-            .shrink_to_fit(|id| SymbolTable::hash_name(&table.symbols[*id].name));
-        table
-    }
-}
+        let Self { mut symbols, .. } = self;
 
-impl Deref for SymbolTableBuilder {
-    type Target = SymbolTable;
+        let mut symbols_by_name = symbols.indices().collect::<Vec<_>>();
+        if symbols_by_name.len() > SymbolTable::LINEAR_LOOKUP_THRESHOLD {
+            symbols_by_name
+                .sort_unstable_by(|left, right| symbols[*left].name().cmp(symbols[*right].name()));
+        }
 
-    fn deref(&self) -> &Self::Target {
-        &self.table
-    }
-}
-
-impl DerefMut for SymbolTableBuilder {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.table
+        symbols.shrink_to_fit();
+        SymbolTable {
+            symbols: symbols.into(),
+            symbols_by_name: symbols_by_name.into_boxed_slice(),
+        }
     }
 }


### PR DESCRIPTION
## Summary

`SymbolTable` currently retains the same hash table used while semantic indexing is built, even though the retained table only needs name-to-ID lookup after construction.

This separates the builder representation from the retained representation. The builder continues to use a hash table while adding and updating symbols; the finished `SymbolTable` stores symbols in a frozen index vector plus a compact ID list for lookup, using linear search for small scopes and binary search for larger scopes.

On the PyTorch memory benchmark, this reduced retained memory by 4.61 MB (0.32%).