### PR TITLE
[ty] Compact retained member lookups

### DIFF
--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -1,4 +1,4 @@
-use ruff_index::{IndexVec, newtype_index};
+use ruff_index::{FrozenIndexVec, IndexVec, newtype_index};
 use ruff_python_ast::{self as ast, name::Name};
 use ruff_text_size::{TextLen as _, TextRange, TextSize};
 
@@ -7,9 +7,9 @@ use hashbrown::hash_table::Entry;
 use rustc_hash::FxHasher;
 use smallvec::SmallVec;
 
+use std::cmp::Ordering;
 use std::fmt::Write as _;
 use std::hash::{Hash, Hasher as _};
-use std::ops::{Deref, DerefMut};
 
 /// A member access, e.g. `x.y` or `x[1]` or `x["foo"]`.
 #[derive(Clone, Debug, PartialEq, Eq, get_size2::GetSize)]
@@ -400,6 +400,12 @@ impl<'a> MemberExprRef<'a> {
     }
 }
 
+fn compare_member_expression_refs(left: &MemberExprRef<'_>, right: &MemberExprRef<'_>) -> Ordering {
+    left.path
+        .cmp(right.path)
+        .then_with(|| left.segments.iter().cmp(right.segments.iter()))
+}
+
 impl<'a> From<&'a MemberExpr> for MemberExprRef<'a> {
     fn from(value: &'a MemberExpr) -> Self {
         value.as_ref()
@@ -420,17 +426,17 @@ impl Hash for MemberExprRef<'_> {
 pub struct ScopedMemberId;
 
 /// The members of a scope. Allows lookup by member path and [`ScopedMemberId`].
-#[derive(Default, get_size2::GetSize)]
+#[derive(get_size2::GetSize)]
 pub(super) struct MemberTable {
-    members: IndexVec<ScopedMemberId, Member>,
+    members: FrozenIndexVec<ScopedMemberId, Member>,
 
     /// Map from member path to its ID.
-    ///
-    /// Uses a hash table to avoid storing the path twice.
-    map: hashbrown::HashTable<ScopedMemberId>,
+    members_by_expression: Box<[ScopedMemberId]>,
 }
 
 impl MemberTable {
+    const LINEAR_LOOKUP_THRESHOLD: usize = 16;
+
     /// Returns the member with the given ID.
     ///
     /// ## Panics
@@ -438,15 +444,6 @@ impl MemberTable {
     #[track_caller]
     pub(crate) fn member(&self, id: ScopedMemberId) -> &Member {
         &self.members[id]
-    }
-
-    /// Returns a mutable reference to the member with the given ID.
-    ///
-    /// ## Panics
-    /// If the ID is not valid for this table.
-    #[track_caller]
-    pub(super) fn member_mut(&mut self, id: ScopedMemberId) -> &mut Member {
-        &mut self.members[id]
     }
 
     /// Returns an iterator over all members in the table.
@@ -464,10 +461,19 @@ impl MemberTable {
         member: impl Into<MemberExprRef<'a>>,
     ) -> Option<ScopedMemberId> {
         let member = member.into();
-        let hash = Self::hash_member_expression_ref(&member);
-        self.map
-            .find(hash, |id| self.members[*id].expression == member)
-            .copied()
+        if self.members_by_expression.len() <= Self::LINEAR_LOOKUP_THRESHOLD {
+            self.members_by_expression
+                .iter()
+                .find(|id| self.members[**id].expression == member)
+                .copied()
+        } else {
+            self.members_by_expression
+                .binary_search_by(|id| {
+                    compare_member_expression_refs(&self.members[*id].expression.as_ref(), &member)
+                })
+                .ok()
+                .map(|index| self.members_by_expression[index])
+        }
     }
 
     pub(crate) fn place_id_by_instance_attribute_name(&self, name: &str) -> Option<ScopedMemberId> {
@@ -498,7 +504,12 @@ impl std::fmt::Debug for MemberTable {
 
 #[derive(Debug, Default)]
 pub(super) struct MemberTableBuilder {
-    table: MemberTable,
+    members: IndexVec<ScopedMemberId, Member>,
+
+    /// Map from member path to its ID.
+    ///
+    /// Uses a hash table to avoid storing the path twice.
+    map: hashbrown::HashTable<ScopedMemberId>,
 }
 
 impl MemberTableBuilder {
@@ -508,11 +519,11 @@ impl MemberTableBuilder {
     pub(super) fn add(&mut self, mut member: Member) -> (ScopedMemberId, bool) {
         let member_ref = member.expression.as_ref();
         let hash = MemberTable::hash_member_expression_ref(&member_ref);
-        let entry = self.table.map.entry(
+        let entry = self.map.entry(
             hash,
-            |id| self.table.members[*id].expression.as_ref() == member.expression.as_ref(),
+            |id| self.members[*id].expression.as_ref() == member.expression.as_ref(),
             |id| {
-                let ref_expr = self.table.members[*id].expression.as_ref();
+                let ref_expr = self.members[*id].expression.as_ref();
                 MemberTable::hash_member_expression_ref(&ref_expr)
             },
         );
@@ -530,35 +541,55 @@ impl MemberTableBuilder {
             Entry::Vacant(entry) => {
                 member.expression.shrink_to_fit();
 
-                let id = self.table.members.push(member);
+                let id = self.members.push(member);
                 entry.insert(id);
                 (id, true)
             }
         }
     }
 
+    pub(crate) fn member(&self, id: ScopedMemberId) -> &Member {
+        &self.members[id]
+    }
+
+    pub(super) fn member_mut(&mut self, id: ScopedMemberId) -> &mut Member {
+        &mut self.members[id]
+    }
+
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Member> {
+        self.members.iter()
+    }
+
+    pub(crate) fn member_id<'a>(
+        &self,
+        member: impl Into<MemberExprRef<'a>>,
+    ) -> Option<ScopedMemberId> {
+        let member = member.into();
+        self.map
+            .find(MemberTable::hash_member_expression_ref(&member), |id| {
+                self.members[*id].expression == member
+            })
+            .copied()
+    }
+
     pub(super) fn build(self) -> MemberTable {
-        let mut table = self.table;
-        table.members.shrink_to_fit();
-        table.map.shrink_to_fit(|id| {
-            let ref_expr = table.members[*id].expression.as_ref();
-            MemberTable::hash_member_expression_ref(&ref_expr)
-        });
-        table
-    }
-}
+        let Self { mut members, .. } = self;
 
-impl Deref for MemberTableBuilder {
-    type Target = MemberTable;
+        let mut members_by_expression = members.indices().collect::<Vec<_>>();
+        if members_by_expression.len() > MemberTable::LINEAR_LOOKUP_THRESHOLD {
+            members_by_expression.sort_unstable_by(|left, right| {
+                compare_member_expression_refs(
+                    &members[*left].expression.as_ref(),
+                    &members[*right].expression.as_ref(),
+                )
+            });
+        }
 
-    fn deref(&self) -> &Self::Target {
-        &self.table
-    }
-}
-
-impl DerefMut for MemberTableBuilder {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.table
+        members.shrink_to_fit();
+        MemberTable {
+            members: members.into(),
+            members_by_expression: members_by_expression.into_boxed_slice(),
+        }
     }
 }
 
@@ -611,7 +642,7 @@ impl Segments {
 /// Layout: [kind: 2 bits][offset: 30 bits]
 /// - Bits 0-1: `SegmentKind` (0=Attribute, 1=IntSubscript, 2=StringSubscript)
 /// - Bits 2-31: Absolute offset from start of path (up to 1,073,741,823 bytes)
-#[derive(Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, get_size2::GetSize)]
 struct SegmentInfo(u32);
 
 const KIND_MASK: u32 = 0b11;

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -173,7 +173,10 @@ impl PlaceTable {
     /// Iterate over the "root" expressions of the place (e.g. `x.y.z`, `x.y`, `x` for `x.y.z[0]`).
     ///
     /// Note, this iterator may skip some parents if they are not defined in the current scope.
-    pub fn parents<'a>(&'a self, place_expr: impl Into<PlaceExprRef<'a>>) -> ParentPlaceIter<'a> {
+    pub fn parents<'a>(
+        &'a self,
+        place_expr: impl Into<PlaceExprRef<'a>>,
+    ) -> impl Iterator<Item = ScopedPlaceId> + 'a {
         match place_expr.into() {
             PlaceExprRef::Symbol(_) => ParentPlaceIter::for_symbol(),
             PlaceExprRef::Member(member) => {
@@ -484,28 +487,56 @@ impl From<FilePlaceId> for ScopedPlaceId {
     }
 }
 
-pub struct ParentPlaceIter<'a> {
-    state: Option<ParentPlaceIterState<'a>>,
+pub(crate) struct ParentPlaceIter<'a, S = SymbolTable, M = MemberTable> {
+    state: Option<ParentPlaceIterState<'a, S, M>>,
 }
 
-enum ParentPlaceIterState<'a> {
+trait SymbolLookup {
+    fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId>;
+}
+
+impl SymbolLookup for SymbolTable {
+    fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
+        SymbolTable::symbol_id(self, name)
+    }
+}
+
+impl SymbolLookup for SymbolTableBuilder {
+    fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
+        SymbolTableBuilder::symbol_id(self, name)
+    }
+}
+
+trait MemberLookup {
+    fn member_id<'a>(&self, member: impl Into<MemberExprRef<'a>>) -> Option<ScopedMemberId>;
+}
+
+impl MemberLookup for MemberTable {
+    fn member_id<'a>(&self, member: impl Into<MemberExprRef<'a>>) -> Option<ScopedMemberId> {
+        MemberTable::member_id(self, member)
+    }
+}
+
+impl MemberLookup for MemberTableBuilder {
+    fn member_id<'a>(&self, member: impl Into<MemberExprRef<'a>>) -> Option<ScopedMemberId> {
+        MemberTable::member_id(self, member)
+    }
+}
+
+enum ParentPlaceIterState<'a, S, M> {
     Symbol {
         symbol_name: &'a str,
-        symbols: &'a SymbolTable,
+        symbols: &'a S,
     },
     Member {
-        symbols: &'a SymbolTable,
-        members: &'a MemberTable,
+        symbols: &'a S,
+        members: &'a M,
         next_member: MemberExprRef<'a>,
     },
 }
 
-impl<'a> ParentPlaceIterState<'a> {
-    fn parent_state(
-        expression: &MemberExprRef<'a>,
-        symbols: &'a SymbolTable,
-        members: &'a MemberTable,
-    ) -> Self {
+impl<'a, S, M> ParentPlaceIterState<'a, S, M> {
+    fn parent_state(expression: &MemberExprRef<'a>, symbols: &'a S, members: &'a M) -> Self {
         match expression.parent() {
             Some(parent) => Self::Member {
                 next_member: parent,
@@ -520,15 +551,15 @@ impl<'a> ParentPlaceIterState<'a> {
     }
 }
 
-impl<'a> ParentPlaceIter<'a> {
+impl<'a, S, M> ParentPlaceIter<'a, S, M> {
     pub(super) fn for_symbol() -> Self {
         ParentPlaceIter { state: None }
     }
 
     pub(super) fn for_member(
         expression: &'a MemberExpr,
-        symbol_table: &'a SymbolTable,
-        member_table: &'a MemberTable,
+        symbol_table: &'a S,
+        member_table: &'a M,
     ) -> Self {
         let expr_ref = expression.as_ref();
         ParentPlaceIter {
@@ -541,7 +572,11 @@ impl<'a> ParentPlaceIter<'a> {
     }
 }
 
-impl Iterator for ParentPlaceIter<'_> {
+impl<S, M> Iterator for ParentPlaceIter<'_, S, M>
+where
+    S: SymbolLookup,
+    M: MemberLookup,
+{
     type Item = ScopedPlaceId;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -574,7 +609,12 @@ impl Iterator for ParentPlaceIter<'_> {
     }
 }
 
-impl FusedIterator for ParentPlaceIter<'_> {}
+impl<S, M> FusedIterator for ParentPlaceIter<'_, S, M>
+where
+    S: SymbolLookup,
+    M: MemberLookup,
+{
+}
 
 /// Builder for computing the conservative set of places that could possibly be narrowed.
 ///

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -519,7 +519,7 @@ impl MemberLookup for MemberTable {
 
 impl MemberLookup for MemberTableBuilder {
     fn member_id<'a>(&self, member: impl Into<MemberExprRef<'a>>) -> Option<ScopedMemberId> {
-        MemberTable::member_id(self, member)
+        MemberTableBuilder::member_id(self, member)
     }
 }
 

--- a/crates/ty_python_core/src/symbol.rs
+++ b/crates/ty_python_core/src/symbol.rs
@@ -1,10 +1,9 @@
 use bitflags::bitflags;
 use hashbrown::hash_table::Entry;
-use ruff_index::{IndexVec, newtype_index};
+use ruff_index::{FrozenIndexVec, IndexVec, newtype_index};
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHasher;
 use std::hash::{Hash as _, Hasher as _};
-use std::ops::{Deref, DerefMut};
 
 /// Uniquely identifies a symbol in a given scope.
 #[newtype_index]
@@ -157,17 +156,17 @@ impl Symbol {
 /// The symbols of a given scope.
 ///
 /// Allows lookup by name and a symbol's ID.
-#[derive(Default, get_size2::GetSize)]
+#[derive(get_size2::GetSize)]
 pub(super) struct SymbolTable {
-    symbols: IndexVec<ScopedSymbolId, Symbol>,
+    symbols: FrozenIndexVec<ScopedSymbolId, Symbol>,
 
     /// Map from symbol name to its ID.
-    ///
-    /// Uses a hash table to avoid storing the name twice.
-    map: hashbrown::HashTable<ScopedSymbolId>,
+    symbols_by_name: Box<[ScopedSymbolId]>,
 }
 
 impl SymbolTable {
+    const LINEAR_LOOKUP_THRESHOLD: usize = 16;
+
     /// Look up a symbol by its ID.
     ///
     /// ## Panics
@@ -177,20 +176,19 @@ impl SymbolTable {
         &self.symbols[id]
     }
 
-    /// Look up a symbol by its ID, mutably.
-    ///
-    /// ## Panics
-    /// If the ID is not valid for this symbol table.
-    #[track_caller]
-    pub(crate) fn symbol_mut(&mut self, id: ScopedSymbolId) -> &mut Symbol {
-        &mut self.symbols[id]
-    }
-
     /// Look up the ID of a symbol by its name.
     pub(crate) fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
-        self.map
-            .find(Self::hash_name(name), |id| self.symbols[*id].name == name)
-            .copied()
+        if self.symbols_by_name.len() <= Self::LINEAR_LOOKUP_THRESHOLD {
+            self.symbols_by_name
+                .iter()
+                .find(|id| self.symbols[**id].name == name)
+                .copied()
+        } else {
+            self.symbols_by_name
+                .binary_search_by(|id| self.symbols[*id].name().as_str().cmp(name))
+                .ok()
+                .map(|index| self.symbols_by_name[index])
+        }
     }
 
     /// Iterate over the symbols in this symbol table.
@@ -222,17 +220,22 @@ impl std::fmt::Debug for SymbolTable {
 
 #[derive(Debug, Default)]
 pub(super) struct SymbolTableBuilder {
-    table: SymbolTable,
+    symbols: IndexVec<ScopedSymbolId, Symbol>,
+
+    /// Map from symbol name to its ID.
+    ///
+    /// Uses a hash table to avoid storing the name twice.
+    map: hashbrown::HashTable<ScopedSymbolId>,
 }
 
 impl SymbolTableBuilder {
     /// Add a new symbol to this scope or update the flags if a symbol with the same name already exists.
     pub(super) fn add(&mut self, mut symbol: Symbol) -> (ScopedSymbolId, bool) {
         let hash = SymbolTable::hash_name(symbol.name());
-        let entry = self.table.map.entry(
+        let entry = self.map.entry(
             hash,
-            |id| &self.table.symbols[*id].name == symbol.name(),
-            |id| SymbolTable::hash_name(&self.table.symbols[*id].name),
+            |id| &self.symbols[*id].name == symbol.name(),
+            |id| SymbolTable::hash_name(&self.symbols[*id].name),
         );
 
         match entry {
@@ -247,33 +250,48 @@ impl SymbolTableBuilder {
             }
             Entry::Vacant(entry) => {
                 symbol.name.shrink_to_fit();
-                let id = self.table.symbols.push(symbol);
+                let id = self.symbols.push(symbol);
                 entry.insert(id);
                 (id, true)
             }
         }
     }
 
+    #[track_caller]
+    pub(crate) fn symbol(&self, id: ScopedSymbolId) -> &Symbol {
+        &self.symbols[id]
+    }
+
+    #[track_caller]
+    pub(crate) fn symbol_mut(&mut self, id: ScopedSymbolId) -> &mut Symbol {
+        &mut self.symbols[id]
+    }
+
+    pub(crate) fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
+        self.map
+            .find(SymbolTable::hash_name(name), |id| {
+                self.symbols[*id].name == name
+            })
+            .copied()
+    }
+
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Symbol> {
+        self.symbols.iter()
+    }
+
     pub(super) fn build(self) -> SymbolTable {
-        let mut table = self.table;
-        table.symbols.shrink_to_fit();
-        table
-            .map
-            .shrink_to_fit(|id| SymbolTable::hash_name(&table.symbols[*id].name));
-        table
-    }
-}
+        let Self { mut symbols, .. } = self;
 
-impl Deref for SymbolTableBuilder {
-    type Target = SymbolTable;
+        let mut symbols_by_name = symbols.indices().collect::<Vec<_>>();
+        if symbols_by_name.len() > SymbolTable::LINEAR_LOOKUP_THRESHOLD {
+            symbols_by_name
+                .sort_unstable_by(|left, right| symbols[*left].name().cmp(symbols[*right].name()));
+        }
 
-    fn deref(&self) -> &Self::Target {
-        &self.table
-    }
-}
-
-impl DerefMut for SymbolTableBuilder {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.table
+        symbols.shrink_to_fit();
+        SymbolTable {
+            symbols: symbols.into(),
+            symbols_by_name: symbols_by_name.into_boxed_slice(),
+        }
     }
 }


### PR DESCRIPTION
## Summary

`MemberTable` currently retains the hash table used while semantic indexing is built, even though the retained table only needs member-expression-to-ID lookup after construction.

This separates the builder representation from the retained representation. The builder continues to use a hash table while adding and updating members; the finished `MemberTable` stores members in a frozen index vector plus a compact ID list for lookup, using linear search for small scopes and binary search for larger scopes.

On the PyTorch memory benchmark, this reduced retained memory by 3.14 MB (0.22%) on top of #25738.