### PR TITLE
[ty] Propagate nested ParamSpec specializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -601,6 +601,16 @@ def id_callable[**P, R](x: Callable[P, R]) -> Callable[P, R]:
 f5_paramspec: Callable[[int], int] = id_callable(lambda x: reveal_type(x))  # revealed: int
 reveal_type(f5_paramspec)  # revealed: (x: int) -> int
 
+# The inner call's concrete ParamSpec specialization should propagate to the outer call.
+def outer_id_callable[**P, R](x: Callable[P, R]) -> Callable[P, R]:
+    return x
+
+def target(value: str, count: int = 1) -> int:
+    return count
+
+nested_paramspec = outer_id_callable(id_callable(target))
+reveal_type(nested_paramspec)  # revealed: (value: str, count: int = 1) -> int
+
 # TODO: This should not error once we support `Unpack`.
 # error: [invalid-assignment]
 f6: Callable[[*tuple[int, ...]], None] = lambda x, y, z: None

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -605,11 +605,17 @@ reveal_type(f5_paramspec)  # revealed: (x: int) -> int
 def outer_id_callable[**P, R](x: Callable[P, R]) -> Callable[P, R]:
     return x
 
+def outermost_id_callable[**P, R](x: Callable[P, R]) -> Callable[P, R]:
+    return x
+
 def target(value: str, count: int = 1) -> int:
     return count
 
 nested_paramspec = outer_id_callable(id_callable(target))
 reveal_type(nested_paramspec)  # revealed: (value: str, count: int = 1) -> int
+
+triply_nested_paramspec = outermost_id_callable(outer_id_callable(id_callable(target)))
+reveal_type(triply_nested_paramspec)  # revealed: (value: str, count: int = 1) -> int
 
 # TODO: This should not error once we support `Unpack`.
 # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -681,6 +681,17 @@ def keyword_only2(*, y: int) -> int:
 # common supertype, so it should result in an error.
 # error: [invalid-argument-type] "Argument to function `multiple` is incorrect: Expected `(*, x: int) -> int`, found `def keyword_only2(*, y: int) -> int`"
 reveal_type(multiple(keyword_only1, keyword_only2))  # revealed: (*, x: int) -> bool
+
+def takes_int(value: int) -> int:
+    return value
+
+def takes_str(value: str) -> int:
+    return len(value)
+
+# A return-type context must not change the first-seen behavior for actual arguments.
+# error: [invalid-assignment]
+# error: [invalid-argument-type]
+preferred_second: Callable[[str], bool] = multiple(takes_int, takes_str)
 ```
 
 ### Constructors of user-defined generic class on `ParamSpec`

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4882,6 +4882,13 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     for binding in solution {
                         let identity = binding.bound_typevar.identity(self.db);
                         if let Some(&ty) = preferred.get(&identity) {
+                            // Defer preferred `ParamSpec` mappings until after argument inference
+                            // so that a concrete argument-derived mapping is propagated through
+                            // the return type to an outer generic call.
+                            if binding.bound_typevar.is_paramspec(self.db) {
+                                continue;
+                            }
+
                             builder.add_type_mapping(
                                 binding.bound_typevar,
                                 ty,
@@ -5019,6 +5026,20 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         error,
                         argument_index: adjusted_argument_index,
                     });
+                }
+            }
+        }
+
+        // The legacy solver keeps the first `ParamSpec` mapping. Add the type-context preference
+        // last so that it acts as a fallback when no argument inferred a specialization.
+        if let Some(generic_context) = self.signature.generic_context {
+            for typevar in generic_context
+                .variables(self.db)
+                .filter(|typevar| typevar.is_paramspec(self.db))
+            {
+                if let Some(&preferred_ty) = preferred_type_mappings.get(&typevar.identity(self.db))
+                {
+                    builder.add_type_mapping(typevar, preferred_ty, TypeVarVariance::Invariant);
                 }
             }
         }


### PR DESCRIPTION
## Summary

The legacy specialization builder keeps the first mapping inferred for a `ParamSpec`. Bidirectional inference installed the symbolic mapping from the outer call's return context before processing the inner call's arguments, so the later concrete argument-derived mapping was discarded. Adding the contextual mapping last makes it a fallback while allowing the concrete specialization to flow through the inner return type into the outer call.

Closes astral-sh/ty#3691

## Validation

Add test cases.
