### PR TITLE
[ty] Add TypeVarTuple support

### DIFF
--- a/crates/mdtest/src/matcher.rs
+++ b/crates/mdtest/src/matcher.rs
@@ -260,31 +260,13 @@ impl UnmatchedWithColumn for &Diagnostic {
 
 /// Discard `@Todo`-type metadata from expected types, which is not available
 /// when running in release mode.
-///
-/// Some `@Todo` variants (like `@Todo(StarredExpression)` and `@Todo(typing.Unpack)`)
-/// are hardcoded enum variants that always display their message, so we preserve those.
 fn discard_todo_metadata(ty: &str) -> Cow<'_, str> {
     #[cfg(not(debug_assertions))]
     {
-        /// `@Todo` variants that are hardcoded and always display their message,
-        /// even in release mode.
-        const PRESERVED_TODO_VARIANTS: &[&str] = &[
-            "@Todo(StarredExpression)",
-            "@Todo(typing.Unpack)",
-            "@Todo(TypeVarTuple)",
-        ];
-
         static TODO_METADATA_REGEX: LazyLock<regex::Regex> =
             LazyLock::new(|| regex::Regex::new(r"@Todo\([^)]*\)").unwrap());
 
-        TODO_METADATA_REGEX.replace_all(ty, |caps: &regex::Captures| {
-            let matched = caps.get(0).unwrap().as_str();
-            if PRESERVED_TODO_VARIANTS.contains(&matched) {
-                matched.to_string()
-            } else {
-                "@Todo".to_string()
-            }
-        })
+        TODO_METADATA_REGEX.replace_all(ty, "@Todo")
     }
 
     #[cfg(debug_assertions)]

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -725,10 +725,20 @@ mod tests {
             "#,
         );
 
-        // TODO: Goto type definition currently doesn't work for type var tuples
-        // because the inference doesn't support them yet.
-        // This snapshot should show a single target pointing to `T`
-        assert_snapshot!(test.goto_type_definition(), @"No type definitions found");
+        assert_snapshot!(test.goto_type_definition(), @r"
+        info[goto-type definition]: Go to type definition
+         --> main.py:2:31
+          |
+        2 | type Alias[*Ts = ()] = tuple[*Ts]
+          |                               ^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:2:13
+          |
+        2 | type Alias[*Ts = ()] = tuple[*Ts]
+          |             --
+          |
+        ");
     }
 
     #[test]
@@ -1490,7 +1500,20 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No type definitions found");
+        assert_snapshot!(test.goto_type_definition(), @r"
+        info[goto-type definition]: Go to type definition
+         --> main.py:2:38
+          |
+        2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
+          |                                      ^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:2:14
+          |
+        2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
+          |              --
+          |
+        ");
     }
 
     #[test]

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -4034,10 +4034,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        @Todo
+        AB@Alias3 (covariant)
         ---------------------------------------------
         ```python
-        @Todo
+        AB@Alias3 (covariant)
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -4196,10 +4196,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        @Todo
+        Ts@Alias (covariant)
         ---------------------------------------------
         ```python
-        @Todo
+        Ts@Alias (covariant)
         ```
         ---------------------------------------------
         info[hover]: Hovered content is

--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -435,9 +435,8 @@ from typing_extensions import Callable, TypeVarTuple
 
 Ts = TypeVarTuple("Ts")
 
-def _(c: Callable[[int, *Ts], int]):
-    # TODO: Should reveal the correct signature
-    reveal_type(c)  # revealed: (...) -> int
+def unpack_operator(c: Callable[[int, *Ts], int]):
+    reveal_type(c)  # revealed: (int, /, *Ts@unpack_operator) -> int
 ```
 
 And, using the legacy syntax using `Unpack`:
@@ -445,9 +444,8 @@ And, using the legacy syntax using `Unpack`:
 ```py
 from typing_extensions import Unpack
 
-def _(c: Callable[[int, Unpack[Ts]], int]):
-    # TODO: Should reveal the correct signature
-    reveal_type(c)  # revealed: (...) -> int
+def unpack_special_form(c: Callable[[int, Unpack[Ts]], int]):
+    reveal_type(c)  # revealed: (int, /, *Ts@unpack_special_form) -> int
 ```
 
 ## Member lookup

--- a/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
@@ -13,16 +13,18 @@ from typing_extensions import TypeVarTuple
 Ts = TypeVarTuple("Ts")
 
 def append_int(*args: *Ts) -> tuple[*Ts, int]:
-    reveal_type(args)  # revealed: @Todo(PEP 646)
+    reveal_type(args)  # revealed: tuple[*Ts@append_int]
 
     return (*args, 1)
 
-# TODO should be tuple[Literal[True], Literal["a"], int]
-reveal_type(append_int(True, "a"))  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(append_int(True, "a"))  # revealed: tuple[Literal[True], Literal["a"], int]
+reveal_type(append_int())  # revealed: tuple[int]
 
 def first_arg_int(*args: *tuple[int, *tuple[str, ...]]): ...
 
 first_arg_int(42, "42", "42")  # fine
-first_arg_int("not an int", "42", "42")  # TODO: should error
-first_arg_int(56, "42", 56)  # TODO: should error
+# error: [invalid-argument-type] "Argument to function `first_arg_int` is incorrect: Expected `tuple[int, *tuple[str, ...]]`, found `tuple[Literal["not an int"], Literal["42"], Literal["42"]]`"
+first_arg_int("not an int", "42", "42")
+# error: [invalid-argument-type] "Argument to function `first_arg_int` is incorrect: Expected `tuple[int, *tuple[str, ...]]`, found `tuple[Literal[56], Literal["42"], Literal[56]]`"
+first_arg_int(56, "42", 56)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -13,7 +13,7 @@ Ts = TypeVarTuple("Ts")
 R_co = TypeVar("R_co", covariant=True)
 
 def f(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
-    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
+    reveal_type(args)  # revealed: tuple[*Ts@f]
     return args
 
 def i(callback: Callable[Concatenate[int, P], R_co], *args: P.args, **kwargs: P.kwargs) -> R_co:
@@ -45,8 +45,8 @@ def ex3(msg: str):
 def first_arg_int(*args: Unpack[tuple[int, Unpack[tuple[str, ...]]]]): ...
 
 first_arg_int(42, "42", "42")  # fine
-first_arg_int("not an int", "42", "42")  # TODO: should error
-first_arg_int(56, "42", 56)  # TODO: should error
+first_arg_int("not an int", "42", "42")  # error: [invalid-argument-type]
+first_arg_int(56, "42", 56)  # error: [invalid-argument-type]
 ```
 
 ## Allowed `Unpack` contexts
@@ -74,10 +74,10 @@ class Pair(Generic[T, U]): ...
 class Triple(Generic[T, U, Unpack[Us]]): ...
 
 def variadic_typevartuple(*args: Unpack[Ts]) -> None:
-    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
+    reveal_type(args)  # revealed: tuple[*Ts@variadic_typevartuple]
 
 def variadic_tuple(*args: Unpack[tuple[int, str]]) -> None:
-    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
+    reveal_type(args)  # revealed: tuple[int, str]
 
 def allowed(
     tuple_fixed: tuple[int, Unpack[tuple[str, bytes]]],
@@ -95,8 +95,8 @@ def allowed(
 ) -> None:
     reveal_type(tuple_fixed)  # revealed: tuple[int, str, bytes]
     reveal_type(tuple_variadic)  # revealed: tuple[int, *tuple[str, ...], bytes]
-    reveal_type(callable_typevartuple)  # revealed: (...) -> None
-    reveal_type(callable_tuple)  # revealed: (tuple[int, str], /) -> None
+    reveal_type(callable_typevartuple)  # revealed: (int, /, *Ts@allowed) -> None
+    reveal_type(callable_tuple)  # revealed: (*tuple[int, str]) -> None
     reveal_type(pair)  # revealed: Pair[int, str]
     reveal_type(quoted_pair_argument)  # revealed: Pair[int, str]
     reveal_type(quoted_tuple)  # revealed: tuple[int, str, bytes]

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
@@ -42,8 +42,7 @@ y: Bar[int, str, bytes]  # fine
 
 class Baz[*Ts]: ...
 
-# TODO: false positive
-z: Baz[int, str, bytes]  # error: [not-subscriptable]
+z: Baz[int, str, bytes]
 ```
 
 And we also provide some basic validation in some cases:

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -601,10 +601,9 @@ def id_callable[**P, R](x: Callable[P, R]) -> Callable[P, R]:
 f5_paramspec: Callable[[int], int] = id_callable(lambda x: reveal_type(x))  # revealed: int
 reveal_type(f5_paramspec)  # revealed: (x: int) -> int
 
-# TODO: This should not error once we support `Unpack`.
 # error: [invalid-assignment]
 f6: Callable[[*tuple[int, ...]], None] = lambda x, y, z: None
-reveal_type(f6)  # revealed: (tuple[int, ...], /) -> None
+reveal_type(f6)  # revealed: (*tuple[int, ...]) -> None
 
 f7: Callable[[int, str], None] = lambda *args: None
 reveal_type(f7)  # revealed: (*args) -> None
@@ -614,9 +613,11 @@ reveal_type(f7)  # revealed: (*args) -> None
 f8: Callable[[int], None] = lambda *, x=1: None
 reveal_type(f8)  # revealed: (int, /) -> None
 
-# TODO: This should reveal `(*args: int, *, x=1) -> None` once we support `Unpack`.
+# `Callable` annotations only describe positional parameters, so the keyword-only `x` is not
+# compatible with the positional suffix in the annotation.
+# error: [invalid-assignment]
 f9: Callable[[*tuple[int, ...], int], None] = lambda *args, x=1: None
-reveal_type(f9)  # revealed: (*args, *, x=1) -> None
+reveal_type(f9)  # revealed: (*tuple[int, ...], int) -> None
 
 f10: Callable[[str, int, str], tuple[str, int, str]] = lambda x, y, z: reveal_type((x, y, z))  # revealed: tuple[str, int, str]
 reveal_type(f10)  # revealed: (x: str, y: int, z: str) -> tuple[str, int, str]

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.md
@@ -180,8 +180,6 @@ T = TypeVar("T", A, B)
 
 def _(x: T, y: int) -> T:
     # error: [invalid-argument-type]
-    # error: [invalid-argument-type]
-    # error: [invalid-argument-type]
     return x.foo(y)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -38,11 +38,14 @@ reveal_type(generic_context(SingleParamSpec))
 # revealed: ty_extensions.GenericContext[P@TypeVarAndParamSpec, T@TypeVarAndParamSpec]
 reveal_type(generic_context(TypeVarAndParamSpec))
 
-# TODO: support `TypeVarTuple` properly (these should not reveal `None`)
-reveal_type(generic_context(SingleTypeVarTuple))  # revealed: None
-reveal_type(generic_context(TypeVarAndTypeVarTuple))  # revealed: None
-reveal_type(generic_context(StarredSingleTypeVarTuple))  # revealed: None
-reveal_type(generic_context(StarredTypeVarAndTypeVarTuple))  # revealed: None
+# revealed: ty_extensions.GenericContext[Ts@SingleTypeVarTuple]
+reveal_type(generic_context(SingleTypeVarTuple))
+# revealed: ty_extensions.GenericContext[T@TypeVarAndTypeVarTuple, Ts@TypeVarAndTypeVarTuple]
+reveal_type(generic_context(TypeVarAndTypeVarTuple))
+# revealed: ty_extensions.GenericContext[Ts@StarredSingleTypeVarTuple]
+reveal_type(generic_context(StarredSingleTypeVarTuple))
+# revealed: ty_extensions.GenericContext[T@StarredTypeVarAndTypeVarTuple, Ts@StarredTypeVarAndTypeVarTuple]
+reveal_type(generic_context(StarredTypeVarAndTypeVarTuple))
 ```
 
 Inheriting from `Generic` multiple times yields a `duplicate-base` diagnostic, just like any other
@@ -60,7 +63,7 @@ You cannot use the same typevar more than once.
 class RepeatedTypevar(Generic[T, T]): ...
 ```
 
-You can only specialize `typing.Generic` with typevars (TODO: or param specs or typevar tuples).
+You can only specialize `typing.Generic` with typevars, param specs, or typevar tuples.
 
 ```py
 # error: [invalid-argument-type] "`<class 'int'>` is not a valid argument to `Generic`"

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -12,7 +12,7 @@ python-version = "3.11"
 
 ```py
 from ty_extensions import generic_context
-from typing_extensions import Generic, TypeVar, TypeVarTuple, ParamSpec, Unpack
+from typing_extensions import Generic, ParamSpec, Protocol, TypeVar, TypeVarTuple, Unpack
 
 T = TypeVar("T")
 S = TypeVar("S")
@@ -68,6 +68,17 @@ You can only specialize `typing.Generic` with typevars, param specs, or typevar 
 ```py
 # error: [invalid-argument-type] "`<class 'int'>` is not a valid argument to `Generic`"
 class GenericOfType(Generic[int]): ...
+
+# error: [invalid-argument-type] "`<special-form 'typing.Unpack'>` is not a valid argument to `Generic`"
+class GenericOfInvalidUnpack(Generic[T, Unpack[int]]): ...
+
+# error: [invalid-argument-type] "`<special-form 'typing.Unpack'>` is not a valid argument to `Protocol`"
+class ProtocolOfInvalidUnpack(Protocol[T, Unpack[int]]): ...
+class GenericOfUnresolvedUnpack(Generic[T, Unpack[Missing]]): ...  # error: [unresolved-reference]
+
+# The first invalid argument takes priority over the later invalid `Unpack` operand.
+# error: [invalid-argument-type] "`<class 'int'>` is not a valid argument to `Generic`"
+class GenericOfMixedInvalidArguments(Generic[int, Unpack[str]]): ...
 ```
 
 You can also define a generic class by inheriting from some _other_ generic class, and specializing

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -19,8 +19,7 @@ from typing import TypeVarTuple
 Ts = TypeVarTuple("Ts")
 reveal_type(type(Ts))  # revealed: <class 'TypeVarTuple'>
 reveal_type(Ts)  # revealed: TypeVarTuple
-# TODO: revealed: Literal["Ts"]
-reveal_type(Ts.__name__)  # revealed: str
+reveal_type(Ts.__name__)  # revealed: Literal["Ts"]
 ```
 
 The `TypeVarTuple` name can also be provided as a keyword argument:
@@ -29,8 +28,7 @@ The `TypeVarTuple` name can also be provided as a keyword argument:
 from typing import TypeVarTuple
 
 Ts = TypeVarTuple(name="Ts")
-# TODO: revealed: Literal["Ts"]
-reveal_type(Ts.__name__)  # revealed: str
+reveal_type(Ts.__name__)  # revealed: Literal["Ts"]
 ```
 
 ### Must be directly assigned to a variable
@@ -40,10 +38,10 @@ from typing import TypeVarTuple
 
 Ts = TypeVarTuple("Ts")
 
-# TODO: error: [invalid-legacy-type-variable]
+# error: [invalid-legacy-type-variable]
 Ts1: TypeVarTuple = TypeVarTuple("Ts1")
 
-# TODO: error: [invalid-legacy-type-variable]
+# error: [invalid-legacy-type-variable]
 tuple_with_typevartuple = ("foo", TypeVarTuple("Us"))
 reveal_type(tuple_with_typevartuple[1])  # revealed: TypeVarTuple
 ```
@@ -55,7 +53,7 @@ from typing import Generic, TypeVarTuple
 
 Ts1 = TypeVarTuple("Ts1")
 
-# TODO: error: [mismatched-type-name]
+# error: [mismatched-type-name]
 Ts2 = TypeVarTuple("Ts3")
 
 class Array(Generic[*Ts2]): ...
@@ -68,11 +66,9 @@ class Array(Generic[*Ts2]): ...
 ```py
 from typing import TypeVarTuple
 
-# TODO: error: [invalid-legacy-type-variable]
-# error: [unknown-argument]
+# error: [invalid-legacy-type-variable]
 Ts1 = TypeVarTuple("Ts1", bound=int)
-# TODO: error: [invalid-legacy-type-variable]
-# error: [too-many-positional-arguments]
+# error: [invalid-legacy-type-variable]
 Ts2 = TypeVarTuple("Ts2", int, str)
 ```
 
@@ -95,10 +91,9 @@ Ts = TypeVarTuple("Ts")
 class InvariantArray(Generic[*Ts]):
     values: tuple[*Ts]
 
-invariant_out: InvariantArray[object] = InvariantArray[int]()  # TODO: error: [invalid-assignment]
-invariant_in: InvariantArray[int] = InvariantArray[object]()  # TODO: error: [invalid-assignment]
+invariant_out: InvariantArray[object] = InvariantArray[int]()  # error: [invalid-assignment]
+invariant_in: InvariantArray[int] = InvariantArray[object]()  # error: [invalid-assignment]
 
-# error: [unknown-argument]
 Ts_Co = TypeVarTuple("Ts_Co", covariant=True)
 
 class CovariantArray(Generic[*Ts_Co]):
@@ -106,9 +101,8 @@ class CovariantArray(Generic[*Ts_Co]):
         raise NotImplementedError
 
 covariant_ok: CovariantArray[object] = CovariantArray[int]()
-covariant_error: CovariantArray[int] = CovariantArray[object]()  # TODO: error: [invalid-assignment]
+covariant_error: CovariantArray[int] = CovariantArray[object]()  # error: [invalid-assignment]
 
-# error: [unknown-argument]
 Ts_Contra = TypeVarTuple("Ts_Contra", contravariant=True)
 
 class ContravariantArray(Generic[*Ts_Contra]):
@@ -116,9 +110,8 @@ class ContravariantArray(Generic[*Ts_Contra]):
         raise NotImplementedError
 
 contravariant_ok: ContravariantArray[int] = ContravariantArray[object]()
-contravariant_error: ContravariantArray[object] = ContravariantArray[int]()  # TODO: error: [invalid-assignment]
+contravariant_error: ContravariantArray[object] = ContravariantArray[int]()  # error: [invalid-assignment]
 
-# error: [unknown-argument]
 Ts_Inferred_Co = TypeVarTuple("Ts_Inferred_Co", infer_variance=True)
 
 class InferredCovariantArray(Generic[*Ts_Inferred_Co]):
@@ -126,9 +119,8 @@ class InferredCovariantArray(Generic[*Ts_Inferred_Co]):
         raise NotImplementedError
 
 inferred_covariant_ok: InferredCovariantArray[object] = InferredCovariantArray[int]()
-inferred_covariant_error: InferredCovariantArray[int] = InferredCovariantArray[object]()  # TODO: error: [invalid-assignment]
+inferred_covariant_error: InferredCovariantArray[int] = InferredCovariantArray[object]()  # error: [invalid-assignment]
 
-# error: [unknown-argument]
 Ts_Inferred_Contra = TypeVarTuple("Ts_Inferred_Contra", infer_variance=True)
 
 class InferredContravariantArray(Generic[*Ts_Inferred_Contra]):
@@ -136,7 +128,7 @@ class InferredContravariantArray(Generic[*Ts_Inferred_Contra]):
         raise NotImplementedError
 
 inferred_contravariant_ok: InferredContravariantArray[int] = InferredContravariantArray[object]()
-# TODO: error: [invalid-assignment]
+# error: [invalid-assignment]
 inferred_contravariant_error: InferredContravariantArray[object] = InferredContravariantArray[int]()
 ```
 
@@ -149,22 +141,15 @@ from typing import TypeVarTuple
 def cond() -> bool:
     return True
 
-# TODO: error: [invalid-legacy-type-variable]
-# error: [unknown-argument]
-# error: [unknown-argument]
+# error: [invalid-legacy-type-variable]
 Both = TypeVarTuple("Both", covariant=True, contravariant=True)
-# TODO: error: [invalid-legacy-type-variable]
-# error: [unknown-argument]
+# error: [invalid-legacy-type-variable]
 AmbiguousCovariant = TypeVarTuple("AmbiguousCovariant", covariant=cond())
-# TODO: error: [invalid-legacy-type-variable]
-# error: [unknown-argument]
+# error: [invalid-legacy-type-variable]
 AmbiguousContravariant = TypeVarTuple("AmbiguousContravariant", contravariant=cond())
-# TODO: error: [invalid-legacy-type-variable]
-# error: [unknown-argument]
+# error: [invalid-legacy-type-variable]
 AmbiguousInferVariance = TypeVarTuple("AmbiguousInferVariance", infer_variance=cond())
-# TODO: error: [invalid-legacy-type-variable]
-# error: [unknown-argument]
-# error: [unknown-argument]
+# error: [invalid-legacy-type-variable]
 CovariantAndInferred = TypeVarTuple("CovariantAndInferred", covariant=True, infer_variance=True)
 ```
 
@@ -182,79 +167,54 @@ U = TypeVar("U")
 class Simple(Generic[*Ts]):
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[()]
-reveal_type(Simple[()]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, str]
-reveal_type(Simple[int, str]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, str]
-reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: Unknown
+reveal_type(Simple[()]().attr)  # revealed: tuple[()]
+reveal_type(Simple[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[int, str]
 
-# TODO: error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-# TODO: revealed: tuple[Unknown]
-reveal_type(Simple[[int, str]]().attr)  # revealed: Unknown
-# TODO: error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-# TODO: revealed: tuple[Unknown, ...]
-reveal_type(Simple[*[int, str]]().attr)  # revealed: Unknown
+# error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[Unknown]
+# error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ```py
 class Prefix(Generic[T, *Ts]):
-    # error: [unbound-type-variable]
     attr: tuple[T, *Ts]
 
-# TODO: revealed: tuple[int]
-reveal_type(Prefix[int]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, bool]
-reveal_type(Prefix[int, bool]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Prefix[int, bool, str]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: Unknown
+reveal_type(Prefix[int]().attr)  # revealed: tuple[int]
+reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, bool]
+reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, bool, str]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...]]
-reveal_type(Prefix().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...]]
 ```
 
 ```py
 class Suffix(Generic[*Ts, T]):
-    # error: [unbound-type-variable]
     attr: tuple[*Ts, T]
 
-# TODO: revealed: tuple[int]
-reveal_type(Suffix[int]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, str]
-reveal_type(Suffix[int, str]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, str, bool]
-reveal_type(Suffix[int, str, bool]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, str, bool]
-reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: Unknown
+reveal_type(Suffix[int]().attr)  # revealed: tuple[int]
+reveal_type(Suffix[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[int, str, bool]
+reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[int, str, bool]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[*tuple[Unknown, ...], Unknown]
-reveal_type(Suffix().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(Suffix().attr)  # revealed: tuple[*tuple[Unknown, ...], Unknown]
 ```
 
 ```py
 class Between(Generic[T, *Ts, U]):
-    # error: [unbound-type-variable]
-    # error: [unbound-type-variable]
     attr: tuple[T, *Ts, U]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(Between[int, str]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Between[int, bool, str]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, bool, bytes, str]
-reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: Unknown
+reveal_type(Between[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, bool, bytes, str]
+reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, bool, str]
 
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-reveal_type(Between().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: error: [invalid-type-arguments] "No type argument provided for required type variable `U` of class `Between`"
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-reveal_type(Between[int]().attr)  # revealed: Unknown
+reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+# error: [invalid-type-arguments] "No type argument provided for required type variable `U` of class `Between`"
+reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Inferred specialization from construction
@@ -275,21 +235,15 @@ class Variadic(Generic[*Ts]):
     def __init__(self, *shape: *Ts) -> None:
         self.shape = shape
 
-# TODO: revealed: Positional[()]
-reveal_type(Positional(()))  # revealed: Positional
-# TODO: revealed: Positional[int, str]
-reveal_type(Positional((1, "a")))  # revealed: Positional
+reveal_type(Positional(()))  # revealed: Positional[()]
+reveal_type(Positional((1, "a")))  # revealed: Positional[int, str]
 
-# TODO: revealed: Variadic[()]
-reveal_type(Variadic())  # revealed: Variadic
-# TODO: revealed: Variadic[int, str]
-reveal_type(Variadic(1, "a"))  # revealed: Variadic
+reveal_type(Variadic())  # revealed: Variadic[()]
+reveal_type(Variadic(1, "a"))  # revealed: Variadic[int, str]
 
 def _(i: int, s: str) -> None:
-    # TODO: revealed: Positional[int, str]
-    reveal_type(Positional((i, s)))  # revealed: Positional
-    # TODO: revealed: Variadic[int, str]
-    reveal_type(Variadic(i, s))  # revealed: Variadic
+    reveal_type(Positional((i, s)))  # revealed: Positional[int, str]
+    reveal_type(Variadic(i, s))  # revealed: Variadic[int, str]
 ```
 
 ### Unspecified type arguments
@@ -308,10 +262,8 @@ class Unspecified(Generic[*Ts]):
     attr: tuple[*Ts]
 
 unspecified = Unspecified()
-# TODO: revealed: Unspecified[*tuple[Unknown, ...]]
-reveal_type(unspecified)  # revealed: Unspecified
-# TODO: revealed: tuple[Unknown, ...]
-reveal_type(unspecified.attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(unspecified)  # revealed: Unspecified[*tuple[Unknown, ...]]
+reveal_type(unspecified.attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ### Default type arguments
@@ -332,10 +284,8 @@ Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
 class WithDefault(Generic[*Ts]):
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithDefault().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[bool, bytes]
-reveal_type(WithDefault[bool, bytes]().attr)  # revealed: Unknown
+reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
+reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
 ```
 
 ### Backported default type arguments
@@ -356,8 +306,7 @@ Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
 class WithBackportedDefault(Generic[*Ts]):
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithBackportedDefault().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(WithBackportedDefault().attr)  # revealed: tuple[int, str]
 ```
 
 ## Type Aliases
@@ -386,29 +335,19 @@ def _(
     a7: Prefix[bool, int, str],
     a8: Suffix[bool],
     a9: Suffix[int, str, bool],
-    # TODO: error: [invalid-type-arguments] "No type argument provided for required type variable `U`"
+    # error: [invalid-type-arguments] "No type argument provided for required type variable `U`"
     a10: Between[int],
 ):
-    # TODO: revealed: tuple[()]
-    reveal_type(a1)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a2)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a3)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, bool, str]
-    reveal_type(a4)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, bool, bytes, str]
-    reveal_type(a5)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a6)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[bool, int, str]
-    reveal_type(a7)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a8)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a9)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-    reveal_type(a10)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(a1)  # revealed: tuple[()]
+    reveal_type(a2)  # revealed: tuple[int, str]
+    reveal_type(a3)  # revealed: tuple[int, str]
+    reveal_type(a4)  # revealed: tuple[int, bool, str]
+    reveal_type(a5)  # revealed: tuple[int, bool, bytes, str]
+    reveal_type(a6)  # revealed: tuple[bool]
+    reveal_type(a7)  # revealed: tuple[bool, int, str]
+    reveal_type(a8)  # revealed: tuple[bool]
+    reveal_type(a9)  # revealed: tuple[int, str, bool]
+    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Unpacked tuple type arguments
@@ -421,10 +360,8 @@ Ts = TypeVarTuple("Ts")
 Alias = tuple[int, *Ts]
 
 def _(a1: Alias[*tuple[str, bool]], a2: Alias[*tuple[str, ...]]) -> None:
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a1)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, *tuple[str, ...]]
-    reveal_type(a2)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(a1)  # revealed: tuple[int, str, bool]
+    reveal_type(a2)  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
 ### Unspecified alias type arguments
@@ -439,10 +376,8 @@ Ts = TypeVarTuple("Ts")
 Alias = tuple[bytes, *Ts]
 
 def _(a1: Alias, a2: Alias[*tuple[Any, ...]]) -> None:
-    # TODO: revealed: tuple[bytes, *tuple[Unknown, ...]]
-    reveal_type(a1)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[bytes, *tuple[Any, ...]]
-    reveal_type(a2)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(a1)  # revealed: tuple[bytes, *tuple[Unknown, ...]]
+    reveal_type(a2)  # revealed: tuple[bytes, *tuple[Any, ...]]
 ```
 
 ### Splitting arbitrary-length tuples
@@ -462,14 +397,10 @@ def _(
     s1: Second[*tuple[int, ...]],
     s2: Second[str, *tuple[int, ...]],
 ):
-    # TODO: revealed: tuple[*tuple[int, ...], int]
-    reveal_type(f1)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[*tuple[int, ...], str]
-    reveal_type(f2)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, *tuple[int, ...]]
-    reveal_type(s1)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[str, *tuple[int, ...]]
-    reveal_type(s2)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(f1)  # revealed: tuple[*tuple[int, ...], int]
+    reveal_type(f2)  # revealed: tuple[*tuple[int, ...], str]
+    reveal_type(s1)  # revealed: tuple[int, *tuple[int, ...]]
+    reveal_type(s2)  # revealed: tuple[str, *tuple[int, ...]]
 ```
 
 ### Variadic substitutions
@@ -485,8 +416,6 @@ First = tuple[bytes, *Ts]
 Second = First[int, *Ts]
 
 def f(a1: First[str, bool], a2: Second[str, bool]) -> None:
-    # TODO: revealed: tuple[bytes, str, bool]
-    reveal_type(a1)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[bytes, int, str, bool]
-    reveal_type(a2)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(a1)  # revealed: tuple[bytes, str, bool]
+    reveal_type(a2)  # revealed: tuple[bytes, int, str, bool]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
@@ -21,12 +21,9 @@ Ts = TypeVarTuple("Ts")
 class Array(Generic[Unpack[Ts]]):
     value: tuple[Unpack[Ts]]
 
-# TODO: revealed: tuple[()]
-reveal_type(Array[()]().value)  # revealed: @Todo(ParamSpecs and TypeVarTuples)
-# TODO: revealed: tuple[int, str]
-reveal_type(Array[int, str]().value)  # revealed: @Todo(ParamSpecs and TypeVarTuples)
-# TODO: revealed: tuple[int, str]
-reveal_type(Array[Unpack[tuple[int, str]]]().value)  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+reveal_type(Array[()]().value)  # revealed: tuple[()]
+reveal_type(Array[int, str]().value)  # revealed: tuple[int, str]
+reveal_type(Array[Unpack[tuple[int, str]]]().value)  # revealed: tuple[int, str]
 ```
 
 ## Variadic parameter inference
@@ -40,14 +37,11 @@ from typing import TypeVarTuple, Unpack
 Ts = TypeVarTuple("Ts")
 
 def collect(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
-    # TODO: revealed: tuple[*Ts@collect]
-    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
+    reveal_type(args)  # revealed: tuple[*Ts@collect]
     raise NotImplementedError
 
-# TODO: revealed: tuple[()]
-reveal_type(collect())  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[Literal[1], Literal["a"]]
-reveal_type(collect(1, "a"))  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(collect())  # revealed: tuple[()]
+reveal_type(collect(1, "a"))  # revealed: tuple[Literal[1], Literal["a"]]
 ```
 
 ## Callable parameters
@@ -71,7 +65,7 @@ def format_value(value: int, label: str, /) -> str:
     return f"{label}: {value}"
 
 reveal_type(invoke(format_value, 1, "value"))  # revealed: str
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> str`, found `def format_value(value: int, label: str, /) -> str`"
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> str`, found `def format_value(value: int, label: str, /) -> str`"
 reveal_type(invoke(format_value, 1))  # revealed: str
 ```
 
@@ -90,10 +84,8 @@ def f(
     fixed: Alias[str, bool],
     unbounded: Alias[Unpack[tuple[str, ...]]],
 ) -> None:
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(fixed)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, *tuple[str, ...]]
-    reveal_type(unbounded)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(fixed)  # revealed: tuple[int, str, bool]
+    reveal_type(unbounded)  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
 ## Concrete and nested tuple unpacking
@@ -109,7 +101,7 @@ def accept(
 
 accept(True, "phase", "status", b"ok")
 accept(True, b"ok")
-# TODO: error: [invalid-argument-type] "Argument to function `accept` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
+# error: [invalid-argument-type] "Argument to function `accept` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
 accept(True, 1, b"bad")
 ```
 
@@ -130,10 +122,8 @@ Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
 class WithDefault(Generic[Unpack[Ts]]):
     value: tuple[Unpack[Ts]]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithDefault().value)  # revealed: @Todo(ParamSpecs and TypeVarTuples)
-# TODO: revealed: tuple[bool, bytes]
-reveal_type(WithDefault[bool, bytes]().value)  # revealed: @Todo(ParamSpecs and TypeVarTuples)
+reveal_type(WithDefault().value)  # revealed: tuple[int, str]
+reveal_type(WithDefault[bool, bytes]().value)  # revealed: tuple[bool, bytes]
 ```
 
 ## Validation
@@ -148,31 +138,28 @@ Ts = TypeVarTuple("Ts")
 
 class Pair(Generic[Unpack[Ts], U]): ...
 
-# TODO: error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
+# error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
 class InvalidGeneric(Generic[U, Unpack[int]]): ...
 
 def invalid(
-    # TODO: error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
+    # error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
     non_tuple: Pair[Unpack[int], str],
     # error: [invalid-type-form] "Multiple unpacked variadic tuples are not allowed in a `tuple` specialization"
     multiple: tuple[Unpack[Ts], Unpack[tuple[str, ...]]],
 ) -> None:
-    # TODO: revealed: Pair[*tuple[Unknown, ...], str]
-    reveal_type(non_tuple)  # revealed: @Todo(specialized non-generic class)
+    reveal_type(non_tuple)  # revealed: Pair[*tuple[Unknown, ...], str]
 
-# TODO: error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
+# error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
 def invalid_vararg(*args: Unpack[int]) -> None:
-    # TODO: revealed: tuple[Unknown, ...]
-    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
+    reveal_type(args)  # revealed: tuple[Unknown, ...]
 
-# TODO: error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
+# error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
 def invalid_stringified_vararg(*args: "Unpack[int]") -> None:
-    # TODO: revealed: tuple[Unknown, ...]
-    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
+    reveal_type(args)  # revealed: tuple[Unknown, ...]
 
-# TODO: error: [invalid-type-form] "`Unpack` cannot be nested"
+# error: [invalid-type-form] "`Unpack` cannot be nested"
 def nested(*args: Unpack[Unpack[tuple[int, ...]]]) -> None: ...
 
-# TODO: error: [invalid-type-form] "Bare TypeVarTuple `Ts` is not valid in this context in a parameter annotation"
+# error: [invalid-type-form] "Bare TypeVarTuple `Ts` is not valid in this context in a parameter annotation"
 def nested_bare_typevartuple(*args: Unpack[tuple[Ts]]) -> None: ...
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
@@ -138,9 +138,6 @@ Ts = TypeVarTuple("Ts")
 
 class Pair(Generic[Unpack[Ts], U]): ...
 
-# error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
-class InvalidGeneric(Generic[U, Unpack[int]]): ...
-
 def invalid(
     # error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
     non_tuple: Pair[Unpack[int], str],

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -26,15 +26,13 @@ reveal_type(generic_context(SingleTypevar))
 # revealed: ty_extensions.GenericContext[T@MultipleTypevars, S@MultipleTypevars]
 reveal_type(generic_context(MultipleTypevars))
 
-# TODO: support `TypeVarTuple` properly
-# (these should include the `TypeVarTuple`s in their generic contexts)
 # revealed: ty_extensions.GenericContext[P@SingleParamSpec]
 reveal_type(generic_context(SingleParamSpec))
 # revealed: ty_extensions.GenericContext[T@TypeVarAndParamSpec, P@TypeVarAndParamSpec]
 reveal_type(generic_context(TypeVarAndParamSpec))
-# revealed: ty_extensions.GenericContext[]
+# revealed: ty_extensions.GenericContext[Ts@SingleTypeVarTuple]
 reveal_type(generic_context(SingleTypeVarTuple))
-# revealed: ty_extensions.GenericContext[T@TypeVarAndTypeVarTuple]
+# revealed: ty_extensions.GenericContext[T@TypeVarAndTypeVarTuple, Ts@TypeVarAndTypeVarTuple]
 reveal_type(generic_context(TypeVarAndTypeVarTuple))
 ```
 
@@ -709,18 +707,20 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 
 ```py
 # snapshot: invalid-type-variable-default
+# error: [invalid-type-form]
+# error: [invalid-type-form]
 type Alias4[*Us, *Ts = *tuple[int, str]] = tuple[*Us, *Ts]
 ```
 
 ```snapshot
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
- --> src/mdtest_snippet.py:8:13
-  |
-8 | type Alias4[*Us, *Ts = *tuple[int, str]] = tuple[*Us, *Ts]
-  |             ---  ^^^^^^^^^^^^^^^^^^^^^^ `Ts` has a default
-  |             |
-  |             `Us` is a TypeVarTuple
-  |
+  --> src/mdtest_snippet.py:10:13
+   |
+10 | type Alias4[*Us, *Ts = *tuple[int, str]] = tuple[*Us, *Ts]
+   |             ---  ^^^^^^^^^^^^^^^^^^^^^^ `Ts` has a default
+   |             |
+   |             `Us` is a TypeVarTuple
+   |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -25,15 +25,13 @@ reveal_type(generic_context(SingleTypevar))
 # revealed: ty_extensions.GenericContext[T@MultipleTypevars, S@MultipleTypevars]
 reveal_type(generic_context(MultipleTypevars))
 
-# TODO: support `TypeVarTuple` properly
-# (these should include the `TypeVarTuple`s in their generic contexts)
 # revealed: ty_extensions.GenericContext[P@SingleParamSpec]
 reveal_type(generic_context(SingleParamSpec))
 # revealed: ty_extensions.GenericContext[T@TypeVarAndParamSpec, P@TypeVarAndParamSpec]
 reveal_type(generic_context(TypeVarAndParamSpec))
-# revealed: ty_extensions.GenericContext[]
+# revealed: ty_extensions.GenericContext[Ts@SingleTypeVarTuple]
 reveal_type(generic_context(SingleTypeVarTuple))
-# revealed: ty_extensions.GenericContext[T@TypeVarAndTypeVarTuple]
+# revealed: ty_extensions.GenericContext[T@TypeVarAndTypeVarTuple, Ts@TypeVarAndTypeVarTuple]
 reveal_type(generic_context(TypeVarAndTypeVarTuple))
 ```
 
@@ -978,7 +976,7 @@ class Quux[*Ts, T1 = int, **P = [int, str]]: ...
 class Corge[*Ts, T1 = int, T2 = str, **P = [int, str]]: ...
 
 # error: [invalid-type-variable-default]
-class Grault[*Us, *Ts = *tuple[int, str]]: ...
+class Grault[*Us, *Ts = *tuple[int, str]]: ...  # error: [invalid-type-form]
 
 # These are fine:
 class Ok1[T, *Ts]: ...

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -564,8 +564,6 @@ def only_variadic(*args: str, **kwargs: int) -> None: ...
 
 reveal_type(only_variadic)  # revealed: (...) -> None
 
-# TODO: This should accept the callable and reveal `(*args: str, **kwargs: int) -> None`.
-# error: [invalid-argument-type]
 @decorator
 def unpack_variadic(*args: *tuple[int, *tuple[str, ...]], **kwargs: int) -> None: ...
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -11,10 +11,8 @@ A PEP 695 type variable tuple is introduced with a single starred type parameter
 
 ```py
 def foo[*Ts](*args: *Ts) -> None:
-    # TODO: revealed: TypeVarTuple
-    reveal_type(Ts)  # revealed: @Todo(PEP-695 TypeVarTuple definition types)
-    # TODO: revealed: tuple[*Ts@foo]
-    reveal_type(args)  # revealed: @Todo(PEP 646)
+    reveal_type(Ts)  # revealed: TypeVarTuple
+    reveal_type(args)  # revealed: tuple[*Ts@foo]
 ```
 
 ## Variance inference
@@ -26,33 +24,21 @@ class CovariantArray[*Ts]:
     def get(self) -> tuple[*Ts]:
         raise NotImplementedError
 
-# error: [not-subscriptable]
-# error: [not-subscriptable]
 covariant_ok: CovariantArray[object] = CovariantArray[int]()
-# error: [not-subscriptable]
-# error: [not-subscriptable]
-covariant_error: CovariantArray[int] = CovariantArray[object]()  # TODO: error: [invalid-assignment]
+covariant_error: CovariantArray[int] = CovariantArray[object]()  # error: [invalid-assignment]
 
 class ContravariantArray[*Ts]:
     def set(self, value: tuple[*Ts]) -> None:
         raise NotImplementedError
 
-# error: [not-subscriptable]
-# error: [not-subscriptable]
 contravariant_ok: ContravariantArray[int] = ContravariantArray[object]()
-# error: [not-subscriptable]
-# error: [not-subscriptable]
-contravariant_error: ContravariantArray[object] = ContravariantArray[int]()  # TODO: error: [invalid-assignment]
+contravariant_error: ContravariantArray[object] = ContravariantArray[int]()  # error: [invalid-assignment]
 
 class InvariantArray[*Ts]:
     values: tuple[*Ts]
 
-# error: [not-subscriptable]
-# error: [not-subscriptable]
-invariant_out: InvariantArray[object] = InvariantArray[int]()  # TODO: error: [invalid-assignment]
-# error: [not-subscriptable]
-# error: [not-subscriptable]
-invariant_in: InvariantArray[int] = InvariantArray[object]()  # TODO: error: [invalid-assignment]
+invariant_out: InvariantArray[object] = InvariantArray[int]()  # error: [invalid-assignment]
+invariant_in: InvariantArray[int] = InvariantArray[object]()  # error: [invalid-assignment]
 ```
 
 ## Generic Classes
@@ -63,88 +49,54 @@ invariant_in: InvariantArray[int] = InvariantArray[object]()  # TODO: error: [in
 class Simple[*Ts]:
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[()]
-reveal_type(Simple[()]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, str]
-# error: [not-subscriptable]
-reveal_type(Simple[int, str]().attr)  # revealed: Unknown
-# TODO: revealed: tuple[int, str]
-# error: [not-subscriptable]
-reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: Unknown
+reveal_type(Simple[()]().attr)  # revealed: tuple[()]
+reveal_type(Simple[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[int, str]
 
-# TODO: error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-# TODO: revealed: tuple[Unknown]
-# error: [not-subscriptable]
-reveal_type(Simple[[int, str]]().attr)  # revealed: Unknown
-# TODO: error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [not-subscriptable]
-reveal_type(Simple[*[int, str]]().attr)  # revealed: Unknown
+# error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[Unknown]
+# error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ```py
 class Prefix[T, *Ts]:
     attr: tuple[T, *Ts]
 
-# TODO: revealed: tuple[int]
-reveal_type(Prefix[int]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, bool]
-# error: [invalid-type-arguments]
-reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, bool, str]
-# error: [invalid-type-arguments]
-reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, bool, str]
-# error: [invalid-type-arguments]
-reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(Prefix[int]().attr)  # revealed: tuple[int]
+reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, bool]
+reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, bool, str]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...]]
-reveal_type(Prefix().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...]]
 ```
 
 ```py
 class Suffix[*Ts, T]:
     attr: tuple[*Ts, T]
 
-# TODO: revealed: tuple[int]
-reveal_type(Suffix[int]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, str]
-# error: [invalid-type-arguments]
-reveal_type(Suffix[int, str]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, str, bool]
-# error: [invalid-type-arguments]
-reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, str, bool]
-# error: [invalid-type-arguments]
-reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(Suffix[int]().attr)  # revealed: tuple[int]
+reveal_type(Suffix[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[int, str, bool]
+reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[int, str, bool]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[*tuple[Unknown, ...], Unknown]
-reveal_type(Suffix().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(Suffix().attr)  # revealed: tuple[*tuple[Unknown, ...], Unknown]
 ```
 
 ```py
 class Between[T, *Ts, U]:
     attr: tuple[T, *Ts, U]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(Between[int, str]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, bool, str]
-# error: [invalid-type-arguments]
-reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, bool, bytes, str]
-# error: [invalid-type-arguments]
-reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, bool, str]
-# error: [invalid-type-arguments]
-reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(Between[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, bool, bytes, str]
+reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, bool, str]
 
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-reveal_type(Between().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 # error: [invalid-type-arguments] "No type argument provided for required type variable `U` of class `Between`"
-reveal_type(Between[int]().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Inferred specialization from construction
@@ -161,21 +113,15 @@ class Variadic[*Ts]:
     def __init__(self, *shape: *Ts) -> None:
         self.shape = shape
 
-# TODO: revealed: Positional[()]
-reveal_type(Positional(()))  # revealed: Positional[]
-# TODO: revealed: Positional[int, str]
-reveal_type(Positional((1, "a")))  # revealed: Positional[]
+reveal_type(Positional(()))  # revealed: Positional[()]
+reveal_type(Positional((1, "a")))  # revealed: Positional[int, str]
 
-# TODO: revealed: Variadic[()]
-reveal_type(Variadic())  # revealed: Variadic[]
-# TODO: revealed: Variadic[int, str]
-reveal_type(Variadic(1, "a"))  # revealed: Variadic[]
+reveal_type(Variadic())  # revealed: Variadic[()]
+reveal_type(Variadic(1, "a"))  # revealed: Variadic[int, str]
 
 def _(i: int, s: str) -> None:
-    # TODO: revealed: Positional[int, str]
-    reveal_type(Positional((i, s)))  # revealed: Positional[]
-    # TODO: revealed: Variadic[int, str]
-    reveal_type(Variadic(i, s))  # revealed: Variadic[]
+    reveal_type(Positional((i, s)))  # revealed: Positional[int, str]
+    reveal_type(Variadic(i, s))  # revealed: Variadic[int, str]
 ```
 
 ### Unspecified type arguments
@@ -189,10 +135,8 @@ class Unspecified[*Ts]:
     attr: tuple[*Ts]
 
 unspecified = Unspecified()
-# TODO: revealed: Unspecified[*tuple[Unknown, ...]]
-reveal_type(unspecified)  # revealed: Unspecified[]
-# TODO: revealed: tuple[Unknown, ...]
-reveal_type(unspecified.attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(unspecified)  # revealed: Unspecified[*tuple[Unknown, ...]]
+reveal_type(unspecified.attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ### Default type arguments
@@ -209,11 +153,8 @@ python-version = "3.13"
 class WithDefault[*Ts = *tuple[int, str]]:
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithDefault().attr)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[bool, bytes]
-# error: [not-subscriptable]
-reveal_type(WithDefault[bool, bytes]().attr)  # revealed: Unknown
+reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
+reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
 ```
 
 ### Assignment checks
@@ -222,15 +163,11 @@ reveal_type(WithDefault[bool, bytes]().attr)  # revealed: Unknown
 class Array[*Ts]:
     values: tuple[*Ts]
 
-# error: [not-subscriptable]
 def takes_int_str(x: Array[int, str]) -> None: ...
 def takes_int_str_tuple(x: tuple[int, str]) -> None: ...
-
-# error: [not-subscriptable]
-# error: [not-subscriptable]
 def f(x: Array[int, str], y: Array[str, int], xs: tuple[int, str], ys: tuple[str, int]) -> None:
     takes_int_str(x)
-    takes_int_str(y)  # TODO: error: [invalid-argument-type]
+    takes_int_str(y)  # error: [invalid-argument-type]
     takes_int_str_tuple(xs)
     takes_int_str_tuple(ys)  # error: [invalid-argument-type]
 ```
@@ -244,7 +181,6 @@ class.
 from typing import Any
 
 class Array[*Ts]:
-    # error: [not-subscriptable]
     def erase_shape(self) -> "Array[*tuple[Any, ...]]":
         return self
 ```
@@ -265,15 +201,13 @@ class Scalar:
     def clone(self) -> Self:
         raise NotImplementedError
 
-# error: [not-subscriptable]
 Container = TypeVar("Container", Packed[*tuple[Any, ...]], Scalar)
 
 def operate(value: Container) -> None:
     value.operate()
 
 def clone(value: Container) -> Container:
-    # TODO: revealed: Container@clone
-    reveal_type(value.clone())  # revealed: Unknown | Container@clone
+    reveal_type(value.clone())  # revealed: Container@clone
     return value.clone()
 ```
 
@@ -295,16 +229,11 @@ def with_both[T, *Ts, U](x: tuple[T, *Ts, U]) -> tuple[*Ts]:
     raise NotImplementedError
 
 def f(i: int, s: str, b: bool) -> None:
-    # TODO: revealed: tuple[()]
-    reveal_type(simple(()))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(simple((i, s)))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(with_prefix(i, (s, b)))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(with_suffix((i, s), b))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[str]
-    reveal_type(with_both((i, s, b)))  # revealed: tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(simple(()))  # revealed: tuple[()]
+    reveal_type(simple((i, s)))  # revealed: tuple[int, str]
+    reveal_type(with_prefix(i, (s, b)))  # revealed: tuple[int, str, bool]
+    reveal_type(with_suffix((i, s), b))  # revealed: tuple[int, str, bool]
+    reveal_type(with_both((i, s, b)))  # revealed: tuple[str]
 ```
 
 ### Starred variadic parameters
@@ -314,8 +243,7 @@ call site.
 
 ```py
 def simple[*Ts](*args: *Ts) -> tuple[*Ts]:
-    # TODO: revealed: tuple[*Ts@simple]
-    reveal_type(args)  # revealed: @Todo(PEP 646)
+    reveal_type(args)  # revealed: tuple[*Ts@simple]
     raise NotImplementedError
 
 def with_prefix[T, *Ts](prefix: T, *args: *Ts) -> tuple[T, *Ts]:
@@ -325,17 +253,12 @@ def kw_only[T, *Ts](*args: *Ts, kw: T) -> tuple[*Ts, T]:
     raise NotImplementedError
 
 def f(i: int, s: str, b: bool) -> None:
-    # TODO: revealed: tuple[()]
-    reveal_type(simple())  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(simple(i, s))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(with_prefix(i, s, b))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(kw_only(i, s, kw=b))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str, bool, Unknown]
+    reveal_type(simple())  # revealed: tuple[()]
+    reveal_type(simple(i, s))  # revealed: tuple[int, str]
+    reveal_type(with_prefix(i, s, b))  # revealed: tuple[int, str, bool]
+    reveal_type(kw_only(i, s, kw=b))  # revealed: tuple[int, str, bool]
     # error: [missing-argument] "No argument provided for required parameter `kw` of function `kw_only`"
-    reveal_type(kw_only(i, s, b))  # revealed: tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(kw_only(i, s, b))  # revealed: tuple[int, str, bool, Unknown]
 ```
 
 ### Callable parameters
@@ -346,8 +269,7 @@ def f(i: int, s: str, b: bool) -> None:
 from typing import Any, Callable
 
 def simple[*Ts](callback: Callable[[*Ts], tuple[*Ts]]) -> tuple[*Ts]:
-    # TODO: revealed: (*Ts@simple) -> tuple[*Ts@simple]
-    reveal_type(callback)  # revealed: (...) -> tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(callback)  # revealed: (*Ts@simple) -> tuple[*Ts@simple]
     raise NotImplementedError
 
 def positional_only(x: int, y: str, /) -> tuple[int, str]:
@@ -368,21 +290,15 @@ def variadic2(*args: int) -> tuple[str, ...]:
 def keyword_only(*, x: int) -> tuple[int]:
     raise NotImplementedError
 
-# TODO: revealed: tuple[int, str]
-reveal_type(simple(positional_only))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(simple(standard))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, *tuple[str, ...]]
-reveal_type(simple(positional_variadic))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: revealed: tuple[int, ...]
-reveal_type(simple(variadic1))  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(simple(positional_only))  # revealed: tuple[int, str]
+reveal_type(simple(standard))  # revealed: tuple[int, str]
+reveal_type(simple(positional_variadic))  # revealed: tuple[int, *tuple[str, ...]]
+reveal_type(simple(variadic1))  # revealed: tuple[int, ...]
 
-# TODO: error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: int) -> tuple[int, ...]`, found `def variadic2(*args: int) -> tuple[str, ...]`"
-# TODO: revealed: tuple[int, ...]
-reveal_type(simple(variadic2))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-# TODO: error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: Unknown) -> tuple[Unknown, ...]`, found `def keyword_only(*, x: int) -> tuple[int]`"
-# TODO: revealed: tuple[Unknown, ...]
-reveal_type(simple(keyword_only))  # revealed: tuple[@Todo(TypeVarTuple), ...]
+# error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: int) -> tuple[int, ...]`, found `def variadic2(*args: int) -> tuple[str, ...]`"
+reveal_type(simple(variadic2))  # revealed: tuple[int, ...]
+# error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: Unknown) -> tuple[Unknown, ...]`, found `def keyword_only(*, x: int) -> tuple[int]`"
+reveal_type(simple(keyword_only))  # revealed: tuple[Unknown, ...]
 ```
 
 This usage pattern is similar to how `ParamSpec` can be used to accept a callable and its arguments
@@ -393,22 +309,22 @@ def invoke[*Ts, R](callback: Callable[[*Ts], R], *args: *Ts) -> R:
     raise NotImplementedError
 
 reveal_type(invoke(positional_only, 1, "a"))  # revealed: tuple[int, str]
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
 reveal_type(invoke(positional_only))  # revealed: tuple[int, str]
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
 reveal_type(invoke(positional_only, 1))  # revealed: tuple[int, str]
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(int, Literal[2] | str, /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(int, Literal[2] | str, /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
 reveal_type(invoke(positional_only, 1, 2))  # revealed: tuple[int, str]
 
 reveal_type(invoke(standard, 1, "a"))  # revealed: tuple[int, str]
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def standard(x: int, y: str) -> tuple[int, str]`"
 # error: [unknown-argument] "Argument `x` does not match any known parameter of function `invoke`"
 # error: [unknown-argument] "Argument `y` does not match any known parameter of function `invoke`"
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def standard(x: int, y: str) -> tuple[int, str]`"
 reveal_type(invoke(standard, x=1, y="a"))  # revealed: tuple[int, str]
 
 reveal_type(invoke(positional_variadic, 1, "a", "b"))  # revealed: tuple[int, *tuple[str, ...]]
 reveal_type(invoke(positional_variadic, 1))  # revealed: tuple[int, *tuple[str, ...]]
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, *tuple[str, ...]]`, found `def positional_variadic(x: int, *args: str) -> tuple[int, *tuple[str, ...]]`"
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, *tuple[str, ...]]`, found `def positional_variadic(x: int, *args: str) -> tuple[int, *tuple[str, ...]]`"
 reveal_type(invoke(positional_variadic))  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
@@ -422,11 +338,9 @@ def foo[*Ts](arg1: tuple[*Ts], arg2: tuple[*Ts]) -> tuple[*Ts]:
     raise NotImplementedError
 
 def f(i: int, s: str, b: bool) -> None:
-    # TODO: revealed: tuple[int, str | int]
-    reveal_type(foo((i, s), (b, i)))  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: error: [invalid-argument-type] "Argument to function `foo` is incorrect: Expected `tuple[int]`, found `tuple[str, bool]`"
-    # TODO: revealed: tuple[int]
-    reveal_type(foo((i,), (s, b)))  # revealed: tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(foo((i, s), (b, i)))  # revealed: tuple[int, str | int]
+    # error: [invalid-argument-type] "Argument to function `foo` is incorrect: Expected `tuple[int]`, found `tuple[str, bool]`"
+    reveal_type(foo((i,), (s, b)))  # revealed: tuple[int]
 ```
 
 ## Type concatenation
@@ -440,59 +354,34 @@ class B: ...
 class C: ...
 class D: ...
 
-# error: [not-subscriptable]
-# error: [not-subscriptable]
 def add_letter_a[*Ts](x: Array[*Ts]) -> Array[A, *Ts]:
     raise NotImplementedError
 
-# error: [not-subscriptable]
-# error: [not-subscriptable]
 def del_letter_a[*Ts](x: Array[A, *Ts]) -> Array[*Ts]:
     raise NotImplementedError
 
-# error: [not-subscriptable]
-# error: [not-subscriptable]
 def add_letters[*Ts](x: Array[*Ts]) -> Array[A, *Ts, C]:
     raise NotImplementedError
 
-# error: [not-subscriptable]
-# error: [not-subscriptable]
 def del_letter_c[*Ts](x: Array[*Ts, C]) -> Array[*Ts]:
     raise NotImplementedError
 
-# error: [not-subscriptable]
-# error: [not-subscriptable]
 def generic[T, *Ts](x: T, y: Array[*Ts]) -> Array[T, *Ts]:
     raise NotImplementedError
 
-# TODO: revealed: Array[A, B, D, C]
-# error: [not-subscriptable]
-reveal_type(add_letters(Array[B, D]()))  # revealed: Unknown
-# TODO: revealed: Array[A, B, C]
-# error: [not-subscriptable]
-reveal_type(add_letter_a(Array[B, C]()))  # revealed: Unknown
+reveal_type(add_letters(Array[B, D]()))  # revealed: Array[A, B, D, C]
+reveal_type(add_letter_a(Array[B, C]()))  # revealed: Array[A, B, C]
 
-# TODO: revealed: Array[B]
-# error: [not-subscriptable]
-reveal_type(del_letter_a(Array[A, B]()))  # revealed: Unknown
+reveal_type(del_letter_a(Array[A, B]()))  # revealed: Array[B]
 # TODO: error: [invalid-argument-type]
-# TODO: revealed: Array[C]
-# error: [not-subscriptable]
-reveal_type(del_letter_a(Array[B, C]()))  # revealed: Unknown
+reveal_type(del_letter_a(Array[B, C]()))  # revealed: Array[C]
 
-# TODO: revealed: Array[A, B]
-# error: [not-subscriptable]
-reveal_type(del_letter_c(Array[A, B, C]()))  # revealed: Unknown
+reveal_type(del_letter_c(Array[A, B, C]()))  # revealed: Array[A, B]
 # TODO: error: [invalid-argument-type]
-# TODO: revealed: Array[A]
-# error: [not-subscriptable]
-reveal_type(del_letter_c(Array[A, B]()))  # revealed: Unknown
+reveal_type(del_letter_c(Array[A, B]()))  # revealed: Array[A]
 
-# TODO: revealed: Array[A, B, D]
-# error: [not-subscriptable]
-reveal_type(generic(A(), Array[B, D]()))  # revealed: Unknown
-# TODO: revealed: Array[A]
-reveal_type(generic(A(), Array[()]()))  # revealed: Unknown
+reveal_type(generic(A(), Array[B, D]()))  # revealed: Array[A, B, D]
+reveal_type(generic(A(), Array[()]()))  # revealed: Array[A]
 ```
 
 ## Unpacking Unbounded Tuple Types
@@ -517,8 +406,7 @@ def f(
     accept_any_in_between(multi)
     # error: [invalid-argument-type] "Argument to function `accept_any_in_between` is incorrect: Expected `tuple[bytes, *tuple[Any, ...], int]`, found `tuple[bytes]`"
     accept_any_in_between(truncated)
-    # TODO: revealed: tuple[Any, ...]
-    reveal_type(carry_items(dynamic))  # revealed: tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(carry_items(dynamic))  # revealed: tuple[Any, ...]
 ```
 
 A tuple containing an unpacked tuple can precisely describe heterogeneous positional arguments,
@@ -531,11 +419,10 @@ def remove_bytes[*Prefix](*args: *tuple[*Prefix, bytes]) -> tuple[*Prefix]:
 
 accept_str_in_between(True, "phase", "status", b"ok")
 accept_str_in_between(True, b"ok")
-# TODO: error: [invalid-argument-type] "Argument to function `accept_str_in_between` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
+# error: [invalid-argument-type] "Argument to function `accept_str_in_between` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
 accept_str_in_between(True, 1, b"bad")
 
-# TODO: revealed: tuple[Literal[1], Literal["record"]]
-reveal_type(remove_bytes(1, "record", b"sum"))  # revealed: tuple[@Todo(TypeVarTuple), ...]
+reveal_type(remove_bytes(1, "record", b"sum"))  # revealed: tuple[Literal[1], Literal["record"]]
 ```
 
 ## Type Aliases
@@ -550,42 +437,27 @@ type Between[T, *Ts, U] = tuple[T, *Ts, U]
 
 def _(
     a1: Simple[()],
-    # error: [not-subscriptable]
     a2: Simple[int, str],
     a3: Between[int, str],
-    # error: [invalid-type-arguments]
     a4: Between[int, bool, str],
-    # error: [invalid-type-arguments]
     a5: Between[int, bool, bytes, str],
     a6: Prefix[bool],
-    # error: [invalid-type-arguments]
     a7: Prefix[bool, int, str],
     a8: Suffix[bool],
-    # error: [invalid-type-arguments]
     a9: Suffix[int, str, bool],
     # error: [invalid-type-arguments] "No type argument provided for required type variable `U`"
     a10: Between[int],
 ):
-    # TODO: revealed: tuple[()]
-    reveal_type(a1)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a2)  # revealed: Unknown
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a3)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, bool, str]
-    reveal_type(a4)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, bool, bytes, str]
-    reveal_type(a5)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a6)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[bool, int, str]
-    reveal_type(a7)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a8)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a9)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-    reveal_type(a10)  # revealed: tuple[@Todo(TypeVarTuple), ...]
+    reveal_type(a1)  # revealed: tuple[()]
+    reveal_type(a2)  # revealed: tuple[int, str]
+    reveal_type(a3)  # revealed: tuple[int, str]
+    reveal_type(a4)  # revealed: tuple[int, bool, str]
+    reveal_type(a5)  # revealed: tuple[int, bool, bytes, str]
+    reveal_type(a6)  # revealed: tuple[bool]
+    reveal_type(a7)  # revealed: tuple[bool, int, str]
+    reveal_type(a8)  # revealed: tuple[bool]
+    reveal_type(a9)  # revealed: tuple[int, str, bool]
+    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Unpacked tuple type arguments
@@ -593,13 +465,9 @@ def _(
 ```py
 type Alias[*Ts] = tuple[int, *Ts]
 
-# error: [not-subscriptable]
-# error: [not-subscriptable]
 def _(a1: Alias[*tuple[str, bool]], a2: Alias[*tuple[str, ...]]) -> None:
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a1)  # revealed: Unknown
-    # TODO: revealed: tuple[int, *tuple[str, ...]]
-    reveal_type(a2)  # revealed: Unknown
+    reveal_type(a1)  # revealed: tuple[int, str, bool]
+    reveal_type(a2)  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
 ### Unspecified alias type arguments
@@ -612,12 +480,9 @@ from typing import Any
 
 type Headered[*Fields] = tuple[bytes, *Fields]
 
-# error: [not-subscriptable]
 def _(a1: Headered, a2: Headered[*tuple[Any, ...]]) -> None:
-    # TODO: revealed: tuple[bytes, *tuple[Unknown, ...]]
-    reveal_type(a1)  # revealed: tuple[@Todo(TypeVarTuple), ...]
-    # TODO: revealed: tuple[bytes, *tuple[Any, ...]]
-    reveal_type(a2)  # revealed: Unknown
+    reveal_type(a1)  # revealed: tuple[bytes, *tuple[Unknown, ...]]
+    reveal_type(a2)  # revealed: tuple[bytes, *tuple[Any, ...]]
 ```
 
 ### Splitting arbitrary-length tuples
@@ -626,16 +491,10 @@ def _(a1: Headered, a2: Headered[*tuple[Any, ...]]) -> None:
 type First[*Ts, T] = tuple[*Ts, T]
 type Second[T, *Ts] = tuple[T, *Ts]
 
-# TODO: revealed: <type alias 'First[*tuple[int, ...], int]'>
-reveal_type(First[*tuple[int, ...]])  # revealed: <type alias 'First[tuple[int, ...]]'>
-# TODO: revealed: <type alias 'First[*tuple[int, ...], str]'>
-# error: [invalid-type-arguments]
-reveal_type(First[*tuple[int, ...], str])  # revealed: <type alias 'First[Unknown]'>
-# TODO: revealed: <type alias 'Second[int, *tuple[int, ...]]'>
-reveal_type(Second[*tuple[int, ...]])  # revealed: <type alias 'Second[tuple[int, ...]]'>
-# TODO: revealed: <type alias 'Second[str, *tuple[int, ...]]'>
-# error: [invalid-type-arguments]
-reveal_type(Second[str, *tuple[int, ...]])  # revealed: <type alias 'Second[Unknown]'>
+reveal_type(First[*tuple[int, ...]])  # revealed: <type alias 'First[*tuple[int, ...], int]'>
+reveal_type(First[*tuple[int, ...], str])  # revealed: <type alias 'First[*tuple[int, ...], str]'>
+reveal_type(Second[*tuple[int, ...]])  # revealed: <type alias 'Second[int, *tuple[int, ...]]'>
+reveal_type(Second[str, *tuple[int, ...]])  # revealed: <type alias 'Second[str, *tuple[int, ...]]'>
 ```
 
 ### Variadic substitutions
@@ -644,15 +503,10 @@ A variadic alias can forward its remaining arguments to another variadic alias.
 
 ```py
 type First[*Ts] = tuple[bytes, *Ts]
-# error: [not-subscriptable]
 type Second[*Ts] = First[int, *Ts]
 
-# TODO: revealed: <type alias 'First[str, bool]'>
-# error: [not-subscriptable]
-reveal_type(First[str, bool])  # revealed: Unknown
-# TODO: revealed: <type alias 'Second[str, bool]'>
-# error: [not-subscriptable]
-reveal_type(Second[str, bool])  # revealed: Unknown
+reveal_type(First[str, bool])  # revealed: <type alias 'First[str, bool]'>
+reveal_type(Second[str, bool])  # revealed: <type alias 'Second[str, bool]'>
 ```
 
 ## Accessing Individual Types
@@ -668,24 +522,15 @@ class Row[*Cells]:
         raise NotImplementedError
 
     @overload
-    # error: [not-subscriptable]
-    # error: [not-subscriptable]
     def rotate_left[A, B](self: "Row[A, B]") -> "Row[B, A]": ...
     @overload
-    # error: [not-subscriptable]
-    # error: [not-subscriptable]
     def rotate_left[A, B, C](self: "Row[A, B, C]") -> "Row[B, C, A]": ...
-    # error: [not-subscriptable]
     def rotate_left(self) -> "Row[*tuple[Any, ...]]":
         raise NotImplementedError
 
-# error: [not-subscriptable]
-# error: [not-subscriptable]
 def f(pair: Row[int, str], triple: Row[int, str, bytes]) -> None:
-    # TODO: revealed: Row[str, int]
-    reveal_type(pair.rotate_left())  # revealed: Unknown
-    # TODO: revealed: Row[str, bytes, int]
-    reveal_type(triple.rotate_left())  # revealed: Unknown
+    reveal_type(pair.rotate_left())  # revealed: Row[str, int]
+    reveal_type(triple.rotate_left())  # revealed: Row[str, bytes, int]
 ```
 
 ## Invalid Forms
@@ -695,18 +540,18 @@ def f(pair: Row[int, str], triple: Row[int, str, bytes]) -> None:
 Only one type variable tuple can appear in a type parameter list.
 
 ```py
-# TODO: error: [invalid-type-form]
+# error: [invalid-type-form]
 class Array[*Ts1, *Ts2]: ...
 ```
 
 ### Must always be unpacked
 
 ```py
-def invalid[*Ts](x: Ts) -> None: ...  # TODO: error: [invalid-type-form]
-def invalid_args[*Ts](*args: Ts) -> None: ...  # TODO: error: [invalid-type-form]
+def invalid[*Ts](x: Ts) -> None: ...  # error: [invalid-type-form]
+def invalid_args[*Ts](*args: Ts) -> None: ...  # error: [invalid-type-form]
 
 class InvalidTupleElement[*Ts]:
-    # TODO: error: [invalid-type-form] "Bare TypeVarTuple `Ts` is not valid in this context in a type expression"
+    # error: [invalid-type-form] "Bare TypeVarTuple `Ts` is not valid in this context in a type expression"
     values: tuple[Ts]
 
 def valid[*Ts](x: tuple[*Ts]) -> tuple[*Ts]:
@@ -718,20 +563,17 @@ def valid[*Ts](x: tuple[*Ts]) -> tuple[*Ts]:
 Only tuple types and type variable tuples can be unpacked in a type expression.
 
 ```py
-# TODO: error: [invalid-type-form] "`*` can only unpack a tuple type or `TypeVarTuple`"
+# error: [invalid-type-form] "`*` can only unpack a tuple type or `TypeVarTuple`"
 def invalid(*args: *int) -> None:
-    # TODO: revealed: tuple[Unknown, ...]
-    reveal_type(args)  # revealed: @Todo(PEP 646)
+    reveal_type(args)  # revealed: tuple[Unknown, ...]
 
 class Pair[*Ts, U]: ...
 
 def invalid_generic(
-    # TODO: error: [invalid-type-form] "`*` can only unpack a tuple type or `TypeVarTuple`"
-    # error: [invalid-type-arguments]
+    # error: [invalid-type-form] "`*` can only unpack a tuple type or `TypeVarTuple`"
     value: Pair[*int, str],
 ) -> None:
-    # TODO: revealed: Pair[*tuple[Unknown, ...], str]
-    reveal_type(value)  # revealed: Pair[Unknown]
+    reveal_type(value)  # revealed: Pair[*tuple[Unknown, ...], str]
 ```
 
 ### Only one variadic unpack
@@ -740,7 +582,7 @@ def invalid_generic(
 def f[*Ts](
     ok1: tuple[int, *Ts],
     ok2: tuple[int, *Ts, str],
-    bad1: tuple[*Ts, *tuple[str, ...]],  # TODO: error: [invalid-type-form]
-    bad2: tuple[*tuple[str, ...], *Ts],  # TODO: error: [invalid-type-form]
+    bad1: tuple[*Ts, *tuple[str, ...]],  # error: [invalid-type-form]
+    bad2: tuple[*tuple[str, ...], *Ts],  # error: [invalid-type-form]
 ) -> None: ...
 ```

--- a/crates/ty_python_semantic/resources/mdtest/regression/typevartuple_exception_handler.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/typevartuple_exception_handler.md
@@ -1,0 +1,36 @@
+# `TypeVarTuple` in exception handlers
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+Semantic analysis should not panic when syntax recovery exposes a PEP 695 `TypeVarTuple` as an
+exception handler type on an older Python version.
+
+```py
+# error: [invalid-syntax]
+def regular[*Ts]() -> None:
+    try:
+        pass
+    # error: [invalid-exception-caught] "Invalid object caught in an exception handler: Object has type `TypeVarTuple`"
+    except Ts:
+        pass
+
+# error: [invalid-syntax]
+def tuple_handler[*Ts]() -> None:
+    try:
+        pass
+    # error: [invalid-exception-caught]
+    except (Ts,):
+        pass
+
+# error: [invalid-syntax]
+def starred[*Us]() -> None:
+    try:
+        pass
+    # error: 11 [invalid-syntax] "Cannot use `except*` on Python 3.10 (syntax was added in Python 3.11)"
+    # error: [invalid-exception-caught] "Invalid object caught in an exception handler: Object has type `TypeVarTuple`"
+    except* Us:
+        pass
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Default_type_paramet…_(6bb09b09c131074).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Default_type_paramet…_(6bb09b09c131074).snap
@@ -36,7 +36,7 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.
 21 | class Corge[*Ts, T1 = int, T2 = str, **P = [int, str]]: ...
 22 | 
 23 | # error: [invalid-type-variable-default]
-24 | class Grault[*Us, *Ts = *tuple[int, str]]: ...
+24 | class Grault[*Us, *Ts = *tuple[int, str]]: ...  # error: [invalid-type-form]
 25 | 
 26 | # These are fine:
 27 | class Ok1[T, *Ts]: ...
@@ -128,10 +128,23 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 ```
 
 ```
+error[invalid-type-form]: Only one TypeVarTuple parameter is allowed
+  --> src/mdtest_snippet.py:24:14
+   |
+24 | class Grault[*Us, *Ts = *tuple[int, str]]: ...  # error: [invalid-type-form]
+   |              ---  ^^^^^^^^^^^^^^^^^^^^^^ `Ts` is an additional TypeVarTuple
+   |              |
+   |              `Us` is the first TypeVarTuple
+   |
+info: See https://typing.python.org/en/latest/spec/generics.html#multiple-type-variable-tuples-not-allowed
+
+```
+
+```
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
   --> src/mdtest_snippet.py:24:14
    |
-24 | class Grault[*Us, *Ts = *tuple[int, str]]: ...
+24 | class Grault[*Us, *Ts = *tuple[int, str]]: ...  # error: [invalid-type-form]
    |              ---  ^^^^^^^^^^^^^^^^^^^^^^ `Ts` has a default
    |              |
    |              `Us` is a TypeVarTuple

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Attribute_access_on_…_(7bdb97302c27c412).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/union_call.md_-_Calling_a_union_of_f…_-_Try_to_cover_all_pos…_-_Attribute_access_on_…_(7bdb97302c27c412).snap
@@ -27,42 +27,16 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/union_call.m
 12 | 
 13 | def _(x: T, y: int) -> T:
 14 |     # error: [invalid-argument-type]
-15 |     # error: [invalid-argument-type]
-16 |     # error: [invalid-argument-type]
-17 |     return x.foo(y)
+15 |     return x.foo(y)
 ```
 
 # Diagnostics
 
 ```
-error[invalid-argument-type]: Argument to bound method `A.foo` is incorrect
-  --> src/mdtest_snippet.py:17:12
-   |
-17 |     return x.foo(y)
-   |            ^^^^^^^^ Argument type `T@_` does not satisfy upper bound `A` of type variable `Self`
-   |
-info: Union variant `bound method T@_.foo(x: int) -> T@_` is incompatible with this call site
-info: Attempted to call union type `(bound method T@_.foo(x: int) -> T@_) | (bound method T@_.foo(x: str) -> T@_)`
-
-```
-
-```
 error[invalid-argument-type]: Argument to bound method `B.foo` is incorrect
-  --> src/mdtest_snippet.py:17:12
+  --> src/mdtest_snippet.py:15:18
    |
-17 |     return x.foo(y)
-   |            ^^^^^^^^ Argument type `T@_` does not satisfy upper bound `B` of type variable `Self`
-   |
-info: Union variant `bound method T@_.foo(x: str) -> T@_` is incompatible with this call site
-info: Attempted to call union type `(bound method T@_.foo(x: int) -> T@_) | (bound method T@_.foo(x: str) -> T@_)`
-
-```
-
-```
-error[invalid-argument-type]: Argument to bound method `B.foo` is incorrect
-  --> src/mdtest_snippet.py:17:18
-   |
-17 |     return x.foo(y)
+15 |     return x.foo(y)
    |                  ^ Expected `str`, found `int`
    |
 info: Method defined here

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1476,6 +1476,34 @@ def g3(obj: Foo[tuple[A]]):
     f3(obj)
 ```
 
+### Assignability of generic types parameterized by typevar tuples
+
+For a class parameterized by a typevar tuple, the whole unpacked tuple participates in the generic
+class's variance.
+
+```py
+from typing import Generic, TypeVarTuple
+from ty_extensions import static_assert, is_assignable_to
+
+Ts = TypeVarTuple("Ts")
+
+class Array(Generic[*Ts]):
+    values: tuple[*Ts]
+
+static_assert(is_assignable_to(Array[int, str], Array[int, str]))
+static_assert(not is_assignable_to(Array[str, int], Array[int, str]))
+static_assert(not is_assignable_to(Array[int], Array[int, str]))
+
+OutTs = TypeVarTuple("OutTs", covariant=True)
+
+class CovariantArray(Generic[*OutTs]):
+    def get(self) -> tuple[*OutTs]:
+        raise NotImplementedError
+
+static_assert(is_assignable_to(CovariantArray[int, str], CovariantArray[object, object]))
+static_assert(not is_assignable_to(CovariantArray[object, object], CovariantArray[int, str]))
+```
+
 ## Generic aliases
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1177,10 +1177,7 @@ impl<'db> Type<'db> {
             | DynamicType::UnknownGeneric(_)
             | DynamicType::UnspecializedTypeVar
             | DynamicType::AmbiguousOverload => false,
-            DynamicType::Todo(_)
-            | DynamicType::TodoStarredExpression
-            | DynamicType::TodoUnpack
-            | DynamicType::TodoTypeVarTuple => true,
+            DynamicType::Todo(_) => true,
         })
     }
 
@@ -1920,11 +1917,8 @@ impl<'db> Type<'db> {
                 DynamicType::Unknown
                 | DynamicType::UnknownGeneric(_)
                 | DynamicType::UnspecializedTypeVar
-                | DynamicType::TodoUnpack
-                | DynamicType::TodoTypeVarTuple
                 | DynamicType::Todo(_)
                 | DynamicType::InvalidConcatenateUnknown
-                | DynamicType::TodoStarredExpression
                 | DynamicType::AmbiguousOverload => false,
             },
         }
@@ -5561,6 +5555,16 @@ impl<'db> Type<'db> {
                             fallback_type: Type::unknown(),
                         });
                     }
+                    if !inference_flags.contains(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT)
+                        && typevar.is_typevartuple(db)
+                    {
+                        return Err(InvalidTypeExpressionError {
+                            invalid_expressions: smallvec_inline![
+                                InvalidTypeExpression::InvalidBareTypeVarTuple(*typevar)
+                            ],
+                            fallback_type: Type::unknown(),
+                        });
+                    }
                     let index = semantic_index(db, scope_id.file(db));
                     Ok(bind_typevar(
                         db,
@@ -5693,7 +5697,9 @@ impl<'db> Type<'db> {
                 Some(KnownClass::TypeVar) => Ok(todo_type!(
                     "Support for `typing.TypeVar` instances in type expressions"
                 )),
-                Some(KnownClass::TypeVarTuple) => Ok(Type::Dynamic(DynamicType::TodoTypeVarTuple)),
+                Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple) => Ok(
+                    todo_type!("Support for `typing.TypeVarTuple` instances in type expressions"),
+                ),
                 _ => Err(InvalidTypeExpressionError {
                     invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
                         *self, scope_id
@@ -6264,6 +6270,14 @@ impl<'db> Type<'db> {
                 {
                     Some(*bound_typevar)
                 }
+                TypeVarKind::TypeVarTuple
+                    if binding_context.is_none_or(|binding_context| {
+                        bound_typevar.binding_context(db)
+                            == BindingContext::Definition(binding_context)
+                    }) =>
+                {
+                    Some(*bound_typevar)
+                }
                 TypeVarKind::ParamSpec => {
                     // For `ParamSpec`, we're only interested in `P` itself, not `P.args` or
                     // `P.kwargs`.
@@ -6700,9 +6714,6 @@ impl<'db> Type<'db> {
             Self::Divergent(_)
             | Self::Dynamic(
                 DynamicType::Todo(_)
-                | DynamicType::TodoUnpack
-                | DynamicType::TodoStarredExpression
-                | DynamicType::TodoTypeVarTuple
                 | DynamicType::InvalidConcatenateUnknown
                 | DynamicType::UnspecializedTypeVar,
             )
@@ -7364,12 +7375,6 @@ pub enum DynamicType<'db> {
     ///
     /// This variant should be created with the `todo_type!` macro.
     Todo(TodoType),
-    /// A special Todo-variant for `Unpack[Ts]`, so that we can treat it specially in `Generic[Unpack[Ts]]`
-    TodoUnpack,
-    /// A special Todo-variant for `*Ts`, so that we can treat it specially in `Generic[*Ts]`
-    TodoStarredExpression,
-    /// A special Todo-variant for `TypeVarTuple` instances encountered in type expressions
-    TodoTypeVarTuple,
 }
 
 impl DynamicType<'_> {
@@ -7378,7 +7383,7 @@ impl DynamicType<'_> {
     }
 
     pub(crate) fn is_todo(&self) -> bool {
-        matches!(self, Self::Todo(_) | Self::TodoUnpack)
+        matches!(self, Self::Todo(_))
     }
 }
 
@@ -7394,9 +7399,6 @@ impl std::fmt::Display for DynamicType<'_> {
             // `DynamicType::Todo`'s display should be explicit that is not a valid display of
             // any other type
             DynamicType::Todo(todo) => write!(f, "@Todo{todo}"),
-            DynamicType::TodoUnpack => f.write_str("@Todo(typing.Unpack)"),
-            DynamicType::TodoStarredExpression => f.write_str("@Todo(StarredExpression)"),
-            DynamicType::TodoTypeVarTuple => f.write_str("@Todo(TypeVarTuple)"),
         }
     }
 }
@@ -7600,6 +7602,7 @@ enum InvalidTypeExpression<'db> {
     /// Some types are always invalid in type expressions
     InvalidType(Type<'db>, ScopeId<'db>),
     InvalidBareParamSpec(TypeVarInstance<'db>),
+    InvalidBareTypeVarTuple(TypeVarInstance<'db>),
 }
 
 impl<'db> InvalidTypeExpression<'db> {
@@ -7721,6 +7724,11 @@ impl<'db> InvalidTypeExpression<'db> {
                         "Bare ParamSpec `{}` is not valid in this context in a {location}",
                         paramspec.name(self.db)
                     ),
+                    InvalidTypeExpression::InvalidBareTypeVarTuple(typevartuple) => write!(
+                        f,
+                        "Bare TypeVarTuple `{}` is not valid in this context in a {location}",
+                        typevartuple.name(self.db)
+                    ),
                     InvalidTypeExpression::Concatenate => write!(
                         f,
                         "`typing.Concatenate` is not allowed in this context in a {location}",
@@ -7799,6 +7807,8 @@ impl<'db> InvalidTypeExpression<'db> {
             diagnostic.info(" - as the default type for another ParamSpec");
             diagnostic.info(" - as part of a type parameter list when defining a generic class");
             diagnostic.info(" - or as part of an argument list when specializing a generic class");
+        } else if matches!(self, InvalidTypeExpression::InvalidBareTypeVarTuple(_)) {
+            diagnostic.info("A TypeVarTuple must be unpacked with `*` or `Unpack[]`.");
         } else if matches!(self, InvalidTypeExpression::Concatenate) {
             diagnostic.info("`typing.Concatenate` is only valid:");
             diagnostic.info(" - as the first argument to `Callable`");

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -54,7 +54,7 @@ use crate::types::signatures::{
     CallableSignature, Parameter, ParameterForm, ParameterKind, Parameters, ParametersKind,
     PartialApplication, PartialSignatureApplication,
 };
-use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
+use crate::types::tuple::{TupleLength, TupleSpec, TupleSpecBuilder, TupleType};
 use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_value_type;
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarNonceGenerator};
 use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
@@ -5185,21 +5185,119 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         specialization_errors: &mut Vec<BindingError<'db>>,
     ) -> bool {
         let parameters = self.signature.parameters();
-        for (argument_index, adjusted_argument_index, _, argument_types) in
+        let starred_typevartuple_declared_type = |parameter: &Parameter<'db>| {
+            if !parameter.has_starred_annotation() {
+                return None;
+            }
+            if let Type::TypeVar(typevar) = parameter.annotated_type()
+                && typevar.is_typevartuple(self.db)
+            {
+                return Some(Type::tuple(TupleType::new(
+                    self.db,
+                    &TupleSpecBuilder::with_capacity(0)
+                        .concat_variadic_typevar(self.db, typevar)
+                        .build(),
+                )));
+            }
+            let tuple = parameter
+                .annotated_type()
+                .exact_tuple_instance_spec(self.db)?;
+            let TupleSpec::Variable(variable) = tuple.as_ref() else {
+                return None;
+            };
+            if matches!(
+                variable.variable(),
+                Type::TypeVar(typevar) if typevar.is_typevartuple(self.db)
+            ) {
+                Some(parameter.annotated_type())
+            } else {
+                None
+            }
+        };
+
+        let mut starred_typevartuple_declared_types = None;
+        for (parameter_index, parameter) in parameters.iter().enumerate() {
+            let Some(declared_type) = starred_typevartuple_declared_type(parameter) else {
+                continue;
+            };
+            let declared_types = starred_typevartuple_declared_types
+                .get_or_insert_with(|| vec![None; parameters.len()]);
+            declared_types[parameter_index] = Some(declared_type);
+        }
+
+        let mut starred_typevartuple_arguments: FxHashMap<usize, Vec<Type<'db>>> =
+            FxHashMap::default();
+        if let Some(starred_typevartuple_declared_types) = &starred_typevartuple_declared_types {
+            for (argument_index, _, _, argument_types) in self.enumerate_argument_types() {
+                for matched_parameter in self.argument_matches[argument_index].iter() {
+                    let parameter_index = matched_parameter.index;
+                    if starred_typevartuple_declared_types[parameter_index].is_some() {
+                        starred_typevartuple_arguments
+                            .entry(parameter_index)
+                            .or_default()
+                            .push(argument_types.get_default().unwrap_or(Type::unknown()));
+                    }
+                }
+            }
+            for (parameter_index, declared_type) in
+                starred_typevartuple_declared_types.iter().enumerate()
+            {
+                if declared_type.is_some() {
+                    starred_typevartuple_arguments
+                        .entry(parameter_index)
+                        .or_default();
+                }
+            }
+        }
+
+        for (parameter_index, argument_types) in &starred_typevartuple_arguments {
+            let declared_type = starred_typevartuple_declared_types
+                .as_ref()
+                .and_then(|declared_types| declared_types[*parameter_index])
+                .unwrap_or_else(Type::unknown);
+            let argument_type = Type::heterogeneous_tuple(self.db, argument_types.iter().copied());
+            let specialization_result = builder.infer(declared_type, argument_type);
+
+            if let Err(error) = specialization_result {
+                specialization_errors.push(BindingError::SpecializationError {
+                    error,
+                    argument_index: None,
+                });
+            }
+        }
+
+        for (argument_index, adjusted_argument_index, argument, argument_types) in
             self.enumerate_argument_types()
         {
             for matched_parameter in self.argument_matches[argument_index].iter() {
                 let parameter_index = matched_parameter.index;
+                if starred_typevartuple_arguments.contains_key(&parameter_index) {
+                    continue;
+                }
                 if self.is_gradual_variadic_parameter(parameter_index) {
                     continue;
                 }
 
                 let declared_type = parameters[parameter_index].annotated_type();
                 let argument_type = argument_types.get_for_declared_type(declared_type);
-                let specialization_result = builder.infer(
+                let argument_type = matched_parameter.argument_type.unwrap_or(argument_type);
+                if self.is_correlated_constrained_self_argument(
+                    argument,
+                    argument_type,
                     declared_type,
-                    matched_parameter.argument_type.unwrap_or(argument_type),
-                );
+                ) {
+                    if let Type::TypeVar(typevar) = declared_type
+                        && typevar.is_inferable(self.db, self.inferable_typevars)
+                    {
+                        builder.add_type_mapping(
+                            typevar,
+                            argument_type,
+                            TypeVarVariance::Covariant,
+                        );
+                    }
+                    continue;
+                }
+                let specialization_result = builder.infer(declared_type, argument_type);
 
                 if let Err(error) = specialization_result {
                     specialization_errors.push(BindingError::SpecializationError {
@@ -5235,6 +5333,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         }
 
         let mut expected_ty = parameter.annotated_type();
+        let correlated_constrained_self =
+            self.is_correlated_constrained_self_argument(argument, argument_type, expected_ty);
         if let Some(specialization) = self.specialization {
             argument_type = argument_type.apply_specialization(self.db, specialization);
             expected_ty = expected_ty.apply_specialization(self.db, specialization);
@@ -5253,7 +5353,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // building them in an earlier separate step.
         //
         // TODO: handle starred annotations, e.g. `*args: *Ts` or `*args: *tuple[int, *tuple[str, ...]]`
-        if !self.constraint_set_errors[argument_index]
+        if !correlated_constrained_self
+            && !self.constraint_set_errors[argument_index]
             && !parameter.has_starred_annotation()
             && argument_type
                 .when_assignable_to(self.db, expected_ty, constraints, self.inferable_typevars)
@@ -5300,6 +5401,43 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         } else {
             self.parameter_tys[parameter_index] = Some(argument_type);
         }
+    }
+
+    fn is_correlated_constrained_self_argument(
+        &self,
+        argument: Argument<'_>,
+        argument_type: Type<'db>,
+        parameter_type: Type<'db>,
+    ) -> bool {
+        if !matches!(argument, Argument::Synthetic) {
+            return false;
+        }
+
+        let Type::TypeVar(argument_typevar) = argument_type else {
+            return false;
+        };
+        let Some(TypeVarBoundOrConstraints::Constraints(constraints)) = argument_typevar
+            .typevar(self.db)
+            .bound_or_constraints(self.db)
+        else {
+            return false;
+        };
+
+        let parameter_type = if let Type::TypeVar(parameter_typevar) = parameter_type
+            && parameter_typevar.typevar(self.db).is_self(self.db)
+            && let Some(TypeVarBoundOrConstraints::UpperBound(bound)) = parameter_typevar
+                .typevar(self.db)
+                .bound_or_constraints(self.db)
+        {
+            bound
+        } else {
+            parameter_type
+        };
+
+        constraints
+            .elements(self.db)
+            .iter()
+            .any(|constraint| constraint.is_assignable_to(self.db, parameter_type))
     }
 
     fn is_gradual_variadic_parameter(&self, parameter_index: usize) -> bool {
@@ -5357,6 +5495,67 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let is_paramspec_component_parameter = |parameter_index: usize| {
             paramspec_component_start.is_some_and(|start| parameter_index >= start)
         };
+
+        for (parameter_index, parameter) in self.signature.parameters().iter().enumerate() {
+            if !parameter.is_variadic()
+                || !parameter.has_starred_annotation()
+                || parameter
+                    .annotated_type()
+                    .exact_tuple_instance_spec(self.db)
+                    .is_none()
+            {
+                continue;
+            }
+
+            let mut positional_types = Vec::new();
+            let mut diagnostic_argument_index = None;
+            let mut has_unpacked_argument = false;
+            for (argument_index, adjusted_argument_index, argument, argument_types) in
+                self.enumerate_argument_types()
+            {
+                if !self.argument_matches[argument_index]
+                    .iter()
+                    .any(|matched_parameter| matched_parameter.index == parameter_index)
+                {
+                    continue;
+                }
+                if matches!(argument, Argument::Variadic) {
+                    has_unpacked_argument = true;
+                    break;
+                }
+                if !matches!(argument, Argument::Positional | Argument::Synthetic) {
+                    continue;
+                }
+                positional_types
+                    .push(argument_types.get_for_declared_type(parameter.annotated_type()));
+                diagnostic_argument_index = diagnostic_argument_index.or(adjusted_argument_index);
+            }
+            if has_unpacked_argument {
+                continue;
+            }
+
+            let provided_ty = Type::heterogeneous_tuple(self.db, positional_types);
+            let expected_ty = self.specialization.map_or_else(
+                || parameter.annotated_type(),
+                |specialization| {
+                    parameter
+                        .annotated_type()
+                        .apply_specialization(self.db, specialization)
+                },
+            );
+            if provided_ty
+                .when_assignable_to(self.db, expected_ty, constraints, self.inferable_typevars)
+                .is_never_satisfied(self.db)
+            {
+                self.errors.push(BindingError::InvalidArgumentType {
+                    parameter: ParameterContext::new(parameter, parameter_index, false),
+                    argument_index: diagnostic_argument_index,
+                    expected_ty,
+                    provided_ty,
+                    provenance: InvalidArgumentTypeProvenance::Argument,
+                });
+            }
+        }
 
         for (argument_index, adjusted_argument_index, argument, argument_types) in
             self.enumerate_argument_types()

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -107,6 +107,7 @@ pub enum KnownClass {
     ParamSpecKwargs,
     ProtocolMeta,
     TypeVarTuple,
+    ExtensionsTypeVarTuple, // must be distinct from typing.TypeVarTuple, backports new features
     TypeAliasType,
     NoDefaultType,
     NewType,
@@ -187,6 +188,7 @@ impl KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::Super
             | Self::WrapperDescriptorType
@@ -340,6 +342,7 @@ impl KnownClass {
             | KnownClass::ParamSpecArgs
             | KnownClass::ParamSpecKwargs
             | KnownClass::TypeVarTuple
+            | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
             | KnownClass::NoDefaultType
@@ -441,6 +444,7 @@ impl KnownClass {
             | KnownClass::ParamSpecArgs
             | KnownClass::ParamSpecKwargs
             | KnownClass::TypeVarTuple
+            | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
             | KnownClass::NoDefaultType
@@ -542,6 +546,7 @@ impl KnownClass {
             | KnownClass::ParamSpecArgs
             | KnownClass::ParamSpecKwargs
             | KnownClass::TypeVarTuple
+            | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
             | KnownClass::NoDefaultType
@@ -650,6 +655,7 @@ impl KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::TypeAliasType
             | Self::NoDefaultType
@@ -763,6 +769,7 @@ impl KnownClass {
             | KnownClass::ParamSpecKwargs
             | KnownClass::ProtocolMeta
             | KnownClass::TypeVarTuple
+            | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
             | KnownClass::NoDefaultType
@@ -846,6 +853,7 @@ impl KnownClass {
             Self::ParamSpecArgs => "ParamSpecArgs",
             Self::ParamSpecKwargs => "ParamSpecKwargs",
             Self::TypeVarTuple => "TypeVarTuple",
+            Self::ExtensionsTypeVarTuple => "TypeVarTuple",
             Self::Sentinel => "Sentinel",
             Self::TypeAliasType => "TypeAliasType",
             Self::NoDefaultType => "_NoDefaultType",
@@ -1225,10 +1233,11 @@ impl KnownClass {
             | Self::Mapping
             | Self::ProtocolMeta
             | Self::ParamSpec
+            | Self::TypeVarTuple
             | Self::SupportsIndex => KnownModule::Typing,
             Self::TypeAliasType
             | Self::ExtensionsTypeVar
-            | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::ExtensionsParamSpec
             | Self::ParamSpecArgs
@@ -1331,6 +1340,7 @@ impl KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::Enum
             | Self::EnumProperty
@@ -1437,6 +1447,7 @@ impl KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::Enum
             | Self::EnumProperty
@@ -1537,7 +1548,7 @@ impl KnownClass {
             "ParamSpec" => &[Self::ParamSpec, Self::ExtensionsParamSpec],
             "ParamSpecArgs" => &[Self::ParamSpecArgs],
             "ParamSpecKwargs" => &[Self::ParamSpecKwargs],
-            "TypeVarTuple" => &[Self::TypeVarTuple],
+            "TypeVarTuple" => &[Self::TypeVarTuple, Self::ExtensionsTypeVarTuple],
             "Sentinel" => &[Self::Sentinel],
             "ChainMap" => &[Self::ChainMap],
             "Counter" => &[Self::Counter],
@@ -1657,6 +1668,8 @@ impl KnownClass {
             | Self::ExtensionsTypeVar
             | Self::ParamSpec
             | Self::ExtensionsParamSpec
+            | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::NamedTupleLike
             | Self::ExactlySized
@@ -1680,7 +1693,6 @@ impl KnownClass {
             | Self::SupportsIndex
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
-            | Self::TypeVarTuple
             | Self::Iterable
             | Self::Iterator
             | Self::AsyncIterator
@@ -1972,6 +1984,7 @@ mod tests {
                     KnownClass::BaseExceptionGroup | KnownClass::ExceptionGroup => {
                         PythonVersion::PY311
                     }
+                    KnownClass::TypeVarTuple => PythonVersion::PY311,
                     KnownClass::GenericAlias => PythonVersion::PY39,
                     KnownClass::EnumProperty
                     | KnownClass::Member

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -64,12 +64,7 @@ impl<'db> ClassBase<'db> {
                 | DynamicType::AmbiguousOverload,
             ) => "Unknown",
             ClassBase::Dynamic(DynamicType::UnspecializedTypeVar) => "UnspecializedTypeVar",
-            ClassBase::Dynamic(
-                DynamicType::Todo(_)
-                | DynamicType::TodoUnpack
-                | DynamicType::TodoStarredExpression
-                | DynamicType::TodoTypeVarTuple,
-            ) => "@Todo",
+            ClassBase::Dynamic(DynamicType::Todo(_)) => "@Todo",
             ClassBase::Divergent(_) => "Divergent",
             ClassBase::Protocol => "Protocol",
             ClassBase::Generic => "Generic",

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1500,6 +1500,30 @@ impl<'db> FmtDetailed<'db> for DisplayTuple<'_, 'db> {
             // S is included if there is either a prefix or a suffix. The initial `tuple[` and
             // trailing `]` are printed elsewhere. The `yyy, ...` is printed no matter what.)
             TupleSpec::Variable(tuple) => {
+                if let Type::TypeVar(typevar) = tuple.variable()
+                    && typevar.is_typevartuple(self.db)
+                {
+                    if !tuple.prefix_elements().is_empty() {
+                        tuple
+                            .prefix_elements()
+                            .display_with(self.db, self.settings.singleline())
+                            .fmt_detailed(f)?;
+                        f.write_str(", ")?;
+                    }
+                    f.write_char('*')?;
+                    Type::TypeVar(typevar)
+                        .display_with(self.db, self.settings.singleline())
+                        .fmt_detailed(f)?;
+                    if !tuple.suffix_elements().is_empty() {
+                        f.write_str(", ")?;
+                        tuple
+                            .suffix_elements()
+                            .display_with(self.db, self.settings.singleline())
+                            .fmt_detailed(f)?;
+                    }
+                    f.write_str("]")?;
+                    return Ok(());
+                }
                 if !tuple.prefix_elements().is_empty() {
                     tuple
                         .prefix_elements()
@@ -1846,6 +1870,8 @@ impl<'db> DisplayGenericContext<'_, 'db> {
             let typevar = bound_typevar.typevar(self.db);
             if typevar.is_paramspec(self.db) {
                 f.write_str("**")?;
+            } else if typevar.is_typevartuple(self.db) {
+                f.write_char('*')?;
             }
             write!(
                 f.with_type(Type::TypeVar(bound_typevar)),
@@ -1931,13 +1957,64 @@ struct DisplaySpecialization<'db> {
 impl<'db> DisplaySpecialization<'db> {
     fn fmt_normal(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
         f.write_char('[')?;
+        let variables = self
+            .specialization
+            .generic_context(self.db)
+            .variables(self.db)
+            .collect::<Vec<_>>();
         let types = self.specialization.types(self.db);
-        for (idx, ty) in types.iter().enumerate() {
-            if idx > 0 {
+        let mut wrote_any = false;
+        for (typevar, ty) in variables.iter().zip(types) {
+            if typevar.is_typevartuple(self.db) {
+                let Some(tuple) = ty.exact_tuple_instance_spec(self.db) else {
+                    if wrote_any {
+                        f.write_str(", ")?;
+                    }
+                    ty.display_with(self.db, self.settings.clone())
+                        .fmt_detailed(f)?;
+                    wrote_any = true;
+                    continue;
+                };
+                match tuple.as_ref() {
+                    TupleSpec::Fixed(fixed) if fixed.elements_slice().is_empty() => {
+                        if variables.len() == 1 {
+                            if wrote_any {
+                                f.write_str(", ")?;
+                            }
+                            f.write_str("()")?;
+                            wrote_any = true;
+                        }
+                    }
+                    TupleSpec::Fixed(fixed) => {
+                        for element in fixed.elements_slice() {
+                            if wrote_any {
+                                f.write_str(", ")?;
+                            }
+                            element
+                                .display_with(self.db, self.settings.clone())
+                                .fmt_detailed(f)?;
+                            wrote_any = true;
+                        }
+                    }
+                    TupleSpec::Variable(_) => {
+                        if wrote_any {
+                            f.write_str(", ")?;
+                        }
+                        f.write_char('*')?;
+                        ty.display_with(self.db, self.settings.clone())
+                            .fmt_detailed(f)?;
+                        wrote_any = true;
+                    }
+                }
+                continue;
+            }
+
+            if wrote_any {
                 f.write_str(", ")?;
             }
             ty.display_with(self.db, self.settings.clone())
                 .fmt_detailed(f)?;
+            wrote_any = true;
         }
         if self.tuple_specialization.is_yes() {
             f.write_str(", ...")?;
@@ -2258,11 +2335,16 @@ impl<'db> FmtDetailed<'db> for DisplayParameters<'_, 'db> {
         ) -> fmt::Result {
             let mut star_added = false;
             let mut needs_slash = false;
+            let mut after_synthetic_unpack = false;
             let mut first = true;
 
             for parameter in parameters {
+                let is_synthetic_unpack = parameter.definition().is_none()
+                    && parameter.is_variadic()
+                    && parameter.has_starred_annotation();
+
                 // Handle special separators
-                if parameter.is_positional_only() {
+                if parameter.is_positional_only() && !after_synthetic_unpack {
                     needs_slash = true;
                 } else if needs_slash {
                     if !first {
@@ -2295,6 +2377,7 @@ impl<'db> FmtDetailed<'db> for DisplayParameters<'_, 'db> {
                     .display_with(display.db, display.settings.singleline())
                     .fmt_detailed(&mut f.with_detail(TypeDetail::Parameter(param_name)))?;
 
+                after_synthetic_unpack |= is_synthetic_unpack;
                 first = false;
             }
 
@@ -2407,6 +2490,18 @@ struct DisplayParameter<'a, 'db> {
 
 impl<'db> FmtDetailed<'db> for DisplayParameter<'_, 'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        if self.param.definition().is_none()
+            && self.param.is_variadic()
+            && self.param.has_starred_annotation()
+        {
+            f.write_str("*")?;
+            self.param
+                .annotated_type()
+                .display_with(self.db, self.settings.clone())
+                .fmt_detailed(f)?;
+            return Ok(());
+        }
+
         if let Some(name) = self.param.display_name() {
             f.write_str(&name)?;
             if self.param.should_annotation_be_displayed() {
@@ -3137,6 +3232,8 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
             KnownInstanceType::TypeVar(typevar_instance) => {
                 if typevar_instance.kind(self.db).is_paramspec() {
                     f.with_type(ty).write_str("ParamSpec")
+                } else if typevar_instance.kind(self.db).is_typevartuple() {
+                    f.with_type(ty).write_str("TypeVarTuple")
                 } else {
                     f.with_type(ty).write_str("TypeVar")
                 }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 
 use crate::types::callable::walk_callable_type;
 use crate::types::class::ClassType;
@@ -19,9 +20,10 @@ use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
 use crate::types::signatures::{
-    CallableSignature, Parameters, ReturnCallableTypeVarScope, SignatureRelationVisitor,
+    CallableSignature, Parameter, Parameters, ReturnCallableTypeVarScope, Signature,
+    SignatureRelationVisitor,
 };
-use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
+use crate::types::tuple::{TupleSpec, TupleSpecBuilder, TupleType, walk_tuple_type};
 use crate::types::type_alias::{walk_manual_pep_695_type_alias, walk_pep_695_type_alias};
 use crate::types::typevar::{
     BoundTypeVarIdentity, TypeVarIdentity, TypeVarInstance, walk_type_var_bounds,
@@ -570,8 +572,16 @@ impl<'db> GenericContext<'db> {
                 };
                 Some(typevar.with_binding_context(db, binding_context))
             }
-            // TODO: Support this!
-            ast::TypeParam::TypeVarTuple(_) => None,
+            ast::TypeParam::TypeVarTuple(node) => {
+                let definition = index.expect_single_definition(node);
+                let declared = inferred_declaration(db, definition).declared()?;
+                let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+                    declared.inner_type()
+                else {
+                    return None;
+                };
+                Some(typevar.with_binding_context(db, binding_context))
+            }
         }
     }
 
@@ -884,9 +894,21 @@ impl<'db> GenericContext<'db> {
     pub(crate) fn unknown_specialization(self, db: &'db dyn Db) -> Specialization<'db> {
         match self.len(db) {
             0 => self.specialize(db, &[]),
-            1 => self.specialize(db, &[Type::unknown(); 1]),
-            2 => self.specialize(db, &[Type::unknown(); 2]),
-            len => self.specialize(db, vec![Type::unknown(); len]),
+            len => self.specialize(
+                db,
+                self.variables(db)
+                    .take(len)
+                    .map(|typevar| {
+                        if typevar.is_typevartuple(db) {
+                            Type::homogeneous_tuple(db, Type::unknown())
+                        } else if typevar.is_paramspec(db) {
+                            Type::paramspec_value_callable(db, Parameters::unknown())
+                        } else {
+                            Type::unknown()
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            ),
         }
     }
 
@@ -1027,6 +1049,8 @@ impl<'db> GenericContext<'db> {
         for typevar in variables.clone() {
             if typevar.is_paramspec(db) {
                 expanded.push(Type::paramspec_value_callable(db, Parameters::unknown()));
+            } else if typevar.is_typevartuple(db) {
+                expanded.push(Type::homogeneous_tuple(db, Type::unknown()));
             } else {
                 expanded.push(Type::unknown());
             }
@@ -1916,7 +1940,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         if generic_context
             .variables_inner(self.db)
             .values()
-            .any(|typevar| typevar.is_paramspec(self.db))
+            .any(|typevar| typevar.is_paramspec(self.db) || typevar.is_typevartuple(self.db))
         {
             return self.solve_hash_map_with(generic_context, choose);
         }
@@ -2190,6 +2214,26 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     return;
                 }
 
+                if bound_typevar.is_typevartuple(self.db) {
+                    let accumulator = entry.get_mut();
+                    let existing = accumulator.get_or_build(self.db);
+                    let Some(existing_tuple) = existing.exact_tuple_instance_spec(self.db) else {
+                        return;
+                    };
+                    let Some(new_tuple) = ty.exact_tuple_instance_spec(self.db) else {
+                        return;
+                    };
+                    if existing_tuple.len() != new_tuple.len() {
+                        return;
+                    }
+                    let unioned = TupleSpecBuilder::from(existing_tuple.as_ref())
+                        .union(self.db, &new_tuple)
+                        .build();
+                    *accumulator =
+                        UnionAccumulator::new(Type::tuple(TupleType::new(self.db, &unioned)));
+                    return;
+                }
+
                 entry.get_mut().add(self.db, ty);
             }
             Entry::Vacant(entry) => {
@@ -2355,6 +2399,100 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             .then_some(mapping_when)
     }
 
+    fn infer_typevartuple_from_callable_parameters(
+        &mut self,
+        formal_signature: &Signature<'db>,
+        variadic_index: usize,
+        typevartuple: BoundTypeVarInstance<'db>,
+        actual_signature: &Signature<'db>,
+    ) {
+        let formal_parameters = formal_signature.parameters().as_slice();
+        let suffix_len = formal_parameters.len() - variadic_index - 1;
+        if !formal_parameters[..variadic_index]
+            .iter()
+            .chain(&formal_parameters[variadic_index + 1..])
+            .all(Parameter::is_positional)
+        {
+            return;
+        }
+
+        let actual_parameters = actual_signature.parameters().as_slice();
+        if actual_parameters
+            .iter()
+            .any(|parameter| !parameter.is_positional() && !parameter.is_variadic())
+        {
+            return;
+        }
+
+        let tuple = if let Some(actual_variadic_index) =
+            actual_parameters.iter().position(Parameter::is_variadic)
+        {
+            // An actual variadic parameter can only satisfy the open-ended portion of the formal
+            // callable. It cannot provide a fixed suffix because callers are not required to pass
+            // any arguments to it.
+            if suffix_len > 0
+                || actual_variadic_index < variadic_index
+                || actual_variadic_index + 1 != actual_parameters.len()
+            {
+                return;
+            }
+
+            Type::tuple(TupleType::new(
+                self.db,
+                &TupleSpecBuilder::Variable {
+                    prefix: actual_parameters[variadic_index..actual_variadic_index]
+                        .iter()
+                        .map(Parameter::annotated_type)
+                        .collect(),
+                    variable: actual_parameters[actual_variadic_index].annotated_type(),
+                    suffix: vec![],
+                }
+                .build(),
+            ))
+        } else {
+            if actual_parameters.len() < variadic_index + suffix_len {
+                return;
+            }
+
+            let middle_end = actual_parameters.len() - suffix_len;
+            Type::heterogeneous_tuple(
+                self.db,
+                actual_parameters[variadic_index..middle_end]
+                    .iter()
+                    .map(Parameter::annotated_type),
+            )
+        };
+        self.add_type_mapping(typevartuple, tuple, TypeVarVariance::Contravariant);
+
+        let _ = self.infer_map_impl(
+            formal_signature.return_ty,
+            actual_signature.return_ty,
+            TypeVarVariance::Covariant,
+            &mut FxHashSet::default(),
+        );
+    }
+
+    fn typevartuple_variadic_parameter(
+        &self,
+        signature: &Signature<'db>,
+    ) -> Option<(usize, BoundTypeVarInstance<'db>)> {
+        signature
+            .parameters()
+            .as_slice()
+            .iter()
+            .find_position(|parameter| {
+                parameter.is_variadic() && parameter.has_starred_annotation()
+            })
+            .and_then(|(index, parameter)| {
+                let Type::TypeVar(typevartuple) = parameter.annotated_type() else {
+                    return None;
+                };
+                typevartuple
+                    .is_typevartuple(self.db)
+                    .then_some((index, typevartuple))
+            })
+    }
+
     /// Infer type mappings by comparing formal callable signatures against actual callables.
     fn infer_from_callable_signature(
         &mut self,
@@ -2362,6 +2500,16 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         actual_callables: &CallableTypes<'db>,
     ) -> Result<(), ()> {
         let formal_is_single_paramspec = formal_signature.is_single_paramspec().is_some();
+        let typevartuple_formal_overloads: SmallVec<[_; 1]> = formal_signature
+            .iter()
+            .filter_map(|formal_overload| {
+                self.typevartuple_variadic_parameter(formal_overload).map(
+                    |(variadic_index, typevartuple)| {
+                        (formal_overload, variadic_index, typevartuple)
+                    },
+                )
+            })
+            .collect();
 
         for actual_callable in actual_callables.as_slice() {
             if formal_is_single_paramspec {
@@ -2381,6 +2529,17 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     .overloads
                     .iter()
                     .filter_map(|actual_signature| {
+                        for (formal_overload, variadic_index, typevartuple) in
+                            &typevartuple_formal_overloads
+                        {
+                            self.infer_typevartuple_from_callable_parameters(
+                                formal_overload,
+                                *variadic_index,
+                                *typevartuple,
+                                actual_signature,
+                            );
+                        }
+
                         let when = actual_signature.when_constraint_set_assignable_to_signatures(
                             db,
                             formal_signature,
@@ -2833,6 +2992,46 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     formal.tuple_instance_spec(self.db),
                     actual_nominal.tuple_spec(self.db),
                 ) {
+                    if let TupleSpec::Variable(formal_variable) = formal_tuple.as_ref()
+                        && let Type::TypeVar(typevartuple) = formal_variable.variable()
+                        && typevartuple.is_typevartuple(self.db)
+                        && let TupleSpec::Fixed(actual_fixed) = actual_tuple.as_ref()
+                    {
+                        let prefix_len = formal_variable.prefix_elements().len();
+                        let suffix_len = formal_variable.suffix_elements().len();
+                        let actual_len = actual_fixed.len();
+                        let Some(middle_end) = actual_len.checked_sub(suffix_len) else {
+                            return Ok(());
+                        };
+                        if middle_end < prefix_len {
+                            return Ok(());
+                        }
+
+                        let actual_elements = actual_fixed.elements_slice();
+                        let variance = TypeVarVariance::Covariant.compose(polarity);
+                        for (formal_element, actual_element) in formal_variable
+                            .prefix_elements()
+                            .iter()
+                            .zip(&actual_elements[..prefix_len])
+                        {
+                            self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
+                        }
+                        for (formal_element, actual_element) in formal_variable
+                            .suffix_elements()
+                            .iter()
+                            .zip(&actual_elements[middle_end..])
+                        {
+                            self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
+                        }
+
+                        let packed = Type::heterogeneous_tuple(
+                            self.db,
+                            actual_elements[prefix_len..middle_end].iter().copied(),
+                        );
+                        self.add_type_mapping(typevartuple, packed, variance);
+                        return Ok(());
+                    }
+
                     let Some(most_precise_length) =
                         formal_tuple.len().most_precise(actual_tuple.len())
                     else {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -80,8 +80,11 @@ bitflags::bitflags! {
     /// Metadata for expressions inferred as type expressions.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, salsa::Update)]
     pub(crate) struct TypeExpressionFlags: u8 {
-        /// The expression is syntactically an `Unpack[...]` type expression.
+        /// The expression syntactically unpacks a type using either `Unpack[...]` or `*...`.
         const UNPACK = 1 << 0;
+
+        /// The operand of an `Unpack[...]` expression is neither a tuple nor a `TypeVarTuple`.
+        const INVALID_UNPACK = 1 << 1;
     }
 }
 
@@ -1623,17 +1626,17 @@ bitflags::bitflags! {
         /// Whether the visitor is currently visiting a `**kwargs` annotation.
         const IN_KWARG_ANNOTATION = 1 << 9;
 
-        /// Whether we're in a context where `Unpack` can be legal.
-        const IN_VALID_UNPACK_CONTEXT = 1 << 10;
-
         /// Whether the visitor is currently visiting a type expression.
         const IN_TYPE_EXPRESSION = 1 << 12;
 
         /// Whether the visitor is currently visiting a nested position in a type expression.
         const IN_NESTED_TYPE_EXPRESSION = 1 << 13;
 
-        /// Whether the visitor is currently visiting the argument to `Unpack[...]`.
+        /// Whether the visitor is currently visiting the argument to `Unpack[...]` or `*`.
         const IN_UNPACK_TYPE_ARGUMENT = 1 << 14;
+
+        /// Whether we're in a context where `Unpack` can be legal.
+        const IN_VALID_UNPACK_CONTEXT = 1 << 10;
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::hash::Hash;
 use std::rc::Rc;
 
 use itertools::Itertools;
@@ -14,7 +15,7 @@ use ruff_python_ast::{
 use ruff_python_stdlib::builtins::version_builtin_was_added;
 use ruff_python_stdlib::typing::as_pep_585_generic;
 use ruff_text_size::{Ranged, TextRange};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use strum::IntoEnumIterator;
 use ty_module_resolver::{KnownModule, ModuleName, resolve_module};
@@ -426,10 +427,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.expressions
             .extend(inference.expressions.iter().copied());
-        self.declarations.extend(inference.declarations());
+        self.declarations.extend_unique(inference.declarations());
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
-            self.bindings.extend(inference.bindings());
+            self.bindings.extend_unique(inference.bindings());
         }
 
         if let Some(extra) = &inference.extra {
@@ -467,10 +468,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.expressions
             .extend(inference.expressions.iter().copied());
-        self.declarations.extend(inference.declarations());
+        self.declarations.extend_unique(inference.declarations());
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
-            self.bindings.extend(inference.bindings());
+            self.bindings.extend_unique(inference.bindings());
         }
 
         if let Some(extra) = &inference.extra {
@@ -520,7 +521,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             if !matches!(self.region, InferenceRegion::Scope(..)) {
-                self.bindings.extend(extra.bindings.iter().copied());
+                self.bindings.extend_unique(extra.bindings.iter().copied());
             }
         }
     }
@@ -1128,6 +1129,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             DefinitionKind::ParamSpec(paramspec) => {
                 self.infer_paramspec_deferred(paramspec.node(self.module()));
             }
+            DefinitionKind::TypeVarTuple(typevartuple) => {
+                self.infer_typevartuple_deferred(typevartuple.node(self.module()));
+            }
             DefinitionKind::Assignment(assignment) => {
                 self.infer_assignment_deferred(
                     assignment.target(self.module()),
@@ -1728,6 +1732,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Check that no type parameter with a default follows a TypeVarTuple
         // in the type alias's PEP 695 type parameter list.
         if let Some(type_params) = type_alias.type_params.as_deref() {
+            post_inference::type_param_validation::check_single_typevar_tuple_pep695(
+                &self.context,
+                type_params,
+            );
             post_inference::type_param_validation::check_no_default_after_typevar_tuple_pep695(
                 &self.context,
                 type_params,
@@ -1940,11 +1948,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             for (index, element) in tuple_spec.all_elements().iter().enumerate() {
                 builder = builder.add(
-                    if element.is_assignable_to(self.db(), type_base_exception) {
-                        element.to_instance(self.db()).expect(
-                            "`Type::to_instance()` should always return `Some()` \
-                                if called on a type assignable to `type[BaseException]`",
-                        )
+                    if element.is_assignable_to(self.db(), type_base_exception)
+                        && let Some(instance) = element.to_instance(self.db())
+                    {
+                        instance
                     } else {
                         invalid_elements.push((index, element));
                         Type::unknown()
@@ -1979,6 +1986,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.exception_handler_symbol_ty_from_valid_ty(node_ty, type_base_exception)
         {
             symbol_ty
+        } else if is_typevartuple_type_or_instance(self.db(), node_ty) {
+            if let Some(node) = node {
+                report_invalid_exception_caught(&self.context, node, node_ty);
+            }
+            Type::unknown()
         } else if node_ty.is_assignable_to(
             self.db(),
             UnionType::from_two_elements(
@@ -2016,16 +2028,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ty: Type<'db>,
         type_base_exception: Type<'db>,
     ) -> Option<Type<'db>> {
+        if is_typevartuple_type_or_instance(self.db(), ty) {
+            return None;
+        }
+
         if let Some(tuple_spec) = ty.tuple_instance_spec(self.db()) {
             // `except (ValueError, TypeError) as e:`
             UnionType::try_from_elements(
                 self.db(),
                 tuple_spec.all_elements().iter().map(|element| {
                     if element.is_assignable_to(self.db(), type_base_exception) {
-                        Some(element.to_instance(self.db()).expect(
-                            "`Type::to_instance()` should always return `Some()` \
-                                if called on a type assignable to `type[BaseException]`",
-                        ))
+                        element.to_instance(self.db())
                     } else {
                         None
                     }
@@ -2033,10 +2046,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             )
         } else if ty.is_assignable_to(self.db(), type_base_exception) {
             // `except ValueError as e:`
-            Some(ty.to_instance(self.db()).expect(
-                "`Type::to_instance()` should always return `Some()` \
-                    if called on a type assignable to `type[BaseException]`",
-            ))
+            ty.to_instance(self.db())
         } else if ty.is_assignable_to(
             self.db(),
             Type::homogeneous_tuple(self.db(), type_base_exception),
@@ -3687,6 +3697,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 definition,
                                 paramspec_class,
                             ),
+                            Some(
+                                typevartuple_class @ (KnownClass::TypeVarTuple
+                                | KnownClass::ExtensionsTypeVarTuple),
+                            ) => self.infer_legacy_typevartuple(
+                                target,
+                                call_expr,
+                                definition,
+                                typevartuple_class,
+                            ),
                             Some(KnownClass::NewType) => {
                                 self.infer_newtype_expression(target, call_expr, definition)
                             }
@@ -3968,6 +3987,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && function.is_known(self.db(), KnownFunction::NewClass)
         {
             self.infer_new_class_deferred(definition, value);
+            return;
+        }
+        if matches!(
+            known_class,
+            Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple)
+        ) {
+            if let Some(default) = arguments.find_keyword("default") {
+                self.infer_typevartuple_default(&default.value, None);
+            }
             return;
         }
         let mut constraint_tys = Vec::new();
@@ -8369,6 +8397,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         );
                     }
                 }
+                Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple) => {
+                    if let Some(builder) = self
+                        .context
+                        .report_lint(&INVALID_LEGACY_TYPE_VARIABLE, call_expression)
+                    {
+                        builder.into_diagnostic(
+                            "A `TypeVarTuple` definition must be a simple variable assignment",
+                        );
+                    }
+                }
                 Some(KnownClass::NewType) => {
                     if let Some(builder) =
                         self.context.report_lint(&INVALID_NEWTYPE, call_expression)
@@ -8607,6 +8645,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let db = self.db();
         let iterable_type = self.infer_expression(value, tcx);
+        if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = iterable_type
+            && typevar.is_typevartuple(db)
+            && let Some(bound_typevar) = bind_typevar(
+                db,
+                self.index,
+                self.scope().file_scope_id(db),
+                self.typevar_binding_context,
+                typevar,
+            )
+        {
+            return Type::tuple(TupleType::new(
+                db,
+                &TupleSpecBuilder::with_capacity(0)
+                    .concat_variadic_typevar(db, bound_typevar)
+                    .build(),
+            ));
+        }
+        if let Type::TypeVar(typevar) = iterable_type
+            && typevar.is_typevartuple(db)
+        {
+            return Type::tuple(TupleType::new(
+                db,
+                &TupleSpecBuilder::with_capacity(0)
+                    .concat_variadic_typevar(db, typevar)
+                    .build(),
+            ));
+        }
         iterable_type
             .try_iterate(db)
             .map(|spec| Type::tuple(TupleType::new(db, &spec)))
@@ -11041,6 +11106,39 @@ where
     }
 }
 
+impl<K, V> VecMap<K, V>
+where
+    K: Copy + Eq + Hash,
+    K: std::fmt::Debug,
+    V: std::fmt::Debug,
+{
+    fn insert_unique(&mut self, key: K, value: V) {
+        // Cached inference regions can overlap when a nested definition is reached through
+        // multiple paths, for example a named expression in the shared RHS of a multi-target
+        // assignment. Region lookups use the first entry, so preserve that behavior when merging.
+        if !self.0.iter().any(|(existing_key, _)| existing_key == &key) {
+            self.0.push((key, value));
+        }
+    }
+
+    #[inline]
+    fn extend_unique<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
+        let iter = iter.into_iter();
+        let additional = iter.size_hint().0;
+        if self.0.len() + additional > 32 {
+            let mut seen =
+                FxHashSet::with_capacity_and_hasher(self.0.len() + additional, FxBuildHasher);
+            seen.extend(self.0.iter().map(|(key, _)| *key));
+            self.0.extend(iter.filter(|(key, _)| seen.insert(*key)));
+            return;
+        }
+
+        for (key, value) in iter {
+            self.insert_unique(key, value);
+        }
+    }
+}
+
 impl<K, V> Default for VecMap<K, V> {
     fn default() -> Self {
         Self(Vec::default())
@@ -11296,6 +11394,14 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
                         .zip(safe_mutable_class.generic_origin(db))
                         .is_some_and(|(l, r)| l == r)
             })
+    }
+}
+
+fn is_typevartuple_type_or_instance<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty {
+        Type::TypeVar(typevar) => typevar.is_typevartuple(db),
+        Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => typevar.is_typevartuple(db),
+        _ => false,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -530,26 +530,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 })
             }
 
-            (
-                todo @ Type::Dynamic(
-                    DynamicType::Todo(_)
-                    | DynamicType::TodoUnpack
-                    | DynamicType::TodoStarredExpression
-                    | DynamicType::TodoTypeVarTuple,
-                ),
-                _,
-                _,
-            )
-            | (
-                _,
-                todo @ Type::Dynamic(
-                    DynamicType::Todo(_)
-                    | DynamicType::TodoUnpack
-                    | DynamicType::TodoStarredExpression
-                    | DynamicType::TodoTypeVarTuple,
-                ),
-                _,
-            ) => Some(todo),
+            (todo @ Type::Dynamic(DynamicType::Todo(_)), _, _)
+            | (_, todo @ Type::Dynamic(DynamicType::Todo(_)), _) => Some(todo),
 
             (Type::Never, _, _) | (_, Type::Never, _) => Some(Type::Never),
 

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -28,6 +28,7 @@ use crate::{
         infer_definition_types, infer_scope_types,
         signatures::ReturnCallableTypeVarScope,
         todo_type,
+        tuple::{TupleSpecBuilder, TupleType},
         typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation,
     },
 };
@@ -883,10 +884,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
 
         if let Some(annotation) = parameter.annotation() {
-            let ty = if annotation.is_starred_expr() {
-                todo_type!("PEP 646")
+            let annotated_type = self.file_expression_type(annotation);
+            let has_unpacked_annotation = self
+                .file_type_expression_flags(annotation)
+                .contains(TypeExpressionFlags::UNPACK);
+            let ty = if annotation.is_starred_expr() || has_unpacked_annotation {
+                if let Type::TypeVar(typevar) = annotated_type
+                    && typevar.is_typevartuple(db)
+                {
+                    Type::tuple(TupleType::new(
+                        db,
+                        &TupleSpecBuilder::with_capacity(0)
+                            .concat_variadic_typevar(db, typevar)
+                            .build(),
+                    ))
+                } else if annotated_type.exact_tuple_instance_spec(db).is_some() {
+                    annotated_type
+                } else {
+                    todo_type!("PEP 646")
+                }
             } else {
-                let annotated_type = self.file_expression_type(annotation);
                 if let Type::TypeVar(typevar) = annotated_type
                     && typevar.is_paramspec(db)
                 {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -125,7 +125,10 @@ fn check_legacy_typevar_defaults<'db>(
         // by `check_default_for_outer_scope_typevars` in the type parameter scope.
         if !matches!(
             typevar.kind(db),
-            TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::ParamSpec
+            TypeVarKind::Legacy
+                | TypeVarKind::Pep613Alias
+                | TypeVarKind::ParamSpec
+                | TypeVarKind::TypeVarTuple
         ) {
             continue;
         }
@@ -250,7 +253,10 @@ fn check_legacy_typevar_ordering<'db>(
         // Only check legacy TypeVars; PEP 695 ordering is validated by the parser.
         if !matches!(
             typevar.kind(db),
-            TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::ParamSpec
+            TypeVarKind::Legacy
+                | TypeVarKind::Pep613Alias
+                | TypeVarKind::ParamSpec
+                | TypeVarKind::TypeVarTuple
         ) {
             continue;
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -747,6 +747,7 @@ pub(crate) fn check_static_class_definitions<'db>(
     // This is prohibited by the typing spec because a TypeVarTuple consumes
     // all remaining positional type arguments.
     if let Some(type_params) = class_node.type_params.as_deref() {
+        super::type_param_validation::check_single_typevar_tuple_pep695(context, type_params);
         super::type_param_validation::check_no_default_after_typevar_tuple_pep695(
             context,
             type_params,

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/type_param_validation.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/type_param_validation.rs
@@ -2,7 +2,56 @@ use ruff_python_ast as ast;
 use ruff_text_size::Ranged;
 
 use crate::diagnostic::format_enumeration;
-use crate::types::{context::InferContext, diagnostic::INVALID_TYPE_VARIABLE_DEFAULT};
+use crate::types::{
+    context::InferContext,
+    diagnostic::{INVALID_TYPE_FORM, INVALID_TYPE_VARIABLE_DEFAULT},
+};
+
+/// Check that a PEP 695 type parameter list contains at most one `TypeVarTuple`.
+pub(crate) fn check_single_typevar_tuple_pep695(
+    context: &InferContext<'_, '_>,
+    type_params: &ast::TypeParams,
+) {
+    let mut first_typevar_tuple: Option<&ast::TypeParamTypeVarTuple> = None;
+
+    for type_param in type_params {
+        let ast::TypeParam::TypeVarTuple(typevar_tuple) = type_param else {
+            continue;
+        };
+
+        let Some(first_typevar_tuple) = first_typevar_tuple else {
+            first_typevar_tuple = Some(typevar_tuple);
+            continue;
+        };
+
+        let Some(builder) = context.report_lint(&INVALID_TYPE_FORM, typevar_tuple) else {
+            return;
+        };
+
+        let mut diagnostic = builder.into_diagnostic("Only one TypeVarTuple parameter is allowed");
+
+        diagnostic.set_concise_message(format_args!(
+            "TypeVarTuple `{}` cannot appear after TypeVarTuple `{}`",
+            &typevar_tuple.name, &first_typevar_tuple.name
+        ));
+
+        diagnostic.set_primary_message(format_args!(
+            "`{}` is an additional TypeVarTuple",
+            &typevar_tuple.name
+        ));
+
+        diagnostic.annotate(context.secondary(first_typevar_tuple).message(format_args!(
+            "`{}` is the first TypeVarTuple",
+            &first_typevar_tuple.name
+        )));
+
+        diagnostic.info(
+            "See https://typing.python.org/en/latest/spec/generics.html#multiple-type-variable-tuples-not-allowed",
+        );
+
+        return;
+    }
+}
 
 /// Check that no type parameter with a default follows a `TypeVarTuple` in a PEP 695
 /// type parameter list. This is prohibited by the typing spec because a `TypeVarTuple`

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -11,7 +11,7 @@ use crate::types::call::CallErrorKind;
 use crate::types::call::bind::CallableDescription;
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::diagnostic::{
-    self, CALL_NON_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_KEY,
+    CALL_NON_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_KEY,
     INVALID_TYPE_ARGUMENTS, INVALID_TYPE_FORM, NOT_SUBSCRIPTABLE, POSSIBLY_MISSING_IMPLICIT_CALL,
     TypedDictDeleteErrorKind, report_cannot_delete_typed_dict_key,
     report_invalid_arguments_to_annotated, report_invalid_key_on_typed_dict,
@@ -364,16 +364,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             ast::ExprRef::from(subscript),
                             TypeExpressionFlags::INVALID_UNPACK,
                         );
-                        if !inner_ty.is_unknown()
-                            && let Some(builder) =
-                                self.context.report_lint(&INVALID_TYPE_FORM, subscript)
-                        {
-                            diagnostic::add_type_expression_reference_link(
-                                builder.into_diagnostic(
-                                    "`Unpack` can only unpack a tuple type or `TypeVarTuple`",
-                                ),
-                            );
-                        }
                         Type::unknown()
                     };
                 }
@@ -1339,7 +1329,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         &self,
         subscript: &ast::ExprSubscript,
         value_ty: Type<'db>,
-        slice_ty: Type<'db>,
+        mut slice_ty: Type<'db>,
         expr_context: ExprContext,
     ) -> Type<'db> {
         let db = self.db();
@@ -1348,18 +1338,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             value_ty,
             Type::SpecialForm(SpecialFormType::Generic | SpecialFormType::Protocol)
         ) {
-            let has_invalid_unpack_argument = match subscript.slice.as_ref() {
-                ast::Expr::Tuple(tuple) => tuple.elts.iter().any(|argument| {
-                    self.type_expression_flags(argument)
-                        .contains(TypeExpressionFlags::INVALID_UNPACK)
-                }),
-                argument => self
-                    .type_expression_flags(argument)
-                    .contains(TypeExpressionFlags::INVALID_UNPACK),
-            };
-            if has_invalid_unpack_argument {
-                return Type::unknown();
-            }
+            slice_ty = self.recover_invalid_legacy_generic_unpack_arguments(
+                subscript.slice.as_ref(),
+                slice_ty,
+            );
         }
 
         // Special typing forms for which subscriptions are context-dependent are parsed here,
@@ -1402,6 +1384,53 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             e.report_diagnostics(&self.context, subscript);
             e.result_type()
         })
+    }
+
+    fn recover_invalid_legacy_generic_unpack_arguments(
+        &self,
+        slice: &ast::Expr,
+        slice_ty: Type<'db>,
+    ) -> Type<'db> {
+        let recover_argument = |argument: &ast::Expr, argument_ty| {
+            if !self
+                .type_expression_flags(argument)
+                .contains(TypeExpressionFlags::INVALID_UNPACK)
+            {
+                return argument_ty;
+            }
+
+            let operand = match argument {
+                ast::Expr::Subscript(subscript) => subscript.slice.as_ref(),
+                ast::Expr::Starred(starred) => starred.value.as_ref(),
+                _ => return argument_ty,
+            };
+
+            if self.expression_type(operand).is_unknown() {
+                argument_ty
+            } else {
+                Type::SpecialForm(SpecialFormType::Unpack)
+            }
+        };
+
+        let ast::Expr::Tuple(tuple) = slice else {
+            return recover_argument(slice, slice_ty);
+        };
+        let tuple_spec = slice_ty.exact_tuple_instance_spec(self.db());
+        let Some(Tuple::Fixed(argument_types)) = tuple_spec.as_deref() else {
+            return slice_ty;
+        };
+        if tuple.elts.len() != argument_types.elements_slice().len() {
+            return slice_ty;
+        }
+
+        Type::heterogeneous_tuple(
+            self.db(),
+            tuple
+                .elts
+                .iter()
+                .zip(argument_types.elements_slice())
+                .map(|(argument, argument_ty)| recover_argument(argument, *argument_ty)),
+        )
     }
 
     pub(super) fn infer_slice_expression(&mut self, slice: &ast::ExprSlice) -> Type<'db> {
@@ -2243,6 +2272,13 @@ fn infer_legacy_generic_subscript<'db>(
     match legacy_generic_class_context(db, index, file_scope_id, typevar_binding_context, slice_ty)
     {
         Ok(context) => Ok(Type::KnownInstance(wrap_ok(context))),
+        // An `Unknown` argument is the recovery type for a more specific diagnostic emitted while
+        // inferring the argument, such as an unresolved reference in `Unpack[Missing]`.
+        Err(LegacyGenericContextError::InvalidArgument(argument_ty))
+            if argument_ty.is_unknown() =>
+        {
+            Ok(Type::unknown())
+        }
         Err(LegacyGenericContextError::InvalidArgument(argument_ty)) => Err(SubscriptError::new(
             Type::unknown(),
             SubscriptErrorKind::InvalidLegacyGenericArgument {

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -11,7 +11,7 @@ use crate::types::call::CallErrorKind;
 use crate::types::call::bind::CallableDescription;
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::diagnostic::{
-    CALL_NON_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_KEY,
+    self, CALL_NON_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_KEY,
     INVALID_TYPE_ARGUMENTS, INVALID_TYPE_FORM, NOT_SUBSCRIPTABLE, POSSIBLY_MISSING_IMPLICIT_CALL,
     TypedDictDeleteErrorKind, report_cannot_delete_typed_dict_key,
     report_invalid_arguments_to_annotated, report_invalid_key_on_typed_dict,
@@ -23,7 +23,7 @@ use crate::types::infer::builder::{ArgExpr, ArgumentsIter, MultiInferenceGuard};
 use crate::types::infer::{InferenceFlags, TypeExpressionFlags};
 use crate::types::special_form::AliasSpec;
 use crate::types::subscript::{LegacyGenericOrigin, SubscriptError, SubscriptErrorKind};
-use crate::types::tuple::{Tuple, TupleType};
+use crate::types::tuple::{Tuple, TupleSpecBuilder, TupleType};
 use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::{
     BoundTypeVarInstance, CallArguments, CallDunderError, CallableBinding, CycleDetector,
@@ -337,6 +337,46 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     return Type::KnownInstance(KnownInstanceType::Callable(callable));
                 }
+                SpecialFormType::Unpack => {
+                    self.store_type_expression_flags(
+                        ast::ExprRef::from(subscript),
+                        TypeExpressionFlags::UNPACK,
+                    );
+
+                    let previously_in_unpack_type_argument = self
+                        .context
+                        .inference_flags
+                        .replace(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT, true);
+                    let inner_ty = self.infer_type_expression(slice);
+                    self.context.inference_flags.set(
+                        InferenceFlags::IN_UNPACK_TYPE_ARGUMENT,
+                        previously_in_unpack_type_argument,
+                    );
+
+                    return if matches!(
+                        inner_ty,
+                        Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                    ) || inner_ty.exact_tuple_instance_spec(db).is_some()
+                    {
+                        inner_ty
+                    } else {
+                        self.store_type_expression_flags(
+                            ast::ExprRef::from(subscript),
+                            TypeExpressionFlags::INVALID_UNPACK,
+                        );
+                        if !inner_ty.is_unknown()
+                            && let Some(builder) =
+                                self.context.report_lint(&INVALID_TYPE_FORM, subscript)
+                        {
+                            diagnostic::add_type_expression_reference_link(
+                                builder.into_diagnostic(
+                                    "`Unpack` can only unpack a tuple type or `TypeVarTuple`",
+                                ),
+                            );
+                        }
+                        Type::unknown()
+                    };
+                }
                 SpecialFormType::LegacyStdlibAlias(alias) => {
                     let AliasSpec {
                         class,
@@ -513,6 +553,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         /// A type argument after expanding any allowed `Unpack[tuple[...]]` syntax.
+        #[derive(Clone, Copy)]
         struct TypeArgument<'ast, 'db> {
             /// The source expression used for diagnostics and deferred inference.
             node: &'ast ast::Expr,
@@ -541,11 +582,30 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let typevars = generic_context.variables(db).collect::<Vec<_>>();
         let typevars_len = typevars.len();
+        let typevartuple_index = typevars
+            .iter()
+            .position(|typevar| typevar.is_typevartuple(db));
 
         let mut expanded_type_arguments = Vec::with_capacity(type_arguments.len());
 
         for (source_index, expr) in type_arguments.iter().enumerate() {
-            let typevar = typevars.get(expanded_type_arguments.len()).copied();
+            let typevar = if let Some(typevartuple_index) = typevartuple_index {
+                let suffix_len = typevars_len - typevartuple_index - 1;
+                let suffix_source_start = type_arguments.len().saturating_sub(suffix_len);
+                if suffix_len > 0
+                    && type_arguments.len() >= typevartuple_index + suffix_len
+                    && source_index >= suffix_source_start
+                {
+                    let suffix_index = source_index - suffix_source_start;
+                    typevars
+                        .get(typevars_len - suffix_len + suffix_index)
+                        .copied()
+                } else {
+                    typevars.get(expanded_type_arguments.len()).copied()
+                }
+            } else {
+                typevars.get(expanded_type_arguments.len()).copied()
+            };
             if exactly_one_paramspec || typevar.is_some_and(|typevar| typevar.is_paramspec(db)) {
                 expanded_type_arguments.push(TypeArgument {
                     node: expr,
@@ -575,9 +635,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             inferred_type_arguments[source_index] = Some(provided_type);
 
-            let is_unpack = self
-                .type_expression_flags(expr)
-                .contains(TypeExpressionFlags::UNPACK);
+            let type_expression_flags = self.type_expression_flags(expr);
+            let is_unpack = type_expression_flags.contains(TypeExpressionFlags::UNPACK);
 
             if is_unpack
                 && let Some(tuple) = provided_type.exact_tuple_instance_spec(db)
@@ -603,14 +662,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     && !self
                         .inference_flags()
                         .contains(InferenceFlags::IN_KWARG_ANNOTATION)
-                    && !matches!(
-                        value_ty,
-                        Type::GenericAlias(alias)
-                            if alias
-                                .specialization(db)
-                                .types(db)
-                                .contains(&Type::Dynamic(DynamicType::TodoTypeVarTuple))
-                    )
+                    && typevartuple_index.is_none()
+                    && !type_expression_flags.contains(TypeExpressionFlags::INVALID_UNPACK)
                     && let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, expr)
                 {
                     builder.into_diagnostic(
@@ -625,6 +678,174 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 });
             }
         }
+
+        let expanded_type_arguments = if let Some(typevartuple_index) = typevartuple_index {
+            let suffix_len = typevars_len - typevartuple_index - 1;
+            let typevartuple_end = expanded_type_arguments
+                .len()
+                .saturating_sub(suffix_len)
+                .max(typevartuple_index);
+            let mut packed = Vec::with_capacity(typevars_len);
+
+            let mut tuple_builder = TupleSpecBuilder::with_capacity(
+                typevartuple_end.saturating_sub(typevartuple_index),
+            );
+            for type_argument in
+                &expanded_type_arguments[..expanded_type_arguments.len().min(typevartuple_index)]
+            {
+                let provided_type = type_argument.ty.unwrap_or_else(Type::unknown);
+                let is_unpack = self
+                    .type_expression_flags(type_argument.node)
+                    .contains(TypeExpressionFlags::UNPACK);
+                if is_unpack
+                    && let Some(tuple) = provided_type.exact_tuple_instance_spec(db)
+                    && let Tuple::Variable(variable) = tuple.as_ref()
+                    && variable.prefix_elements().is_empty()
+                    && variable.suffix_elements().is_empty()
+                    && !matches!(
+                        variable.variable(),
+                        Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                    )
+                {
+                    tuple_builder = tuple_builder.concat(db, &tuple);
+                    packed.push(TypeArgument {
+                        ty: Some(variable.variable()),
+                        ..*type_argument
+                    });
+                } else if is_unpack
+                    && (matches!(
+                        provided_type,
+                        Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                    ) || matches!(
+                        provided_type.exact_tuple_instance_spec(db).as_deref(),
+                        Some(Tuple::Variable(variable))
+                            if matches!(
+                                variable.variable(),
+                                Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                            )
+                    ))
+                {
+                    if let Some(builder) = self
+                        .context
+                        .report_lint(&INVALID_TYPE_FORM, type_argument.node)
+                    {
+                        builder.into_diagnostic(
+                            "A TypeVarTuple cannot be split to provide a fixed type argument",
+                        );
+                    }
+                    packed.push(TypeArgument {
+                        ty: Some(Type::unknown()),
+                        ..*type_argument
+                    });
+                } else {
+                    packed.push(*type_argument);
+                }
+            }
+
+            let typevartuple_start = expanded_type_arguments.len().min(typevartuple_index);
+            for type_argument in &expanded_type_arguments
+                [typevartuple_start..expanded_type_arguments.len().min(typevartuple_end)]
+            {
+                let provided_type = type_argument.ty.unwrap_or_else(|| {
+                    let previously_in_valid_unpack_context = self
+                        .context
+                        .inference_flags
+                        .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
+                    let provided_type = self.infer_type_expression(type_argument.node);
+                    self.context.inference_flags.set(
+                        InferenceFlags::IN_VALID_UNPACK_CONTEXT,
+                        previously_in_valid_unpack_context,
+                    );
+                    inferred_type_arguments[type_argument.source_index] = Some(provided_type);
+                    provided_type
+                });
+                let is_unpack = self
+                    .type_expression_flags(type_argument.node)
+                    .contains(TypeExpressionFlags::UNPACK);
+                if is_unpack && let Some(tuple) = provided_type.exact_tuple_instance_spec(db) {
+                    tuple_builder = tuple_builder.concat(db, &tuple);
+                } else if is_unpack
+                    && let Type::TypeVar(typevar) = provided_type
+                    && typevar.is_typevartuple(db)
+                {
+                    tuple_builder = tuple_builder.concat_variadic_typevar(db, typevar);
+                } else {
+                    tuple_builder.push(provided_type);
+                }
+            }
+
+            let mut packed_suffix = Vec::with_capacity(suffix_len);
+            if suffix_len > 0 && expanded_type_arguments.len() >= typevartuple_index + suffix_len {
+                for type_argument in
+                    &expanded_type_arguments[expanded_type_arguments.len() - suffix_len..]
+                {
+                    let provided_type = type_argument.ty.unwrap_or_else(Type::unknown);
+                    let is_unpack = self
+                        .type_expression_flags(type_argument.node)
+                        .contains(TypeExpressionFlags::UNPACK);
+                    if is_unpack
+                        && let Some(tuple) = provided_type.exact_tuple_instance_spec(db)
+                        && let Tuple::Variable(variable) = tuple.as_ref()
+                        && variable.prefix_elements().is_empty()
+                        && variable.suffix_elements().is_empty()
+                        && !matches!(
+                            variable.variable(),
+                            Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                        )
+                    {
+                        tuple_builder = tuple_builder.concat(db, &tuple);
+                        packed_suffix.push(TypeArgument {
+                            ty: Some(variable.variable()),
+                            ..*type_argument
+                        });
+                    } else if is_unpack
+                        && (matches!(
+                            provided_type,
+                            Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                        ) || matches!(
+                            provided_type.exact_tuple_instance_spec(db).as_deref(),
+                            Some(Tuple::Variable(variable))
+                                if matches!(
+                                    variable.variable(),
+                                    Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                                )
+                        ))
+                    {
+                        if let Some(builder) = self
+                            .context
+                            .report_lint(&INVALID_TYPE_FORM, type_argument.node)
+                        {
+                            builder.into_diagnostic(
+                                "A TypeVarTuple cannot be split to provide a fixed type argument",
+                            );
+                        }
+                        packed_suffix.push(TypeArgument {
+                            ty: Some(Type::unknown()),
+                            ..*type_argument
+                        });
+                    } else {
+                        packed_suffix.push(*type_argument);
+                    }
+                }
+            }
+
+            if expanded_type_arguments.len() >= typevartuple_index {
+                packed.push(TypeArgument {
+                    node: expanded_type_arguments
+                        .get(typevartuple_index)
+                        .map_or(slice_node, |argument| argument.node),
+                    ty: Some(Type::tuple(TupleType::new(db, &tuple_builder.build()))),
+                    source_index: expanded_type_arguments
+                        .get(typevartuple_index)
+                        .map_or(0, |argument| argument.source_index),
+                });
+            }
+            packed.extend(packed_suffix);
+
+            packed
+        } else {
+            expanded_type_arguments
+        };
 
         let mut specialization_types = Vec::with_capacity(typevars_len);
         let mut typevar_with_defaults = 0;
@@ -820,15 +1041,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         if let Some(first_excess_type_argument_index) = first_excess_type_argument_index {
-            if let Type::GenericAlias(alias) = value_ty
-                && alias
-                    .specialization(db)
-                    .types(db)
-                    .contains(&Type::Dynamic(DynamicType::TodoTypeVarTuple))
-            {
-                // Avoid false-positive errors when specializing a class
-                // that's generic over a legacy TypeVarTuple
-            } else if typevars_len == 0 {
+            if typevars_len == 0 {
                 // Type parameter list cannot be empty, so if we reach here, `value_ty` is not a generic type.
                 if let Some(builder) = self.context.report_lint(&NOT_SUBSCRIPTABLE, subscript) {
                     let mut diagnostic = builder.into_diagnostic(format_args!(
@@ -899,6 +1112,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .map(|typevar| {
                         Some(if typevar.is_paramspec(db) {
                             Type::paramspec_value_callable(db, Parameters::unknown())
+                        } else if typevar.is_typevartuple(db) {
+                            Type::homogeneous_tuple(db, Type::unknown())
                         } else {
                             Type::unknown()
                         })
@@ -1128,6 +1343,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         expr_context: ExprContext,
     ) -> Type<'db> {
         let db = self.db();
+
+        if matches!(
+            value_ty,
+            Type::SpecialForm(SpecialFormType::Generic | SpecialFormType::Protocol)
+        ) {
+            let has_invalid_unpack_argument = match subscript.slice.as_ref() {
+                ast::Expr::Tuple(tuple) => tuple.elts.iter().any(|argument| {
+                    self.type_expression_flags(argument)
+                        .contains(TypeExpressionFlags::INVALID_UNPACK)
+                }),
+                argument => self
+                    .type_expression_flags(argument)
+                    .contains(TypeExpressionFlags::INVALID_UNPACK),
+            };
+            if has_invalid_unpack_argument {
+                return Type::unknown();
+            }
+        }
 
         // Special typing forms for which subscriptions are context-dependent are parsed here,
         // outside of `Type::subscript`, which is a pure function that doesn't depend on the
@@ -2046,11 +2279,23 @@ fn legacy_generic_class_context<'db>(
 ) -> Result<GenericContext<'db>, LegacyGenericContextError<'db>> {
     let typevars_class_tuple_spec = typevars.exact_tuple_instance_spec(db);
 
+    let unpacked_typevars;
     let typevars = if let Some(tuple_spec) = typevars_class_tuple_spec.as_deref() {
         match tuple_spec {
             Tuple::Fixed(typevars) => typevars.elements_slice(),
-            Tuple::Variable(_) => {
-                return Err(LegacyGenericContextError::VariadicTupleArguments);
+            Tuple::Variable(variable) => {
+                if let Type::TypeVar(typevartuple) = variable.variable()
+                    && typevartuple.is_typevartuple(db)
+                {
+                    unpacked_typevars = variable
+                        .iter_prefix_elements()
+                        .chain(std::iter::once(Type::TypeVar(typevartuple)))
+                        .chain(variable.iter_suffix_elements())
+                        .collect::<Vec<_>>();
+                    &unpacked_typevars
+                } else {
+                    return Err(LegacyGenericContextError::VariadicTupleArguments);
+                }
             }
         }
     } else {
@@ -2063,18 +2308,32 @@ fn legacy_generic_class_context<'db>(
         if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = argument_ty {
             let bound = bind_typevar(db, index, file_scope_id, typevar_binding_context, typevar)
                 .ok_or(LegacyGenericContextError::InvalidArgument(argument_ty))?;
+            if bound.is_typevartuple(db) {
+                return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked);
+            }
             if !validated_typevars.insert(bound) {
                 return Err(LegacyGenericContextError::DuplicateTypevar(
                     typevar.name(db),
                 ));
             }
+        } else if let Type::TypeVar(bound) = argument_ty
+            && bound.is_typevartuple(db)
+        {
+            if !validated_typevars.insert(bound) {
+                return Err(LegacyGenericContextError::DuplicateTypevar(bound.name(db)));
+            }
         } else if let Type::NominalInstance(instance) = argument_ty
-            && instance.has_known_class(db, KnownClass::TypeVarTuple)
+            && matches!(
+                instance.known_class(db),
+                Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple)
+            )
         {
             return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked);
         } else if any_over_type(db, argument_ty, true, |inner_ty| match inner_ty {
-            Type::Dynamic(DynamicType::TodoUnpack | DynamicType::TodoStarredExpression) => true,
-            Type::NominalInstance(nominal) => nominal.has_known_class(db, KnownClass::TypeVarTuple),
+            Type::NominalInstance(nominal) => matches!(
+                nominal.known_class(db),
+                Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple)
+            ),
             _ => false,
         }) {
             return Err(LegacyGenericContextError::NotYetSupported);

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1,5 +1,6 @@
 use itertools::Either;
 use ruff_python_ast::helpers::is_dotted_name;
+use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, PythonVersion};
 use ruff_text_size::Ranged;
 
@@ -187,7 +188,29 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let value_ty = self.infer_expression(value, TypeContext::default());
 
                 if is_dotted_name(value) {
-                    self.infer_subscript_type_expression_no_store(subscript, slice, value_ty)
+                    // Preserve the flag for another `Unpack` so that nested unpacking emits a
+                    // diagnostic. Other subscripts are no longer the direct unpack operand.
+                    let previously_in_unpack_type_argument =
+                        if value_ty == Type::SpecialForm(SpecialFormType::Unpack) {
+                            None
+                        } else {
+                            Some(
+                                self.context
+                                    .inference_flags
+                                    .replace(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT, false),
+                            )
+                        };
+                    let ty =
+                        self.infer_subscript_type_expression_no_store(subscript, slice, value_ty);
+                    if let Some(previously_in_unpack_type_argument) =
+                        previously_in_unpack_type_argument
+                    {
+                        self.context.inference_flags.set(
+                            InferenceFlags::IN_UNPACK_TYPE_ARGUMENT,
+                            previously_in_unpack_type_argument,
+                        );
+                    }
+                    ty
                 } else {
                     if !self.in_string_annotation() {
                         self.infer_expression(slice, TypeContext::default());
@@ -850,11 +873,38 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ctx: _,
         } = starred;
 
+        self.store_type_expression_flags(ast::ExprRef::from(starred), TypeExpressionFlags::UNPACK);
+
+        let previously_in_unpack_type_argument = self
+            .context
+            .inference_flags
+            .replace(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT, true);
         let starred_type = self.infer_type_expression(value);
-        if starred_type.exact_tuple_instance_spec(self.db()).is_some() {
+        self.context.inference_flags.set(
+            InferenceFlags::IN_UNPACK_TYPE_ARGUMENT,
+            previously_in_unpack_type_argument,
+        );
+
+        if starred_type.exact_tuple_instance_spec(self.db()).is_some()
+            || matches!(
+                starred_type,
+                Type::TypeVar(typevar) if typevar.is_typevartuple(self.db())
+            )
+        {
             starred_type
         } else {
-            Type::Dynamic(DynamicType::TodoStarredExpression)
+            self.store_type_expression_flags(
+                ast::ExprRef::from(starred),
+                TypeExpressionFlags::INVALID_UNPACK,
+            );
+            if !starred_type.is_unknown()
+                && let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, starred)
+            {
+                diagnostic::add_type_expression_reference_link(
+                    builder.into_diagnostic("`*` can only unpack a tuple type or `TypeVarTuple`"),
+                );
+            }
+            Type::homogeneous_tuple(self.db(), Type::unknown())
         }
     }
 
@@ -931,36 +981,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         &mut self,
         tuple: &ast::ExprSubscript,
     ) -> Option<TupleType<'db>> {
-        /// In most cases, if a subelement of the tuple is inferred as `Todo`,
-        /// we should only infer `Todo` for that specific subelement.
-        /// Certain specific AST nodes can however change the meaning of the entire tuple,
-        /// however: for example, `tuple[int, ...]` or `tuple[int, *tuple[str, ...]]` are a
-        /// homogeneous tuple and a partly homogeneous tuple (respectively) due to the `...`
-        /// and the starred expression (respectively), Neither is supported by us right now,
-        /// so we should infer `Todo` for the *entire* tuple if we encounter one of those elements.
-        fn element_could_alter_type_of_whole_tuple(
-            element: &ast::Expr,
-            element_ty: Type,
-            builder: &mut TypeInferenceBuilder,
-        ) -> bool {
-            if !element_ty.is_todo() {
-                return false;
-            }
-
-            match element {
-                ast::Expr::Starred(_) => {
-                    element_ty.exact_tuple_instance_spec(builder.db()).is_none()
-                }
-                ast::Expr::Subscript(ast::ExprSubscript { value, .. }) => {
-                    let value_ty = builder.expression_type(value);
-
-                    value_ty == Type::SpecialForm(SpecialFormType::Unpack)
-                }
-                _ => false,
-            }
-        }
-
-        // TODO: TypeVarTuple
         match &*tuple.slice {
             ast::Expr::Tuple(elements) => {
                 if let [element, ellipsis @ ast::Expr::EllipsisLiteral(_)] = &*elements.elts {
@@ -989,10 +1009,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                 let mut element_types = TupleSpecBuilder::with_capacity(elements.len());
 
-                // Whether to infer `Todo` for the whole tuple
-                // (see docstring for `element_could_alter_type_of_whole_tuple`)
-                let mut return_todo = false;
-
                 let mut first_unpacked_variadic_tuple = None;
 
                 for element in elements {
@@ -1018,25 +1034,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         InferenceFlags::IN_VALID_UNPACK_CONTEXT,
                         previously_in_valid_unpack_context,
                     );
-                    return_todo |=
-                        element_could_alter_type_of_whole_tuple(element, element_ty, self);
-
                     // Determine if this element unpacks a tuple: either `*expr` or `Unpack[expr]`
-                    let unpack_inner = if let ast::Expr::Starred(ast::ExprStarred {
-                        value, ..
-                    }) = element
-                    {
-                        Some(&**value)
-                    } else if let ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. }) =
-                        element
-                        && self.expression_type(value) == Type::SpecialForm(SpecialFormType::Unpack)
-                    {
-                        Some(&**slice)
-                    } else {
-                        None
-                    };
+                    let is_unpack = matches!(element, ast::Expr::Starred(_))
+                        || matches!(
+                            element,
+                            ast::Expr::Subscript(ast::ExprSubscript { value, .. })
+                                if self.expression_type(value)
+                                    == Type::SpecialForm(SpecialFormType::Unpack)
+                        );
 
-                    if let Some(unpack_inner) = unpack_inner {
+                    if is_unpack {
                         let mut report_too_many_unpacked_tuples = || {
                             if let Some(first_unpacked_variadic_tuple) =
                                 first_unpacked_variadic_tuple
@@ -1070,10 +1077,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             if inner_tuple.is_variadic() {
                                 report_too_many_unpacked_tuples();
                             }
-                        } else if self.expression_type(unpack_inner)
-                            == Type::Dynamic(DynamicType::TodoTypeVarTuple)
+                        } else if let Type::TypeVar(typevar) = element_ty
+                            && typevar.is_typevartuple(self.db())
                         {
                             report_too_many_unpacked_tuples();
+                            element_types.push(element_ty);
                         } else {
                             // TODO: emit a diagnostic
                         }
@@ -1082,14 +1090,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                 }
 
-                let ty = if return_todo {
-                    Some(TupleType::homogeneous(
-                        self.db(),
-                        Type::Dynamic(DynamicType::TodoTypeVarTuple),
-                    ))
-                } else {
-                    TupleType::new(self.db(), &element_types.build())
-                };
+                let ty = TupleType::new(self.db(), &element_types.build());
 
                 // Here, we store the type for the inner `int, str` tuple-expression,
                 // while the type for the outer `tuple[int, str]` slice-expression is
@@ -1120,15 +1121,27 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     InferenceFlags::IN_VALID_UNPACK_CONTEXT,
                     previously_in_valid_unpack_context,
                 );
-                if element_could_alter_type_of_whole_tuple(single_element, single_element_ty, self)
-                {
-                    Some(TupleType::homogeneous(
-                        self.db(),
-                        Type::Dynamic(DynamicType::TodoTypeVarTuple),
-                    ))
-                } else {
-                    TupleType::heterogeneous(self.db(), std::iter::once(single_element_ty))
+                let single_element_is_unpack = matches!(single_element, ast::Expr::Starred(_))
+                    || matches!(
+                        single_element,
+                        ast::Expr::Subscript(ast::ExprSubscript { value, .. })
+                            if self.expression_type(value)
+                                == Type::SpecialForm(SpecialFormType::Unpack)
+                    );
+                if single_element_is_unpack {
+                    if let Some(inner_tuple) =
+                        single_element_ty.exact_tuple_instance_spec(self.db())
+                    {
+                        return TupleType::new(self.db(), &inner_tuple);
+                    } else if let Type::TypeVar(typevar) = single_element_ty
+                        && typevar.is_typevartuple(self.db())
+                    {
+                        let mut tuple_spec = TupleSpecBuilder::with_capacity(1);
+                        tuple_spec.push(Type::TypeVar(typevar));
+                        return TupleType::new(self.db(), &tuple_spec.build());
+                    }
                 }
+                TupleType::heterogeneous(self.db(), std::iter::once(single_element_ty))
             }
         }
     }
@@ -2282,10 +2295,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                 if self
                     .inference_flags()
-                    .contains(InferenceFlags::IN_KWARG_ANNOTATION)
-                    && self
-                        .inference_flags()
-                        .contains(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT)
+                    .contains(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT)
                 {
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                         diagnostic::add_type_expression_reference_link(
@@ -2343,20 +2353,29 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return inner_ty;
                 }
 
-                // When the argument is a tuple type, return it directly so that
-                // `Unpack[tuple[int, ...]]` behaves identically to `*tuple[int, ...]`.
-                //
-                // However, we still need a Todo type for things like
-                // `def f(*args: Unpack[tuple[int, Unpack[tuple[str, ...]]]]): ...`,
-                // which we don't yet support.
-                if self
-                    .inference_flags()
-                    .contains(InferenceFlags::IN_VARARG_ANNOTATION)
-                    || inner_ty.exact_tuple_instance_spec(self.db()).is_none()
+                // Preserve valid unpack targets so that `Unpack[...]` follows the same
+                // argument-binding path as an equivalent starred annotation.
+                if inner_ty.exact_tuple_instance_spec(self.db()).is_some()
+                    || matches!(
+                        inner_ty,
+                        Type::TypeVar(typevar) if typevar.is_typevartuple(self.db())
+                    )
                 {
-                    todo_type!("`Unpack[]` special form")
-                } else {
                     inner_ty
+                } else {
+                    self.store_type_expression_flags(
+                        ast::ExprRef::from(subscript),
+                        TypeExpressionFlags::INVALID_UNPACK,
+                    );
+                    if !inner_ty.is_unknown()
+                        && let Some(builder) =
+                            self.context.report_lint(&INVALID_TYPE_FORM, subscript)
+                    {
+                        diagnostic::add_type_expression_reference_link(builder.into_diagnostic(
+                            "`Unpack` can only unpack a tuple type or `TypeVarTuple`",
+                        ));
+                    }
+                    Type::homogeneous_tuple(self.db(), Type::unknown())
                 }
             }
             SpecialFormType::NoReturn
@@ -2594,10 +2613,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return None;
                 }
 
-                let mut parameter_types = Vec::with_capacity(params.len());
-
-                // Whether to infer `Todo` for the parameters
-                let mut return_todo = false;
+                let mut parameters = Vec::with_capacity(params.len());
 
                 let previously_in_valid_unpack_context = self
                     .context
@@ -2605,30 +2621,41 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
                 for param in params {
                     let param_type = self.infer_type_expression(param);
-                    // This is similar to what we currently do for inferring tuple type expression.
-                    // We currently infer `Todo` for the parameters to avoid invalid diagnostics
-                    // when trying to check for assignability or any other relation. For example,
-                    // `*tuple[int, str]`, `Unpack[]`, etc. are not yet supported.
-                    return_todo |= param_type.is_todo()
-                        && matches!(param, ast::Expr::Starred(_) | ast::Expr::Subscript(_));
-                    parameter_types.push(param_type);
+                    let is_unpack = self
+                        .type_expression_flags(param)
+                        .contains(TypeExpressionFlags::UNPACK);
+
+                    if is_unpack {
+                        if let Type::TypeVar(typevar) = param_type
+                            && typevar.is_typevartuple(self.db())
+                        {
+                            parameters.push(
+                                Parameter::variadic(Name::new_static("args"))
+                                    .with_annotated_type(Type::TypeVar(typevar))
+                                    .with_starred_annotation(),
+                            );
+                            continue;
+                        }
+
+                        if param_type.exact_tuple_instance_spec(self.db()).is_some() {
+                            parameters.push(
+                                Parameter::variadic(Name::new_static("args"))
+                                    .with_annotated_type(param_type)
+                                    .with_starred_annotation(),
+                            );
+                            continue;
+                        }
+                    }
+
+                    parameters
+                        .push(Parameter::positional_only(None).with_annotated_type(param_type));
                 }
                 self.context.inference_flags.set(
                     InferenceFlags::IN_VALID_UNPACK_CONTEXT,
                     previously_in_valid_unpack_context,
                 );
 
-                return Some(if return_todo {
-                    // TODO: `Unpack`
-                    Parameters::todo()
-                } else {
-                    Parameters::new(
-                        self.db(),
-                        parameter_types.iter().map(|param_type| {
-                            Parameter::positional_only(None).with_annotated_type(*param_type)
-                        }),
-                    )
-                });
+                return Some(Parameters::new(self.db(), parameters));
             }
             ast::Expr::Subscript(subscript) => {
                 let value_ty = self.infer_expression(&subscript.value, TypeContext::default());

--- a/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
@@ -2,7 +2,7 @@ use ruff_python_ast::{self as ast};
 
 use super::TypeInferenceBuilder;
 use crate::types::diagnostic::INVALID_TYPE_FORM;
-use crate::types::{DynamicType, KnownClass, Type, TypeContext, TypeFormType};
+use crate::types::{KnownClass, SpecialFormType, Type, TypeContext, TypeFormType};
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// In a `TypeForm` context, keep the ordinary value interpretation if it is
@@ -56,10 +56,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let contextual_ty = self
                 .speculate()
                 .infer_value_expression_impl(expression, TypeContext::new(Some(target)));
-            // TODO: Remove this exception once `Unpack` produces a precise type instead of a
-            // dynamic placeholder in ordinary expression inference.
             if contextual_ty.is_assignable_to(self.db(), target)
-                && contextual_ty != Type::Dynamic(DynamicType::TodoUnpack)
+                && !self.is_unpack_subscript(expression)
             {
                 return None;
             }
@@ -92,6 +90,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .any(|element| self.contains_type_form_value(expression, *element)),
             _ => false,
         }
+    }
+
+    fn is_unpack_subscript(&self, expression: &ast::Expr) -> bool {
+        let ast::Expr::Subscript(subscript) = expression else {
+            return false;
+        };
+
+        self.speculate()
+            .infer_expression(&subscript.value, TypeContext::default())
+            == Type::SpecialForm(SpecialFormType::Unpack)
     }
 
     pub(super) fn infer_type_form_call_expression(

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -13,7 +13,6 @@ use crate::{
             InferenceFlags, TypeInferenceBuilder,
             builder::{BoundOrConstraintsNodes, DeclaredAndInferredType, DeferredExpressionState},
         },
-        todo_type,
         typevar::{
             TypeVarBoundOrConstraintsEvaluation, TypeVarConstraints, TypeVarDefaultEvaluation,
             TypeVarIdentity, TypeVarInstance,
@@ -659,16 +658,325 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let ast::TypeParamTypeVarTuple {
             range: _,
             node_index: _,
-            name: _,
+            name,
             default,
         } = node;
-        self.infer_optional_expression(default.as_deref(), TypeContext::default());
-        let pep_695_todo = todo_type!("PEP-695 TypeVarTuple definition types");
+
+        let db = self.db();
+
+        if default.is_some() {
+            self.deferred.insert(definition);
+        }
+        let identity = TypeVarIdentity::new(
+            db,
+            &name.id,
+            Some(definition),
+            TypeVarKind::Pep695TypeVarTuple,
+        );
+        let ty = Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
+            db,
+            identity,
+            None,
+            None, // explicit_variance
+            default.as_deref().map(|_| TypeVarDefaultEvaluation::Lazy),
+        )));
         self.add_declaration_with_binding(
             node.into(),
             definition,
-            &DeclaredAndInferredType::are_the_same_type(pep_695_todo),
+            &DeclaredAndInferredType::are_the_same_type(ty),
         );
+    }
+
+    pub(super) fn infer_typevartuple_deferred(&mut self, node: &ast::TypeParamTypeVarTuple) {
+        let ast::TypeParamTypeVarTuple {
+            range: _,
+            node_index: _,
+            name,
+            default: Some(default),
+        } = node
+        else {
+            return;
+        };
+        let previous_deferred_state =
+            std::mem::replace(&mut self.deferred_state, DeferredExpressionState::Deferred);
+        self.infer_typevartuple_default(default, Some(&name.id));
+        self.deferred_state = previous_deferred_state;
+    }
+
+    pub(super) fn infer_typevartuple_default(
+        &mut self,
+        default_expr: &ast::Expr,
+        typevartuple_name: Option<&str>,
+    ) {
+        let previously_in_valid_unpack_context = self
+            .context
+            .inference_flags
+            .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
+        let default_ty = self.infer_type_expression(default_expr);
+        self.context.inference_flags.set(
+            InferenceFlags::IN_VALID_UNPACK_CONTEXT,
+            previously_in_valid_unpack_context,
+        );
+
+        if let Some(name) = typevartuple_name
+            && self.check_default_for_outer_scope_typevars(default_ty, default_expr, name)
+        {
+            return;
+        }
+
+        if default_ty.exact_tuple_instance_spec(self.db()).is_none()
+            && !matches!(
+                default_ty,
+                Type::TypeVar(typevar) if typevar.is_typevartuple(self.db())
+            )
+            && let Some(builder) = self
+                .context
+                .report_lint(&INVALID_LEGACY_TYPE_VARIABLE, default_expr)
+        {
+            builder.into_diagnostic(
+                "The default value for `TypeVarTuple` must be an unpacked tuple type \
+                    or another TypeVarTuple",
+            );
+        }
+    }
+
+    pub(super) fn infer_legacy_typevartuple(
+        &mut self,
+        target: &ast::Expr,
+        call_expr: &ast::ExprCall,
+        definition: Definition<'db>,
+        known_class: KnownClass,
+    ) -> Type<'db> {
+        fn error<'db>(
+            context: &InferContext<'db, '_>,
+            message: impl std::fmt::Display,
+            node: impl Ranged,
+        ) -> Type<'db> {
+            if let Some(builder) = context.report_lint(&INVALID_LEGACY_TYPE_VARIABLE, node) {
+                builder.into_diagnostic(message);
+            }
+            KnownClass::TypeVarTuple.to_instance(context.db())
+        }
+
+        let db = self.db();
+        let arguments = &call_expr.arguments;
+        let is_typing_extensions = known_class == KnownClass::ExtensionsTypeVarTuple;
+        let assume_all_features = self.in_stub() || is_typing_extensions;
+        let python_version = Program::get(db).python_version(db);
+        let have_features_from =
+            |version: PythonVersion| assume_all_features || python_version >= version;
+
+        let mut default = None;
+        let mut covariant = false;
+        let mut contravariant = false;
+        let mut infer_variance = false;
+        let mut name_param_ty = None;
+        let mut name_param_node = None;
+
+        if arguments.args.len() > 1 {
+            return error(
+                &self.context,
+                "`TypeVarTuple` can only have one positional argument",
+                call_expr,
+            );
+        }
+
+        if let Some(starred) = arguments.args.iter().find(|arg| arg.is_starred_expr()) {
+            return error(
+                &self.context,
+                "Starred arguments are not supported in `TypeVarTuple` creation",
+                starred,
+            );
+        }
+
+        for kwarg in &arguments.keywords {
+            let Some(identifier) = kwarg.arg.as_ref() else {
+                return error(
+                    &self.context,
+                    "Starred arguments are not supported in `TypeVarTuple` creation",
+                    kwarg,
+                );
+            };
+            match identifier.id().as_str() {
+                "name" => {
+                    if !arguments.args.is_empty() {
+                        return error(
+                            &self.context,
+                            "The `name` parameter of `TypeVarTuple` can only be provided once",
+                            kwarg,
+                        );
+                    }
+                    name_param_node = Some(&kwarg.value);
+                    name_param_ty =
+                        Some(self.infer_expression(&kwarg.value, TypeContext::default()));
+                }
+                "default" => {
+                    if !have_features_from(PythonVersion::PY313) {
+                        error(
+                            &self.context,
+                            "The `default` parameter of `typing.TypeVarTuple` was added in Python 3.13",
+                            kwarg,
+                        );
+                    }
+                    default = Some(TypeVarDefaultEvaluation::Lazy);
+                }
+                "bound" => {
+                    return error(
+                        &self.context,
+                        "The `bound` argument for `TypeVarTuple` is not supported",
+                        call_expr,
+                    );
+                }
+                "covariant" => {
+                    match self
+                        .infer_expression(&kwarg.value, TypeContext::default())
+                        .bool(db)
+                    {
+                        Truthiness::AlwaysTrue => covariant = true,
+                        Truthiness::AlwaysFalse => {}
+                        Truthiness::Ambiguous => {
+                            return error(
+                                &self.context,
+                                "The `covariant` parameter of `TypeVarTuple` \
+                                cannot have an ambiguous truthiness",
+                                &kwarg.value,
+                            );
+                        }
+                    }
+                }
+                "contravariant" => {
+                    match self
+                        .infer_expression(&kwarg.value, TypeContext::default())
+                        .bool(db)
+                    {
+                        Truthiness::AlwaysTrue => contravariant = true,
+                        Truthiness::AlwaysFalse => {}
+                        Truthiness::Ambiguous => {
+                            return error(
+                                &self.context,
+                                "The `contravariant` parameter of `TypeVarTuple` \
+                                cannot have an ambiguous truthiness",
+                                &kwarg.value,
+                            );
+                        }
+                    }
+                }
+                "infer_variance" => {
+                    if !have_features_from(PythonVersion::PY312) {
+                        error(
+                            &self.context,
+                            "The `infer_variance` parameter of `typing.TypeVarTuple` was added in Python 3.12",
+                            kwarg,
+                        );
+                    }
+                    match self
+                        .infer_expression(&kwarg.value, TypeContext::default())
+                        .bool(db)
+                    {
+                        Truthiness::AlwaysTrue => infer_variance = true,
+                        Truthiness::AlwaysFalse => {}
+                        Truthiness::Ambiguous => {
+                            return error(
+                                &self.context,
+                                "The `infer_variance` parameter of `TypeVarTuple` \
+                                cannot have an ambiguous truthiness",
+                                &kwarg.value,
+                            );
+                        }
+                    }
+                }
+                name => {
+                    error(
+                        &self.context,
+                        format_args!(
+                            "Unknown keyword argument `{name}` in `TypeVarTuple` creation"
+                        ),
+                        kwarg,
+                    );
+                    self.infer_expression(&kwarg.value, TypeContext::default());
+                }
+            }
+        }
+
+        let variance = match (covariant, contravariant, infer_variance) {
+            (true, true, _) => {
+                return error(
+                    &self.context,
+                    "A `TypeVarTuple` cannot be both covariant and contravariant",
+                    call_expr,
+                );
+            }
+            (true, false, true) | (false, true, true) => {
+                return error(
+                    &self.context,
+                    "A `TypeVarTuple` cannot specify variance when `infer_variance=True`",
+                    call_expr,
+                );
+            }
+            (true, false, false) => Some(TypeVarVariance::Covariant),
+            (false, true, false) => Some(TypeVarVariance::Contravariant),
+            (false, false, false) => Some(TypeVarVariance::Invariant),
+            (false, false, true) => None,
+        };
+
+        let Some(name_param_ty) = name_param_ty.or_else(|| {
+            arguments
+                .find_positional(0)
+                .map(|arg| self.infer_expression(arg, TypeContext::default()))
+        }) else {
+            return error(
+                &self.context,
+                "The `name` parameter of `TypeVarTuple` is required.",
+                call_expr,
+            );
+        };
+
+        let Some(name_param) = name_param_ty.as_string_literal().map(|name| name.value(db)) else {
+            return error(
+                &self.context,
+                "The first argument to `TypeVarTuple` must be a string literal",
+                call_expr,
+            );
+        };
+        let name_param_node = name_param_node.or_else(|| arguments.find_positional(0));
+
+        let ast::Expr::Name(ast::ExprName {
+            id: target_name, ..
+        }) = target
+        else {
+            return error(
+                &self.context,
+                "A `TypeVarTuple` definition must be a simple variable assignment",
+                target,
+            );
+        };
+
+        if name_param != target_name {
+            report_mismatched_type_name(
+                &self.context,
+                name_param_node
+                    .map(Ranged::range)
+                    .unwrap_or_else(|| call_expr.range()),
+                "TypeVarTuple",
+                target_name,
+                Some(name_param),
+                name_param_ty,
+            );
+        }
+
+        if default.is_some() {
+            self.deferred.insert(definition);
+        }
+
+        let identity = TypeVarIdentity::new(
+            db,
+            target_name.clone(),
+            Some(definition),
+            TypeVarKind::TypeVarTuple,
+        );
+        Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
+            db, identity, None, variance, default,
+        )))
     }
 
     pub(super) fn infer_legacy_paramspec(

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -268,6 +268,9 @@ impl<'db> KnownInstanceType<'db> {
             Self::TypeVar(typevar_instance) if typevar_instance.is_paramspec(db) => {
                 KnownClass::ParamSpec
             }
+            Self::TypeVar(typevar_instance) if typevar_instance.is_typevartuple(db) => {
+                KnownClass::TypeVarTuple
+            }
             Self::TypeVar(_) => KnownClass::TypeVar,
             Self::TypeAliasType(TypeAliasType::PEP695(alias)) if alias.is_specialized(db) => {
                 KnownClass::GenericAlias

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -393,6 +393,7 @@ impl<'db> AllMembers<'db> {
                                     Some(
                                         KnownClass::TypeVar
                                             | KnownClass::TypeVarTuple
+                                            | KnownClass::ExtensionsTypeVarTuple
                                             | KnownClass::ParamSpec
                                             | KnownClass::UnionType
                                     )

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -15,6 +15,7 @@ use crate::types::enums::is_single_member_enum;
 use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
+use crate::types::tuple::Tuple;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -1300,6 +1301,20 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.always()
             }
 
+            // A gradual `TypeVarTuple` value (`*tuple[Any, ...]` or
+            // `*tuple[Unknown, ...]`) is assignability-consistent with any concrete
+            // `TypeVarTuple` value. This only applies to fixed `TypeVarTuple` values in
+            // already-specialized generic aliases; inferable `TypeVarTuple`s are handled by
+            // the inference paths below.
+            (Type::TypeVar(bound_typevar), other) | (other, Type::TypeVar(bound_typevar))
+                if self.relation.is_assignability()
+                    && !bound_typevar.is_inferable(db, self.inferable)
+                    && bound_typevar.is_typevartuple(db)
+                    && Self::is_gradual_typevartuple_value(db, other) =>
+            {
+                self.always()
+            }
+
             // Any concrete specialization of a `ParamSpec` is a subtype of the top
             // materialization of a `ParamSpec` value.
             (Type::TypeVar(bound_typevar), Type::Callable(other))
@@ -2189,6 +2204,17 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 .signatures(db)
                 .iter()
                 .all(|signature| signature.parameters().kind() == ParametersKind::Top)
+    }
+
+    /// Return `true` if `ty` is a gradual value for a `TypeVarTuple`.
+    fn is_gradual_typevartuple_value(db: &'db dyn Db, ty: Type<'db>) -> bool {
+        matches!(
+            ty.exact_tuple_instance_spec(db).as_deref(),
+            Some(Tuple::Variable(tuple))
+                if tuple.prefix_elements().is_empty()
+                    && tuple.suffix_elements().is_empty()
+                    && tuple.variable().is_dynamic()
+        )
     }
 }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -31,6 +31,7 @@ use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
 use crate::types::relation::{
     HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
+use crate::types::tuple::Tuple;
 use crate::types::typed_dict::{
     UnpackedTypedDictKey, extract_unpacked_typed_dict_keys_from_kwargs_annotation,
     extract_unpacked_typed_dict_keys_from_value_type,
@@ -3659,12 +3660,67 @@ impl<'db> Parameters<'db> {
         // Parameters are in contravariant position, so we need to flip the type mapping.
         let type_mapping = type_mapping.flip();
 
-        let value: Box<[_]> = self
+        if !self
             .data
             .value
             .iter()
-            .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
-            .collect();
+            .any(|param| param.is_variadic() && param.has_starred_annotation())
+        {
+            let value: Box<[_]> = self
+                .data
+                .value
+                .iter()
+                .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
+                .collect();
+
+            return Self::from_parts(value, self.data.kind);
+        }
+
+        let mut expanded = false;
+        let mut value = Vec::with_capacity(self.data.value.len());
+        for param in &self.data.value {
+            let mapped = param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor);
+            if mapped.is_variadic()
+                && mapped.has_starred_annotation()
+                && let Some(tuple) = mapped.annotated_type().exact_tuple_instance_spec(db)
+            {
+                expanded = true;
+                match tuple.as_ref() {
+                    Tuple::Fixed(tuple) => {
+                        value.extend(
+                            tuple
+                                .iter_all_elements()
+                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
+                        );
+                    }
+                    Tuple::Variable(variable) => {
+                        value.extend(
+                            variable
+                                .iter_prefix_elements()
+                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
+                        );
+                        let name = mapped
+                            .name()
+                            .cloned()
+                            .unwrap_or_else(|| Name::new_static("args"));
+                        value.push(
+                            Parameter::variadic(name).with_annotated_type(variable.variable()),
+                        );
+                        value.extend(
+                            variable
+                                .iter_suffix_elements()
+                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
+                        );
+                    }
+                }
+            } else {
+                value.push(mapped);
+            }
+        }
+
+        if expanded {
+            return Self::new(db, value);
+        }
 
         Self::from_parts(value, self.data.kind)
     }
@@ -3927,6 +3983,11 @@ impl<'db> Parameter<'db> {
         self
     }
 
+    pub(crate) fn with_starred_annotation(mut self) -> Self {
+        self.annotation_kind = ParameterAnnotationKind::Starred;
+        self
+    }
+
     pub(crate) fn with_default_type(mut self, default: Type<'db>) -> Self {
         match &mut self.kind {
             ParameterKind::PositionalOnly { default_type, .. }
@@ -4085,28 +4146,29 @@ impl<'db> Parameter<'db> {
         let index = semantic_index(db, function_definition.file(db));
         let definition = Some(index.expect_single_definition(parameter));
 
-        let (annotated_type, inferred_annotation, has_starred_annotation) =
+        let (annotated_type, inferred_annotation, annotation_flags, has_starred_annotation) =
             if let Some(annotation) = parameter.annotation() {
                 (
                     function_signature_expression_type(db, function_definition, annotation),
                     false,
+                    function_signature_type_expression_flags(db, function_definition, annotation),
                     annotation.is_starred_expr(),
                 )
             } else {
-                (Type::unknown(), true, false)
+                (Type::unknown(), true, TypeExpressionFlags::empty(), false)
             };
+        let has_unpacked_variadic_annotation = matches!(&kind, ParameterKind::Variadic { .. })
+            && annotation_flags.contains(TypeExpressionFlags::UNPACK);
         let is_unpacked_typed_dict_kwargs = matches!(&kind, ParameterKind::KeywordVariadic { .. })
-            && parameter.annotation().is_some_and(|annotation| {
-                extract_unpacked_typed_dict_keys_from_kwargs_annotation(
-                    db,
-                    annotated_type,
-                    function_signature_type_expression_flags(db, function_definition, annotation),
-                )
-                .is_some()
-            });
+            && extract_unpacked_typed_dict_keys_from_kwargs_annotation(
+                db,
+                annotated_type,
+                annotation_flags,
+            )
+            .is_some();
         let annotation_kind = if is_unpacked_typed_dict_kwargs {
             ParameterAnnotationKind::UnpackedTypedDictKwargs
-        } else if has_starred_annotation {
+        } else if has_starred_annotation || has_unpacked_variadic_annotation {
             ParameterAnnotationKind::Starred
         } else {
             ParameterAnnotationKind::Normal
@@ -4196,8 +4258,9 @@ impl<'db> Parameter<'db> {
         self.definition
     }
 
-    /// Return `true` if this parameter has a starred annotation,
-    /// e.g. `*args: *Ts` or `*args: *tuple[int, *tuple[str, ...], bytes]`
+    /// Return `true` if this parameter has an unpacked variadic annotation,
+    /// e.g. `*args: *Ts`, `*args: Unpack[Ts]`, or
+    /// `*args: *tuple[int, *tuple[str, ...], bytes]`.
     pub(crate) fn has_starred_annotation(&self) -> bool {
         matches!(self.annotation_kind, ParameterAnnotationKind::Starred)
     }

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -23,8 +23,8 @@ use super::instance::SliceLiteral;
 use super::special_form::SpecialFormType;
 use super::tuple::TupleSpec;
 use super::{
-    DynamicType, IntersectionBuilder, IntersectionType, KnownInstanceType, Type, TypeAliasType,
-    TypedDictType, UnionBuilder, UnionType, todo_type,
+    IntersectionBuilder, IntersectionType, KnownInstanceType, Type, TypeAliasType, TypedDictType,
+    UnionBuilder, UnionType, todo_type,
 };
 
 /// The kind of subscriptable type that had an out-of-bounds index.
@@ -747,7 +747,7 @@ impl<'db> Type<'db> {
             }
 
             (Type::SpecialForm(SpecialFormType::Unpack), _) => {
-                Some(Ok(Type::Dynamic(DynamicType::TodoUnpack)))
+                Some(Ok(Type::unknown()))
             }
 
             (Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar)), _) => {

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -151,9 +151,34 @@ impl<'db> TupleType<'db> {
     pub(crate) fn new(db: &'db dyn Db, spec: &TupleSpec<'db>) -> Option<Self> {
         // If a fixed-length (i.e., mandatory) element of the tuple is `Never`, then it's not
         // possible to instantiate the tuple as a whole.
-        if spec.fixed_elements().any(Type::is_never) {
-            return None;
+        let mut unpacked_typevartuple = None;
+        for (index, element) in spec.fixed_elements().enumerate() {
+            if element.is_never() {
+                return None;
+            }
+            if matches!(spec, TupleSpec::Fixed(_))
+                && unpacked_typevartuple.is_none()
+                && let Type::TypeVar(typevar) = element
+                && typevar.is_typevartuple(db)
+            {
+                unpacked_typevartuple = Some((index, *typevar));
+            }
         }
+
+        // A `TypeVarTuple` can only reach a tuple spec as an unpacked element. Normalize it to the
+        // variable-length representation used for variadic matching and substitution.
+        let normalized = if let Some((index, typevar)) = unpacked_typevartuple
+            && let TupleSpec::Fixed(tuple) = spec
+        {
+            Some(VariableLengthTuple::mixed(
+                tuple.elements_slice()[..index].iter().copied(),
+                Type::TypeVar(typevar),
+                tuple.elements_slice()[index + 1..].iter().copied(),
+            ))
+        } else {
+            None
+        };
+        let spec = normalized.as_ref().unwrap_or(spec);
 
         // If the variable-length portion is Never, it can only be instantiated with zero elements.
         // That means this isn't a variable-length tuple after all!
@@ -1132,6 +1157,32 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> TupleSpec<'db> {
+        if let Type::TypeVar(typevar) = self.variable()
+            && typevar.is_typevartuple(db)
+        {
+            let prefix = self
+                .prefix_elements()
+                .iter()
+                .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+            let suffix = self
+                .suffix_elements()
+                .iter()
+                .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+            let mapped =
+                Type::TypeVar(typevar).apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+            if let Some(mapped_tuple) = mapped.exact_tuple_instance_spec(db) {
+                let mut builder = TupleSpecBuilder::with_capacity(self.elements.len());
+                for element in prefix {
+                    builder.push(element);
+                }
+                builder = builder.concat(db, &mapped_tuple);
+                for element in suffix {
+                    builder.push(element);
+                }
+                return builder.build();
+            }
+        }
+
         Self::mixed(
             self.prefix_elements()
                 .iter()
@@ -1706,6 +1757,15 @@ impl<'db> TupleSpecBuilder<'db> {
             TupleSpecBuilder::Fixed(elements) => elements.push(element),
             TupleSpecBuilder::Variable { suffix, .. } => suffix.push(element),
         }
+    }
+
+    pub(crate) fn concat_variadic_typevar(
+        self,
+        db: &'db dyn Db,
+        typevar: BoundTypeVarInstance<'db>,
+    ) -> Self {
+        let other = VariableLengthTuple::mixed([], Type::TypeVar(typevar), []);
+        self.concat(db, &other)
     }
 
     /// Concatenates another tuple to the end of this tuple, returning a new tuple.

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -217,6 +217,10 @@ impl<'db> TypeVarInstance<'db> {
         self.kind(db).is_paramspec()
     }
 
+    pub(crate) fn is_typevartuple(self, db: &'db dyn Db) -> bool {
+        self.kind(db).is_typevartuple()
+    }
+
     pub(crate) fn upper_bound(self, db: &'db dyn Db) -> Option<Type<'db>> {
         if let Some(TypeVarBoundOrConstraints::UpperBound(ty)) = self.bound_or_constraints(db) {
             Some(ty)
@@ -547,10 +551,7 @@ impl<'db> TypeVarInstance<'db> {
                         )
                     }),
                 Type::Dynamic(dynamic) => match dynamic {
-                    DynamicType::Todo(_)
-                    | DynamicType::TodoUnpack
-                    | DynamicType::TodoStarredExpression
-                    | DynamicType::TodoTypeVarTuple => Parameters::todo(),
+                    DynamicType::Todo(_) => Parameters::todo(),
                     DynamicType::Any
                     | DynamicType::Unknown
                     | DynamicType::UnknownGeneric(_)
@@ -602,6 +603,11 @@ impl<'db> TypeVarInstance<'db> {
                 let default_ty =
                     definition_expression_type(db, definition, paramspec_node.default.as_ref()?);
                 convert_type_to_paramspec_value(db, default_ty)
+            }
+            // PEP 695 TypeVarTuple
+            DefinitionKind::TypeVarTuple(typevartuple) => {
+                let typevartuple_node = typevartuple.node(&module);
+                definition_expression_type(db, definition, typevartuple_node.default.as_ref()?)
             }
             _ => return None,
         };
@@ -859,6 +865,10 @@ impl<'db> BoundTypeVarInstance<'db> {
 
     pub(crate) fn is_paramspec(self, db: &'db dyn Db) -> bool {
         self.kind(db).is_paramspec()
+    }
+
+    pub(crate) fn is_typevartuple(self, db: &'db dyn Db) -> bool {
+        self.kind(db).is_typevartuple()
     }
 
     /// Returns a new bound typevar instance with the given `ParamSpec` attribute set.
@@ -1240,6 +1250,10 @@ pub enum TypeVarKind {
     ParamSpec,
     /// `def foo[**P]() -> None: ...`
     Pep695ParamSpec,
+    /// `Ts = TypeVarTuple("Ts")`
+    TypeVarTuple,
+    /// `def foo[*Ts]() -> None: ...`
+    Pep695TypeVarTuple,
     /// `Alias: typing.TypeAlias = T`
     Pep613Alias,
 }
@@ -1247,6 +1261,10 @@ pub enum TypeVarKind {
 impl TypeVarKind {
     pub(super) const fn is_paramspec(self) -> bool {
         matches!(self, Self::ParamSpec | Self::Pep695ParamSpec)
+    }
+
+    pub(super) const fn is_typevartuple(self) -> bool {
+        matches!(self, Self::TypeVarTuple | Self::Pep695TypeVarTuple)
     }
 }
 


### PR DESCRIPTION
## Summary

- add initial support for `TypeVarTuple` and both `*` and `typing.Unpack` spellings
- support variadic generic specialization, tuple and callable inference, defaults, variance, and diagnostic validation
- preserve invalid `Unpack` operand provenance so `Generic` and `Protocol` report the appropriate generic-argument diagnostic without duplicates

This is stacked on #25767, which contains the test-only expectations. It replaces the implementation draft #25240 with a clean branch based on current `main`; #25240 has not been modified.

## Validation

- focused legacy `classes.md` and `unpack.md` mdtests in debug and release
- full `cargo test -p ty_python_semantic`
- `cargo check -p ty_python_semantic`
- `cargo check --release -p ty_python_semantic`
- `cargo fmt --all --check`
- `uvx prek run --files` for the follow-up files
- snapshot audit: no changed or pending snapshots
