### PR TITLE
[ty] Avoid crash when hovering over Callable

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -4104,6 +4104,37 @@ def function():
     }
 
     #[test]
+    fn hover_callable_special_forms() {
+        let test = hover_test(
+            r#"
+            from collections.abc import Callable
+
+            Callable<CURSOR>
+            "#,
+        );
+
+        let hover = test.hover();
+        assert!(
+            hover.starts_with("<special-form 'collections.abc.Callable'>"),
+            "{hover}"
+        );
+
+        let test = hover_test(
+            r#"
+            from typing import Callable
+
+            Callable<CURSOR>
+            "#,
+        );
+
+        let hover = test.hover();
+        assert!(
+            hover.starts_with("<special-form 'typing.Callable'>"),
+            "{hover}"
+        );
+    }
+
+    #[test]
     fn hover_type_of_expression_with_type_var_type() {
         let test = hover_test(
             r#"

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -468,10 +468,11 @@ impl<'db> SemanticModel<'db> {
                 else {
                     return TypeQualifiers::empty();
                 };
-                let module = parsed_module(self.db, self.file).load(self.db);
+                let definition_file = definition.file(self.db);
+                let module = parsed_module(self.db, definition_file).load(self.db);
                 if !definition
                     .kind(self.db)
-                    .category(self.file.is_stub(self.db), &module)
+                    .category(definition_file.is_stub(self.db), &module)
                     .is_declaration()
                 {
                     return TypeQualifiers::empty();


### PR DESCRIPTION
## Summary

When resolving qualifiers for an imported name, use the resolved definition's file to interpret its AST-backed definition kind. Previously, hover combined a definition from typeshed with the importing module's AST, which could panic for `typing.Callable` and `collections.abc.Callable`.

Add regression coverage for both imports.

Closes https://github.com/astral-sh/ty/issues/3698.
