### PR TITLE
[ty] Fix site-package error when multiple versions of pythons are installed in system path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,6 +3062,7 @@ dependencies = [
  "ruff_text_size",
  "rustc-hash",
  "salsa",
+ "same-file",
  "schemars",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4782,6 +4782,7 @@ dependencies = [
  "ruff_text_size",
  "strum",
  "strum_macros",
+ "tempfile",
  "tracing",
  "ty_static",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ salsa = { version = "0.27.0", default-features = false, features = [
     "salsa_unstable",
     "inventory",
 ] }
+same-file = { version = "1.0.6" }
 schemars = { version = "1.0.4" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -37,6 +37,7 @@ pathdiff = { workspace = true }
 quick-junit = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 salsa = { workspace = true }
+same-file = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -61,7 +62,7 @@ tempfile = { workspace = true }
 [features]
 cache = ["ruff_cache"]
 junit = ["dep:quick-junit"]
-os = ["ignore", "dep:etcetera", "dep:which"]
+os = ["ignore", "dep:etcetera", "dep:same-file", "dep:which"]
 serde = [
     "camino/serde1",
     "dep:serde",

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -66,9 +66,7 @@ pub trait System: Debug + Sync + Send {
     fn canonicalize_path(&self, path: &SystemPath) -> Result<SystemPathBuf>;
 
     /// Returns `true` if both paths refer to the same file.
-    fn is_same_file(&self, first: &SystemPath, second: &SystemPath) -> Result<bool> {
-        Ok(self.canonicalize_path(first)? == self.canonicalize_path(second)?)
-    }
+    fn is_same_file(&self, first: &SystemPath, second: &SystemPath) -> Result<bool>;
 
     /// Returns the source type for `path` if known or `None`.
     ///

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -65,6 +65,11 @@ pub trait System: Debug + Sync + Send {
     /// See [dunce::canonicalize] for more information.
     fn canonicalize_path(&self, path: &SystemPath) -> Result<SystemPathBuf>;
 
+    /// Returns `true` if both paths refer to the same file.
+    fn is_same_file(&self, first: &SystemPath, second: &SystemPath) -> Result<bool> {
+        Ok(self.canonicalize_path(first)? == self.canonicalize_path(second)?)
+    }
+
     /// Returns the source type for `path` if known or `None`.
     ///
     /// The default is to always return `None`, assuming the system

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -93,6 +93,10 @@ impl System for OsSystem {
         })
     }
 
+    fn is_same_file(&self, first: &SystemPath, second: &SystemPath) -> Result<bool> {
+        same_file::is_same_file(first.as_std_path(), second.as_std_path())
+    }
+
     fn read_to_string(&self, path: &SystemPath) -> Result<String> {
         std::fs::read_to_string(path.as_std_path())
     }

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -364,6 +364,12 @@ impl System for InMemorySystem {
         self.memory_fs.canonicalize(path)
     }
 
+    fn is_same_file(&self, first: &SystemPath, second: &SystemPath) -> Result<bool> {
+        // The in-memory file system does not support hard links, so canonical paths uniquely
+        // identify files.
+        Ok(self.canonicalize_path(first)? == self.canonicalize_path(second)?)
+    }
+
     fn read_to_string(&self, path: &SystemPath) -> Result<String> {
         self.memory_fs.read_to_string(path)
     }

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -101,6 +101,10 @@ impl System for TestSystem {
         self.system().canonicalize_path(path)
     }
 
+    fn is_same_file(&self, first: &SystemPath, second: &SystemPath) -> Result<bool> {
+        self.system().is_same_file(first, second)
+    }
+
     fn read_to_string(&self, path: &SystemPath) -> Result<String> {
         self.system().read_to_string(path)
     }

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -177,6 +177,10 @@ impl System for LSPSystem {
         self.native_system.canonicalize_path(path)
     }
 
+    fn is_same_file(&self, first: &SystemPath, second: &SystemPath) -> Result<bool> {
+        self.native_system.is_same_file(first, second)
+    }
+
     fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
         self.native_system.path_exists_case_sensitive(path, prefix)
     }

--- a/crates/ty_site_packages/Cargo.toml
+++ b/crates/ty_site_packages/Cargo.toml
@@ -32,6 +32,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 ruff_db = { workspace = true, features = ["testing", "os"] }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -238,6 +238,32 @@ fn is_versioned_interpreter_path(file_name: &str) -> bool {
     !version.is_empty() && PythonVersion::from_str(version.trim_end_matches('t')).is_ok()
 }
 
+/// Extract the Python version from a path that looks like a versioned Python executable.
+///
+/// For example:
+/// - `/opt/bin/python3.14` -> `Some(PythonVersion(3, 14))`
+/// - `/usr/bin/python3` -> `None` (ambiguous, no minor version)
+/// - `/usr/bin/python` -> `None`
+/// - `.venv/bin/python3.12` -> `Some(PythonVersion(3, 12))`
+/// - `/opt/bin/python3.13t` -> `Some(PythonVersion(3, 13))` (free-threaded)
+/// - `C:\Python3.14\python3.14.exe` -> `Some(PythonVersion(3, 14))` (Windows)
+fn python_version_from_executable_path(path: &SystemPath) -> Option<PythonVersion> {
+    let file_name = path.file_name()?;
+    // Strip the platform-specific executable suffix (e.g. `.exe` on Windows)
+    // so that `python3.14.exe` is parsed the same as `python3.14`.
+    let file_name = file_name
+        .strip_suffix(std::env::consts::EXE_SUFFIX)
+        .unwrap_or(file_name);
+    let version_str = file_name
+        .strip_prefix("python")
+        .or_else(|| file_name.strip_prefix("pypy"))?
+        .trim_end_matches('t');
+    if version_str.is_empty() {
+        return None;
+    }
+    PythonVersion::from_str(version_str).ok()
+}
+
 impl<const N: usize> From<[SystemPathBuf; N]> for SitePackagesPaths {
     fn from(paths: [SystemPathBuf; N]) -> Self {
         Self(
@@ -347,6 +373,10 @@ impl PythonEnvironment {
         origin: SysPrefixPathOrigin,
         system: &dyn System,
     ) -> SitePackagesDiscoveryResult<Self> {
+        // Extract the Python version from the executable path (e.g. `python3.14` → 3.14)
+        // BEFORE it gets resolved to sys.prefix, so we can still identify the correct
+        // site-packages directory even for system installations without pyvenv.cfg.
+        let python_version = python_version_from_executable_path(path.as_ref());
         let path = SysPrefixPath::new(path.as_ref(), origin, system)?;
 
         // Attempt to inspect as a virtual environment first
@@ -356,7 +386,7 @@ impl PythonEnvironment {
             Err(SitePackagesDiscoveryError::NoPyvenvCfgFile(path, _, _))
                 if !path.origin.must_be_virtual_env() =>
             {
-                Ok(Self::System(SystemEnvironment::new(path)))
+                Ok(Self::System(SystemEnvironment::new(path, python_version)))
             }
             Err(err) => Err(err),
         }
@@ -980,16 +1010,22 @@ struct RawPyvenvCfg<'s> {
 #[derive(Debug)]
 pub struct SystemEnvironment {
     root_path: SysPrefixPath,
+    // we also need python version in the case of multiple versions of pythons are installed
+    // see [ty using incorrect site-packages]: https://github.com/astral-sh/ty/issues/3424
+    python_version: Option<PythonVersion>,
 }
 
 impl SystemEnvironment {
-    /// Create a new system environment from the given path.
+    /// Create a new system environment with an optionally known Python version.
     ///
-    /// At this time, there is no eager validation and this is infallible. Instead, validation
-    /// will occur in [`site_packages_directories_from_sys_prefix`] — which will fail if there is not
-    /// a Python environment at the given path.
-    pub(crate) fn new(path: SysPrefixPath) -> Self {
-        Self { root_path: path }
+    /// When the Python version is known (e.g., from `--python /opt/bin/python3.14`),
+    /// the site-packages discovery can target the exact version directory
+    /// instead of scanning all Python versions under `sys.prefix`.
+    pub(crate) fn new(path: SysPrefixPath, python_version: Option<PythonVersion>) -> Self {
+        Self {
+            root_path: path,
+            python_version,
+        }
     }
 
     /// Return a list of `site-packages` directories that are available from this environment.
@@ -999,11 +1035,14 @@ impl SystemEnvironment {
         &self,
         system: &dyn System,
     ) -> SitePackagesDiscoveryResult<SitePackagesPaths> {
-        let SystemEnvironment { root_path } = self;
+        let SystemEnvironment {
+            root_path,
+            python_version,
+        } = self;
 
         let site_packages_directories = site_packages_directories_from_sys_prefix(
             root_path,
-            None,
+            *python_version,
             PythonImplementation::Unknown,
             system,
         )?;
@@ -1021,7 +1060,10 @@ impl SystemEnvironment {
         &self,
         system: &dyn System,
     ) -> StdlibDiscoveryResult<SystemPathBuf> {
-        let SystemEnvironment { root_path } = self;
+        let SystemEnvironment {
+            root_path,
+            python_version: _,
+        } = self;
 
         let stdlib_directory = real_stdlib_directory_from_sys_prefix(
             root_path,
@@ -3568,21 +3610,16 @@ mod tests {
         let site_packages_314 = sys_prefix.join("lib/python3.14/site-packages");
         let site_packages_313 = sys_prefix.join("lib/python3.13/site-packages");
 
-        memory_fs.create_directory_all(sys_prefix.join("bin")).unwrap();
         memory_fs
-            .create_directory_all(&site_packages_314)
+            .create_directory_all(sys_prefix.join("bin"))
             .unwrap();
-        memory_fs
-            .create_directory_all(&site_packages_313)
-            .unwrap();
+        memory_fs.create_directory_all(&site_packages_314).unwrap();
+        memory_fs.create_directory_all(&site_packages_313).unwrap();
         memory_fs.write_file_all(&python_314_exe, "").unwrap();
 
-        let env = PythonEnvironment::new(
-            &python_314_exe,
-            SysPrefixPathOrigin::PythonCliFlag,
-            &system,
-        )
-        .unwrap();
+        let env =
+            PythonEnvironment::new(&python_314_exe, SysPrefixPathOrigin::PythonCliFlag, &system)
+                .unwrap();
 
         let PythonEnvironment::System(system_env) = &env else {
             panic!("Expected a system environment, got virtual: {env:?}");

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -228,54 +228,7 @@ fn settings_diagnostic_path_from_sys_prefix(
 /// Returns `true` if the file name appears to be that of a versioned interpreter
 /// (e.g., `python3.15`).
 fn is_versioned_interpreter_path(file_name: &str) -> bool {
-    let Some(version) = file_name
-        .strip_prefix("python")
-        .or_else(|| file_name.strip_prefix("pypy"))
-    else {
-        return false;
-    };
-
-    !version.is_empty() && PythonVersion::from_str(version.trim_end_matches('t')).is_ok()
-}
-
-/// Extract the Python version from a path that looks like a versioned Python executable,
-/// following symlinks if the filename itself isn't versioned.
-///
-/// For example:
-/// - `/opt/bin/python3.14` -> `Some(PythonVersion(3, 14))`
-/// - `/usr/bin/python3` -> `None` (ambiguous, no minor version)
-/// - `/usr/bin/python` -> `None`
-/// - `.venv/bin/python3.12` -> `Some(PythonVersion(3, 12))`
-/// - `/opt/bin/python3.13t` -> `Some(PythonVersion(3, 13))` (free-threaded)
-/// - `C:\Python3.14\python3.14.exe` -> `Some(PythonVersion(3, 14))` (Windows)
-/// - `/usr/bin/python3` (symlink to `python3.14`) -> `Some(PythonVersion(3, 14))`
-fn python_version_from_executable_path(
-    path: &SystemPath,
-    system: &dyn System,
-) -> Option<PythonVersion> {
-    let extract = |file_name: &str| -> Option<PythonVersion> {
-        let file_name = file_name
-            .strip_suffix(std::env::consts::EXE_SUFFIX)
-            .unwrap_or(file_name);
-        let version_str = file_name
-            .strip_prefix("python")
-            .or_else(|| file_name.strip_prefix("pypy"))?
-            .trim_end_matches('t');
-        if version_str.is_empty() {
-            return None;
-        }
-        PythonVersion::from_str(version_str).ok()
-    };
-
-    // try extracting version from the path filename directly.
-    if let Some(version) = extract(path.file_name()?) {
-        return Some(version);
-    }
-
-    // if the filename isn't directly versioned, it might be a symlink
-    // then follow it and try again on the real target.
-    let canonical = system.canonicalize_path(path).ok()?;
-    extract(canonical.file_name()?)
+    PythonInterpreterLayout::from_file_name(file_name).is_some()
 }
 
 impl<const N: usize> From<[SystemPathBuf; N]> for SitePackagesPaths {
@@ -387,20 +340,16 @@ impl PythonEnvironment {
         origin: SysPrefixPathOrigin,
         system: &dyn System,
     ) -> SitePackagesDiscoveryResult<Self> {
-        // Extract the Python version from the executable path (e.g. `python3.14` → 3.14)
-        // BEFORE it gets resolved to sys.prefix, so we can still identify the correct
-        // site-packages directory even for system installations without pyvenv.cfg.
-        let python_version = python_version_from_executable_path(path.as_ref(), system);
-        let path = SysPrefixPath::new(path.as_ref(), origin, system)?;
+        let path = PythonEnvironmentPath::new(path.as_ref(), origin, system)?;
 
         // Attempt to inspect as a virtual environment first
-        match VirtualEnvironment::new(path, system) {
+        match VirtualEnvironment::new(path.sys_prefix(), system) {
             Ok(venv) => Ok(Self::Virtual(venv)),
             // If there's not a `pyvenv.cfg` marker, attempt to inspect as a system environment
-            Err(SitePackagesDiscoveryError::NoPyvenvCfgFile(path, _, _))
-                if !path.origin.must_be_virtual_env() =>
+            Err(SitePackagesDiscoveryError::NoPyvenvCfgFile(_, _, _))
+                if !path.origin().must_be_virtual_env() =>
             {
-                Ok(Self::System(SystemEnvironment::new(path, python_version)))
+                Ok(Self::System(SystemEnvironment::new(path)))
             }
             Err(err) => Err(err),
         }
@@ -436,7 +385,7 @@ impl PythonEnvironment {
     pub fn origin(&self) -> &SysPrefixPathOrigin {
         match self {
             Self::Virtual(env) => &env.root_path.origin,
-            Self::System(env) => &env.root_path.origin,
+            Self::System(env) => env.path.origin(),
         }
     }
 
@@ -541,12 +490,64 @@ pub(crate) enum PythonImplementation {
     Unknown,
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+struct PythonInterpreterLayout {
+    version: Option<PythonVersion>,
+    implementation: PythonImplementation,
+    /// `None` when the executable name does not distinguish between regular and free-threaded.
+    free_threaded: Option<bool>,
+}
+
+impl PythonInterpreterLayout {
+    fn from_file_name(file_name: &str) -> Option<Self> {
+        let file_name = file_name
+            .strip_suffix(std::env::consts::EXE_SUFFIX)
+            .unwrap_or(file_name);
+
+        let (version, implementation) = if let Some(version) = file_name.strip_prefix("python") {
+            (version, PythonImplementation::CPython)
+        } else {
+            (file_name.strip_prefix("pypy")?, PythonImplementation::PyPy)
+        };
+
+        let (version, free_threaded) = if implementation == PythonImplementation::CPython {
+            version
+                .strip_suffix('t')
+                .map_or((version, false), |version| (version, true))
+        } else {
+            (version, false)
+        };
+
+        let version = PythonVersion::from_str(version).ok()?;
+        if free_threaded && !version.free_threaded_build_available() {
+            return None;
+        }
+
+        Some(Self {
+            version: Some(version),
+            implementation,
+            free_threaded: Some(free_threaded),
+        })
+    }
+}
+
 impl PythonImplementation {
     /// Return the relative path from `sys.prefix` to the directory containing the python stdlib's
     /// .pys if this is a known implementation. Return `None` if this is an unknown implementation.
-    fn relative_stdlib_path(self, version: Option<PythonVersion>) -> Option<String> {
+    fn relative_stdlib_path(
+        self,
+        version: Option<PythonVersion>,
+        free_threaded: Option<bool>,
+    ) -> Option<String> {
         match self {
-            Self::CPython | Self::GraalPy => version.map(|version| format!("lib/python{version}")),
+            Self::CPython | Self::GraalPy => version.map(|version| {
+                let suffix = if self == Self::CPython && free_threaded == Some(true) {
+                    "t"
+                } else {
+                    ""
+                };
+                format!("lib/python{version}{suffix}")
+            }),
             Self::PyPy => version.map(|version| format!("lib/pypy{version}")),
             Self::Unknown => None,
         }
@@ -586,7 +587,7 @@ pub struct VirtualEnvironment {
 
 impl VirtualEnvironment {
     pub(crate) fn new(
-        path: SysPrefixPath,
+        path: &SysPrefixPath,
         system: &dyn System,
     ) -> SitePackagesDiscoveryResult<Self> {
         let pyvenv_cfg_path = path.join("pyvenv.cfg");
@@ -596,7 +597,7 @@ impl VirtualEnvironment {
             Ok(pyvenv_cfg) => pyvenv_cfg,
             Err(err) => {
                 return Err(SitePackagesDiscoveryError::NoPyvenvCfgFile(
-                    path,
+                    path.clone(),
                     err,
                     system.dyn_clone(),
                 ));
@@ -679,7 +680,7 @@ impl VirtualEnvironment {
         });
 
         let metadata = Self {
-            root_path: path,
+            root_path: path.clone(),
             base_executable_home_path,
             include_system_site_packages,
             version,
@@ -1023,23 +1024,19 @@ struct RawPyvenvCfg<'s> {
 /// this captures both Homebrew-installed Python versions and the bundled macOS Python installation.
 #[derive(Debug)]
 pub struct SystemEnvironment {
-    root_path: SysPrefixPath,
-    // we also need python version in the case of multiple versions of pythons are installed
-    // see [ty using incorrect site-packages]: https://github.com/astral-sh/ty/issues/3424
-    python_version: Option<PythonVersion>,
+    path: PythonEnvironmentPath,
 }
 
 impl SystemEnvironment {
-    /// Create a new system environment with an optionally known Python version.
+    /// Create a system environment from the selected environment path.
     ///
-    /// When the Python version is known (e.g., from `--python /opt/bin/python3.14`),
-    /// the site-packages discovery can target the exact version directory
-    /// instead of scanning all Python versions under `sys.prefix`.
-    pub(crate) fn new(path: SysPrefixPath, python_version: Option<PythonVersion>) -> Self {
-        Self {
-            root_path: path,
-            python_version,
-        }
+    /// Validation remains lazy and occurs when resolving site-packages or the stdlib.
+    fn new(path: PythonEnvironmentPath) -> Self {
+        tracing::trace!(
+            "Resolved system Python environment from `{}`",
+            path.selected_path()
+        );
+        Self { path }
     }
 
     /// Return a list of `site-packages` directories that are available from this environment.
@@ -1049,15 +1046,9 @@ impl SystemEnvironment {
         &self,
         system: &dyn System,
     ) -> SitePackagesDiscoveryResult<SitePackagesPaths> {
-        let SystemEnvironment {
-            root_path,
-            python_version,
-        } = self;
-
-        let site_packages_directories = site_packages_directories_from_sys_prefix(
-            root_path,
-            *python_version,
-            PythonImplementation::Unknown,
+        let site_packages_directories = site_packages_directories_from_sys_prefix_with_layout(
+            self.path.sys_prefix(),
+            self.path.interpreter_layout().unwrap_or_default(),
             system,
         )?;
 
@@ -1074,15 +1065,9 @@ impl SystemEnvironment {
         &self,
         system: &dyn System,
     ) -> StdlibDiscoveryResult<SystemPathBuf> {
-        let SystemEnvironment {
-            root_path,
-            python_version: _,
-        } = self;
-
-        let stdlib_directory = real_stdlib_directory_from_sys_prefix(
-            root_path,
-            None,
-            PythonImplementation::Unknown,
+        let stdlib_directory = real_stdlib_directory_from_sys_prefix_with_layout(
+            self.path.sys_prefix(),
+            self.path.interpreter_layout().unwrap_or_default(),
             system,
         )?;
 
@@ -1374,31 +1359,47 @@ when trying to resolve the `home` value to a directory on disk: {io_err}"
 fn probe_package_dirs(
     prefix_dir: &SystemPath,
     suffix: InstallationDir,
-    python_version: PythonVersion,
-    implementation: PythonImplementation,
+    layout: PythonInterpreterLayout,
     system: &dyn System,
     settings_diagnostic_path: Option<&SystemPath>,
     directories: &mut SitePackagesPaths,
 ) {
+    let PythonInterpreterLayout {
+        version: Some(python_version),
+        implementation,
+        free_threaded,
+    } = layout
+    else {
+        return;
+    };
     let settings_diagnostic_path = || settings_diagnostic_path.map(SystemPath::to_path_buf);
 
     // Try to insert the CPython-style package path into `directories`.
     // Returns `true` if a matching directory was found, so the caller can
     // decide whether to fall back to probing other implementations.
     let probe_cpython_path = |directories: &mut SitePackagesPaths| {
-        let path = prefix_dir.join(format!("python{python_version}/{suffix}"));
+        let path = |free_threaded| {
+            let suffix_marker = if free_threaded { "t" } else { "" };
+            prefix_dir.join(format!("python{python_version}{suffix_marker}/{suffix}"))
+        };
+
+        let path = match free_threaded {
+            Some(free_threaded) => path(free_threaded),
+            None => {
+                // Preserve the existing regular-first fallback when the build flavor is unknown.
+                let regular = path(false);
+                if system.is_directory(&regular) || !python_version.free_threaded_build_available()
+                {
+                    regular
+                } else {
+                    path(true)
+                }
+            }
+        };
+
         if system.is_directory(&path) {
             directories.insert_with_settings_diagnostic_path(path, settings_diagnostic_path());
             true
-        } else if python_version.free_threaded_build_available() {
-            // CPython free-threaded (3.13+) variant: pythonX.Yt
-            let alt = prefix_dir.join(format!("python{python_version}t/{suffix}"));
-            if system.is_directory(&alt) {
-                directories.insert_with_settings_diagnostic_path(alt, settings_diagnostic_path());
-                true
-            } else {
-                false
-            }
         } else {
             false
         }
@@ -1494,6 +1495,22 @@ fn site_packages_directories_from_sys_prefix(
     implementation: PythonImplementation,
     system: &dyn System,
 ) -> SitePackagesDiscoveryResult<SitePackagesPaths> {
+    site_packages_directories_from_sys_prefix_with_layout(
+        sys_prefix_path,
+        PythonInterpreterLayout {
+            version: python_version,
+            implementation,
+            free_threaded: None,
+        },
+        system,
+    )
+}
+
+fn site_packages_directories_from_sys_prefix_with_layout(
+    sys_prefix_path: &SysPrefixPath,
+    layout: PythonInterpreterLayout,
+    system: &dyn System,
+) -> SitePackagesDiscoveryResult<SitePackagesPaths> {
     tracing::debug!(
         "Searching for site-packages directory in sys.prefix {}",
         sys_prefix_path.inner
@@ -1548,13 +1565,12 @@ fn site_packages_directories_from_sys_prefix(
     // Insert these first for correct precedence.
     // Only check /usr/local/lib (not lib64): Debian/Ubuntu pip installs
     // do not use /usr/local/lib64.
-    if let Some(python_version) = python_version {
+    if layout.version.is_some() {
         if is_debian_system_prefix {
             probe_package_dirs(
                 SystemPath::new("/usr/local/lib"),
                 InstallationDir::DistPackages,
-                python_version,
-                implementation,
+                layout,
                 system,
                 settings_diagnostic_path.as_deref(),
                 &mut directories,
@@ -1567,8 +1583,7 @@ fn site_packages_directories_from_sys_prefix(
                 probe_package_dirs(
                     &prefix,
                     suffix,
-                    python_version,
-                    implementation,
+                    layout,
                     system,
                     settings_diagnostic_path.as_deref(),
                     &mut directories,
@@ -1580,7 +1595,7 @@ fn site_packages_directories_from_sys_prefix(
             discover_package_dirs(
                 SystemPath::new("/usr/local/lib"),
                 &[InstallationDir::DistPackages],
-                implementation,
+                layout.implementation,
                 system,
                 settings_diagnostic_path.as_deref(),
                 &mut directories,
@@ -1592,7 +1607,7 @@ fn site_packages_directories_from_sys_prefix(
             discover_package_dirs(
                 &prefix,
                 &InstallationDir::iter(),
-                implementation,
+                layout.implementation,
                 system,
                 settings_diagnostic_path.as_deref(),
                 &mut directories,
@@ -1604,7 +1619,7 @@ fn site_packages_directories_from_sys_prefix(
     // for packages that work across multiple Python versions.
     // See: https://wiki.debian.org/Python#Deviations_from_upstream
     if matches!(
-        implementation,
+        layout.implementation,
         PythonImplementation::CPython | PythonImplementation::Unknown
     ) {
         let debian_dist_packages = sys_prefix_path.join("lib/python3/dist-packages");
@@ -1648,6 +1663,22 @@ fn real_stdlib_directory_from_sys_prefix(
     implementation: PythonImplementation,
     system: &dyn System,
 ) -> StdlibDiscoveryResult<SystemPathBuf> {
+    real_stdlib_directory_from_sys_prefix_with_layout(
+        sys_prefix_path,
+        PythonInterpreterLayout {
+            version: python_version,
+            implementation,
+            free_threaded: None,
+        },
+        system,
+    )
+}
+
+fn real_stdlib_directory_from_sys_prefix_with_layout(
+    sys_prefix_path: &SysPrefixPath,
+    layout: PythonInterpreterLayout,
+    system: &dyn System,
+) -> StdlibDiscoveryResult<SystemPathBuf> {
     tracing::debug!(
         "Searching for real stdlib directory in sys.prefix {}",
         sys_prefix_path.inner
@@ -1662,18 +1693,22 @@ fn real_stdlib_directory_from_sys_prefix(
 
     // If we were able to figure out what Python version this installation is,
     // we should be able to avoid iterating through all items in the `lib/` directory:
-    if let Some(expected_relative_path) = implementation.relative_stdlib_path(python_version) {
+    if let Some(expected_relative_path) = layout
+        .implementation
+        .relative_stdlib_path(layout.version, layout.free_threaded)
+    {
         let expected_absolute_path = sys_prefix_path.join(expected_relative_path);
         if system.is_directory(&expected_absolute_path) {
             return Ok(expected_absolute_path);
         }
 
         // CPython free-threaded (3.13+) variant: pythonXYt
-        if matches!(implementation, PythonImplementation::CPython)
-            && python_version.is_some_and(PythonVersion::free_threaded_build_available)
+        if let Some(version) = layout.version
+            && matches!(layout.implementation, PythonImplementation::CPython)
+            && layout.free_threaded.is_none()
+            && version.free_threaded_build_available()
         {
-            let alternative_path =
-                sys_prefix_path.join(format!("lib/python{}t", python_version.unwrap()));
+            let alternative_path = sys_prefix_path.join(format!("lib/python{version}t"));
             if system.is_directory(&alternative_path) {
                 return Ok(alternative_path);
             }
@@ -1744,38 +1779,54 @@ pub struct SysPrefixPath {
     origin: SysPrefixPathOrigin,
 }
 
-impl SysPrefixPath {
+fn sys_prefix_from_executable_path(path: &SystemPath) -> Option<&SystemPath> {
+    if cfg!(windows) {
+        // On Windows, the relative path to the executable from `sys.prefix` is different
+        // depending on whether it's a virtual environment or a system installation.
+        // System installations have their executable at `<sys.prefix>/python.exe`,
+        // whereas virtual environments have their executable at `<sys.prefix>/Scripts/python.exe`.
+        path.parent().and_then(|parent| {
+            if parent.file_name() == Some("Scripts") {
+                parent.parent()
+            } else {
+                Some(parent)
+            }
+        })
+    } else {
+        // On Unix, `sys.prefix` is always the grandparent directory of the Python executable,
+        // regardless of whether it's a virtual environment or a system installation.
+        path.ancestors().nth(2)
+    }
+}
+
+/// A selected Python environment path resolved to its `sys.prefix`.
+#[derive(Debug)]
+enum PythonEnvironmentPath {
+    Prefix(SysPrefixPath),
+    Executable {
+        path: SystemPathBuf,
+        sys_prefix: SysPrefixPath,
+        layout: Option<PythonInterpreterLayout>,
+    },
+}
+
+impl PythonEnvironmentPath {
     fn new(
         unvalidated_path: &SystemPath,
         origin: SysPrefixPathOrigin,
         system: &dyn System,
     ) -> SitePackagesDiscoveryResult<Self> {
-        let sys_prefix = if !origin.must_point_directly_to_sys_prefix()
+        let executable_path = (!origin.must_point_directly_to_sys_prefix()
             && system.is_file(unvalidated_path)
             && unvalidated_path.file_name().is_some_and(|name| {
                 name.starts_with("python")
+                    || name.starts_with("pypy")
                     || name.eq_ignore_ascii_case(&format!("ty{}", std::env::consts::EXE_SUFFIX))
-            }) {
-            // It looks like they passed us a path to an executable, e.g. `.venv/bin/python3`. Try
-            // to figure out the `sys.prefix` value from the Python executable.
-            let sys_prefix = if cfg!(windows) {
-                // On Windows, the relative path to the executable from `sys.prefix` is different
-                // depending on whether it's a virtual environment or a system installation.
-                // System installations have their executable at `<sys.prefix>/python.exe`,
-                // whereas virtual environments have their executable at `<sys.prefix>/Scripts/python.exe`.
-                unvalidated_path.parent().and_then(|parent| {
-                    if parent.file_name() == Some("Scripts") {
-                        parent.parent()
-                    } else {
-                        Some(parent)
-                    }
-                })
-            } else {
-                // On Unix, `sys.prefix` is always the grandparent directory of the Python executable,
-                // regardless of whether it's a virtual environment or a system installation.
-                unvalidated_path.ancestors().nth(2)
-            };
-            let Some(sys_prefix) = sys_prefix else {
+            }))
+        .then_some(unvalidated_path);
+
+        let unvalidated_sys_prefix = if let Some(executable_path) = executable_path {
+            let Some(sys_prefix) = sys_prefix_from_executable_path(executable_path) else {
                 return Err(SitePackagesDiscoveryError::PathNotExecutableOrDirectory(
                     unvalidated_path.to_path_buf(),
                     origin,
@@ -1791,7 +1842,7 @@ impl SysPrefixPath {
         // It's important to resolve symlinks here rather than simply making the path absolute,
         // since system Python installations often only put symlinks in the "expected"
         // locations for `home` and `site-packages`
-        let sys_prefix = match system.canonicalize_path(sys_prefix) {
+        let sys_prefix = match system.canonicalize_path(unvalidated_sys_prefix) {
             Ok(path) => path,
             Err(io_err) => {
                 let unvalidated_path = unvalidated_path.to_path_buf();
@@ -1823,11 +1874,70 @@ impl SysPrefixPath {
             ));
         }
 
-        Ok(Self {
+        let layout = executable_path.and_then(|executable_path| {
+            if let Some(layout) = executable_path
+                .file_name()
+                .and_then(PythonInterpreterLayout::from_file_name)
+            {
+                return Some(layout);
+            }
+
+            let canonical_executable = system.canonicalize_path(executable_path).ok()?;
+            let layout = canonical_executable
+                .file_name()
+                .and_then(PythonInterpreterLayout::from_file_name)?;
+            let canonical_executable_prefix =
+                sys_prefix_from_executable_path(&canonical_executable)?;
+            let canonical_executable_prefix =
+                system.canonicalize_path(canonical_executable_prefix).ok()?;
+
+            // Metadata from a symlink target can only describe the selected environment when both
+            // executable paths resolve to the same installation prefix.
+            (canonical_executable_prefix == sys_prefix).then_some(layout)
+        });
+
+        let sys_prefix = SysPrefixPath {
             inner: sys_prefix,
             origin,
-        })
+        };
+
+        if let Some(executable_path) = executable_path {
+            Ok(Self::Executable {
+                path: executable_path.to_path_buf(),
+                sys_prefix,
+                layout,
+            })
+        } else {
+            Ok(Self::Prefix(sys_prefix))
+        }
     }
+
+    fn sys_prefix(&self) -> &SysPrefixPath {
+        match self {
+            Self::Prefix(sys_prefix) | Self::Executable { sys_prefix, .. } => sys_prefix,
+        }
+    }
+
+    fn origin(&self) -> &SysPrefixPathOrigin {
+        &self.sys_prefix().origin
+    }
+
+    fn interpreter_layout(&self) -> Option<PythonInterpreterLayout> {
+        match self {
+            Self::Executable { layout, .. } => *layout,
+            Self::Prefix(_) => None,
+        }
+    }
+
+    fn selected_path(&self) -> &SystemPath {
+        match self {
+            Self::Prefix(sys_prefix) => sys_prefix,
+            Self::Executable { path, .. } => path,
+        }
+    }
+}
+
+impl SysPrefixPath {
     fn from_executable_home_path(path: &PythonHomePath) -> Option<Self> {
         // No need to check whether `path.parent()` is a directory:
         // the parent of a canonicalised path that is known to exist
@@ -2090,6 +2200,8 @@ impl PartialEq<SystemPathBuf> for PythonHomePath {
 #[cfg(test)]
 mod tests {
     use ruff_db::system::TestSystem;
+    #[cfg(unix)]
+    use ruff_db::system::{OsSystem, SystemPath};
 
     use super::*;
 
@@ -2348,8 +2460,8 @@ mod tests {
             );
 
             assert_eq!(
-                env.root_path,
-                SysPrefixPath {
+                env.path.sys_prefix(),
+                &SysPrefixPath {
                     inner: self.system.canonicalize_path(expected_env_path).unwrap(),
                     origin: self.origin.clone(),
                 }
@@ -3606,57 +3718,107 @@ mod tests {
     }
 
     /// Regression test for <https://github.com/astral-sh/ty/issues/3424>.
-    ///
-    /// When `--python /opt/bin/python3.14` is passed, ty should only discover
-    /// the site-packages for Python 3.14, not for other Python versions
-    /// that happen to be installed in the same sys.prefix directory.
     #[cfg(not(windows))]
     #[test]
-    fn uses_correct_site_packages_when_python_executable_path_has_version() {
+    fn uses_selected_system_interpreter_layout() {
         let system = TestSystem::default();
         let memory_fs = system.memory_file_system();
-
-        // Simulate: /opt/ has Python 3.13 and 3.14 both installed
-        // and python 3.13 should not be found
         let sys_prefix = SystemPathBuf::from("/opt");
 
-        let python_314_exe = sys_prefix.join("bin/python3.14");
-        let site_packages_314 = sys_prefix.join("lib/python3.14/site-packages");
-        let site_packages_313 = sys_prefix.join("lib/python3.13/site-packages");
-
         memory_fs
-            .create_directory_all(sys_prefix.join("bin"))
+            .create_directory_all(sys_prefix.join("lib/python3.13/site-packages"))
             .unwrap();
-        memory_fs.create_directory_all(&site_packages_314).unwrap();
-        memory_fs.create_directory_all(&site_packages_313).unwrap();
-        memory_fs.write_file_all(&python_314_exe, "").unwrap();
 
-        let env =
-            PythonEnvironment::new(&python_314_exe, SysPrefixPathOrigin::PythonCliFlag, &system)
+        let layouts = [
+            (
+                "python3.14",
+                "lib/python3.14/site-packages",
+                "lib/python3.14",
+            ),
+            (
+                "python3.14t",
+                "lib/python3.14t/site-packages",
+                "lib/python3.14t",
+            ),
+            ("pypy3.14", "lib/pypy3.14/site-packages", "lib/pypy3.14"),
+        ];
+
+        for (executable, site_packages, _) in layouts {
+            memory_fs
+                .write_file_all(sys_prefix.join("bin").join(executable), "")
                 .unwrap();
+            memory_fs
+                .create_directory_all(sys_prefix.join(site_packages))
+                .unwrap();
+        }
 
-        let PythonEnvironment::System(system_env) = &env else {
-            panic!("Expected a system environment, got virtual: {env:?}");
-        };
+        for (executable, site_packages, stdlib) in layouts {
+            let environment = PythonEnvironment::new(
+                sys_prefix.join("bin").join(executable),
+                SysPrefixPathOrigin::PythonCliFlag,
+                &system,
+            )
+            .unwrap();
 
-        let site_packages = system_env.site_packages_directories(&system).unwrap();
-        let dirs: Vec<_> = site_packages.into_iter().collect();
+            assert_eq!(
+                environment.site_packages_paths(&system).unwrap().into_vec(),
+                [sys_prefix.join(site_packages)]
+            );
+            assert_eq!(
+                environment.real_stdlib_path(&system).unwrap(),
+                sys_prefix.join(stdlib)
+            );
+        }
+    }
 
-        assert!(
-            dirs.iter()
-                .any(|p| p.as_str() == "/opt/lib/python3.14/site-packages"),
-            "Expected to find /opt/lib/python3.14/site-packages, got: {dirs:?}"
-        );
-        assert!(
-            dirs.iter()
-                .all(|p| p.as_str() != "/opt/lib/python3.13/site-packages"),
-            "Should NOT include /opt/lib/python3.13/site-packages when --python points to python3.14, got: {dirs:?}"
-        );
+    #[cfg(unix)]
+    #[test]
+    fn only_uses_symlink_target_layout_within_same_prefix() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = SystemPath::from_std_path(temp_dir.path()).unwrap();
+        let system = OsSystem::new(root);
+
+        let prefix = root.join("prefix");
+        let bin = prefix.join("bin");
+        std::fs::create_dir_all(bin.as_std_path()).unwrap();
+        std::fs::File::create(bin.join("python3.14").as_std_path()).unwrap();
+        std::os::unix::fs::symlink("python3.14", bin.join("python").as_std_path()).unwrap();
+
+        let path = PythonEnvironmentPath::new(
+            &bin.join("python"),
+            SysPrefixPathOrigin::PythonCliFlag,
+            &system,
+        )
+        .unwrap();
+
         assert_eq!(
-            dirs.len(),
-            1,
-            "Expected exactly one site-packages path, got {count}: {dirs:?}",
-            count = dirs.len(),
+            path.interpreter_layout(),
+            Some(PythonInterpreterLayout {
+                version: Some(PythonVersion::PY314),
+                implementation: PythonImplementation::CPython,
+                free_threaded: Some(false),
+            })
+        );
+
+        let other_prefix = root.join("other");
+        let other_bin = other_prefix.join("bin");
+        std::fs::create_dir_all(other_bin.as_std_path()).unwrap();
+        std::fs::File::create(other_bin.join("python3.14").as_std_path()).unwrap();
+        std::os::unix::fs::symlink(
+            other_bin.join("python3.14").as_std_path(),
+            bin.join("python-other").as_std_path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            PythonEnvironmentPath::new(
+                &bin.join("python-other"),
+                SysPrefixPathOrigin::PythonCliFlag,
+                &system,
+            )
+            .unwrap()
+            .interpreter_layout(),
+            None
         );
     }
 }

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -238,7 +238,8 @@ fn is_versioned_interpreter_path(file_name: &str) -> bool {
     !version.is_empty() && PythonVersion::from_str(version.trim_end_matches('t')).is_ok()
 }
 
-/// Extract the Python version from a path that looks like a versioned Python executable.
+/// Extract the Python version from a path that looks like a versioned Python executable,
+/// following symlinks if the filename itself isn't versioned.
 ///
 /// For example:
 /// - `/opt/bin/python3.14` -> `Some(PythonVersion(3, 14))`
@@ -247,21 +248,34 @@ fn is_versioned_interpreter_path(file_name: &str) -> bool {
 /// - `.venv/bin/python3.12` -> `Some(PythonVersion(3, 12))`
 /// - `/opt/bin/python3.13t` -> `Some(PythonVersion(3, 13))` (free-threaded)
 /// - `C:\Python3.14\python3.14.exe` -> `Some(PythonVersion(3, 14))` (Windows)
-fn python_version_from_executable_path(path: &SystemPath) -> Option<PythonVersion> {
-    let file_name = path.file_name()?;
-    // Strip the platform-specific executable suffix (e.g. `.exe` on Windows)
-    // so that `python3.14.exe` is parsed the same as `python3.14`.
-    let file_name = file_name
-        .strip_suffix(std::env::consts::EXE_SUFFIX)
-        .unwrap_or(file_name);
-    let version_str = file_name
-        .strip_prefix("python")
-        .or_else(|| file_name.strip_prefix("pypy"))?
-        .trim_end_matches('t');
-    if version_str.is_empty() {
-        return None;
+/// - `/usr/bin/python3` (symlink to `python3.14`) -> `Some(PythonVersion(3, 14))`
+fn python_version_from_executable_path(
+    path: &SystemPath,
+    system: &dyn System,
+) -> Option<PythonVersion> {
+    let extract = |file_name: &str| -> Option<PythonVersion> {
+        let file_name = file_name
+            .strip_suffix(std::env::consts::EXE_SUFFIX)
+            .unwrap_or(file_name);
+        let version_str = file_name
+            .strip_prefix("python")
+            .or_else(|| file_name.strip_prefix("pypy"))?
+            .trim_end_matches('t');
+        if version_str.is_empty() {
+            return None;
+        }
+        PythonVersion::from_str(version_str).ok()
+    };
+
+    // try extracting version from the path filename directly.
+    if let Some(version) = extract(path.file_name()?) {
+        return Some(version);
     }
-    PythonVersion::from_str(version_str).ok()
+
+    // if the filename isn't directly versioned, it might be a symlink
+    // then follow it and try again on the real target.
+    let canonical = system.canonicalize_path(path).ok()?;
+    extract(canonical.file_name()?)
 }
 
 impl<const N: usize> From<[SystemPathBuf; N]> for SitePackagesPaths {
@@ -376,7 +390,7 @@ impl PythonEnvironment {
         // Extract the Python version from the executable path (e.g. `python3.14` → 3.14)
         // BEFORE it gets resolved to sys.prefix, so we can still identify the correct
         // site-packages directory even for system installations without pyvenv.cfg.
-        let python_version = python_version_from_executable_path(path.as_ref());
+        let python_version = python_version_from_executable_path(path.as_ref(), system);
         let path = SysPrefixPath::new(path.as_ref(), origin, system)?;
 
         // Attempt to inspect as a virtual environment first

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -3548,4 +3548,64 @@ mod tests {
             "Should NOT find python3.11 dist-packages when version=3.12 is known, got: {dirs:?}"
         );
     }
+
+    /// Regression test for <https://github.com/astral-sh/ty/issues/3424>.
+    ///
+    /// When `--python /opt/bin/python3.14` is passed, ty should only discover
+    /// the site-packages for Python 3.14, not for other Python versions
+    /// that happen to be installed in the same sys.prefix directory.
+    #[cfg(not(windows))]
+    #[test]
+    fn uses_correct_site_packages_when_python_executable_path_has_version() {
+        let system = TestSystem::default();
+        let memory_fs = system.memory_file_system();
+
+        // Simulate: /opt/ has Python 3.13 and 3.14 both installed
+        // and python 3.13 should not be found
+        let sys_prefix = SystemPathBuf::from("/opt");
+
+        let python_314_exe = sys_prefix.join("bin/python3.14");
+        let site_packages_314 = sys_prefix.join("lib/python3.14/site-packages");
+        let site_packages_313 = sys_prefix.join("lib/python3.13/site-packages");
+
+        memory_fs.create_directory_all(sys_prefix.join("bin")).unwrap();
+        memory_fs
+            .create_directory_all(&site_packages_314)
+            .unwrap();
+        memory_fs
+            .create_directory_all(&site_packages_313)
+            .unwrap();
+        memory_fs.write_file_all(&python_314_exe, "").unwrap();
+
+        let env = PythonEnvironment::new(
+            &python_314_exe,
+            SysPrefixPathOrigin::PythonCliFlag,
+            &system,
+        )
+        .unwrap();
+
+        let PythonEnvironment::System(system_env) = &env else {
+            panic!("Expected a system environment, got virtual: {env:?}");
+        };
+
+        let site_packages = system_env.site_packages_directories(&system).unwrap();
+        let dirs: Vec<_> = site_packages.into_iter().collect();
+
+        assert!(
+            dirs.iter()
+                .any(|p| p.as_str() == "/opt/lib/python3.14/site-packages"),
+            "Expected to find /opt/lib/python3.14/site-packages, got: {dirs:?}"
+        );
+        assert!(
+            dirs.iter()
+                .all(|p| p.as_str() != "/opt/lib/python3.13/site-packages"),
+            "Should NOT include /opt/lib/python3.13/site-packages when --python points to python3.14, got: {dirs:?}"
+        );
+        assert_eq!(
+            dirs.len(),
+            1,
+            "Expected exactly one site-packages path, got {count}: {dirs:?}",
+            count = dirs.len(),
+        );
+    }
 }

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -228,7 +228,13 @@ fn settings_diagnostic_path_from_sys_prefix(
 /// Returns `true` if the file name appears to be that of a versioned interpreter
 /// (e.g., `python3.15`).
 fn is_versioned_interpreter_path(file_name: &str) -> bool {
-    PythonInterpreterLayout::from_file_name(file_name).is_some()
+    matches!(
+        PythonInterpreterLayout::from_file_name(file_name),
+        Some(PythonInterpreterLayout {
+            version: Some(_),
+            ..
+        })
+    )
 }
 
 impl<const N: usize> From<[SystemPathBuf; N]> for SitePackagesPaths {
@@ -349,7 +355,11 @@ impl PythonEnvironment {
             Err(SitePackagesDiscoveryError::NoPyvenvCfgFile(_, _, _))
                 if !path.origin().must_be_virtual_env() =>
             {
-                Ok(Self::System(SystemEnvironment::new(path)))
+                tracing::trace!(
+                    "Resolved system Python environment from `{}`",
+                    path.selected_path()
+                );
+                Ok(Self::System(SystemEnvironment { path }))
             }
             Err(err) => Err(err),
         }
@@ -490,66 +500,118 @@ pub(crate) enum PythonImplementation {
     Unknown,
 }
 
+impl PythonImplementation {
+    const fn is_cpython(self) -> bool {
+        matches!(self, Self::CPython)
+    }
+
+    fn split_executable_name(file_name: &str) -> Option<(Self, &str)> {
+        if let Some(suffix) = file_name.strip_prefix("python") {
+            Some((Self::CPython, suffix))
+        } else if let Some(suffix) = file_name.strip_prefix("pypy") {
+            Some((Self::PyPy, suffix))
+        } else {
+            file_name
+                .strip_prefix("graalpy")
+                .map(|suffix| (Self::GraalPy, suffix))
+        }
+    }
+}
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
 struct PythonInterpreterLayout {
     version: Option<PythonVersion>,
     implementation: PythonImplementation,
-    /// `None` when the executable name does not distinguish between regular and free-threaded.
-    free_threaded: Option<bool>,
+    variant: PythonBuildVariant,
 }
 
 impl PythonInterpreterLayout {
+    const fn unknown(implementation: PythonImplementation, version: Option<PythonVersion>) -> Self {
+        Self {
+            version,
+            implementation,
+            variant: PythonBuildVariant::Unknown,
+        }
+    }
+
     fn from_file_name(file_name: &str) -> Option<Self> {
         let file_name = file_name
             .strip_suffix(std::env::consts::EXE_SUFFIX)
             .unwrap_or(file_name);
 
-        let (version, implementation) = if let Some(version) = file_name.strip_prefix("python") {
-            (version, PythonImplementation::CPython)
-        } else {
-            (file_name.strip_prefix("pypy")?, PythonImplementation::PyPy)
-        };
+        let (implementation, version) = PythonImplementation::split_executable_name(file_name)?;
+        let (version, mut variant) = PythonBuildVariant::split_executable_suffix(version);
+        let version = PythonVersion::from_str(version).ok();
 
-        let (version, free_threaded) = if implementation == PythonImplementation::CPython {
-            version
-                .strip_suffix('t')
-                .map_or((version, false), |version| (version, true))
-        } else {
-            (version, false)
-        };
-
-        let version = PythonVersion::from_str(version).ok()?;
-        if free_threaded && !version.free_threaded_build_available() {
+        if variant == PythonBuildVariant::FreeThreaded
+            && (!implementation.is_cpython()
+                || !version.is_some_and(PythonVersion::free_threaded_build_available))
+        {
             return None;
         }
 
+        if version.is_none() {
+            variant = PythonBuildVariant::Unknown;
+        }
+
         Some(Self {
-            version: Some(version),
+            version,
             implementation,
-            free_threaded: Some(free_threaded),
+            variant,
         })
+    }
+
+    /// Return the relative path from `sys.prefix` to the directory containing the Python stdlib's
+    /// `.py` files if the interpreter layout is known.
+    fn relative_stdlib_path(self) -> Option<String> {
+        let version = self.version?;
+
+        match self.implementation {
+            PythonImplementation::CPython => {
+                let variant = self.variant.directory_suffix();
+                Some(format!("lib/python{version}{variant}"))
+            }
+            PythonImplementation::GraalPy => Some(format!("lib/python{version}")),
+            PythonImplementation::PyPy => Some(format!("lib/pypy{version}")),
+            PythonImplementation::Unknown => None,
+        }
+    }
+
+    fn free_threaded_stdlib_fallback_path(self) -> Option<String> {
+        let version = self.version?;
+
+        (self.implementation.is_cpython()
+            && self.variant.is_unknown()
+            && version.free_threaded_build_available())
+        .then(|| format!("lib/python{version}t"))
     }
 }
 
-impl PythonImplementation {
-    /// Return the relative path from `sys.prefix` to the directory containing the python stdlib's
-    /// .pys if this is a known implementation. Return `None` if this is an unknown implementation.
-    fn relative_stdlib_path(
-        self,
-        version: Option<PythonVersion>,
-        free_threaded: Option<bool>,
-    ) -> Option<String> {
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+enum PythonBuildVariant {
+    #[default]
+    Unknown,
+    Default,
+    FreeThreaded,
+}
+
+impl PythonBuildVariant {
+    const fn is_unknown(self) -> bool {
+        matches!(self, Self::Unknown)
+    }
+
+    fn split_executable_suffix(version: &str) -> (&str, Self) {
+        if let Some(version) = version.strip_suffix('t') {
+            (version, Self::FreeThreaded)
+        } else {
+            (version, Self::Default)
+        }
+    }
+
+    const fn directory_suffix(self) -> &'static str {
         match self {
-            Self::CPython | Self::GraalPy => version.map(|version| {
-                let suffix = if self == Self::CPython && free_threaded == Some(true) {
-                    "t"
-                } else {
-                    ""
-                };
-                format!("lib/python{version}{suffix}")
-            }),
-            Self::PyPy => version.map(|version| format!("lib/pypy{version}")),
-            Self::Unknown => None,
+            Self::Unknown | Self::Default => "",
+            Self::FreeThreaded => "t",
         }
     }
 }
@@ -709,9 +771,10 @@ impl VirtualEnvironment {
         } = self;
 
         let version = version.as_ref().map(|v| v.version);
+        let layout = PythonInterpreterLayout::unknown(*implementation, version);
 
         let mut site_packages_directories =
-            site_packages_directories_from_sys_prefix(root_path, version, *implementation, system)?;
+            site_packages_directories_from_sys_prefix(root_path, layout, system)?;
 
         if let Some(parent_env_site_packages) = parent_environment.as_deref() {
             match parent_env_site_packages.site_packages_paths(system) {
@@ -736,12 +799,7 @@ impl VirtualEnvironment {
             // or if we fail to resolve the `site-packages` from the `sys.prefix` path,
             // we should probably print a warning but *not* abort type checking
             if let Some(sys_prefix_path) = system_sys_prefix {
-                match site_packages_directories_from_sys_prefix(
-                    &sys_prefix_path,
-                    version,
-                    *implementation,
-                    system,
-                ) {
+                match site_packages_directories_from_sys_prefix(&sys_prefix_path, layout, system) {
                     Ok(system_directories) => {
                         site_packages_directories.extend(system_directories);
                     }
@@ -789,15 +847,12 @@ System site-packages will not be used for module resolution.",
         // `include_system_site_packages` is true, as those site-packages should be a subdir
         // of the dir we're looking for.
         let version = version.as_ref().map(|v| v.version);
+        let layout = PythonInterpreterLayout::unknown(*implementation, version);
         if let Some(system_sys_prefix) =
             SysPrefixPath::from_executable_home_path_real(system, base_executable_home_path)
         {
-            let real_stdlib_directory = real_stdlib_directory_from_sys_prefix(
-                &system_sys_prefix,
-                version,
-                *implementation,
-                system,
-            );
+            let real_stdlib_directory =
+                real_stdlib_directory_from_sys_prefix(&system_sys_prefix, layout, system);
             match &real_stdlib_directory {
                 Ok(path) => tracing::debug!(
                     "Resolved real stdlib path for this virtual environment is: {path}"
@@ -1028,17 +1083,6 @@ pub struct SystemEnvironment {
 }
 
 impl SystemEnvironment {
-    /// Create a system environment from the selected environment path.
-    ///
-    /// Validation remains lazy and occurs when resolving site-packages or the stdlib.
-    fn new(path: PythonEnvironmentPath) -> Self {
-        tracing::trace!(
-            "Resolved system Python environment from `{}`",
-            path.selected_path()
-        );
-        Self { path }
-    }
-
     /// Return a list of `site-packages` directories that are available from this environment.
     ///
     /// See the documentation for [`site_packages_directories_from_sys_prefix`] for more details.
@@ -1046,7 +1090,7 @@ impl SystemEnvironment {
         &self,
         system: &dyn System,
     ) -> SitePackagesDiscoveryResult<SitePackagesPaths> {
-        let site_packages_directories = site_packages_directories_from_sys_prefix_with_layout(
+        let site_packages_directories = site_packages_directories_from_sys_prefix(
             self.path.sys_prefix(),
             self.path.interpreter_layout().unwrap_or_default(),
             system,
@@ -1065,7 +1109,7 @@ impl SystemEnvironment {
         &self,
         system: &dyn System,
     ) -> StdlibDiscoveryResult<SystemPathBuf> {
-        let stdlib_directory = real_stdlib_directory_from_sys_prefix_with_layout(
+        let stdlib_directory = real_stdlib_directory_from_sys_prefix(
             self.path.sys_prefix(),
             self.path.interpreter_layout().unwrap_or_default(),
             system,
@@ -1367,7 +1411,7 @@ fn probe_package_dirs(
     let PythonInterpreterLayout {
         version: Some(python_version),
         implementation,
-        free_threaded,
+        variant,
     } = layout
     else {
         return;
@@ -1378,21 +1422,23 @@ fn probe_package_dirs(
     // Returns `true` if a matching directory was found, so the caller can
     // decide whether to fall back to probing other implementations.
     let probe_cpython_path = |directories: &mut SitePackagesPaths| {
-        let path = |free_threaded| {
-            let suffix_marker = if free_threaded { "t" } else { "" };
-            prefix_dir.join(format!("python{python_version}{suffix_marker}/{suffix}"))
+        let path = |variant: PythonBuildVariant| {
+            prefix_dir.join(format!(
+                "python{python_version}{variant}/{suffix}",
+                variant = variant.directory_suffix()
+            ))
         };
 
-        let path = match free_threaded {
-            Some(free_threaded) => path(free_threaded),
-            None => {
+        let path = match variant {
+            PythonBuildVariant::Default | PythonBuildVariant::FreeThreaded => path(variant),
+            PythonBuildVariant::Unknown => {
                 // Preserve the existing regular-first fallback when the build flavor is unknown.
-                let regular = path(false);
+                let regular = path(PythonBuildVariant::Default);
                 if system.is_directory(&regular) || !python_version.free_threaded_build_available()
                 {
                     regular
                 } else {
-                    path(true)
+                    path(PythonBuildVariant::FreeThreaded)
                 }
             }
         };
@@ -1486,27 +1532,8 @@ fn discover_package_dirs(
 /// associated with a given Python installation.
 ///
 /// The location of the `site-packages` directories can vary according to the
-/// Python version that this installation represents. The Python version may
-/// or may not be known at this point, which is why the `python_version`
-/// parameter is an `Option`.
+/// interpreter layout represented by this installation.
 fn site_packages_directories_from_sys_prefix(
-    sys_prefix_path: &SysPrefixPath,
-    python_version: Option<PythonVersion>,
-    implementation: PythonImplementation,
-    system: &dyn System,
-) -> SitePackagesDiscoveryResult<SitePackagesPaths> {
-    site_packages_directories_from_sys_prefix_with_layout(
-        sys_prefix_path,
-        PythonInterpreterLayout {
-            version: python_version,
-            implementation,
-            free_threaded: None,
-        },
-        system,
-    )
-}
-
-fn site_packages_directories_from_sys_prefix_with_layout(
     sys_prefix_path: &SysPrefixPath,
     layout: PythonInterpreterLayout,
     system: &dyn System,
@@ -1653,28 +1680,9 @@ fn site_packages_directories_from_sys_prefix_with_layout(
 /// Attempt to retrieve the real stdlib directory
 /// associated with a given Python installation.
 ///
-/// The location of the stdlib directory can vary according to the
-/// Python version that this installation represents. The Python version may
-/// or may not be known at this point, which is why the `python_version`
-/// parameter is an `Option`.
+/// The location of the stdlib directory can vary according to the interpreter
+/// layout represented by this installation.
 fn real_stdlib_directory_from_sys_prefix(
-    sys_prefix_path: &SysPrefixPath,
-    python_version: Option<PythonVersion>,
-    implementation: PythonImplementation,
-    system: &dyn System,
-) -> StdlibDiscoveryResult<SystemPathBuf> {
-    real_stdlib_directory_from_sys_prefix_with_layout(
-        sys_prefix_path,
-        PythonInterpreterLayout {
-            version: python_version,
-            implementation,
-            free_threaded: None,
-        },
-        system,
-    )
-}
-
-fn real_stdlib_directory_from_sys_prefix_with_layout(
     sys_prefix_path: &SysPrefixPath,
     layout: PythonInterpreterLayout,
     system: &dyn System,
@@ -1693,22 +1701,15 @@ fn real_stdlib_directory_from_sys_prefix_with_layout(
 
     // If we were able to figure out what Python version this installation is,
     // we should be able to avoid iterating through all items in the `lib/` directory:
-    if let Some(expected_relative_path) = layout
-        .implementation
-        .relative_stdlib_path(layout.version, layout.free_threaded)
-    {
+    if let Some(expected_relative_path) = layout.relative_stdlib_path() {
         let expected_absolute_path = sys_prefix_path.join(expected_relative_path);
         if system.is_directory(&expected_absolute_path) {
             return Ok(expected_absolute_path);
         }
 
         // CPython free-threaded (3.13+) variant: pythonXYt
-        if let Some(version) = layout.version
-            && matches!(layout.implementation, PythonImplementation::CPython)
-            && layout.free_threaded.is_none()
-            && version.free_threaded_build_available()
-        {
-            let alternative_path = sys_prefix_path.join(format!("lib/python{version}t"));
+        if let Some(alternative_relative_path) = layout.free_threaded_stdlib_fallback_path() {
+            let alternative_path = sys_prefix_path.join(alternative_relative_path);
             if system.is_directory(&alternative_path) {
                 return Ok(alternative_path);
             }
@@ -1819,8 +1820,7 @@ impl PythonEnvironmentPath {
         let executable_path = (!origin.must_point_directly_to_sys_prefix()
             && system.is_file(unvalidated_path)
             && unvalidated_path.file_name().is_some_and(|name| {
-                name.starts_with("python")
-                    || name.starts_with("pypy")
+                PythonImplementation::split_executable_name(name).is_some()
                     || name.eq_ignore_ascii_case(&format!("ty{}", std::env::consts::EXE_SUFFIX))
             }))
         .then_some(unvalidated_path);
@@ -1875,25 +1875,30 @@ impl PythonEnvironmentPath {
         }
 
         let layout = executable_path.and_then(|executable_path| {
-            if let Some(layout) = executable_path
+            let direct_layout = executable_path
                 .file_name()
-                .and_then(PythonInterpreterLayout::from_file_name)
-            {
-                return Some(layout);
+                .and_then(PythonInterpreterLayout::from_file_name);
+
+            if direct_layout.is_some_and(|layout| layout.version.is_some()) {
+                return direct_layout;
             }
 
-            let canonical_executable = system.canonicalize_path(executable_path).ok()?;
-            let layout = canonical_executable
-                .file_name()
-                .and_then(PythonInterpreterLayout::from_file_name)?;
-            let canonical_executable_prefix =
-                sys_prefix_from_executable_path(&canonical_executable)?;
-            let canonical_executable_prefix =
-                system.canonicalize_path(canonical_executable_prefix).ok()?;
+            let target_layout = (|| {
+                let canonical_executable = system.canonicalize_path(executable_path).ok()?;
+                let layout = canonical_executable
+                    .file_name()
+                    .and_then(PythonInterpreterLayout::from_file_name)?;
+                let canonical_executable_prefix =
+                    sys_prefix_from_executable_path(&canonical_executable)?;
+                let canonical_executable_prefix =
+                    system.canonicalize_path(canonical_executable_prefix).ok()?;
 
-            // Metadata from a symlink target can only describe the selected environment when both
-            // executable paths resolve to the same installation prefix.
-            (canonical_executable_prefix == sys_prefix).then_some(layout)
+                // Metadata from a symlink target can only describe the selected environment when
+                // both executable paths resolve to the same installation prefix.
+                (canonical_executable_prefix == sys_prefix).then_some(layout)
+            })();
+
+            target_layout.or(direct_layout)
         });
 
         let sys_prefix = SysPrefixPath {
@@ -3057,11 +3062,13 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            Some(PythonVersion {
-                major: 3,
-                minor: 12,
-            }),
-            PythonImplementation::CPython,
+            PythonInterpreterLayout::unknown(
+                PythonImplementation::CPython,
+                Some(PythonVersion {
+                    major: 3,
+                    minor: 12,
+                }),
+            ),
             &system,
         )
         .unwrap();
@@ -3102,11 +3109,13 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            Some(PythonVersion {
-                major: 3,
-                minor: 12,
-            }),
-            PythonImplementation::CPython,
+            PythonInterpreterLayout::unknown(
+                PythonImplementation::CPython,
+                Some(PythonVersion {
+                    major: 3,
+                    minor: 12,
+                }),
+            ),
             &system,
         )
         .unwrap();
@@ -3143,11 +3152,13 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            Some(PythonVersion {
-                major: 3,
-                minor: 12,
-            }),
-            PythonImplementation::PyPy,
+            PythonInterpreterLayout::unknown(
+                PythonImplementation::PyPy,
+                Some(PythonVersion {
+                    major: 3,
+                    minor: 12,
+                }),
+            ),
             &system,
         )
         .unwrap();
@@ -3189,11 +3200,13 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            Some(PythonVersion {
-                major: 3,
-                minor: 12,
-            }),
-            PythonImplementation::CPython,
+            PythonInterpreterLayout::unknown(
+                PythonImplementation::CPython,
+                Some(PythonVersion {
+                    major: 3,
+                    minor: 12,
+                }),
+            ),
             &system,
         )
         .unwrap();
@@ -3229,11 +3242,13 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            Some(PythonVersion {
-                major: 3,
-                minor: 12,
-            }),
-            PythonImplementation::CPython,
+            PythonInterpreterLayout::unknown(
+                PythonImplementation::CPython,
+                Some(PythonVersion {
+                    major: 3,
+                    minor: 12,
+                }),
+            ),
             &system,
         )
         .unwrap();
@@ -3276,11 +3291,13 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            Some(PythonVersion {
-                major: 3,
-                minor: 12,
-            }),
-            PythonImplementation::CPython,
+            PythonInterpreterLayout::unknown(
+                PythonImplementation::CPython,
+                Some(PythonVersion {
+                    major: 3,
+                    minor: 12,
+                }),
+            ),
             &system,
         )
         .unwrap();
@@ -3317,8 +3334,7 @@ mod tests {
         // Use Unknown implementation to trigger fallback enumeration
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            None,
-            PythonImplementation::Unknown,
+            PythonInterpreterLayout::unknown(PythonImplementation::Unknown, None),
             &system,
         )
         .unwrap();
@@ -3360,8 +3376,7 @@ mod tests {
         // Use Unknown implementation to trigger fallback enumeration
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            None,
-            PythonImplementation::Unknown,
+            PythonInterpreterLayout::unknown(PythonImplementation::Unknown, None),
             &system,
         )
         .unwrap();
@@ -3397,8 +3412,7 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            None,
-            PythonImplementation::Unknown,
+            PythonInterpreterLayout::unknown(PythonImplementation::Unknown, None),
             &system,
         )
         .unwrap();
@@ -3435,8 +3449,7 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            None,
-            PythonImplementation::CPython,
+            PythonInterpreterLayout::unknown(PythonImplementation::CPython, None),
             &system,
         )
         .unwrap();
@@ -3478,8 +3491,7 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            None,
-            PythonImplementation::PyPy,
+            PythonInterpreterLayout::unknown(PythonImplementation::PyPy, None),
             &system,
         )
         .unwrap();
@@ -3520,11 +3532,13 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            Some(PythonVersion {
-                major: 3,
-                minor: 12,
-            }),
-            PythonImplementation::CPython,
+            PythonInterpreterLayout::unknown(
+                PythonImplementation::CPython,
+                Some(PythonVersion {
+                    major: 3,
+                    minor: 12,
+                }),
+            ),
             &system,
         )
         .unwrap();
@@ -3564,11 +3578,13 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            Some(PythonVersion {
-                major: 3,
-                minor: 12,
-            }),
-            PythonImplementation::Unknown,
+            PythonInterpreterLayout::unknown(
+                PythonImplementation::Unknown,
+                Some(PythonVersion {
+                    major: 3,
+                    minor: 12,
+                }),
+            ),
             &system,
         )
         .unwrap();
@@ -3610,11 +3626,13 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            Some(PythonVersion {
-                major: 3,
-                minor: 12,
-            }),
-            PythonImplementation::Unknown,
+            PythonInterpreterLayout::unknown(
+                PythonImplementation::Unknown,
+                Some(PythonVersion {
+                    major: 3,
+                    minor: 12,
+                }),
+            ),
             &system,
         )
         .unwrap();
@@ -3649,11 +3667,13 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            Some(PythonVersion {
-                major: 3,
-                minor: 12,
-            }),
-            PythonImplementation::Unknown,
+            PythonInterpreterLayout::unknown(
+                PythonImplementation::Unknown,
+                Some(PythonVersion {
+                    major: 3,
+                    minor: 12,
+                }),
+            ),
             &system,
         )
         .unwrap();
@@ -3695,11 +3715,13 @@ mod tests {
 
         let directories = site_packages_directories_from_sys_prefix(
             &sys_prefix_path,
-            Some(PythonVersion {
-                major: 3,
-                minor: 12,
-            }),
-            PythonImplementation::CPython,
+            PythonInterpreterLayout::unknown(
+                PythonImplementation::CPython,
+                Some(PythonVersion {
+                    major: 3,
+                    minor: 12,
+                }),
+            ),
             &system,
         )
         .unwrap();
@@ -3741,6 +3763,11 @@ mod tests {
                 "lib/python3.14t",
             ),
             ("pypy3.14", "lib/pypy3.14/site-packages", "lib/pypy3.14"),
+            (
+                "graalpy3.14",
+                "lib/python3.14/site-packages",
+                "lib/python3.14",
+            ),
         ];
 
         for (executable, site_packages, _) in layouts {
@@ -3771,6 +3798,33 @@ mod tests {
         }
     }
 
+    #[cfg(not(windows))]
+    #[test]
+    fn recognizes_unversioned_graalpy_executable() {
+        let system = TestSystem::default();
+        let memory_fs = system.memory_file_system();
+        let sys_prefix = SystemPathBuf::from("/graal");
+
+        memory_fs
+            .write_file_all(sys_prefix.join("bin/graalpy"), "")
+            .unwrap();
+        memory_fs
+            .create_directory_all(sys_prefix.join("lib/python3.14/site-packages"))
+            .unwrap();
+
+        let environment = PythonEnvironment::new(
+            sys_prefix.join("bin/graalpy"),
+            SysPrefixPathOrigin::PythonCliFlag,
+            &system,
+        )
+        .unwrap();
+
+        assert_eq!(
+            environment.site_packages_paths(&system).unwrap().into_vec(),
+            [sys_prefix.join("lib/python3.14/site-packages")]
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn only_uses_symlink_target_layout_within_same_prefix() {
@@ -3796,7 +3850,7 @@ mod tests {
             Some(PythonInterpreterLayout {
                 version: Some(PythonVersion::PY314),
                 implementation: PythonImplementation::CPython,
-                free_threaded: Some(false),
+                variant: PythonBuildVariant::Default,
             })
         );
 
@@ -3818,7 +3872,10 @@ mod tests {
             )
             .unwrap()
             .interpreter_layout(),
-            None
+            Some(PythonInterpreterLayout::unknown(
+                PythonImplementation::CPython,
+                None
+            ))
         );
     }
 }

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -511,9 +511,7 @@ impl PythonImplementation {
         } else if let Some(suffix) = file_name.strip_prefix("pypy") {
             Some((Self::PyPy, suffix))
         } else {
-            file_name
-                .strip_prefix("graalpy")
-                .map(|suffix| (Self::GraalPy, suffix))
+            Some((Self::GraalPy, file_name.strip_prefix("graalpy")?))
         }
     }
 }
@@ -534,12 +532,16 @@ impl PythonInterpreterLayout {
         }
     }
 
+    fn from_path(path: &SystemPath) -> Option<Self> {
+        Self::from_file_name(path.file_name()?)
+    }
+
     fn from_file_name(file_name: &str) -> Option<Self> {
         let file_name = file_name
             .strip_suffix(std::env::consts::EXE_SUFFIX)
             .unwrap_or(file_name);
 
-        let (implementation, version) = PythonImplementation::split_executable_name(file_name)?;
+        let (mut implementation, version) = PythonImplementation::split_executable_name(file_name)?;
         let (version, mut variant) = PythonBuildVariant::split_executable_suffix(version);
         let version = PythonVersion::from_str(version).ok();
 
@@ -552,6 +554,12 @@ impl PythonInterpreterLayout {
 
         if version.is_none() {
             variant = PythonBuildVariant::Unknown;
+
+            // PyPy also uses generic executable names such as `python` and `python3`, so an
+            // unversioned name in the `python` family does not identify the implementation.
+            if implementation.is_cpython() {
+                implementation = PythonImplementation::Unknown;
+            }
         }
 
         Some(Self {
@@ -1786,13 +1794,12 @@ fn sys_prefix_from_executable_path(path: &SystemPath) -> Option<&SystemPath> {
         // depending on whether it's a virtual environment or a system installation.
         // System installations have their executable at `<sys.prefix>/python.exe`,
         // whereas virtual environments have their executable at `<sys.prefix>/Scripts/python.exe`.
-        path.parent().and_then(|parent| {
-            if parent.file_name() == Some("Scripts") {
-                parent.parent()
-            } else {
-                Some(parent)
-            }
-        })
+        let parent = path.parent()?;
+        if parent.file_name() == Some("Scripts") {
+            parent.parent()
+        } else {
+            Some(parent)
+        }
     } else {
         // On Unix, `sys.prefix` is always the grandparent directory of the Python executable,
         // regardless of whether it's a virtual environment or a system installation.
@@ -1875,30 +1882,21 @@ impl PythonEnvironmentPath {
         }
 
         let layout = executable_path.and_then(|executable_path| {
-            let direct_layout = executable_path
-                .file_name()
-                .and_then(PythonInterpreterLayout::from_file_name);
+            let direct_layout = PythonInterpreterLayout::from_path(executable_path);
 
-            if direct_layout.is_some_and(|layout| layout.version.is_some()) {
-                return direct_layout;
+            if let Some(layout) = direct_layout
+                && layout.version.is_some()
+            {
+                return Some(layout);
             }
 
-            let target_layout = (|| {
-                let canonical_executable = system.canonicalize_path(executable_path).ok()?;
-                let layout = canonical_executable
-                    .file_name()
-                    .and_then(PythonInterpreterLayout::from_file_name)?;
-                let canonical_executable_prefix =
-                    sys_prefix_from_executable_path(&canonical_executable)?;
-                let canonical_executable_prefix =
-                    system.canonicalize_path(canonical_executable_prefix).ok()?;
+            if let Ok(canonical_executable) = system.canonicalize_path(executable_path)
+                && let Some(layout) = PythonInterpreterLayout::from_path(&canonical_executable)
+            {
+                return Some(layout);
+            }
 
-                // Metadata from a symlink target can only describe the selected environment when
-                // both executable paths resolve to the same installation prefix.
-                (canonical_executable_prefix == sys_prefix).then_some(layout)
-            })();
-
-            target_layout.or(direct_layout)
+            direct_layout
         });
 
         let sys_prefix = SysPrefixPath {
@@ -3827,7 +3825,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn only_uses_symlink_target_layout_within_same_prefix() {
+    fn uses_symlink_target_layout() {
         let temp_dir = tempfile::tempdir().unwrap();
         let root = SystemPath::from_std_path(temp_dir.path()).unwrap();
         let system = OsSystem::new(root);
@@ -3858,24 +3856,38 @@ mod tests {
         let other_bin = other_prefix.join("bin");
         std::fs::create_dir_all(other_bin.as_std_path()).unwrap();
         std::fs::File::create(other_bin.join("python3.14").as_std_path()).unwrap();
+
+        let facade_prefix = root.join("facade");
+        let facade_bin = facade_prefix.join("bin");
+        let python313_site_packages = facade_prefix.join("lib/python3.13/site-packages");
+        let python314_site_packages = facade_prefix.join("lib/python3.14/site-packages");
+        std::fs::create_dir_all(facade_bin.as_std_path()).unwrap();
+        std::fs::create_dir_all(python313_site_packages.as_std_path()).unwrap();
+        std::fs::create_dir_all(python314_site_packages.as_std_path()).unwrap();
         std::os::unix::fs::symlink(
             other_bin.join("python3.14").as_std_path(),
-            bin.join("python-other").as_std_path(),
+            facade_bin.join("python").as_std_path(),
         )
         .unwrap();
 
+        let executable = facade_bin.join("python");
         assert_eq!(
-            PythonEnvironmentPath::new(
-                &bin.join("python-other"),
-                SysPrefixPathOrigin::PythonCliFlag,
-                &system,
-            )
-            .unwrap()
-            .interpreter_layout(),
-            Some(PythonInterpreterLayout::unknown(
-                PythonImplementation::CPython,
-                None
-            ))
+            PythonEnvironmentPath::new(&executable, SysPrefixPathOrigin::PythonCliFlag, &system,)
+                .unwrap()
+                .interpreter_layout(),
+            Some(PythonInterpreterLayout {
+                version: Some(PythonVersion::PY314),
+                implementation: PythonImplementation::CPython,
+                variant: PythonBuildVariant::Default,
+            })
+        );
+
+        let environment =
+            PythonEnvironment::new(&executable, SysPrefixPathOrigin::PythonCliFlag, &system)
+                .unwrap();
+        assert_eq!(
+            environment.site_packages_paths(&system).unwrap().into_vec(),
+            [system.canonicalize_path(&python314_site_packages).unwrap()]
         );
     }
 }

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -532,8 +532,38 @@ impl PythonInterpreterLayout {
         }
     }
 
-    fn from_path(path: &SystemPath) -> Option<Self> {
-        Self::from_file_name(path.file_name()?)
+    fn from_path(path: &SystemPath, system: &dyn System) -> Option<Self> {
+        let mut layout = Self::from_file_name(path.file_name()?)?;
+
+        if layout.implementation.is_cpython()
+            && layout.variant.is_unknown()
+            && let Some(version) = layout.version
+            && version.free_threaded_build_available()
+            && let Some(parent) = path.parent()
+        {
+            let variant = PythonBuildVariant::FreeThreaded.suffix();
+            let free_threaded_executable = parent.join(format!(
+                "python{version}{variant}{}",
+                std::env::consts::EXE_SUFFIX
+            ));
+
+            // CPython's Unix installer hard-links `pythonX.Y` to `pythonX.Yt` for a
+            // free-threaded build, so neither the file name nor canonicalization can
+            // distinguish the two executable paths.
+            if !system.is_file(&free_threaded_executable) {
+                layout.variant = PythonBuildVariant::Default;
+            } else if let Ok(is_free_threaded) =
+                system.is_same_file(path, &free_threaded_executable)
+            {
+                layout.variant = if is_free_threaded {
+                    PythonBuildVariant::FreeThreaded
+                } else {
+                    PythonBuildVariant::Default
+                };
+            }
+        }
+
+        Some(layout)
     }
 
     fn from_file_name(file_name: &str) -> Option<Self> {
@@ -541,29 +571,42 @@ impl PythonInterpreterLayout {
             .strip_suffix(std::env::consts::EXE_SUFFIX)
             .unwrap_or(file_name);
 
-        let (mut implementation, version) = PythonImplementation::split_executable_name(file_name)?;
-        let (version, mut variant) = PythonBuildVariant::split_executable_suffix(version);
-        let version = PythonVersion::from_str(version).ok();
+        let (implementation, version) = PythonImplementation::split_executable_name(file_name)?;
+        let (version, variant) = PythonBuildVariant::split_executable_suffix(version);
+        let version = match PythonVersion::from_str(version) {
+            Ok(version) => version,
+            Err(_) if variant == PythonBuildVariant::FreeThreaded => return None,
+            Err(_) => {
+                // PyPy also uses generic executable names such as `python` and `python3`, so an
+                // unversioned name in the `python` family does not identify the implementation.
+                let implementation = if implementation.is_cpython() {
+                    PythonImplementation::Unknown
+                } else {
+                    implementation
+                };
+                return Some(Self::unknown(implementation, None));
+            }
+        };
 
         if variant == PythonBuildVariant::FreeThreaded
-            && (!implementation.is_cpython()
-                || !version.is_some_and(PythonVersion::free_threaded_build_available))
+            && (!implementation.is_cpython() || !version.free_threaded_build_available())
         {
             return None;
         }
 
-        if version.is_none() {
-            variant = PythonBuildVariant::Unknown;
-
-            // PyPy also uses generic executable names such as `python` and `python3`, so an
-            // unversioned name in the `python` family does not identify the implementation.
-            if implementation.is_cpython() {
-                implementation = PythonImplementation::Unknown;
-            }
-        }
+        // CPython may install `pythonX.Y` as a hard link to `pythonX.Yt`, so defer the build
+        // variant until `from_path` can compare the two executable paths.
+        let variant = if variant == PythonBuildVariant::Default
+            && implementation.is_cpython()
+            && version.free_threaded_build_available()
+        {
+            PythonBuildVariant::Unknown
+        } else {
+            variant
+        };
 
         Some(Self {
-            version,
+            version: Some(version),
             implementation,
             variant,
         })
@@ -576,7 +619,7 @@ impl PythonInterpreterLayout {
 
         match self.implementation {
             PythonImplementation::CPython => {
-                let variant = self.variant.directory_suffix();
+                let variant = self.variant.suffix();
                 Some(format!("lib/python{version}{variant}"))
             }
             PythonImplementation::GraalPy => Some(format!("lib/python{version}")),
@@ -616,7 +659,7 @@ impl PythonBuildVariant {
         }
     }
 
-    const fn directory_suffix(self) -> &'static str {
+    const fn suffix(self) -> &'static str {
         match self {
             Self::Unknown | Self::Default => "",
             Self::FreeThreaded => "t",
@@ -1433,7 +1476,7 @@ fn probe_package_dirs(
         let path = |variant: PythonBuildVariant| {
             prefix_dir.join(format!(
                 "python{python_version}{variant}/{suffix}",
-                variant = variant.directory_suffix()
+                variant = variant.suffix()
             ))
         };
 
@@ -1882,21 +1925,28 @@ impl PythonEnvironmentPath {
         }
 
         let layout = executable_path.and_then(|executable_path| {
-            let direct_layout = PythonInterpreterLayout::from_path(executable_path);
+            let canonical_layout = system
+                .canonicalize_path(executable_path)
+                .ok()
+                .and_then(|path| PythonInterpreterLayout::from_path(&path, system));
 
+            // A complete layout from the symlink target describes the actual interpreter, while
+            // the selected path may only be a facade. Keep its layout as a fallback when the
+            // target name does not include a version.
+            if let Some(layout) = canonical_layout
+                && layout.version.is_some()
+            {
+                return Some(layout);
+            }
+
+            let direct_layout = PythonInterpreterLayout::from_path(executable_path, system);
             if let Some(layout) = direct_layout
                 && layout.version.is_some()
             {
                 return Some(layout);
             }
 
-            if let Ok(canonical_executable) = system.canonicalize_path(executable_path)
-                && let Some(layout) = PythonInterpreterLayout::from_path(&canonical_executable)
-            {
-                return Some(layout);
-            }
-
-            direct_layout
+            canonical_layout.or(direct_layout)
         });
 
         let sys_prefix = SysPrefixPath {
@@ -3825,6 +3875,76 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn distinguishes_unsuffixed_default_from_free_threaded_executable() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = SystemPath::from_std_path(temp_dir.path()).unwrap();
+        let system = OsSystem::new(root);
+
+        let prefix = root.join("prefix");
+        let bin = prefix.join("bin");
+        let versioned_executable = bin.join("python3.14");
+        let site_packages = prefix.join("lib/python3.14/site-packages");
+
+        std::fs::create_dir_all(bin.as_std_path()).unwrap();
+        std::fs::File::create(versioned_executable.as_std_path()).unwrap();
+        std::fs::File::create(bin.join("python3.14t").as_std_path()).unwrap();
+        std::fs::create_dir_all(site_packages.as_std_path()).unwrap();
+        std::fs::create_dir_all(prefix.join("lib/python3.14t/site-packages").as_std_path())
+            .unwrap();
+
+        let environment = PythonEnvironment::new(
+            &versioned_executable,
+            SysPrefixPathOrigin::PythonCliFlag,
+            &system,
+        )
+        .unwrap();
+
+        assert_eq!(
+            environment.site_packages_paths(&system).unwrap().into_vec(),
+            [system.canonicalize_path(&site_packages).unwrap()]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identifies_unsuffixed_free_threaded_hard_link() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = SystemPath::from_std_path(temp_dir.path()).unwrap();
+        let system = OsSystem::new(root);
+
+        let prefix = root.join("prefix");
+        let bin = prefix.join("bin");
+        let versioned_executable = bin.join("python3.14");
+        let free_threaded_executable = bin.join("python3.14t");
+        let free_threaded_site_packages = prefix.join("lib/python3.14t/site-packages");
+
+        std::fs::create_dir_all(bin.as_std_path()).unwrap();
+        std::fs::File::create(free_threaded_executable.as_std_path()).unwrap();
+        std::fs::hard_link(
+            free_threaded_executable.as_std_path(),
+            versioned_executable.as_std_path(),
+        )
+        .unwrap();
+        std::fs::create_dir_all(prefix.join("lib/python3.14/site-packages").as_std_path()).unwrap();
+        std::fs::create_dir_all(free_threaded_site_packages.as_std_path()).unwrap();
+
+        let environment = PythonEnvironment::new(
+            &versioned_executable,
+            SysPrefixPathOrigin::PythonCliFlag,
+            &system,
+        )
+        .unwrap();
+
+        assert_eq!(
+            environment.site_packages_paths(&system).unwrap().into_vec(),
+            [system
+                .canonicalize_path(&free_threaded_site_packages)
+                .unwrap()]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn uses_symlink_target_layout() {
         let temp_dir = tempfile::tempdir().unwrap();
         let root = SystemPath::from_std_path(temp_dir.path()).unwrap();
@@ -3864,30 +3984,36 @@ mod tests {
         std::fs::create_dir_all(facade_bin.as_std_path()).unwrap();
         std::fs::create_dir_all(python313_site_packages.as_std_path()).unwrap();
         std::fs::create_dir_all(python314_site_packages.as_std_path()).unwrap();
-        std::os::unix::fs::symlink(
-            other_bin.join("python3.14").as_std_path(),
-            facade_bin.join("python").as_std_path(),
-        )
-        .unwrap();
+        for executable_name in ["python", "python3.13"] {
+            std::os::unix::fs::symlink(
+                other_bin.join("python3.14").as_std_path(),
+                facade_bin.join(executable_name).as_std_path(),
+            )
+            .unwrap();
 
-        let executable = facade_bin.join("python");
-        assert_eq!(
-            PythonEnvironmentPath::new(&executable, SysPrefixPathOrigin::PythonCliFlag, &system,)
+            let executable = facade_bin.join(executable_name);
+            assert_eq!(
+                PythonEnvironmentPath::new(
+                    &executable,
+                    SysPrefixPathOrigin::PythonCliFlag,
+                    &system,
+                )
                 .unwrap()
                 .interpreter_layout(),
-            Some(PythonInterpreterLayout {
-                version: Some(PythonVersion::PY314),
-                implementation: PythonImplementation::CPython,
-                variant: PythonBuildVariant::Default,
-            })
-        );
+                Some(PythonInterpreterLayout {
+                    version: Some(PythonVersion::PY314),
+                    implementation: PythonImplementation::CPython,
+                    variant: PythonBuildVariant::Default,
+                })
+            );
 
-        let environment =
-            PythonEnvironment::new(&executable, SysPrefixPathOrigin::PythonCliFlag, &system)
-                .unwrap();
-        assert_eq!(
-            environment.site_packages_paths(&system).unwrap().into_vec(),
-            [system.canonicalize_path(&python314_site_packages).unwrap()]
-        );
+            let environment =
+                PythonEnvironment::new(&executable, SysPrefixPathOrigin::PythonCliFlag, &system)
+                    .unwrap();
+            assert_eq!(
+                environment.site_packages_paths(&system).unwrap().into_vec(),
+                [system.canonicalize_path(&python314_site_packages).unwrap()]
+            );
+        }
     }
 }

--- a/crates/ty_site_packages/src/lib.rs
+++ b/crates/ty_site_packages/src/lib.rs
@@ -541,26 +541,33 @@ impl PythonInterpreterLayout {
             && version.free_threaded_build_available()
             && let Some(parent) = path.parent()
         {
-            let variant = PythonBuildVariant::FreeThreaded.suffix();
-            let free_threaded_executable = parent.join(format!(
-                "python{version}{variant}{}",
-                std::env::consts::EXE_SUFFIX
-            ));
+            let mut variant = PythonBuildVariant::Default;
 
-            // CPython's Unix installer hard-links `pythonX.Y` to `pythonX.Yt` for a
-            // free-threaded build, so neither the file name nor canonicalization can
-            // distinguish the two executable paths.
-            if !system.is_file(&free_threaded_executable) {
-                layout.variant = PythonBuildVariant::Default;
-            } else if let Ok(is_free_threaded) =
-                system.is_same_file(path, &free_threaded_executable)
-            {
-                layout.variant = if is_free_threaded {
-                    PythonBuildVariant::FreeThreaded
-                } else {
-                    PythonBuildVariant::Default
-                };
+            // CPython's Unix installer hard-links `pythonX.Y` to its versioned executable for a
+            // free-threaded build, so neither the file name nor canonicalization can distinguish
+            // the two executable paths. Debug builds use the `td` ABI flags but retain the `t`
+            // suffix for their library directory.
+            for abi_flags in ["t", "td"] {
+                let free_threaded_executable = parent.join(format!(
+                    "python{version}{abi_flags}{}",
+                    std::env::consts::EXE_SUFFIX
+                ));
+
+                if !system.is_file(&free_threaded_executable) {
+                    continue;
+                }
+
+                match system.is_same_file(path, &free_threaded_executable) {
+                    Ok(true) => {
+                        variant = PythonBuildVariant::FreeThreaded;
+                        break;
+                    }
+                    Ok(false) => {}
+                    Err(_) => variant = PythonBuildVariant::Unknown,
+                }
             }
+
+            layout.variant = variant;
         }
 
         Some(layout)
@@ -652,6 +659,9 @@ impl PythonBuildVariant {
     }
 
     fn split_executable_suffix(version: &str) -> (&str, Self) {
+        // Debug builds add `d` to the ABI flags, but this does not change the library layout.
+        let version = version.strip_suffix('d').unwrap_or(version);
+
         if let Some(version) = version.strip_suffix('t') {
             (version, Self::FreeThreaded)
         } else {
@@ -3907,40 +3917,42 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn identifies_unsuffixed_free_threaded_hard_link() {
+    fn identifies_free_threaded_hard_links() {
         let temp_dir = tempfile::tempdir().unwrap();
         let root = SystemPath::from_std_path(temp_dir.path()).unwrap();
         let system = OsSystem::new(root);
 
-        let prefix = root.join("prefix");
-        let bin = prefix.join("bin");
-        let versioned_executable = bin.join("python3.14");
-        let free_threaded_executable = bin.join("python3.14t");
-        let free_threaded_site_packages = prefix.join("lib/python3.14t/site-packages");
+        for executable_name in ["python3.14t", "python3.14td"] {
+            let prefix = root.join(executable_name);
+            let bin = prefix.join("bin");
+            let versioned_executable = bin.join("python3.14");
+            let free_threaded_executable = bin.join(executable_name);
+            let free_threaded_site_packages = prefix.join("lib/python3.14t/site-packages");
 
-        std::fs::create_dir_all(bin.as_std_path()).unwrap();
-        std::fs::File::create(free_threaded_executable.as_std_path()).unwrap();
-        std::fs::hard_link(
-            free_threaded_executable.as_std_path(),
-            versioned_executable.as_std_path(),
-        )
-        .unwrap();
-        std::fs::create_dir_all(prefix.join("lib/python3.14/site-packages").as_std_path()).unwrap();
-        std::fs::create_dir_all(free_threaded_site_packages.as_std_path()).unwrap();
+            std::fs::create_dir_all(bin.as_std_path()).unwrap();
+            std::fs::File::create(free_threaded_executable.as_std_path()).unwrap();
+            std::fs::hard_link(
+                free_threaded_executable.as_std_path(),
+                versioned_executable.as_std_path(),
+            )
+            .unwrap();
+            std::fs::create_dir_all(prefix.join("lib/python3.14/site-packages").as_std_path())
+                .unwrap();
+            std::fs::create_dir_all(free_threaded_site_packages.as_std_path()).unwrap();
 
-        let environment = PythonEnvironment::new(
-            &versioned_executable,
-            SysPrefixPathOrigin::PythonCliFlag,
-            &system,
-        )
-        .unwrap();
+            for executable in [&versioned_executable, &free_threaded_executable] {
+                let environment =
+                    PythonEnvironment::new(executable, SysPrefixPathOrigin::PythonCliFlag, &system)
+                        .unwrap();
 
-        assert_eq!(
-            environment.site_packages_paths(&system).unwrap().into_vec(),
-            [system
-                .canonicalize_path(&free_threaded_site_packages)
-                .unwrap()]
-        );
+                assert_eq!(
+                    environment.site_packages_paths(&system).unwrap().into_vec(),
+                    [system
+                        .canonicalize_path(&free_threaded_site_packages)
+                        .unwrap()]
+                );
+            }
+        }
     }
 
     #[cfg(unix)]

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -372,6 +372,15 @@ impl System for MdtestSystem {
         }
     }
 
+    fn is_same_file(
+        &self,
+        first: &SystemPath,
+        second: &SystemPath,
+    ) -> ruff_db::system::Result<bool> {
+        self.as_system()
+            .is_same_file(&self.normalize_path(first), &self.normalize_path(second))
+    }
+
     fn read_to_string(&self, path: &SystemPath) -> ruff_db::system::Result<String> {
         self.as_system().read_to_string(&self.normalize_path(path))
     }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -1576,6 +1576,16 @@ impl System for WasmSystem {
         self.fs.canonicalize(path)
     }
 
+    fn is_same_file(
+        &self,
+        first: &SystemPath,
+        second: &SystemPath,
+    ) -> ruff_db::system::Result<bool> {
+        // The in-memory file system does not support hard links, so canonical paths uniquely
+        // identify files.
+        Ok(self.canonicalize_path(first)? == self.canonicalize_path(second)?)
+    }
+
     fn read_to_string(&self, path: &SystemPath) -> ruff_db::system::Result<String> {
         self.fs.read_to_string(path)
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (´)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fix astral-sh/ty#3424

When --python /opt/bin/python3.14 is passed, the sys.prefix is derived as /opt (grandparent of the executable), but the Python version (3.14) embedded in the filename was discarded. For system installations without a pyvenv.cfg, SystemEnvironment had no way to know the version, so site_packages_directories_from_sys_prefix scanned all python3.* directories under the lib dir, picking up site-packages from unrelated Python versions. 

Fix by extracting the Python version from the executable path before it's resolved to sys.prefix, and threading it through `SystemEnvironment` into the site-packages discovery, so it can target the exact version directory via `probe_package_dirs` instead of scanning all versions.

A noticeable change is that

```rust
pub struct SystemEnvironment {
    root_path: SysPrefixPath,
    python_version: Option<PythonVersion>, //! newly added
}
```

the struct was changed to convey version info. May it cause potential influence to other modules?

CC @MichaReiser . Thanks for reviewing.

## Test Plan

<!-- How was it tested? -->

A new unit test `uses_correct_site_packages_when_python_executable_path_has_version` was added by simulating the issue's system path.

<img width="827" height="602" alt="image" src="https://github.com/user-attachments/assets/1355cd67-228f-4dbc-8474-4e041af2e8ba" />
