### PR TITLE
[ty] Require subtyping for transitive constraint pivots

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -450,6 +450,36 @@ reveal_type(C(1))  # revealed: C[int]
 wrong_innards: C[int] = C("five")
 ```
 
+### Many invariant parameters with dynamic bounds
+
+Treating unrelated classes with `Any` in their MRO as transitive pivots caused inference time to
+grow combinatorially in [ty#3607](https://github.com/astral-sh/ty/issues/3607).
+
+```py
+from typing import Any, Generic, TypeVar
+
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
+T6 = TypeVar("T6")
+
+class C(Generic[T1, T2, T3, T4, T5, T6]): ...
+
+class W(Generic[T1, T2, T3, T4, T5, T6]):
+    def __init__(self, value: C[T1, T2, T3, T4, T5, T6]) -> None: ...
+
+class A1(Any): ...
+class A2(Any): ...
+class A3(Any): ...
+class A4(Any): ...
+class A5(Any): ...
+class A6(Any): ...
+
+reveal_type(W(C[A1, A2, A3, A4, A5, A6]()))  # revealed: W[A1, A2, A3, A4, A5, A6]
+```
+
 ### Identical `__new__` and `__init__` signatures
 
 ```py

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -393,9 +393,7 @@ impl From<TypeRelation> for UpcastPolicy {
             TypeRelation::Subtyping
             | TypeRelation::Redundancy { .. }
             | TypeRelation::SubtypingAssuming => UpcastPolicy::Sound,
-            TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability => {
-                UpcastPolicy::Unsound
-            }
+            TypeRelation::Assignability => UpcastPolicy::Unsound,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2175,7 +2175,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     | TypeRelation::SubtypingAssuming => {
                         ConstraintSet::from_bool(self.constraints, target.is_object(db))
                     }
-                    TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability => {
+                    TypeRelation::Assignability => {
                         ConstraintSet::from_bool(self.constraints, !target.is_final(db))
                     }
                 },

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -6405,6 +6405,34 @@ mod tests {
     }
 
     #[test]
+    fn lazy_subtyping_materializes_dynamic_bounds() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+
+        let upper_builder = ConstraintSetBuilder::new();
+        let upper =
+            Type::TypeVar(t).when_constraint_set_subtype_of(&db, Type::any(), &upper_builder);
+        assert_eq!(
+            upper
+                .node
+                .root_constraint(&upper_builder)
+                .map(|constraint| upper_builder.constraint_data(constraint).bounds),
+            Some(ConstraintBounds::new(None, Some(Type::Never)))
+        );
+
+        let lower_builder = ConstraintSetBuilder::new();
+        let lower =
+            Type::any().when_constraint_set_subtype_of(&db, Type::TypeVar(t), &lower_builder);
+        assert_eq!(
+            lower
+                .node
+                .root_constraint(&lower_builder)
+                .map(|constraint| lower_builder.constraint_data(constraint).bounds),
+            Some(ConstraintBounds::new(Some(Type::object()), None))
+        );
+    }
+
+    #[test]
     fn constraint_implications_are_cached() {
         let db = setup_db();
         let t = create_typevar(&db, "T");

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -6405,34 +6405,6 @@ mod tests {
     }
 
     #[test]
-    fn lazy_subtyping_materializes_dynamic_bounds() {
-        let db = setup_db();
-        let t = create_typevar(&db, "T");
-
-        let upper_builder = ConstraintSetBuilder::new();
-        let upper =
-            Type::TypeVar(t).when_constraint_set_subtype_of(&db, Type::any(), &upper_builder);
-        assert_eq!(
-            upper
-                .node
-                .root_constraint(&upper_builder)
-                .map(|constraint| upper_builder.constraint_data(constraint).bounds),
-            Some(ConstraintBounds::new(None, Some(Type::Never)))
-        );
-
-        let lower_builder = ConstraintSetBuilder::new();
-        let lower =
-            Type::any().when_constraint_set_subtype_of(&db, Type::TypeVar(t), &lower_builder);
-        assert_eq!(
-            lower
-                .node
-                .root_constraint(&lower_builder)
-                .map(|constraint| lower_builder.constraint_data(constraint).bounds),
-            Some(ConstraintBounds::new(Some(Type::object()), None))
-        );
-    }
-
-    #[test]
     fn constraint_implications_are_cached() {
         let db = setup_db();
         let t = create_typevar(&db, "T");

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -4997,6 +4997,9 @@ impl SequentMap {
         let bound_typevar = bound_constraint_data.typevar;
         let constrained_constraint_data = builder.constraint_data(constrained_constraint);
         let constrained_typevar = constrained_constraint_data.typevar;
+
+        // Transitive pivots require subtyping; classes with dynamic bases can be assignable to
+        // unrelated types without being subtypes.
         let (new_lower, new_upper) = match (
             constrained_constraint_data.bounds.lower,
             constrained_constraint_data.bounds.upper,
@@ -5038,7 +5041,7 @@ impl SequentMap {
                     && !constrained_upper.is_object()
                     && constrained_upper
                         .top_materialization(db)
-                        .is_constraint_set_assignable_to(
+                        .is_constraint_set_subtype_of(
                             db,
                             bound_lower.bottom_materialization(db),
                         ) =>
@@ -5052,7 +5055,7 @@ impl SequentMap {
                     && !constrained_lower.is_object()
                     && bound_upper
                         .top_materialization(db)
-                        .is_constraint_set_assignable_to(
+                        .is_constraint_set_subtype_of(
                             db,
                             constrained_lower.bottom_materialization(db),
                         ) =>

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1553,28 +1553,22 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 MaterializationKind::Bottom,
             ),
             // And A <~ B (assignability) is Bottom[A] <: Top[B]
-            (
-                None,
-                Some(target_mat),
-                TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability,
-            ) => self.check_subtyping_in_invariant_position(
-                db,
-                source_type,
-                MaterializationKind::Bottom,
-                target_type,
-                target_mat,
-            ),
-            (
-                Some(source_mat),
-                None,
-                TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability,
-            ) => self.check_subtyping_in_invariant_position(
-                db,
-                source_type,
-                source_mat,
-                target_type,
-                MaterializationKind::Top,
-            ),
+            (None, Some(target_mat), TypeRelation::Assignability) => self
+                .check_subtyping_in_invariant_position(
+                    db,
+                    source_type,
+                    MaterializationKind::Bottom,
+                    target_type,
+                    target_mat,
+                ),
+            (Some(source_mat), None, TypeRelation::Assignability) => self
+                .check_subtyping_in_invariant_position(
+                    db,
+                    source_type,
+                    source_mat,
+                    target_type,
+                    MaterializationKind::Top,
+                ),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6025,7 +6025,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ///
     /// This lets `list` in a `Callable[[], list[str]]` context be treated as `list[str]`.
     fn specialize_generic_class_from_context(&self, ty: Type<'db>, target: Type<'db>) -> Type<'db> {
-        // TODO: The ConstraintSetAssignability type relation should already be
+        // TODO: The constraint-set assignability rules should already be
         // able to determine that `list` (coerced into a callable) is assignable
         // to `Callable[[], list[str]]` when `_T@list = str`. However, when
         // comparing callables, if either is generic, we existentially quantify

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1039,18 +1039,28 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // only has to hold when the typevar has a valid specialization (i.e., one that
             // satisfies the upper bound/constraints).
             if let Type::TypeVar(bound_typevar) = source {
+                let upper = if self.relation.is_subtyping() {
+                    target.bottom_materialization(db)
+                } else {
+                    target
+                };
                 return ConstraintSet::constrain_typevar_upper_bound(
                     db,
                     self.constraints,
                     bound_typevar,
-                    target,
+                    upper,
                 );
             } else if let Type::TypeVar(bound_typevar) = target {
+                let lower = if self.relation.is_subtyping() {
+                    source.top_materialization(db)
+                } else {
+                    source
+                };
                 return ConstraintSet::constrain_typevar_lower_bound(
                     db,
                     self.constraints,
                     bound_typevar,
-                    source,
+                    lower,
                 );
             }
         }
@@ -1833,10 +1843,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             (Type::TypedDict(typed_dict), _) => self.with_recursion_guard(source, target, || {
-                let dict_value_type = if matches!(
-                    self.relation,
-                    TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability
-                ) {
+                let dict_value_type = if self.relation.is_assignability() {
                     typed_dict.assignable_dict_value_type(db)
                 } else {
                     typed_dict.dict_value_type(db)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -205,6 +205,19 @@ pub(crate) enum TypeRelation {
     SubtypingAssuming,
 }
 
+/// Determines when comparisons involving type variables are evaluated.
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub(crate) enum TypeVarEvaluation {
+    /// Check immediately whether the relation holds for all or any valid specializations,
+    /// depending on whether the type variable is inferable.
+    Eager,
+
+    /// Move comparisons involving a type variable into the constraint set for later evaluation.
+    ///
+    /// This is currently opt-in, but will eventually replace eager type-variable evaluation.
+    Lazy,
+}
+
 impl TypeRelation {
     pub(crate) const fn is_assignability(self) -> bool {
         matches!(self, TypeRelation::Assignability)
@@ -331,7 +344,7 @@ impl<'db> Type<'db> {
             constraints,
             inferable,
             relation: TypeRelation::SubtypingAssuming,
-            use_constraint_set_rules: false,
+            typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: ErrorContextTree::disabled(),
             given: assuming,
             relation_visitor: &relation_visitor,
@@ -368,7 +381,7 @@ impl<'db> Type<'db> {
             constraints: &builder,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
-            use_constraint_set_rules: false,
+            typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: ErrorContextTree::enabled(),
             given: ConstraintSet::from_bool(&builder, false),
             relation_visitor: &HasRelationToVisitor::default(&builder),
@@ -457,13 +470,13 @@ impl<'db> Type<'db> {
         ) -> OwnedConstraintSet<'db> {
             let constraints = ConstraintSetBuilder::new();
             constraints.into_owned(|constraints| {
-                source.has_relation_to_with_constraint_set_rules(
+                source.has_relation_to_with_typevar_evaluation(
                     db,
                     target,
                     constraints,
                     InferableTypeVars::None,
                     TypeRelation::Assignability,
-                    true,
+                    TypeVarEvaluation::Lazy,
                 )
             })
         }
@@ -483,13 +496,13 @@ impl<'db> Type<'db> {
         target: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        self.has_relation_to_with_constraint_set_rules(
+        self.has_relation_to_with_typevar_evaluation(
             db,
             target,
             constraints,
             InferableTypeVars::None,
             TypeRelation::Assignability,
-            true,
+            TypeVarEvaluation::Lazy,
         )
     }
 
@@ -499,13 +512,13 @@ impl<'db> Type<'db> {
         target: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        self.has_relation_to_with_constraint_set_rules(
+        self.has_relation_to_with_typevar_evaluation(
             db,
             target,
             constraints,
             InferableTypeVars::None,
             TypeRelation::Subtyping,
-            true,
+            TypeVarEvaluation::Lazy,
         )
     }
 
@@ -545,24 +558,24 @@ impl<'db> Type<'db> {
         inferable: InferableTypeVars<'db>,
         relation: TypeRelation,
     ) -> ConstraintSet<'db, 'c> {
-        self.has_relation_to_with_constraint_set_rules(
+        self.has_relation_to_with_typevar_evaluation(
             db,
             target,
             constraints,
             inferable,
             relation,
-            false,
+            TypeVarEvaluation::Eager,
         )
     }
 
-    fn has_relation_to_with_constraint_set_rules<'c>(
+    fn has_relation_to_with_typevar_evaluation<'c>(
         self,
         db: &'db dyn Db,
         target: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
         relation: TypeRelation,
-        use_constraint_set_rules: bool,
+        typevar_evaluation: TypeVarEvaluation,
     ) -> ConstraintSet<'db, 'c> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
@@ -572,7 +585,7 @@ impl<'db> Type<'db> {
             constraints,
             inferable,
             relation,
-            use_constraint_set_rules,
+            typevar_evaluation,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor: &relation_visitor,
@@ -697,8 +710,11 @@ impl<'db> Type<'db> {
 }
 
 /// A [`PairVisitor`] that is used in `has_relation_to` methods.
-pub(crate) type HasRelationToVisitor<'db, 'c> =
-    CycleDetector<TypeRelation, (Type<'db>, Type<'db>, TypeRelation, bool), ConstraintSet<'db, 'c>>;
+pub(crate) type HasRelationToVisitor<'db, 'c> = CycleDetector<
+    TypeRelation,
+    (Type<'db>, Type<'db>, TypeRelation, TypeVarEvaluation),
+    ConstraintSet<'db, 'c>,
+>;
 
 impl<'db, 'c> HasRelationToVisitor<'db, 'c> {
     pub(crate) fn default(constraints: &'c ConstraintSetBuilder<'db>) -> Self {
@@ -723,7 +739,7 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     pub(super) inferable: InferableTypeVars<'db>,
     pub(super) relation: TypeRelation,
-    pub(super) use_constraint_set_rules: bool,
+    pub(super) typevar_evaluation: TypeVarEvaluation,
     context_tree: ErrorContextTree<'db>,
     pub(super) given: ConstraintSet<'db, 'c>,
 
@@ -752,7 +768,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             constraints,
             inferable,
             relation: TypeRelation::Subtyping,
-            use_constraint_set_rules: false,
+            typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -773,7 +789,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             constraints,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
-            use_constraint_set_rules: true,
+            typevar_evaluation: TypeVarEvaluation::Lazy,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -794,7 +810,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             constraints,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
-            use_constraint_set_rules: true,
+            typevar_evaluation: TypeVarEvaluation::Lazy,
             context_tree: ErrorContextTree::enabled(),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -815,7 +831,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             constraints,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
-            use_constraint_set_rules: false,
+            typevar_evaluation: TypeVarEvaluation::Eager,
             context_tree: ErrorContextTree::enabled(),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -832,8 +848,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         }
     }
 
-    pub(super) const fn is_plain_assignability(&self) -> bool {
-        self.relation.is_assignability() && !self.use_constraint_set_rules
+    pub(super) const fn is_eager_assignability(&self) -> bool {
+        self.relation.is_assignability()
+            && matches!(self.typevar_evaluation, TypeVarEvaluation::Eager)
     }
 
     pub(super) fn into_error_context(self) -> ErrorContextTree<'db> {
@@ -902,7 +919,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         work: impl FnOnce() -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
         self.relation_visitor.visit(
-            (source, target, self.relation, self.use_constraint_set_rules),
+            (source, target, self.relation, self.typevar_evaluation),
             work,
         )
     }
@@ -1013,9 +1030,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 .implies_subtype_of(db, self.constraints, source, target);
         }
 
-        // When using constraint-set typevar rules, comparisons with a typevar are translated
-        // directly into a constraint set.
-        if self.use_constraint_set_rules {
+        // With lazy evaluation, comparisons with a type variable are translated directly into a
+        // constraint set.
+        if self.typevar_evaluation == TypeVarEvaluation::Lazy {
             // A typevar satisfies a relation when...it satisfies the relation. Yes that's a
             // tautology! We're moving the caller's subtyping/assignability requirement into a
             // constraint set. If the typevar has an upper bound or constraints, then the relation
@@ -1070,7 +1087,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // but this is not true for divergent types (and moving this case any lower down appears to cause
             // "too many cycle iterations" panics).
             (Type::Divergent(_), _) | (_, Type::Divergent(_)) => {
-                ConstraintSet::from_bool(self.constraints, self.is_plain_assignability())
+                ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
             }
 
             (Type::TypeAlias(source_alias), _) => self.with_recursion_guard(source, target, || {
@@ -1184,7 +1201,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             //     3. If neither a converter nor a default value is provided, we allow the field to be
             //        considered assignable to any type.
             (Type::KnownInstance(KnownInstanceType::Field(field)), _)
-                if self.is_plain_assignability() =>
+                if self.is_eager_assignability() =>
             {
                 field
                     .default_type(db)
@@ -1289,7 +1306,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.always()
             }
             (Type::Intersection(intersection), _)
-                if self.is_plain_assignability()
+                if self.is_eager_assignability()
                     && intersection.positive(db).iter().any(Type::is_dynamic) =>
             {
                 // If the intersection contains `Any`/`Unknown`/`@Todo`, it is assignable to any type.
@@ -1335,7 +1352,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // paths below.
             (Type::TypeVar(bound_typevar), Type::Callable(other))
             | (Type::Callable(other), Type::TypeVar(bound_typevar))
-                if self.is_plain_assignability()
+                if self.is_eager_assignability()
                     && !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.is_paramspec(db)
                     && Self::is_gradual_paramspec_value(db, other) =>
@@ -1655,7 +1672,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // TODO: Infer specializations here
             (_, Type::TypeVar(typevar)) if typevar.is_inferable(db, self.inferable) => {
-                if self.is_plain_assignability() {
+                if self.is_eager_assignability() {
                     // TODO: record the unification constraints
                     typevar.typevar(db).upper_bound(db).when_none_or(
                         db,
@@ -1795,7 +1812,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // if `type` is a subtype of that protocol.
             (Type::SubclassOf(source_subclass_ty), Type::ProtocolInstance(_))
                 if (source_subclass_ty.is_dynamic() || source_subclass_ty.is_type_var())
-                    && !self.is_plain_assignability() =>
+                    && !self.is_eager_assignability() =>
             {
                 self.check_type_pair(db, KnownClass::Type.to_instance(db), target)
             }
@@ -2038,7 +2055,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         self.check_class_pair(db, source_cls.default_specialization(db), target_cls)
                     })
                     .unwrap_or_else(|| {
-                        ConstraintSet::from_bool(self.constraints, self.is_plain_assignability())
+                        ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
                     })
             }
 
@@ -2069,7 +2086,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         self.check_class_pair(db, ClassType::Generic(source_alias), target_cls)
                     })
                     .unwrap_or_else(|| {
-                        ConstraintSet::from_bool(self.constraints, self.is_plain_assignability())
+                        ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
                     })
             }
 
@@ -2094,7 +2111,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             (Type::SubclassOf(subclass_of_ty), _) if subclass_of_ty.is_dynamic() => {
                 self.check_type_pair(db, KnownClass::Type.to_instance(db), target)
                     .or(db, self.constraints, || {
-                        ConstraintSet::from_bool(self.constraints, self.is_plain_assignability())
+                        ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
                             .and(db, self.constraints, || {
                                 self.check_type_pair(db, target, KnownClass::Type.to_instance(db))
                             })
@@ -2103,7 +2120,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // Any `type[...]` type is assignable to `type[Any]`
             (_, Type::SubclassOf(subclass_of_ty))
-                if subclass_of_ty.is_dynamic() && self.is_plain_assignability() =>
+                if subclass_of_ty.is_dynamic() && self.is_eager_assignability() =>
             {
                 self.check_type_pair(db, source, KnownClass::Type.to_instance(db))
             }
@@ -2261,7 +2278,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
     ) -> TypeRelationChecker<'a, 'c, 'db> {
         TypeRelationChecker {
             relation: TypeRelation::Redundancy { pure: true },
-            use_constraint_set_rules: false,
+            typevar_evaluation: TypeVarEvaluation::Eager,
             constraints: self.constraints,
             context_tree: ErrorContextTree::disabled(),
             given: self.given,
@@ -2346,7 +2363,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
     ) -> TypeRelationChecker<'_, 'c, 'db> {
         TypeRelationChecker {
             relation,
-            use_constraint_set_rules: false,
+            typevar_evaluation: TypeVarEvaluation::Eager,
             constraints: self.constraints,
             inferable: self.inferable,
             context_tree: ErrorContextTree::disabled(),

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -203,20 +203,11 @@ pub(crate) enum TypeRelation {
     ///   are not actually subtypes of each other. (That is, `implies_subtype_of(false, int, str)`
     ///   will return true!)
     SubtypingAssuming,
-
-    /// A placeholder for the new assignability relation that uses constraint sets to encode
-    /// relationships with a typevar. This will eventually replace `Assignability`, but allows us
-    /// to start using the new relation in a controlled manner in some places.
-    ConstraintSetAssignability,
 }
 
 impl TypeRelation {
     pub(crate) const fn is_assignability(self) -> bool {
         matches!(self, TypeRelation::Assignability)
-    }
-
-    pub(crate) const fn is_constraint_set_assignability(self) -> bool {
-        matches!(self, TypeRelation::ConstraintSetAssignability)
     }
 
     pub(crate) const fn is_subtyping(self) -> bool {
@@ -225,9 +216,7 @@ impl TypeRelation {
 
     pub(crate) const fn can_safely_assume_reflexivity(self, ty: Type) -> bool {
         match self {
-            TypeRelation::Assignability
-            | TypeRelation::ConstraintSetAssignability
-            | TypeRelation::Redundancy { .. } => true,
+            TypeRelation::Assignability | TypeRelation::Redundancy { .. } => true,
             TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => {
                 ty.subtyping_is_always_reflexive()
             }
@@ -342,6 +331,7 @@ impl<'db> Type<'db> {
             constraints,
             inferable,
             relation: TypeRelation::SubtypingAssuming,
+            use_constraint_set_rules: false,
             context_tree: ErrorContextTree::disabled(),
             given: assuming,
             relation_visitor: &relation_visitor,
@@ -378,6 +368,7 @@ impl<'db> Type<'db> {
             constraints: &builder,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
+            use_constraint_set_rules: false,
             context_tree: ErrorContextTree::enabled(),
             given: ConstraintSet::from_bool(&builder, false),
             relation_visitor: &HasRelationToVisitor::default(&builder),
@@ -389,14 +380,17 @@ impl<'db> Type<'db> {
         checker.context_tree
     }
 
-    /// Return true if this type is assignable to type `target` using constraint-set assignability.
-    ///
-    /// This uses `TypeRelation::ConstraintSetAssignability`, which encodes typevar relations into
-    /// a constraint set and lets `satisfied_by_all_typevars` perform existential vs universal
-    /// reasoning depending on inferable typevars.
+    /// Return true if this type is assignable to type `target` using constraint-set typevar rules.
     pub fn is_constraint_set_assignable_to(self, db: &'db dyn Db, target: Type<'db>) -> bool {
         let constraints = ConstraintSetBuilder::new();
         self.when_constraint_set_assignable_to(db, target, &constraints)
+            .is_always_satisfied(db)
+    }
+
+    /// Return true if this type is a subtype of `target` using constraint-set typevar rules.
+    pub(super) fn is_constraint_set_subtype_of(self, db: &'db dyn Db, target: Type<'db>) -> bool {
+        let constraints = ConstraintSetBuilder::new();
+        self.when_constraint_set_subtype_of(db, target, &constraints)
             .is_always_satisfied(db)
     }
 
@@ -463,12 +457,13 @@ impl<'db> Type<'db> {
         ) -> OwnedConstraintSet<'db> {
             let constraints = ConstraintSetBuilder::new();
             constraints.into_owned(|constraints| {
-                source.has_relation_to(
+                source.has_relation_to_with_constraint_set_rules(
                     db,
                     target,
                     constraints,
                     InferableTypeVars::None,
-                    TypeRelation::ConstraintSetAssignability,
+                    TypeRelation::Assignability,
+                    true,
                 )
             })
         }
@@ -488,12 +483,29 @@ impl<'db> Type<'db> {
         target: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        self.has_relation_to(
+        self.has_relation_to_with_constraint_set_rules(
             db,
             target,
             constraints,
             InferableTypeVars::None,
-            TypeRelation::ConstraintSetAssignability,
+            TypeRelation::Assignability,
+            true,
+        )
+    }
+
+    pub(super) fn when_constraint_set_subtype_of<'c>(
+        self,
+        db: &'db dyn Db,
+        target: Type<'db>,
+        constraints: &'c ConstraintSetBuilder<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        self.has_relation_to_with_constraint_set_rules(
+            db,
+            target,
+            constraints,
+            InferableTypeVars::None,
+            TypeRelation::Subtyping,
+            true,
         )
     }
 
@@ -533,6 +545,25 @@ impl<'db> Type<'db> {
         inferable: InferableTypeVars<'db>,
         relation: TypeRelation,
     ) -> ConstraintSet<'db, 'c> {
+        self.has_relation_to_with_constraint_set_rules(
+            db,
+            target,
+            constraints,
+            inferable,
+            relation,
+            false,
+        )
+    }
+
+    fn has_relation_to_with_constraint_set_rules<'c>(
+        self,
+        db: &'db dyn Db,
+        target: Type<'db>,
+        constraints: &'c ConstraintSetBuilder<'db>,
+        inferable: InferableTypeVars<'db>,
+        relation: TypeRelation,
+        use_constraint_set_rules: bool,
+    ) -> ConstraintSet<'db, 'c> {
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
@@ -541,6 +572,7 @@ impl<'db> Type<'db> {
             constraints,
             inferable,
             relation,
+            use_constraint_set_rules,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor: &relation_visitor,
@@ -666,7 +698,7 @@ impl<'db> Type<'db> {
 
 /// A [`PairVisitor`] that is used in `has_relation_to` methods.
 pub(crate) type HasRelationToVisitor<'db, 'c> =
-    CycleDetector<TypeRelation, (Type<'db>, Type<'db>, TypeRelation), ConstraintSet<'db, 'c>>;
+    CycleDetector<TypeRelation, (Type<'db>, Type<'db>, TypeRelation, bool), ConstraintSet<'db, 'c>>;
 
 impl<'db, 'c> HasRelationToVisitor<'db, 'c> {
     pub(crate) fn default(constraints: &'c ConstraintSetBuilder<'db>) -> Self {
@@ -691,6 +723,7 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     pub(super) inferable: InferableTypeVars<'db>,
     pub(super) relation: TypeRelation,
+    pub(super) use_constraint_set_rules: bool,
     context_tree: ErrorContextTree<'db>,
     pub(super) given: ConstraintSet<'db, 'c>,
 
@@ -719,6 +752,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             constraints,
             inferable,
             relation: TypeRelation::Subtyping,
+            use_constraint_set_rules: false,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -738,7 +772,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable: InferableTypeVars::None,
-            relation: TypeRelation::ConstraintSetAssignability,
+            relation: TypeRelation::Assignability,
+            use_constraint_set_rules: true,
             context_tree: ErrorContextTree::disabled(),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -758,7 +793,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         Self {
             constraints,
             inferable: InferableTypeVars::None,
-            relation: TypeRelation::ConstraintSetAssignability,
+            relation: TypeRelation::Assignability,
+            use_constraint_set_rules: true,
             context_tree: ErrorContextTree::enabled(),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -779,6 +815,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             constraints,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
+            use_constraint_set_rules: false,
             context_tree: ErrorContextTree::enabled(),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
@@ -793,6 +830,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable,
             ..self.clone()
         }
+    }
+
+    pub(super) const fn is_plain_assignability(&self) -> bool {
+        self.relation.is_assignability() && !self.use_constraint_set_rules
     }
 
     pub(super) fn into_error_context(self) -> ErrorContextTree<'db> {
@@ -860,8 +901,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         target: Type<'db>,
         work: impl FnOnce() -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        self.relation_visitor
-            .visit((source, target, self.relation), work)
+        self.relation_visitor.visit(
+            (source, target, self.relation, self.use_constraint_set_rules),
+            work,
+        )
     }
 
     /// Is `target` a metaclass instance (a nominal instance of a subclass of `builtins.type`)?
@@ -970,9 +1013,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 .implies_subtype_of(db, self.constraints, source, target);
         }
 
-        // Handle the constraint-set-based assignability relation next. Comparisons with a
-        // typevar are translated directly into a constraint set.
-        if self.relation.is_constraint_set_assignability() {
+        // When using constraint-set typevar rules, comparisons with a typevar are translated
+        // directly into a constraint set.
+        if self.use_constraint_set_rules {
             // A typevar satisfies a relation when...it satisfies the relation. Yes that's a
             // tautology! We're moving the caller's subtyping/assignability requirement into a
             // constraint set. If the typevar has an upper bound or constraints, then the relation
@@ -1027,7 +1070,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // but this is not true for divergent types (and moving this case any lower down appears to cause
             // "too many cycle iterations" panics).
             (Type::Divergent(_), _) | (_, Type::Divergent(_)) => {
-                ConstraintSet::from_bool(self.constraints, self.relation.is_assignability())
+                ConstraintSet::from_bool(self.constraints, self.is_plain_assignability())
             }
 
             (Type::TypeAlias(source_alias), _) => self.with_recursion_guard(source, target, || {
@@ -1141,7 +1184,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             //     3. If neither a converter nor a default value is provided, we allow the field to be
             //        considered assignable to any type.
             (Type::KnownInstance(KnownInstanceType::Field(field)), _)
-                if self.relation.is_assignability() =>
+                if self.is_plain_assignability() =>
             {
                 field
                     .default_type(db)
@@ -1197,7 +1240,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.constraints,
                 match self.relation {
                     TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => false,
-                    TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability => true,
+                    TypeRelation::Assignability => true,
                     TypeRelation::Redundancy { .. } => match target {
                         Type::Dynamic(_) => true,
                         Type::Union(union) => union.elements(db).iter().any(Type::is_dynamic),
@@ -1209,7 +1252,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.constraints,
                 match self.relation {
                     TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => false,
-                    TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability => true,
+                    TypeRelation::Assignability => true,
                     TypeRelation::Redundancy { .. } => match source {
                         Type::Dynamic(_) => true,
                         Type::Intersection(intersection) => {
@@ -1246,7 +1289,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.always()
             }
             (Type::Intersection(intersection), _)
-                if self.relation.is_assignability()
+                if self.is_plain_assignability()
                     && intersection.positive(db).iter().any(Type::is_dynamic) =>
             {
                 // If the intersection contains `Any`/`Unknown`/`@Todo`, it is assignable to any type.
@@ -1292,7 +1335,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // paths below.
             (Type::TypeVar(bound_typevar), Type::Callable(other))
             | (Type::Callable(other), Type::TypeVar(bound_typevar))
-                if self.relation.is_assignability()
+                if self.is_plain_assignability()
                     && !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.is_paramspec(db)
                     && Self::is_gradual_paramspec_value(db, other) =>
@@ -1524,9 +1567,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         TypeRelation::Subtyping
                         | TypeRelation::Redundancy { .. }
                         | TypeRelation::SubtypingAssuming => source,
-                        TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability => {
-                            source.bottom_materialization(db)
-                        }
+                        TypeRelation::Assignability => source.bottom_materialization(db),
                     };
                     intersection
                         .negative(db)
@@ -1536,10 +1577,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                                 TypeRelation::Subtyping
                                 | TypeRelation::Redundancy { .. }
                                 | TypeRelation::SubtypingAssuming => neg_ty,
-                                TypeRelation::Assignability
-                                | TypeRelation::ConstraintSetAssignability => {
-                                    neg_ty.bottom_materialization(db)
-                                }
+                                TypeRelation::Assignability => neg_ty.bottom_materialization(db),
                             };
                             self.as_disjointness_checker()
                                 .check_type_pair(db, source_ty, neg_ty)
@@ -1617,7 +1655,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // TODO: Infer specializations here
             (_, Type::TypeVar(typevar)) if typevar.is_inferable(db, self.inferable) => {
-                if self.relation.is_assignability() {
+                if self.is_plain_assignability() {
                     // TODO: record the unification constraints
                     typevar.typevar(db).upper_bound(db).when_none_or(
                         db,
@@ -1668,11 +1706,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             (
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_partial)),
                 Type::FunctionLiteral(target_function),
-            ) if matches!(
-                self.relation,
-                TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability
-            ) =>
-            {
+            ) if matches!(self.relation, TypeRelation::Assignability) => {
                 self.with_recursion_guard(source, target, || {
                     self.check_callable_signature_pair(
                         db,
@@ -1761,7 +1795,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // if `type` is a subtype of that protocol.
             (Type::SubclassOf(source_subclass_ty), Type::ProtocolInstance(_))
                 if (source_subclass_ty.is_dynamic() || source_subclass_ty.is_type_var())
-                    && !self.relation.is_assignability() =>
+                    && !self.is_plain_assignability() =>
             {
                 self.check_type_pair(db, KnownClass::Type.to_instance(db), target)
             }
@@ -2004,7 +2038,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         self.check_class_pair(db, source_cls.default_specialization(db), target_cls)
                     })
                     .unwrap_or_else(|| {
-                        ConstraintSet::from_bool(self.constraints, self.relation.is_assignability())
+                        ConstraintSet::from_bool(self.constraints, self.is_plain_assignability())
                     })
             }
 
@@ -2035,7 +2069,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         self.check_class_pair(db, ClassType::Generic(source_alias), target_cls)
                     })
                     .unwrap_or_else(|| {
-                        ConstraintSet::from_bool(self.constraints, self.relation.is_assignability())
+                        ConstraintSet::from_bool(self.constraints, self.is_plain_assignability())
                     })
             }
 
@@ -2057,18 +2091,19 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             ),
 
             // `type[Any]` is a subtype of `type[object]`, and is assignable to any `type[...]`
-            (Type::SubclassOf(subclass_of_ty), _) if subclass_of_ty.is_dynamic() => self
-                .check_type_pair(db, KnownClass::Type.to_instance(db), target)
-                .or(db, self.constraints, || {
-                    ConstraintSet::from_bool(self.constraints, self.relation.is_assignability())
-                        .and(db, self.constraints, || {
-                            self.check_type_pair(db, target, KnownClass::Type.to_instance(db))
-                        })
-                }),
+            (Type::SubclassOf(subclass_of_ty), _) if subclass_of_ty.is_dynamic() => {
+                self.check_type_pair(db, KnownClass::Type.to_instance(db), target)
+                    .or(db, self.constraints, || {
+                        ConstraintSet::from_bool(self.constraints, self.is_plain_assignability())
+                            .and(db, self.constraints, || {
+                                self.check_type_pair(db, target, KnownClass::Type.to_instance(db))
+                            })
+                    })
+            }
 
             // Any `type[...]` type is assignable to `type[Any]`
             (_, Type::SubclassOf(subclass_of_ty))
-                if subclass_of_ty.is_dynamic() && self.relation.is_assignability() =>
+                if subclass_of_ty.is_dynamic() && self.is_plain_assignability() =>
             {
                 self.check_type_pair(db, source, KnownClass::Type.to_instance(db))
             }
@@ -2226,6 +2261,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
     ) -> TypeRelationChecker<'a, 'c, 'db> {
         TypeRelationChecker {
             relation: TypeRelation::Redundancy { pure: true },
+            use_constraint_set_rules: false,
             constraints: self.constraints,
             context_tree: ErrorContextTree::disabled(),
             given: self.given,
@@ -2310,6 +2346,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
     ) -> TypeRelationChecker<'_, 'c, 'db> {
         TypeRelationChecker {
             relation,
+            use_constraint_set_rules: false,
             constraints: self.constraints,
             inferable: self.inferable,
             context_tree: ErrorContextTree::disabled(),

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -28,7 +28,7 @@ use crate::types::generics::{
 };
 use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
 use crate::types::relation::{
-    HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
+    HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker, TypeVarEvaluation,
 };
 use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation;
 use crate::types::typevar::{BoundTypeVarIdentity, max_typevar_freshness_matching_generic_context};
@@ -535,7 +535,7 @@ pub(crate) struct SignatureRelationKey<'db> {
     source_definition: Definition<'db>,
     target_definition: Definition<'db>,
     relation: TypeRelation,
-    use_constraint_set_rules: bool,
+    typevar_evaluation: TypeVarEvaluation,
 }
 
 impl<'db> SignatureRelationKey<'db> {
@@ -543,13 +543,13 @@ impl<'db> SignatureRelationKey<'db> {
         source: &Signature<'db>,
         target: &Signature<'db>,
         relation: TypeRelation,
-        use_constraint_set_rules: bool,
+        typevar_evaluation: TypeVarEvaluation,
     ) -> Option<Self> {
         Some(Self {
             source_definition: source.definition?,
             target_definition: target.definition?,
             relation,
-            use_constraint_set_rules,
+            typevar_evaluation,
         })
     }
 }
@@ -1588,7 +1588,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source_overloads: &[Signature<'db>],
         target_overloads: &[Signature<'db>],
     ) -> ConstraintSet<'db, 'c> {
-        if self.use_constraint_set_rules {
+        if self.typevar_evaluation == TypeVarEvaluation::Lazy {
             // TODO: Oof, maybe ParamSpec needs to live at CallableSignature, not Signature?
             let source_is_single_paramspec =
                 CallableSignature::signatures_is_single_paramspec(source_overloads);
@@ -1698,7 +1698,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         match (source_overloads, target_overloads) {
             ([source_signature], [target_signature]) => {
                 // Base case: both callable types contain a single signature.
-                if self.use_constraint_set_rules
+                if self.typevar_evaluation == TypeVarEvaluation::Lazy
                     && (source_signature
                         .parameters
                         .as_paramspec_with_prefix()
@@ -1833,7 +1833,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             source,
             target,
             self.relation,
-            self.use_constraint_set_rules,
+            self.typevar_evaluation,
         ) else {
             return work();
         };
@@ -2001,7 +2001,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .is_never_satisfied(db)
         };
 
-        if self.use_constraint_set_rules {
+        if self.typevar_evaluation == TypeVarEvaluation::Lazy {
             let source_paramspec = source.parameters.as_paramspec_with_prefix();
             let target_paramspec = target.parameters.as_paramspec_with_prefix();
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -535,6 +535,7 @@ pub(crate) struct SignatureRelationKey<'db> {
     source_definition: Definition<'db>,
     target_definition: Definition<'db>,
     relation: TypeRelation,
+    use_constraint_set_rules: bool,
 }
 
 impl<'db> SignatureRelationKey<'db> {
@@ -542,11 +543,13 @@ impl<'db> SignatureRelationKey<'db> {
         source: &Signature<'db>,
         target: &Signature<'db>,
         relation: TypeRelation,
+        use_constraint_set_rules: bool,
     ) -> Option<Self> {
         Some(Self {
             source_definition: source.definition?,
             target_definition: target.definition?,
             relation,
+            use_constraint_set_rules,
         })
     }
 }
@@ -1585,7 +1588,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source_overloads: &[Signature<'db>],
         target_overloads: &[Signature<'db>],
     ) -> ConstraintSet<'db, 'c> {
-        if self.relation.is_constraint_set_assignability() {
+        if self.use_constraint_set_rules {
             // TODO: Oof, maybe ParamSpec needs to live at CallableSignature, not Signature?
             let source_is_single_paramspec =
                 CallableSignature::signatures_is_single_paramspec(source_overloads);
@@ -1695,7 +1698,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         match (source_overloads, target_overloads) {
             ([source_signature], [target_signature]) => {
                 // Base case: both callable types contain a single signature.
-                if self.relation.is_constraint_set_assignability()
+                if self.use_constraint_set_rules
                     && (source_signature
                         .parameters
                         .as_paramspec_with_prefix()
@@ -1826,7 +1829,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target: &Signature<'db>,
         work: impl FnOnce() -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        let Some(key) = SignatureRelationKey::from_signatures(source, target, self.relation) else {
+        let Some(key) = SignatureRelationKey::from_signatures(
+            source,
+            target,
+            self.relation,
+            self.use_constraint_set_rules,
+        ) else {
             return work();
         };
 
@@ -1993,7 +2001,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .is_never_satisfied(db)
         };
 
-        if self.relation.is_constraint_set_assignability() {
+        if self.use_constraint_set_rules {
             let source_paramspec = source.parameters.as_paramspec_with_prefix();
             let target_paramspec = target.parameters.as_paramspec_with_prefix();
 
@@ -2751,7 +2759,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         source.parameters.is_gradual() && target.parameters.is_gradual(),
                     ),
                 ),
-                TypeRelation::Assignability | TypeRelation::ConstraintSetAssignability => result,
+                TypeRelation::Assignability => result,
             };
         }
 

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -304,11 +304,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             (SubclassOfInner::Dynamic(_), SubclassOfInner::Class(target_class)) => {
                 ConstraintSet::from_bool(
                     self.constraints,
-                    target_class.is_object(db) || self.relation.is_assignability(),
+                    target_class.is_object(db) || self.is_plain_assignability(),
                 )
             }
             (SubclassOfInner::Class(_), SubclassOfInner::Dynamic(_)) => {
-                ConstraintSet::from_bool(self.constraints, self.relation.is_assignability())
+                ConstraintSet::from_bool(self.constraints, self.is_plain_assignability())
             }
 
             // For example, `type[bool]` describes all possible runtime subclasses of the class `bool`,

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -304,11 +304,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             (SubclassOfInner::Dynamic(_), SubclassOfInner::Class(target_class)) => {
                 ConstraintSet::from_bool(
                     self.constraints,
-                    target_class.is_object(db) || self.is_plain_assignability(),
+                    target_class.is_object(db) || self.is_eager_assignability(),
                 )
             }
             (SubclassOfInner::Class(_), SubclassOfInner::Dynamic(_)) => {
-                ConstraintSet::from_bool(self.constraints, self.is_plain_assignability())
+                ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
             }
 
             // For example, `type[bool]` describes all possible runtime subclasses of the class `bool`,

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -294,7 +294,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             Tuple::Fixed(target) => {
                 let equal_length = source_tuple.0.len() == target.0.len();
 
-                if !equal_length && self.is_plain_assignability() {
+                if !equal_length && self.is_eager_assignability() {
                     self.provide_context(|| ErrorContext::TupleLengthMismatch {
                         source_len: source_tuple.0.len(),
                         target_len: target_tuple.len(),
@@ -390,7 +390,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // (or any other dynamic type), then the `...` is the _gradual choice_ of all
                 // possible lengths. This means that `tuple[Any, ...]` can match any tuple of any
                 // length.
-                if !self.is_plain_assignability() || !source.variable().is_dynamic() {
+                if !self.is_eager_assignability() || !source.variable().is_dynamic() {
                     return self.never();
                 }
 
@@ -462,7 +462,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             // provide, unless the lhs has a dynamic variable-length portion
                             // that can materialize to provide it (for assignability only),
                             // as in `tuple[Any, ...]` matching `tuple[int, int]`.
-                            if !self.is_plain_assignability() || !source.variable().is_dynamic() {
+                            if !self.is_eager_assignability() || !source.variable().is_dynamic() {
                                 return self.never();
                             }
                             self.check_type_pair(db, source.variable(), other_ty)
@@ -499,7 +499,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             // provide, unless the lhs has a dynamic variable-length portion
                             // that can materialize to provide it (for assignability only),
                             // as in `tuple[Any, ...]` matching `tuple[int, int]`.
-                            if !self.is_plain_assignability() || !source.variable().is_dynamic() {
+                            if !self.is_eager_assignability() || !source.variable().is_dynamic() {
                                 return self.never();
                             }
                             self.check_type_pair(db, source.variable(), target_ty)

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -294,7 +294,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             Tuple::Fixed(target) => {
                 let equal_length = source_tuple.0.len() == target.0.len();
 
-                if !equal_length && self.relation.is_assignability() {
+                if !equal_length && self.is_plain_assignability() {
                     self.provide_context(|| ErrorContext::TupleLengthMismatch {
                         source_len: source_tuple.0.len(),
                         target_len: target_tuple.len(),
@@ -390,7 +390,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // (or any other dynamic type), then the `...` is the _gradual choice_ of all
                 // possible lengths. This means that `tuple[Any, ...]` can match any tuple of any
                 // length.
-                if !self.relation.is_assignability() || !source.variable().is_dynamic() {
+                if !self.is_plain_assignability() || !source.variable().is_dynamic() {
                     return self.never();
                 }
 
@@ -462,8 +462,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             // provide, unless the lhs has a dynamic variable-length portion
                             // that can materialize to provide it (for assignability only),
                             // as in `tuple[Any, ...]` matching `tuple[int, int]`.
-                            if !self.relation.is_assignability() || !source.variable().is_dynamic()
-                            {
+                            if !self.is_plain_assignability() || !source.variable().is_dynamic() {
                                 return self.never();
                             }
                             self.check_type_pair(db, source.variable(), other_ty)
@@ -500,8 +499,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             // provide, unless the lhs has a dynamic variable-length portion
                             // that can materialize to provide it (for assignability only),
                             // as in `tuple[Any, ...]` matching `tuple[int, int]`.
-                            if !self.relation.is_assignability() || !source.variable().is_dynamic()
-                            {
+                            if !self.is_plain_assignability() || !source.variable().is_dynamic() {
                                 return self.never();
                             }
                             self.check_type_pair(db, source.variable(), target_ty)


### PR DESCRIPTION
## Summary

When building sequent maps for constraints on different type variables, we use materialized bounds as pivots to derive transitive relationships. We previously accepted a pivot when those bounds were assignable. Unrelated classes with dynamic bases are mutually assignable, so this connected otherwise independent invariant type variables and caused the constraint set in the issue reproducer to grow combinatorially.

This changes those pivot checks to require subtyping. Because the bounds can themselves contain type variables, the new check uses constraint-set-aware subtyping rather than the ordinary subtype relation. Constraint-set type-variable handling is now an independent mode on `TypeRelationChecker`, so it can be combined with either subtyping or assignability; the mode is also included in relation and signature recursion keys so cached results are not shared across comparison modes.

In a local benchmark of the issue reproducer, check time fell from 14.5 seconds with constraint-set assignability to 46 milliseconds with constraint-set subtyping.

Closes https://github.com/astral-sh/ty/issues/3607.