### PR TITLE
[ty] Fix wildcard import symbol range

### DIFF
--- a/crates/ty_ide/src/all_symbols.rs
+++ b/crates/ty_ide/src/all_symbols.rs
@@ -703,10 +703,10 @@ def zqzqzq():
 
         assert_snapshot!(test.all_symbols("zqzqzq"), @"
         info[all-symbols]: AllSymbolInfo
-         --> pandas/__init__.py:2:5
+         --> pandas/__init__.py:2:27
           |
         2 | from pandas.io.api import *
-          |     ^^^^^^
+          |                           ^
           |
         info: Function zqzqzq
         ");

--- a/crates/ty_ide/src/all_symbols.rs
+++ b/crates/ty_ide/src/all_symbols.rs
@@ -710,6 +710,13 @@ def zqzqzq():
           |
         info: Function zqzqzq
         ");
+
+        let symbols = all_symbols(&test.db, test.cursor.file, &QueryPattern::fuzzy("zqzqzq"));
+        let symbol = symbols
+            .iter()
+            .find_map(|info| info.symbol.as_ref())
+            .expect("wildcard-imported symbol");
+        assert_eq!(symbol.full_range, symbol.name_range);
     }
 
     /// This tests that when we have multiple re-exports

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -1041,6 +1041,11 @@ impl<'db> SymbolVisitor<'db> {
             self.all_invalid = true;
             return;
         };
+        let star_range = import_from
+            .names
+            .iter()
+            .find(|alias| &alias.name == "*")
+            .map(Ranged::range);
         self.symbols
             .extend(symbols.symbols.iter().filter_map(|symbol| {
                 // If there's no `__all__`, then names with an underscore
@@ -1050,6 +1055,10 @@ impl<'db> SymbolVisitor<'db> {
                     return None;
                 }
                 let mut symbol = symbol.clone();
+                if let Some(star_range) = star_range {
+                    symbol.name_range = star_range;
+                    symbol.full_range = star_range;
+                }
                 let Some(imported_from) = ImportedFrom::import_from(
                     self.db,
                     self.file,


### PR DESCRIPTION
## Summary

I am attempting to address astral-sh/ty#3571. The caret range for the wildcard import is incorrect, and the correct range would be to point at the symbol name, but the symbol is imported through a wildcard star. It is not possible to point the carets at the symbol name (which is what the other tests in that file do), so instead we point the caret at the wildcard star.

## Test Plan

Updated and passed tests.