### PR TITLE
[`pylint`] Exempt Python version comparisons (`PLR2004`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pylint/magic-value-comparison.md
+++ b/crates/ruff_linter/resources/mdtest/pylint/magic-value-comparison.md
@@ -1,0 +1,55 @@
+# `magic-value-comparison` (`PLR2004`)
+
+```toml
+[lint]
+select = ["PLR2004"]
+```
+
+## `sys.version` family
+
+Comparisons against `sys.version`, `sys.version_info`, and
+`sys.implementation.version` are exempt, including subscripts and attribute
+access on them. The literal in those comparisons names a specific Python
+version, not an unnamed constant, so no diagnostics fire below:
+
+```py
+import sys
+
+if sys.version_info[0] >= 3:
+    pass
+
+if sys.version_info.major >= 3:
+    pass
+
+if sys.implementation.version[0] >= 3:
+    pass
+
+if sys.implementation.version[0] < 3:
+    pass
+
+if 3 <= sys.implementation.version[0]:
+    pass
+
+if sys.implementation.version.major >= 3:
+    pass
+
+if sys.version[0] >= "3":
+    pass
+
+if sys.version >= "3.10":
+    pass
+
+if 0 < sys.implementation.version[0] < 4:
+    pass
+```
+
+The exemption only applies when the magic value is compared *against* a
+member of the `sys.version` family. An unrelated comparison with the same
+literal still fires:
+
+```py
+x = 3
+
+if x >= 3:  # error: [magic-value-comparison]
+    pass
+```

--- a/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
@@ -1,5 +1,7 @@
 use itertools::Itertools;
+use ruff_python_ast::helpers::map_subscript;
 use ruff_python_ast::{self as ast, Expr, Int, LiteralExpressionRef, UnaryOp};
+use ruff_python_semantic::SemanticModel;
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::Ranged;
@@ -18,7 +20,9 @@ use crate::rules::pylint::settings::ConstantType;
 /// Such values are discouraged by [PEP 8].
 ///
 /// For convenience, this rule excludes a variety of common values from the
-/// "magic" value definition, such as `0`, `1`, `""`, and `"__main__"`.
+/// "magic" value definition, such as `0`, `1`, `""`, and `"__main__"`. It
+/// also exempts comparisons against `sys.version`, `sys.version_info`, and
+/// `sys.implementation.version`.
 ///
 /// ## Example
 /// ```python
@@ -99,6 +103,21 @@ fn is_magic_value(literal_expr: LiteralExpressionRef, allowed_types: &[ConstantT
     }
 }
 
+/// Returns `true` if `expr` is a comparand whose value is derived from the
+/// running interpreter's version, such as `sys.version`, `sys.version_info`,
+/// `sys.implementation.version`, or a subscript/attribute access on any of
+/// them (for example, `sys.version_info[0]` or
+/// `sys.implementation.version.major`).
+fn is_sys_version_comparand(expr: &Expr, semantic: &SemanticModel) -> bool {
+    let Some(qualified_name) = semantic.resolve_qualified_name(map_subscript(expr)) else {
+        return false;
+    };
+    matches!(
+        qualified_name.segments(),
+        ["sys", "version" | "version_info", ..] | ["sys", "implementation", "version", ..]
+    )
+}
+
 /// PLR2004
 pub(crate) fn magic_value_comparison(checker: &Checker, left: &Expr, comparators: &[Expr]) {
     for (left, right) in std::iter::once(left).chain(comparators).tuple_windows() {
@@ -109,16 +128,24 @@ pub(crate) fn magic_value_comparison(checker: &Checker, left: &Expr, comparators
         }
     }
 
-    for comparison_expr in std::iter::once(left).chain(comparators) {
-        if let Some(value) = as_literal(comparison_expr) {
-            if is_magic_value(value, &checker.settings().pylint.allow_magic_value_types) {
-                checker.report_diagnostic(
-                    MagicValueComparison {
-                        value: checker.locator().slice(comparison_expr).to_string(),
-                    },
-                    comparison_expr.range(),
-                );
-            }
+    let mut previous = None;
+    let mut operands = std::iter::once(left).chain(comparators).peekable();
+    while let Some(comparison_expr) = operands.next() {
+        if let Some(value) = as_literal(comparison_expr)
+            && is_magic_value(value, &checker.settings().pylint.allow_magic_value_types)
+            && !previous.is_some_and(|expr| is_sys_version_comparand(expr, checker.semantic()))
+            && !operands
+                .peek()
+                .is_some_and(|expr| is_sys_version_comparand(expr, checker.semantic()))
+        {
+            checker.report_diagnostic(
+                MagicValueComparison {
+                    value: checker.locator().slice(comparison_expr).to_string(),
+                },
+                comparison_expr.range(),
+            );
         }
+
+        previous = Some(comparison_expr);
     }
 }


### PR DESCRIPTION
## Summary

Closes #25588.
  
This PR adds an exception to PLR2004 (the magic-value-comparison rule). The rule fires when a literal value (like 3) is compared against something. The new exception allows PLR2004 to not fire when the literal is being compared against `sys.version`, `sys.version_info`, or `sys.implementation.version`, including subscripts and attribute access on either. 

Also added regression cases to the fixture and ran `cargo test`, `cargo fmt --check`, `cargo clippy -- -D warnings`, with all returning clean, as part of this PR.