### PR TITLE
[ty] Avoid standalone expression queries during scope inference

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5882,6 +5882,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         expression: &ast::Expr,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
+        if matches!(self.region, InferenceRegion::Scope(..)) {
+            return self.infer_expression_impl(expression, tcx);
+        }
+
         if let Some(standalone_expression) = self.index.try_expression(expression) {
             self.infer_standalone_expression_impl(expression, standalone_expression, tcx)
         } else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1648,8 +1648,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn infer_body(&mut self, suite: &[ast::Stmt]) {
-        for statement in suite {
-            self.infer_maybe_standalone_statement(statement);
+        for (index, statement) in suite.iter().enumerate() {
+            self.infer_maybe_standalone_statement(statement, index + 1 < suite.len());
 
             if let ast::Stmt::Expr(ast::StmtExpr {
                 range: _,
@@ -5834,9 +5834,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
-    fn infer_maybe_standalone_statement(&mut self, statement: &ast::Stmt) {
+    fn infer_maybe_standalone_statement(
+        &mut self,
+        statement: &ast::Stmt,
+        has_following_statement: bool,
+    ) {
         if let Some(standalone_statement) = self.index.try_statement(statement) {
             self.infer_standalone_statement_impl(standalone_statement);
+        } else if has_following_statement
+            && matches!(self.region, InferenceRegion::Scope(..))
+            && let ast::Stmt::Expr(ast::StmtExpr { value, .. }) = statement
+            && let Some(standalone_expression) = self.index.try_expression(value)
+        {
+            // A following statement can consume this call's `IsNonTerminalCall` predicate.
+            // Preserve the standalone query so reachability reuses the inferred call type.
+            self.infer_standalone_expression_impl(
+                value,
+                standalone_expression,
+                TypeContext::default(),
+            );
         } else {
             self.infer_statement(statement);
         }


### PR DESCRIPTION
## Summary

`infer_maybe_standalone_expression` used the standalone-expression query path even while the enclosing scope query was already walking the same expression. That retained a separate `infer_expression_types` result and then merged it back into the active scope builder.

This bypasses that query when inference is already running in a scope region, inferring the expression directly into the current builder instead. Definition and standalone expression regions keep the existing standalone query path.

## Test Plan

- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic`
- `uvx prek run --files crates/ty_python_semantic/src/types/infer/builder.rs`