### PR TITLE
[ty] Avoid redundant constraint saturation work

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -5154,6 +5154,21 @@ impl SequentMap {
         left_constraint: ConstraintId,
         right_constraint: ConstraintId,
     ) {
+        // Keep this precheck aligned with `variance_of`, which visits lazy types.
+        let has_typevar_bound = |bounds: ConstraintBounds<'db>| {
+            bounds
+                .lower
+                .is_some_and(|bound| any_over_type(db, bound, true, Type::is_type_var))
+                || bounds
+                    .upper
+                    .is_some_and(|bound| any_over_type(db, bound, true, Type::is_type_var))
+        };
+        if !has_typevar_bound(builder.constraint_data(left_constraint).bounds)
+            && !has_typevar_bound(builder.constraint_data(right_constraint).bounds)
+        {
+            return;
+        }
+
         let mut try_tightening =
             |bound_constraint: ConstraintId, constrained_constraint: ConstraintId| {
                 let bound_data = builder.constraint_data(bound_constraint);

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -401,6 +401,7 @@ impl<'db> Type<'db> {
     }
 
     /// Return true if this type is a subtype of `target` using constraint-set typevar rules.
+    #[salsa::tracked(cycle_initial=|_, _, _, _| true, heap_size=ruff_memory_usage::heap_size)]
     pub(super) fn is_constraint_set_subtype_of(self, db: &'db dyn Db, target: Type<'db>) -> bool {
         let constraints = ConstraintSetBuilder::new();
         self.when_constraint_set_subtype_of(db, target, &constraints)


### PR DESCRIPTION
## Summary

The constraint-set subtype checks introduced in #25778 can be repeated many times while saturating pairs of constraints. On pytest-robotframework, that increased median check time from 105.8 ms on main to 159.9 ms with #25778.

This caches those checks for the lifetime of a constraint-set builder.

As a separate, semantics-preserving optimization, this also skips calling `add_nested_typevar_sequents` when neither constraint has a type variable in its bounds. In that case, the method cannot derive any sequents: all of its variance checks return `Bivariant`. The precheck visits lazy types to match the traversal performed by `variance_of`.

With this change, pytest-robotframework takes 108.5 ms, 2.6% above main, with byte-for-byte identical diagnostics. The full `ty_python_semantic` test suite, focused Clippy, and repository hooks pass.