### PR TITLE
[ty] Avoid caching same-file raw signatures

### DIFF
--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -858,7 +858,7 @@ impl<'db> FunctionLiteral<'db> {
     /// calling query is not in the same file as this function is defined in, then this will create
     /// a cross-module dependency directly on the full AST which will lead to cache
     /// over-invalidation.
-    fn last_definition_raw_signature(
+    pub(super) fn last_definition_raw_signature(
         self,
         db: &'db dyn Db,
         return_callable_typevar_scope: ReturnCallableTypeVarScope,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -18,9 +18,7 @@ use crate::types::infer::original_class_type;
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
-use crate::types::signatures::{
-    CallableSignature, Parameters, ReturnCallableTypeVarScope, SignatureRelationVisitor,
-};
+use crate::types::signatures::{CallableSignature, Parameters, SignatureRelationVisitor};
 use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
 use crate::types::type_alias::{walk_manual_pep_695_type_alias, walk_pep_695_type_alias};
 use crate::types::typevar::{
@@ -123,22 +121,21 @@ pub(crate) fn bind_typevar<'db>(
     // Walk ancestor scopes, tracking whether we've crossed a class scope boundary.
     // Class-scoped type variables are not visible from inner class scopes.
     let mut crossed_class_scope = false;
-    for (_, ancestor_scope) in index.ancestor_scopes(containing_scope) {
+    for (ancestor_scope_id, ancestor_scope) in index.ancestor_scopes(containing_scope) {
         let is_class_scope = ancestor_scope.kind().is_class();
-        let generic_context = match ancestor_scope.node() {
-            NodeWithScopeKind::FunctionTypeParameters(function) => {
+        if let NodeWithScopeKind::FunctionTypeParameters(function) = ancestor_scope.node() {
+            // PEP 695 type parameters are defined in the function's type-parameter scope.
+            // Check that directly instead of reconstructing the function's signature.
+            if typevar
+                .definition(db)
+                .is_some_and(|definition| definition.file_scope(db) == ancestor_scope_id)
+            {
                 let definition = index.expect_single_definition(function);
-                infer_definition_types(db, definition)
-                    .function_type(definition)
-                    .and_then(|function_type| {
-                        function_type
-                            .literal(db)
-                            .last_definition_raw_signature(db, ReturnCallableTypeVarScope::Lexical)
-                            .generic_context
-                    })
+                return Some(typevar.with_binding_context(db, definition));
             }
-            node => GenericContext::of_node(db, node, index),
-        };
+            continue;
+        }
+        let generic_context = GenericContext::of_node(db, ancestor_scope.node(), index);
         // If we've already crossed a class boundary, skip class-scoped generic contexts.
         // This prevents inner classes from accessing type parameters of outer classes.
         if (!is_class_scope || !crossed_class_scope)

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -132,6 +132,7 @@ pub(crate) fn bind_typevar<'db>(
                     .function_type(definition)
                     .and_then(|function_type| {
                         function_type
+                            .literal(db)
                             .last_definition_raw_signature(db, ReturnCallableTypeVarScope::Lexical)
                             .generic_context
                     })

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5085,6 +5085,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // i.e. type variables in the return type are non-inferable,
                     // and the return types of async functions are not wrapped in `CoroutineType[...]`.
                     let return_ty = func
+                        .literal(self.db())
                         .last_definition_raw_signature(
                             self.db(),
                             ReturnCallableTypeVarScope::Lexical,
@@ -8617,6 +8618,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         };
         let declared_return_ty = enclosing_function
+            .literal(self.db())
             .last_definition_raw_signature(self.db(), ReturnCallableTypeVarScope::Public)
             .return_ty;
         let return_type_span = enclosing_function.spans(self.db()).return_type;
@@ -8665,6 +8667,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         };
         let annotated_return_ty = enclosing_function
+            .literal(self.db())
             .last_definition_raw_signature(self.db(), ReturnCallableTypeVarScope::Public)
             .return_ty;
 

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -81,6 +81,7 @@ impl<'db> ExpectedReturnType<'db> {
         let public = normalize(
             db,
             function
+                .literal(db)
                 .last_definition_raw_signature(db, ReturnCallableTypeVarScope::Public)
                 .return_ty,
         );
@@ -88,6 +89,7 @@ impl<'db> ExpectedReturnType<'db> {
             normalize(
                 db,
                 function
+                    .literal(db)
                     .last_definition_raw_signature(db, ReturnCallableTypeVarScope::Lexical)
                     .return_ty,
             )
@@ -168,6 +170,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let enclosing_function = nearest_enclosing_function(db, self.index, self.scope())
                 .expect("should be in a function body scope");
             let declared_ty = enclosing_function
+                .literal(db)
                 .last_definition_raw_signature(db, ReturnCallableTypeVarScope::Public)
                 .return_ty;
             let expected_return =


### PR DESCRIPTION
## Summary

`FunctionType::last_definition_raw_signature` is a tracked query so cross-query callers can ask for a function signature without depending directly on the defining AST node. Several inference paths call it while already operating on the same file and only need the raw last-definition signature for local return-type or generic-context handling.

This exposes the underlying `FunctionLiteral` helper within the `types` module and routes those same-file inference call sites through it directly. Cross-file and external callers continue to use the tracked `FunctionType` query; the bypass is limited to callers that are already in same-file inference context.
