### PR TITLE
[ty] Short-circuit trivial redundancy checks

### DIFF
--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -518,8 +518,30 @@ impl<'db> Type<'db> {
                 .is_always_satisfied(db)
         }
 
-        if self == other {
+        if self == other || matches!(self, Type::Never) {
             return true;
+        }
+
+        match (self, other) {
+            (_, Type::NominalInstance(target)) if target.is_object() => return true,
+            (_, Type::ProtocolInstance(target)) if target.is_equivalent_to_object(db) => {
+                return true;
+            }
+            (Type::Dynamic(_), Type::Dynamic(_)) => return true,
+            (Type::Dynamic(_), Type::Union(union))
+                if union.elements(db).iter().any(Type::is_dynamic) =>
+            {
+                return true;
+            }
+            (Type::Dynamic(_), _) => return false,
+            (_, Type::Dynamic(_)) => {
+                return matches!(self, Type::Intersection(intersection) if intersection
+                    .positive(db)
+                    .iter()
+                    .any(Type::is_non_divergent_dynamic));
+            }
+            (_, Type::Union(union)) if union.elements(db).contains(&self) => return true,
+            _ => {}
         }
 
         is_redundant_with_impl(db, self, other)


### PR DESCRIPTION
## Summary

`Type::is_redundant_with` currently creates a retained Salsa query before the relation checker handles several immediate cases. This means union simplification keeps query entries for pairs that are already known from the outer type shape.

This returns before entering `is_redundant_with_impl` for cases that the relation checker already treats as immediate: `Never`, object-like targets, dynamic pairs, dynamic-containing unions/intersections, and direct containment in a target union. Non-trivial redundancy checks continue through the existing tracked implementation and cycle recovery.

During the split experiment, this accounted for about 18.52 MB (0.58%) of retained-memory reduction on the local `target/torch` fixture.

## Test Plan

- `cargo test -p ty_python_semantic`
- `uvx prek run --files crates/ty_python_semantic/src/types/relation.rs`