### PR TITLE
[ty] Render reStructuredText hyperlinks in docstring Markdown

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -8,10 +8,6 @@
 
 mod markdown;
 mod rest;
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired into reST rendering in a follow-up change")
-)]
 mod sections;
 
 use indexmap::IndexMap;
@@ -191,6 +187,13 @@ fn render_markdown(docstring: &str) -> String {
     // break out of it, even if they're writing python documentation about markdown
     // code fences and are showing off how you can use more than 3 backticks.
     const FENCE: &str = "```````````";
+
+    let docstring = if rest::may_contain_top_level_field_list(docstring) {
+        rest::Docstring::parse(docstring).render_markdown()
+    } else {
+        Cow::Borrowed(docstring)
+    };
+
     // TODO: there is a convention that `singletick` is for items that can
     // be looked up in-scope while ``multitick`` is for opaque inline code.
     // While rendering this we should make note of all the `singletick` locations
@@ -1972,12 +1975,14 @@ mod tests {
         assert_snapshot!(docstring.render_markdown(), @"
         This is a function description.<HB>
         <HB>
-        :param str param1: The first parameter description<HB>
-        :param int param2: The second parameter description<HB>
+        ## Parameters<HB>
+        `param1` (`str`): The first parameter description<HB>
+        `param2` (`int`): The second parameter description<HB>
         &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
-        :param param3: A parameter without type annotation<HB>
-        :returns: The return value description<HB>
-        :rtype: str
+        `param3`: A parameter without type annotation<HB>
+        <HB>
+        ## Returns<HB>
+        `str`: The return value description
         ");
     }
 
@@ -2041,8 +2046,9 @@ mod tests {
         Args:<HB>
         &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter<HB>
         <HB>
-        :param int param2: reST-style parameter<HB>
-        :param param3: Another reST-style parameter<HB>
+        ## Parameters<HB>
+        `param2` (`int`): reST-style parameter<HB>
+        `param3`: Another reST-style parameter<HB>
         <HB>
         Parameters<HB>
         ----------<HB>

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -200,6 +200,7 @@ fn render_markdown(docstring: &str) -> String {
     // and (possibly in a higher up piece of logic) try to resolve the names for
     // cross-linking. (Similar to `TypeDetails` in the type formatting code.)
     let mut output = String::new();
+    let mut inline_markup = rest::InlineMarkupRenderer::default();
     let mut first_line = true;
     let mut block_indent = 0;
     let mut in_doctest = false;
@@ -213,17 +214,20 @@ fn render_markdown(docstring: &str) -> String {
         let trimmed_source_line = line.trim_start_matches(' ');
         let mut rendered_line = trimmed_source_line;
         let line_indent = line.len() - trimmed_source_line.len();
+        let mut line_prefix = String::new();
+        let mut source_line_prefix = String::new();
 
         // First thing's first, add a newline to start the new line
         if !first_line {
             // If we're not in a codeblock, add trailing space to the line to authentically wrap it
             // (Lines ending with two spaces tell markdown to preserve a linebreak)
             if !in_any_code {
-                output.push_str("  ");
+                line_prefix.push_str("  ");
             }
             // Only push newlines if we're not scanning for a real line
             if starting_literal.is_none() {
-                output.push('\n');
+                line_prefix.push('\n');
+                source_line_prefix.push('\n');
             }
         }
         first_line = false;
@@ -232,6 +236,10 @@ fn render_markdown(docstring: &str) -> String {
         // TODO: we should remove all the trailing blank lines
         // (Just pop all trailing `\n` from `output`?)
         if in_literal && line_indent < block_indent && !rendered_line.is_empty() {
+            inline_markup.flush_pending_as_plain(&mut output);
+            output.push_str(&line_prefix);
+            line_prefix.clear();
+            source_line_prefix.clear();
             in_literal = false;
             in_any_code = false;
             block_indent = 0;
@@ -244,6 +252,10 @@ fn render_markdown(docstring: &str) -> String {
         if let Some(literal) = starting_literal
             && !rendered_line.is_empty()
         {
+            inline_markup.flush_pending_as_plain(&mut output);
+            output.push_str(&line_prefix);
+            line_prefix.clear();
+            source_line_prefix.clear();
             starting_literal = None;
             in_literal = true;
             in_any_code = true;
@@ -256,6 +268,10 @@ fn render_markdown(docstring: &str) -> String {
 
         // If we're not in a codeblock and we see something that signals a doctest, start one
         if !in_any_code && rendered_line.starts_with(">>>") {
+            inline_markup.flush_pending_as_plain(&mut output);
+            output.push_str(&line_prefix);
+            line_prefix.clear();
+            source_line_prefix.clear();
             block_indent = line_indent;
             in_doctest = true;
             in_any_code = true;
@@ -266,6 +282,7 @@ fn render_markdown(docstring: &str) -> String {
 
         // If we're not in a codeblock and we see a markdown codefence, start one
         if !in_any_code && let Some(fence) = markdown::MarkdownFence::find(trimmed_source_line) {
+            inline_markup.flush_pending_as_plain(&mut output);
             // Unlike other blocks we don't need to emit fences because it's already markdown
             block_indent = line_indent;
             in_any_code = true;
@@ -284,16 +301,19 @@ fn render_markdown(docstring: &str) -> String {
             //
             // We "make this work" by stripping the indent on the fences but preserving the
             // full indent of the lines between the fences
+            output.push_str(&line_prefix);
             output.push_str(rendered_line);
             continue;
         // If we're in a markdown code fence and this line seems to terminate it, end the block
         } else if let Some(fence) = in_markdown_with_fence
             && fence.is_closed_by(rendered_line)
         {
+            inline_markup.flush_pending_as_plain(&mut output);
             in_any_code = false;
             block_indent = 0;
             in_markdown_with_fence = None;
             // Render the line without its indent and move on.
+            output.push_str(&line_prefix);
             output.push_str(rendered_line);
             continue;
         }
@@ -398,9 +418,11 @@ fn render_markdown(docstring: &str) -> String {
             if !in_any_code {
                 // TODO: would the raw unicode codepoint be handled *better* or *worse*
                 // by various IDEs? VS Code handles this approach well, at least.
-                output.push_str("&nbsp;");
+                line_prefix.push_str("&nbsp;");
+                source_line_prefix.push(' ');
             } else {
-                output.push(' ');
+                line_prefix.push(' ');
+                source_line_prefix.push(' ');
             }
         }
 
@@ -414,69 +436,15 @@ fn render_markdown(docstring: &str) -> String {
             // Things that need to be escaped: underscores and HTML-sensitive characters.
             //
             // e.g. we want __init__ => \_\_init\_\_ but `__init__` => `__init__`
-            let escape = |input: &str| {
-                input
-                    .replace('&', "&amp;")
-                    .replace('<', "&lt;")
-                    .replace('>', "&gt;")
-                    .replace('_', "\\_")
-            };
-
-            let mut in_inline_code = false;
-            let mut first_chunk = true;
-            let mut opening_tick_count = 0;
-            let mut current_tick_count = 0;
-            for chunk in rendered_line.split('`') {
-                // First chunk is definitionally not in inline-code and so always plaintext
-                if first_chunk {
-                    first_chunk = false;
-                    output.push_str(&escape(chunk));
-                    continue;
-                }
-                // Not in first chunk, emit the ` between the last chunk and this one
-                output.push('`');
-                current_tick_count += 1;
-
-                // If we're in an inline block and have enough close-ticks to terminate it, do so.
-                // TODO: we parse ``hello```there` as (hello)(there) which probably isn't correct
-                // (definitely not for markdown) but it's close enough for horse grenades in this
-                // MVP impl. Notably we're verbatime emitting all the `'s so as long as reST and
-                // markdown agree we're *fine*. The accuracy of this parsing only affects the
-                // accuracy of where we apply escaping (so we need to misparse and see escapables
-                // for any of this to matter).
-                if opening_tick_count > 0 && current_tick_count >= opening_tick_count {
-                    opening_tick_count = 0;
-                    current_tick_count = 0;
-                    in_inline_code = false;
-                }
-
-                // If this chunk is completely empty we're just in a run of ticks, continue
-                if chunk.is_empty() {
-                    continue;
-                }
-
-                // Ok the chunk is non-empty, our run of ticks is complete
-                if in_inline_code {
-                    // The previous check for >= open_tick_count didn't trip, so these can't close
-                    // and these ticks will be verbatim rendered in the content
-                    current_tick_count = 0;
-                } else if current_tick_count > 0 {
-                    // Ok we're now in inline code
-                    opening_tick_count = current_tick_count;
-                    current_tick_count = 0;
-                    in_inline_code = true;
-                }
-
-                // Finally include the content either escaped or not
-                if in_inline_code {
-                    output.push_str(chunk);
-                } else {
-                    output.push_str(&escape(chunk));
-                }
-            }
-            // NOTE: explicitly not "flushing" the ticks here.
-            // We respect however the user closed their inline code.
+            inline_markup.render_line(
+                &mut output,
+                &line_prefix,
+                &source_line_prefix,
+                rendered_line,
+            );
         } else if rendered_line.is_empty() {
+            inline_markup.flush_pending_as_plain(&mut output);
+            output.push_str(&line_prefix);
             if in_doctest {
                 // This is the end of a doctest
                 block_indent = 0;
@@ -485,10 +453,13 @@ fn render_markdown(docstring: &str) -> String {
                 output.push_str(FENCE);
             }
         } else {
+            inline_markup.flush_pending_as_plain(&mut output);
+            output.push_str(&line_prefix);
             // Print the line verbatim, it's in code
             output.push_str(rendered_line);
         }
     }
+    inline_markup.flush_pending_as_plain(&mut output);
     // Flush codeblock
     if in_any_code {
         output.push('\n');
@@ -870,6 +841,47 @@ mod tests {
         <HB>
         So does `inline <code>`.
         "#);
+    }
+
+    #[test]
+    fn rest_hyperlinks() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = r#"
+        See `datetime-like <https://numpy.org/doc/stable/reference/arrays.datetime.html>`_ values.
+        Wrapped links render too: `timezone conversion and
+        localization
+        <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html
+        #time-zone-handling>`_.
+        Anonymous links work too: `project docs <https://example.com/docs>`__.
+        Raw placeholders still escape: <scheme>://<netloc>/<path>.
+        Link text escapes: `name_with_[chars] & <tags> <https://example.com/a path?q=(value)>`_.
+
+        Markdown code fences keep reST links literal:
+
+        ```text
+        `not a link <https://example.com>`_
+        ```
+
+        Missing underscores stay as inline code: `not a link <https://example.com>`.
+        "#;
+
+        let docstring = Docstring::new(docstring.to_owned());
+
+        assert_snapshot!(docstring.render_markdown(), @r"
+        See [datetime-like](https://numpy.org/doc/stable/reference/arrays.datetime.html) values.<HB>
+        Wrapped links render too: [timezone conversion and localization](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#time-zone-handling).<HB>
+        Anonymous links work too: [project docs](https://example.com/docs).<HB>
+        Raw placeholders still escape: &lt;scheme&gt;://&lt;netloc&gt;/&lt;path&gt;.<HB>
+        Link text escapes: [name\_with\_\[chars\] &amp; &lt;tags&gt;](https://example.com/a%20path?q=\(value\)).<HB>
+        <HB>
+        Markdown code fences keep reST links literal:<HB>
+        <HB>
+        ```text
+        `not a link <https://example.com>`_
+        ```<HB>
+        <HB>
+        Missing underscores stay as inline code: `not a link <https://example.com>`.
+        ");
     }
 
     // A literal block where the `::` is flush with the paragraph

--- a/crates/ty_ide/src/docstring/rest.rs
+++ b/crates/ty_ide/src/docstring/rest.rs
@@ -126,6 +126,307 @@ impl<'a> Docstring<'a> {
     }
 }
 
+/// Renders inline reST markup while buffering possible hyperlinks that wrap across lines.
+#[derive(Default)]
+pub(super) struct InlineMarkupRenderer {
+    pending_hyperlink: Option<PendingHyperlink>,
+}
+
+impl InlineMarkupRenderer {
+    /// Renders a prose line, using `source_prefix` only while recognizing wrapped reST links.
+    pub(super) fn render_line(
+        &mut self,
+        output: &mut String,
+        markdown_prefix: &str,
+        source_prefix: &str,
+        line: &str,
+    ) {
+        if let Some(pending_hyperlink) = &mut self.pending_hyperlink {
+            pending_hyperlink.push_line(markdown_prefix, source_prefix, line);
+            if line.is_empty() {
+                self.flush_pending_as_plain(output);
+            } else {
+                self.render_pending_hyperlink(output);
+            }
+        } else {
+            output.push_str(markdown_prefix);
+            self.render_fragment(output, line);
+        }
+    }
+
+    pub(super) fn flush_pending_as_plain(&mut self, output: &mut String) {
+        if let Some(pending_hyperlink) = self.pending_hyperlink.take() {
+            pending_hyperlink.render_as_plain(output);
+        }
+    }
+
+    fn render_pending_hyperlink(&mut self, output: &mut String) {
+        let Some(pending_hyperlink) = self.pending_hyperlink.take() else {
+            return;
+        };
+
+        if let Some(hyperlink) = Hyperlink::parse(&pending_hyperlink.candidate) {
+            hyperlink.render_markdown(output);
+            let remaining = pending_hyperlink.candidate[hyperlink.len..].to_owned();
+            self.render_fragment(output, &remaining);
+        } else {
+            self.pending_hyperlink = Some(pending_hyperlink);
+        }
+    }
+
+    fn render_fragment(&mut self, output: &mut String, line: &str) {
+        let mut rest = line;
+
+        while let Some(opening_index) = rest.find('`') {
+            push_escaped_markdown_text(output, &rest[..opening_index]);
+            rest = &rest[opening_index..];
+
+            if let Some(hyperlink) = Hyperlink::parse(rest) {
+                hyperlink.render_markdown(output);
+                rest = &rest[hyperlink.len..];
+                continue;
+            }
+
+            if Hyperlink::can_start_wrapped(rest) {
+                self.pending_hyperlink = Some(PendingHyperlink::new(rest));
+                return;
+            }
+
+            render_inline_code_or_text(output, rest, &mut rest);
+        }
+
+        push_escaped_markdown_text(output, rest);
+    }
+}
+
+struct PendingHyperlink {
+    candidate: String,
+    fallback: String,
+}
+
+impl PendingHyperlink {
+    fn new(first_line: &str) -> Self {
+        let mut fallback = String::new();
+        render_inline_markup_line(&mut fallback, first_line);
+
+        Self {
+            candidate: first_line.to_owned(),
+            fallback,
+        }
+    }
+
+    fn push_line(&mut self, markdown_prefix: &str, source_prefix: &str, line: &str) {
+        self.candidate.push_str(source_prefix);
+        self.candidate.push_str(line);
+        self.fallback.push_str(markdown_prefix);
+        render_inline_markup_line(&mut self.fallback, line);
+    }
+
+    fn render_as_plain(self, output: &mut String) {
+        output.push_str(&self.fallback);
+    }
+}
+
+fn render_inline_markup_line(output: &mut String, line: &str) {
+    let mut rest = line;
+
+    while let Some(opening_index) = rest.find('`') {
+        push_escaped_markdown_text(output, &rest[..opening_index]);
+        rest = &rest[opening_index..];
+
+        if let Some(hyperlink) = Hyperlink::parse(rest) {
+            hyperlink.render_markdown(output);
+            rest = &rest[hyperlink.len..];
+            continue;
+        }
+
+        render_inline_code_or_text(output, rest, &mut rest);
+    }
+
+    push_escaped_markdown_text(output, rest);
+}
+
+fn render_inline_code_or_text<'a>(output: &mut String, input: &'a str, rest: &mut &'a str) {
+    let tick_count = input.bytes().take_while(|byte| *byte == b'`').count();
+    let delimiter = &input[..tick_count];
+    let after_opening = &input[tick_count..];
+
+    output.push_str(delimiter);
+
+    let Some(closing_index) = find_closing_backtick_run(after_opening, tick_count) else {
+        output.push_str(after_opening);
+        *rest = "";
+        return;
+    };
+
+    output.push_str(&after_opening[..closing_index]);
+    output.push_str(delimiter);
+    *rest = &after_opening[closing_index + tick_count..];
+}
+
+fn find_closing_backtick_run(input: &str, opening_tick_count: usize) -> Option<usize> {
+    let mut offset = 0;
+
+    while let Some(index) = input[offset..].find('`') {
+        let index = offset + index;
+        let tick_count = input[index..]
+            .bytes()
+            .take_while(|byte| *byte == b'`')
+            .count();
+
+        if tick_count >= opening_tick_count {
+            return Some(index);
+        }
+
+        offset = index + tick_count;
+    }
+
+    None
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Hyperlink<'a> {
+    text: &'a str,
+    target: &'a str,
+    len: usize,
+}
+
+impl<'a> Hyperlink<'a> {
+    fn parse(input: &'a str) -> Option<Self> {
+        if !input.starts_with('`') || input.as_bytes().get(1) == Some(&b'`') {
+            return None;
+        }
+
+        let after_opening = &input[1..];
+        let closing_index = after_opening.find('`')?;
+        let after_closing = &after_opening[closing_index + 1..];
+        let underscore_count = after_closing
+            .bytes()
+            .take_while(|byte| *byte == b'_')
+            .count();
+        if !(1..=2).contains(&underscore_count) {
+            return None;
+        }
+
+        let content = &after_opening[..closing_index];
+        let (text, target) = Self::parse_text_and_target(content)?;
+        Some(Self {
+            text,
+            target,
+            len: 1 + closing_index + 1 + underscore_count,
+        })
+    }
+
+    fn parse_text_and_target(content: &'a str) -> Option<(&'a str, &'a str)> {
+        let content = content.trim();
+        let target_start = content.rfind('<')?;
+        if !content.ends_with('>') {
+            return None;
+        }
+
+        let before_target = &content[..target_start];
+        if !before_target
+            .chars()
+            .next_back()
+            .is_some_and(char::is_whitespace)
+        {
+            return None;
+        }
+
+        let text = before_target.trim();
+        let target = content[target_start + 1..content.len() - 1].trim();
+        (!text.is_empty() && !target.is_empty()).then_some((text, target))
+    }
+
+    fn can_start_wrapped(input: &str) -> bool {
+        input.starts_with('`')
+            && input.as_bytes().get(1) != Some(&b'`')
+            && !input[1..].contains('`')
+    }
+
+    fn render_markdown(&self, output: &mut String) {
+        output.push('[');
+        push_escaped_markdown_link_text(output, self.text);
+        output.push_str("](");
+        push_markdown_link_destination(output, self.target);
+        output.push(')');
+    }
+}
+
+fn push_escaped_markdown_text(output: &mut String, input: &str) {
+    for char in input.chars() {
+        match char {
+            '&' => output.push_str("&amp;"),
+            '<' => output.push_str("&lt;"),
+            '>' => output.push_str("&gt;"),
+            '_' => output.push_str("\\_"),
+            _ => output.push(char),
+        }
+    }
+}
+
+fn push_escaped_markdown_link_text(output: &mut String, input: &str) {
+    let mut pending_whitespace = false;
+
+    for char in input.chars() {
+        if char.is_whitespace() {
+            pending_whitespace = true;
+            continue;
+        }
+
+        if pending_whitespace {
+            output.push(' ');
+            pending_whitespace = false;
+        }
+
+        match char {
+            '[' | ']' | '\\' => {
+                output.push('\\');
+                output.push(char);
+            }
+            '&' => output.push_str("&amp;"),
+            '<' => output.push_str("&lt;"),
+            '>' => output.push_str("&gt;"),
+            '_' => output.push_str("\\_"),
+            _ => output.push(char),
+        }
+    }
+}
+
+fn push_markdown_link_destination(output: &mut String, input: &str) {
+    let mut chars = input.chars().peekable();
+
+    while let Some(char) = chars.next() {
+        if char.is_whitespace() {
+            let mut has_line_break = matches!(char, '\n' | '\r');
+            let mut whitespace_count = 1;
+
+            while let Some(char) = chars.next_if(|char| char.is_whitespace()) {
+                has_line_break |= matches!(char, '\n' | '\r');
+                whitespace_count += 1;
+            }
+
+            if !has_line_break {
+                for _ in 0..whitespace_count {
+                    output.push_str("%20");
+                }
+            }
+
+            continue;
+        }
+
+        match char {
+            '(' | ')' | '\\' => {
+                output.push('\\');
+                output.push(char);
+            }
+            '<' => output.push_str("%3C"),
+            '>' => output.push_str("%3E"),
+            _ => output.push(char),
+        }
+    }
+}
+
 /// Cursor over docstring lines and their line numbers.
 #[derive(Clone)]
 struct Lines<'a> {

--- a/crates/ty_ide/src/docstring/rest.rs
+++ b/crates/ty_ide/src/docstring/rest.rs
@@ -1,22 +1,68 @@
+use std::borrow::Cow;
 use std::iter::{Enumerate, Peekable};
 
 use compact_str::{CompactString, ToCompactString};
 use ruff_python_trivia::leading_indentation;
 use ruff_source_file::{Line as SourceLine, UniversalNewlineIterator, UniversalNewlines};
 use ruff_text_size::{TextRange, TextSize};
+use rustc_hash::FxHashMap;
 
 use super::markdown;
+use super::sections::{DocstringItem, DocstringSectionKind, DocstringSections};
+
+/// Returns whether a normalized docstring may contain a top-level field list
+/// that markdown rendering would rewrite.
+pub(super) fn may_contain_top_level_field_list(raw: &str) -> bool {
+    let bytes = raw.as_bytes();
+    memchr::memchr_iter(b':', bytes).any(|colon| {
+        (colon == 0 || bytes[colon - 1] == b'\n')
+            && starts_renderable_field_header(&raw[colon + 1..])
+    })
+}
+
+fn starts_renderable_field_header(after_opening_colon: &str) -> bool {
+    let line = after_opening_colon
+        .split_once('\n')
+        .map_or(after_opening_colon, |(line, _)| line);
+
+    let Some(name_end) = line.find(|char: char| char == ':' || char.is_whitespace()) else {
+        return false;
+    };
+
+    let name = &line[..name_end];
+    matches!(
+        name,
+        "param"
+            | "parameter"
+            | "arg"
+            | "argument"
+            | "key"
+            | "keyword"
+            | "kwarg"
+            | "kwparam"
+            | "var"
+            | "ivar"
+            | "cvar"
+            | "return"
+            | "returns"
+            | "raises"
+            | "raise"
+            | "except"
+            | "exception"
+    ) && line[name_end..].contains(':')
+}
 
 /// Represents a parsed restructured text (reST) docstring.
-pub(super) struct Docstring {
+pub(super) struct Docstring<'a> {
+    raw: &'a str,
     field_lists: Vec<FieldList>,
 }
 
-impl Docstring {
+impl<'a> Docstring<'a> {
     /// Constructs a parsed representation from a raw docstring.
-    pub(super) fn parse(raw: &str) -> Self {
+    pub(super) fn parse(raw: &'a str) -> Self {
         let field_lists = FieldList::parse_all(raw);
-        Self { field_lists }
+        Self { raw, field_lists }
     }
 
     /// Returns the parameter documentation that we were able to recognize in a docstring.
@@ -46,6 +92,37 @@ impl Docstring {
         }
 
         parameters
+    }
+
+    /// Returns the original docstring when no supported field list is rendered.
+    pub(super) fn render_markdown(&self) -> Cow<'a, str> {
+        let mut output: Option<String> = None;
+        let mut rendered_through = TextSize::default();
+
+        for field_list in &self.field_lists {
+            if field_list.indent != TextSize::default()
+                || field_list.range.start() < rendered_through
+            {
+                continue;
+            }
+
+            let Some(markdown) = field_list.render_markdown() else {
+                continue;
+            };
+
+            let output = output.get_or_insert_with(String::new);
+            output.push_str(
+                &self.raw[rendered_through.to_usize()..field_list.range.start().to_usize()],
+            );
+            output.push_str(&markdown);
+            rendered_through = field_list.range.end();
+        }
+
+        let Some(mut output) = output else {
+            return Cow::Borrowed(self.raw);
+        };
+        output.push_str(&self.raw[rendered_through.to_usize()..]);
+        Cow::Owned(output)
     }
 }
 
@@ -238,6 +315,191 @@ impl FieldList {
 
         FieldHeader::indentation(non_blank_line.text) > indent
             || FieldHeader::at_indent(non_blank_line.text, indent).is_some()
+    }
+
+    fn render_markdown(&self) -> Option<String> {
+        let plan = FieldListRenderPlan::from_fields(&self.fields)?;
+        let markdown = plan.render(&self.fields);
+        (!markdown.is_empty()).then_some(markdown)
+    }
+}
+
+/// Validates a field list and stores cross-field metadata needed while rendering.
+struct FieldListRenderPlan<'a> {
+    parameter_types: FxHashMap<&'a str, &'a str>,
+    attribute_types: FxHashMap<&'a str, &'a str>,
+    return_type: Option<&'a str>,
+}
+
+impl<'a> FieldListRenderPlan<'a> {
+    fn from_fields(fields: &'a [Field]) -> Option<Self> {
+        let mut has_rendered_field = false;
+        let mut has_returns = false;
+        let mut has_return_type = false;
+        let mut parameters: FxHashMap<&'a str, TypedFieldRenderState> = FxHashMap::default();
+        let mut attributes: FxHashMap<&'a str, TypedFieldRenderState> = FxHashMap::default();
+        let mut parameter_types: FxHashMap<&'a str, &'a str> = FxHashMap::default();
+        let mut attribute_types: FxHashMap<&'a str, &'a str> = FxHashMap::default();
+        let mut return_type = None;
+
+        for field in fields {
+            match field {
+                Field::Parameter {
+                    lookup_name, ty, ..
+                } => {
+                    has_rendered_field = true;
+                    parameters
+                        .entry(lookup_name.as_str())
+                        .or_default()
+                        .record_field(ty.is_some());
+                }
+                Field::Attribute { name, ty, .. } => {
+                    has_rendered_field = true;
+                    attributes
+                        .entry(name.as_str())
+                        .or_default()
+                        .record_field(ty.is_some());
+                }
+                Field::Returns { .. } => {
+                    has_rendered_field = true;
+                    has_returns = true;
+                }
+                Field::Raises { .. } => {
+                    has_rendered_field = true;
+                }
+                Field::ParameterType { lookup_name, ty } => {
+                    if parameter_types
+                        .insert(lookup_name.as_str(), ty.as_str())
+                        .is_some()
+                    {
+                        return None;
+                    }
+                }
+                Field::AttributeType { name, ty } => {
+                    if attribute_types.insert(name.as_str(), ty.as_str()).is_some() {
+                        return None;
+                    }
+                }
+                Field::ReturnType { ty } => {
+                    if has_return_type {
+                        return None;
+                    }
+                    has_return_type = true;
+                    return_type = (!ty.is_empty()).then_some(ty.as_str());
+                }
+                Field::Metadata => {}
+                Field::Unknown { .. } => return None,
+            }
+        }
+
+        for lookup_name in parameter_types.keys() {
+            if !parameters
+                .get(*lookup_name)
+                .is_some_and(TypedFieldRenderState::accepts_separate_type)
+            {
+                return None;
+            }
+        }
+
+        for name in attribute_types.keys() {
+            if !attributes
+                .get(*name)
+                .is_some_and(TypedFieldRenderState::accepts_separate_type)
+            {
+                return None;
+            }
+        }
+
+        if !has_rendered_field || (has_return_type && !has_returns) {
+            return None;
+        }
+
+        Some(Self {
+            parameter_types,
+            attribute_types,
+            return_type,
+        })
+    }
+
+    fn render(&self, fields: &'a [Field]) -> String {
+        let mut sections = DocstringSections::default();
+        for field in fields {
+            match field {
+                Field::Parameter {
+                    display_name,
+                    lookup_name,
+                    ty,
+                    description,
+                } => sections.push(
+                    DocstringSectionKind::Parameters,
+                    DocstringItem::new(
+                        Some(display_name.as_str()),
+                        ty.as_deref().or_else(|| {
+                            self.parameter_types
+                                .get(lookup_name.as_str())
+                                .copied()
+                                .filter(|ty| !ty.is_empty())
+                        }),
+                        description.as_str(),
+                    ),
+                ),
+                Field::Attribute {
+                    name,
+                    ty,
+                    description,
+                } => sections.push(
+                    DocstringSectionKind::Attributes,
+                    DocstringItem::new(
+                        Some(name.as_str()),
+                        ty.as_deref().or_else(|| {
+                            self.attribute_types
+                                .get(name.as_str())
+                                .copied()
+                                .filter(|ty| !ty.is_empty())
+                        }),
+                        description.as_str(),
+                    ),
+                ),
+                Field::Returns { name, description } => sections.push(
+                    DocstringSectionKind::Returns,
+                    DocstringItem::new(name.as_deref(), self.return_type, description.as_str()),
+                ),
+                Field::Raises {
+                    exception,
+                    description,
+                } => sections.push(
+                    DocstringSectionKind::Raises,
+                    DocstringItem::new(exception.as_deref(), None, description.as_str()),
+                ),
+                Field::ParameterType { .. }
+                | Field::AttributeType { .. }
+                | Field::ReturnType { .. }
+                | Field::Metadata
+                | Field::Unknown { .. } => {}
+            }
+        }
+
+        sections.render_markdown()
+    }
+}
+
+#[derive(Default)]
+struct TypedFieldRenderState {
+    has_untyped_field: bool,
+    has_inline_typed_field: bool,
+}
+
+impl TypedFieldRenderState {
+    fn record_field(&mut self, has_inline_type: bool) {
+        if has_inline_type {
+            self.has_inline_typed_field = true;
+        } else {
+            self.has_untyped_field = true;
+        }
+    }
+
+    fn accepts_separate_type(&self) -> bool {
+        self.has_untyped_field && !self.has_inline_typed_field
     }
 }
 
@@ -837,7 +1099,7 @@ struct ParameterName<'a> {
 mod tests {
     use insta::{assert_debug_snapshot, assert_snapshot};
 
-    use super::Docstring;
+    use super::{Docstring, may_contain_top_level_field_list};
 
     #[test]
     fn parameter_documentation_extracts_rest_parameters() {
@@ -858,6 +1120,26 @@ mod tests {
           This is a continuation of param2 description.
         kwargs: Extra keyword arguments.
         ");
+    }
+
+    #[test]
+    fn field_list_precheck_detects_renderable_top_level_fields() {
+        assert!(may_contain_top_level_field_list(
+            "Summary.\n:param value: The value."
+        ));
+        assert!(may_contain_top_level_field_list(
+            ":type value: int\n:param value: The value."
+        ));
+        assert!(!may_contain_top_level_field_list(
+            "Summary: no field list here."
+        ));
+        assert!(!may_contain_top_level_field_list(
+            ":class:`Foo` instances are accepted.\n:meta private:"
+        ));
+        assert!(!may_contain_top_level_field_list(
+            "    :param value: Nested field lists are preserved."
+        ));
+        assert!(!may_contain_top_level_field_list(":rtype: str"));
     }
 
     #[test]
@@ -1183,6 +1465,276 @@ Section::
         let param_docs = parameter_documentation(docstring);
 
         assert_snapshot!(param_docs, @"real: Real parameter.");
+    }
+
+    #[test]
+    fn field_lists_render_supported_sections() {
+        let docstring = "\
+This is a function description.
+:class:`Foo` instances can be passed here.
+
+:param str param1: The first parameter description
+:meta private:
+:param param2: The second parameter description
+:type param2: int
+:kwparam retries: Retry attempts.
+:paramtype retries: int
+:param *args: Extra positional arguments.
+:type args: tuple[str, ...]
+:param **kwargs: Extra keyword arguments.
+:type **kwargs: dict[str, object]
+:var cache: Cached data.
+:vartype cache: dict[str,
+    object]
+:ivar state: Instance state.
+:var str title: Display title.
+:cvar VERSION: Package version.
+:vartype VERSION: str
+:returns baz: The return value description
+:rtype: dict[str,
+    int]
+:raises ValueError: If the value is invalid.
+:meta hide-value:
+:exception RuntimeError: If the system is unavailable.";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        This is a function description.
+        :class:`Foo` instances can be passed here.
+
+        ## Parameters
+        `param1` (`str`): The first parameter description
+        `param2` (`int`): The second parameter description
+        `retries` (`int`): Retry attempts.
+        `*args` (`tuple[str, ...]`): Extra positional arguments.
+        `**kwargs` (`dict[str, object]`): Extra keyword arguments.
+
+        ## Attributes
+        `cache` (`dict[str, object]`): Cached data.
+        `state`: Instance state.
+        `title` (`str`): Display title.
+        `VERSION` (`str`): Package version.
+
+        ## Returns
+        `baz` (`dict[str, int]`): The return value description
+
+        ## Raises
+        `ValueError`: If the value is invalid.
+        `RuntimeError`: If the system is unavailable.
+        ");
+    }
+
+    #[test]
+    fn field_lists_ignore_metadata_fields_when_rendering() {
+        let docstring = "\
+:meta private:
+:param value: The value to validate.
+:meta public:";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Parameters
+        `value`: The value to validate.
+        ");
+
+        let metadata_only = "\
+:meta private:
+:meta public:";
+        assert_eq!(
+            Docstring::parse(metadata_only).render_markdown(),
+            metadata_only
+        );
+    }
+
+    #[test]
+    fn field_lists_preserve_unrenderable_lists() {
+        let docstring = "\
+:param first: First parameter
+:meta private:
+:param second: Second parameter
+:type orphan: str
+:param **: Missing a parameter name.";
+
+        assert_eq!(Docstring::parse(docstring).render_markdown(), docstring);
+
+        assert_snapshot!(parameter_documentation(docstring), @"
+        first: First parameter
+        second: Second parameter
+        ");
+
+        for docstring in [
+            "\
+:param value: The value to validate.
+:rtype: str",
+            "\
+:param value: The value to validate.
+:type value: str
+:type value: int",
+            "\
+:param str value: The value to validate.
+:type value: int",
+            "\
+:var value: The value.
+:vartype orphan: str",
+            "\
+:var value: The value.
+:vartype value: str
+:vartype value: int",
+            "\
+:var str value: The value.
+:vartype value: int",
+            "\
+:returns:",
+            "\
+:raises:",
+            "\
+:meta private:
+:returns:
+:raises:",
+        ] {
+            assert_eq!(Docstring::parse(docstring).render_markdown(), docstring);
+        }
+    }
+
+    #[test]
+    fn field_lists_skip_empty_rendered_sections() {
+        let docstring = "\
+:param value: The value to validate.
+:returns:
+:raises:";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Parameters
+        `value`: The value to validate.
+        ");
+    }
+
+    #[test]
+    fn field_lists_render_return_type_without_name() {
+        let docstring = "\
+:returns: The return value description.
+:rtype: dict[str,
+    int]";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Returns
+        `dict[str, int]`: The return value description.
+        ");
+    }
+
+    #[test]
+    fn field_lists_render_sections_in_canonical_order() {
+        let docstring = "\
+:raises ValueError: If validation fails.
+:param value: The value to validate.
+:returns: The normalized value.
+:raises TypeError: If validation has the wrong type.";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Parameters
+        `value`: The value to validate.
+
+        ## Returns
+        The normalized value.
+
+        ## Raises
+        `ValueError`: If validation fails.
+        `TypeError`: If validation has the wrong type.
+        ");
+    }
+
+    #[test]
+    fn field_lists_render_list_descriptions_as_blocks() {
+        let docstring = "\
+:param value:
+    - First option.
+    - Second option.
+:param steps:
+    1. Validate the input.
+    2. Return the result.
+:param done: Whether work is done.";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Parameters
+        `value`:
+        - First option.
+        - Second option.
+
+        `steps`:
+        1. Validate the input.
+        2. Return the result.
+
+        `done`: Whether work is done.
+        ");
+    }
+
+    #[test]
+    fn field_lists_render_well_formed_lists_after_unrenderable_lists() {
+        let docstring = "\
+:param first: First parameter.
+
+Some prose between field lists.
+
+:meta private:
+
+More prose between field lists.
+
+:param second: Second parameter.";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        ## Parameters
+        `first`: First parameter.
+
+        Some prose between field lists.
+
+        :meta private:
+
+        More prose between field lists.
+
+        ## Parameters
+        `second`: Second parameter.
+        ");
+    }
+
+    #[test]
+    fn field_lists_inside_code_examples_are_preserved() {
+        let docstring = "\
+Markdown input:
+
+```text
+:param sample: This is sample input
+```
+
+Doctest output:
+
+>>> print(\"field list\")
+:param sample: This is sample output
+
+Literal block::
+
+    :param sample: This is sample input
+
+:param real: Real parameter";
+
+        assert_snapshot!(Docstring::parse(docstring).render_markdown(), @"
+        Markdown input:
+
+        ```text
+        :param sample: This is sample input
+        ```
+
+        Doctest output:
+
+        >>> print(\"field list\")
+        :param sample: This is sample output
+
+        Literal block::
+
+            :param sample: This is sample input
+
+        ## Parameters
+        `real`: Real parameter
+        ");
+
+        assert_snapshot!(parameter_documentation(docstring), @"real: Real parameter");
     }
 
     fn parameter_documentation(docstring: &str) -> String {

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -5175,6 +5175,56 @@ def function():
     }
 
     #[test]
+    fn hover_func_docstring_renders_rest_hyperlinks_in_markdown() {
+        let test = hover_test(
+            r#"
+        def to_<CURSOR>datetime():
+            """Convert argument to datetime.
+
+            See `timezone conversion and
+            localization
+            <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html
+            #time-zone-handling>`_
+            for details.
+            """
+            return
+        "#,
+        );
+
+        assert_snapshot!(test.hover(), @r#"
+        def to_datetime() -> Unknown
+        ---------------------------------------------
+        Convert argument to datetime.
+
+        See `timezone conversion and
+        localization
+        <https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html
+        #time-zone-handling>`_
+        for details.
+
+        ---------------------------------------------
+        ```python
+        def to_datetime() -> Unknown
+        ```
+        ---
+        Convert argument to datetime.<HB>
+        <HB>
+        See [timezone conversion and localization](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#time-zone-handling)<HB>
+        for details.
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:2:5
+          |
+        2 | def to_datetime():
+          |     ^^^-^^^^^^^
+          |     |  |
+          |     |  Cursor offset
+          |     source
+          |
+        "#);
+    }
+
+    #[test]
     fn hover_func_with_plus_docstring() {
         let test = hover_test(
             r#"


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Closes https://github.com/astral-sh/ty/issues/3529.

## Test Plan

Please see included tests.
<!-- How was it tested? -->
