### PR TITLE
[ty] Update conformance suite pin

### DIFF
--- a/.github/workflows/typing_conformance.yaml
+++ b/.github/workflows/typing_conformance.yaml
@@ -36,7 +36,7 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_DEV_DEBUG: line-tables-only
-  CONFORMANCE_SUITE_COMMIT: 735dba9cea697bf163be39d4c1a62ed4351e3877
+  CONFORMANCE_SUITE_COMMIT: f9664d894c8cbfca8fba44624bdedef09add1aa7
   PYTHON_VERSION: 3.12
 
 jobs:


### PR DESCRIPTION
Update the `python/typing` pin to the latest main. This picks up https://github.com/python/typing/pull/2300, which lets us infer a better solution in a generic function call involving multiple list literals.