### PR TITLE
[ty] Fix panic that occurs when resolving type qualifiers for imported symbols on hover

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -4602,6 +4602,48 @@ def function():
     }
 
     #[test]
+    fn hover_imported_type_alias() {
+        let test = CursorTest::builder()
+            .source(
+                "library.py",
+                r#"
+                from typing import TypeAlias
+
+                class Target: ...
+                Alias: TypeAlias = Target
+                "#,
+            )
+            .source(
+                "main.py",
+                r#"
+                from library import Alias
+
+                def test(a: Ali<CURSOR>as) -> str:
+                    return "42"
+                "#,
+            )
+            .build();
+
+        assert_snapshot!(test.hover(), @r#"
+        Target
+        ---------------------------------------------
+        ```python
+        Target
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:4:13
+          |
+        4 | def test(a: Alias) -> str:
+          |             ^^^-^
+          |             |  |
+          |             |  Cursor offset
+          |             source
+          |
+        "#);
+    }
+
+    #[test]
     fn hover_final_variable() {
         let test = hover_test(
             r#"

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -468,10 +468,11 @@ impl<'db> SemanticModel<'db> {
                 else {
                     return TypeQualifiers::empty();
                 };
-                let module = parsed_module(self.db, self.file).load(self.db);
+                let definition_file = definition.file(self.db);
+                let module = parsed_module(self.db, definition_file).load(self.db);
                 if !definition
                     .kind(self.db)
-                    .category(self.file.is_stub(self.db), &module)
+                    .category(definition_file.is_stub(self.db), &module)
                     .is_declaration()
                 {
                     return TypeQualifiers::empty();


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This fixes a panic that was caused by incorrect resolution of type qualifiers for an imported symbol on hover. Previously, we incorrectly always used the file that the hover request was initiated from to resolve type qualifiers; now we will correctly use whichever file defines the hover target.

Closes https://github.com/astral-sh/ty/issues/3673.

## Test Plan

Please see included tests.
<!-- How was it tested? -->
