### PR TITLE
[ty] Implement Duboc's TDD optimization for narrowing constraints

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1000,10 +1000,32 @@ fn benchmark_large_isinstance_narrowing(criterion: &mut Criterion) {
     });
 }
 
-/// Benchmark for preserving compact narrowing across calls in a long `isinstance` elif chain.
-fn large_isinstance_narrowing_across_calls_code(mixed_calls: bool) -> String {
+/// Regression benchmark for dropping failed earlier `isinstance` checks after branches that
+/// contain ordinary calls merge.
+///
+/// Every matching branch reaches the statements after the chain, so the merged type should be
+/// `C0 | C1 | ...` without retaining the failed checks from the preceding branches.
+///
+/// Sample code structure:
+/// ```python
+/// def f(obj: Base) -> None:
+///     if isinstance(obj, C0):
+///         noop()
+///     elif isinstance(obj, C1):
+///         noop()
+///     ...
+///     else:
+///         return
+///
+///     obj
+///     obj
+///     ...
+/// ```
+fn benchmark_large_isinstance_narrowing_across_calls(criterion: &mut Criterion) {
     const NUM_CLASSES: usize = 50;
     const NUM_USES: usize = 10;
+
+    setup_rayon();
 
     let mut code = "class Base: ...\n".to_string();
     for i in 0..NUM_CLASSES {
@@ -1018,10 +1040,68 @@ fn large_isinstance_narrowing_across_calls_code(mixed_calls: bool) -> String {
         } else {
             writeln!(&mut code, "    elif isinstance(obj, C{i}):").ok();
         }
-        if mixed_calls && i > 0 {
-            code.push_str("        pass\n");
-        } else {
+        code.push_str("        noop()\n");
+    }
+    code.push_str("    else:\n        return\n\n");
+    for _ in 0..NUM_USES {
+        code.push_str("    obj\n");
+    }
+
+    criterion.bench_function("ty_micro[large_isinstance_narrowing_across_calls]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Regression benchmark for dropping failed earlier `isinstance` checks when branches with and
+/// without ordinary calls merge.
+///
+/// Every matching branch reaches the statements after the chain, but only the first branch
+/// contains a call. The merged type should still be `C0 | C1 | ...` without retaining the failed
+/// checks from the preceding branches.
+///
+/// Sample code structure:
+/// ```python
+/// def f(obj: Base) -> None:
+///     if isinstance(obj, C0):
+///         noop()
+///     elif isinstance(obj, C1):
+///         pass
+///     ...
+///     else:
+///         return
+///
+///     obj
+///     obj
+///     ...
+/// ```
+fn benchmark_large_isinstance_narrowing_mixed_calls(criterion: &mut Criterion) {
+    const NUM_CLASSES: usize = 50;
+    const NUM_USES: usize = 10;
+
+    setup_rayon();
+
+    let mut code = "class Base: ...\n".to_string();
+    for i in 0..NUM_CLASSES {
+        writeln!(&mut code, "class C{i}(Base): ...").ok();
+    }
+    code.push_str("\ndef noop() -> None: ...\n\n");
+
+    code.push_str("def f(obj: Base) -> None:\n");
+    for i in 0..NUM_CLASSES {
+        if i == 0 {
+            writeln!(&mut code, "    if isinstance(obj, C{i}):").ok();
             code.push_str("        noop()\n");
+        } else {
+            writeln!(&mut code, "    elif isinstance(obj, C{i}):").ok();
+            code.push_str("        pass\n");
         }
     }
     code.push_str("    else:\n        return\n\n");
@@ -1029,29 +1109,17 @@ fn large_isinstance_narrowing_across_calls_code(mixed_calls: bool) -> String {
         code.push_str("    obj\n");
     }
 
-    code
-}
-
-fn benchmark_large_isinstance_narrowing_across_calls(criterion: &mut Criterion) {
-    setup_rayon();
-
-    for (name, mixed_calls) in [
-        ("ty_micro[large_isinstance_narrowing_across_calls]", false),
-        ("ty_micro[large_isinstance_narrowing_mixed_calls]", true),
-    ] {
-        let code = large_isinstance_narrowing_across_calls_code(mixed_calls);
-        criterion.bench_function(name, |b| {
-            b.iter_batched_ref(
-                || setup_micro_case(&code),
-                |case| {
-                    let Case { db, .. } = case;
-                    let result = db.check();
-                    assert_eq!(result.len(), 0);
-                },
-                BatchSize::SmallInput,
-            );
-        });
-    }
+    criterion.bench_function("ty_micro[large_isinstance_narrowing_mixed_calls]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
 }
 
 const NUM_LITERAL_FALLTHROUGH_ARMS: usize = 40;
@@ -1637,6 +1705,7 @@ criterion_group!(
     benchmark_large_union_narrowing,
     benchmark_large_isinstance_narrowing,
     benchmark_large_isinstance_narrowing_across_calls,
+    benchmark_large_isinstance_narrowing_mixed_calls,
     benchmark_literal_match_fallthrough,
     benchmark_literal_match_fallthrough_guarded_any,
     benchmark_literal_equality_fallthrough_guarded_any,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -959,22 +959,49 @@ fn benchmark_large_union_narrowing(criterion: &mut Criterion) {
 /// class C1(Base): ...
 /// ...
 ///
-/// def noop() -> None: ...
-///
 /// def f(obj: Base) -> None:
 ///     if isinstance(obj, C0):
-///         noop()
+///         pass
 ///     elif isinstance(obj, C1):
-///         noop()
-///     ...
-///     else:
-///         return
-///
-///     obj
-///     obj
+///         pass
 ///     ...
 /// ```
-fn large_isinstance_narrowing_code(mixed_calls: bool) -> String {
+fn benchmark_large_isinstance_narrowing(criterion: &mut Criterion) {
+    const NUM_CLASSES: usize = 50;
+
+    setup_rayon();
+
+    let mut code = "class Base: ...\n".to_string();
+    for i in 0..NUM_CLASSES {
+        writeln!(&mut code, "class C{i}(Base): ...").ok();
+    }
+    code.push('\n');
+
+    code.push_str("def f(obj: Base) -> None:\n");
+    for i in 0..NUM_CLASSES {
+        if i == 0 {
+            writeln!(&mut code, "    if isinstance(obj, C{i}):").ok();
+        } else {
+            writeln!(&mut code, "    elif isinstance(obj, C{i}):").ok();
+        }
+        code.push_str("        pass\n");
+    }
+
+    criterion.bench_function("ty_micro[large_isinstance_narrowing]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Benchmark for preserving compact narrowing across calls in a long `isinstance` elif chain.
+fn large_isinstance_narrowing_across_calls_code(mixed_calls: bool) -> String {
     const NUM_CLASSES: usize = 50;
     const NUM_USES: usize = 10;
 
@@ -1005,11 +1032,11 @@ fn large_isinstance_narrowing_code(mixed_calls: bool) -> String {
     code
 }
 
-fn benchmark_large_isinstance_narrowing(criterion: &mut Criterion) {
+fn benchmark_large_isinstance_narrowing_across_calls(criterion: &mut Criterion) {
     setup_rayon();
 
-    let code = large_isinstance_narrowing_code(false);
-    criterion.bench_function("ty_micro[large_isinstance_narrowing]", |b| {
+    let code = large_isinstance_narrowing_across_calls_code(false);
+    criterion.bench_function("ty_micro[large_isinstance_narrowing_across_calls]", |b| {
         b.iter_batched_ref(
             || setup_micro_case(&code),
             |case| {
@@ -1021,7 +1048,7 @@ fn benchmark_large_isinstance_narrowing(criterion: &mut Criterion) {
         );
     });
 
-    let code = large_isinstance_narrowing_code(true);
+    let code = large_isinstance_narrowing_across_calls_code(true);
     criterion.bench_function("ty_micro[large_isinstance_narrowing_mixed_calls]", |b| {
         b.iter_batched_ref(
             || setup_micro_case(&code),
@@ -1617,6 +1644,7 @@ criterion_group!(
     benchmark_very_large_tuple,
     benchmark_large_union_narrowing,
     benchmark_large_isinstance_narrowing,
+    benchmark_large_isinstance_narrowing_across_calls,
     benchmark_literal_match_fallthrough,
     benchmark_literal_match_fallthrough_guarded_any,
     benchmark_literal_equality_fallthrough_guarded_any,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -974,11 +974,9 @@ fn benchmark_large_union_narrowing(criterion: &mut Criterion) {
 ///     obj
 ///     ...
 /// ```
-fn benchmark_large_isinstance_narrowing(criterion: &mut Criterion) {
+fn large_isinstance_narrowing_code(mixed_calls: bool) -> String {
     const NUM_CLASSES: usize = 50;
     const NUM_USES: usize = 10;
-
-    setup_rayon();
 
     let mut code = "class Base: ...\n".to_string();
     for i in 0..NUM_CLASSES {
@@ -993,14 +991,38 @@ fn benchmark_large_isinstance_narrowing(criterion: &mut Criterion) {
         } else {
             writeln!(&mut code, "    elif isinstance(obj, C{i}):").ok();
         }
-        code.push_str("        noop()\n");
+        if mixed_calls && i > 0 {
+            code.push_str("        pass\n");
+        } else {
+            code.push_str("        noop()\n");
+        }
     }
     code.push_str("    else:\n        return\n\n");
     for _ in 0..NUM_USES {
         code.push_str("    obj\n");
     }
 
+    code
+}
+
+fn benchmark_large_isinstance_narrowing(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let code = large_isinstance_narrowing_code(false);
     criterion.bench_function("ty_micro[large_isinstance_narrowing]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    let code = large_isinstance_narrowing_code(true);
+    criterion.bench_function("ty_micro[large_isinstance_narrowing_mixed_calls]", |b| {
         b.iter_batched_ref(
             || setup_micro_case(&code),
             |case| {

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -959,15 +959,24 @@ fn benchmark_large_union_narrowing(criterion: &mut Criterion) {
 /// class C1(Base): ...
 /// ...
 ///
+/// def noop() -> None: ...
+///
 /// def f(obj: Base) -> None:
 ///     if isinstance(obj, C0):
-///         pass
+///         noop()
 ///     elif isinstance(obj, C1):
-///         pass
+///         noop()
+///     ...
+///     else:
+///         return
+///
+///     obj
+///     obj
 ///     ...
 /// ```
 fn benchmark_large_isinstance_narrowing(criterion: &mut Criterion) {
     const NUM_CLASSES: usize = 50;
+    const NUM_USES: usize = 10;
 
     setup_rayon();
 
@@ -975,7 +984,7 @@ fn benchmark_large_isinstance_narrowing(criterion: &mut Criterion) {
     for i in 0..NUM_CLASSES {
         writeln!(&mut code, "class C{i}(Base): ...").ok();
     }
-    code.push('\n');
+    code.push_str("\ndef noop() -> None: ...\n\n");
 
     code.push_str("def f(obj: Base) -> None:\n");
     for i in 0..NUM_CLASSES {
@@ -984,7 +993,11 @@ fn benchmark_large_isinstance_narrowing(criterion: &mut Criterion) {
         } else {
             writeln!(&mut code, "    elif isinstance(obj, C{i}):").ok();
         }
-        code.push_str("        pass\n");
+        code.push_str("        noop()\n");
+    }
+    code.push_str("    else:\n        return\n\n");
+    for _ in 0..NUM_USES {
+        code.push_str("    obj\n");
     }
 
     criterion.bench_function("ty_micro[large_isinstance_narrowing]", |b| {

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1035,31 +1035,23 @@ fn large_isinstance_narrowing_across_calls_code(mixed_calls: bool) -> String {
 fn benchmark_large_isinstance_narrowing_across_calls(criterion: &mut Criterion) {
     setup_rayon();
 
-    let code = large_isinstance_narrowing_across_calls_code(false);
-    criterion.bench_function("ty_micro[large_isinstance_narrowing_across_calls]", |b| {
-        b.iter_batched_ref(
-            || setup_micro_case(&code),
-            |case| {
-                let Case { db, .. } = case;
-                let result = db.check();
-                assert_eq!(result.len(), 0);
-            },
-            BatchSize::SmallInput,
-        );
-    });
-
-    let code = large_isinstance_narrowing_across_calls_code(true);
-    criterion.bench_function("ty_micro[large_isinstance_narrowing_mixed_calls]", |b| {
-        b.iter_batched_ref(
-            || setup_micro_case(&code),
-            |case| {
-                let Case { db, .. } = case;
-                let result = db.check();
-                assert_eq!(result.len(), 0);
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    for (name, mixed_calls) in [
+        ("ty_micro[large_isinstance_narrowing_across_calls]", false),
+        ("ty_micro[large_isinstance_narrowing_mixed_calls]", true),
+    ] {
+        let code = large_isinstance_narrowing_across_calls_code(mixed_calls);
+        criterion.bench_function(name, |b| {
+            b.iter_batched_ref(
+                || setup_micro_case(&code),
+                |case| {
+                    let Case { db, .. } = case;
+                    let result = db.check();
+                    assert_eq!(result.len(), 0);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
 }
 
 const NUM_LITERAL_FALLTHROUGH_ARMS: usize = 40;

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1215,6 +1215,68 @@ fn benchmark_typeis_narrowing(criterion: &mut Criterion) {
     });
 }
 
+/// Regression benchmark for repeatedly using a value after a long `TypeIs` `elif` chain.
+///
+/// Every matching branch reaches the calls after the chain, while the `else` branch returns. The
+/// merged type should be `C0 | C1 | ...` instead of keeping `not C0`, `not C1`, and so on in each
+/// later branch.
+fn benchmark_typeis_elif_narrowing(criterion: &mut Criterion) {
+    const NUM_CLASSES: usize = 40;
+    const LOADS_AFTER_CHAIN: usize = 10;
+
+    setup_rayon();
+
+    let mut code = r#"
+from typing import TypeVar
+from typing_extensions import TypeIs
+
+T = TypeVar("T")
+
+class Source: ...
+"#
+    .to_string();
+
+    for i in 0..NUM_CLASSES {
+        writeln!(&mut code, "class C{i}(Source): ...").ok();
+    }
+
+    code.push_str(
+        r#"
+def istype(value: object, cls: type[T]) -> TypeIs[T]:
+    raise NotImplementedError
+
+def consume(value: object) -> None: ...
+
+def check(source: Source) -> None:
+"#,
+    );
+
+    for i in 0..NUM_CLASSES {
+        if i == 0 {
+            writeln!(&mut code, "    if istype(source, C{i}):").ok();
+        } else {
+            writeln!(&mut code, "    elif istype(source, C{i}):").ok();
+        }
+        code.push_str("        pass\n");
+    }
+    code.push_str("    else:\n        return\n\n");
+    for _ in 0..LOADS_AFTER_CHAIN {
+        code.push_str("    consume(source)\n");
+    }
+
+    criterion.bench_function("ty_micro[typeis_elif_narrowing]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 fn benchmark_pandas_tdd(criterion: &mut Criterion) {
     setup_rayon();
 
@@ -1524,6 +1586,7 @@ criterion_group!(
     benchmark_literal_match_fallthrough_guarded_any,
     benchmark_literal_equality_fallthrough_guarded_any,
     benchmark_typeis_narrowing,
+    benchmark_typeis_elif_narrowing,
     benchmark_pandas_tdd,
     benchmark_recursive_typed_dict_union_contextual_inference,
     benchmark_pydantic_core_schema_dict,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3899,22 +3899,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                         if self.in_function_scope() {
                             self.record_reachability_constraint_id(predicate_id);
-
-                            // Also gate narrowing by this constraint: if the call returns
-                            // `Never`, any narrowing in the current branch should be
-                            // invalidated (since this path is unreachable). This enables
-                            // narrowing to be preserved after if-statements where one branch
-                            // calls a `NoReturn` function like `sys.exit()`.
-                            self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
-                        } else {
-                            // In non-function scopes, we only record a narrowing constraint
-                            // (not a reachability constraint). Recording reachability for
-                            // calls in module scope is simply too expensive, and it's not
-                            // too important of a use case.
-                            self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
                         }
+
+                        // Gate narrowing by this constraint: if the call returns `Never`, any
+                        // narrowing in the current branch should be invalidated. In non-function
+                        // scopes, only record narrowing because call reachability is too expensive.
+                        self.current_use_def_map_mut()
+                            .record_narrowing_constraint_for_all_places(narrowing_constraint);
                     }
                 }
             }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3192,33 +3192,41 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.visit_body(clause_body);
                 }
 
-                let final_clause = self.flow_snapshot();
-                let mut preceding_predicates = Vec::with_capacity(post_clauses.len());
-                let mut merged_reachable_clause = false;
+                // An ordinary `if` only has one saved branch. Keep the final branch in place so
+                // that we avoid cloning the entire flow state just to merge the two branches.
+                if post_clauses.len() == 1
+                    && let Some((post_clause_state, _)) = post_clauses.pop()
+                {
+                    self.flow_merge(post_clause_state);
+                } else {
+                    let final_clause = self.flow_snapshot();
+                    let mut preceding_predicates = Vec::with_capacity(post_clauses.len());
+                    let mut merged_reachable_clause = false;
 
-                for (post_clause_state, predicate) in post_clauses {
-                    if !post_clause_state.is_always_unreachable() {
-                        if merged_reachable_clause {
-                            self.flow_merge_after_branches(
-                                post_clause_state,
-                                &preceding_predicates,
-                            );
-                        } else {
-                            self.flow_restore(post_clause_state);
-                            merged_reachable_clause = true;
+                    for (post_clause_state, predicate) in post_clauses {
+                        if !post_clause_state.is_always_unreachable() {
+                            if merged_reachable_clause {
+                                self.flow_merge_after_branches(
+                                    post_clause_state,
+                                    &preceding_predicates,
+                                );
+                            } else {
+                                self.flow_restore(post_clause_state);
+                                merged_reachable_clause = true;
+                            }
                         }
+                        preceding_predicates.push(predicate);
                     }
-                    preceding_predicates.push(predicate);
-                }
 
-                if !final_clause.is_always_unreachable() {
-                    if merged_reachable_clause {
-                        self.flow_merge_after_branches(final_clause, &preceding_predicates);
-                    } else {
+                    if !final_clause.is_always_unreachable() {
+                        if merged_reachable_clause {
+                            self.flow_merge_after_branches(final_clause, &preceding_predicates);
+                        } else {
+                            self.flow_restore(final_clause);
+                        }
+                    } else if !merged_reachable_clause {
                         self.flow_restore(final_clause);
                     }
-                } else if !merged_reachable_clause {
-                    self.flow_restore(final_clause);
                 }
 
                 self.in_type_checking_block = is_outer_block_in_type_checking;

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1209,6 +1209,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.current_use_def_map_mut().merge(state);
     }
 
+    fn flow_merge_after_branches(
+        &mut self,
+        state: FlowSnapshot,
+        preceding_branch_predicates: &[ScopedPredicateId],
+    ) {
+        self.current_use_def_map_mut()
+            .merge_after_branches(state, preceding_branch_predicates);
+    }
+
     /// Add a symbol to the place table and the use-def map.
     /// Return the [`ScopedPlaceId`] that uniquely identifies the symbol in both.
     fn add_symbol(&mut self, name: Name) -> ScopedSymbolId {
@@ -1623,7 +1632,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     .reachability_constraints
                     .mark_used(live_binding.reachability_constraint());
                 use_def
-                    .reachability_constraints
+                    .narrowing_constraints
                     .mark_used(live_binding.narrowing_constraint());
             }
         }
@@ -1773,7 +1782,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     /// Adds and records a narrowing constraint for only the places that could possibly be narrowed.
     ///
     /// Returns the `ScopedPredicateId` for the positive predicate, which can later be passed to
-    /// `record_negated_narrowing_constraint` for TDD-level negation.
+    /// `record_negated_narrowing_constraint` to record the opposite result of the same check.
     fn record_narrowing_constraint(
         &mut self,
         predicate: PredicateOrLiteral<'db>,
@@ -1824,9 +1833,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     /// Negates the given predicate and then adds it as a narrowing constraint to the places
     /// that could possibly be narrowed.
     ///
-    /// Takes the `ScopedPredicateId` from the positive recording so that TDD-level negation
-    /// (`add_not_constraint`) uses the same atom. This ensures `atom(P) OR NOT(atom(P))`
-    /// simplifies to `ALWAYS_TRUE`, correctly cancelling narrowing after complete if/else blocks.
+    /// Takes the `ScopedPredicateId` from the positive recording so that both constraints refer to
+    /// the same check. This lets the positive and negative cases cancel after a complete
+    /// `if`/`else`.
     fn record_negated_narrowing_constraint(
         &mut self,
         predicate: PredicateOrLiteral<'db>,
@@ -3117,7 +3126,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 self.visit_body(&node.body);
 
-                let mut post_clauses: Vec<FlowSnapshot> = vec![];
+                let mut post_clauses: Vec<(FlowSnapshot, ScopedPredicateId)> = vec![];
                 let elif_else_clauses = node
                     .elif_else_clauses
                     .iter()
@@ -3137,7 +3146,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 for (clause_test, clause_body) in elif_else_clauses {
                     // snapshot after every block except the last; the last one will just become
                     // the state that we merge the other snapshots into
-                    post_clauses.push(self.flow_snapshot());
+                    post_clauses.push((self.flow_snapshot(), last_narrowing_id));
                     // we can only take an elif/else branch if none of the previous ones were
                     // taken
                     self.flow_restore(condition_flow_snapshot.falsy());
@@ -3183,8 +3192,33 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     self.visit_body(clause_body);
                 }
 
-                for post_clause_state in post_clauses {
-                    self.flow_merge(post_clause_state);
+                let final_clause = self.flow_snapshot();
+                let mut preceding_predicates = Vec::with_capacity(post_clauses.len());
+                let mut merged_reachable_clause = false;
+
+                for (post_clause_state, predicate) in post_clauses {
+                    if !post_clause_state.is_always_unreachable() {
+                        if merged_reachable_clause {
+                            self.flow_merge_after_branches(
+                                post_clause_state,
+                                &preceding_predicates,
+                            );
+                        } else {
+                            self.flow_restore(post_clause_state);
+                            merged_reachable_clause = true;
+                        }
+                    }
+                    preceding_predicates.push(predicate);
+                }
+
+                if !final_clause.is_always_unreachable() {
+                    if merged_reachable_clause {
+                        self.flow_merge_after_branches(final_clause, &preceding_predicates);
+                    } else {
+                        self.flow_restore(final_clause);
+                    }
+                } else if !merged_reachable_clause {
+                    self.flow_restore(final_clause);
                 }
 
                 self.in_type_checking_block = is_outer_block_in_type_checking;
@@ -3422,8 +3456,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             node: PredicateNode::Expression(guard_expr),
                             is_positive: true,
                         });
-                        // Add the predicate once, then use TDD-level negation for the failure
-                        // path. This ensures the positive and negative atoms share the same ID.
+                        // Use the same predicate ID for the successful and failed checks.
                         let guard_predicate_id = self.add_predicate(predicate);
                         let possibly_narrowed = self.compute_possibly_narrowed_places(&predicate);
                         self.flow_restore(condition_flow_snapshot.falsy());
@@ -3857,10 +3890,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             is_positive: true,
                         };
 
+                        let predicate_id =
+                            self.add_predicate(PredicateOrLiteral::Predicate(predicate));
+                        let narrowing_constraint = self
+                            .current_use_def_map_mut()
+                            .narrowing_constraints
+                            .add_atom(predicate_id);
+
                         if self.in_function_scope() {
-                            let constraint = self.record_reachability_constraint(
-                                PredicateOrLiteral::Predicate(predicate),
-                            );
+                            self.record_reachability_constraint_id(predicate_id);
 
                             // Also gate narrowing by this constraint: if the call returns
                             // `Never`, any narrowing in the current branch should be
@@ -3868,19 +3906,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             // narrowing to be preserved after if-statements where one branch
                             // calls a `NoReturn` function like `sys.exit()`.
                             self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(constraint);
+                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
                         } else {
                             // In non-function scopes, we only record a narrowing constraint
                             // (not a reachability constraint). Recording reachability for
                             // calls in module scope is simply too expensive, and it's not
                             // too important of a use case.
-                            let predicate_id =
-                                self.add_predicate(PredicateOrLiteral::Predicate(predicate));
-                            let constraint = self
-                                .current_reachability_constraints_mut()
-                                .add_atom(predicate_id);
                             self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(constraint);
+                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
                         }
                     }
                 }

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -1,30 +1,645 @@
 //! # Narrowing constraints
 //!
-//! When building a semantic index for a file, we associate each binding with a _narrowing
-//! constraint_, which constrains the type of the binding's place. Note that a binding can be
-//! associated with a different narrowing constraint at different points in a file. See the
-//! `use_def` module for more details.
+//! When building a semantic index for a file, we associate each binding with a narrowing
+//! constraint, which constrains the type of the binding's place. A binding can be associated with
+//! a different narrowing constraint at different points in a file. See the `use_def` module for
+//! more details.
 //!
-//! Narrowing constraints are represented as TDD (ternary decision diagram) nodes, sharing the
-//! same graph as reachability constraints. This allows narrowing constraints to support AND, OR,
-//! and NOT operations, which is essential for correctly preserving narrowing information across
-//! control flow merges (e.g. after if/elif/else with terminal branches).
+//! A narrowing constraint is a boolean formula over predicates such as `isinstance(x, A)`.
+//! Internally, we store these formulas in a ternary decision diagram (TDD). Each interior node has
+//! three outgoing edges:
 //!
-//! [`Predicate`]: crate::predicate::Predicate
+//! - `if_true` applies when the predicate is true.
+//! - `if_false` applies when the predicate is false.
+//! - `if_uncertain` applies either way.
+//!
+//! Despite its name, `if_uncertain` does not mean that the predicate's value is unknown. It is a
+//! "don't care" edge: the formula on that edge does not depend on the predicate. A node represents
+//! this formula:
+//!
+//! ```text
+//! if_uncertain OR (predicate AND if_true) OR (NOT predicate AND if_false)
+//! ```
+//!
+//! The extra edge keeps repeated unions small. For example, `A OR B` can store `A` once on `B`'s
+//! `if_uncertain` edge instead of copying `A` into both of `B`'s other edges.
+
+use std::cmp::Ordering;
+
+use ruff_index::{Idx, IndexVec};
+use rustc_hash::FxHashMap;
 
 use crate::ast_ids::ScopedUseId;
-use crate::reachability_constraints::ScopedReachabilityConstraintId;
+use crate::predicate::ScopedPredicateId;
+use crate::rank::RankBitBox;
 use crate::scope::FileScopeId;
 
-/// A narrowing constraint associated with a live binding.
+/// The ID of a narrowing formula within one scope.
 ///
-/// This is a TDD node ID in the shared reachability constraints graph.
-/// `ALWAYS_TRUE` means "no narrowing constraint" (the base type is unchanged).
-pub type ScopedNarrowingConstraint = ScopedReachabilityConstraintId;
+/// `ALWAYS_TRUE` means that no narrowing applies. `ALWAYS_FALSE` means that the path is
+/// impossible.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct ScopedNarrowingConstraint(u32);
+
+impl ScopedNarrowingConstraint {
+    pub const ALWAYS_TRUE: Self = Self(u32::MAX);
+    pub const ALWAYS_FALSE: Self = Self(u32::MAX - 1);
+
+    pub fn is_terminal(self) -> bool {
+        self.0 >= Self::ALWAYS_FALSE.0
+    }
+}
+
+impl Idx for ScopedNarrowingConstraint {
+    fn new(value: usize) -> Self {
+        assert!(value <= Self::ALWAYS_FALSE.0 as usize);
+        #[expect(clippy::cast_possible_truncation)]
+        Self(value as u32)
+    }
+
+    fn index(self) -> usize {
+        debug_assert!(!self.is_terminal());
+        self.0 as usize
+    }
+}
+
+const ALWAYS_TRUE: ScopedNarrowingConstraint = ScopedNarrowingConstraint::ALWAYS_TRUE;
+const ALWAYS_FALSE: ScopedNarrowingConstraint = ScopedNarrowingConstraint::ALWAYS_FALSE;
+
+/// Once a scope reaches this limit, operations return `ALWAYS_TRUE`. Dropping narrowing is less
+/// precise, but avoids exponential growth on pathological input.
+const MAX_INTERIOR_NODES: usize = 512 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize)]
+pub struct InteriorNode {
+    /// The predicate tested by this node.
+    atom: ScopedPredicateId,
+    /// The remaining formula when the predicate is true.
+    if_true: ScopedNarrowingConstraint,
+    /// The part of the formula that applies regardless of the predicate.
+    if_uncertain: ScopedNarrowingConstraint,
+    /// The remaining formula when the predicate is false.
+    if_false: ScopedNarrowingConstraint,
+}
+
+impl InteriorNode {
+    pub const fn atom(self) -> ScopedPredicateId {
+        self.atom
+    }
+
+    pub const fn if_true(self) -> ScopedNarrowingConstraint {
+        self.if_true
+    }
+
+    pub const fn if_uncertain(self) -> ScopedNarrowingConstraint {
+        self.if_uncertain
+    }
+
+    pub const fn if_false(self) -> ScopedNarrowingConstraint {
+        self.if_false
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+pub struct NarrowingConstraints {
+    used_interiors: Box<[InteriorNode]>,
+    used_indices: Option<Box<RankBitBox>>,
+}
+
+impl NarrowingConstraints {
+    pub fn get_interior_node(&self, id: ScopedNarrowingConstraint) -> InteriorNode {
+        debug_assert!(!id.is_terminal());
+        let raw_index = id.0 as usize;
+        if let Some(used_indices) = &self.used_indices {
+            debug_assert!(
+                used_indices.get_bit(raw_index).unwrap_or(false),
+                "all used narrowing constraints should have been marked as used",
+            );
+            self.used_interiors[used_indices.rank(raw_index) as usize]
+        } else {
+            self.used_interiors[raw_index]
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct NarrowingConstraintsBuilder {
+    interiors: IndexVec<ScopedNarrowingConstraint, InteriorNode>,
+    interior_used: IndexVec<ScopedNarrowingConstraint, bool>,
+    interior_cache: FxHashMap<InteriorNode, ScopedNarrowingConstraint>,
+    and_cache: FxHashMap<
+        (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
+        ScopedNarrowingConstraint,
+    >,
+    or_cache: FxHashMap<
+        (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
+        ScopedNarrowingConstraint,
+    >,
+    remove_predicate_cache:
+        FxHashMap<(ScopedNarrowingConstraint, ScopedPredicateId), ScopedNarrowingConstraint>,
+    bdd_or_cache: FxHashMap<
+        (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
+        ScopedNarrowingConstraint,
+    >,
+    bdd_projection_cache: FxHashMap<ScopedNarrowingConstraint, ScopedNarrowingConstraint>,
+}
+
+impl NarrowingConstraintsBuilder {
+    pub(crate) fn build(self) -> NarrowingConstraints {
+        if self.interior_used.iter().all(|used| *used) {
+            NarrowingConstraints {
+                used_interiors: self.interiors.raw.into_boxed_slice(),
+                used_indices: None,
+            }
+        } else {
+            let used_indices = RankBitBox::from_bits(self.interior_used.iter().copied());
+            let used_interiors = self
+                .interiors
+                .into_iter()
+                .zip(self.interior_used)
+                .filter_map(|(interior, used)| used.then_some(interior))
+                .collect();
+            NarrowingConstraints {
+                used_interiors,
+                used_indices: Some(Box::new(used_indices)),
+            }
+        }
+    }
+
+    pub(crate) fn mark_used(&mut self, node: ScopedNarrowingConstraint) {
+        if !node.is_terminal() && !self.interior_used[node] {
+            self.interior_used[node] = true;
+            let node = self.interiors[node];
+            self.mark_used(node.if_true);
+            self.mark_used(node.if_uncertain);
+            self.mark_used(node.if_false);
+        }
+    }
+
+    fn cmp_atoms(&self, a: ScopedNarrowingConstraint, b: ScopedNarrowingConstraint) -> Ordering {
+        if a == b || (a.is_terminal() && b.is_terminal()) {
+            Ordering::Equal
+        } else if a.is_terminal() {
+            Ordering::Greater
+        } else if b.is_terminal() {
+            Ordering::Less
+        } else {
+            self.interiors[a]
+                .atom
+                .cmp(&self.interiors[b].atom)
+                .reverse()
+        }
+    }
+
+    fn add_interior(&mut self, node: InteriorNode) -> ScopedNarrowingConstraint {
+        if node.if_uncertain == ALWAYS_TRUE {
+            return ALWAYS_TRUE;
+        }
+        if node.if_true == node.if_false {
+            return self.add_or_constraint(node.if_true, node.if_uncertain);
+        }
+
+        *self.interior_cache.entry(node).or_insert_with(|| {
+            self.interior_used.push(false);
+            self.interiors.push(node)
+        })
+    }
+
+    pub(crate) fn add_atom(&mut self, predicate: ScopedPredicateId) -> ScopedNarrowingConstraint {
+        if predicate == ScopedPredicateId::ALWAYS_FALSE {
+            ALWAYS_FALSE
+        } else if predicate == ScopedPredicateId::ALWAYS_TRUE {
+            ALWAYS_TRUE
+        } else {
+            self.add_interior(InteriorNode {
+                atom: predicate,
+                if_true: ALWAYS_TRUE,
+                if_uncertain: ALWAYS_FALSE,
+                if_false: ALWAYS_FALSE,
+            })
+        }
+    }
+
+    pub(crate) fn add_negated_atom(
+        &mut self,
+        predicate: ScopedPredicateId,
+    ) -> ScopedNarrowingConstraint {
+        if predicate == ScopedPredicateId::ALWAYS_FALSE {
+            ALWAYS_TRUE
+        } else if predicate == ScopedPredicateId::ALWAYS_TRUE {
+            ALWAYS_FALSE
+        } else {
+            self.add_interior(InteriorNode {
+                atom: predicate,
+                if_true: ALWAYS_FALSE,
+                if_uncertain: ALWAYS_FALSE,
+                if_false: ALWAYS_TRUE,
+            })
+        }
+    }
+
+    pub(crate) fn add_or_constraint(
+        &mut self,
+        a: ScopedNarrowingConstraint,
+        b: ScopedNarrowingConstraint,
+    ) -> ScopedNarrowingConstraint {
+        match (a, b) {
+            (ALWAYS_TRUE, _) | (_, ALWAYS_TRUE) => return ALWAYS_TRUE,
+            (ALWAYS_FALSE, other) | (other, ALWAYS_FALSE) => return other,
+            _ if a == b => return a,
+            _ => {}
+        }
+
+        let (a, b) = if b.0 < a.0 { (b, a) } else { (a, b) };
+        if let Some(cached) = self.or_cache.get(&(a, b)) {
+            return *cached;
+        }
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return ALWAYS_TRUE;
+        }
+
+        let result = match self.cmp_atoms(a, b) {
+            Ordering::Equal => {
+                let a_node = self.interiors[a];
+                let b_node = self.interiors[b];
+                let if_true = self.add_or_constraint(a_node.if_true, b_node.if_true);
+                let if_uncertain = self.add_or_constraint(a_node.if_uncertain, b_node.if_uncertain);
+                let if_false = self.add_or_constraint(a_node.if_false, b_node.if_false);
+                self.add_interior(InteriorNode {
+                    atom: a_node.atom,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                })
+            }
+            Ordering::Less => {
+                let node = self.interiors[a];
+                let if_uncertain = self.add_or_constraint(node.if_uncertain, b);
+                self.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true: node.if_true,
+                    if_uncertain,
+                    if_false: node.if_false,
+                })
+            }
+            Ordering::Greater => {
+                let node = self.interiors[b];
+                let if_uncertain = self.add_or_constraint(a, node.if_uncertain);
+                self.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true: node.if_true,
+                    if_uncertain,
+                    if_false: node.if_false,
+                })
+            }
+        };
+
+        self.or_cache.insert((a, b), result);
+        result
+    }
+
+    /// Combines two formulas as an ordinary BDD, without creating `if_uncertain` edges.
+    ///
+    /// Other control-flow merges use this operation so they keep producing narrowed types in the
+    /// same order as before. The `if`/`elif` continuation merge uses
+    /// [`Self::add_or_constraint`] to avoid copying every earlier branch into every later one.
+    pub(crate) fn add_bdd_or_constraint(
+        &mut self,
+        a: ScopedNarrowingConstraint,
+        b: ScopedNarrowingConstraint,
+    ) -> ScopedNarrowingConstraint {
+        let a = self.project_to_bdd(a);
+        let b = self.project_to_bdd(b);
+        self.add_bdd_or(a, b)
+    }
+
+    pub(crate) fn add_and_constraint(
+        &mut self,
+        a: ScopedNarrowingConstraint,
+        b: ScopedNarrowingConstraint,
+    ) -> ScopedNarrowingConstraint {
+        match (a, b) {
+            (ALWAYS_FALSE, _) | (_, ALWAYS_FALSE) => return ALWAYS_FALSE,
+            (ALWAYS_TRUE, other) | (other, ALWAYS_TRUE) => return other,
+            _ if a == b => return a,
+            _ => {}
+        }
+
+        let (a, b) = if b.0 < a.0 { (b, a) } else { (a, b) };
+        if let Some(cached) = self.and_cache.get(&(a, b)) {
+            return *cached;
+        }
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return ALWAYS_TRUE;
+        }
+
+        let result = match self.cmp_atoms(a, b) {
+            Ordering::Equal => {
+                let a_node = self.interiors[a];
+                let b_node = self.interiors[b];
+
+                let b_true_or_uncertain =
+                    self.add_or_constraint(b_node.if_true, b_node.if_uncertain);
+                let true_from_a = self.add_and_constraint(a_node.if_true, b_true_or_uncertain);
+                let true_from_uncertain =
+                    self.add_and_constraint(a_node.if_uncertain, b_node.if_true);
+                let if_true = self.add_or_constraint(true_from_a, true_from_uncertain);
+
+                let if_uncertain =
+                    self.add_and_constraint(a_node.if_uncertain, b_node.if_uncertain);
+
+                let b_false_or_uncertain =
+                    self.add_or_constraint(b_node.if_false, b_node.if_uncertain);
+                let false_from_a = self.add_and_constraint(a_node.if_false, b_false_or_uncertain);
+                let false_from_uncertain =
+                    self.add_and_constraint(a_node.if_uncertain, b_node.if_false);
+                let if_false = self.add_or_constraint(false_from_a, false_from_uncertain);
+
+                self.add_interior(InteriorNode {
+                    atom: a_node.atom,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                })
+            }
+            Ordering::Less => {
+                let node = self.interiors[a];
+                let if_true = self.add_and_constraint(node.if_true, b);
+                let if_uncertain = self.add_and_constraint(node.if_uncertain, b);
+                let if_false = self.add_and_constraint(node.if_false, b);
+                self.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                })
+            }
+            Ordering::Greater => {
+                let node = self.interiors[b];
+                let if_true = self.add_and_constraint(a, node.if_true);
+                let if_uncertain = self.add_and_constraint(a, node.if_uncertain);
+                let if_false = self.add_and_constraint(a, node.if_false);
+                self.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                })
+            }
+        };
+
+        self.and_cache.insert((a, b), result);
+        result
+    }
+
+    /// Removes the listed predicates from a formula.
+    ///
+    /// The result is true whenever the original formula is true for either value of each removed
+    /// predicate.
+    pub(crate) fn remove_predicates(
+        &mut self,
+        mut constraint: ScopedNarrowingConstraint,
+        predicates: &[ScopedPredicateId],
+    ) -> ScopedNarrowingConstraint {
+        for &predicate in predicates {
+            constraint = self.remove_predicate(constraint, predicate);
+        }
+        constraint
+    }
+
+    fn remove_predicate(
+        &mut self,
+        constraint: ScopedNarrowingConstraint,
+        predicate: ScopedPredicateId,
+    ) -> ScopedNarrowingConstraint {
+        if constraint.is_terminal() {
+            return constraint;
+        }
+        if let Some(cached) = self.remove_predicate_cache.get(&(constraint, predicate)) {
+            return *cached;
+        }
+
+        let node = self.interiors[constraint];
+        let if_true = self.remove_predicate(node.if_true, predicate);
+        let if_uncertain = self.remove_predicate(node.if_uncertain, predicate);
+        let if_false = self.remove_predicate(node.if_false, predicate);
+        let result = if node.atom == predicate {
+            let either_branch = self.add_or_constraint(if_true, if_false);
+            self.add_or_constraint(either_branch, if_uncertain)
+        } else {
+            self.add_interior(InteriorNode {
+                atom: node.atom,
+                if_true,
+                if_uncertain,
+                if_false,
+            })
+        };
+        self.remove_predicate_cache
+            .insert((constraint, predicate), result);
+        result
+    }
+
+    pub(crate) fn are_equivalent(
+        &mut self,
+        a: ScopedNarrowingConstraint,
+        b: ScopedNarrowingConstraint,
+    ) -> bool {
+        self.project_to_bdd(a) == self.project_to_bdd(b)
+    }
+
+    /// Expands the `if_uncertain` edge into both other edges, producing a canonical BDD.
+    fn project_to_bdd(
+        &mut self,
+        constraint: ScopedNarrowingConstraint,
+    ) -> ScopedNarrowingConstraint {
+        match constraint {
+            ALWAYS_TRUE | ALWAYS_FALSE => constraint,
+            _ => {
+                if let Some(cached) = self.bdd_projection_cache.get(&constraint) {
+                    return *cached;
+                }
+                if self.interiors.len() >= MAX_INTERIOR_NODES {
+                    return ALWAYS_TRUE;
+                }
+
+                let node = self.interiors[constraint];
+                let if_true = self.project_to_bdd(node.if_true);
+                let if_uncertain = self.project_to_bdd(node.if_uncertain);
+                let if_false = self.project_to_bdd(node.if_false);
+                let if_true = self.add_bdd_or(if_true, if_uncertain);
+                let if_false = self.add_bdd_or(if_false, if_uncertain);
+                let result = self.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true,
+                    if_uncertain: ALWAYS_FALSE,
+                    if_false,
+                });
+                self.bdd_projection_cache.insert(constraint, result);
+                result
+            }
+        }
+    }
+
+    /// Computes OR for formulas that have already been converted to ordinary BDDs.
+    fn add_bdd_or(
+        &mut self,
+        a: ScopedNarrowingConstraint,
+        b: ScopedNarrowingConstraint,
+    ) -> ScopedNarrowingConstraint {
+        match (a, b) {
+            (ALWAYS_TRUE, _) | (_, ALWAYS_TRUE) => return ALWAYS_TRUE,
+            (ALWAYS_FALSE, other) | (other, ALWAYS_FALSE) => return other,
+            _ if a == b => return a,
+            _ => {}
+        }
+
+        let (a, b) = if b.0 < a.0 { (b, a) } else { (a, b) };
+        if let Some(cached) = self.bdd_or_cache.get(&(a, b)) {
+            return *cached;
+        }
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return ALWAYS_TRUE;
+        }
+
+        let result = match self.cmp_atoms(a, b) {
+            Ordering::Equal => {
+                let a_node = self.interiors[a];
+                let b_node = self.interiors[b];
+                debug_assert_eq!(a_node.if_uncertain, ALWAYS_FALSE);
+                debug_assert_eq!(b_node.if_uncertain, ALWAYS_FALSE);
+                let if_true = self.add_bdd_or(a_node.if_true, b_node.if_true);
+                let if_false = self.add_bdd_or(a_node.if_false, b_node.if_false);
+                self.add_interior(InteriorNode {
+                    atom: a_node.atom,
+                    if_true,
+                    if_uncertain: ALWAYS_FALSE,
+                    if_false,
+                })
+            }
+            Ordering::Less => {
+                let node = self.interiors[a];
+                debug_assert_eq!(node.if_uncertain, ALWAYS_FALSE);
+                let if_true = self.add_bdd_or(node.if_true, b);
+                let if_false = self.add_bdd_or(node.if_false, b);
+                self.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true,
+                    if_uncertain: ALWAYS_FALSE,
+                    if_false,
+                })
+            }
+            Ordering::Greater => {
+                let node = self.interiors[b];
+                debug_assert_eq!(node.if_uncertain, ALWAYS_FALSE);
+                let if_true = self.add_bdd_or(a, node.if_true);
+                let if_false = self.add_bdd_or(a, node.if_false);
+                self.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true,
+                    if_uncertain: ALWAYS_FALSE,
+                    if_false,
+                })
+            }
+        };
+        self.bdd_or_cache.insert((a, b), result);
+        result
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ConstraintKey {
     NarrowingConstraint(ScopedNarrowingConstraint),
     NestedScope(FileScopeId),
     UseId(ScopedUseId),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn predicate(index: usize) -> ScopedPredicateId {
+        ScopedPredicateId::new(index)
+    }
+
+    fn evaluate(
+        constraints: &NarrowingConstraintsBuilder,
+        constraint: ScopedNarrowingConstraint,
+        values: &[bool],
+    ) -> bool {
+        match constraint {
+            ALWAYS_TRUE => true,
+            ALWAYS_FALSE => false,
+            _ => {
+                let node = constraints.interiors[constraint];
+                evaluate(constraints, node.if_uncertain, values)
+                    || if values[node.atom.index()] {
+                        evaluate(constraints, node.if_true, values)
+                    } else {
+                        evaluate(constraints, node.if_false, values)
+                    }
+            }
+        }
+    }
+
+    #[test]
+    fn boolean_operations_match_their_truth_tables() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let a = constraints.add_atom(predicate(0));
+        let b = constraints.add_atom(predicate(1));
+
+        let a_or_b = constraints.add_or_constraint(a, b);
+        let not_c = constraints.add_negated_atom(predicate(2));
+        let formula = constraints.add_and_constraint(a_or_b, not_c);
+
+        for mask in 0_u8..8 {
+            let values = [mask & 0b001 != 0, mask & 0b010 != 0, mask & 0b100 != 0];
+            assert_eq!(
+                evaluate(&constraints, formula, &values),
+                (values[0] || values[1]) && !values[2],
+            );
+        }
+    }
+
+    #[test]
+    fn union_parks_the_other_operand_in_the_uncertain_branch() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let a = constraints.add_atom(predicate(0));
+        let b = constraints.add_atom(predicate(1));
+
+        let union = constraints.add_or_constraint(a, b);
+        let root = constraints.interiors[union];
+
+        assert_eq!(root.atom, predicate(1));
+        assert_eq!(root.if_true, ALWAYS_TRUE);
+        assert_eq!(root.if_uncertain, a);
+        assert_eq!(root.if_false, ALWAYS_FALSE);
+    }
+
+    #[test]
+    fn removing_a_predicate_accepts_either_value() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let b = constraints.add_atom(predicate(1));
+        let not_a = constraints.add_negated_atom(predicate(0));
+        let branch = constraints.add_and_constraint(not_a, b);
+
+        let without_a = constraints.remove_predicates(branch, &[predicate(0)]);
+
+        assert!(constraints.are_equivalent(without_a, b));
+    }
+
+    #[test]
+    fn removing_a_predicate_is_only_safe_after_a_preceding_branch_reaches_the_merge() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let a = constraints.add_atom(predicate(0));
+        let b = constraints.add_atom(predicate(1));
+        let not_a = constraints.add_negated_atom(predicate(0));
+        let later_branch = constraints.add_and_constraint(not_a, b);
+        let without_a = constraints.remove_predicates(later_branch, &[predicate(0)]);
+
+        let merged = constraints.add_or_constraint(a, later_branch);
+        let merged_without_a = constraints.add_or_constraint(a, without_a);
+        assert!(constraints.are_equivalent(merged, merged_without_a));
+
+        assert!(!constraints.are_equivalent(later_branch, without_a));
+    }
 }

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -308,6 +308,10 @@ impl NarrowingConstraintsBuilder {
         a: ScopedNarrowingConstraint,
         b: ScopedNarrowingConstraint,
     ) -> ScopedNarrowingConstraint {
+        if a == b {
+            return a;
+        }
+
         let a = self.project_to_bdd(a);
         let b = self.project_to_bdd(b);
         self.add_bdd_or(a, b)
@@ -613,6 +617,17 @@ mod tests {
         assert_eq!(root.if_true, ALWAYS_TRUE);
         assert_eq!(root.if_uncertain, a);
         assert_eq!(root.if_false, ALWAYS_FALSE);
+    }
+
+    #[test]
+    fn ordinary_merge_preserves_an_identical_tdd() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let a = constraints.add_atom(predicate(0));
+        let b = constraints.add_atom(predicate(1));
+        let union = constraints.add_or_constraint(a, b);
+
+        assert_ne!(constraints.interiors[union].if_uncertain, ALWAYS_FALSE);
+        assert_eq!(constraints.add_bdd_or_constraint(union, union), union);
     }
 
     #[test]

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -338,22 +338,35 @@ impl NarrowingConstraintsBuilder {
                 let a_node = self.interiors[a];
                 let b_node = self.interiors[b];
 
-                let b_true_or_uncertain =
-                    self.add_or_constraint(b_node.if_true, b_node.if_uncertain);
-                let true_from_a = self.add_and_constraint(a_node.if_true, b_true_or_uncertain);
-                let true_from_uncertain =
-                    self.add_and_constraint(a_node.if_uncertain, b_node.if_true);
-                let if_true = self.add_or_constraint(true_from_a, true_from_uncertain);
+                let (if_true, if_uncertain, if_false) = if a_node.if_uncertain == ALWAYS_FALSE
+                    && b_node.if_uncertain == ALWAYS_FALSE
+                {
+                    (
+                        self.add_and_constraint(a_node.if_true, b_node.if_true),
+                        ALWAYS_FALSE,
+                        self.add_and_constraint(a_node.if_false, b_node.if_false),
+                    )
+                } else {
+                    let b_true_or_uncertain =
+                        self.add_or_constraint(b_node.if_true, b_node.if_uncertain);
+                    let true_from_a = self.add_and_constraint(a_node.if_true, b_true_or_uncertain);
+                    let true_from_uncertain =
+                        self.add_and_constraint(a_node.if_uncertain, b_node.if_true);
+                    let if_true = self.add_or_constraint(true_from_a, true_from_uncertain);
 
-                let if_uncertain =
-                    self.add_and_constraint(a_node.if_uncertain, b_node.if_uncertain);
+                    let if_uncertain =
+                        self.add_and_constraint(a_node.if_uncertain, b_node.if_uncertain);
 
-                let b_false_or_uncertain =
-                    self.add_or_constraint(b_node.if_false, b_node.if_uncertain);
-                let false_from_a = self.add_and_constraint(a_node.if_false, b_false_or_uncertain);
-                let false_from_uncertain =
-                    self.add_and_constraint(a_node.if_uncertain, b_node.if_false);
-                let if_false = self.add_or_constraint(false_from_a, false_from_uncertain);
+                    let b_false_or_uncertain =
+                        self.add_or_constraint(b_node.if_false, b_node.if_uncertain);
+                    let false_from_a =
+                        self.add_and_constraint(a_node.if_false, b_false_or_uncertain);
+                    let false_from_uncertain =
+                        self.add_and_constraint(a_node.if_uncertain, b_node.if_false);
+                    let if_false = self.add_or_constraint(false_from_a, false_from_uncertain);
+
+                    (if_true, if_uncertain, if_false)
+                };
 
                 self.add_interior(InteriorNode {
                     atom: a_node.atom,
@@ -365,7 +378,11 @@ impl NarrowingConstraintsBuilder {
             Ordering::Less => {
                 let node = self.interiors[a];
                 let if_true = self.add_and_constraint(node.if_true, b);
-                let if_uncertain = self.add_and_constraint(node.if_uncertain, b);
+                let if_uncertain = if node.if_uncertain == ALWAYS_FALSE {
+                    ALWAYS_FALSE
+                } else {
+                    self.add_and_constraint(node.if_uncertain, b)
+                };
                 let if_false = self.add_and_constraint(node.if_false, b);
                 self.add_interior(InteriorNode {
                     atom: node.atom,
@@ -377,7 +394,11 @@ impl NarrowingConstraintsBuilder {
             Ordering::Greater => {
                 let node = self.interiors[b];
                 let if_true = self.add_and_constraint(a, node.if_true);
-                let if_uncertain = self.add_and_constraint(a, node.if_uncertain);
+                let if_uncertain = if node.if_uncertain == ALWAYS_FALSE {
+                    ALWAYS_FALSE
+                } else {
+                    self.add_and_constraint(a, node.if_uncertain)
+                };
                 let if_false = self.add_and_constraint(a, node.if_false);
                 self.add_interior(InteriorNode {
                     atom: node.atom,

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -308,10 +308,6 @@ impl NarrowingConstraintsBuilder {
         a: ScopedNarrowingConstraint,
         b: ScopedNarrowingConstraint,
     ) -> ScopedNarrowingConstraint {
-        if a == b {
-            return a;
-        }
-
         let a = self.project_to_bdd(a);
         let b = self.project_to_bdd(b);
         self.add_bdd_or(a, b)
@@ -617,17 +613,6 @@ mod tests {
         assert_eq!(root.if_true, ALWAYS_TRUE);
         assert_eq!(root.if_uncertain, a);
         assert_eq!(root.if_false, ALWAYS_FALSE);
-    }
-
-    #[test]
-    fn ordinary_merge_preserves_an_identical_tdd() {
-        let mut constraints = NarrowingConstraintsBuilder::default();
-        let a = constraints.add_atom(predicate(0));
-        let b = constraints.add_atom(predicate(1));
-        let union = constraints.add_or_constraint(a, b);
-
-        assert_ne!(constraints.interiors[union].if_uncertain, ALWAYS_FALSE);
-        assert_eq!(constraints.add_bdd_or_constraint(union, union), union);
     }
 
     #[test]

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -338,35 +338,22 @@ impl NarrowingConstraintsBuilder {
                 let a_node = self.interiors[a];
                 let b_node = self.interiors[b];
 
-                let (if_true, if_uncertain, if_false) = if a_node.if_uncertain == ALWAYS_FALSE
-                    && b_node.if_uncertain == ALWAYS_FALSE
-                {
-                    (
-                        self.add_and_constraint(a_node.if_true, b_node.if_true),
-                        ALWAYS_FALSE,
-                        self.add_and_constraint(a_node.if_false, b_node.if_false),
-                    )
-                } else {
-                    let b_true_or_uncertain =
-                        self.add_or_constraint(b_node.if_true, b_node.if_uncertain);
-                    let true_from_a = self.add_and_constraint(a_node.if_true, b_true_or_uncertain);
-                    let true_from_uncertain =
-                        self.add_and_constraint(a_node.if_uncertain, b_node.if_true);
-                    let if_true = self.add_or_constraint(true_from_a, true_from_uncertain);
+                let b_true_or_uncertain =
+                    self.add_or_constraint(b_node.if_true, b_node.if_uncertain);
+                let true_from_a = self.add_and_constraint(a_node.if_true, b_true_or_uncertain);
+                let true_from_uncertain =
+                    self.add_and_constraint(a_node.if_uncertain, b_node.if_true);
+                let if_true = self.add_or_constraint(true_from_a, true_from_uncertain);
 
-                    let if_uncertain =
-                        self.add_and_constraint(a_node.if_uncertain, b_node.if_uncertain);
+                let if_uncertain =
+                    self.add_and_constraint(a_node.if_uncertain, b_node.if_uncertain);
 
-                    let b_false_or_uncertain =
-                        self.add_or_constraint(b_node.if_false, b_node.if_uncertain);
-                    let false_from_a =
-                        self.add_and_constraint(a_node.if_false, b_false_or_uncertain);
-                    let false_from_uncertain =
-                        self.add_and_constraint(a_node.if_uncertain, b_node.if_false);
-                    let if_false = self.add_or_constraint(false_from_a, false_from_uncertain);
-
-                    (if_true, if_uncertain, if_false)
-                };
+                let b_false_or_uncertain =
+                    self.add_or_constraint(b_node.if_false, b_node.if_uncertain);
+                let false_from_a = self.add_and_constraint(a_node.if_false, b_false_or_uncertain);
+                let false_from_uncertain =
+                    self.add_and_constraint(a_node.if_uncertain, b_node.if_false);
+                let if_false = self.add_or_constraint(false_from_a, false_from_uncertain);
 
                 self.add_interior(InteriorNode {
                     atom: a_node.atom,
@@ -378,11 +365,7 @@ impl NarrowingConstraintsBuilder {
             Ordering::Less => {
                 let node = self.interiors[a];
                 let if_true = self.add_and_constraint(node.if_true, b);
-                let if_uncertain = if node.if_uncertain == ALWAYS_FALSE {
-                    ALWAYS_FALSE
-                } else {
-                    self.add_and_constraint(node.if_uncertain, b)
-                };
+                let if_uncertain = self.add_and_constraint(node.if_uncertain, b);
                 let if_false = self.add_and_constraint(node.if_false, b);
                 self.add_interior(InteriorNode {
                     atom: node.atom,
@@ -394,11 +377,7 @@ impl NarrowingConstraintsBuilder {
             Ordering::Greater => {
                 let node = self.interiors[b];
                 let if_true = self.add_and_constraint(a, node.if_true);
-                let if_uncertain = if node.if_uncertain == ALWAYS_FALSE {
-                    ALWAYS_FALSE
-                } else {
-                    self.add_and_constraint(a, node.if_uncertain)
-                };
+                let if_uncertain = self.add_and_constraint(a, node.if_uncertain);
                 let if_false = self.add_and_constraint(a, node.if_false);
                 self.add_interior(InteriorNode {
                     atom: node.atom,

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -250,7 +250,9 @@ use thin_vec::ThinVec;
 use crate::ast_ids::ScopedUseId;
 use crate::definition::{Definition, DefinitionState};
 use crate::member::ScopedMemberId;
-use crate::narrowing_constraints::{ConstraintKey, ScopedNarrowingConstraint};
+use crate::narrowing_constraints::{
+    ConstraintKey, NarrowingConstraints, NarrowingConstraintsBuilder, ScopedNarrowingConstraint,
+};
 use crate::place::{PlaceExprRef, ScopedPlaceId};
 use crate::predicate::{PredicateOrLiteral, Predicates, PredicatesBuilder, ScopedPredicateId};
 use crate::reachability_constraints::{
@@ -447,11 +449,12 @@ impl RetainedBindingsBuilder {
 
     fn finish(
         self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) -> RetainedBindings {
         for binding in &self.live_bindings {
             reachability_constraints.mark_used(binding.reachability_constraint());
-            reachability_constraints.mark_used(binding.narrowing_constraint());
+            narrowing_constraints.mark_used(binding.narrowing_constraint());
         }
         RetainedBindings {
             ranges: self.ranges.into(),
@@ -504,6 +507,9 @@ pub struct UseDefMap<'db> {
 
     /// Array of reachability constraints in this scope.
     reachability_constraints: ReachabilityConstraints,
+
+    /// Array of narrowing constraints in this scope.
+    narrowing_constraints: NarrowingConstraints,
 
     /// Interned [`Bindings`] values.
     interned_bindings: RetainedBindings,
@@ -610,6 +616,10 @@ impl<'db> UseDefMap<'db> {
         &self.reachability_constraints
     }
 
+    pub fn narrowing_constraints(&self) -> &NarrowingConstraints {
+        &self.narrowing_constraints
+    }
+
     pub fn predicates(&self) -> &Predicates<'db> {
         &self.predicates
     }
@@ -672,7 +682,7 @@ impl<'db> UseDefMap<'db> {
                 ApplicableConstraints::UnboundBinding(NarrowingEvaluator {
                     constraint,
                     predicates: &self.predicates,
-                    reachability_constraints: &self.reachability_constraints,
+                    narrowing_constraints: &self.narrowing_constraints,
                 })
             }
             ConstraintKey::NestedScope(nested_scope) => {
@@ -702,7 +712,7 @@ impl<'db> UseDefMap<'db> {
         NarrowingEvaluator {
             constraint,
             predicates: &self.predicates,
-            reachability_constraints: &self.reachability_constraints,
+            narrowing_constraints: &self.narrowing_constraints,
         }
     }
 
@@ -928,6 +938,7 @@ impl<'db> UseDefMap<'db> {
         BindingWithConstraintsIterator {
             all_definitions: &self.all_definitions,
             predicates: &self.predicates,
+            narrowing_constraints: &self.narrowing_constraints,
             reachability_constraints: &self.reachability_constraints,
             boundness_analysis,
             inner: bindings.iter(),
@@ -983,6 +994,7 @@ type EnclosingSnapshots = IndexVec<ScopedEnclosingSnapshotId, EnclosingSnapshot>
 pub struct BindingWithConstraintsIterator<'map, 'db> {
     all_definitions: &'map IndexSlice<ScopedDefinitionId, DefinitionState<'db>>,
     predicates: &'map Predicates<'db>,
+    narrowing_constraints: &'map NarrowingConstraints,
     reachability_constraints: &'map ReachabilityConstraints,
     boundness_analysis: BoundnessAnalysis,
     inner: LiveBindingsIterator<'map>,
@@ -1007,7 +1019,7 @@ impl<'map, 'db> Iterator for BindingWithConstraintsIterator<'map, 'db> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let predicates = self.predicates;
-        let reachability_constraints = self.reachability_constraints;
+        let narrowing_constraints = self.narrowing_constraints;
 
         self.inner
             .next()
@@ -1016,7 +1028,7 @@ impl<'map, 'db> Iterator for BindingWithConstraintsIterator<'map, 'db> {
                 narrowing_constraint: NarrowingEvaluator {
                     constraint: live_binding.narrowing_constraint(),
                     predicates,
-                    reachability_constraints,
+                    narrowing_constraints,
                 },
                 reachability_constraint: live_binding.reachability_constraint(),
             })
@@ -1034,7 +1046,7 @@ pub struct BindingWithConstraints<'map, 'db> {
 pub struct NarrowingEvaluator<'map, 'db> {
     constraint: ScopedNarrowingConstraint,
     predicates: &'map Predicates<'db>,
-    reachability_constraints: &'map ReachabilityConstraints,
+    narrowing_constraints: &'map NarrowingConstraints,
 }
 
 impl<'map, 'db> NarrowingEvaluator<'map, 'db> {
@@ -1046,8 +1058,8 @@ impl<'map, 'db> NarrowingEvaluator<'map, 'db> {
         self.predicates
     }
 
-    pub fn reachability_constraints(&self) -> &'map ReachabilityConstraints {
-        self.reachability_constraints
+    pub fn narrowing_constraints(&self) -> &'map NarrowingConstraints {
+        self.narrowing_constraints
     }
 }
 
@@ -1146,6 +1158,9 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// Builder of reachability constraints.
     pub(super) reachability_constraints: ReachabilityConstraintsBuilder,
 
+    /// Builder of narrowing constraints.
+    pub(super) narrowing_constraints: NarrowingConstraintsBuilder,
+
     /// Live bindings at each so-far-recorded use.
     bindings_by_use: IndexVec<ScopedUseId, Bindings>,
 
@@ -1194,6 +1209,7 @@ impl<'db> UseDefMapBuilder<'db> {
             used_bindings: IndexVec::from_iter([false]),
             predicates: PredicatesBuilder::default(),
             reachability_constraints: ReachabilityConstraintsBuilder::default(),
+            narrowing_constraints: NarrowingConstraintsBuilder::default(),
             bindings_by_use: IndexVec::new(),
             multi_bindings_by_use: FxHashMap::default(),
             reachability: ScopedReachabilityConstraintId::ALWAYS_TRUE,
@@ -1356,16 +1372,14 @@ impl<'db> UseDefMapBuilder<'db> {
             return;
         }
 
-        let atom = self.reachability_constraints.add_atom(predicate);
+        let atom = self.narrowing_constraints.add_atom(predicate);
         self.record_narrowing_constraint_node_for_places(atom, places);
     }
 
     /// Records a negated narrowing constraint for only the specified places.
     ///
-    /// Uses TDD-level negation (`add_not_constraint`) rather than creating a new predicate atom
-    /// for the negated predicate. This ensures that `atom(P) OR NOT(atom(P))` simplifies to
-    /// `ALWAYS_TRUE` in the TDD, so narrowing is correctly cancelled out after complete
-    /// if/else blocks.
+    /// The positive and negative constraints use the same predicate ID. This lets `P or not P`
+    /// simplify to `ALWAYS_TRUE`, so narrowing cancels out after a complete `if`/`else`.
     pub(super) fn record_negated_narrowing_constraint_for_places(
         &mut self,
         predicate: ScopedPredicateId,
@@ -1377,12 +1391,11 @@ impl<'db> UseDefMapBuilder<'db> {
             return;
         }
 
-        let atom = self.reachability_constraints.add_atom(predicate);
-        let negated = self.reachability_constraints.add_not_constraint(atom);
+        let negated = self.narrowing_constraints.add_negated_atom(predicate);
         self.record_narrowing_constraint_node_for_places(negated, places);
     }
 
-    /// Records a TDD narrowing constraint node for the specified places.
+    /// Records a narrowing constraint node for the specified places.
     fn record_narrowing_constraint_node_for_places(
         &mut self,
         constraint: ScopedNarrowingConstraint,
@@ -1397,7 +1410,7 @@ impl<'db> UseDefMapBuilder<'db> {
                 ScopedPlaceId::Symbol(symbol_id) => {
                     if let Some(state) = self.symbol_states.get_mut(*symbol_id) {
                         state.record_narrowing_constraint(
-                            &mut self.reachability_constraints,
+                            &mut self.narrowing_constraints,
                             constraint,
                         );
                     }
@@ -1405,7 +1418,7 @@ impl<'db> UseDefMapBuilder<'db> {
                 ScopedPlaceId::Member(member_id) => {
                     if let Some(state) = self.member_states.get_mut(*member_id) {
                         state.record_narrowing_constraint(
-                            &mut self.reachability_constraints,
+                            &mut self.narrowing_constraints,
                             constraint,
                         );
                     }
@@ -1486,7 +1499,12 @@ impl<'db> UseDefMapBuilder<'db> {
             negated_reachability_id,
         );
 
-        self.symbol_states[symbol].merge(post_definition_state, &mut self.reachability_constraints);
+        self.symbol_states[symbol].merge(
+            post_definition_state,
+            &mut self.narrowing_constraints,
+            &mut self.reachability_constraints,
+            &[],
+        );
 
         // And similarly for all associated members:
         #[expect(
@@ -1509,8 +1527,12 @@ impl<'db> UseDefMapBuilder<'db> {
                 negated_reachability_id,
             );
 
-            self.member_states[member_id]
-                .merge(post_definition_state, &mut self.reachability_constraints);
+            self.member_states[member_id].merge(
+                post_definition_state,
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+                &[],
+            );
         }
     }
 
@@ -1524,11 +1546,11 @@ impl<'db> UseDefMapBuilder<'db> {
         constraint: ScopedNarrowingConstraint,
     ) {
         for state in &mut self.symbol_states {
-            state.record_narrowing_constraint(&mut self.reachability_constraints, constraint);
+            state.record_narrowing_constraint(&mut self.narrowing_constraints, constraint);
         }
 
         for state in &mut self.member_states {
-            state.record_narrowing_constraint(&mut self.reachability_constraints, constraint);
+            state.record_narrowing_constraint(&mut self.narrowing_constraints, constraint);
         }
     }
 
@@ -1772,7 +1794,9 @@ impl<'db> UseDefMapBuilder<'db> {
                 let new_symbol_state = &self.symbol_states[enclosing_symbol];
                 bindings.merge(
                     new_symbol_state.bindings().clone(),
+                    &mut self.narrowing_constraints,
                     &mut self.reachability_constraints,
+                    &[],
                 );
             }
             Some(EnclosingSnapshot::Constraint(constraint)) => {
@@ -1856,6 +1880,22 @@ impl<'db> UseDefMapBuilder<'db> {
     /// path to get here. The new state for each place should include definitions from both the
     /// prior state and the snapshot.
     pub(super) fn merge(&mut self, snapshot: FlowSnapshot) {
+        self.merge_inner(snapshot, &[]);
+    }
+
+    pub(super) fn merge_after_branches(
+        &mut self,
+        snapshot: FlowSnapshot,
+        preceding_branch_predicates: &[ScopedPredicateId],
+    ) {
+        self.merge_inner(snapshot, preceding_branch_predicates);
+    }
+
+    fn merge_inner(
+        &mut self,
+        snapshot: FlowSnapshot,
+        preceding_branch_predicates: &[ScopedPredicateId],
+    ) {
         // As an optimization, if we know statically that either of the snapshots is always
         // unreachable, we can leave it out of the merged result entirely. Note that we cannot
         // perform any type inference at this point, so this is largely limited to unreachability
@@ -1879,28 +1919,30 @@ impl<'db> UseDefMapBuilder<'db> {
 
         let mut snapshot_definitions_iter = snapshot.symbol_states.into_iter();
         for current in &mut self.symbol_states {
-            if let Some(snapshot) = snapshot_definitions_iter.next() {
-                current.merge(snapshot, &mut self.reachability_constraints);
-            } else {
-                current.merge(
-                    PlaceState::undefined(snapshot.reachability),
-                    &mut self.reachability_constraints,
-                );
-                // Place not present in snapshot, so it's unbound/undeclared from that path.
-            }
+            let branch = snapshot_definitions_iter
+                .next()
+                // A place missing from the snapshot was undefined on that path.
+                .unwrap_or_else(|| PlaceState::undefined(snapshot.reachability));
+            current.merge(
+                branch,
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+                preceding_branch_predicates,
+            );
         }
 
         let mut snapshot_definitions_iter = snapshot.member_states.into_iter();
         for current in &mut self.member_states {
-            if let Some(snapshot) = snapshot_definitions_iter.next() {
-                current.merge(snapshot, &mut self.reachability_constraints);
-            } else {
-                current.merge(
-                    PlaceState::undefined(snapshot.reachability),
-                    &mut self.reachability_constraints,
-                );
-                // Place not present in snapshot, so it's unbound/undeclared from that path.
-            }
+            let branch = snapshot_definitions_iter
+                .next()
+                // A place missing from the snapshot was undefined on that path.
+                .unwrap_or_else(|| PlaceState::undefined(snapshot.reachability));
+            current.merge(
+                branch,
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+                preceding_branch_predicates,
+            );
         }
 
         self.reachability = self
@@ -1977,12 +2019,18 @@ impl<'db> UseDefMapBuilder<'db> {
 
         // We only walk the fields that are copied through to the UseDefMap when we finish building
         // it.
-        let interned_bindings = interned_bindings.finish(&mut self.reachability_constraints);
+        let interned_bindings = interned_bindings.finish(
+            &mut self.narrowing_constraints,
+            &mut self.reachability_constraints,
+        );
         for declarations in &mut interned_declarations {
             declarations.finish(&mut self.reachability_constraints);
         }
         for bindings in self.multi_bindings_by_use.values_mut().flatten() {
-            bindings.finish(&mut self.reachability_constraints);
+            bindings.finish(
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+            );
         }
         for &(_, RangeInfo { reachability, .. }) in &self.range_reachability {
             self.reachability_constraints.mark_used(reachability);
@@ -1990,7 +2038,7 @@ impl<'db> UseDefMapBuilder<'db> {
         for enclosing_snapshot in &enclosing_snapshots {
             // Bindings are already marked above.
             if let InternedEnclosingSnapshotId::Constraint(constraint) = enclosing_snapshot {
-                self.reachability_constraints.mark_used(*constraint);
+                self.narrowing_constraints.mark_used(*constraint);
             }
         }
         self.reachability_constraints.mark_used(self.reachability);
@@ -2005,6 +2053,7 @@ impl<'db> UseDefMapBuilder<'db> {
             used_bindings: self.used_bindings.into(),
             predicates: self.predicates.build(),
             reachability_constraints: self.reachability_constraints.build(),
+            narrowing_constraints: self.narrowing_constraints.build(),
             interned_bindings,
             interned_declarations: interned_declarations.into(),
             bindings_by_use: bindings_by_use.into(),

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -603,6 +603,10 @@ fn merge_narrowing_constraints(
     }
 
     let merged = constraints.add_or_constraint(accumulated, branch);
+    if merged == ScopedNarrowingConstraint::ALWAYS_TRUE {
+        return merged;
+    }
+
     let branch_without_preceding_predicates =
         constraints.remove_predicates(branch, preceding_branch_predicates);
     let merged_without_preceding_predicates =

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -598,6 +598,10 @@ fn merge_narrowing_constraints(
     branch: ScopedNarrowingConstraint,
     preceding_branch_predicates: &[ScopedPredicateId],
 ) -> ScopedNarrowingConstraint {
+    if accumulated == branch {
+        return accumulated;
+    }
+
     if preceding_branch_predicates.is_empty() {
         return constraints.add_bdd_or_constraint(accumulated, branch);
     }

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -47,7 +47,8 @@ use ruff_index::newtype_index;
 use smallvec::{SmallVec, smallvec};
 
 use crate::ReachabilityConstraintsBuilder;
-use crate::narrowing_constraints::ScopedNarrowingConstraint;
+use crate::narrowing_constraints::{NarrowingConstraintsBuilder, ScopedNarrowingConstraint};
+use crate::predicate::ScopedPredicateId;
 use crate::reachability_constraints::ScopedReachabilityConstraintId;
 
 /// A newtype-index for a definition in a particular scope.
@@ -180,9 +181,8 @@ impl Declarations {
 
         // Invariant: merge_join_by consumes the two iterators in sorted order, which ensures that
         // the merged `live_declarations` vec remains sorted. If a definition is found in both `a`
-        // and `b`, we compose the constraints from the two paths in an appropriate way
-        // (intersection for narrowing constraints; ternary OR for reachability constraints). If a
-        // definition is found in only one path, it is used as-is.
+        // and `b`, we combine its reachability constraints. If a definition is found in only one
+        // path, it is used as-is.
         let a = a.live_declarations.into_iter();
         let b = b.live_declarations.into_iter();
         for zipped in a.merge_join_by(b, |a, b| a.declaration.cmp(&b.declaration)) {
@@ -252,11 +252,15 @@ impl Bindings {
             .unwrap_or(self.live_bindings[0].narrowing_constraint)
     }
 
-    pub(super) fn finish(&mut self, reachability_constraints: &mut ReachabilityConstraintsBuilder) {
+    pub(super) fn finish(
+        &mut self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+    ) {
         self.live_bindings.shrink_to_fit();
         for binding in &self.live_bindings {
             reachability_constraints.mark_used(binding.reachability_constraint);
-            reachability_constraints.mark_used(binding.narrowing_constraint);
+            narrowing_constraints.mark_used(binding.narrowing_constraint);
         }
     }
 }
@@ -388,12 +392,12 @@ impl Bindings {
     /// Add given constraint to all live bindings.
     pub(super) fn record_narrowing_constraint(
         &mut self,
-        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         constraint: ScopedNarrowingConstraint,
     ) {
         for binding in &mut self.live_bindings {
-            binding.narrowing_constraint = reachability_constraints
-                .add_and_constraint(binding.narrowing_constraint, constraint);
+            binding.narrowing_constraint =
+                narrowing_constraints.add_and_constraint(binding.narrowing_constraint, constraint);
         }
     }
 
@@ -421,7 +425,9 @@ impl Bindings {
     pub(super) fn merge(
         &mut self,
         b: Self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
+        preceding_branch_predicates: &[ScopedPredicateId],
     ) {
         let a = std::mem::take(self);
 
@@ -429,15 +435,18 @@ impl Bindings {
             .unbound_narrowing_constraint
             .zip(b.unbound_narrowing_constraint)
         {
-            self.unbound_narrowing_constraint =
-                Some(reachability_constraints.add_or_constraint(a, b));
+            self.unbound_narrowing_constraint = Some(merge_narrowing_constraints(
+                narrowing_constraints,
+                a,
+                b,
+                preceding_branch_predicates,
+            ));
         }
 
         // Invariant: merge_join_by consumes the two iterators in sorted order, which ensures that
         // the merged `live_bindings` vec remains sorted. If a definition is found in both `a` and
-        // `b`, we compose the constraints from the two paths using ternary OR for both narrowing
-        // and reachability constraints. If a definition is found in only one path, it is used
-        // as-is.
+        // `b`, we combine its boolean narrowing constraints and its ternary reachability
+        // constraints. If a definition is found in only one path, it is used as-is.
         let a = a.live_bindings.into_iter();
         let b = b.live_bindings.into_iter();
         for zipped in a.merge_join_by(b, |a, b| a.binding().cmp(&b.binding())) {
@@ -445,8 +454,12 @@ impl Bindings {
                 EitherOrBoth::Both(a, b) => {
                     // If the same definition is visible through both paths, we OR the narrowing
                     // constraints: the type should be narrowed by whichever path was taken.
-                    let narrowing_constraint = reachability_constraints
-                        .add_or_constraint(a.narrowing_constraint, b.narrowing_constraint);
+                    let narrowing_constraint = merge_narrowing_constraints(
+                        narrowing_constraints,
+                        a.narrowing_constraint,
+                        b.narrowing_constraint,
+                        preceding_branch_predicates,
+                    );
 
                     // For reachability constraints, we also merge using a ternary OR operation:
                     let reachability_constraint = reachability_constraints
@@ -508,11 +521,11 @@ impl PlaceState {
     /// Add given constraint to all live bindings.
     pub(super) fn record_narrowing_constraint(
         &mut self,
-        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         constraint: ScopedNarrowingConstraint,
     ) {
         self.bindings
-            .record_narrowing_constraint(reachability_constraints, constraint);
+            .record_narrowing_constraint(narrowing_constraints, constraint);
     }
 
     /// Add given reachability constraint to all live bindings.
@@ -544,9 +557,16 @@ impl PlaceState {
     pub(super) fn merge(
         &mut self,
         b: PlaceState,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
+        preceding_branch_predicates: &[ScopedPredicateId],
     ) {
-        self.bindings.merge(b.bindings, reachability_constraints);
+        self.bindings.merge(
+            b.bindings,
+            narrowing_constraints,
+            reachability_constraints,
+            preceding_branch_predicates,
+        );
         self.declarations
             .merge(b.declarations, reachability_constraints);
     }
@@ -561,6 +581,36 @@ impl PlaceState {
 
     pub(super) fn into_parts(self) -> (Bindings, Declarations) {
         (self.bindings, self.declarations)
+    }
+}
+
+/// Combines the narrowing from two branches that meet after an `if`/`elif` chain.
+///
+/// A later branch includes the failed checks from every earlier branch. For example, the two
+/// branches in `if A: ... elif B: ...` contribute `A` and `not A and B`. If both branches reach
+/// the next statement, `not A` is redundant and the merged condition can be stored as `A or B`.
+///
+/// We only remove an earlier predicate when the complete merged condition remains the same. This
+/// preserves `not A` when the `A` branch returns and only the `B` branch reaches the merge.
+fn merge_narrowing_constraints(
+    constraints: &mut NarrowingConstraintsBuilder,
+    accumulated: ScopedNarrowingConstraint,
+    branch: ScopedNarrowingConstraint,
+    preceding_branch_predicates: &[ScopedPredicateId],
+) -> ScopedNarrowingConstraint {
+    if preceding_branch_predicates.is_empty() {
+        return constraints.add_bdd_or_constraint(accumulated, branch);
+    }
+
+    let merged = constraints.add_or_constraint(accumulated, branch);
+    let branch_without_preceding_predicates =
+        constraints.remove_predicates(branch, preceding_branch_predicates);
+    let merged_without_preceding_predicates =
+        constraints.add_or_constraint(accumulated, branch_without_preceding_predicates);
+    if constraints.are_equivalent(merged, merged_without_preceding_predicates) {
+        merged_without_preceding_predicates
+    } else {
+        merged
     }
 }
 
@@ -677,7 +727,7 @@ mod tests {
 
     #[test]
     fn record_constraint() {
-        let mut reachability_constraints = ReachabilityConstraintsBuilder::default();
+        let mut narrowing_constraints = NarrowingConstraintsBuilder::default();
         let mut sym = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
         sym.record_binding(
             ScopedDefinitionId::from_u32(1),
@@ -687,14 +737,15 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        let atom = reachability_constraints.add_atom(ScopedPredicateId::new(0));
-        sym.record_narrowing_constraint(&mut reachability_constraints, atom);
+        let atom = narrowing_constraints.add_atom(ScopedPredicateId::new(0));
+        sym.record_narrowing_constraint(&mut narrowing_constraints, atom);
 
         assert_bindings(&sym, &[(1, atom)]);
     }
 
     #[test]
     fn merge() {
+        let mut narrowing_constraints = NarrowingConstraintsBuilder::default();
         let mut reachability_constraints = ReachabilityConstraintsBuilder::default();
 
         // merging the same definition with the same constraint keeps the constraint
@@ -707,8 +758,8 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        let atom0 = reachability_constraints.add_atom(ScopedPredicateId::new(0));
-        sym1a.record_narrowing_constraint(&mut reachability_constraints, atom0);
+        let atom0 = narrowing_constraints.add_atom(ScopedPredicateId::new(0));
+        sym1a.record_narrowing_constraint(&mut narrowing_constraints, atom0);
 
         let mut sym1b = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
         sym1b.record_binding(
@@ -719,9 +770,14 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        sym1b.record_narrowing_constraint(&mut reachability_constraints, atom0);
+        sym1b.record_narrowing_constraint(&mut narrowing_constraints, atom0);
 
-        sym1a.merge(sym1b, &mut reachability_constraints);
+        sym1a.merge(
+            sym1b,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+            &[],
+        );
         let mut sym1 = sym1a;
         // Same constraint on both sides → OR(atom0, atom0) = atom0
         assert_bindings(&sym1, &[(1, atom0)]);
@@ -736,8 +792,8 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        let atom1 = reachability_constraints.add_atom(ScopedPredicateId::new(1));
-        sym2a.record_narrowing_constraint(&mut reachability_constraints, atom1);
+        let atom1 = narrowing_constraints.add_atom(ScopedPredicateId::new(1));
+        sym2a.record_narrowing_constraint(&mut narrowing_constraints, atom1);
 
         let mut sym1b = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
         sym1b.record_binding(
@@ -748,10 +804,15 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        let atom2 = reachability_constraints.add_atom(ScopedPredicateId::new(2));
-        sym1b.record_narrowing_constraint(&mut reachability_constraints, atom2);
+        let atom2 = narrowing_constraints.add_atom(ScopedPredicateId::new(2));
+        sym1b.record_narrowing_constraint(&mut narrowing_constraints, atom2);
 
-        sym2a.merge(sym1b, &mut reachability_constraints);
+        sym2a.merge(
+            sym1b,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+            &[],
+        );
         let sym2 = sym2a;
         // Different constraints: OR(atom1, atom2) produces a new TDD node (not a terminal)
         let merged_constraint = sym2.bindings().iter().next().unwrap().narrowing_constraint;
@@ -770,12 +831,17 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        let atom3 = reachability_constraints.add_atom(ScopedPredicateId::new(3));
-        sym3a.record_narrowing_constraint(&mut reachability_constraints, atom3);
+        let atom3 = narrowing_constraints.add_atom(ScopedPredicateId::new(3));
+        sym3a.record_narrowing_constraint(&mut narrowing_constraints, atom3);
 
         let sym2b = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
 
-        sym3a.merge(sym2b, &mut reachability_constraints);
+        sym3a.merge(
+            sym2b,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+            &[],
+        );
         let sym3 = sym3a;
         let bindings: Vec<_> = sym3
             .bindings()
@@ -788,7 +854,12 @@ mod tests {
         assert_eq!(bindings[1].1, atom3);
 
         // merging different definitions keeps them each with their existing constraints
-        sym1.merge(sym3, &mut reachability_constraints);
+        sym1.merge(
+            sym3,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+            &[],
+        );
         let sym = sym1;
         let bindings: Vec<_> = sym
             .bindings()
@@ -838,6 +909,7 @@ mod tests {
 
     #[test]
     fn record_declaration_merge() {
+        let mut narrowing_constraints = NarrowingConstraintsBuilder::default();
         let mut reachability_constraints = ReachabilityConstraintsBuilder::default();
         let mut sym = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
         sym.record_declaration(
@@ -851,13 +923,19 @@ mod tests {
             ScopedReachabilityConstraintId::ALWAYS_TRUE,
         );
 
-        sym.merge(sym2, &mut reachability_constraints);
+        sym.merge(
+            sym2,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+            &[],
+        );
 
         assert_declarations(&sym, &["1", "2"]);
     }
 
     #[test]
     fn record_declaration_merge_partial_undeclared() {
+        let mut narrowing_constraints = NarrowingConstraintsBuilder::default();
         let mut reachability_constraints = ReachabilityConstraintsBuilder::default();
         let mut sym = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
         sym.record_declaration(
@@ -867,7 +945,12 @@ mod tests {
 
         let sym2 = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
 
-        sym.merge(sym2, &mut reachability_constraints);
+        sym.merge(
+            sym2,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+            &[],
+        );
 
         assert_declarations(&sym, &["undeclared", "1"]);
     }

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -70,7 +70,66 @@ def _(x: A | B | C):
 
     # Only the if-branch (A) and elif-branch (B) flow through.
     # The else-branch returned, so its narrowing doesn't participate.
-    reveal_type(x)  # revealed: B | (A & ~B)
+    reveal_type(x)  # revealed: B | A
+```
+
+## Earlier branch checks can be dropped after the paths merge
+
+When two branches both reach the next statement, the later branch no longer needs to remember the
+failed check that sent execution past the earlier branch.
+
+```py
+from typing import Any
+from typing_extensions import TypeGuard, TypeIs
+
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+
+def is_a(x: object) -> TypeIs[A]:
+    return isinstance(x, A)
+
+def is_b(x: object) -> TypeIs[B]:
+    return isinstance(x, B)
+
+def is_c(x: object) -> TypeIs[C]:
+    return isinstance(x, C)
+
+def guard_a(x: object) -> TypeGuard[A]:
+    return isinstance(x, A)
+
+def exact_narrowing(x: A | B | C | D):
+    if is_a(x):
+        pass
+    elif is_b(x):
+        pass
+    elif is_c(x):
+        pass
+    else:
+        return
+
+    reveal_type(x)  # revealed: C | B | A
+
+def one_sided_narrowing(x: A | B | C):
+    if guard_a(x):
+        pass
+    elif is_b(x):
+        pass
+    else:
+        return
+
+    reveal_type(x)  # revealed: B | A
+
+def gradual_narrowing(x: Any):
+    if is_a(x):
+        pass
+    elif is_b(x):
+        pass
+    else:
+        return
+
+    reveal_type(x)  # revealed: (Any & B) | (Any & A)
 ```
 
 ## Narrowing is preserved with multiple terminal branches
@@ -92,7 +151,7 @@ def _(x: A | B | C | D):
         return
 
     # Only the elif-B and elif-C branches flow through.
-    reveal_type(x)  # revealed: (C & ~A) | (B & ~A & ~C)
+    reveal_type(x)  # revealed: (C & ~A & ~B) | (B & ~A)
 ```
 
 ## Opaque branch predicates should not manufacture narrowing

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -79,7 +79,7 @@ When two branches both reach the next statement, the later branch no longer need
 failed check that sent execution past the earlier branch.
 
 ```py
-from typing import Any
+from typing import Any, NoReturn
 from typing_extensions import TypeGuard, TypeIs
 
 class A: ...
@@ -110,6 +110,34 @@ def exact_narrowing(x: A | B | C | D):
         return
 
     reveal_type(x)  # revealed: C | B | A
+
+def noop() -> None:
+    pass
+
+def stop() -> NoReturn:
+    raise RuntimeError
+
+def calls_in_branches(x: A | B | C | D):
+    if is_a(x):
+        noop()
+    elif is_b(x):
+        noop()
+    elif is_c(x):
+        noop()
+    else:
+        return
+
+    reveal_type(x)  # revealed: C | B | A
+
+def noreturn_call_removes_branch(x: A | B | C):
+    if is_a(x):
+        stop()
+    elif is_b(x):
+        noop()
+    else:
+        return
+
+    reveal_type(x)  # revealed: B & ~A
 
 def one_sided_narrowing(x: A | B | C):
     if guard_a(x):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -129,6 +129,18 @@ def calls_in_branches(x: A | B | C | D):
 
     reveal_type(x)  # revealed: C | B | A
 
+def mixed_call_branches(x: A | B | C | D):
+    if is_a(x):
+        noop()
+    elif is_b(x):
+        pass
+    elif is_c(x):
+        pass
+    else:
+        return
+
+    reveal_type(x)  # revealed: C | B | A
+
 def noreturn_call_removes_branch(x: A | B | C):
     if is_a(x):
         stop()

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -212,6 +212,7 @@ use ty_python_core::{
     BindingWithConstraints, DeclarationWithConstraint, DeclarationsIterator, FileScopeId,
     ScopedDefinitionId, SemanticIndex, Truthiness, UseDefMap,
     definition::DefinitionState,
+    narrowing_constraints::{NarrowingConstraints, ScopedNarrowingConstraint},
     place::ScopedPlaceId,
     place_table,
     predicate::{
@@ -512,16 +513,6 @@ fn accumulate_constraint<'db>(
 }
 
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
-    /// Narrow a type by walking a TDD narrowing constraint.
-    fn narrow_by_constraint(
-        &self,
-        db: &'db dyn Db,
-        predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-        id: ScopedReachabilityConstraintId,
-        base_ty: Type<'db>,
-        place: ScopedPlaceId,
-    ) -> Type<'db>;
-
     /// Analyze the statically known reachability for a given constraint.
     fn evaluate(
         &self,
@@ -532,47 +523,6 @@ pub(crate) trait ReachabilityConstraintsExtension<'db> {
 }
 
 impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
-    /// Narrow a type by walking a TDD narrowing constraint.
-    ///
-    /// The TDD represents a ternary formula over predicates that encodes which predicates
-    /// hold along a particular control flow path. We walk from root to leaves, accumulating
-    /// narrowing constraints.
-    ///
-    /// At each interior node, we branch based on whether the predicate is true or false:
-    /// - True branch: apply positive narrowing from the predicate
-    /// - False branch: apply negative narrowing from the predicate
-    ///
-    /// The "ambiguous" branch in the TDD is not followed for narrowing purposes, because
-    /// narrowing constraints record which predicates hold along the control flow path.
-    /// The predicates may be statically ambiguous (we can't determine their truthiness
-    /// at analysis time), but they still hold dynamically at runtime and should be used
-    /// for narrowing.
-    ///
-    /// At leaves:
-    /// - `ALWAYS_TRUE` or `AMBIGUOUS`: apply all accumulated narrowing to the base type
-    /// - `ALWAYS_FALSE`: this path is impossible → Never
-    ///
-    /// The final result is the union of all path results.
-    fn narrow_by_constraint(
-        &self,
-        db: &'db dyn Db,
-        predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-        id: ScopedReachabilityConstraintId,
-        base_ty: Type<'db>,
-        place: ScopedPlaceId,
-    ) -> Type<'db> {
-        let mut projector = NarrowingProjector::new(db, self, predicates, place);
-        let projected_root = projector.project(id);
-        let mut context = ProjectedNarrowingContext {
-            db,
-            base_ty,
-            graph: &projector.graph,
-            joins: projector.graph.joins(projected_root),
-            join_cache: FxHashMap::default(),
-        };
-        context.narrow(projected_root, None)
-    }
-
     /// Analyze the statically known reachability for a given constraint.
     fn evaluate(
         &self,
@@ -597,6 +547,26 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
             }
         }
     }
+}
+
+pub(crate) fn narrow_type_by_constraint<'db>(
+    db: &'db dyn Db,
+    constraints: &NarrowingConstraints,
+    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
+    id: ScopedNarrowingConstraint,
+    base_ty: Type<'db>,
+    place: ScopedPlaceId,
+) -> Type<'db> {
+    let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
+    let projected_root = projector.project(id);
+    let mut context = ProjectedNarrowingContext {
+        db,
+        base_ty,
+        graph: &projector.graph,
+        joins: projector.graph.joins(projected_root),
+        join_cache: FxHashMap::default(),
+    };
+    context.narrow(projected_root, None)
 }
 
 fn apply_accumulated_narrowing<'db>(
@@ -632,10 +602,11 @@ impl ProjectedNarrowingNodeId {
 struct ProjectedNarrowingNode {
     atom: ScopedPredicateId,
     if_true: ProjectedNarrowingNodeId,
+    if_uncertain: ProjectedNarrowingNodeId,
     if_false: ProjectedNarrowingNodeId,
 }
 
-/// Reduced reachability graph containing only predicates relevant to one place.
+/// Narrowing graph containing only predicates that can narrow one place.
 #[derive(Default)]
 struct ProjectedNarrowingGraph<'db> {
     nodes: Vec<ProjectedNarrowingNode>,
@@ -659,8 +630,11 @@ impl ProjectedNarrowingGraph<'_> {
 
     /// Interns a projected node, collapsing nodes with identical branches.
     fn add_node(&mut self, node: ProjectedNarrowingNode) -> ProjectedNarrowingNodeId {
+        if node.if_uncertain == ProjectedNarrowingNodeId::ALWAYS_TRUE {
+            return ProjectedNarrowingNodeId::ALWAYS_TRUE;
+        }
         if node.if_true == node.if_false {
-            return node.if_true;
+            return self.or(node.if_true, node.if_uncertain);
         }
 
         if let Some(cached) = self.node_cache.get(&node) {
@@ -689,7 +663,7 @@ impl ProjectedNarrowingGraph<'_> {
             }
 
             let node = self.node(id);
-            for next in [node.if_true, node.if_false] {
+            for next in [node.if_true, node.if_uncertain, node.if_false] {
                 if !next.is_terminal() {
                     if std::mem::replace(&mut referenced[next.0], true) {
                         joins[next.0] = true;
@@ -702,7 +676,7 @@ impl ProjectedNarrowingGraph<'_> {
         joins
     }
 
-    /// Constructs the canonical disjunction of two projected subgraphs.
+    /// Combines two paths without copying one path into both outcomes of the other's predicate.
     fn or(
         &mut self,
         left: ProjectedNarrowingNodeId,
@@ -735,29 +709,31 @@ impl ProjectedNarrowingGraph<'_> {
         let result = match left_node.atom.cmp(&right_node.atom).reverse() {
             std::cmp::Ordering::Equal => {
                 let if_true = self.or(left_node.if_true, right_node.if_true);
+                let if_uncertain = self.or(left_node.if_uncertain, right_node.if_uncertain);
                 let if_false = self.or(left_node.if_false, right_node.if_false);
                 self.add_node(ProjectedNarrowingNode {
                     atom: left_node.atom,
                     if_true,
+                    if_uncertain,
                     if_false,
                 })
             }
             std::cmp::Ordering::Less => {
-                let if_true = self.or(left_node.if_true, right);
-                let if_false = self.or(left_node.if_false, right);
+                let if_uncertain = self.or(left_node.if_uncertain, right);
                 self.add_node(ProjectedNarrowingNode {
                     atom: left_node.atom,
-                    if_true,
-                    if_false,
+                    if_true: left_node.if_true,
+                    if_uncertain,
+                    if_false: left_node.if_false,
                 })
             }
             std::cmp::Ordering::Greater => {
-                let if_true = self.or(left, right_node.if_true);
-                let if_false = self.or(left, right_node.if_false);
+                let if_uncertain = self.or(left, right_node.if_uncertain);
                 self.add_node(ProjectedNarrowingNode {
                     atom: right_node.atom,
-                    if_true,
-                    if_false,
+                    if_true: right_node.if_true,
+                    if_uncertain,
+                    if_false: right_node.if_false,
                 })
             }
         };
@@ -767,13 +743,13 @@ impl ProjectedNarrowingGraph<'_> {
     }
 }
 
-/// Projects reachability constraints onto the predicates that can narrow one place.
+/// Removes predicates that cannot narrow one place from a narrowing constraint.
 struct NarrowingProjector<'a, 'db> {
     db: &'db dyn Db,
-    constraints: &'a ReachabilityConstraints,
+    constraints: &'a NarrowingConstraints,
     predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
     place: ScopedPlaceId,
-    project_cache: FxHashMap<ScopedReachabilityConstraintId, ProjectedNarrowingNodeId>,
+    project_cache: FxHashMap<ScopedNarrowingConstraint, ProjectedNarrowingNodeId>,
     graph: ProjectedNarrowingGraph<'db>,
 }
 
@@ -781,7 +757,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     /// Creates a projector for narrowing `place`.
     fn new(
         db: &'db dyn Db,
-        constraints: &'a ReachabilityConstraints,
+        constraints: &'a NarrowingConstraints,
         predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
         place: ScopedPlaceId,
     ) -> Self {
@@ -815,40 +791,50 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         constraints
     }
 
-    /// Projects a reachability node into the reduced narrowing graph.
-    fn project(&mut self, id: ScopedReachabilityConstraintId) -> ProjectedNarrowingNodeId {
-        type Id = ScopedReachabilityConstraintId;
+    /// Projects one constraint node into the graph for this place.
+    fn project(&mut self, id: ScopedNarrowingConstraint) -> ProjectedNarrowingNodeId {
+        type Id = ScopedNarrowingConstraint;
 
         if let Some(cached) = self.project_cache.get(&id) {
             return *cached;
         }
 
         let projected = match id {
-            Id::ALWAYS_TRUE | Id::AMBIGUOUS => ProjectedNarrowingNodeId::ALWAYS_TRUE,
+            Id::ALWAYS_TRUE => ProjectedNarrowingNodeId::ALWAYS_TRUE,
             Id::ALWAYS_FALSE => ProjectedNarrowingNodeId::ALWAYS_FALSE,
             _ => {
                 let node = self.constraints.get_interior_node(id);
                 let predicate = self.predicates[node.atom()];
 
                 if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
+                    let if_uncertain = self.project(node.if_uncertain());
                     match analyze_single(self.db, &predicate) {
-                        Truthiness::AlwaysTrue => self.project(node.if_true()),
-                        Truthiness::AlwaysFalse => self.project(node.if_false()),
+                        Truthiness::AlwaysTrue => {
+                            let if_true = self.project(node.if_true());
+                            self.graph.or(if_true, if_uncertain)
+                        }
+                        Truthiness::AlwaysFalse => {
+                            let if_false = self.project(node.if_false());
+                            self.graph.or(if_false, if_uncertain)
+                        }
                         Truthiness::Ambiguous => {
                             unreachable!("`IsNonTerminalCall` predicates should never be Ambiguous")
                         }
                     }
                 } else {
                     let if_true = self.project(node.if_true());
+                    let if_uncertain = self.project(node.if_uncertain());
                     let if_false = self.project(node.if_false());
                     let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom());
 
                     if pos_constraint.is_none() && neg_constraint.is_none() {
-                        self.graph.or(if_true, if_false)
+                        let either = self.graph.or(if_true, if_false);
+                        self.graph.or(either, if_uncertain)
                     } else {
                         self.graph.add_node(ProjectedNarrowingNode {
                             atom: node.atom(),
                             if_true,
+                            if_uncertain,
                             if_false,
                         })
                     }
@@ -921,21 +907,16 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
             let (pos_constraint, neg_constraint) =
                 self.graph.predicate_constraints_cache[&node.atom].clone();
 
-            if node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
-                self.narrow(node.if_false, false_accumulated)
-            } else if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-                let true_accumulated = accumulate_constraint(accumulated, pos_constraint);
-                self.narrow(node.if_true, true_accumulated)
-            } else {
-                let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
-                let true_ty = self.narrow(node.if_true, true_accumulated);
+            let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
+            let true_ty = self.narrow(node.if_true, true_accumulated);
 
-                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
-                let false_ty = self.narrow(node.if_false, false_accumulated);
+            let uncertain_ty = self.narrow(node.if_uncertain, accumulated.clone());
 
-                UnionType::from_two_elements(self.db, true_ty, false_ty)
-            }
+            let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+            let false_ty = self.narrow(node.if_false, false_accumulated);
+
+            let true_or_uncertain = UnionType::from_two_elements(self.db, true_ty, uncertain_ty);
+            UnionType::from_two_elements(self.db, true_or_uncertain, false_ty)
         }
     }
 }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -559,6 +559,11 @@ pub(crate) fn narrow_type_by_constraint<'db>(
 ) -> Type<'db> {
     let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
     let projected_root = projector.project(id);
+    let projected_root = if projector.resolved_nonterminal_call {
+        projector.graph.reduce(projected_root)
+    } else {
+        projected_root
+    };
     let mut context = ProjectedNarrowingContext {
         db,
         base_ty,
@@ -804,6 +809,7 @@ struct NarrowingProjector<'a, 'db> {
     place: ScopedPlaceId,
     project_cache: FxHashMap<ScopedNarrowingConstraint, ProjectedNarrowingNodeId>,
     graph: ProjectedNarrowingGraph<'db>,
+    resolved_nonterminal_call: bool,
 }
 
 impl<'a, 'db> NarrowingProjector<'a, 'db> {
@@ -821,6 +827,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             place,
             project_cache: FxHashMap::default(),
             graph: ProjectedNarrowingGraph::default(),
+            resolved_nonterminal_call: false,
         }
     }
 
@@ -860,8 +867,9 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                 let predicate = self.predicates[node.atom()];
 
                 if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
+                    self.resolved_nonterminal_call = true;
                     let if_uncertain = self.project(node.if_uncertain());
-                    let projected = match analyze_single(self.db, &predicate) {
+                    match analyze_single(self.db, &predicate) {
                         Truthiness::AlwaysTrue => {
                             let if_true = self.project(node.if_true());
                             self.graph.or(if_true, if_uncertain)
@@ -873,8 +881,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                         Truthiness::Ambiguous => {
                             unreachable!("`IsNonTerminalCall` predicates should never be Ambiguous")
                         }
-                    };
-                    self.graph.reduce(projected)
+                    }
                 } else {
                     let if_true = self.project(node.if_true());
                     let if_uncertain = self.project(node.if_uncertain());

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -907,10 +907,42 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
             let (pos_constraint, neg_constraint) =
                 self.graph.predicate_constraints_cache[&node.atom].clone();
 
+            if node.if_uncertain == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                if node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                    let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+                    return self.narrow(node.if_false, false_accumulated);
+                }
+                if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                    let true_accumulated = accumulate_constraint(accumulated, pos_constraint);
+                    return self.narrow(node.if_true, true_accumulated);
+                }
+
+                let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
+                let true_ty = self.narrow(node.if_true, true_accumulated);
+
+                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+                let false_ty = self.narrow(node.if_false, false_accumulated);
+
+                return UnionType::from_two_elements(self.db, true_ty, false_ty);
+            }
+
+            let uncertain_ty = self.narrow(node.if_uncertain, accumulated.clone());
+            if node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                    return uncertain_ty;
+                }
+
+                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+                let false_ty = self.narrow(node.if_false, false_accumulated);
+                return UnionType::from_two_elements(self.db, uncertain_ty, false_ty);
+            }
+
             let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
             let true_ty = self.narrow(node.if_true, true_accumulated);
 
-            let uncertain_ty = self.narrow(node.if_uncertain, accumulated.clone());
+            if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE {
+                return UnionType::from_two_elements(self.db, true_ty, uncertain_ty);
+            }
 
             let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
             let false_ty = self.narrow(node.if_false, false_accumulated);

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -613,6 +613,7 @@ struct ProjectedNarrowingGraph<'db> {
     node_cache: FxHashMap<ProjectedNarrowingNode, ProjectedNarrowingNodeId>,
     or_cache:
         FxHashMap<(ProjectedNarrowingNodeId, ProjectedNarrowingNodeId), ProjectedNarrowingNodeId>,
+    reduction_cache: FxHashMap<ProjectedNarrowingNodeId, ProjectedNarrowingNodeId>,
     predicate_constraints_cache: FxHashMap<
         ScopedPredicateId,
         (
@@ -645,6 +646,58 @@ impl ProjectedNarrowingGraph<'_> {
         self.nodes.push(node);
         self.node_cache.insert(node, id);
         id
+    }
+
+    /// Removes conditions made redundant by another path through the graph.
+    ///
+    /// Resolving a call predicate can expose a formula such as `A or (not A and B)`. The earlier
+    /// `A` path means that `not A` no longer narrows the `B` path, so this reduces the formula to
+    /// `A or B`.
+    fn reduce(&mut self, id: ProjectedNarrowingNodeId) -> ProjectedNarrowingNodeId {
+        if id.is_terminal() {
+            return id;
+        }
+        if let Some(cached) = self.reduction_cache.get(&id) {
+            return *cached;
+        }
+
+        let node = self.node(id);
+        let if_true = self.reduce(node.if_true);
+        let if_uncertain = self.reduce(node.if_uncertain);
+        let if_false = self.reduce(node.if_false);
+
+        let when_true = self.or(if_true, if_uncertain);
+        let when_true = self.reduce(when_true);
+        let when_false = self.or(if_false, if_uncertain);
+        let when_false = self.reduce(when_false);
+
+        let reduced = if when_true == when_false {
+            when_true
+        } else if when_true == ProjectedNarrowingNodeId::ALWAYS_TRUE {
+            self.add_node(ProjectedNarrowingNode {
+                atom: node.atom,
+                if_true: ProjectedNarrowingNodeId::ALWAYS_TRUE,
+                if_uncertain: when_false,
+                if_false: ProjectedNarrowingNodeId::ALWAYS_FALSE,
+            })
+        } else if when_false == ProjectedNarrowingNodeId::ALWAYS_TRUE {
+            self.add_node(ProjectedNarrowingNode {
+                atom: node.atom,
+                if_true: ProjectedNarrowingNodeId::ALWAYS_FALSE,
+                if_uncertain: when_true,
+                if_false: ProjectedNarrowingNodeId::ALWAYS_TRUE,
+            })
+        } else {
+            self.add_node(ProjectedNarrowingNode {
+                atom: node.atom,
+                if_true,
+                if_uncertain,
+                if_false,
+            })
+        };
+
+        self.reduction_cache.insert(id, reduced);
+        reduced
     }
 
     /// Returns the projected nodes that join multiple incoming paths.
@@ -808,7 +861,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
 
                 if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
                     let if_uncertain = self.project(node.if_uncertain());
-                    match analyze_single(self.db, &predicate) {
+                    let projected = match analyze_single(self.db, &predicate) {
                         Truthiness::AlwaysTrue => {
                             let if_true = self.project(node.if_true());
                             self.graph.or(if_true, if_uncertain)
@@ -820,7 +873,8 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                         Truthiness::Ambiguous => {
                             unreachable!("`IsNonTerminalCall` predicates should never be Ambiguous")
                         }
-                    }
+                    };
+                    self.graph.reduce(projected)
                 } else {
                     let if_true = self.project(node.if_true());
                     let if_uncertain = self.project(node.if_uncertain());

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,5 +1,5 @@
 use crate::Db;
-use crate::reachability::ReachabilityConstraintsExtension;
+use crate::reachability::narrow_type_by_constraint;
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
@@ -2764,8 +2764,9 @@ pub(crate) trait NarrowingEvaluatorExtension<'db> {
 
 impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
     fn narrow(&self, db: &'db dyn Db, base_type: Type<'db>, place: ScopedPlaceId) -> Type<'db> {
-        self.reachability_constraints().narrow_by_constraint(
+        narrow_type_by_constraint(
             db,
+            self.narrowing_constraints(),
             self.predicates(),
             self.constraint(),
             base_type,


### PR DESCRIPTION
## Summary

This implements the alternative Doug outlined in [his review of #25729](https://github.com/astral-sh/ruff/pull/25729#pullrequestreview-4461683461): apply Duboc's TDD optimization directly to narrowing constraints.

For an `if`/`elif` chain like:

```python
if is_a(value):
    pass
elif is_b(value):
    pass
elif is_c(value):
    pass
else:
    return

reveal_type(value)  # C | B | A
```

Each later branch is reached only after the earlier checks fail, so we record the paths as `A`, `not A and B`, and `not A and not B and C`. Once the successful branches meet, those earlier failed checks are redundant, but retaining them makes the formula grow quickly and makes every later load of `value` expensive.

Narrowing constraints previously reused the reachability TDD. Reachability uses its third branch for an ambiguous result in Kleene three-valued logic, while narrowing formulas are boolean and do not use that branch. This gives narrowing constraints their own graph and uses the third edge as a "don't care" edge, following the Duboc optimization already used for specialization constraints in #23881. For example, `A or B` can store `A` once on `B`'s "don't care" edge instead of copying it into both outcomes of `B`. Projected narrowing now uses the same representation.

When merging an `if`/`elif` continuation, we remove preceding branch predicates from each later branch and use the smaller formula only when the resulting merge is equivalent to the original. This simplifies the example to `A or B or C`, while preserving exclusions when an earlier branch returns and does not reach the merge. Other control-flow merges retain the existing canonical representation to avoid unrelated revealed-type changes.
