### PR TITLE
[ty] Short-circuit trivial two-element unions

### DIFF
--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -67,6 +67,14 @@ impl<'db> UnionType<'db> {
     }
 
     /// Create a union type `A | B` from two elements `A` and `B`.
+    pub fn from_two_elements(db: &'db dyn Db, a: Type<'db>, b: Type<'db>) -> Type<'db> {
+        match (a, b) {
+            _ if a == b => a,
+            (Type::Never, other) | (other, Type::Never) => other,
+            _ => Self::from_two_elements_impl(db, a, b),
+        }
+    }
+
     #[salsa::tracked(
         cycle_initial=|_, id, _, _| Type::divergent(id),
         cycle_fn=|db, cycle, previous: &Type<'db>, result: Type<'db>, _, _| {
@@ -74,7 +82,7 @@ impl<'db> UnionType<'db> {
         },
         heap_size=ruff_memory_usage::heap_size
     )]
-    pub fn from_two_elements(db: &'db dyn Db, a: Type<'db>, b: Type<'db>) -> Type<'db> {
+    fn from_two_elements_impl(db: &'db dyn Db, a: Type<'db>, b: Type<'db>) -> Type<'db> {
         UnionBuilder::new(db).add(a).add(b).build()
     }
 


### PR DESCRIPTION
## Summary

`UnionType::from_two_elements` is a tracked query even for unions that collapse before the builder needs to do any work, such as `T | T` or `Never | T`.

This keeps the public constructor as a small wrapper that returns those trivial results directly and only calls the tracked implementation for non-trivial pairs. The existing builder and cycle recovery remain in use for all other two-element unions.

During the split experiment, this accounted for about 4.82 MB (0.15%) of retained-memory reduction on the local `target/torch` fixture.

## Test Plan

- `cargo test -p ty_python_semantic`
- `uvx prek run --files crates/ty_python_semantic/src/types/set_theoretic.rs`