### PR TITLE
[ty] Factor De Morgan narrowing conditions

### DIFF
--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1000,7 +1000,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
 ///
 /// Instead of separately narrowing under `A` and `~A & B`, the plan combines them into `A | B`
 /// and evaluates the shared continuation once. Factoring is only available when every predicate
-/// contributes direct complementary intersection constraints `T` and `~T`.
+/// contributes exact structurally complementary intersection constraints.
 struct ProjectedBranchFactorPlan<'db> {
     conditions: Vec<Option<Type<'db>>>,
 }
@@ -1020,9 +1020,10 @@ impl<'db> ProjectedBranchFactorPlan<'db> {
         })
     }
 
-    /// Returns the positive type for a predicate represented exactly by `T` and `~T`.
+    /// Returns the positive type for a predicate with exact structural complements.
     ///
-    /// Replacement, disjunctive, semantically equivalent, and gradual complements are rejected.
+    /// This accepts direct `T` / `~T` pairs and De Morgan DNF pairs. Replacement, merely
+    /// semantically equivalent, and gradual complements are rejected.
     fn atomic_condition(
         db: &'db dyn Db,
         graph: &ProjectedNarrowingGraph<'db>,
@@ -1030,18 +1031,13 @@ impl<'db> ProjectedBranchFactorPlan<'db> {
     ) -> Option<Type<'db>> {
         let (positive, negative) = &graph.predicate_constraints_cache[&node.atom];
         let (positive, negative) = (positive.as_ref()?, negative.as_ref()?);
-        if !positive.is_direct_complement_of(db, negative) {
-            return None;
-        }
-
-        let positive = positive.single_intersection_type()?;
-        let negative = negative.single_intersection_type()?;
+        let condition = positive.exact_complement_condition(db, negative)?;
         // Gradual types do not have an exact set-theoretic complement.
-        if positive.has_dynamic(db) || negative.has_dynamic(db) {
+        if condition.has_dynamic(db) {
             return None;
         }
 
-        Some(positive)
+        Some(condition)
     }
 
     fn factor_condition(

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -592,12 +592,15 @@ impl<'db> NarrowingConstraint<'db> {
         self.replacement_disjuncts.is_empty().then_some(*conjunct)
     }
 
-    /// Returns whether these constraints are represented directly as `T` and `~T`.
+    /// Returns the positive condition when these constraints are exact complements.
     ///
-    /// This checks the stored type shape rather than asking whether arbitrary type expressions are
-    /// semantically complementary. The caller reconstructs the branch condition from the positive
-    /// constraint, so the negative constraint must be its literal `~T` representation.
-    pub(crate) fn is_direct_complement_of(&self, db: &'db dyn Db, other: &Self) -> bool {
+    /// This accepts direct `T` / `~T` pairs and structural De Morgan pairs such as `A | B` /
+    /// `~A & ~B`. It does not ask whether arbitrary type expressions are semantically equivalent.
+    pub(crate) fn exact_complement_condition(
+        &self,
+        db: &'db dyn Db,
+        other: &Self,
+    ) -> Option<Type<'db>> {
         fn is_direct_negation<'db>(db: &'db dyn Db, ty: Type<'db>, negated: Type<'db>) -> bool {
             let Type::Intersection(intersection) = negated else {
                 return false;
@@ -607,12 +610,144 @@ impl<'db> NarrowingConstraint<'db> {
                 && intersection.negative(db).contains(&ty)
         }
 
-        self.single_intersection_type()
+        fn are_direct_complements<'db>(db: &'db dyn Db, left: Type<'db>, right: Type<'db>) -> bool {
+            is_direct_negation(db, left, right) || is_direct_negation(db, right, left)
+        }
+
+        fn are_pairwise_negated<'db>(
+            db: &'db dyn Db,
+            positive: &[Type<'db>],
+            negative: &[Type<'db>],
+        ) -> bool {
+            if positive.len() != negative.len() {
+                return false;
+            }
+
+            let mut unmatched = negative.to_vec();
+            for positive in positive {
+                let Some(index) = unmatched
+                    .iter()
+                    .position(|negative| are_direct_complements(db, *positive, *negative))
+                else {
+                    return false;
+                };
+                unmatched.swap_remove(index);
+            }
+            true
+        }
+
+        if let Some(condition) = self
+            .single_intersection_type()
             .zip(other.single_intersection_type())
-            .is_some_and(|(self_ty, other_ty)| {
-                is_direct_negation(db, self_ty, other_ty)
-                    || is_direct_negation(db, other_ty, self_ty)
+            .and_then(|(self_ty, other_ty)| {
+                are_direct_complements(db, self_ty, other_ty).then_some(self_ty)
             })
+        {
+            return Some(condition);
+        }
+
+        if !self.replacement_disjuncts.is_empty() || !other.replacement_disjuncts.is_empty() {
+            return None;
+        }
+
+        match (
+            &*self.intersection_disjuncts,
+            &*other.intersection_disjuncts,
+        ) {
+            (positive, [negative]) if positive.len() > 1 => {
+                let positive = positive
+                    .iter()
+                    .map(|disjunct| match &*disjunct.conjuncts {
+                        [conjunct] => Some(*conjunct),
+                        _ => None,
+                    })
+                    .collect::<Option<Vec<_>>>()?;
+                are_pairwise_negated(db, &positive, &negative.conjuncts)
+                    .then(|| UnionType::from_elements(db, positive))
+            }
+            ([positive], negative) if positive.conjuncts.len() > 1 && negative.len() > 1 => {
+                let negative = negative
+                    .iter()
+                    .map(|disjunct| match &*disjunct.conjuncts {
+                        [conjunct] => Some(*conjunct),
+                        _ => None,
+                    })
+                    .collect::<Option<Vec<_>>>()?;
+                are_pairwise_negated(db, &positive.conjuncts, &negative)
+                    .then(|| positive.clone().evaluate_constraint_type(db))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Conjunctions, NarrowingConstraint, Type, UnionType};
+    use crate::db::tests::setup_db;
+    use smallvec::{smallvec, smallvec_inline};
+
+    #[test]
+    fn exact_de_morgan_complement_condition() {
+        let db = setup_db();
+        let a = Type::int_literal(1);
+        let b = Type::int_literal(2);
+
+        let direct = NarrowingConstraint::intersection(a);
+        let negated_direct = NarrowingConstraint::intersection(a.negate(&db));
+        assert_eq!(
+            direct.exact_complement_condition(&db, &negated_direct),
+            Some(a)
+        );
+
+        let union = NarrowingConstraint {
+            intersection_disjuncts: smallvec![
+                Conjunctions::singleton(a),
+                Conjunctions::singleton(b),
+            ],
+            replacement_disjuncts: smallvec![],
+        };
+        let negated_union = NarrowingConstraint {
+            intersection_disjuncts: smallvec![Conjunctions {
+                conjuncts: smallvec![a.negate(&db), b.negate(&db)],
+            }],
+            replacement_disjuncts: smallvec![],
+        };
+        assert_eq!(
+            union.exact_complement_condition(&db, &negated_union),
+            Some(UnionType::from_two_elements(&db, a, b))
+        );
+
+        let intersection = NarrowingConstraint {
+            intersection_disjuncts: smallvec![Conjunctions {
+                conjuncts: smallvec![a, b],
+            }],
+            replacement_disjuncts: smallvec![],
+        };
+        let negated_intersection = NarrowingConstraint {
+            intersection_disjuncts: smallvec![
+                Conjunctions::singleton(a.negate(&db)),
+                Conjunctions::singleton(b.negate(&db)),
+            ],
+            replacement_disjuncts: smallvec![],
+        };
+        assert_eq!(
+            intersection.exact_complement_condition(&db, &negated_intersection),
+            Some(
+                Conjunctions {
+                    conjuncts: smallvec_inline![a, b],
+                }
+                .evaluate_constraint_type(&db)
+            )
+        );
+
+        let mismatched = NarrowingConstraint {
+            intersection_disjuncts: smallvec![Conjunctions {
+                conjuncts: smallvec![a.negate(&db), Type::int_literal(3).negate(&db)],
+            }],
+            replacement_disjuncts: smallvec![],
+        };
+        assert_eq!(union.exact_complement_condition(&db, &mismatched), None);
     }
 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -605,9 +605,7 @@ impl<'db> NarrowingConstraint<'db> {
             let Type::Intersection(intersection) = negated else {
                 return false;
             };
-            intersection.positive(db).is_empty()
-                && intersection.negative(db).len() == 1
-                && intersection.negative(db).contains(&ty)
+            intersection.is_simple_negation(db) && intersection.negative(db).contains(&ty)
         }
 
         fn are_direct_complements<'db>(db: &'db dyn Db, left: Type<'db>, right: Type<'db>) -> bool {
@@ -636,6 +634,25 @@ impl<'db> NarrowingConstraint<'db> {
             true
         }
 
+        fn de_morgan_disjunction<'db>(
+            db: &'db dyn Db,
+            disjunction: &[Conjunctions<'db>],
+            conjunction: &Conjunctions<'db>,
+        ) -> Option<SmallVec<[Type<'db>; 2]>> {
+            if disjunction.len() < 2 || conjunction.conjuncts.len() < 2 {
+                return None;
+            }
+
+            let disjunction = disjunction
+                .iter()
+                .map(|disjunct| match &*disjunct.conjuncts {
+                    [conjunct] => Some(*conjunct),
+                    _ => None,
+                })
+                .collect::<Option<SmallVec<_>>>()?;
+            are_pairwise_negated(db, &disjunction, &conjunction.conjuncts).then_some(disjunction)
+        }
+
         if let Some(condition) = self
             .single_intersection_type()
             .zip(other.single_intersection_type())
@@ -654,27 +671,13 @@ impl<'db> NarrowingConstraint<'db> {
             &*self.intersection_disjuncts,
             &*other.intersection_disjuncts,
         ) {
-            (positive, [negative]) if positive.len() > 1 => {
-                let positive = positive
-                    .iter()
-                    .map(|disjunct| match &*disjunct.conjuncts {
-                        [conjunct] => Some(*conjunct),
-                        _ => None,
-                    })
-                    .collect::<Option<Vec<_>>>()?;
-                are_pairwise_negated(db, &positive, &negative.conjuncts)
-                    .then(|| UnionType::from_elements(db, positive))
+            (disjunction, [conjunction]) => {
+                let disjunction = de_morgan_disjunction(db, disjunction, conjunction)?;
+                Some(UnionType::from_elements(db, disjunction))
             }
-            ([positive], negative) if positive.conjuncts.len() > 1 && negative.len() > 1 => {
-                let negative = negative
-                    .iter()
-                    .map(|disjunct| match &*disjunct.conjuncts {
-                        [conjunct] => Some(*conjunct),
-                        _ => None,
-                    })
-                    .collect::<Option<Vec<_>>>()?;
-                are_pairwise_negated(db, &positive.conjuncts, &negative)
-                    .then(|| positive.clone().evaluate_constraint_type(db))
+            ([conjunction], disjunction) => {
+                de_morgan_disjunction(db, disjunction, conjunction)?;
+                Some(conjunction.clone().evaluate_constraint_type(db))
             }
             _ => None,
         }
@@ -683,71 +686,47 @@ impl<'db> NarrowingConstraint<'db> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Conjunctions, NarrowingConstraint, Type, UnionType};
+    use super::{Conjunctions, IntersectionType, NarrowingConstraint, Type, UnionType};
     use crate::db::tests::setup_db;
-    use smallvec::{smallvec, smallvec_inline};
+    use smallvec::SmallVec;
+
+    fn constraint<'db>(disjuncts: &[&[Type<'db>]]) -> NarrowingConstraint<'db> {
+        NarrowingConstraint {
+            intersection_disjuncts: disjuncts
+                .iter()
+                .map(|conjuncts| Conjunctions {
+                    conjuncts: conjuncts.iter().copied().collect(),
+                })
+                .collect(),
+            replacement_disjuncts: SmallVec::default(),
+        }
+    }
 
     #[test]
     fn exact_de_morgan_complement_condition() {
         let db = setup_db();
         let a = Type::int_literal(1);
         let b = Type::int_literal(2);
+        let not_a = a.negate(&db);
+        let not_b = b.negate(&db);
 
-        let direct = NarrowingConstraint::intersection(a);
-        let negated_direct = NarrowingConstraint::intersection(a.negate(&db));
+        let union = constraint(&[&[a], &[b]]);
         assert_eq!(
-            direct.exact_complement_condition(&db, &negated_direct),
-            Some(a)
-        );
-
-        let union = NarrowingConstraint {
-            intersection_disjuncts: smallvec![
-                Conjunctions::singleton(a),
-                Conjunctions::singleton(b),
-            ],
-            replacement_disjuncts: smallvec![],
-        };
-        let negated_union = NarrowingConstraint {
-            intersection_disjuncts: smallvec![Conjunctions {
-                conjuncts: smallvec![a.negate(&db), b.negate(&db)],
-            }],
-            replacement_disjuncts: smallvec![],
-        };
-        assert_eq!(
-            union.exact_complement_condition(&db, &negated_union),
+            union.exact_complement_condition(&db, &constraint(&[&[not_a, not_b]])),
             Some(UnionType::from_two_elements(&db, a, b))
         );
 
-        let intersection = NarrowingConstraint {
-            intersection_disjuncts: smallvec![Conjunctions {
-                conjuncts: smallvec![a, b],
-            }],
-            replacement_disjuncts: smallvec![],
-        };
-        let negated_intersection = NarrowingConstraint {
-            intersection_disjuncts: smallvec![
-                Conjunctions::singleton(a.negate(&db)),
-                Conjunctions::singleton(b.negate(&db)),
-            ],
-            replacement_disjuncts: smallvec![],
-        };
+        let intersection = constraint(&[&[a, b]]);
         assert_eq!(
-            intersection.exact_complement_condition(&db, &negated_intersection),
-            Some(
-                Conjunctions {
-                    conjuncts: smallvec_inline![a, b],
-                }
-                .evaluate_constraint_type(&db)
-            )
+            intersection.exact_complement_condition(&db, &constraint(&[&[not_a], &[not_b]])),
+            Some(IntersectionType::from_elements(&db, [a, b]))
         );
 
-        let mismatched = NarrowingConstraint {
-            intersection_disjuncts: smallvec![Conjunctions {
-                conjuncts: smallvec![a.negate(&db), Type::int_literal(3).negate(&db)],
-            }],
-            replacement_disjuncts: smallvec![],
-        };
-        assert_eq!(union.exact_complement_condition(&db, &mismatched), None);
+        let not_c = Type::int_literal(3).negate(&db);
+        assert_eq!(
+            union.exact_complement_condition(&db, &constraint(&[&[not_a, not_c]])),
+            None
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Stacked on #25729.

#25729 factors projected narrowing when a condition and its negation are represented directly as `T` and `~T`. Compound conditions can encode the same exact relationship using De Morgan's law:

```python
if isinstance(value, A) or isinstance(value, B):
    ...
```

The condition above is represented as `A | B`, while the path where it is false is represented as `~A & ~B`. This change recognizes that literal pair, along with the inverse `A & B` / `~A | ~B`, so the projected narrowing evaluator can use the same factoring as it does for a single condition.

The existing `T` / `~T` case remains the fast path. Replacement narrowing, gradual types, mismatched terms, and types that are only semantically equivalent still use the existing evaluator.

These compound complements occur in pandas and PyTorch. Diagnostics remain byte-identical on both benchmark projects. Local timing was noisy and slightly worse on PyTorch, so this is a draft to evaluate the effect in CodSpeed and the full benchmark matrix.
