### PR TITLE
Bump docstring-adder pin

### DIFF
--- a/.github/workflows/sync_typeshed.yaml
+++ b/.github/workflows/sync_typeshed.yaml
@@ -198,7 +198,12 @@ jobs:
           # consistent with the other typeshed stubs around them.
           # Typeshed formats code using black in their CI, so we just invoke
           # black on the stubs the same way that typeshed does.
-          uvx black "${VENDORED_TYPESHED}/stdlib" --config "${VENDORED_TYPESHED}/pyproject.toml" || true
+          # TODO: Switch to a released version of Black once a release includes
+          # https://github.com/psf/black/commit/f665703258bfa1916f8a6c1cbab0bc384b90cbac.
+          uvx \
+            --from="git+https://github.com/psf/black.git@e34bb1bef70e83410c2816dfd07485ec026959aa" \
+            black "${VENDORED_TYPESHED}/stdlib" \
+            --config "${VENDORED_TYPESHED}/pyproject.toml" || true
           git commit -am "Format codemodded docstrings" --allow-empty
       - name: Remove typeshed pyproject.toml file
         if: ${{ success() }}

--- a/scripts/codemod_docstrings.sh
+++ b/scripts/codemod_docstrings.sh
@@ -6,10 +6,10 @@
 # so that we codemod in docstrings that only exist on certain versions.
 #
 # The codemod will only add docstrings to functions/classes that do not
-# already have docstrings. We run with Python 3.14 before running with
-# any other Python version so that we get the Python 3.14 version of the
+# already have docstrings. We run with Python 3.15 before running with
+# any other Python version so that we get the Python 3.15 version of the
 # docstring for a definition that exists on all Python versions: if we
-# ran with Python 3.9 first, then the later runs with Python 3.10+ would
+# ran with Python 3.10 first, then the later runs with Python 3.11+ would
 # not modify the docstring that had already been added using the old version of Python.
 #
 # Note that the codemod can only add docstrings if they exist on the Python platform
@@ -18,10 +18,10 @@
 
 set -eu
 
-docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@1628984426d65ae0549fc43ed182d7a6157648cc"
+docstring_adder="git+https://github.com/astral-sh/docstring-adder.git@084654f4e9c94481f4a1ebeeb9f5dbc82c1933df"
 stdlib_path="./crates/ty_vendored/vendor/typeshed/stdlib"
 
-for python_version in 3.14 3.13 3.12 3.11 3.10
+for python_version in 3.15 3.14 3.13 3.12 3.11 3.10
 do
   PYTHONUTF8=1 uvx --python="$python_version" --force-reinstall --from="${docstring_adder}" add-docstrings --stdlib-path="${stdlib_path}"
 done


### PR DESCRIPTION
## Summary

Pulls in https://github.com/astral-sh/docstring-adder/pull/169, so that we have a version of docstring-adder that supports 3.15. This enables us to add docstrings for the new-in-3.15 branches in typeshed.

I also switched us to temporarily use a version of Black from git, because I'm too impatient to wait for a release that includes https://github.com/psf/black/commit/f665703258bfa1916f8a6c1cbab0bc384b90cbac.

## Test Plan

CI on docstring-adder