### PR TITLE
[ty] Co-locate retained use-def definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erasable"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437cfb75878119ed8265685c41a115724eae43fb7cc5a0bf0e4ecc3b803af1c4"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3946,6 +3956,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "slice-dst"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93a9d7bbfeec8bb3296a8685fbfe89532de4a1f75e691083bae0a2c5de5b313b"
+dependencies = [
+ "autocfg",
+ "erasable",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4649,6 +4669,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.11.1",
  "bitvec",
+ "erasable",
  "get-size2",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
@@ -4665,6 +4686,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "slice-dst",
  "smallvec",
  "static_assertions",
  "thin-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ datatest-stable = { version = "0.3.3" }
 divan = { package = "codspeed-divan-compat", version = "4.4.1" }
 drop_bomb = { version = "0.1.5" }
 dunce = { version = "1.0.5" }
+erasable = { version = "1.3.0" }
 etcetera = { version = "0.11.0" }
 fern = { version = "0.7.0" }
 filetime = { version = "0.2.23" }
@@ -174,6 +175,7 @@ serde_with = { version = "3.6.0", default-features = false, features = [
 ] }
 shellexpand = { version = "3.0.0" }
 similar = { version = "3.0.0", features = ["inline"] }
+slice-dst = { version = "1.6.0", features = ["erasable"] }
 smallvec = { version = "1.13.2", features = ["union", "const_generics", "const_new"] }
 snapbox = { version = "1.0.0", features = [
     "diff",

--- a/crates/ty_python_core/Cargo.toml
+++ b/crates/ty_python_core/Cargo.toml
@@ -25,6 +25,7 @@ ty_combine = { workspace = true }
 
 bitflags = { workspace = true }
 bitvec = { workspace = true }
+erasable = { workspace = true }
 get-size2 = { workspace = true, features = ["indexmap", "ordermap", "thin-vec"] }
 hashbrown = { workspace = true }
 itertools = { workspace = true }
@@ -34,6 +35,7 @@ salsa = { workspace = true, features = ["compact_str", "ordermap"] }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = {workspace = true, optional = true }
+slice-dst = { workspace = true }
 smallvec = { workspace = true }
 static_assertions = { workspace = true }
 thin-vec = { workspace = true }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2448,7 +2448,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let mut use_def_maps: IndexVec<_, _> = self
             .use_def_maps
             .into_iter()
-            .map(|builder| Arc::new(builder.finish()))
+            .map(UseDefMapBuilder::finish)
             .collect();
 
         let ast_ids = super::ast_ids::AstIds::from_builders(self.ast_ids);

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -93,12 +93,12 @@ pub fn place_table<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<PlaceTable>
 /// Using [`use_def_map`] over [`semantic_index`] has the advantage that
 /// Salsa can avoid invalidating dependent queries if this scope's use-def map
 /// is unchanged.
-#[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-pub fn use_def_map<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<UseDefMap<'db>> {
+#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+pub fn use_def_map<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> UseDefMap<'db> {
     let file = scope.file(db);
     let _span = tracing::trace_span!("use_def_map", scope=?scope.as_id(), ?file).entered();
     let index = semantic_index(db, file);
-    Arc::clone(&index.use_def_maps[scope.file_scope_id(db)])
+    index.use_def_maps[scope.file_scope_id(db)].clone()
 }
 
 /// All the bindings made in a loop, which are visible to the entire loop via "loop header
@@ -332,7 +332,7 @@ pub struct SemanticIndex<'db> {
     scope_ids_by_scope: FrozenIndexVec<FileScopeId, ScopeId<'db>>,
 
     /// Use-def map for each scope in this file.
-    use_def_maps: FrozenIndexVec<FileScopeId, Arc<UseDefMap<'db>>>,
+    use_def_maps: FrozenIndexVec<FileScopeId, UseDefMap<'db>>,
 
     /// Lookup table to map between node ids and ast nodes.
     ///

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -240,11 +240,16 @@
 //! visits a `StmtIf` node.
 
 use std::collections::hash_map::Entry;
+use std::mem::size_of_val;
 use std::ops::{Index, Range};
+use std::sync::Arc;
 
+use erasable::Thin;
+use get_size2::{GetSize, GetSizeTracker};
 use ruff_index::{FrozenIndexVec, Idx, IndexSlice, IndexVec, newtype_index};
 use ruff_text_size::TextRange;
 use rustc_hash::{FxBuildHasher, FxHashMap};
+use slice_dst::SliceWithHeader;
 use thin_vec::ThinVec;
 
 use crate::ast_ids::ScopedUseId;
@@ -487,13 +492,21 @@ enum InternedEnclosingSnapshotId {
     Bindings(InternedBindingsId),
 }
 
-/// Applicable definitions and constraints for every use of a name.
-#[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+/// Pointer-sized shared handle to the applicable definitions and constraints for every use of a
+/// name.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UseDefMap<'db> {
-    /// Array of [`Definition`] in this scope. Only the first entry should be [`DefinitionState::Undefined`];
-    /// this represents the implicit "unbound"/"undeclared" definition of every place.
-    all_definitions: FrozenIndexVec<ScopedDefinitionId, DefinitionState<'db>>,
+    data: Thin<Arc<UseDefMapData<'db>>>,
+}
 
+/// Fixed use-def data followed by the definitions for the scope.
+///
+/// The trailing slice is never empty: its first entry is the implicit "unbound"/"undeclared"
+/// definition of every place.
+type UseDefMapData<'db> = SliceWithHeader<UseDefMapHeader<'db>, DefinitionState<'db>>;
+
+#[derive(Debug, PartialEq, Eq, get_size2::GetSize)]
+struct UseDefMapHeader<'db> {
     /// A bitset-like map indicating whether each binding definition has at least one use.
     ///
     /// This uses the same index as `all_definitions`.
@@ -572,6 +585,42 @@ pub struct UseDefMap<'db> {
     end_of_scope_reachability: ScopedReachabilityConstraintId,
 }
 
+#[expect(unsafe_code)]
+unsafe impl salsa::Update for UseDefMap<'_> {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        let old = unsafe { &mut *old_pointer };
+        if Thin::ptr_eq(&old.data, &new_value.data) {
+            false
+        } else {
+            // Preserve the previous shared-`Arc` update behavior. Deeply comparing every retained
+            // use-def map here would add work to incremental updates.
+            *old = new_value;
+            true
+        }
+    }
+}
+
+impl GetSize for UseDefMap<'_> {
+    fn get_heap_size_with_tracker<Tracker: GetSizeTracker>(
+        &self,
+        mut tracker: Tracker,
+    ) -> (usize, Tracker) {
+        if !tracker.track(std::ptr::from_ref(&self.data.header)) {
+            return (0, tracker);
+        }
+
+        let mut size = size_of_val(&*self.data);
+        let (header_size, mut tracker) = self.data.header.get_heap_size_with_tracker(tracker);
+        size += header_size;
+        for definition in &self.data.slice {
+            let (definition_size, next_tracker) = definition.get_heap_size_with_tracker(tracker);
+            size += definition_size;
+            tracker = next_tracker;
+        }
+        (size, tracker)
+    }
+}
+
 /// Information about a given range of source code.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 struct RangeInfo {
@@ -606,38 +655,47 @@ pub enum ApplicableConstraints<'map, 'db> {
 }
 
 impl<'db> UseDefMap<'db> {
+    fn header(&self) -> &UseDefMapHeader<'db> {
+        &self.data.header
+    }
+
+    fn all_definitions(&self) -> &IndexSlice<ScopedDefinitionId, DefinitionState<'db>> {
+        IndexSlice::from_raw(&self.data.slice)
+    }
+
     pub fn reachability_constraints(&self) -> &ReachabilityConstraints {
-        &self.reachability_constraints
+        &self.header().reachability_constraints
     }
 
     pub fn predicates(&self) -> &Predicates<'db> {
-        &self.predicates
+        &self.header().predicates
     }
 
     pub fn range_reachability(
         &self,
     ) -> impl Iterator<Item = (TextRange, ScopedReachabilityConstraintId)> + '_ {
-        self.range_reachability
+        self.header()
+            .range_reachability
             .iter()
             .map(|&(range, RangeInfo { reachability, .. })| (range, reachability))
     }
 
     pub fn end_of_scope_reachability(&self) -> ScopedReachabilityConstraintId {
-        self.end_of_scope_reachability
+        self.header().end_of_scope_reachability
     }
 
     pub fn all_definitions_with_usage(
         &self,
     ) -> impl Iterator<Item = (ScopedDefinitionId, DefinitionState<'db>, bool)> + '_ {
-        self.all_definitions
+        self.all_definitions()
             .iter_enumerated()
-            .map(|(id, &state)| (id, state, self.used_bindings[id]))
+            .map(|(id, &state)| (id, state, self.header().used_bindings[id]))
     }
 
     pub fn bindings_at_use(&self, use_id: ScopedUseId) -> BindingWithConstraintsIterator<'_, 'db> {
-        let bindings_id = self.bindings_by_use[use_id];
+        let bindings_id = self.header().bindings_by_use[use_id];
         self.bindings_iterator(
-            &self.interned_bindings[bindings_id],
+            &self.header().interned_bindings[bindings_id],
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -646,7 +704,8 @@ impl<'db> UseDefMap<'db> {
         &self,
         use_id: ScopedUseId,
     ) -> impl Iterator<Item = BindingWithConstraintsIterator<'_, 'db>> {
-        self.multi_bindings_by_use
+        self.header()
+            .multi_bindings_by_use
             .get(use_id)
             .map(|member_bindings| {
                 member_bindings.iter().map(|bindings| {
@@ -671,8 +730,8 @@ impl<'db> UseDefMap<'db> {
             ConstraintKey::NarrowingConstraint(constraint) => {
                 ApplicableConstraints::UnboundBinding(NarrowingEvaluator {
                     constraint,
-                    predicates: &self.predicates,
-                    reachability_constraints: &self.reachability_constraints,
+                    predicates: &self.header().predicates,
+                    reachability_constraints: &self.header().reachability_constraints,
                 })
             }
             ConstraintKey::NestedScope(nested_scope) => {
@@ -692,7 +751,7 @@ impl<'db> UseDefMap<'db> {
     }
 
     pub fn definition(&self, id: ScopedDefinitionId) -> DefinitionState<'db> {
-        self.all_definitions[id]
+        self.all_definitions()[id]
     }
 
     pub fn narrowing_evaluator(
@@ -701,13 +760,14 @@ impl<'db> UseDefMap<'db> {
     ) -> NarrowingEvaluator<'_, 'db> {
         NarrowingEvaluator {
             constraint,
-            predicates: &self.predicates,
-            reachability_constraints: &self.reachability_constraints,
+            predicates: &self.header().predicates,
+            reachability_constraints: &self.header().reachability_constraints,
         }
     }
 
     pub(crate) fn is_range_in_type_checking_block(&self, range: TextRange) -> bool {
-        self.range_reachability
+        self.header()
+            .range_reachability
             .iter()
             .take_while(|(entry_range, _)| entry_range.start() <= range.start())
             .any(|&(entry_range, block)| {
@@ -728,9 +788,9 @@ impl<'db> UseDefMap<'db> {
         &self,
         symbol: ScopedSymbolId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let place_state_id = self.symbol_states[symbol].end_of_scope;
+        let place_state_id = self.header().symbol_states[symbol].end_of_scope;
         self.bindings_iterator(
-            &self.interned_bindings[place_state_id.bindings_id()],
+            &self.header().interned_bindings[place_state_id.bindings_id()],
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -739,9 +799,9 @@ impl<'db> UseDefMap<'db> {
         &self,
         member: ScopedMemberId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let place_state_id = self.member_states[member].end_of_scope;
+        let place_state_id = self.header().member_states[member].end_of_scope;
         self.bindings_iterator(
-            &self.interned_bindings[place_state_id.bindings_id()],
+            &self.header().interned_bindings[place_state_id.bindings_id()],
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -760,8 +820,8 @@ impl<'db> UseDefMap<'db> {
         &self,
         symbol: ScopedSymbolId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let place_state_id = self.symbol_states[symbol].reachable;
-        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
+        let place_state_id = self.header().symbol_states[symbol].reachable;
+        let bindings = &self.header().interned_bindings[place_state_id.bindings_id()];
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -769,8 +829,8 @@ impl<'db> UseDefMap<'db> {
         &self,
         member: ScopedMemberId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let place_state_id = self.member_states[member].reachable;
-        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
+        let place_state_id = self.header().member_states[member].reachable;
+        let bindings = &self.header().interned_bindings[place_state_id.bindings_id()];
         self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
     }
 
@@ -786,17 +846,15 @@ impl<'db> UseDefMap<'db> {
             BoundnessAnalysis::AssumeBound
         };
 
-        match self.enclosing_snapshots.get(snapshot_id) {
+        match self.header().enclosing_snapshots.get(snapshot_id) {
             Some(InternedEnclosingSnapshotId::Constraint(constraint)) => {
                 EnclosingSnapshotResult::FoundConstraint(*constraint)
             }
             Some(InternedEnclosingSnapshotId::Bindings(bindings_id)) => {
-                EnclosingSnapshotResult::FoundBindings(
-                    self.bindings_iterator(
-                        &self.interned_bindings[*bindings_id],
-                        boundness_analysis,
-                    ),
-                )
+                EnclosingSnapshotResult::FoundBindings(self.bindings_iterator(
+                    &self.header().interned_bindings[*bindings_id],
+                    boundness_analysis,
+                ))
             }
             None => EnclosingSnapshotResult::NotFound,
         }
@@ -806,9 +864,9 @@ impl<'db> UseDefMap<'db> {
         &self,
         definition: Definition<'db>,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let bindings_id = self.definitions_by_definition[&definition].bindings;
+        let bindings_id = self.header().definitions_by_definition[&definition].bindings;
         self.bindings_iterator(
-            &self.interned_bindings[bindings_id],
+            &self.header().interned_bindings[bindings_id],
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -817,11 +875,11 @@ impl<'db> UseDefMap<'db> {
         &self,
         binding: Definition<'db>,
     ) -> DeclarationsIterator<'_, 'db> {
-        let declarations_id = self.definitions_by_definition[&binding]
+        let declarations_id = self.header().definitions_by_definition[&binding]
             .declarations
             .expect("binding definition should have retained declarations");
         self.declarations_iterator(
-            &self.interned_declarations[declarations_id],
+            &self.header().interned_declarations[declarations_id],
             BoundnessAnalysis::BasedOnUnboundVisibility,
         )
     }
@@ -840,8 +898,8 @@ impl<'db> UseDefMap<'db> {
         &'map self,
         symbol: ScopedSymbolId,
     ) -> DeclarationsIterator<'map, 'db> {
-        let place_state_id = self.symbol_states[symbol].end_of_scope;
-        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
+        let place_state_id = self.header().symbol_states[symbol].end_of_scope;
+        let declarations = &self.header().interned_declarations[place_state_id.declarations_id()];
         self.declarations_iterator(declarations, BoundnessAnalysis::BasedOnUnboundVisibility)
     }
 
@@ -849,8 +907,8 @@ impl<'db> UseDefMap<'db> {
         &'map self,
         member: ScopedMemberId,
     ) -> DeclarationsIterator<'map, 'db> {
-        let place_state_id = self.member_states[member].end_of_scope;
-        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
+        let place_state_id = self.header().member_states[member].end_of_scope;
+        let declarations = &self.header().interned_declarations[place_state_id.declarations_id()];
         self.declarations_iterator(declarations, BoundnessAnalysis::BasedOnUnboundVisibility)
     }
 
@@ -858,8 +916,8 @@ impl<'db> UseDefMap<'db> {
         &self,
         symbol: ScopedSymbolId,
     ) -> DeclarationsIterator<'_, 'db> {
-        let place_state_id = self.symbol_states[symbol].reachable;
-        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
+        let place_state_id = self.header().symbol_states[symbol].reachable;
+        let declarations = &self.header().interned_declarations[place_state_id.declarations_id()];
         self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
     }
 
@@ -867,8 +925,8 @@ impl<'db> UseDefMap<'db> {
         &self,
         member: ScopedMemberId,
     ) -> DeclarationsIterator<'_, 'db> {
-        let place_state_id = self.member_states[member].reachable;
-        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
+        let place_state_id = self.header().member_states[member].reachable;
+        let declarations = &self.header().interned_declarations[place_state_id.declarations_id()];
         self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
     }
 
@@ -882,7 +940,8 @@ impl<'db> UseDefMap<'db> {
     pub fn all_end_of_scope_symbol_declarations<'map>(
         &'map self,
     ) -> impl Iterator<Item = (ScopedSymbolId, DeclarationsIterator<'map, 'db>)> + 'map {
-        self.symbol_states
+        self.header()
+            .symbol_states
             .indices()
             .map(|symbol_id| (symbol_id, self.end_of_scope_symbol_declarations(symbol_id)))
     }
@@ -891,7 +950,8 @@ impl<'db> UseDefMap<'db> {
         &'map self,
     ) -> impl Iterator<Item = (ScopedSymbolId, BindingWithConstraintsIterator<'map, 'db>)> + 'map
     {
-        self.symbol_states
+        self.header()
+            .symbol_states
             .indices()
             .map(|symbol_id| (symbol_id, self.end_of_scope_symbol_bindings(symbol_id)))
     }
@@ -905,14 +965,14 @@ impl<'db> UseDefMap<'db> {
             BindingWithConstraintsIterator<'map, 'db>,
         ),
     > + 'map {
-        self.symbol_states.iter_enumerated().map(
+        self.header().symbol_states.iter_enumerated().map(
             |(symbol_id, RetainedPlaceStates { reachable, .. })| {
                 let declarations = self.declarations_iterator(
-                    &self.interned_declarations[reachable.declarations_id()],
+                    &self.header().interned_declarations[reachable.declarations_id()],
                     BoundnessAnalysis::AssumeBound,
                 );
                 let bindings = self.bindings_iterator(
-                    &self.interned_bindings[reachable.bindings_id()],
+                    &self.header().interned_bindings[reachable.bindings_id()],
                     BoundnessAnalysis::AssumeBound,
                 );
                 (symbol_id, declarations, bindings)
@@ -926,9 +986,9 @@ impl<'db> UseDefMap<'db> {
         boundness_analysis: BoundnessAnalysis,
     ) -> BindingWithConstraintsIterator<'map, 'db> {
         BindingWithConstraintsIterator {
-            all_definitions: &self.all_definitions,
-            predicates: &self.predicates,
-            reachability_constraints: &self.reachability_constraints,
+            all_definitions: self.all_definitions(),
+            predicates: &self.header().predicates,
+            reachability_constraints: &self.header().reachability_constraints,
             boundness_analysis,
             inner: bindings.iter(),
         }
@@ -940,9 +1000,9 @@ impl<'db> UseDefMap<'db> {
         boundness_analysis: BoundnessAnalysis,
     ) -> DeclarationsIterator<'map, 'db> {
         DeclarationsIterator {
-            all_definitions: &self.all_definitions,
-            predicates: &self.predicates,
-            reachability_constraints: &self.reachability_constraints,
+            all_definitions: self.all_definitions(),
+            predicates: &self.header().predicates,
+            reachability_constraints: &self.header().reachability_constraints,
             boundness_analysis,
             inner: declarations.iter(),
         }
@@ -1901,7 +1961,6 @@ impl<'db> UseDefMapBuilder<'db> {
     }
 
     pub(super) fn finish(mut self) -> UseDefMap<'db> {
-        self.all_definitions.shrink_to_fit();
         self.used_bindings.shrink_to_fit();
         self.symbol_states.shrink_to_fit();
         self.member_states.shrink_to_fit();
@@ -1992,8 +2051,7 @@ impl<'db> UseDefMapBuilder<'db> {
             Self::zip_place_states(end_of_scope_members, reachable_definitions_by_member);
         let multi_bindings_by_use = MultiBindingsByUse::from_map(self.multi_bindings_by_use);
 
-        UseDefMap {
-            all_definitions: self.all_definitions.into(),
+        let header = UseDefMapHeader {
             used_bindings: self.used_bindings.into(),
             predicates: self.predicates.build(),
             reachability_constraints: self.reachability_constraints.build(),
@@ -2007,7 +2065,9 @@ impl<'db> UseDefMapBuilder<'db> {
             definitions_by_definition,
             enclosing_snapshots: enclosing_snapshots.into(),
             end_of_scope_reachability: self.reachability,
-        }
+        };
+        let data: Arc<UseDefMapData<'db>> = SliceWithHeader::new(header, self.all_definitions);
+        UseDefMap { data: data.into() }
     }
 
     fn zip_place_states<I: Idx, T>(
@@ -2147,5 +2207,30 @@ impl<'db> UseDefMapBuilder<'db> {
 
         interned_ids_by_snapshot.shrink_to_fit();
         interned_ids_by_snapshot
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn use_def_map_is_pointer_sized() {
+        assert_eq!(
+            std::mem::size_of::<UseDefMap<'_>>(),
+            std::mem::size_of::<usize>()
+        );
+    }
+
+    #[test]
+    fn use_def_map_clones_share_data() {
+        let map = UseDefMapBuilder::new(false).finish();
+        let cloned = map.clone();
+
+        assert!(Thin::ptr_eq(&map.data, &cloned.data));
+        assert_eq!(
+            cloned.definition(ScopedDefinitionId::UNBOUND),
+            DefinitionState::Undefined
+        );
     }
 }


### PR DESCRIPTION
## Summary

Each scope currently retains an `Arc<UseDefMap>` allocation whose `all_definitions` field points to a separate boxed-slice allocation. The definition slice is always nonempty because its first entry represents the implicit unbound definition.

This changes `UseDefMap` into a pointer-sized shared handle over `Thin<Arc<SliceWithHeader<UseDefMapHeader, DefinitionState>>>`. The fixed use-def fields and definition states now share one allocation, while `SemanticIndex` and the per-scope Salsa query continue to expose `&UseDefMap`.

The custom DST needs explicit `GetSize` and Salsa `Update` implementations because those traits are not provided by `slice-dst` or `erasable`. The update implementation preserves the previous shared-`Arc` behavior by treating different allocations as changed instead of deeply comparing the full map.

Local memory-report results:

| Project | Retained memory | Scopes |
| --- | ---: | ---: |
| flake8 | -35.80 kB (-0.09%) | 4,583 |
| trio | -65.32 kB (-0.06%) | 8,361 |
| sphinx | -110.64 kB (-0.05%) | 14,162 |
| prefect | -302.87 kB (-0.04%) | 38,767 |

The tracked reduction is exactly 8 bytes per scope. These figures do not include allocator metadata for the removed allocation, so the RSS effect may differ.

On flake8, 10 local runs showed no meaningful wall-time difference: 297.2 ms +/- 18.5 ms on `main` and 303.3 ms +/- 19.2 ms with this change.

This is a draft to assess the broader CI memory, ecosystem, and performance results before deciding whether the allocation reduction is worth the additional representation complexity.
