### PR TITLE
[ty] Improve equality-based narrowing for `==`, `!=`, and `match`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/intersections.md
@@ -81,7 +81,7 @@ if x != "abc":
 ```py
 def _(x: int):
     if x != 1:
-        reveal_type(x)  # revealed: int & ~Literal[1]
+        reveal_type(x)  # revealed: int & ~Literal[1] & ~Literal[True]
 
         reveal_type(x != 1)  # revealed: bool
         reveal_type(x != 2)  # revealed: bool

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/elif_else.md
@@ -8,9 +8,9 @@ def _(x: int):
         # cannot narrow; could be a subclass of `int`
         reveal_type(x)  # revealed: int
     elif x == 2:
-        reveal_type(x)  # revealed: int & ~Literal[1]
+        reveal_type(x)  # revealed: int & ~Literal[1] & ~Literal[True]
     elif x != 3:
-        reveal_type(x)  # revealed: int & ~Literal[1] & ~Literal[2] & ~Literal[3]
+        reveal_type(x)  # revealed: int & ~Literal[1] & ~Literal[True] & ~Literal[2] & ~Literal[3]
 ```
 
 ## Positive contributions become negative in elif-else blocks, with simplification

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -241,7 +241,8 @@ def _(answer: AmbiguousEnum):
 ```
 
 `==` and `!=` must use the semantics of their respective dunder methods. In particular, a custom
-`__ne__` method does not affect narrowing based on `__eq__`:
+`__ne__` method does not affect narrowing based on `__eq__`. Conversely, a custom `__eq__` method
+affects narrowing based on both operators because the default `__ne__` delegates to `__eq__`:
 
 ```py
 from enum import Enum
@@ -263,6 +264,24 @@ def _(answer: IndependentEquality):
         reveal_type(answer)  # revealed: IndependentEquality
     else:
         reveal_type(answer)  # revealed: IndependentEquality
+
+class CoupledInequality(Enum):
+    NO = 0
+    YES = 1
+
+    def __eq__(self, other: object) -> bool:
+        return True
+
+def _(answer: CoupledInequality):
+    if answer == CoupledInequality.NO:
+        reveal_type(answer)  # revealed: CoupledInequality
+    else:
+        reveal_type(answer)  # revealed: CoupledInequality
+
+    if answer != CoupledInequality.NO:
+        reveal_type(answer)  # revealed: CoupledInequality
+    else:
+        reveal_type(answer)  # revealed: CoupledInequality
 ```
 
 ## Known built-in equality behavior

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -122,6 +122,89 @@ def enum_complement_rhs(x: Color, y: Intersection[Color, Not[Literal[Color.RED]]
         reveal_type(x)  # revealed: Literal[Color.GREEN, Color.BLUE]
 ```
 
+An assigned enum construction hook can replace the value declared in the class body. In that case,
+we cannot compare an enum member with its declared value statically:
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from enum import EnumMeta, StrEnum
+from typing import Any, Literal, cast
+
+def external_new(cls: type[Any], value: object) -> Any: ...
+def external_init(self: Any, value: object) -> None: ...
+def external_prepare(*args: Any, **kwargs: Any) -> Any: ...
+
+class OpaqueNew(StrEnum):
+    __new__ = cast(Any, staticmethod(external_new))
+
+    MEMBER = "member"
+
+class OpaqueInit(StrEnum):
+    __init__ = cast(Any, external_init)
+
+    MEMBER = "member"
+
+class OpaqueMeta(EnumMeta):
+    __prepare__ = cast(Any, external_prepare)
+
+class TransformedByMeta(StrEnum, metaclass=OpaqueMeta):
+    MEMBER = "member"
+
+def opaque_new(value: Literal[OpaqueNew.MEMBER] | Literal["member"]):
+    if value == "member":
+        reveal_type(value)  # revealed: OpaqueNew | Literal["member"]
+    else:
+        reveal_type(value)  # revealed: OpaqueNew
+
+def opaque_init(value: Literal[OpaqueInit.MEMBER] | Literal["member"]):
+    if value == "member":
+        reveal_type(value)  # revealed: OpaqueInit | Literal["member"]
+    else:
+        reveal_type(value)  # revealed: OpaqueInit
+
+def transformed_by_metaclass(value: Literal[TransformedByMeta.MEMBER] | Literal["member"]):
+    if value == "member":
+        reveal_type(value)  # revealed: TransformedByMeta | Literal["member"]
+    else:
+        reveal_type(value)  # revealed: TransformedByMeta
+```
+
+An opaque `_generate_next_value_` affects `auto()` members, but explicit members still have their
+declared values:
+
+```py
+from enum import StrEnum, auto
+from typing import Any, Literal, cast
+
+def external_generate_next_value(*args: Any) -> Any: ...
+
+class OpaqueGenerator(StrEnum):
+    _generate_next_value_ = cast(Any, staticmethod(external_generate_next_value))
+
+    AUTOMATIC = auto()
+    EXPLICIT = "explicit"
+
+def opaque_generated_value(
+    value: Literal[OpaqueGenerator.AUTOMATIC] | Literal["automatic"],
+):
+    if value == "automatic":
+        reveal_type(value)  # revealed: Literal[OpaqueGenerator.AUTOMATIC, "automatic"]
+    else:
+        reveal_type(value)  # revealed: Literal[OpaqueGenerator.AUTOMATIC]
+
+def explicit_value(
+    value: Literal[OpaqueGenerator.EXPLICIT] | Literal["other"],
+):
+    if value == "explicit":
+        reveal_type(value)  # revealed: Literal[OpaqueGenerator.EXPLICIT]
+    else:
+        reveal_type(value)  # revealed: Literal[OpaqueGenerator.EXPLICIT, "other"]
+```
+
 This narrowing behavior is only safe if the enum has no custom `__eq__`/`__ne__` method:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -367,11 +367,11 @@ else:
 ## Union with `Any`
 
 ```py
-from typing import Any
+from typing import Any, Literal
 
 def _(x: Any | None, y: Any | None):
     if x != 1:
-        reveal_type(x)  # revealed: (Any & ~Literal[1]) | None
+        reveal_type(x)  # revealed: (Any & ~Literal[1] & ~Literal[True]) | None
     if y == 1:
         reveal_type(y)  # revealed: Any & ~None
 
@@ -385,6 +385,12 @@ def _(x: Any):
         reveal_type(x)  # revealed: Any & ~Literal[True] & ~Literal[1]
     else:
         reveal_type(x)  # revealed: Any
+
+def _(x: Literal["foo", "bar"] | Any):
+    if x != "bar":
+        reveal_type(x)  # revealed: Literal["foo"] | (Any & ~Literal["bar"])
+    else:
+        reveal_type(x)  # revealed: Literal["bar"] | (Any & ~Literal["foo"])
 ```
 
 ## Booleans and integers

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -286,15 +286,22 @@ def _(answer: CoupledInequality):
 
 ## Known built-in equality behavior
 
-`bool`, `LiteralString`, and `TypedDict` have known built-in equality behavior. Comparing two values
-with the same known behavior can therefore eliminate `None`:
+`bool`, `LiteralString`, `TypedDict`, and final classes that inherit `object.__eq__` have known
+built-in equality behavior. Comparing two values with the same known behavior can therefore
+eliminate disjoint union elements:
 
 ```py
-from typing import TypedDict
+from typing import TypedDict, final
 from typing_extensions import LiteralString
 
 class Payload(TypedDict):
     value: int
+
+@final
+class A: ...
+
+@final
+class B: ...
 
 def narrow_bool(value: bool | None, other: bool):
     if value == other:
@@ -318,6 +325,10 @@ def narrow_typed_dict(value: Payload | None, other: Payload):
         reveal_type(value)  # revealed: Payload
     else:
         reveal_type(value)  # revealed: Payload | None
+
+def narrow_final_object_equality(value: A | B, other: A):
+    if value == other:
+        reveal_type(value)  # revealed: A
 ```
 
 ## Comparisons with user-defined methods

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -161,6 +161,68 @@ def _(answer: AmbiguousEnum):
         reveal_type(answer)  # revealed: AmbiguousEnum
 ```
 
+`==` and `!=` must use the semantics of their respective dunder methods. In particular, a custom
+`__ne__` method does not affect narrowing based on `__eq__`:
+
+```py
+from enum import Enum
+from typing import Literal
+
+class IndependentEquality(Enum):
+    NO = 0
+    YES = 1
+
+    def __ne__(self, other: object) -> Literal[True]:
+        return True
+
+def _(answer: IndependentEquality):
+    if answer == IndependentEquality.NO:
+        reveal_type(answer)  # revealed: Literal[IndependentEquality.NO]
+    else:
+        reveal_type(answer)  # revealed: Literal[IndependentEquality.YES]
+
+    if answer != IndependentEquality.NO:
+        reveal_type(answer)  # revealed: IndependentEquality
+    else:
+        reveal_type(answer)  # revealed: Never
+```
+
+## Equality between concrete runtime classes
+
+Types such as `bool`, `LiteralString`, and `TypedDict` correspond to specific runtime classes.
+Equality with another instance of the same runtime class can therefore eliminate `None`:
+
+```py
+from typing import TypedDict
+from typing_extensions import LiteralString
+
+class Payload(TypedDict):
+    value: int
+
+def narrow_bool(value: bool | None, other: bool):
+    if value == other:
+        reveal_type(value)  # revealed: bool
+    else:
+        reveal_type(value)  # revealed: bool | None
+
+    if value != other:
+        reveal_type(value)  # revealed: bool | None
+    else:
+        reveal_type(value)  # revealed: bool
+
+def narrow_literal_string(value: LiteralString | None, other: LiteralString):
+    if value == other:
+        reveal_type(value)  # revealed: LiteralString
+    else:
+        reveal_type(value)  # revealed: LiteralString | None
+
+def narrow_typed_dict(value: Payload | None, other: Payload):
+    if value == other:
+        reveal_type(value)  # revealed: Payload
+    else:
+        reveal_type(value)  # revealed: Payload | None
+```
+
 ## `x != y` where `y` is of literal type
 
 ```py
@@ -326,8 +388,7 @@ def _(s: LiteralString | None, t: LiteralString | Any):
         reveal_type(s)  # revealed: Never
 
     if t == "foo":
-        # TODO could be `Literal["foo"] | Any`
-        reveal_type(t)  # revealed: LiteralString | Any
+        reveal_type(t)  # revealed: Literal["foo"] | Any
 ```
 
 ## Narrowing with tuple types

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -352,21 +352,6 @@ def narrow_different_equality_implementations(value: FinalObject | FinalInt, oth
         reveal_type(value)  # revealed: FinalObject
 ```
 
-Singleton nominal instances compare equal to themselves when they inherit a known equality
-implementation:
-
-```py
-import sys
-from typing_extensions import assert_never
-
-def narrow_singleton_nominal_instance():
-    value = sys.version_info
-    if value == sys.version_info:
-        reveal_type(value)  # revealed: _version_info
-    else:
-        assert_never(value)
-```
-
 ## Constrained type variables
 
 Equality analysis expands the constraints of a constrained type variable in either operand position.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -166,13 +166,12 @@ def _(answer: AmbiguousEnum):
 
 ```py
 from enum import Enum
-from typing import Literal
 
 class IndependentEquality(Enum):
     NO = 0
     YES = 1
 
-    def __ne__(self, other: object) -> Literal[True]:
+    def __ne__(self, other: object) -> bool:
         return True
 
 def _(answer: IndependentEquality):
@@ -184,7 +183,7 @@ def _(answer: IndependentEquality):
     if answer != IndependentEquality.NO:
         reveal_type(answer)  # revealed: IndependentEquality
     else:
-        reveal_type(answer)  # revealed: Never
+        reveal_type(answer)  # revealed: IndependentEquality
 ```
 
 ## Equality between concrete runtime classes
@@ -221,6 +220,39 @@ def narrow_typed_dict(value: Payload | None, other: Payload):
         reveal_type(value)  # revealed: Payload
     else:
         reveal_type(value)  # revealed: Payload | None
+```
+
+## Comparisons with user-defined methods
+
+Arbitrary user-defined comparison methods are not used for narrowing. This keeps both operand orders
+conservative without needing to model Python's reflected-comparison dispatch:
+
+```py
+class Left:
+    def __eq__(self, other: object) -> bool:
+        return True
+
+class Right:
+    def __eq__(self, other: object) -> bool:
+        return False
+
+def _(value: Right | None):
+    if Left() == value:
+        reveal_type(value)  # revealed: Right | None
+    else:
+        reveal_type(value)  # revealed: Right | None
+```
+
+Distinct objects with known identity-based comparison semantics remain definitively unequal:
+
+```py
+def callback() -> None: ...
+def _(flag: bool):
+    value = callback if flag else None
+    if value == int:
+        reveal_type(value)  # revealed: Never
+    else:
+        reveal_type(value)  # revealed: (def callback() -> None) | None
 ```
 
 ## `x != y` where `y` is of literal type
@@ -342,6 +374,17 @@ def _(x: Any | None, y: Any | None):
         reveal_type(x)  # revealed: (Any & ~Literal[1]) | None
     if y == 1:
         reveal_type(y)  # revealed: Any & ~None
+
+def _(x: Any):
+    if x == True:
+        reveal_type(x)  # revealed: Any
+    else:
+        reveal_type(x)  # revealed: Any & ~Literal[True] & ~Literal[1]
+
+    if x != True:
+        reveal_type(x)  # revealed: Any & ~Literal[True] & ~Literal[1]
+    else:
+        reveal_type(x)  # revealed: Any
 ```
 
 ## Booleans and integers

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -492,6 +492,51 @@ def _(b: bool, i: Literal[1, 2]):
         reveal_type(i)  # revealed: Literal[2]
 ```
 
+## Final subclasses of scalar builtins
+
+Final subclasses can inherit the equality behavior of `int`, `str`, or `bytes`. Instances of these
+subclasses can compare equal to builtin literals even though the subclass and literal types are
+disjoint, so equality does not narrow the subclass to the literal type.
+
+```py
+from typing import final
+
+@final
+class FinalInt(int): ...
+
+@final
+class FinalStr(str): ...
+
+@final
+class FinalBytes(bytes): ...
+
+def _(value: FinalInt):
+    if value == 1:
+        reveal_type(value)  # revealed: FinalInt
+    else:
+        reveal_type(value)  # revealed: FinalInt
+
+    if 1 == value:
+        reveal_type(value)  # revealed: FinalInt
+
+    if value != 1:
+        reveal_type(value)  # revealed: FinalInt
+    else:
+        reveal_type(value)  # revealed: FinalInt
+
+def _(value: FinalStr):
+    if value == "value":
+        reveal_type(value)  # revealed: FinalStr
+    else:
+        reveal_type(value)  # revealed: FinalStr
+
+def _(value: FinalBytes):
+    if value == b"value":
+        reveal_type(value)  # revealed: FinalBytes
+    else:
+        reveal_type(value)  # revealed: FinalBytes
+```
+
 ## Narrowing `LiteralString` in union
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -580,7 +580,30 @@ else:
 ## Union with `Any`
 
 ```py
-from typing import Any, Literal
+import sys
+from enum import Enum, IntEnum
+from typing import Any, Literal, TypeVar
+
+T = TypeVar("T", bound=object)
+RUNTIME_TYPE_VAR = TypeVar("RUNTIME_TYPE_VAR")
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+class NonReflexive(Enum):
+    VALUE = 1
+
+    def __eq__(self, other: object) -> Literal[False]:
+        return False
+
+    def __ne__(self, other: object) -> Literal[True]:
+        return True
+
+class Marker: ...
+
+class SingleIntEnum(IntEnum):
+    VALUE = 1
 
 def _(x: Any | None, y: Any | None):
     if x != 1:
@@ -604,6 +627,49 @@ def _(x: Literal["foo", "bar"] | Any):
         reveal_type(x)  # revealed: Literal["foo"] | (Any & ~Literal["bar"])
     else:
         reveal_type(x)  # revealed: Literal["bar"] | (Any & ~Literal["foo"])
+
+def _(x: Any):
+    if x != Color.RED:
+        reveal_type(x)  # revealed: Any & ~Literal[Color.RED]
+
+    if x != NonReflexive.VALUE:
+        reveal_type(x)  # revealed: Any
+
+    if x != Marker:
+        reveal_type(x)  # revealed: Any & ~<class 'Marker'>
+
+def _(x: T):
+    if x != Color.RED:
+        reveal_type(x)  # revealed: T@_ & ~Literal[Color.RED]
+
+def _(x: Any, y: T | str):
+    if x != y:
+        reveal_type(x)  # revealed: Any
+
+def _(x: Any, y: Any | str):
+    if x != y:
+        reveal_type(x)  # revealed: Any
+
+def _(x: Any):
+    if x != list[Any]:
+        reveal_type(x)  # revealed: Any & ~<class 'list[Any]'>
+
+def _(x: Any, y: SingleIntEnum):
+    if x == y:
+        pass
+    else:
+        reveal_type(x)  # revealed: Any & ~Literal[SingleIntEnum.VALUE]
+
+def _(x: Any):
+    if x == sys.version_info:
+        pass
+    else:
+        reveal_type(x)  # revealed: Any & ~_version_info
+
+    if x == RUNTIME_TYPE_VAR:
+        pass
+    else:
+        reveal_type(x)  # revealed: Any & ~TypeVar
 ```
 
 ## Booleans and integers

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -224,9 +224,9 @@ def narrow_typed_dict(value: Payload | None, other: Payload):
 
 ## Comparisons with user-defined methods
 
-Arbitrary user-defined comparison methods are not used for narrowing, i.e., we don't inspect
-the bodies of user-defined `__eq__` or `__ne__` methods to predict their results, and instead
-require a `Literal` return type annotation:
+Arbitrary user-defined comparison methods are not used for narrowing, i.e., we don't inspect the
+bodies of user-defined `__eq__` or `__ne__` methods to predict their results, and instead require a
+`Literal` return type annotation:
 
 ```py
 class Left:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -269,10 +269,10 @@ def _(answer: IndependentEquality):
         reveal_type(answer)  # revealed: IndependentEquality
 ```
 
-## Equality between concrete runtime classes
+## Known built-in equality behavior
 
-Types such as `bool`, `LiteralString`, and `TypedDict` correspond to specific runtime classes.
-Equality with another instance of the same runtime class can therefore eliminate `None`:
+For `bool`, `LiteralString`, and `TypedDict`, ty knows which built-in equality implementation is
+used. Comparing two values with the same known behavior can therefore eliminate `None`:
 
 ```py
 from typing import TypedDict

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -122,8 +122,8 @@ def enum_complement_rhs(x: Color, y: Intersection[Color, Not[Literal[Color.RED]]
         reveal_type(x)  # revealed: Literal[Color.GREEN, Color.BLUE]
 ```
 
-An assigned enum construction hook can replace the value declared in the class body. In that case,
-we cannot compare an enum member with its declared value statically:
+An assignment to `__new__`, `__init__`, or other methods can replace the value declared in the class
+body. In that case, we cannot compare an enum member with its declared value statically:
 
 ```toml
 [environment]
@@ -132,45 +132,42 @@ python-version = "3.11"
 
 ```py
 from enum import EnumMeta, StrEnum
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
-def external_new(cls: type[Any], value: object) -> Any: ...
-def external_init(self: Any, value: object) -> None: ...
-def external_prepare(*args: Any, **kwargs: Any) -> Any: ...
+def _(new: Any, init: Any, prepare: Any):
+    class OpaqueNew(StrEnum):
+        __new__ = new
 
-class OpaqueNew(StrEnum):
-    __new__ = cast(Any, staticmethod(external_new))
+        MEMBER = "member"
 
-    MEMBER = "member"
+    class OpaqueInit(StrEnum):
+        __init__ = init
 
-class OpaqueInit(StrEnum):
-    __init__ = cast(Any, external_init)
+        MEMBER = "member"
 
-    MEMBER = "member"
+    class OpaqueMeta(EnumMeta):
+        __prepare__ = prepare
 
-class OpaqueMeta(EnumMeta):
-    __prepare__ = cast(Any, external_prepare)
+    class TransformedByMeta(StrEnum, metaclass=OpaqueMeta):
+        MEMBER = "member"
 
-class TransformedByMeta(StrEnum, metaclass=OpaqueMeta):
-    MEMBER = "member"
+    def opaque_new(value: Literal[OpaqueNew.MEMBER] | Literal["member"]):
+        if value == "member":
+            reveal_type(value)  # revealed: OpaqueNew | Literal["member"]
+        else:
+            reveal_type(value)  # revealed: OpaqueNew
 
-def opaque_new(value: Literal[OpaqueNew.MEMBER] | Literal["member"]):
-    if value == "member":
-        reveal_type(value)  # revealed: OpaqueNew | Literal["member"]
-    else:
-        reveal_type(value)  # revealed: OpaqueNew
+    def opaque_init(value: Literal[OpaqueInit.MEMBER] | Literal["member"]):
+        if value == "member":
+            reveal_type(value)  # revealed: OpaqueInit | Literal["member"]
+        else:
+            reveal_type(value)  # revealed: OpaqueInit
 
-def opaque_init(value: Literal[OpaqueInit.MEMBER] | Literal["member"]):
-    if value == "member":
-        reveal_type(value)  # revealed: OpaqueInit | Literal["member"]
-    else:
-        reveal_type(value)  # revealed: OpaqueInit
-
-def transformed_by_metaclass(value: Literal[TransformedByMeta.MEMBER] | Literal["member"]):
-    if value == "member":
-        reveal_type(value)  # revealed: TransformedByMeta | Literal["member"]
-    else:
-        reveal_type(value)  # revealed: TransformedByMeta
+    def transformed_by_metaclass(value: Literal[TransformedByMeta.MEMBER] | Literal["member"]):
+        if value == "member":
+            reveal_type(value)  # revealed: TransformedByMeta | Literal["member"]
+        else:
+            reveal_type(value)  # revealed: TransformedByMeta
 ```
 
 An opaque `_generate_next_value_` affects `auto()` members, but explicit members still have their
@@ -178,31 +175,30 @@ declared values:
 
 ```py
 from enum import StrEnum, auto
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
-def external_generate_next_value(*args: Any) -> Any: ...
+def _(generate_next_value: Any):
+    class OpaqueGenerator(StrEnum):
+        _generate_next_value_ = generate_next_value
 
-class OpaqueGenerator(StrEnum):
-    _generate_next_value_ = cast(Any, staticmethod(external_generate_next_value))
+        AUTOMATIC = auto()
+        EXPLICIT = "explicit"
 
-    AUTOMATIC = auto()
-    EXPLICIT = "explicit"
+    def opaque_generated_value(
+        value: Literal[OpaqueGenerator.AUTOMATIC] | Literal["automatic"],
+    ):
+        if value == "automatic":
+            reveal_type(value)  # revealed: Literal[OpaqueGenerator.AUTOMATIC, "automatic"]
+        else:
+            reveal_type(value)  # revealed: Literal[OpaqueGenerator.AUTOMATIC]
 
-def opaque_generated_value(
-    value: Literal[OpaqueGenerator.AUTOMATIC] | Literal["automatic"],
-):
-    if value == "automatic":
-        reveal_type(value)  # revealed: Literal[OpaqueGenerator.AUTOMATIC, "automatic"]
-    else:
-        reveal_type(value)  # revealed: Literal[OpaqueGenerator.AUTOMATIC]
-
-def explicit_value(
-    value: Literal[OpaqueGenerator.EXPLICIT] | Literal["other"],
-):
-    if value == "explicit":
-        reveal_type(value)  # revealed: Literal[OpaqueGenerator.EXPLICIT]
-    else:
-        reveal_type(value)  # revealed: Literal[OpaqueGenerator.EXPLICIT, "other"]
+    def explicit_value(
+        value: Literal[OpaqueGenerator.EXPLICIT] | Literal["other"],
+    ):
+        if value == "explicit":
+            reveal_type(value)  # revealed: Literal[OpaqueGenerator.EXPLICIT]
+        else:
+            reveal_type(value)  # revealed: Literal[OpaqueGenerator.EXPLICIT, "other"]
 ```
 
 This narrowing behavior is only safe if the enum has no custom `__eq__`/`__ne__` method:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -329,6 +329,122 @@ def narrow_typed_dict(value: Payload | None, other: Payload):
 def narrow_final_object_equality(value: A | B, other: A):
     if value == other:
         reveal_type(value)  # revealed: A
+
+    if value != other:
+        reveal_type(value)  # revealed: A | B
+    else:
+        reveal_type(value)  # revealed: A
+```
+
+Different inherited built-in implementations cannot compare equal:
+
+```py
+from typing import final
+
+@final
+class FinalObject: ...
+
+@final
+class FinalInt(int): ...
+
+def narrow_different_equality_implementations(value: FinalObject | FinalInt, other: FinalObject):
+    if value == other:
+        reveal_type(value)  # revealed: FinalObject
+```
+
+Singleton nominal instances compare equal to themselves when they inherit a known equality
+implementation:
+
+```py
+import sys
+from typing_extensions import assert_never
+
+def narrow_singleton_nominal_instance():
+    value = sys.version_info
+    if value == sys.version_info:
+        reveal_type(value)  # revealed: _version_info
+    else:
+        assert_never(value)
+```
+
+## Constrained type variables
+
+Equality analysis expands the constraints of a constrained type variable in either operand position.
+The resulting constraint is intersected with the type variable, preserving its identity:
+
+```py
+from typing import TypeVar, final
+
+@final
+class ConstraintA: ...
+
+@final
+class ConstraintB: ...
+
+T = TypeVar("T", ConstraintA, ConstraintB)
+
+def constrained_left(value: T | None, other: ConstraintA):
+    if value != other:
+        pass
+    else:
+        reveal_type(value)  # revealed: T@constrained_left & ConstraintA
+
+def constrained_right(value: ConstraintA | None, other: T):
+    if value != other:
+        pass
+    else:
+        reveal_type(value)  # revealed: ConstraintA
+```
+
+## `LiteralString` and string-valued enums
+
+`LiteralString` can be narrowed by comparison with a string-valued enum member that inherits `str`'s
+equality implementation:
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from enum import StrEnum
+from typing_extensions import LiteralString
+
+class Color(StrEnum):
+    RED = "red"
+
+def narrow_literal_string_with_enum(value: LiteralString | None):
+    if value == Color.RED:
+        reveal_type(value)  # revealed: Literal["red"]
+    else:
+        reveal_type(value)  # revealed: (LiteralString & ~Literal["red"]) | None
+
+    if Color.RED != value:
+        reveal_type(value)  # revealed: (LiteralString & ~Literal["red"]) | None
+    else:
+        reveal_type(value)  # revealed: Literal["red"]
+```
+
+## Module literals
+
+Modules compare equal only to the same module object:
+
+```py
+import sys
+import typing
+
+def narrow_module_literal(flag: bool):
+    value = sys if flag else typing
+
+    if value == sys:
+        reveal_type(value)  # revealed: <module 'sys'>
+    else:
+        reveal_type(value)  # revealed: <module 'typing'>
+
+    if value != sys:
+        reveal_type(value)  # revealed: <module 'typing'>
+    else:
+        reveal_type(value)  # revealed: <module 'sys'>
 ```
 
 ## Comparisons with user-defined methods

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -271,8 +271,8 @@ def _(answer: IndependentEquality):
 
 ## Known built-in equality behavior
 
-For `bool`, `LiteralString`, and `TypedDict`, ty knows which built-in equality implementation is
-used. Comparing two values with the same known behavior can therefore eliminate `None`:
+`bool`, `LiteralString`, and `TypedDict` have known built-in equality behavior. Comparing two values
+with the same known behavior can therefore eliminate `None`:
 
 ```py
 from typing import TypedDict

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -585,6 +585,7 @@ from enum import Enum, IntEnum
 from typing import Any, Literal, TypeVar
 
 T = TypeVar("T", bound=object)
+EQUAL_VALUES = TypeVar("EQUAL_VALUES", Literal[0], Literal[False])
 RUNTIME_TYPE_VAR = TypeVar("RUNTIME_TYPE_VAR")
 
 class Color(Enum):
@@ -641,6 +642,11 @@ def _(x: Any):
 def _(x: T):
     if x != Color.RED:
         reveal_type(x)  # revealed: T@_ & ~Literal[Color.RED]
+
+def _(x: Any, y: EQUAL_VALUES):
+    if x != y:
+        # TODO: This can narrow to `Any & ~EQUAL_VALUES@_` because all constraints compare equal.
+        reveal_type(x)  # revealed: Any
 
 def _(x: Any, y: T | str):
     if x != y:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -307,9 +307,8 @@ def narrow_typed_dict(value: Payload | None, other: Payload):
 
 ## Comparisons with user-defined methods
 
-Arbitrary user-defined comparison methods are not used for narrowing, i.e., we don't inspect the
-bodies of user-defined `__eq__` or `__ne__` methods to predict their results, and instead require a
-`Literal` return type annotation:
+Arbitrary user-defined comparison methods are not used to narrow their operands. In particular, we
+don't inspect the bodies of user-defined `__eq__` or `__ne__` methods to predict their results:
 
 ```py
 class Left:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -224,8 +224,9 @@ def narrow_typed_dict(value: Payload | None, other: Payload):
 
 ## Comparisons with user-defined methods
 
-Arbitrary user-defined comparison methods are not used for narrowing. This keeps both operand orders
-conservative without needing to model Python's reflected-comparison dispatch:
+Arbitrary user-defined comparison methods are not used for narrowing, i.e., we don't inspect
+the bodies of user-defined `__eq__` or `__ne__` methods to predict their results, and instead
+require a `Literal` return type annotation:
 
 ```py
 class Left:
@@ -241,18 +242,6 @@ def _(value: Right | None):
         reveal_type(value)  # revealed: Right | None
     else:
         reveal_type(value)  # revealed: Right | None
-```
-
-Distinct objects with known identity-based comparison semantics remain definitively unequal:
-
-```py
-def callback() -> None: ...
-def _(flag: bool):
-    value = callback if flag else None
-    if value == int:
-        reveal_type(value)  # revealed: Never
-    else:
-        reveal_type(value)  # revealed: (def callback() -> None) | None
 ```
 
 ## `x != y` where `y` is of literal type

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
@@ -7,7 +7,7 @@ def _(x: int):
     if x != 1:
         if x != 2:
             if x != 3:
-                reveal_type(x)  # revealed: int & ~Literal[1] & ~Literal[2] & ~Literal[3]
+                reveal_type(x)  # revealed: int & ~Literal[1] & ~Literal[True] & ~Literal[2] & ~Literal[3]
 ```
 
 ## Multiple negative contributions with simplification
@@ -52,7 +52,13 @@ def _(xs: list[int | None], ys: list[str | bytes], list_of_optional_lists: list[
 
     [_ for x in xs if x is not None if reveal_type(x) // 3 != 0]  # revealed: int
 
-    [reveal_type(x) for x in xs if x is not None if x != 0 if x != 1]  # revealed: int & ~Literal[0] & ~Literal[1]
+    [
+        reveal_type(x)  # revealed: int & ~Literal[0] & ~Literal[False] & ~Literal[1] & ~Literal[True]
+        for x in xs
+        if x is not None
+        if x != 0
+        if x != 1
+    ]
 
     [reveal_type((x, y)) for x in xs if x is not None for y in ys if isinstance(y, str)]  # revealed: tuple[int, str]
     [reveal_type((x, y)) for y in ys if isinstance(y, str) for x in xs if x is not None]  # revealed: tuple[int, str]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
@@ -52,13 +52,8 @@ def _(xs: list[int | None], ys: list[str | bytes], list_of_optional_lists: list[
 
     [_ for x in xs if x is not None if reveal_type(x) // 3 != 0]  # revealed: int
 
-    [
-        reveal_type(x)  # revealed: int & ~Literal[0] & ~Literal[False] & ~Literal[1] & ~Literal[True]
-        for x in xs
-        if x is not None
-        if x != 0
-        if x != 1
-    ]
+    # revealed: int & ~Literal[0] & ~Literal[False] & ~Literal[1] & ~Literal[True]
+    [reveal_type(x) for x in xs if x is not None if x != 0 if x != 1]
 
     [reveal_type((x, y)) for x in xs if x is not None for y in ys if isinstance(y, str)]  # revealed: tuple[int, str]
     [reveal_type((x, y)) for y in ys if isinstance(y, str) for x in xs if x is not None]  # revealed: tuple[int, str]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -582,6 +582,80 @@ def _(x: Literal["foo", "bar", 42, b"foo"] | bool | complex):
             reveal_type(x)  # revealed: Literal["bar"] | (int & ~Literal[42]) | float | complex
 ```
 
+## Enum equality semantics
+
+Enum value patterns use the enum class's actual `__eq__` implementation. Members of `StrEnum`
+therefore compare equal to string literals with the same value:
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from enum import Enum, StrEnum
+from typing import Literal, assert_never, reveal_type
+
+class Color(StrEnum):
+    RED = "r"
+    GREEN = "g"
+    BLUE = "b"
+
+def test_literal_as_enum(x: Literal["g"]) -> None:
+    match x:
+        case Color.RED:
+            assert_never(x)
+        case Color.GREEN:
+            reveal_type(x)  # revealed: Literal["g"]
+        case Color.BLUE:
+            assert_never(x)
+        case _:
+            assert_never(x)
+
+def test_enum_as_literal(y: Literal[Color.BLUE]) -> None:
+    match y:
+        case "r":
+            assert_never(y)
+        case "g":
+            assert_never(y)
+        case "b":
+            reveal_type(y)  # revealed: Literal[Color.BLUE]
+        case _:
+            assert_never(y)
+
+class AlwaysEqual(Enum):
+    RED = "r"
+    GREEN = "g"
+
+    def __eq__(self, other: object) -> Literal[True]:
+        return True
+
+def custom_eq(value: AlwaysEqual) -> None:
+    match value:
+        case AlwaysEqual.RED:
+            reveal_type(value)  # revealed: AlwaysEqual
+        case AlwaysEqual.GREEN:
+            reveal_type(value)  # revealed: Never
+        case _:
+            reveal_type(value)  # revealed: Never
+
+class CustomNe(Enum):
+    RED = "r"
+    GREEN = "g"
+
+    def __ne__(self, other: object) -> Literal[True]:
+        return True
+
+def custom_ne_does_not_affect_match(value: CustomNe) -> None:
+    match value:
+        case CustomNe.RED:
+            reveal_type(value)  # revealed: Literal[CustomNe.RED]
+        case CustomNe.GREEN:
+            reveal_type(value)  # revealed: Literal[CustomNe.GREEN]
+        case _:
+            reveal_type(value)  # revealed: Never
+```
+
 ## Value patterns with guard
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -666,10 +666,10 @@ def _(x: Literal["foo", "bar", 42, b"foo"] | bool | complex):
 
 ## Enum equality semantics
 
-Enum value patterns use the enum class's actual `__eq__` implementation. Members of an ordinary
-`Enum` compare by identity and cannot equal `None`. Members of `StrEnum` compare equal to string
-literals with the same value. Matching a member against itself is exhaustive whenever its comparison
-behavior is known, even if its underlying value is not:
+Enum value patterns use the enum class's actual `__eq__` implementation. Members of an enum whose
+`__eq__` resolves to `object.__eq__` compare by identity and cannot equal `None`. `StrEnum` members
+compare equal to string literals with the same value. Matching a member against itself is exhaustive
+whenever its comparison behavior is known, even if its underlying value is not:
 
 ```toml
 [environment]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -581,6 +581,67 @@ def _(value: FinalPatternInt):
             reveal_type(value)  # revealed: FinalPatternInt
 ```
 
+Some precisely modeled objects compare equal to themselves, so an equivalent value pattern is
+exhaustive:
+
+```py
+from types import FunctionType
+from typing import NewType, TypeVar
+
+T = TypeVar("T")
+UserId = NewType("UserId", int)
+
+class ReflexivePatternValues:
+    LIST_INT = list[int]
+    TYPE_VAR = T
+    NEW_TYPE = UserId
+
+def generic_alias_value_pattern() -> int:
+    match list[int]:
+        case ReflexivePatternValues.LIST_INT:
+            return 1
+
+def type_var_value_pattern() -> int:
+    match T:
+        case ReflexivePatternValues.TYPE_VAR:
+            return 1
+
+def new_type_value_pattern() -> int:
+    match UserId:
+        case ReflexivePatternValues.NEW_TYPE:
+            return 1
+
+def helper() -> None: ...
+def wrapper_descriptor_value_pattern() -> int:
+    match FunctionType.__get__:
+        case FunctionType.__get__:
+            return 1
+
+def bound_method_value_pattern() -> int:
+    match helper.__get__:
+        case helper.__get__:
+            return 1
+```
+
+Two calls that construct equivalent objects need not produce equal values. For example, separate
+`partial` objects do not compare equal, so this match is not exhaustive:
+
+```py
+from functools import partial
+
+def target(value: int) -> int:
+    return value
+
+class PartialPatternValues:
+    VALUE = partial(target, 1)
+
+# error: [invalid-return-type]
+def partial_value_pattern() -> int:
+    match partial(target, 1):
+        case PartialPatternValues.VALUE:
+            return 1
+```
+
 ```py
 from typing import Literal
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -638,6 +638,25 @@ def custom_eq(value: AlwaysEqual) -> None:
             reveal_type(value)  # revealed: AlwaysEqual
         case _:
             reveal_type(value)  # revealed: AlwaysEqual
+
+class NeverEqualMeta(type):
+    def __eq__(cls, other: object) -> Literal[False]:
+        return False
+
+class NeverEqualValue(metaclass=NeverEqualMeta):
+    pass
+
+class Constants:
+    VALUE = NeverEqualValue
+
+def non_reflexive_value_pattern_does_not_narrow_fallback(
+    value: tuple[type[NeverEqualValue]],
+) -> None:
+    match value:
+        case [Constants.VALUE]:
+            pass
+        case _:
+            reveal_type(value)  # revealed: tuple[type[NeverEqualValue]]
 ```
 
 ## Value patterns with guard

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -627,7 +627,7 @@ class AlwaysEqual(Enum):
     RED = "r"
     GREEN = "g"
 
-    def __eq__(self, other: object) -> Literal[True]:
+    def __eq__(self, other: object) -> bool:
         return True
 
 def custom_eq(value: AlwaysEqual) -> None:
@@ -635,25 +635,9 @@ def custom_eq(value: AlwaysEqual) -> None:
         case AlwaysEqual.RED:
             reveal_type(value)  # revealed: AlwaysEqual
         case AlwaysEqual.GREEN:
-            reveal_type(value)  # revealed: Never
+            reveal_type(value)  # revealed: AlwaysEqual
         case _:
-            reveal_type(value)  # revealed: Never
-
-class CustomNe(Enum):
-    RED = "r"
-    GREEN = "g"
-
-    def __ne__(self, other: object) -> Literal[True]:
-        return True
-
-def custom_ne_does_not_affect_match(value: CustomNe) -> None:
-    match value:
-        case CustomNe.RED:
-            reveal_type(value)  # revealed: Literal[CustomNe.RED]
-        case CustomNe.GREEN:
-            reveal_type(value)  # revealed: Literal[CustomNe.GREEN]
-        case _:
-            reveal_type(value)  # revealed: Never
+            reveal_type(value)  # revealed: AlwaysEqual
 ```
 
 ## Value patterns with guard

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -638,25 +638,6 @@ def custom_eq(value: AlwaysEqual) -> None:
             reveal_type(value)  # revealed: AlwaysEqual
         case _:
             reveal_type(value)  # revealed: AlwaysEqual
-
-class NeverEqualMeta(type):
-    def __eq__(cls, other: object) -> Literal[False]:
-        return False
-
-class NeverEqualValue(metaclass=NeverEqualMeta):
-    pass
-
-class Constants:
-    VALUE = NeverEqualValue
-
-def non_reflexive_value_pattern_does_not_narrow_fallback(
-    value: tuple[type[NeverEqualValue]],
-) -> None:
-    match value:
-        case [Constants.VALUE]:
-            pass
-        case _:
-            reveal_type(value)  # revealed: tuple[type[NeverEqualValue]]
 ```
 
 ## Value patterns with guard

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -581,8 +581,6 @@ def _(value: FinalPatternInt):
             reveal_type(value)  # revealed: FinalPatternInt
 ```
 
-More examples follow.
-
 ```py
 from typing import Literal
 
@@ -617,7 +615,7 @@ python-version = "3.11"
 
 ```py
 from enum import Enum, StrEnum
-from typing import Literal, assert_never, reveal_type
+from typing import Literal, assert_never
 
 class Color(StrEnum):
     RED = "r"

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -558,6 +558,29 @@ arbitrary `int` subclass with an arbitrary `__eq__`, so we can't actually narrow
 In the second `match`'s `case "bar"` we know `x == "bar"`. As discussed above, this isn't enough to
 rule out `int`, but we know that `"foo" == "bar"` is false so we can eliminate `Literal["foo"]`.
 
+A final subclass with inherited builtin equality can compare equal to a literal despite being
+disjoint from the literal's type. This applies both to literal patterns and dotted value patterns:
+
+```py
+from typing import Final, final
+
+@final
+class FinalPatternInt(int): ...
+
+class PatternValues:
+    ONE: Final = 1
+
+def _(value: FinalPatternInt):
+    match value:
+        case 1 as captured:
+            reveal_type(value)  # revealed: FinalPatternInt
+            reveal_type(captured)  # revealed: @Todo(`match` pattern definition types)
+
+    match value:
+        case PatternValues.ONE:
+            reveal_type(value)  # revealed: FinalPatternInt
+```
+
 More examples follow.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -668,7 +668,8 @@ def _(x: Literal["foo", "bar", 42, b"foo"] | bool | complex):
 
 Enum value patterns use the enum class's actual `__eq__` implementation. Members of an ordinary
 `Enum` compare by identity and cannot equal `None`. Members of `StrEnum` compare equal to string
-literals with the same value:
+literals with the same value. Matching a member against itself is exhaustive whenever its comparison
+behavior is known, even if its underlying value is not:
 
 ```toml
 [environment]
@@ -676,7 +677,7 @@ python-version = "3.11"
 ```
 
 ```py
-from enum import Enum, StrEnum
+from enum import Enum, IntEnum, StrEnum
 from typing import Literal, assert_never
 
 class Color(StrEnum):
@@ -714,6 +715,14 @@ def enum_member_excludes_none(direction: Direction | None) -> None:
     match direction:
         case Direction.NORTH:
             reveal_type(direction)  # revealed: Literal[Direction.NORTH]
+
+class Status(IntEnum):
+    READY = 1
+
+def exact_int_enum_member_is_exhaustive(status: Literal[Status.READY]) -> int:
+    match status:
+        case Status.READY:
+            return 1
 
 class AlwaysEqual(Enum):
     RED = "r"

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -666,8 +666,9 @@ def _(x: Literal["foo", "bar", 42, b"foo"] | bool | complex):
 
 ## Enum equality semantics
 
-Enum value patterns use the enum class's actual `__eq__` implementation. Members of `StrEnum`
-therefore compare equal to string literals with the same value:
+Enum value patterns use the enum class's actual `__eq__` implementation. Members of an ordinary
+`Enum` compare by identity and cannot equal `None`. Members of `StrEnum` compare equal to string
+literals with the same value:
 
 ```toml
 [environment]
@@ -704,6 +705,15 @@ def test_enum_as_literal(y: Literal[Color.BLUE]) -> None:
             reveal_type(y)  # revealed: Literal[Color.BLUE]
         case _:
             assert_never(y)
+
+class Direction(Enum):
+    NORTH = "north"
+    SOUTH = "south"
+
+def enum_member_excludes_none(direction: Direction | None) -> None:
+    match direction:
+        case Direction.NORTH:
+            reveal_type(direction)  # revealed: Literal[Direction.NORTH]
 
 class AlwaysEqual(Enum):
     RED = "r"

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -677,7 +677,7 @@ python-version = "3.11"
 ```
 
 ```py
-from enum import Enum, IntEnum, StrEnum
+from enum import Enum, IntEnum, StrEnum, auto
 from typing import Literal, assert_never
 
 class Color(StrEnum):
@@ -723,6 +723,15 @@ def exact_int_enum_member_is_exhaustive(status: Literal[Status.READY]) -> int:
     match status:
         case Status.READY:
             return 1
+
+class Automatic(StrEnum):
+    GENERATED = auto()
+
+def auto_member_value_is_known(value: Literal["generated"]) -> None:
+    match value:
+        case Automatic.GENERATED:
+            return
+    assert_never(value)
 
 class AlwaysEqual(Enum):
     RED = "r"

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -202,8 +202,9 @@ use crate::{
     types::{
         CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, SpecialFormType,
         Type, TypeContext, UnionType, callable_pattern_type, definite_match_pattern_type,
-        enum_metadata, infer_narrowing_constraints, infer_same_file_expression_type,
-        mapping_pattern_type, sequence_pattern_type_builder, singleton_pattern_type,
+        enum_metadata, equality_truthiness, infer_narrowing_constraints,
+        infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
+        singleton_pattern_type,
     },
 };
 use ruff_index::{Idx, IndexSlice};
@@ -978,9 +979,8 @@ fn analyze_single_pattern_predicate_kind<'db>(
     match predicate_kind {
         PatternPredicateKind::Value(value) => {
             let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
-
             if subject_ty.is_single_valued(db) {
-                Truthiness::from(subject_ty.is_equivalent_to(db, value_ty))
+                equality_truthiness(db, subject_ty, value_ty)
             } else {
                 Truthiness::Ambiguous
             }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -979,6 +979,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
     match predicate_kind {
         PatternPredicateKind::Value(value) => {
             let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
+
             if subject_ty.is_single_valued(db) {
                 equality_truthiness(db, subject_ty, value_ty)
             } else {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -66,6 +66,7 @@ use crate::types::context::{LintDiagnosticGuard, LintDiagnosticGuardBuilder};
 use crate::types::diagnostic::{INVALID_AWAIT, INVALID_TYPE_FORM};
 pub use crate::types::display::{DisplaySettings, TypeDetail, TypeDisplayDetails};
 pub(crate) use crate::types::enums::{EnumComplementType, enum_metadata};
+pub(crate) use crate::types::equality::equality_truthiness;
 use crate::types::function::{
     DataclassTransformerFlags, DataclassTransformerParams, FunctionDecorators, FunctionSpans,
     FunctionType, KnownFunction,
@@ -124,6 +125,7 @@ mod cyclic;
 mod diagnostic;
 mod display;
 mod enums;
+mod equality;
 mod function;
 mod generics;
 pub mod ide_support;

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -188,13 +188,7 @@ impl<'db> EnumMetadata<'db> {
         }
         if let Some(annotation) = self.value_annotation {
             Some(annotation)
-        } else if self.init_function.is_some()
-            || self.new_function.is_some()
-            || self.opaque_init
-            || self.opaque_new
-            || self.custom_enum_metaclass_hooks
-            || (self.opaque_generate_next_value && self.auto_members.contains(member_name))
-        {
+        } else if self.member_value_may_be_transformed(member_name) {
             Some(Type::Dynamic(DynamicType::Any))
         } else if let Some(func_ty) = self.generate_next_value_function
             && self.auto_members.contains(member_name)
@@ -203,6 +197,18 @@ impl<'db> EnumMetadata<'db> {
         } else {
             self.members.get(member_name).copied()
         }
+    }
+
+    /// Return whether enum construction may replace the value declared for `member_name`.
+    ///
+    /// An opaque `_generate_next_value_` only affects members declared with `auto()`.
+    pub(crate) fn member_value_may_be_transformed(&self, member_name: &Name) -> bool {
+        self.init_function.is_some()
+            || self.new_function.is_some()
+            || self.opaque_init
+            || self.opaque_new
+            || self.custom_enum_metaclass_hooks
+            || (self.opaque_generate_next_value && self.auto_members.contains(member_name))
     }
 
     /// Returns the type of `.name`/`._name_` for a given enum member.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1218,10 +1218,7 @@ fn known_literal_equality<'db>(
 fn enum_literal_value<'db>(db: &'db dyn Db, literal: EnumLiteralType<'db>) -> Option<Type<'db>> {
     let metadata = enum_metadata(db, literal.enum_class(db))?;
     let name = metadata.resolve_member(literal.name(db))?;
-    if metadata.init_function.is_some()
-        || metadata.new_function.is_some()
-        || metadata.custom_enum_metaclass_new
-    {
+    if metadata.member_value_may_be_transformed(name) {
         return None;
     }
     if metadata.auto_members.contains(name) {

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -3,8 +3,8 @@ use ruff_python_ast::name::Name;
 use crate::{Db, place::PlaceAndQualifiers};
 
 use super::{
-    CallArguments, EnumLiteralType, IntersectionBuilder, KnownClass, LiteralValueTypeKind,
-    MemberLookupPolicy, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder,
+    EnumLiteralType, IntersectionBuilder, KnownClass, LiteralValueTypeKind, MemberLookupPolicy,
+    Truthiness, Type, TypeVarBoundOrConstraints, UnionBuilder,
     enums::{enum_member_literals, enum_metadata},
 };
 
@@ -49,6 +49,13 @@ impl<'db> ComparisonResult<'db> {
             ComparisonResult::AlwaysFalse => is_positive.then_some(Type::Never),
             ComparisonResult::CanNarrow(narrowed) => Some(narrowed),
             ComparisonResult::Ambiguous => None,
+        }
+    }
+
+    fn discard_narrowing(self) -> Self {
+        match self {
+            ComparisonResult::CanNarrow(_) => ComparisonResult::Ambiguous,
+            result => result,
         }
     }
 }
@@ -159,14 +166,13 @@ fn equality_result<'db>(
             None | Some(TypeVarBoundOrConstraints::UpperBound(_)) => ComparisonResult::Ambiguous,
         },
 
-        (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
-            match equality_result(db, newtype.concrete_base_type(db), other, is_positive) {
-                ComparisonResult::AlwaysTrue => ComparisonResult::AlwaysTrue,
-                ComparisonResult::AlwaysFalse => ComparisonResult::AlwaysFalse,
-                ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
-                    ComparisonResult::Ambiguous
-                }
-            }
+        (Type::NewTypeInstance(newtype), other) => {
+            equality_result(db, newtype.concrete_base_type(db), other, is_positive)
+                .discard_narrowing()
+        }
+        (other, Type::NewTypeInstance(newtype)) => {
+            equality_result(db, other, newtype.concrete_base_type(db), is_positive)
+                .discard_narrowing()
         }
 
         (Type::Union(union), other) => {
@@ -225,52 +231,24 @@ fn equality_result<'db>(
 
         (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::Ambiguous,
         (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
-            match known_equality_semantics(db, other) {
+            match comparison_semantics(db, other, ComparisonOperator::Equality) {
                 Some(KnownComparisonSemantics::Dict) | None => ComparisonResult::Ambiguous,
                 Some(_) => ComparisonResult::AlwaysFalse,
             }
         }
 
-        (Type::ClassLiteral(left_class), Type::ClassLiteral(right_class)) => {
-            if known_instance_semantics(
-                db,
-                left_class.metaclass_instance_type(db),
-                ComparisonOperator::Equality,
-            ) == Some(KnownComparisonSemantics::Object)
-                && known_instance_semantics(
-                    db,
-                    right_class.metaclass_instance_type(db),
-                    ComparisonOperator::Equality,
-                ) == Some(KnownComparisonSemantics::Object)
-            {
-                ComparisonResult::from_bool(left_class == right_class)
-            } else {
-                call_comparison_dunder(db, left, right, "__eq__")
-            }
-        }
-
-        (Type::ClassLiteral(class), other) | (other, Type::ClassLiteral(class)) => {
-            if known_instance_semantics(
-                db,
-                class.metaclass_instance_type(db),
-                ComparisonOperator::Equality,
-            ) == Some(KnownComparisonSemantics::Object)
-                && !matches!(other, Type::ClassLiteral(_))
-            {
-                ComparisonResult::AlwaysFalse
-            } else {
-                call_comparison_dunder(db, left, right, "__eq__")
-            }
-        }
-
-        (Type::FunctionLiteral(left_function), Type::FunctionLiteral(right_function)) => {
-            ComparisonResult::from_bool(left_function == right_function)
-        }
         (Type::ModuleLiteral(left_module), Type::ModuleLiteral(right_module)) => {
             ComparisonResult::from_bool(left_module.module(db) == right_module.module(db))
         }
-        (Type::SpecialForm(left_form), Type::SpecialForm(right_form)) => {
-            ComparisonResult::from_bool(left_form == right_form)
+        (left, right)
+            if has_known_identity_comparison_semantics(db, left, ComparisonOperator::Equality)
+                && has_known_identity_comparison_semantics(
+                    db,
+                    right,
+                    ComparisonOperator::Equality,
+                ) =>
+        {
+            ComparisonResult::from_bool(left == right)
         }
 
         (Type::NominalInstance(left_instance), Type::NominalInstance(right_instance)) => {
@@ -282,7 +260,7 @@ fn equality_result<'db>(
             )
         }
 
-        _ => call_comparison_dunder(db, left, right, "__eq__"),
+        _ => ComparisonResult::Ambiguous,
     }
 }
 
@@ -313,10 +291,6 @@ fn primitive_literal_constraint<'db>(
         Type::Union(union) => union.elements(db).iter().copied().all(is_builtin_primitive),
         left => is_builtin_primitive(left),
     };
-    if !left_is_builtin_primitive {
-        return None;
-    }
-
     let Type::LiteralValue(right) = right.resolve_type_alias(db) else {
         return None;
     };
@@ -339,7 +313,9 @@ fn primitive_literal_constraint<'db>(
         LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_) => return None,
     };
 
-    Some(equal_to_right.negate_if(db, !condition_expects_equality))
+    (left_is_builtin_primitive
+        || (!condition_expects_equality && matches!(right.kind(), LiteralValueTypeKind::Bool(_))))
+    .then(|| equal_to_right.negate_if(db, !condition_expects_equality))
 }
 
 fn inequality_result<'db>(
@@ -416,14 +392,13 @@ fn inequality_result<'db>(
             None | Some(TypeVarBoundOrConstraints::UpperBound(_)) => ComparisonResult::Ambiguous,
         },
 
-        (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
-            match inequality_result(db, newtype.concrete_base_type(db), other, is_positive) {
-                ComparisonResult::AlwaysTrue => ComparisonResult::AlwaysTrue,
-                ComparisonResult::AlwaysFalse => ComparisonResult::AlwaysFalse,
-                ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
-                    ComparisonResult::Ambiguous
-                }
-            }
+        (Type::NewTypeInstance(newtype), other) => {
+            inequality_result(db, newtype.concrete_base_type(db), other, is_positive)
+                .discard_narrowing()
+        }
+        (other, Type::NewTypeInstance(newtype)) => {
+            inequality_result(db, other, newtype.concrete_base_type(db), is_positive)
+                .discard_narrowing()
         }
 
         (Type::Union(union), other) => evaluate_union_left(
@@ -491,52 +466,27 @@ fn inequality_result<'db>(
 
         (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::Ambiguous,
         (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
-            match known_inequality_semantics(db, other) {
+            match comparison_semantics(db, other, ComparisonOperator::Inequality) {
                 Some(KnownComparisonSemantics::Dict) | None => ComparisonResult::Ambiguous,
                 Some(_) => ComparisonResult::AlwaysTrue,
             }
         }
 
-        (Type::ClassLiteral(left_class), Type::ClassLiteral(right_class)) => {
-            if known_instance_semantics(
-                db,
-                left_class.metaclass_instance_type(db),
-                ComparisonOperator::Inequality,
-            ) == Some(KnownComparisonSemantics::Object)
-                && known_instance_semantics(
-                    db,
-                    right_class.metaclass_instance_type(db),
-                    ComparisonOperator::Inequality,
-                ) == Some(KnownComparisonSemantics::Object)
-            {
-                ComparisonResult::from_bool(left_class != right_class)
-            } else {
-                call_comparison_dunder(db, left, right, "__ne__")
-            }
-        }
-
-        (Type::ClassLiteral(class), other) | (other, Type::ClassLiteral(class)) => {
-            if known_instance_semantics(
-                db,
-                class.metaclass_instance_type(db),
-                ComparisonOperator::Inequality,
-            ) == Some(KnownComparisonSemantics::Object)
-                && !matches!(other, Type::ClassLiteral(_))
-            {
-                ComparisonResult::AlwaysTrue
-            } else {
-                call_comparison_dunder(db, left, right, "__ne__")
-            }
-        }
-
-        (Type::FunctionLiteral(left_function), Type::FunctionLiteral(right_function)) => {
-            ComparisonResult::from_bool(left_function != right_function)
-        }
         (Type::ModuleLiteral(left_module), Type::ModuleLiteral(right_module)) => {
             ComparisonResult::from_bool(left_module.module(db) != right_module.module(db))
         }
-        (Type::SpecialForm(left_form), Type::SpecialForm(right_form)) => {
-            ComparisonResult::from_bool(left_form != right_form)
+        (left, right)
+            if has_known_identity_comparison_semantics(
+                db,
+                left,
+                ComparisonOperator::Inequality,
+            ) && has_known_identity_comparison_semantics(
+                db,
+                right,
+                ComparisonOperator::Inequality,
+            ) =>
+        {
+            ComparisonResult::from_bool(left != right)
         }
 
         (Type::NominalInstance(left_instance), Type::NominalInstance(right_instance)) => {
@@ -548,7 +498,7 @@ fn inequality_result<'db>(
             )
         }
 
-        _ => call_comparison_dunder(db, left, right, "__ne__"),
+        _ => ComparisonResult::Ambiguous,
     }
 }
 
@@ -578,6 +528,21 @@ fn evaluate_union_left<'db>(
     is_positive: bool,
     evaluate: fn(&'db dyn Db, Type<'db>, Type<'db>, bool) -> ComparisonResult<'db>,
 ) -> ComparisonResult<'db> {
+    evaluate_target_union(db, elements, is_positive, |element| {
+        evaluate(db, element, other, is_positive)
+    })
+}
+
+fn evaluate_target_union<'db>(
+    db: &'db dyn Db,
+    elements: &[Type<'db>],
+    is_positive: bool,
+    mut evaluate: impl FnMut(Type<'db>) -> ComparisonResult<'db>,
+) -> ComparisonResult<'db> {
+    if elements.is_empty() {
+        return ComparisonResult::Ambiguous;
+    }
+
     let mut all_true = true;
     let mut all_false = true;
     let mut narrowed = Vec::with_capacity(elements.len());
@@ -585,8 +550,7 @@ fn evaluate_union_left<'db>(
     let mut removed_any = false;
 
     for element in elements {
-        let result = evaluate(db, *element, other, is_positive);
-        match result {
+        match evaluate(*element) {
             ComparisonResult::AlwaysTrue => {
                 all_false = false;
                 if is_positive {
@@ -653,22 +617,40 @@ fn evaluate_union_right<'db>(
     is_positive: bool,
     evaluate: fn(&'db dyn Db, Type<'db>, Type<'db>, bool) -> ComparisonResult<'db>,
 ) -> ComparisonResult<'db> {
+    evaluate_against_results(
+        db,
+        left,
+        is_positive,
+        elements
+            .iter()
+            .map(|element| evaluate(db, left, *element, is_positive)),
+    )
+}
+
+fn evaluate_against_results<'db>(
+    db: &'db dyn Db,
+    target: Type<'db>,
+    is_positive: bool,
+    results: impl IntoIterator<Item = ComparisonResult<'db>>,
+) -> ComparisonResult<'db> {
     let mut all_true = true;
     let mut all_false = true;
     let mut builder = UnionBuilder::new(db);
+    let mut any = false;
 
-    for element in elements {
-        match evaluate(db, left, *element, is_positive) {
+    for result in results {
+        any = true;
+        match result {
             ComparisonResult::AlwaysTrue => {
                 all_false = false;
                 if is_positive {
-                    builder = builder.add(left);
+                    builder = builder.add(target);
                 }
             }
             ComparisonResult::AlwaysFalse => {
                 all_true = false;
                 if !is_positive {
-                    builder = builder.add(left);
+                    builder = builder.add(target);
                 }
             }
             ComparisonResult::CanNarrow(narrowed) => {
@@ -679,12 +661,14 @@ fn evaluate_union_right<'db>(
             ComparisonResult::Ambiguous => {
                 all_true = false;
                 all_false = false;
-                builder = builder.add(left);
+                builder = builder.add(target);
             }
         }
     }
 
-    if all_true {
+    if !any {
+        ComparisonResult::Ambiguous
+    } else if all_true {
         ComparisonResult::AlwaysTrue
     } else if all_false {
         ComparisonResult::AlwaysFalse
@@ -703,6 +687,8 @@ fn evaluate_intersection_left<'db>(
 ) -> ComparisonResult<'db> {
     let mut any_true = false;
     let mut any_false = false;
+    let mut any_ambiguous = false;
+    let mut any_narrowing = false;
     let mut builder = IntersectionBuilder::new(db).add_positive(original);
 
     for element in positive {
@@ -710,10 +696,15 @@ fn evaluate_intersection_left<'db>(
             ComparisonResult::AlwaysTrue => any_true = true,
             ComparisonResult::AlwaysFalse => any_false = true,
             ComparisonResult::CanNarrow(narrowed) => {
+                any_narrowing = true;
                 builder = builder.add_positive(narrowed);
             }
-            ComparisonResult::Ambiguous => {}
+            ComparisonResult::Ambiguous => any_ambiguous = true,
         }
+    }
+
+    if any_ambiguous || (any_narrowing && (any_true || any_false)) {
+        return ComparisonResult::Ambiguous;
     }
 
     match (any_true, any_false) {
@@ -829,32 +820,32 @@ fn compare_literal_to_other<'db>(
         return match comparison_semantics(db, other, operator) {
             Some(KnownComparisonSemantics::Str) => ComparisonResult::Ambiguous,
             Some(_) => ComparisonResult::from_bool(operator == ComparisonOperator::Inequality),
-            None => call_comparison_dunder(db, literal_type, other, operator.dunder()),
+            None => ComparisonResult::Ambiguous,
         };
     }
 
     let Some(literal_semantics) = literal_semantics(db, literal, operator) else {
-        return call_comparison_dunder(db, literal_type, other, operator.dunder());
+        return ComparisonResult::Ambiguous;
     };
+    let condition_expects_equality = matches!(
+        (operator, is_positive),
+        (ComparisonOperator::Equality, true) | (ComparisonOperator::Inequality, false)
+    );
     match comparison_semantics(db, other, operator) {
         Some(other_semantics) if literal_semantics != other_semantics => {
             ComparisonResult::from_bool(operator == ComparisonOperator::Inequality)
         }
-        Some(_) => ComparisonResult::Ambiguous,
-        None => {
-            let comparison_proves_target_is_not_literal = matches!(
-                (operator, is_positive),
-                (ComparisonOperator::Equality, false) | (ComparisonOperator::Inequality, true)
-            );
-            if !literal_is_target
-                && comparison_proves_target_is_not_literal
-                && literal_type.is_single_valued(db)
-            {
-                ComparisonResult::CanNarrow(literal_type.negate(db))
-            } else {
-                call_comparison_dunder(db, literal_type, other, operator.dunder())
-            }
+        Some(_) if !literal_is_target && literal_type.is_single_valued(db) => {
+            ComparisonResult::CanNarrow(literal_type.negate_if(db, !condition_expects_equality))
         }
+        Some(_) => ComparisonResult::Ambiguous,
+        None if !literal_is_target
+            && !condition_expects_equality
+            && literal_type.is_single_valued(db) =>
+        {
+            ComparisonResult::CanNarrow(literal_type.negate(db))
+        }
+        None => ComparisonResult::Ambiguous,
     }
 }
 
@@ -867,10 +858,10 @@ fn compare_nominal_instances<'db>(
     let left = Type::NominalInstance(left_instance);
     let right = Type::NominalInstance(right_instance);
     let Some(left_semantics) = comparison_semantics(db, left, operator) else {
-        return call_comparison_dunder(db, left, right, operator.dunder());
+        return ComparisonResult::Ambiguous;
     };
     let Some(right_semantics) = comparison_semantics(db, right, operator) else {
-        return call_comparison_dunder(db, left, right, operator.dunder());
+        return ComparisonResult::Ambiguous;
     };
 
     let classes_differ = left_instance.class_literal(db) != right_instance.class_literal(db);
@@ -918,31 +909,6 @@ fn comparison_semantics<'db>(
     ty: Type<'db>,
     operator: ComparisonOperator,
 ) -> Option<KnownComparisonSemantics> {
-    match operator {
-        ComparisonOperator::Equality => known_equality_semantics(db, ty),
-        ComparisonOperator::Inequality => known_inequality_semantics(db, ty),
-    }
-}
-
-fn known_equality_semantics<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-) -> Option<KnownComparisonSemantics> {
-    known_semantics(db, ty, ComparisonOperator::Equality)
-}
-
-fn known_inequality_semantics<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-) -> Option<KnownComparisonSemantics> {
-    known_semantics(db, ty, ComparisonOperator::Inequality)
-}
-
-fn known_semantics<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    operator: ComparisonOperator,
-) -> Option<KnownComparisonSemantics> {
     match ty {
         Type::LiteralValue(literal) => literal_semantics(db, literal.kind(), operator),
         Type::TypedDict(_) => Some(KnownComparisonSemantics::Dict),
@@ -952,12 +918,21 @@ fn known_semantics<'db>(
             operator,
         ),
         Type::Intersection(intersection) => {
-            let complement = intersection.enum_complement(db)?;
-            known_instance_semantics(
-                db,
-                complement.enum_class(db).to_non_generic_instance(db),
-                operator,
-            )
+            if let Some(complement) = intersection.enum_complement(db) {
+                return known_instance_semantics(
+                    db,
+                    complement.enum_class(db).to_non_generic_instance(db),
+                    operator,
+                );
+            }
+            let mut semantics = intersection
+                .positive(db)
+                .iter()
+                .filter_map(|element| comparison_semantics(db, *element, operator));
+            let first = semantics.next()?;
+            semantics
+                .all(|semantics| semantics == first)
+                .then_some(first)
         }
         Type::NominalInstance(instance)
             if instance.class(db).is_final(db)
@@ -967,6 +942,24 @@ fn known_semantics<'db>(
             known_instance_semantics(db, ty, operator)
         }
         _ => None,
+    }
+}
+
+fn has_known_identity_comparison_semantics<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    operator: ComparisonOperator,
+) -> bool {
+    match ty {
+        Type::FunctionLiteral(_) | Type::ModuleLiteral(_) | Type::SpecialForm(_) => true,
+        Type::ClassLiteral(class) => {
+            known_instance_semantics(db, class.metaclass_instance_type(db), operator)
+                == Some(KnownComparisonSemantics::Object)
+        }
+        _ => {
+            ty.is_singleton(db)
+                && comparison_semantics(db, ty, operator) == Some(KnownComparisonSemantics::Object)
+        }
     }
 }
 
@@ -1041,8 +1034,8 @@ fn known_enum_semantics<'db>(
         KnownComparisonSemantics::Object
     };
 
+    let class = instance.to_meta_type(db);
     let has_custom_dunder = |name| {
-        let class = instance.to_meta_type(db);
         let dunder = class.member_lookup_with_policy(
             db,
             Name::new_static(name),
@@ -1195,25 +1188,4 @@ fn same_enum_member<'db>(
         return left == right;
     };
     metadata.resolve_member(left.name(db)) == metadata.resolve_member(right.name(db))
-}
-
-fn call_comparison_dunder<'db>(
-    db: &'db dyn Db,
-    left: Type<'db>,
-    right: Type<'db>,
-    dunder: &'static str,
-) -> ComparisonResult<'db> {
-    let Ok(bindings) = left.try_call_dunder(
-        db,
-        dunder,
-        CallArguments::positional([right]),
-        TypeContext::default(),
-    ) else {
-        return ComparisonResult::Ambiguous;
-    };
-    match bindings.return_type(db).bool(db) {
-        Truthiness::AlwaysTrue => ComparisonResult::AlwaysTrue,
-        Truthiness::AlwaysFalse => ComparisonResult::AlwaysFalse,
-        Truthiness::Ambiguous => ComparisonResult::Ambiguous,
-    }
 }

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -86,7 +86,7 @@ pub(super) fn evaluate_type_equality<'db>(
     is_positive: bool,
 ) -> Option<Type<'db>> {
     enum_literal_constraint(db, left, right, ComparisonOperator::Equality, is_positive)
-        .or_else(|| primitive_literal_constraint(db, left, right, is_positive))
+        .or_else(|| builtin_literal_constraint(db, left, right, is_positive))
         .or_else(|| {
             if comparison_domain(db, left, right, ComparisonOperator::Equality)
                 == ComparisonDomain::Known
@@ -132,7 +132,7 @@ pub(super) fn evaluate_type_inequality<'db>(
         ComparisonOperator::Inequality,
         !is_positive,
     )
-    .or_else(|| primitive_literal_constraint(db, left, right, !is_positive))
+    .or_else(|| builtin_literal_constraint(db, left, right, !is_positive))
     .or_else(|| {
         comparison_result(db, left, right, is_positive, ComparisonOperator::Inequality)
             .constraint(is_positive)
@@ -324,7 +324,11 @@ fn comparison_result<'db>(
     }
 }
 
-fn is_builtin_primitive(db: &dyn Db, ty: Type) -> bool {
+/// Return whether `ty` is handled by [`builtin_literal_constraint`].
+///
+/// This includes `int`, `bool`, `str`, and `bytes` literals, along with `bool` itself because its
+/// only possible values are `Literal[True]` and `Literal[False]`.
+fn is_builtin_literal_type(db: &dyn Db, ty: Type) -> bool {
     match ty.resolve_type_alias(db) {
         Type::LiteralValue(literal) => matches!(
             literal.kind(),
@@ -338,7 +342,8 @@ fn is_builtin_primitive(db: &dyn Db, ty: Type) -> bool {
     }
 }
 
-/// Return a predicate-shaped constraint for comparison with a primitive literal.
+/// Return a predicate-shaped constraint for comparison with an `int`, `bool`, `str`, or `bytes`
+/// literal.
 ///
 /// Narrowing constraints participate in cyclic inference. Filtering `"B" | "C"` to `"B"` for the
 /// false branch of `x == "C"` can freeze a loop before later iterations widen `x`. Constraining the
@@ -347,7 +352,7 @@ fn is_builtin_primitive(db: &dyn Db, ty: Type) -> bool {
 ///
 /// The constraint also follows Python's equality between booleans and integers: `x != 0` excludes
 /// both `Literal[0]` and `Literal[False]`, while `x != 1` excludes `Literal[1]` and `Literal[True]`.
-fn primitive_literal_constraint<'db>(
+fn builtin_literal_constraint<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
     right: Type<'db>,
@@ -422,8 +427,8 @@ fn primitive_literal_constraint<'db>(
             .elements(db)
             .iter()
             .copied()
-            .all(|element| is_builtin_primitive(db, element)),
-        left => is_builtin_primitive(db, left),
+            .all(|element| is_builtin_literal_type(db, element)),
+        left => is_builtin_literal_type(db, left),
     }
     .then_some(equal_to_right)
 }

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -68,7 +68,39 @@ pub(super) fn evaluate_type_equality<'db>(
 ) -> Option<Type<'db>> {
     enum_literal_constraint(db, left, right, ComparisonOperator::Equality, is_positive)
         .or_else(|| primitive_literal_constraint(db, left, right, is_positive))
-        .or_else(|| equality_result(db, left, right, is_positive).constraint(is_positive))
+        .or_else(|| {
+            if is_equality_narrowing_operand(db, left, right) {
+                equality_result(db, left, right, is_positive).constraint(is_positive)
+            } else {
+                None
+            }
+        })
+}
+
+/// Return whether `ty` can constrain `left` through equality.
+///
+/// The general evaluator distributes over unions, so avoid invoking it for ordinary nominal types
+/// whose comparison semantics are unknown.
+fn is_equality_narrowing_operand<'db>(db: &'db dyn Db, left: Type<'db>, ty: Type<'db>) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| is_equality_narrowing_operand(db, left, *element)),
+        Type::LiteralValue(_) | Type::EnumComplement(_) => true,
+        Type::Intersection(intersection) if intersection.enum_complement(db).is_some() => true,
+        Type::TypedDict(_) => true,
+        Type::NominalInstance(instance) => {
+            instance.tuple_spec(db).is_some()
+                || instance
+                    .class(db)
+                    .known(db)
+                    .is_some_and(|known| known == KnownClass::Bool || known.is_singleton())
+                || left.resolve_type_alias(db).is_union()
+                    && comparison_semantics(db, ty, ComparisonOperator::Equality).is_some()
+        }
+        ty => ty.is_single_valued(db),
+    }
 }
 
 pub(super) fn evaluate_type_inequality<'db>(
@@ -278,13 +310,8 @@ fn equality_result<'db>(
 /// false branch of `x == "C"` can freeze a loop before later iterations widen `x`. Constraining the
 /// target with `~Literal["C"]` instead describes the predicate itself and remains valid as the cycle
 /// reaches its fixed point.
-fn primitive_literal_constraint<'db>(
-    db: &'db dyn Db,
-    left: Type<'db>,
-    right: Type<'db>,
-    condition_expects_equality: bool,
-) -> Option<Type<'db>> {
-    let is_builtin_primitive = |ty: Type<'db>| match ty.resolve_type_alias(db) {
+fn is_builtin_primitive(db: &dyn Db, ty: Type) -> bool {
+    match ty.resolve_type_alias(db) {
         Type::LiteralValue(literal) => matches!(
             literal.kind(),
             LiteralValueTypeKind::Int(_)
@@ -294,11 +321,15 @@ fn primitive_literal_constraint<'db>(
         ),
         Type::NominalInstance(instance) => instance.has_known_class(db, KnownClass::Bool),
         _ => false,
-    };
-    let left_is_builtin_primitive = match left.resolve_type_alias(db) {
-        Type::Union(union) => union.elements(db).iter().copied().all(is_builtin_primitive),
-        left => is_builtin_primitive(left),
-    };
+    }
+}
+
+fn primitive_literal_constraint<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    condition_expects_equality: bool,
+) -> Option<Type<'db>> {
     let Type::LiteralValue(right) = right.resolve_type_alias(db) else {
         return None;
     };
@@ -321,8 +352,57 @@ fn primitive_literal_constraint<'db>(
         LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_) => return None,
     };
 
-    (left_is_builtin_primitive || !condition_expects_equality)
-        .then(|| equal_to_right.negate_if(db, !condition_expects_equality))
+    if !condition_expects_equality {
+        return Some(equal_to_right.negate(db));
+    }
+
+    if matches!(
+        right.kind(),
+        LiteralValueTypeKind::String(_) | LiteralValueTypeKind::Bytes(_)
+    ) && let Type::Union(union) = left.resolve_type_alias(db)
+    {
+        let mut excluded = UnionBuilder::new(db);
+        let mut has_dynamic = false;
+
+        for element in union.elements(db) {
+            match element.resolve_type_alias(db) {
+                Type::LiteralValue(left) => {
+                    match known_literal_equality(
+                        db,
+                        left.kind(),
+                        right.kind(),
+                        ComparisonOperator::Equality,
+                    ) {
+                        Some(true) => {}
+                        Some(false) => excluded = excluded.add(*element),
+                        None => return None,
+                    }
+                }
+                Type::Dynamic(_) => has_dynamic = true,
+                Type::Intersection(intersection)
+                    if !intersection.positive(db).is_empty()
+                        && intersection.positive(db).iter().all(Type::is_dynamic) =>
+                {
+                    has_dynamic = true;
+                }
+                _ => return None,
+            }
+        }
+
+        if has_dynamic {
+            return excluded.try_build().map(|excluded| excluded.negate(db));
+        }
+    }
+
+    match left.resolve_type_alias(db) {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .copied()
+            .all(|element| is_builtin_primitive(db, element)),
+        left => is_builtin_primitive(db, left),
+    }
+    .then_some(equal_to_right)
 }
 
 fn enum_literal_constraint<'db>(

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1204,8 +1204,11 @@ fn known_literal_equality<'db>(
             if left_semantics != right_semantics {
                 return Some(false);
             }
+            if same_enum_member(db, left, right) {
+                return Some(true);
+            }
             if left_semantics == KnownComparisonSemantics::Object {
-                return Some(same_enum_member(db, left, right));
+                return Some(false);
             }
             known_literal_equality(
                 db,

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -313,9 +313,8 @@ fn primitive_literal_constraint<'db>(
         LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_) => return None,
     };
 
-    (left_is_builtin_primitive
-        || (!condition_expects_equality && matches!(right.kind(), LiteralValueTypeKind::Bool(_))))
-    .then(|| equal_to_right.negate_if(db, !condition_expects_equality))
+    (left_is_builtin_primitive || !condition_expects_equality)
+        .then(|| equal_to_right.negate_if(db, !condition_expects_equality))
 }
 
 fn inequality_result<'db>(

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -48,6 +48,14 @@ enum ComparisonResult<'db> {
 }
 
 impl<'db> ComparisonResult<'db> {
+    fn from_bool(value: bool) -> Self {
+        if value {
+            ComparisonResult::AlwaysTrue
+        } else {
+            ComparisonResult::AlwaysFalse
+        }
+    }
+
     /// Convert this result into a constraint for a branch with the given truthiness.
     fn constraint(self, is_positive: bool) -> Option<Type<'db>> {
         match self {
@@ -482,16 +490,6 @@ fn is_same_enum_domain<'db>(db: &'db dyn Db, ty: Type<'db>, right: EnumLiteralTy
             .enum_complement(db)
             .is_some_and(|complement| complement.enum_class(db) == right.enum_class(db)),
         _ => false,
-    }
-}
-
-impl ComparisonResult<'_> {
-    fn from_bool(value: bool) -> Self {
-        if value {
-            ComparisonResult::AlwaysTrue
-        } else {
-            ComparisonResult::AlwaysFalse
-        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -835,6 +835,12 @@ fn compare_literal_to_other<'db>(
         Some(other_semantics) if literal_semantics != other_semantics => {
             ComparisonResult::from_bool(operator == ComparisonOperator::Inequality)
         }
+        Some(KnownComparisonSemantics::Object)
+            if literal_semantics == KnownComparisonSemantics::Object
+                && other.is_disjoint_from(db, literal_type) =>
+        {
+            ComparisonResult::from_bool(operator == ComparisonOperator::Inequality)
+        }
         // Inherited builtin comparison semantics do not imply type overlap. For example, a final
         // `int` subclass can compare equal to `1` despite being disjoint from `Literal[1]`.
         Some(_)

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1,10 +1,16 @@
+//! Equality and inequality reasoning for type narrowing and reachability.
+//!
+//! This module evaluates comparisons with statically known Python semantics, producing branch
+//! constraints and definite truthiness while remaining conservative around custom comparison
+//! methods.
+
 use ruff_python_ast::name::Name;
 
 use crate::{Db, place::PlaceAndQualifiers};
 
 use super::{
     EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass, LiteralValueTypeKind,
-    MemberLookupPolicy, Truthiness, Type, TypeVarBoundOrConstraints, UnionBuilder,
+    MemberLookupPolicy, Truthiness, Type, TypeVarBoundOrConstraints, UnionBuilder, UnionType,
     enums::{enum_member_literals, enum_metadata},
 };
 
@@ -67,6 +73,11 @@ impl<'db> ComparisonResult<'db> {
     }
 
     /// Preserve definite truthiness while discarding a conditional narrowing result.
+    ///
+    /// This is necessary when a comparison is evaluated through a runtime-equivalent type whose
+    /// static identity must be preserved. For example, a `NewType` instance has the comparison
+    /// behavior of its concrete base type, but a constraint derived for that base type cannot be
+    /// applied to the distinct `NewType`.
     fn discard_narrowing(self) -> Self {
         match self {
             ComparisonResult::CanNarrow(_) => ComparisonResult::Ambiguous,
@@ -395,10 +406,11 @@ fn builtin_literal_constraint<'db>(
             }
             builder.build()
         }
-        LiteralValueTypeKind::Bool(value) => UnionBuilder::new(db)
-            .add(Type::LiteralValue(right))
-            .add(Type::int_literal(i64::from(value)))
-            .build(),
+        LiteralValueTypeKind::Bool(value) => UnionType::from_two_elements(
+            db,
+            Type::LiteralValue(right),
+            Type::int_literal(i64::from(value)),
+        ),
         LiteralValueTypeKind::String(_) | LiteralValueTypeKind::Bytes(_) => {
             Type::LiteralValue(right)
         }
@@ -503,6 +515,7 @@ fn enum_literal_constraint<'db>(
     Some(equal_to_right.negate_if(db, !condition_expects_equality))
 }
 
+/// Return whether every possible value of `ty` belongs to the same enum as `right`.
 fn is_same_enum_domain<'db>(db: &'db dyn Db, ty: Type<'db>, right: EnumLiteralType<'db>) -> bool {
     match ty.resolve_type_alias(db) {
         Type::LiteralValue(literal) => matches!(
@@ -523,6 +536,7 @@ fn is_same_enum_domain<'db>(db: &'db dyn Db, ty: Type<'db>, right: EnumLiteralTy
     }
 }
 
+/// Evaluate each alternative of the union being constrained and combine their branch results.
 fn evaluate_union_left<'db>(
     db: &'db dyn Db,
     elements: &[Type<'db>],
@@ -616,6 +630,7 @@ fn evaluate_target_union<'db>(
     ComparisonResult::CanNarrow(builder.build())
 }
 
+/// Evaluate the target against each alternative of a union on the non-target side.
 fn evaluate_union_right<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
@@ -687,6 +702,7 @@ fn evaluate_against_results<'db>(
     }
 }
 
+/// Combine compatible comparison results from the positive elements of an intersection target.
 fn evaluate_intersection_left<'db>(
     db: &'db dyn Db,
     original: Type<'db>,
@@ -756,6 +772,10 @@ fn finite_alternatives<'db>(
     }
 }
 
+/// Return a constraint for literal pairs whose equality cannot be decided statically.
+///
+/// This primarily handles `LiteralString`, which can be constrained by a concrete string literal
+/// or a string-valued enum member without having a single statically known runtime value.
 fn narrow_literal_comparison<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
@@ -809,6 +829,10 @@ fn narrow_literal_string_against_enum<'db>(
     ComparisonResult::CanNarrow(narrowed)
 }
 
+/// Compare a literal with a non-literal type using their known runtime comparison semantics.
+///
+/// A literal on the non-target side can constrain the target only when the types overlap; matching
+/// comparison implementations alone do not establish that the literal inhabits the target type.
 fn compare_literal_to_other<'db>(
     db: &'db dyn Db,
     literal_type: Type<'db>,
@@ -861,6 +885,10 @@ fn compare_literal_to_other<'db>(
     }
 }
 
+/// Compare nominal instances when their inherited comparison implementations are known.
+///
+/// The result is definite only when the implementations cannot compare equal, or when both types
+/// denote the same singleton.
 fn compare_nominal_instances<'db>(
     db: &'db dyn Db,
     left_instance: super::NominalInstanceType<'db>,
@@ -905,6 +933,7 @@ impl ComparisonOperator {
         }
     }
 
+    /// Return whether the selected branch requires the operands to compare equal.
     const fn condition_expects_equality(self, is_positive: bool) -> bool {
         matches!(
             (self, is_positive),
@@ -975,6 +1004,7 @@ impl KnownComparisonSemantics {
         }
     }
 
+    /// Return the builtin comparison implementation used by a literal value.
     fn of_literal<'db>(
         db: &'db dyn Db,
         literal: LiteralValueTypeKind<'db>,
@@ -992,6 +1022,9 @@ impl KnownComparisonSemantics {
         }
     }
 
+    /// Return the builtin comparison implementation inherited by an instance.
+    ///
+    /// Returns `None` when lookup finds custom comparison behavior.
     fn of_instance<'db>(
         db: &'db dyn Db,
         instance: Type<'db>,
@@ -1029,6 +1062,9 @@ impl KnownComparisonSemantics {
         None
     }
 
+    /// Return an enum's inherited scalar or identity comparison implementation.
+    ///
+    /// Custom enum comparison methods make the result unknown.
     fn of_enum<'db>(
         db: &'db dyn Db,
         instance: Type<'db>,
@@ -1157,6 +1193,7 @@ fn has_known_identity_comparison_semantics<'db>(
     }
 }
 
+/// Look up a comparison method without falling back to `object`.
 fn lookup_dunder<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -995,9 +995,7 @@ impl KnownComparisonSemantics {
                     .then_some(first)
             }
             Type::NominalInstance(instance)
-                if instance.class(db).is_final(db)
-                    || instance.tuple_spec(db).is_some()
-                    || enum_metadata(db, instance.class_literal(db)).is_some() =>
+                if instance.class(db).is_final(db) || instance.tuple_spec(db).is_some() =>
             {
                 Self::of_instance(db, ty, operator)
             }

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -83,7 +83,8 @@ pub(super) fn evaluate_type_equality<'db>(
             if comparison_domain(db, left, right, ComparisonOperator::Equality)
                 == ComparisonDomain::Known
             {
-                equality_result(db, left, right, is_positive).constraint(is_positive)
+                comparison_result(db, left, right, is_positive, ComparisonOperator::Equality)
+                    .constraint(is_positive)
             } else {
                 None
             }
@@ -108,7 +109,10 @@ pub(super) fn evaluate_type_inequality<'db>(
         !is_positive,
     )
     .or_else(|| primitive_literal_constraint(db, left, right, !is_positive))
-    .or_else(|| inequality_result(db, left, right, is_positive).constraint(is_positive))
+    .or_else(|| {
+        comparison_result(db, left, right, is_positive, ComparisonOperator::Inequality)
+            .constraint(is_positive)
+    })
 }
 
 /// Return the truthiness of `left == right` when it is known for every represented runtime value.
@@ -119,31 +123,32 @@ pub(crate) fn equality_truthiness<'db>(
     left: Type<'db>,
     right: Type<'db>,
 ) -> Truthiness {
-    match equality_result(db, left, right, true) {
+    match comparison_result(db, left, right, true, ComparisonOperator::Equality) {
         ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
         ComparisonResult::AlwaysFalse => Truthiness::AlwaysFalse,
         ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => Truthiness::Ambiguous,
     }
 }
 
-/// Evaluate equality recursively, treating `left` as the operand being constrained.
+/// Evaluate a comparison recursively, treating `left` as the operand being constrained.
 ///
 /// `is_positive` selects the branch whose constraint is accumulated when either operand expands
 /// into multiple alternatives.
-fn equality_result<'db>(
+fn comparison_result<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
     right: Type<'db>,
     is_positive: bool,
+    operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     let left = left.resolve_type_alias(db);
     let right = right.resolve_type_alias(db);
 
-    if let Some(alternatives) = equality_alternatives(db, left) {
-        return evaluate_union_left(db, &alternatives, right, is_positive, equality_result);
+    if let Some(alternatives) = finite_alternatives(db, left, operator) {
+        return evaluate_union_left(db, &alternatives, right, is_positive, operator);
     }
-    if let Some(alternatives) = equality_alternatives(db, right) {
-        return evaluate_union_right(db, left, &alternatives, is_positive, equality_result);
+    if let Some(alternatives) = finite_alternatives(db, right, operator) {
+        return evaluate_union_right(db, left, &alternatives, is_positive, operator);
     }
 
     match (left, right) {
@@ -171,7 +176,7 @@ fn equality_result<'db>(
         ) => ComparisonResult::Ambiguous,
 
         (Type::Dynamic(_), other) => {
-            if !is_positive && other.is_single_valued(db) {
+            if !operator.condition_expects_equality(is_positive) && other.is_single_valued(db) {
                 ComparisonResult::CanNarrow(
                     IntersectionBuilder::new(db)
                         .add_positive(left)
@@ -187,37 +192,45 @@ fn equality_result<'db>(
         (Type::TypeVar(var), other) => match var.typevar(db).bound_or_constraints(db) {
             None => ComparisonResult::Ambiguous,
             Some(TypeVarBoundOrConstraints::UpperBound(_)) => {
-                if !is_positive && other.is_single_valued(db) {
+                if !operator.condition_expects_equality(is_positive) && other.is_single_valued(db) {
                     ComparisonResult::CanNarrow(other.negate(db))
                 } else {
                     ComparisonResult::Ambiguous
                 }
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                equality_result(db, constraints.as_type(db), other, is_positive)
+                comparison_result(db, constraints.as_type(db), other, is_positive, operator)
             }
         },
         (other, Type::TypeVar(var)) => match var.typevar(db).bound_or_constraints(db) {
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                equality_result(db, other, constraints.as_type(db), is_positive)
+                comparison_result(db, other, constraints.as_type(db), is_positive, operator)
             }
             None | Some(TypeVarBoundOrConstraints::UpperBound(_)) => ComparisonResult::Ambiguous,
         },
 
-        (Type::NewTypeInstance(newtype), other) => {
-            equality_result(db, newtype.concrete_base_type(db), other, is_positive)
-                .discard_narrowing()
-        }
-        (other, Type::NewTypeInstance(newtype)) => {
-            equality_result(db, other, newtype.concrete_base_type(db), is_positive)
-                .discard_narrowing()
-        }
+        (Type::NewTypeInstance(newtype), other) => comparison_result(
+            db,
+            newtype.concrete_base_type(db),
+            other,
+            is_positive,
+            operator,
+        )
+        .discard_narrowing(),
+        (other, Type::NewTypeInstance(newtype)) => comparison_result(
+            db,
+            other,
+            newtype.concrete_base_type(db),
+            is_positive,
+            operator,
+        )
+        .discard_narrowing(),
 
         (Type::Union(union), other) => {
-            evaluate_union_left(db, union.elements(db), other, is_positive, equality_result)
+            evaluate_union_left(db, union.elements(db), other, is_positive, operator)
         }
         (other, Type::Union(union)) => {
-            evaluate_union_right(db, other, union.elements(db), is_positive, equality_result)
+            evaluate_union_right(db, other, union.elements(db), is_positive, operator)
         }
         (Type::Intersection(intersection), other) => evaluate_intersection_left(
             db,
@@ -225,25 +238,19 @@ fn equality_result<'db>(
             intersection.positive(db),
             other,
             is_positive,
-            equality_result,
+            operator,
         ),
 
         (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
-            match known_literal_equality(
-                db,
-                left_literal.kind(),
-                right_literal.kind(),
-                ComparisonOperator::Equality,
-            ) {
-                Some(true) => ComparisonResult::AlwaysTrue,
-                Some(false) => ComparisonResult::AlwaysFalse,
+            match known_literal_equality(db, left_literal.kind(), right_literal.kind(), operator) {
+                Some(equal) => operator.result_from_equality(equal),
                 None => narrow_literal_comparison(
                     db,
                     left,
                     right,
                     left_literal.kind(),
                     right_literal.kind(),
-                    is_positive,
+                    operator.condition_expects_equality(is_positive),
                 ),
             }
         }
@@ -254,7 +261,7 @@ fn equality_result<'db>(
             literal.kind(),
             other,
             is_positive,
-            ComparisonOperator::Equality,
+            operator,
             true,
         ),
         (other, Type::LiteralValue(literal)) => compare_literal_to_other(
@@ -263,39 +270,30 @@ fn equality_result<'db>(
             literal.kind(),
             other,
             is_positive,
-            ComparisonOperator::Equality,
+            operator,
             false,
         ),
 
         (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::Ambiguous,
         (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
-            match comparison_semantics(db, other, ComparisonOperator::Equality) {
+            match comparison_semantics(db, other, operator) {
                 Some(KnownComparisonSemantics::Dict) | None => ComparisonResult::Ambiguous,
-                Some(_) => ComparisonResult::AlwaysFalse,
+                Some(_) => operator.result_from_equality(false),
             }
         }
 
         (Type::ModuleLiteral(left_module), Type::ModuleLiteral(right_module)) => {
-            ComparisonResult::from_bool(left_module.module(db) == right_module.module(db))
+            operator.result_from_equality(left_module.module(db) == right_module.module(db))
         }
         (left, right)
-            if has_known_identity_comparison_semantics(db, left, ComparisonOperator::Equality)
-                && has_known_identity_comparison_semantics(
-                    db,
-                    right,
-                    ComparisonOperator::Equality,
-                ) =>
+            if has_known_identity_comparison_semantics(db, left, operator)
+                && has_known_identity_comparison_semantics(db, right, operator) =>
         {
-            ComparisonResult::from_bool(left == right)
+            operator.result_from_equality(left == right)
         }
 
         (Type::NominalInstance(left_instance), Type::NominalInstance(right_instance)) => {
-            compare_nominal_instances(
-                db,
-                left_instance,
-                right_instance,
-                ComparisonOperator::Equality,
-            )
+            compare_nominal_instances(db, left_instance, right_instance, operator)
         }
 
         _ => ComparisonResult::Ambiguous,
@@ -454,209 +452,12 @@ fn is_same_enum_domain<'db>(db: &'db dyn Db, ty: Type<'db>, right: EnumLiteralTy
     }
 }
 
-/// Evaluate inequality recursively, treating `left` as the operand being constrained.
-///
-/// `is_positive` selects the branch whose constraint is accumulated when either operand expands
-/// into multiple alternatives.
-fn inequality_result<'db>(
-    db: &'db dyn Db,
-    left: Type<'db>,
-    right: Type<'db>,
-    is_positive: bool,
-) -> ComparisonResult<'db> {
-    let left = left.resolve_type_alias(db);
-    let right = right.resolve_type_alias(db);
-
-    if let Some(alternatives) = inequality_alternatives(db, left) {
-        return evaluate_union_left(db, &alternatives, right, is_positive, inequality_result);
-    }
-    if let Some(alternatives) = inequality_alternatives(db, right) {
-        return evaluate_union_right(db, left, &alternatives, is_positive, inequality_result);
-    }
-
-    match (left, right) {
-        (
-            Type::Never
-            | Type::Divergent(_)
-            | Type::AlwaysFalsy
-            | Type::AlwaysTruthy
-            | Type::ProtocolInstance(_)
-            | Type::DataclassTransformer(_)
-            | Type::TypeGuard(_)
-            | Type::TypeIs(_),
-            _,
-        )
-        | (
-            _,
-            Type::Never
-            | Type::Divergent(_)
-            | Type::AlwaysFalsy
-            | Type::AlwaysTruthy
-            | Type::ProtocolInstance(_)
-            | Type::DataclassTransformer(_)
-            | Type::TypeGuard(_)
-            | Type::TypeIs(_),
-        ) => ComparisonResult::Ambiguous,
-
-        (Type::Dynamic(_), other) => {
-            if is_positive && other.is_single_valued(db) {
-                ComparisonResult::CanNarrow(
-                    IntersectionBuilder::new(db)
-                        .add_positive(left)
-                        .add_negative(other)
-                        .build(),
-                )
-            } else {
-                ComparisonResult::Ambiguous
-            }
-        }
-        (_, Type::Dynamic(_)) => ComparisonResult::Ambiguous,
-
-        (Type::TypeVar(var), other) => match var.typevar(db).bound_or_constraints(db) {
-            None => ComparisonResult::Ambiguous,
-            Some(TypeVarBoundOrConstraints::UpperBound(_)) => {
-                if is_positive && other.is_single_valued(db) {
-                    ComparisonResult::CanNarrow(other.negate(db))
-                } else {
-                    ComparisonResult::Ambiguous
-                }
-            }
-            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                inequality_result(db, constraints.as_type(db), other, is_positive)
-            }
-        },
-        (other, Type::TypeVar(var)) => match var.typevar(db).bound_or_constraints(db) {
-            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                inequality_result(db, other, constraints.as_type(db), is_positive)
-            }
-            None | Some(TypeVarBoundOrConstraints::UpperBound(_)) => ComparisonResult::Ambiguous,
-        },
-
-        (Type::NewTypeInstance(newtype), other) => {
-            inequality_result(db, newtype.concrete_base_type(db), other, is_positive)
-                .discard_narrowing()
-        }
-        (other, Type::NewTypeInstance(newtype)) => {
-            inequality_result(db, other, newtype.concrete_base_type(db), is_positive)
-                .discard_narrowing()
-        }
-
-        (Type::Union(union), other) => evaluate_union_left(
-            db,
-            union.elements(db),
-            other,
-            is_positive,
-            inequality_result,
-        ),
-        (other, Type::Union(union)) => evaluate_union_right(
-            db,
-            other,
-            union.elements(db),
-            is_positive,
-            inequality_result,
-        ),
-        (Type::Intersection(intersection), other) => evaluate_intersection_left(
-            db,
-            Type::Intersection(intersection),
-            intersection.positive(db),
-            other,
-            is_positive,
-            inequality_result,
-        ),
-
-        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
-            match known_literal_equality(
-                db,
-                left_literal.kind(),
-                right_literal.kind(),
-                ComparisonOperator::Inequality,
-            ) {
-                Some(true) => ComparisonResult::AlwaysFalse,
-                Some(false) => ComparisonResult::AlwaysTrue,
-                None => narrow_literal_comparison(
-                    db,
-                    left,
-                    right,
-                    left_literal.kind(),
-                    right_literal.kind(),
-                    !is_positive,
-                )
-                .negate(),
-            }
-        }
-
-        (Type::LiteralValue(literal), other) => compare_literal_to_other(
-            db,
-            Type::LiteralValue(literal),
-            literal.kind(),
-            other,
-            is_positive,
-            ComparisonOperator::Inequality,
-            true,
-        ),
-        (other, Type::LiteralValue(literal)) => compare_literal_to_other(
-            db,
-            Type::LiteralValue(literal),
-            literal.kind(),
-            other,
-            is_positive,
-            ComparisonOperator::Inequality,
-            false,
-        ),
-
-        (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::Ambiguous,
-        (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
-            match comparison_semantics(db, other, ComparisonOperator::Inequality) {
-                Some(KnownComparisonSemantics::Dict) | None => ComparisonResult::Ambiguous,
-                Some(_) => ComparisonResult::AlwaysTrue,
-            }
-        }
-
-        (Type::ModuleLiteral(left_module), Type::ModuleLiteral(right_module)) => {
-            ComparisonResult::from_bool(left_module.module(db) != right_module.module(db))
-        }
-        (left, right)
-            if has_known_identity_comparison_semantics(
-                db,
-                left,
-                ComparisonOperator::Inequality,
-            ) && has_known_identity_comparison_semantics(
-                db,
-                right,
-                ComparisonOperator::Inequality,
-            ) =>
-        {
-            ComparisonResult::from_bool(left != right)
-        }
-
-        (Type::NominalInstance(left_instance), Type::NominalInstance(right_instance)) => {
-            compare_nominal_instances(
-                db,
-                left_instance,
-                right_instance,
-                ComparisonOperator::Inequality,
-            )
-        }
-
-        _ => ComparisonResult::Ambiguous,
-    }
-}
-
 impl ComparisonResult<'_> {
     fn from_bool(value: bool) -> Self {
         if value {
             ComparisonResult::AlwaysTrue
         } else {
             ComparisonResult::AlwaysFalse
-        }
-    }
-
-    fn negate(self) -> Self {
-        match self {
-            ComparisonResult::AlwaysTrue => ComparisonResult::AlwaysFalse,
-            ComparisonResult::AlwaysFalse => ComparisonResult::AlwaysTrue,
-            ComparisonResult::CanNarrow(narrowed) => ComparisonResult::CanNarrow(narrowed),
-            ComparisonResult::Ambiguous => ComparisonResult::Ambiguous,
         }
     }
 }
@@ -666,10 +467,10 @@ fn evaluate_union_left<'db>(
     elements: &[Type<'db>],
     other: Type<'db>,
     is_positive: bool,
-    evaluate: fn(&'db dyn Db, Type<'db>, Type<'db>, bool) -> ComparisonResult<'db>,
+    operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     evaluate_target_union(db, elements, is_positive, |element| {
-        evaluate(db, element, other, is_positive)
+        comparison_result(db, element, other, is_positive, operator)
     })
 }
 
@@ -759,7 +560,7 @@ fn evaluate_union_right<'db>(
     left: Type<'db>,
     elements: &[Type<'db>],
     is_positive: bool,
-    evaluate: fn(&'db dyn Db, Type<'db>, Type<'db>, bool) -> ComparisonResult<'db>,
+    operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     evaluate_against_results(
         db,
@@ -767,7 +568,7 @@ fn evaluate_union_right<'db>(
         is_positive,
         elements
             .iter()
-            .map(|element| evaluate(db, left, *element, is_positive)),
+            .map(|element| comparison_result(db, left, *element, is_positive, operator)),
     )
 }
 
@@ -831,7 +632,7 @@ fn evaluate_intersection_left<'db>(
     positive: &crate::FxOrderSet<Type<'db>>,
     other: Type<'db>,
     is_positive: bool,
-    evaluate: fn(&'db dyn Db, Type<'db>, Type<'db>, bool) -> ComparisonResult<'db>,
+    operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     let mut any_true = false;
     let mut any_false = false;
@@ -840,7 +641,7 @@ fn evaluate_intersection_left<'db>(
     let mut builder = IntersectionBuilder::new(db).add_positive(original);
 
     for element in positive {
-        match evaluate(db, *element, other, is_positive) {
+        match comparison_result(db, *element, other, is_positive, operator) {
             ComparisonResult::AlwaysTrue => any_true = true,
             ComparisonResult::AlwaysFalse => any_false = true,
             ComparisonResult::CanNarrow(narrowed) => {
@@ -861,14 +662,6 @@ fn evaluate_intersection_left<'db>(
         (true, true) => ComparisonResult::Ambiguous,
         (false, false) => ComparisonResult::CanNarrow(builder.build()),
     }
-}
-
-fn equality_alternatives<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
-    finite_alternatives(db, ty, ComparisonOperator::Equality)
-}
-
-fn inequality_alternatives<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
-    finite_alternatives(db, ty, ComparisonOperator::Inequality)
 }
 
 /// Expand a type into its finite runtime alternatives when its comparison semantics are known.
@@ -980,10 +773,7 @@ fn compare_literal_to_other<'db>(
     let Some(literal_semantics) = literal_semantics(db, literal, operator) else {
         return ComparisonResult::Ambiguous;
     };
-    let condition_expects_equality = matches!(
-        (operator, is_positive),
-        (ComparisonOperator::Equality, true) | (ComparisonOperator::Inequality, false)
-    );
+    let condition_expects_equality = operator.condition_expects_equality(is_positive);
     match comparison_semantics(db, other, operator) {
         Some(other_semantics) if literal_semantics != other_semantics => {
             ComparisonResult::from_bool(operator == ComparisonOperator::Inequality)
@@ -1044,6 +834,20 @@ impl ComparisonOperator {
             ComparisonOperator::Equality => "__eq__",
             ComparisonOperator::Inequality => "__ne__",
         }
+    }
+
+    const fn condition_expects_equality(self, is_positive: bool) -> bool {
+        matches!(
+            (self, is_positive),
+            (ComparisonOperator::Equality, true) | (ComparisonOperator::Inequality, false)
+        )
+    }
+
+    fn result_from_equality<'db>(self, equal: bool) -> ComparisonResult<'db> {
+        ComparisonResult::from_bool(match self {
+            ComparisonOperator::Equality => equal,
+            ComparisonOperator::Inequality => !equal,
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -53,6 +53,30 @@ enum ComparisonResult<'db> {
     Ambiguous,
 }
 
+/// The branch of a comparison for which a narrowing constraint is being computed.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ComparisonBranch {
+    Positive,
+    Negative,
+}
+
+/// The role of a literal operand in the comparison being evaluated.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum LiteralOperand {
+    Target,
+    Other,
+}
+
+impl From<bool> for ComparisonBranch {
+    fn from(is_positive: bool) -> Self {
+        if is_positive {
+            Self::Positive
+        } else {
+            Self::Negative
+        }
+    }
+}
+
 impl<'db> ComparisonResult<'db> {
     fn from_bool(value: bool) -> Self {
         if value {
@@ -63,10 +87,14 @@ impl<'db> ComparisonResult<'db> {
     }
 
     /// Convert this result into a constraint for a branch with the given truthiness.
-    fn constraint(self, is_positive: bool) -> Option<Type<'db>> {
+    fn constraint(self, branch: ComparisonBranch) -> Option<Type<'db>> {
         match self {
-            ComparisonResult::AlwaysTrue => (!is_positive).then_some(Type::Never),
-            ComparisonResult::AlwaysFalse => is_positive.then_some(Type::Never),
+            ComparisonResult::AlwaysTrue => {
+                (branch == ComparisonBranch::Negative).then_some(Type::Never)
+            }
+            ComparisonResult::AlwaysFalse => {
+                (branch == ComparisonBranch::Positive).then_some(Type::Never)
+            }
             ComparisonResult::CanNarrow(narrowed) => Some(narrowed),
             ComparisonResult::Ambiguous => None,
         }
@@ -96,18 +124,27 @@ pub(super) fn evaluate_type_equality<'db>(
     right: Type<'db>,
     is_positive: bool,
 ) -> Option<Type<'db>> {
-    enum_literal_constraint(db, left, right, ComparisonOperator::Equality, is_positive)
-        .or_else(|| builtin_literal_constraint(db, left, right, is_positive))
-        .or_else(|| {
-            if comparison_domain(db, left, right, ComparisonOperator::Equality)
-                == ComparisonDomain::Known
-            {
-                comparison_result(db, left, right, is_positive, ComparisonOperator::Equality)
-                    .constraint(is_positive)
-            } else {
-                None
-            }
-        })
+    let branch = ComparisonBranch::from(is_positive);
+    let condition_expects_equality =
+        ComparisonOperator::Equality.condition_expects_equality(branch);
+    enum_literal_constraint(
+        db,
+        left,
+        right,
+        ComparisonOperator::Equality,
+        condition_expects_equality,
+    )
+    .or_else(|| builtin_literal_constraint(db, left, right, condition_expects_equality))
+    .or_else(|| {
+        if comparison_domain(db, left, right, ComparisonOperator::Equality)
+            == ComparisonDomain::Known
+        {
+            comparison_result(db, left, right, branch, ComparisonOperator::Equality)
+                .constraint(branch)
+        } else {
+            None
+        }
+    })
 }
 
 /// Return a constraint for `left` in a branch where `left != right` has the given truthiness.
@@ -136,17 +173,20 @@ pub(super) fn evaluate_type_inequality<'db>(
     right: Type<'db>,
     is_positive: bool,
 ) -> Option<Type<'db>> {
+    let branch = ComparisonBranch::from(is_positive);
+    let condition_expects_equality =
+        ComparisonOperator::Inequality.condition_expects_equality(branch);
     enum_literal_constraint(
         db,
         left,
         right,
         ComparisonOperator::Inequality,
-        !is_positive,
+        condition_expects_equality,
     )
-    .or_else(|| builtin_literal_constraint(db, left, right, !is_positive))
+    .or_else(|| builtin_literal_constraint(db, left, right, condition_expects_equality))
     .or_else(|| {
-        comparison_result(db, left, right, is_positive, ComparisonOperator::Inequality)
-            .constraint(is_positive)
+        comparison_result(db, left, right, branch, ComparisonOperator::Inequality)
+            .constraint(branch)
     })
 }
 
@@ -158,7 +198,13 @@ pub(crate) fn equality_truthiness<'db>(
     left: Type<'db>,
     right: Type<'db>,
 ) -> Truthiness {
-    match comparison_result(db, left, right, true, ComparisonOperator::Equality) {
+    match comparison_result(
+        db,
+        left,
+        right,
+        ComparisonBranch::Positive,
+        ComparisonOperator::Equality,
+    ) {
         ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
         ComparisonResult::AlwaysFalse => Truthiness::AlwaysFalse,
         ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => Truthiness::Ambiguous,
@@ -167,23 +213,23 @@ pub(crate) fn equality_truthiness<'db>(
 
 /// Evaluate a comparison recursively, treating `left` as the operand being constrained.
 ///
-/// `is_positive` selects the branch whose constraint is accumulated when either operand expands
+/// `branch` selects the branch whose constraint is accumulated when either operand expands
 /// into multiple alternatives.
 fn comparison_result<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
     right: Type<'db>,
-    is_positive: bool,
+    branch: ComparisonBranch,
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     let left = left.resolve_type_alias(db);
     let right = right.resolve_type_alias(db);
 
     if let Some(alternatives) = finite_alternatives(db, left, operator) {
-        return evaluate_union_left(db, &alternatives, right, is_positive, operator);
+        return evaluate_union_left(db, &alternatives, right, branch, operator);
     }
     if let Some(alternatives) = finite_alternatives(db, right, operator) {
-        return evaluate_union_right(db, left, &alternatives, is_positive, operator);
+        return evaluate_union_right(db, left, &alternatives, branch, operator);
     }
 
     match (left, right) {
@@ -211,7 +257,7 @@ fn comparison_result<'db>(
         ) => ComparisonResult::Ambiguous,
 
         (Type::Dynamic(_), other) => {
-            if !operator.condition_expects_equality(is_positive) && other.is_single_valued(db) {
+            if !operator.condition_expects_equality(branch) && other.is_single_valued(db) {
                 ComparisonResult::CanNarrow(
                     IntersectionBuilder::new(db)
                         .add_positive(left)
@@ -227,52 +273,44 @@ fn comparison_result<'db>(
         (Type::TypeVar(var), other) => match var.typevar(db).bound_or_constraints(db) {
             None => ComparisonResult::Ambiguous,
             Some(TypeVarBoundOrConstraints::UpperBound(_)) => {
-                if !operator.condition_expects_equality(is_positive) && other.is_single_valued(db) {
+                if !operator.condition_expects_equality(branch) && other.is_single_valued(db) {
                     ComparisonResult::CanNarrow(other.negate(db))
                 } else {
                     ComparisonResult::Ambiguous
                 }
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                comparison_result(db, constraints.as_type(db), other, is_positive, operator)
+                comparison_result(db, constraints.as_type(db), other, branch, operator)
             }
         },
         (other, Type::TypeVar(var)) => match var.typevar(db).bound_or_constraints(db) {
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                comparison_result(db, other, constraints.as_type(db), is_positive, operator)
+                comparison_result(db, other, constraints.as_type(db), branch, operator)
             }
             None | Some(TypeVarBoundOrConstraints::UpperBound(_)) => ComparisonResult::Ambiguous,
         },
 
-        (Type::NewTypeInstance(newtype), other) => comparison_result(
-            db,
-            newtype.concrete_base_type(db),
-            other,
-            is_positive,
-            operator,
-        )
-        .discard_narrowing(),
-        (other, Type::NewTypeInstance(newtype)) => comparison_result(
-            db,
-            other,
-            newtype.concrete_base_type(db),
-            is_positive,
-            operator,
-        )
-        .discard_narrowing(),
+        (Type::NewTypeInstance(newtype), other) => {
+            comparison_result(db, newtype.concrete_base_type(db), other, branch, operator)
+                .discard_narrowing()
+        }
+        (other, Type::NewTypeInstance(newtype)) => {
+            comparison_result(db, other, newtype.concrete_base_type(db), branch, operator)
+                .discard_narrowing()
+        }
 
         (Type::Union(union), other) => {
-            evaluate_union_left(db, union.elements(db), other, is_positive, operator)
+            evaluate_union_left(db, union.elements(db), other, branch, operator)
         }
         (other, Type::Union(union)) => {
-            evaluate_union_right(db, other, union.elements(db), is_positive, operator)
+            evaluate_union_right(db, other, union.elements(db), branch, operator)
         }
         (Type::Intersection(intersection), other) => evaluate_intersection_left(
             db,
             Type::Intersection(intersection),
             intersection.positive(db),
             other,
-            is_positive,
+            branch,
             operator,
         ),
 
@@ -285,7 +323,7 @@ fn comparison_result<'db>(
                     right,
                     left_literal.kind(),
                     right_literal.kind(),
-                    operator.condition_expects_equality(is_positive),
+                    operator.condition_expects_equality(branch),
                 ),
             }
         }
@@ -295,18 +333,18 @@ fn comparison_result<'db>(
             Type::LiteralValue(literal),
             literal.kind(),
             other,
-            is_positive,
+            branch,
             operator,
-            true,
+            LiteralOperand::Target,
         ),
         (other, Type::LiteralValue(literal)) => compare_literal_to_other(
             db,
             Type::LiteralValue(literal),
             literal.kind(),
             other,
-            is_positive,
+            branch,
             operator,
-            false,
+            LiteralOperand::Other,
         ),
 
         (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::Ambiguous,
@@ -541,11 +579,11 @@ fn evaluate_union_left<'db>(
     db: &'db dyn Db,
     elements: &[Type<'db>],
     other: Type<'db>,
-    is_positive: bool,
+    branch: ComparisonBranch,
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
-    evaluate_target_union(db, elements, is_positive, |element| {
-        comparison_result(db, element, other, is_positive, operator)
+    evaluate_target_union(db, elements, branch, |element| {
+        comparison_result(db, element, other, branch, operator)
     })
 }
 
@@ -556,7 +594,7 @@ fn evaluate_union_left<'db>(
 fn evaluate_target_union<'db>(
     db: &'db dyn Db,
     elements: &[Type<'db>],
-    is_positive: bool,
+    branch: ComparisonBranch,
     mut evaluate: impl FnMut(Type<'db>) -> ComparisonResult<'db>,
 ) -> ComparisonResult<'db> {
     if elements.is_empty() {
@@ -573,7 +611,7 @@ fn evaluate_target_union<'db>(
         match evaluate(*element) {
             ComparisonResult::AlwaysTrue => {
                 all_false = false;
-                if is_positive {
+                if branch == ComparisonBranch::Positive {
                     narrowed.push(Some(*element));
                 } else {
                     narrowed.push(None);
@@ -583,7 +621,7 @@ fn evaluate_target_union<'db>(
             }
             ComparisonResult::AlwaysFalse => {
                 all_true = false;
-                if is_positive {
+                if branch == ComparisonBranch::Positive {
                     narrowed.push(None);
                     removed = removed.add(*element);
                     removed_any = true;
@@ -635,16 +673,16 @@ fn evaluate_union_right<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
     elements: &[Type<'db>],
-    is_positive: bool,
+    branch: ComparisonBranch,
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     evaluate_against_results(
         db,
         left,
-        is_positive,
+        branch,
         elements
             .iter()
-            .map(|element| comparison_result(db, left, *element, is_positive, operator)),
+            .map(|element| comparison_result(db, left, *element, branch, operator)),
     )
 }
 
@@ -655,7 +693,7 @@ fn evaluate_union_right<'db>(
 fn evaluate_against_results<'db>(
     db: &'db dyn Db,
     target: Type<'db>,
-    is_positive: bool,
+    branch: ComparisonBranch,
     results: impl IntoIterator<Item = ComparisonResult<'db>>,
 ) -> ComparisonResult<'db> {
     let mut all_true = true;
@@ -668,13 +706,13 @@ fn evaluate_against_results<'db>(
         match result {
             ComparisonResult::AlwaysTrue => {
                 all_false = false;
-                if is_positive {
+                if branch == ComparisonBranch::Positive {
                     builder = builder.add(target);
                 }
             }
             ComparisonResult::AlwaysFalse => {
                 all_true = false;
-                if !is_positive {
+                if branch == ComparisonBranch::Negative {
                     builder = builder.add(target);
                 }
             }
@@ -708,7 +746,7 @@ fn evaluate_intersection_left<'db>(
     original: Type<'db>,
     positive: &crate::FxOrderSet<Type<'db>>,
     other: Type<'db>,
-    is_positive: bool,
+    branch: ComparisonBranch,
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     let mut any_true = false;
@@ -718,7 +756,7 @@ fn evaluate_intersection_left<'db>(
     let mut builder = IntersectionBuilder::new(db).add_positive(original);
 
     for element in positive {
-        match comparison_result(db, *element, other, is_positive, operator) {
+        match comparison_result(db, *element, other, branch, operator) {
             ComparisonResult::AlwaysTrue => any_true = true,
             ComparisonResult::AlwaysFalse => any_false = true,
             ComparisonResult::CanNarrow(narrowed) => {
@@ -838,9 +876,9 @@ fn compare_literal_to_other<'db>(
     literal_type: Type<'db>,
     literal: LiteralValueTypeKind<'db>,
     other: Type<'db>,
-    is_positive: bool,
+    branch: ComparisonBranch,
     operator: ComparisonOperator,
-    literal_is_target: bool,
+    literal_operand: LiteralOperand,
 ) -> ComparisonResult<'db> {
     if matches!(literal, LiteralValueTypeKind::LiteralString) {
         return match KnownComparisonSemantics::of_type(db, other, operator) {
@@ -854,7 +892,7 @@ fn compare_literal_to_other<'db>(
     else {
         return ComparisonResult::Ambiguous;
     };
-    let condition_expects_equality = operator.condition_expects_equality(is_positive);
+    let condition_expects_equality = operator.condition_expects_equality(branch);
     match KnownComparisonSemantics::of_type(db, other, operator) {
         Some(other_semantics) if literal_semantics != other_semantics => {
             ComparisonResult::from_bool(operator == ComparisonOperator::Inequality)
@@ -868,14 +906,14 @@ fn compare_literal_to_other<'db>(
         // Inherited builtin comparison semantics do not imply type overlap. For example, a final
         // `int` subclass can compare equal to `1` despite being disjoint from `Literal[1]`.
         Some(_)
-            if !literal_is_target
+            if literal_operand == LiteralOperand::Other
                 && literal_type.is_single_valued(db)
                 && !other.is_disjoint_from(db, literal_type) =>
         {
             ComparisonResult::CanNarrow(literal_type.negate_if(db, !condition_expects_equality))
         }
         Some(_) => ComparisonResult::Ambiguous,
-        None if !literal_is_target
+        None if literal_operand == LiteralOperand::Other
             && !condition_expects_equality
             && literal_type.is_single_valued(db) =>
         {
@@ -934,10 +972,11 @@ impl ComparisonOperator {
     }
 
     /// Return whether the selected branch requires the operands to compare equal.
-    const fn condition_expects_equality(self, is_positive: bool) -> bool {
+    const fn condition_expects_equality(self, branch: ComparisonBranch) -> bool {
         matches!(
-            (self, is_positive),
-            (ComparisonOperator::Equality, true) | (ComparisonOperator::Inequality, false)
+            (self, branch),
+            (ComparisonOperator::Equality, ComparisonBranch::Positive)
+                | (ComparisonOperator::Inequality, ComparisonBranch::Negative)
         )
     }
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -66,7 +66,8 @@ pub(super) fn evaluate_type_equality<'db>(
     right: Type<'db>,
     is_positive: bool,
 ) -> Option<Type<'db>> {
-    primitive_literal_constraint(db, left, right, is_positive)
+    enum_literal_constraint(db, left, right, ComparisonOperator::Equality, is_positive)
+        .or_else(|| primitive_literal_constraint(db, left, right, is_positive))
         .or_else(|| equality_result(db, left, right, is_positive).constraint(is_positive))
 }
 
@@ -76,8 +77,15 @@ pub(super) fn evaluate_type_inequality<'db>(
     right: Type<'db>,
     is_positive: bool,
 ) -> Option<Type<'db>> {
-    primitive_literal_constraint(db, left, right, !is_positive)
-        .or_else(|| inequality_result(db, left, right, is_positive).constraint(is_positive))
+    enum_literal_constraint(
+        db,
+        left,
+        right,
+        ComparisonOperator::Inequality,
+        !is_positive,
+    )
+    .or_else(|| primitive_literal_constraint(db, left, right, !is_positive))
+    .or_else(|| inequality_result(db, left, right, is_positive).constraint(is_positive))
 }
 
 pub(crate) fn equality_truthiness<'db>(
@@ -315,6 +323,50 @@ fn primitive_literal_constraint<'db>(
 
     (left_is_builtin_primitive || !condition_expects_equality)
         .then(|| equal_to_right.negate_if(db, !condition_expects_equality))
+}
+
+fn enum_literal_constraint<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    operator: ComparisonOperator,
+    condition_expects_equality: bool,
+) -> Option<Type<'db>> {
+    let LiteralValueTypeKind::Enum(right) = right.as_literal_value_kind()? else {
+        return None;
+    };
+    let enum_class = right.enum_class(db);
+
+    if !is_same_enum_domain(db, left, right)
+        || known_instance_semantics(db, right.enum_class_instance(db), operator).is_none()
+    {
+        return None;
+    }
+
+    let metadata = enum_metadata(db, enum_class)?;
+    let name = metadata.resolve_member(right.name(db))?.clone();
+    let equal_to_right = Type::enum_literal(EnumLiteralType::new(db, enum_class, name));
+    Some(equal_to_right.negate_if(db, !condition_expects_equality))
+}
+
+fn is_same_enum_domain<'db>(db: &'db dyn Db, ty: Type<'db>, right: EnumLiteralType<'db>) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::LiteralValue(literal) => matches!(
+            literal.kind(),
+            LiteralValueTypeKind::Enum(left)
+                if left.enum_class(db) == right.enum_class(db)
+        ),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| is_same_enum_domain(db, *element, right)),
+        Type::NominalInstance(instance) => instance.class_literal(db) == right.enum_class(db),
+        Type::EnumComplement(complement) => complement.enum_class(db) == right.enum_class(db),
+        Type::Intersection(intersection) => intersection
+            .enum_complement(db)
+            .is_some_and(|complement| complement.enum_class(db) == right.enum_class(db)),
+        _ => false,
+    }
 }
 
 fn inequality_result<'db>(

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1031,12 +1031,6 @@ impl KnownComparisonSemantics {
         instance: Type<'db>,
         operator: ComparisonOperator,
     ) -> Option<Self> {
-        if let Some(nominal) = instance.as_nominal_instance()
-            && enum_metadata(db, nominal.class_literal(db)).is_some()
-        {
-            return Self::of_enum(db, instance, operator);
-        }
-
         let class = instance.to_meta_type(db);
         let dunder = lookup_dunder(db, class, operator.dunder());
 
@@ -1061,59 +1055,6 @@ impl KnownComparisonSemantics {
             }
         }
         None
-    }
-
-    /// Return an enum's inherited scalar or identity comparison implementation.
-    ///
-    /// Custom enum comparison methods make the result unknown.
-    fn of_enum<'db>(
-        db: &'db dyn Db,
-        instance: Type<'db>,
-        operator: ComparisonOperator,
-    ) -> Option<Self> {
-        let base_semantics = if instance.is_subtype_of(db, KnownClass::Str.to_instance(db)) {
-            Self::Str
-        } else if instance.is_subtype_of(db, KnownClass::Int.to_instance(db)) {
-            Self::Int
-        } else if instance.is_subtype_of(db, KnownClass::Bytes.to_instance(db)) {
-            Self::Bytes
-        } else {
-            Self::Object
-        };
-
-        let class = instance.to_meta_type(db);
-        let has_custom_dunder = |name| {
-            let dunder = class.member_lookup_with_policy(
-                db,
-                Name::new_static(name),
-                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
-                    | MemberLookupPolicy::MRO_NO_INT_OR_STR_LOOKUP,
-            );
-            if dunder.place.is_undefined() {
-                return false;
-            }
-            if base_semantics == Self::Bytes
-                && dunder == lookup_dunder(db, KnownClass::Bytes.to_class_literal(db), name)
-            {
-                return false;
-            }
-            true
-        };
-
-        match operator {
-            ComparisonOperator::Equality => {
-                (!has_custom_dunder("__eq__")).then_some(base_semantics)
-            }
-            ComparisonOperator::Inequality => {
-                if has_custom_dunder("__ne__")
-                    || (base_semantics == Self::Object && has_custom_dunder("__eq__"))
-                {
-                    None
-                } else {
-                    Some(base_semantics)
-                }
-            }
-        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -420,10 +420,26 @@ fn primitive_literal_constraint<'db>(
     .then_some(equal_to_right)
 }
 
-/// Return a direct enum-member constraint when the target is entirely from the same enum domain.
+/// Return a constraint when every possible value of `left` is a member of the same enum as `right`.
 ///
-/// This is only valid when the enum inherits comparison behavior that `ty` understands; custom
-/// equality or inequality methods make the result ambiguous.
+/// For example:
+///
+/// ```python
+/// from enum import Enum
+///
+/// class Answer(Enum):
+///     NO = 0
+///     YES = 1
+///
+/// def f(answer: Answer):
+///     if answer != Answer.NO:
+///         reveal_type(answer)  # Literal[Answer.YES]
+///     else:
+///         reveal_type(answer)  # Literal[Answer.NO]
+/// ```
+///
+/// This shortcut is disabled if the enum defines or inherits custom `__eq__` or `__ne__` methods,
+/// because those methods can change whether two members compare equal.
 fn enum_literal_constraint<'db>(
     db: &'db dyn Db,
     left: Type<'db>,

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -8,6 +8,11 @@ use super::{
     enums::{enum_member_literals, enum_metadata},
 };
 
+/// The result of evaluating a runtime comparison between two types.
+///
+/// Definite truthiness is represented separately from a constraint for the operand currently being
+/// narrowed. A comparison can therefore be ambiguous at runtime while still constraining that
+/// operand in either branch.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum ComparisonResult<'db> {
     /// The comparison always evaluates to true.
@@ -18,7 +23,7 @@ enum ComparisonResult<'db> {
     /// object of type `Literal[Foo.X]` in the following example, despite the fact that
     /// `Literal[1]` is disjoint from `Literal[Foo.X]`:
     ///
-    /// ```py
+    /// ```python
     /// from enum import IntEnum
     ///
     /// class Foo(IntEnum):
@@ -43,6 +48,7 @@ enum ComparisonResult<'db> {
 }
 
 impl<'db> ComparisonResult<'db> {
+    /// Convert this result into a constraint for a branch with the given truthiness.
     fn constraint(self, is_positive: bool) -> Option<Type<'db>> {
         match self {
             ComparisonResult::AlwaysTrue => (!is_positive).then_some(Type::Never),
@@ -52,6 +58,7 @@ impl<'db> ComparisonResult<'db> {
         }
     }
 
+    /// Preserve definite truthiness while discarding a conditional narrowing result.
     fn discard_narrowing(self) -> Self {
         match self {
             ComparisonResult::CanNarrow(_) => ComparisonResult::Ambiguous,
@@ -60,6 +67,10 @@ impl<'db> ComparisonResult<'db> {
     }
 }
 
+/// Return a constraint for `left` in a branch where `left == right` has the given truthiness.
+///
+/// Returns `None` when the comparison behavior of either operand is not precise enough to safely
+/// constrain `left`.
 pub(super) fn evaluate_type_equality<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
@@ -79,6 +90,10 @@ pub(super) fn evaluate_type_equality<'db>(
         })
 }
 
+/// Return a constraint for `left` in a branch where `left != right` has the given truthiness.
+///
+/// Returns `None` when the comparison behavior of either operand is not precise enough to safely
+/// constrain `left`.
 pub(super) fn evaluate_type_inequality<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
@@ -96,6 +111,9 @@ pub(super) fn evaluate_type_inequality<'db>(
     .or_else(|| inequality_result(db, left, right, is_positive).constraint(is_positive))
 }
 
+/// Return the truthiness of `left == right` when it is known for every represented runtime value.
+///
+/// A result that only permits narrowing remains ambiguous because it can still evaluate either way.
 pub(crate) fn equality_truthiness<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
@@ -108,6 +126,10 @@ pub(crate) fn equality_truthiness<'db>(
     }
 }
 
+/// Evaluate equality recursively, treating `left` as the operand being constrained.
+///
+/// `is_positive` selects the branch whose constraint is accumulated when either operand expands
+/// into multiple alternatives.
 fn equality_result<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
@@ -280,12 +302,6 @@ fn equality_result<'db>(
     }
 }
 
-/// Return a constraint that does not depend on the target's currently inferred literal union.
-///
-/// Narrowing constraints participate in cyclic inference. Filtering `"B" | "C"` to `"B"` for the
-/// false branch of `x == "C"` can freeze a loop before later iterations widen `x`. Constraining the
-/// target with `~Literal["C"]` instead describes the predicate itself and remains valid as the cycle
-/// reaches its fixed point.
 fn is_builtin_primitive(db: &dyn Db, ty: Type) -> bool {
     match ty.resolve_type_alias(db) {
         Type::LiteralValue(literal) => matches!(
@@ -300,6 +316,15 @@ fn is_builtin_primitive(db: &dyn Db, ty: Type) -> bool {
     }
 }
 
+/// Return a predicate-shaped constraint for comparison with a primitive literal.
+///
+/// Narrowing constraints participate in cyclic inference. Filtering `"B" | "C"` to `"B"` for the
+/// false branch of `x == "C"` can freeze a loop before later iterations widen `x`. Constraining the
+/// target with `~Literal["C"]` instead describes the predicate itself and remains valid as the cycle
+/// reaches its fixed point.
+///
+/// The constraint also follows Python's equality between booleans and integers: `x != 0` excludes
+/// both `Literal[0]` and `Literal[False]`, while `x != 1` excludes `Literal[1]` and `Literal[True]`.
 fn primitive_literal_constraint<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
@@ -381,6 +406,10 @@ fn primitive_literal_constraint<'db>(
     .then_some(equal_to_right)
 }
 
+/// Return a direct enum-member constraint when the target is entirely from the same enum domain.
+///
+/// This is only valid when the enum inherits comparison behavior that `ty` understands; custom
+/// equality or inequality methods make the result ambiguous.
 fn enum_literal_constraint<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
@@ -425,6 +454,10 @@ fn is_same_enum_domain<'db>(db: &'db dyn Db, ty: Type<'db>, right: EnumLiteralTy
     }
 }
 
+/// Evaluate inequality recursively, treating `left` as the operand being constrained.
+///
+/// `is_positive` selects the branch whose constraint is accumulated when either operand expands
+/// into multiple alternatives.
 fn inequality_result<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
@@ -640,6 +673,10 @@ fn evaluate_union_left<'db>(
     })
 }
 
+/// Combine comparison results for the alternatives of the union being constrained.
+///
+/// Alternatives that cannot satisfy the selected branch are removed. Dynamic alternatives retain
+/// negative constraints for removed arms so that the result still describes the branch predicate.
 fn evaluate_target_union<'db>(
     db: &'db dyn Db,
     elements: &[Type<'db>],
@@ -734,6 +771,10 @@ fn evaluate_union_right<'db>(
     )
 }
 
+/// Combine comparison results produced by alternatives of the non-target operand.
+///
+/// The target remains possible when any alternative can satisfy the selected branch; definite
+/// truthiness is reported only when every alternative agrees.
 fn evaluate_against_results<'db>(
     db: &'db dyn Db,
     target: Type<'db>,
@@ -830,6 +871,10 @@ fn inequality_alternatives<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Ty
     finite_alternatives(db, ty, ComparisonOperator::Inequality)
 }
 
+/// Expand a type into its finite runtime alternatives when its comparison semantics are known.
+///
+/// Enum classes with custom comparison methods are deliberately not expanded because their members
+/// may compare equal to values outside the enum domain.
 fn finite_alternatives<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -887,6 +932,7 @@ fn narrow_literal_comparison<'db>(
     }
 }
 
+/// Narrow `LiteralString` against a string-valued enum member with inherited `str` semantics.
 fn narrow_literal_string_against_enum<'db>(
     db: &'db dyn Db,
     enum_literal: EnumLiteralType<'db>,
@@ -1001,6 +1047,10 @@ impl ComparisonOperator {
     }
 }
 
+/// A known builtin implementation that determines the runtime behavior of a comparison.
+///
+/// Two types with different known semantics cannot compare equal. Types with custom or otherwise
+/// unknown comparison methods are not assigned a value of this enum.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum KnownComparisonSemantics {
     Object,
@@ -1067,6 +1117,9 @@ fn comparison_domain<'db>(
     }
 }
 
+/// Determine the builtin comparison implementation inherited by `ty`.
+///
+/// Returns `None` when dunder lookup finds custom or conflicting comparison behavior.
 fn comparison_semantics<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -1108,6 +1161,7 @@ fn comparison_semantics<'db>(
     }
 }
 
+/// Return whether `ty` is a singleton whose comparison uses object identity semantics.
 fn has_known_identity_comparison_semantics<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -1243,6 +1297,10 @@ fn lookup_dunder<'db>(
     )
 }
 
+/// Return the comparison result for two literals when their runtime values determine it.
+///
+/// This accounts for integer/boolean equality and enum aliases or enum values. `None` means custom
+/// or insufficiently known comparison behavior prevents a definitive result.
 fn known_literal_equality<'db>(
     db: &'db dyn Db,
     left: LiteralValueTypeKind<'db>,
@@ -1323,6 +1381,9 @@ fn known_type_value_equality<'db>(
     )
 }
 
+/// Return the statically known runtime value of an enum member.
+///
+/// Custom enum construction can replace the declared value, so members of such enums return `None`.
 fn enum_literal_value<'db>(db: &'db dyn Db, literal: EnumLiteralType<'db>) -> Option<Type<'db>> {
     let metadata = enum_metadata(db, literal.enum_class(db))?;
     let name = metadata.resolve_member(literal.name(db))?;
@@ -1339,6 +1400,7 @@ fn enum_literal_value<'db>(db: &'db dyn Db, literal: EnumLiteralType<'db>) -> Op
     }
 }
 
+/// Return whether two enum literals resolve to the same member, including aliases.
 fn same_enum_member<'db>(
     db: &'db dyn Db,
     left: EnumLiteralType<'db>,

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -95,6 +95,22 @@ pub(super) fn evaluate_type_equality<'db>(
 ///
 /// Returns `None` when the comparison behavior of either operand is not precise enough to safely
 /// constrain `left`.
+///
+/// For example, comparing a literal union against one of its members constrains both branches:
+///
+/// ```python
+/// from typing import Literal
+///
+/// def f(x: Literal[1, 2]):
+///     if x != 1:
+///         reveal_type(x)  # Literal[2]
+///     else:
+///         reveal_type(x)  # Literal[1]
+///
+/// def g(x: Literal[1]):
+///     if x != 1:
+///         reveal_type(x)  # Never
+/// ```
 pub(super) fn evaluate_type_inequality<'db>(
     db: &'db dyn Db,
     left: Type<'db>,

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1052,9 +1052,7 @@ impl KnownComparisonSemantics {
                     .then_some(first)
             }
             Type::NominalInstance(instance)
-                if instance.class(db).is_final(db)
-                    || instance.tuple_spec(db).is_some()
-                    || ty.is_singleton(db) =>
+                if instance.class(db).is_final(db) || instance.tuple_spec(db).is_some() =>
             {
                 Self::of_instance(db, ty, operator)
             }

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -402,21 +402,49 @@ fn comparison_result<'db>(
     }
 }
 
-/// Return whether every value represented by `ty` compares equal to every other represented value.
+/// Return whether every value represented by `ty` is known to compare equal to every other value.
 ///
-/// Dynamic and type-variable types are excluded to avoid recursive comparison through the special
-/// cases that call this helper.
+/// Comparison evaluation is reused so this stays aligned with all modeled equality semantics.
+/// Self-comparisons that can decompose into dynamic types or type variables are rejected before
+/// evaluation because those branches call this helper and would otherwise recurse.
 fn all_values_compare_equal<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
     operator: ComparisonOperator,
 ) -> bool {
     let ty = ty.resolve_type_alias(db);
-    if matches!(ty, Type::Dynamic(_) | Type::TypeVar(_)) {
+
+    // TODO: Avoid recursing into comparison evaluation until we support some kind of fixed point or
+    // cycle detection.
+    if self_comparison_may_cycle(db, ty) {
         return false;
     }
+
     comparison_result(db, ty, ty, ComparisonBranch::Positive, operator)
         == operator.result_from_equality(true)
+}
+
+/// Return whether self-comparison of `ty` may cycle.
+///
+/// Comparison evaluation decomposes unions, positive intersections, and `NewType` bases. Other
+/// types, including generic aliases, are atomic even when their components contain dynamic types
+/// or type variables.
+fn self_comparison_may_cycle<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::Dynamic(_) | Type::TypeVar(_) => true,
+        Type::NewTypeInstance(newtype) => {
+            self_comparison_may_cycle(db, newtype.concrete_base_type(db))
+        }
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .any(|element| self_comparison_may_cycle(db, *element)),
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .any(|element| self_comparison_may_cycle(db, *element)),
+        _ => false,
+    }
 }
 
 /// Return whether `ty` is handled by [`builtin_literal_constraint`].
@@ -437,13 +465,23 @@ fn is_builtin_literal_type(db: &dyn Db, ty: Type) -> bool {
     }
 }
 
-/// Return a predicate-shaped constraint for comparison with an `int`, `bool`, `str`, or `bytes`
-/// literal.
+/// Return a constraint for comparison with an `int`, `bool`, `str`, or `bytes` literal.
 ///
-/// Narrowing constraints participate in cyclic inference. Filtering `"B" | "C"` to `"B"` for the
-/// false branch of `x == "C"` can freeze a loop before later iterations widen `x`. Constraining the
-/// target with `~Literal["C"]` instead describes the predicate itself and remains valid as the cycle
-/// reaches its fixed point.
+/// For example:
+///
+/// ```py
+/// x = "B"
+/// if random():
+///     x = "C"
+/// if x != "C":
+///     while random():
+///         reveal_type(x)  # Literal["B", "D"]
+///         x = "D"
+/// ```
+///
+/// At first, `x != "C"` narrows `x` from `"B" | "C"` to `"B"`. The loop later adds `"D"`. If we
+/// record the result as just `"B"`, the type of `x` can never grow to include `"D"`. Recording it as
+/// "anything except `"C"`" (`~Literal["C"]`) rules out `"C"` but still allows the loop to add `"D"`.
 ///
 /// The constraint also follows Python's equality between booleans and integers: `x != 0` excludes
 /// both `Literal[0]` and `Literal[False]`, while `x != 1` excludes `Literal[1]` and `Literal[True]`.
@@ -1014,7 +1052,9 @@ impl KnownComparisonSemantics {
                     .then_some(first)
             }
             Type::NominalInstance(instance)
-                if instance.class(db).is_final(db) || instance.tuple_spec(db).is_some() =>
+                if instance.class(db).is_final(db)
+                    || instance.tuple_spec(db).is_some()
+                    || ty.is_singleton(db) =>
             {
                 Self::of_instance(db, ty, operator)
             }
@@ -1115,10 +1155,8 @@ fn comparison_domain<'db>(
         }
         Type::NominalInstance(instance) => {
             if instance.tuple_spec(db).is_some()
-                || instance
-                    .class(db)
-                    .known(db)
-                    .is_some_and(|known| known == KnownClass::Bool || known.is_singleton())
+                || ty.is_singleton(db)
+                || instance.has_known_class(db, KnownClass::Bool)
                 || target.is_union()
                     && KnownComparisonSemantics::of_type(db, ty, operator).is_some()
             {

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -810,7 +810,13 @@ fn compare_literal_to_other<'db>(
         Some(other_semantics) if literal_semantics != other_semantics => {
             ComparisonResult::from_bool(operator == ComparisonOperator::Inequality)
         }
-        Some(_) if !literal_is_target && literal_type.is_single_valued(db) => {
+        // Inherited builtin comparison semantics do not imply type overlap. For example, a final
+        // `int` subclass can compare equal to `1` despite being disjoint from `Literal[1]`.
+        Some(_)
+            if !literal_is_target
+                && literal_type.is_single_valued(db)
+                && !other.is_disjoint_from(db, literal_type) =>
+        {
             ComparisonResult::CanNarrow(literal_type.negate_if(db, !condition_expects_equality))
         }
         Some(_) => ComparisonResult::Ambiguous,

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -69,38 +69,14 @@ pub(super) fn evaluate_type_equality<'db>(
     enum_literal_constraint(db, left, right, ComparisonOperator::Equality, is_positive)
         .or_else(|| primitive_literal_constraint(db, left, right, is_positive))
         .or_else(|| {
-            if is_equality_narrowing_operand(db, left, right) {
+            if comparison_domain(db, left, right, ComparisonOperator::Equality)
+                == ComparisonDomain::Known
+            {
                 equality_result(db, left, right, is_positive).constraint(is_positive)
             } else {
                 None
             }
         })
-}
-
-/// Return whether `ty` can constrain `left` through equality.
-///
-/// The general evaluator distributes over unions, so avoid invoking it for ordinary nominal types
-/// whose comparison semantics are unknown.
-fn is_equality_narrowing_operand<'db>(db: &'db dyn Db, left: Type<'db>, ty: Type<'db>) -> bool {
-    match ty.resolve_type_alias(db) {
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .all(|element| is_equality_narrowing_operand(db, left, *element)),
-        Type::LiteralValue(_) | Type::EnumComplement(_) => true,
-        Type::Intersection(intersection) if intersection.enum_complement(db).is_some() => true,
-        Type::TypedDict(_) => true,
-        Type::NominalInstance(instance) => {
-            instance.tuple_spec(db).is_some()
-                || instance
-                    .class(db)
-                    .known(db)
-                    .is_some_and(|known| known == KnownClass::Bool || known.is_singleton())
-                || left.resolve_type_alias(db).is_union()
-                    && comparison_semantics(db, ty, ComparisonOperator::Equality).is_some()
-        }
-        ty => ty.is_single_valued(db),
-    }
 }
 
 pub(super) fn evaluate_type_inequality<'db>(
@@ -1033,6 +1009,62 @@ enum KnownComparisonSemantics {
     Bytes,
     Tuple,
     Dict,
+}
+
+/// Whether the non-target operand has a comparison domain that can safely constrain the target.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ComparisonDomain {
+    /// The operand may use comparison behavior that `ty` does not model.
+    Unknown,
+    /// The operand can be handled by `ty`'s equality-narrowing evaluator.
+    Known,
+}
+
+/// Classify whether `ty` has comparison behavior that can constrain `target`.
+///
+/// Unions only have a known domain if every arm does. Broad nominal types require full dunder
+/// analysis, which is only useful here when it can eliminate an arm from a union target.
+fn comparison_domain<'db>(
+    db: &'db dyn Db,
+    target: Type<'db>,
+    ty: Type<'db>,
+    operator: ComparisonOperator,
+) -> ComparisonDomain {
+    let target = target.resolve_type_alias(db);
+    let ty = ty.resolve_type_alias(db);
+
+    match ty {
+        Type::Union(union) => {
+            if union.elements(db).iter().all(|element| {
+                comparison_domain(db, target, *element, operator) == ComparisonDomain::Known
+            }) {
+                ComparisonDomain::Known
+            } else {
+                ComparisonDomain::Unknown
+            }
+        }
+        Type::LiteralValue(_) | Type::EnumComplement(_) | Type::TypedDict(_) => {
+            ComparisonDomain::Known
+        }
+        Type::Intersection(intersection) if intersection.enum_complement(db).is_some() => {
+            ComparisonDomain::Known
+        }
+        Type::NominalInstance(instance) => {
+            if instance.tuple_spec(db).is_some()
+                || instance
+                    .class(db)
+                    .known(db)
+                    .is_some_and(|known| known == KnownClass::Bool || known.is_singleton())
+                || target.is_union() && comparison_semantics(db, ty, operator).is_some()
+            {
+                ComparisonDomain::Known
+            } else {
+                ComparisonDomain::Unknown
+            }
+        }
+        _ if ty.is_single_valued(db) => ComparisonDomain::Known,
+        _ => ComparisonDomain::Unknown,
+    }
 }
 
 fn comparison_semantics<'db>(

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -28,7 +28,7 @@ enum ComparisonResult<'db> {
 
     /// The comparison always evaluates to false.
     ///
-    /// Similar to [`AlwaysTrue`], this only describes the runtime comparison result; it does not
+    /// Similar to [`Self::AlwaysTrue`], this only describes the runtime comparison result; it does not
     /// necessarily indicate whether the two types are disjoint.
     AlwaysFalse,
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1,0 +1,1219 @@
+use ruff_python_ast::name::Name;
+
+use crate::{Db, place::PlaceAndQualifiers};
+
+use super::{
+    CallArguments, EnumLiteralType, IntersectionBuilder, KnownClass, LiteralValueTypeKind,
+    MemberLookupPolicy, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder,
+    enums::{enum_member_literals, enum_metadata},
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ComparisonResult<'db> {
+    /// The comparison always evaluates to true.
+    ///
+    /// For equality comparisons, this does not necessarily indicate anything about whether the
+    /// two types are the same type, or even whether they have any subtyping or assignability
+    /// relationship. For example, an object of type `Literal[1]` will always compare equal to an
+    /// object of type `Literal[Foo.X]` in the following example, despite the fact that
+    /// `Literal[1]` is disjoint from `Literal[Foo.X]`:
+    ///
+    /// ```py
+    /// from enum import IntEnum
+    ///
+    /// class Foo(IntEnum):
+    ///     X = 1
+    /// ```
+    AlwaysTrue,
+
+    /// The comparison always evaluates to false.
+    ///
+    /// Similar to [`AlwaysTrue`], this only describes the runtime comparison result; it does not
+    /// necessarily indicate whether the two types are disjoint.
+    AlwaysFalse,
+
+    /// The comparison allows the operand being constrained to be narrowed to the wrapped type.
+    ///
+    /// For example, if an object of type `LiteralString` compares equal to an object of type
+    /// `Literal["foo"]`, the equality branch can safely narrow either operand to `Literal["foo"]`.
+    CanNarrow(Type<'db>),
+
+    /// The comparison may evaluate to true or false, depending on runtime values.
+    Ambiguous,
+}
+
+impl<'db> ComparisonResult<'db> {
+    fn constraint(self, is_positive: bool) -> Option<Type<'db>> {
+        match self {
+            ComparisonResult::AlwaysTrue => (!is_positive).then_some(Type::Never),
+            ComparisonResult::AlwaysFalse => is_positive.then_some(Type::Never),
+            ComparisonResult::CanNarrow(narrowed) => Some(narrowed),
+            ComparisonResult::Ambiguous => None,
+        }
+    }
+}
+
+pub(super) fn evaluate_type_equality<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    is_positive: bool,
+) -> Option<Type<'db>> {
+    primitive_literal_constraint(db, left, right, is_positive)
+        .or_else(|| equality_result(db, left, right, is_positive).constraint(is_positive))
+}
+
+pub(super) fn evaluate_type_inequality<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    is_positive: bool,
+) -> Option<Type<'db>> {
+    primitive_literal_constraint(db, left, right, !is_positive)
+        .or_else(|| inequality_result(db, left, right, is_positive).constraint(is_positive))
+}
+
+pub(crate) fn equality_truthiness<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+) -> Truthiness {
+    match equality_result(db, left, right, true) {
+        ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
+        ComparisonResult::AlwaysFalse => Truthiness::AlwaysFalse,
+        ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => Truthiness::Ambiguous,
+    }
+}
+
+fn equality_result<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    is_positive: bool,
+) -> ComparisonResult<'db> {
+    let left = left.resolve_type_alias(db);
+    let right = right.resolve_type_alias(db);
+
+    if let Some(alternatives) = equality_alternatives(db, left) {
+        return evaluate_union_left(db, &alternatives, right, is_positive, equality_result);
+    }
+    if let Some(alternatives) = equality_alternatives(db, right) {
+        return evaluate_union_right(db, left, &alternatives, is_positive, equality_result);
+    }
+
+    match (left, right) {
+        (
+            Type::Never
+            | Type::Divergent(_)
+            | Type::AlwaysFalsy
+            | Type::AlwaysTruthy
+            | Type::ProtocolInstance(_)
+            | Type::DataclassTransformer(_)
+            | Type::TypeGuard(_)
+            | Type::TypeIs(_),
+            _,
+        )
+        | (
+            _,
+            Type::Never
+            | Type::Divergent(_)
+            | Type::AlwaysFalsy
+            | Type::AlwaysTruthy
+            | Type::ProtocolInstance(_)
+            | Type::DataclassTransformer(_)
+            | Type::TypeGuard(_)
+            | Type::TypeIs(_),
+        ) => ComparisonResult::Ambiguous,
+
+        (Type::Dynamic(_), other) => {
+            if !is_positive && other.is_single_valued(db) {
+                ComparisonResult::CanNarrow(
+                    IntersectionBuilder::new(db)
+                        .add_positive(left)
+                        .add_negative(other)
+                        .build(),
+                )
+            } else {
+                ComparisonResult::Ambiguous
+            }
+        }
+        (_, Type::Dynamic(_)) => ComparisonResult::Ambiguous,
+
+        (Type::TypeVar(var), other) => match var.typevar(db).bound_or_constraints(db) {
+            None => ComparisonResult::Ambiguous,
+            Some(TypeVarBoundOrConstraints::UpperBound(_)) => {
+                if !is_positive && other.is_single_valued(db) {
+                    ComparisonResult::CanNarrow(other.negate(db))
+                } else {
+                    ComparisonResult::Ambiguous
+                }
+            }
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                equality_result(db, constraints.as_type(db), other, is_positive)
+            }
+        },
+        (other, Type::TypeVar(var)) => match var.typevar(db).bound_or_constraints(db) {
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                equality_result(db, other, constraints.as_type(db), is_positive)
+            }
+            None | Some(TypeVarBoundOrConstraints::UpperBound(_)) => ComparisonResult::Ambiguous,
+        },
+
+        (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
+            match equality_result(db, newtype.concrete_base_type(db), other, is_positive) {
+                ComparisonResult::AlwaysTrue => ComparisonResult::AlwaysTrue,
+                ComparisonResult::AlwaysFalse => ComparisonResult::AlwaysFalse,
+                ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
+                    ComparisonResult::Ambiguous
+                }
+            }
+        }
+
+        (Type::Union(union), other) => {
+            evaluate_union_left(db, union.elements(db), other, is_positive, equality_result)
+        }
+        (other, Type::Union(union)) => {
+            evaluate_union_right(db, other, union.elements(db), is_positive, equality_result)
+        }
+        (Type::Intersection(intersection), other) => evaluate_intersection_left(
+            db,
+            Type::Intersection(intersection),
+            intersection.positive(db),
+            other,
+            is_positive,
+            equality_result,
+        ),
+
+        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
+            match known_literal_equality(
+                db,
+                left_literal.kind(),
+                right_literal.kind(),
+                ComparisonOperator::Equality,
+            ) {
+                Some(true) => ComparisonResult::AlwaysTrue,
+                Some(false) => ComparisonResult::AlwaysFalse,
+                None => narrow_literal_comparison(
+                    db,
+                    left,
+                    right,
+                    left_literal.kind(),
+                    right_literal.kind(),
+                    is_positive,
+                ),
+            }
+        }
+
+        (Type::LiteralValue(literal), other) => compare_literal_to_other(
+            db,
+            Type::LiteralValue(literal),
+            literal.kind(),
+            other,
+            is_positive,
+            ComparisonOperator::Equality,
+            true,
+        ),
+        (other, Type::LiteralValue(literal)) => compare_literal_to_other(
+            db,
+            Type::LiteralValue(literal),
+            literal.kind(),
+            other,
+            is_positive,
+            ComparisonOperator::Equality,
+            false,
+        ),
+
+        (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::Ambiguous,
+        (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
+            match known_equality_semantics(db, other) {
+                Some(KnownComparisonSemantics::Dict) | None => ComparisonResult::Ambiguous,
+                Some(_) => ComparisonResult::AlwaysFalse,
+            }
+        }
+
+        (Type::ClassLiteral(left_class), Type::ClassLiteral(right_class)) => {
+            if known_instance_semantics(
+                db,
+                left_class.metaclass_instance_type(db),
+                ComparisonOperator::Equality,
+            ) == Some(KnownComparisonSemantics::Object)
+                && known_instance_semantics(
+                    db,
+                    right_class.metaclass_instance_type(db),
+                    ComparisonOperator::Equality,
+                ) == Some(KnownComparisonSemantics::Object)
+            {
+                ComparisonResult::from_bool(left_class == right_class)
+            } else {
+                call_comparison_dunder(db, left, right, "__eq__")
+            }
+        }
+
+        (Type::ClassLiteral(class), other) | (other, Type::ClassLiteral(class)) => {
+            if known_instance_semantics(
+                db,
+                class.metaclass_instance_type(db),
+                ComparisonOperator::Equality,
+            ) == Some(KnownComparisonSemantics::Object)
+                && !matches!(other, Type::ClassLiteral(_))
+            {
+                ComparisonResult::AlwaysFalse
+            } else {
+                call_comparison_dunder(db, left, right, "__eq__")
+            }
+        }
+
+        (Type::FunctionLiteral(left_function), Type::FunctionLiteral(right_function)) => {
+            ComparisonResult::from_bool(left_function == right_function)
+        }
+        (Type::ModuleLiteral(left_module), Type::ModuleLiteral(right_module)) => {
+            ComparisonResult::from_bool(left_module.module(db) == right_module.module(db))
+        }
+        (Type::SpecialForm(left_form), Type::SpecialForm(right_form)) => {
+            ComparisonResult::from_bool(left_form == right_form)
+        }
+
+        (Type::NominalInstance(left_instance), Type::NominalInstance(right_instance)) => {
+            compare_nominal_instances(
+                db,
+                left_instance,
+                right_instance,
+                ComparisonOperator::Equality,
+            )
+        }
+
+        _ => call_comparison_dunder(db, left, right, "__eq__"),
+    }
+}
+
+/// Return a constraint that does not depend on the target's currently inferred literal union.
+///
+/// Narrowing constraints participate in cyclic inference. Filtering `"B" | "C"` to `"B"` for the
+/// false branch of `x == "C"` can freeze a loop before later iterations widen `x`. Constraining the
+/// target with `~Literal["C"]` instead describes the predicate itself and remains valid as the cycle
+/// reaches its fixed point.
+fn primitive_literal_constraint<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    condition_expects_equality: bool,
+) -> Option<Type<'db>> {
+    let is_builtin_primitive = |ty: Type<'db>| match ty.resolve_type_alias(db) {
+        Type::LiteralValue(literal) => matches!(
+            literal.kind(),
+            LiteralValueTypeKind::Int(_)
+                | LiteralValueTypeKind::Bool(_)
+                | LiteralValueTypeKind::String(_)
+                | LiteralValueTypeKind::Bytes(_)
+        ),
+        Type::NominalInstance(instance) => instance.has_known_class(db, KnownClass::Bool),
+        _ => false,
+    };
+    let left_is_builtin_primitive = match left.resolve_type_alias(db) {
+        Type::Union(union) => union.elements(db).iter().copied().all(is_builtin_primitive),
+        left => is_builtin_primitive(left),
+    };
+    if !left_is_builtin_primitive {
+        return None;
+    }
+
+    let Type::LiteralValue(right) = right.resolve_type_alias(db) else {
+        return None;
+    };
+
+    let equal_to_right = match right.kind() {
+        LiteralValueTypeKind::Int(value) => {
+            let mut builder = UnionBuilder::new(db).add(Type::LiteralValue(right));
+            if matches!(value.as_i64(), 0 | 1) {
+                builder = builder.add(Type::bool_literal(value.as_i64() == 1));
+            }
+            builder.build()
+        }
+        LiteralValueTypeKind::Bool(value) => UnionBuilder::new(db)
+            .add(Type::LiteralValue(right))
+            .add(Type::int_literal(i64::from(value)))
+            .build(),
+        LiteralValueTypeKind::String(_) | LiteralValueTypeKind::Bytes(_) => {
+            Type::LiteralValue(right)
+        }
+        LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_) => return None,
+    };
+
+    Some(equal_to_right.negate_if(db, !condition_expects_equality))
+}
+
+fn inequality_result<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    is_positive: bool,
+) -> ComparisonResult<'db> {
+    let left = left.resolve_type_alias(db);
+    let right = right.resolve_type_alias(db);
+
+    if let Some(alternatives) = inequality_alternatives(db, left) {
+        return evaluate_union_left(db, &alternatives, right, is_positive, inequality_result);
+    }
+    if let Some(alternatives) = inequality_alternatives(db, right) {
+        return evaluate_union_right(db, left, &alternatives, is_positive, inequality_result);
+    }
+
+    match (left, right) {
+        (
+            Type::Never
+            | Type::Divergent(_)
+            | Type::AlwaysFalsy
+            | Type::AlwaysTruthy
+            | Type::ProtocolInstance(_)
+            | Type::DataclassTransformer(_)
+            | Type::TypeGuard(_)
+            | Type::TypeIs(_),
+            _,
+        )
+        | (
+            _,
+            Type::Never
+            | Type::Divergent(_)
+            | Type::AlwaysFalsy
+            | Type::AlwaysTruthy
+            | Type::ProtocolInstance(_)
+            | Type::DataclassTransformer(_)
+            | Type::TypeGuard(_)
+            | Type::TypeIs(_),
+        ) => ComparisonResult::Ambiguous,
+
+        (Type::Dynamic(_), other) => {
+            if is_positive && other.is_single_valued(db) {
+                ComparisonResult::CanNarrow(
+                    IntersectionBuilder::new(db)
+                        .add_positive(left)
+                        .add_negative(other)
+                        .build(),
+                )
+            } else {
+                ComparisonResult::Ambiguous
+            }
+        }
+        (_, Type::Dynamic(_)) => ComparisonResult::Ambiguous,
+
+        (Type::TypeVar(var), other) => match var.typevar(db).bound_or_constraints(db) {
+            None => ComparisonResult::Ambiguous,
+            Some(TypeVarBoundOrConstraints::UpperBound(_)) => {
+                if is_positive && other.is_single_valued(db) {
+                    ComparisonResult::CanNarrow(other.negate(db))
+                } else {
+                    ComparisonResult::Ambiguous
+                }
+            }
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                inequality_result(db, constraints.as_type(db), other, is_positive)
+            }
+        },
+        (other, Type::TypeVar(var)) => match var.typevar(db).bound_or_constraints(db) {
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                inequality_result(db, other, constraints.as_type(db), is_positive)
+            }
+            None | Some(TypeVarBoundOrConstraints::UpperBound(_)) => ComparisonResult::Ambiguous,
+        },
+
+        (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
+            match inequality_result(db, newtype.concrete_base_type(db), other, is_positive) {
+                ComparisonResult::AlwaysTrue => ComparisonResult::AlwaysTrue,
+                ComparisonResult::AlwaysFalse => ComparisonResult::AlwaysFalse,
+                ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
+                    ComparisonResult::Ambiguous
+                }
+            }
+        }
+
+        (Type::Union(union), other) => evaluate_union_left(
+            db,
+            union.elements(db),
+            other,
+            is_positive,
+            inequality_result,
+        ),
+        (other, Type::Union(union)) => evaluate_union_right(
+            db,
+            other,
+            union.elements(db),
+            is_positive,
+            inequality_result,
+        ),
+        (Type::Intersection(intersection), other) => evaluate_intersection_left(
+            db,
+            Type::Intersection(intersection),
+            intersection.positive(db),
+            other,
+            is_positive,
+            inequality_result,
+        ),
+
+        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
+            match known_literal_equality(
+                db,
+                left_literal.kind(),
+                right_literal.kind(),
+                ComparisonOperator::Inequality,
+            ) {
+                Some(true) => ComparisonResult::AlwaysFalse,
+                Some(false) => ComparisonResult::AlwaysTrue,
+                None => narrow_literal_comparison(
+                    db,
+                    left,
+                    right,
+                    left_literal.kind(),
+                    right_literal.kind(),
+                    !is_positive,
+                )
+                .negate(),
+            }
+        }
+
+        (Type::LiteralValue(literal), other) => compare_literal_to_other(
+            db,
+            Type::LiteralValue(literal),
+            literal.kind(),
+            other,
+            is_positive,
+            ComparisonOperator::Inequality,
+            true,
+        ),
+        (other, Type::LiteralValue(literal)) => compare_literal_to_other(
+            db,
+            Type::LiteralValue(literal),
+            literal.kind(),
+            other,
+            is_positive,
+            ComparisonOperator::Inequality,
+            false,
+        ),
+
+        (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::Ambiguous,
+        (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
+            match known_inequality_semantics(db, other) {
+                Some(KnownComparisonSemantics::Dict) | None => ComparisonResult::Ambiguous,
+                Some(_) => ComparisonResult::AlwaysTrue,
+            }
+        }
+
+        (Type::ClassLiteral(left_class), Type::ClassLiteral(right_class)) => {
+            if known_instance_semantics(
+                db,
+                left_class.metaclass_instance_type(db),
+                ComparisonOperator::Inequality,
+            ) == Some(KnownComparisonSemantics::Object)
+                && known_instance_semantics(
+                    db,
+                    right_class.metaclass_instance_type(db),
+                    ComparisonOperator::Inequality,
+                ) == Some(KnownComparisonSemantics::Object)
+            {
+                ComparisonResult::from_bool(left_class != right_class)
+            } else {
+                call_comparison_dunder(db, left, right, "__ne__")
+            }
+        }
+
+        (Type::ClassLiteral(class), other) | (other, Type::ClassLiteral(class)) => {
+            if known_instance_semantics(
+                db,
+                class.metaclass_instance_type(db),
+                ComparisonOperator::Inequality,
+            ) == Some(KnownComparisonSemantics::Object)
+                && !matches!(other, Type::ClassLiteral(_))
+            {
+                ComparisonResult::AlwaysTrue
+            } else {
+                call_comparison_dunder(db, left, right, "__ne__")
+            }
+        }
+
+        (Type::FunctionLiteral(left_function), Type::FunctionLiteral(right_function)) => {
+            ComparisonResult::from_bool(left_function != right_function)
+        }
+        (Type::ModuleLiteral(left_module), Type::ModuleLiteral(right_module)) => {
+            ComparisonResult::from_bool(left_module.module(db) != right_module.module(db))
+        }
+        (Type::SpecialForm(left_form), Type::SpecialForm(right_form)) => {
+            ComparisonResult::from_bool(left_form != right_form)
+        }
+
+        (Type::NominalInstance(left_instance), Type::NominalInstance(right_instance)) => {
+            compare_nominal_instances(
+                db,
+                left_instance,
+                right_instance,
+                ComparisonOperator::Inequality,
+            )
+        }
+
+        _ => call_comparison_dunder(db, left, right, "__ne__"),
+    }
+}
+
+impl ComparisonResult<'_> {
+    fn from_bool(value: bool) -> Self {
+        if value {
+            ComparisonResult::AlwaysTrue
+        } else {
+            ComparisonResult::AlwaysFalse
+        }
+    }
+
+    fn negate(self) -> Self {
+        match self {
+            ComparisonResult::AlwaysTrue => ComparisonResult::AlwaysFalse,
+            ComparisonResult::AlwaysFalse => ComparisonResult::AlwaysTrue,
+            ComparisonResult::CanNarrow(narrowed) => ComparisonResult::CanNarrow(narrowed),
+            ComparisonResult::Ambiguous => ComparisonResult::Ambiguous,
+        }
+    }
+}
+
+fn evaluate_union_left<'db>(
+    db: &'db dyn Db,
+    elements: &[Type<'db>],
+    other: Type<'db>,
+    is_positive: bool,
+    evaluate: fn(&'db dyn Db, Type<'db>, Type<'db>, bool) -> ComparisonResult<'db>,
+) -> ComparisonResult<'db> {
+    let mut all_true = true;
+    let mut all_false = true;
+    let mut narrowed = Vec::with_capacity(elements.len());
+    let mut removed = UnionBuilder::new(db);
+    let mut removed_any = false;
+
+    for element in elements {
+        let result = evaluate(db, *element, other, is_positive);
+        match result {
+            ComparisonResult::AlwaysTrue => {
+                all_false = false;
+                if is_positive {
+                    narrowed.push(Some(*element));
+                } else {
+                    narrowed.push(None);
+                    removed = removed.add(*element);
+                    removed_any = true;
+                }
+            }
+            ComparisonResult::AlwaysFalse => {
+                all_true = false;
+                if is_positive {
+                    narrowed.push(None);
+                    removed = removed.add(*element);
+                    removed_any = true;
+                } else {
+                    narrowed.push(Some(*element));
+                }
+            }
+            ComparisonResult::CanNarrow(narrowed_element) => {
+                all_true = false;
+                all_false = false;
+                narrowed.push(Some(narrowed_element));
+            }
+            ComparisonResult::Ambiguous => {
+                all_true = false;
+                all_false = false;
+                narrowed.push(Some(*element));
+            }
+        }
+    }
+
+    if all_true {
+        return ComparisonResult::AlwaysTrue;
+    }
+    if all_false {
+        return ComparisonResult::AlwaysFalse;
+    }
+
+    let removed = removed_any.then(|| removed.build());
+    let mut builder = UnionBuilder::new(db);
+    for (original, narrowed) in elements.iter().zip(narrowed) {
+        let Some(mut narrowed) = narrowed else {
+            continue;
+        };
+        if original.is_dynamic()
+            && let Some(removed) = removed
+        {
+            narrowed = IntersectionBuilder::new(db)
+                .add_positive(narrowed)
+                .add_negative(removed)
+                .build();
+        }
+        builder = builder.add(narrowed);
+    }
+    ComparisonResult::CanNarrow(builder.build())
+}
+
+fn evaluate_union_right<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    elements: &[Type<'db>],
+    is_positive: bool,
+    evaluate: fn(&'db dyn Db, Type<'db>, Type<'db>, bool) -> ComparisonResult<'db>,
+) -> ComparisonResult<'db> {
+    let mut all_true = true;
+    let mut all_false = true;
+    let mut builder = UnionBuilder::new(db);
+
+    for element in elements {
+        match evaluate(db, left, *element, is_positive) {
+            ComparisonResult::AlwaysTrue => {
+                all_false = false;
+                if is_positive {
+                    builder = builder.add(left);
+                }
+            }
+            ComparisonResult::AlwaysFalse => {
+                all_true = false;
+                if !is_positive {
+                    builder = builder.add(left);
+                }
+            }
+            ComparisonResult::CanNarrow(narrowed) => {
+                all_true = false;
+                all_false = false;
+                builder = builder.add(narrowed);
+            }
+            ComparisonResult::Ambiguous => {
+                all_true = false;
+                all_false = false;
+                builder = builder.add(left);
+            }
+        }
+    }
+
+    if all_true {
+        ComparisonResult::AlwaysTrue
+    } else if all_false {
+        ComparisonResult::AlwaysFalse
+    } else {
+        ComparisonResult::CanNarrow(builder.build())
+    }
+}
+
+fn evaluate_intersection_left<'db>(
+    db: &'db dyn Db,
+    original: Type<'db>,
+    positive: &crate::FxOrderSet<Type<'db>>,
+    other: Type<'db>,
+    is_positive: bool,
+    evaluate: fn(&'db dyn Db, Type<'db>, Type<'db>, bool) -> ComparisonResult<'db>,
+) -> ComparisonResult<'db> {
+    let mut any_true = false;
+    let mut any_false = false;
+    let mut builder = IntersectionBuilder::new(db).add_positive(original);
+
+    for element in positive {
+        match evaluate(db, *element, other, is_positive) {
+            ComparisonResult::AlwaysTrue => any_true = true,
+            ComparisonResult::AlwaysFalse => any_false = true,
+            ComparisonResult::CanNarrow(narrowed) => {
+                builder = builder.add_positive(narrowed);
+            }
+            ComparisonResult::Ambiguous => {}
+        }
+    }
+
+    match (any_true, any_false) {
+        (true, false) => ComparisonResult::AlwaysTrue,
+        (false, true) => ComparisonResult::AlwaysFalse,
+        (true, true) => ComparisonResult::Ambiguous,
+        (false, false) => ComparisonResult::CanNarrow(builder.build()),
+    }
+}
+
+fn equality_alternatives<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
+    finite_alternatives(db, ty, ComparisonOperator::Equality)
+}
+
+fn inequality_alternatives<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
+    finite_alternatives(db, ty, ComparisonOperator::Inequality)
+}
+
+fn finite_alternatives<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    operator: ComparisonOperator,
+) -> Option<Vec<Type<'db>>> {
+    match ty {
+        Type::EnumComplement(complement) => comparison_semantics(db, ty, operator)
+            .is_some()
+            .then(|| complement.remaining_literal_types(db)),
+        Type::Intersection(intersection) => {
+            let complement = intersection.enum_complement(db)?;
+            comparison_semantics(db, ty, operator)
+                .is_some()
+                .then(|| complement.remaining_literal_types(db))
+        }
+        Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Bool) => {
+            Some(vec![Type::bool_literal(true), Type::bool_literal(false)])
+        }
+        Type::NominalInstance(instance)
+            if enum_metadata(db, instance.class_literal(db)).is_some()
+                && comparison_semantics(db, ty, operator).is_some() =>
+        {
+            Some(
+                enum_member_literals(db, instance.class_literal(db), None)
+                    .expect("enum metadata is available")
+                    .collect(),
+            )
+        }
+        _ => None,
+    }
+}
+
+fn narrow_literal_comparison<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    left_literal: LiteralValueTypeKind<'db>,
+    right_literal: LiteralValueTypeKind<'db>,
+    equality_is_positive: bool,
+) -> ComparisonResult<'db> {
+    match (left_literal, right_literal) {
+        (LiteralValueTypeKind::LiteralString, LiteralValueTypeKind::String(_)) => {
+            ComparisonResult::CanNarrow(right.negate_if(db, !equality_is_positive))
+        }
+        (LiteralValueTypeKind::String(_), LiteralValueTypeKind::LiteralString) => {
+            ComparisonResult::CanNarrow(left.negate_if(db, !equality_is_positive))
+        }
+        (LiteralValueTypeKind::LiteralString, LiteralValueTypeKind::Enum(enum_literal)) => {
+            narrow_literal_string_against_enum(db, enum_literal, equality_is_positive)
+        }
+        (LiteralValueTypeKind::Enum(enum_literal), LiteralValueTypeKind::LiteralString) => {
+            narrow_literal_string_against_enum(db, enum_literal, equality_is_positive)
+        }
+        _ => ComparisonResult::Ambiguous,
+    }
+}
+
+fn narrow_literal_string_against_enum<'db>(
+    db: &'db dyn Db,
+    enum_literal: EnumLiteralType<'db>,
+    equality_is_positive: bool,
+) -> ComparisonResult<'db> {
+    if comparison_semantics(
+        db,
+        Type::enum_literal(enum_literal),
+        ComparisonOperator::Equality,
+    ) != Some(KnownComparisonSemantics::Str)
+    {
+        return ComparisonResult::Ambiguous;
+    }
+    let Some(value @ Type::LiteralValue(_)) = enum_literal_value(db, enum_literal) else {
+        return ComparisonResult::Ambiguous;
+    };
+    let Some(LiteralValueTypeKind::String(_)) = value.as_literal_value_kind() else {
+        return ComparisonResult::Ambiguous;
+    };
+    let narrowed = UnionBuilder::new(db)
+        .add(value)
+        .add(Type::enum_literal(enum_literal))
+        .build()
+        .negate_if(db, !equality_is_positive);
+    ComparisonResult::CanNarrow(narrowed)
+}
+
+fn compare_literal_to_other<'db>(
+    db: &'db dyn Db,
+    literal_type: Type<'db>,
+    literal: LiteralValueTypeKind<'db>,
+    other: Type<'db>,
+    is_positive: bool,
+    operator: ComparisonOperator,
+    literal_is_target: bool,
+) -> ComparisonResult<'db> {
+    if matches!(literal, LiteralValueTypeKind::LiteralString) {
+        return match comparison_semantics(db, other, operator) {
+            Some(KnownComparisonSemantics::Str) => ComparisonResult::Ambiguous,
+            Some(_) => ComparisonResult::from_bool(operator == ComparisonOperator::Inequality),
+            None => call_comparison_dunder(db, literal_type, other, operator.dunder()),
+        };
+    }
+
+    let Some(literal_semantics) = literal_semantics(db, literal, operator) else {
+        return call_comparison_dunder(db, literal_type, other, operator.dunder());
+    };
+    match comparison_semantics(db, other, operator) {
+        Some(other_semantics) if literal_semantics != other_semantics => {
+            ComparisonResult::from_bool(operator == ComparisonOperator::Inequality)
+        }
+        Some(_) => ComparisonResult::Ambiguous,
+        None => {
+            let comparison_proves_target_is_not_literal = matches!(
+                (operator, is_positive),
+                (ComparisonOperator::Equality, false) | (ComparisonOperator::Inequality, true)
+            );
+            if !literal_is_target
+                && comparison_proves_target_is_not_literal
+                && literal_type.is_single_valued(db)
+            {
+                ComparisonResult::CanNarrow(literal_type.negate(db))
+            } else {
+                call_comparison_dunder(db, literal_type, other, operator.dunder())
+            }
+        }
+    }
+}
+
+fn compare_nominal_instances<'db>(
+    db: &'db dyn Db,
+    left_instance: super::NominalInstanceType<'db>,
+    right_instance: super::NominalInstanceType<'db>,
+    operator: ComparisonOperator,
+) -> ComparisonResult<'db> {
+    let left = Type::NominalInstance(left_instance);
+    let right = Type::NominalInstance(right_instance);
+    let Some(left_semantics) = comparison_semantics(db, left, operator) else {
+        return call_comparison_dunder(db, left, right, operator.dunder());
+    };
+    let Some(right_semantics) = comparison_semantics(db, right, operator) else {
+        return call_comparison_dunder(db, left, right, operator.dunder());
+    };
+
+    let classes_differ = left_instance.class_literal(db) != right_instance.class_literal(db);
+
+    if left_semantics != right_semantics
+        || (left_semantics == KnownComparisonSemantics::Object && classes_differ)
+    {
+        return ComparisonResult::from_bool(operator == ComparisonOperator::Inequality);
+    }
+
+    if left == right && left.is_singleton(db) {
+        ComparisonResult::from_bool(operator == ComparisonOperator::Equality)
+    } else {
+        ComparisonResult::Ambiguous
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ComparisonOperator {
+    Equality,
+    Inequality,
+}
+
+impl ComparisonOperator {
+    const fn dunder(self) -> &'static str {
+        match self {
+            ComparisonOperator::Equality => "__eq__",
+            ComparisonOperator::Inequality => "__ne__",
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum KnownComparisonSemantics {
+    Object,
+    Int,
+    Str,
+    Bytes,
+    Tuple,
+    Dict,
+}
+
+fn comparison_semantics<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    operator: ComparisonOperator,
+) -> Option<KnownComparisonSemantics> {
+    match operator {
+        ComparisonOperator::Equality => known_equality_semantics(db, ty),
+        ComparisonOperator::Inequality => known_inequality_semantics(db, ty),
+    }
+}
+
+fn known_equality_semantics<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<KnownComparisonSemantics> {
+    known_semantics(db, ty, ComparisonOperator::Equality)
+}
+
+fn known_inequality_semantics<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<KnownComparisonSemantics> {
+    known_semantics(db, ty, ComparisonOperator::Inequality)
+}
+
+fn known_semantics<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    operator: ComparisonOperator,
+) -> Option<KnownComparisonSemantics> {
+    match ty {
+        Type::LiteralValue(literal) => literal_semantics(db, literal.kind(), operator),
+        Type::TypedDict(_) => Some(KnownComparisonSemantics::Dict),
+        Type::EnumComplement(complement) => known_instance_semantics(
+            db,
+            complement.enum_class(db).to_non_generic_instance(db),
+            operator,
+        ),
+        Type::Intersection(intersection) => {
+            let complement = intersection.enum_complement(db)?;
+            known_instance_semantics(
+                db,
+                complement.enum_class(db).to_non_generic_instance(db),
+                operator,
+            )
+        }
+        Type::NominalInstance(instance)
+            if instance.class(db).is_final(db)
+                || instance.tuple_spec(db).is_some()
+                || enum_metadata(db, instance.class_literal(db)).is_some() =>
+        {
+            known_instance_semantics(db, ty, operator)
+        }
+        _ => None,
+    }
+}
+
+fn literal_semantics<'db>(
+    db: &'db dyn Db,
+    literal: LiteralValueTypeKind<'db>,
+    operator: ComparisonOperator,
+) -> Option<KnownComparisonSemantics> {
+    match literal {
+        LiteralValueTypeKind::Int(_) | LiteralValueTypeKind::Bool(_) => {
+            Some(KnownComparisonSemantics::Int)
+        }
+        LiteralValueTypeKind::String(_) | LiteralValueTypeKind::LiteralString => {
+            Some(KnownComparisonSemantics::Str)
+        }
+        LiteralValueTypeKind::Bytes(_) => Some(KnownComparisonSemantics::Bytes),
+        LiteralValueTypeKind::Enum(enum_literal) => {
+            known_instance_semantics(db, enum_literal.enum_class_instance(db), operator)
+        }
+    }
+}
+
+fn known_instance_semantics<'db>(
+    db: &'db dyn Db,
+    instance: Type<'db>,
+    operator: ComparisonOperator,
+) -> Option<KnownComparisonSemantics> {
+    if let Some(nominal) = instance.as_nominal_instance()
+        && enum_metadata(db, nominal.class_literal(db)).is_some()
+    {
+        return known_enum_semantics(db, instance, operator);
+    }
+
+    let class = instance.to_meta_type(db);
+    let dunder = lookup_dunder(db, class, operator.dunder());
+
+    if dunder.place.is_undefined() {
+        if operator == ComparisonOperator::Inequality
+            && !lookup_dunder(db, class, "__eq__").place.is_undefined()
+        {
+            return None;
+        }
+        return Some(KnownComparisonSemantics::Object);
+    }
+
+    for (known_class, semantics) in [
+        (KnownClass::Int, KnownComparisonSemantics::Int),
+        (KnownClass::Str, KnownComparisonSemantics::Str),
+        (KnownClass::Bytes, KnownComparisonSemantics::Bytes),
+        (KnownClass::Tuple, KnownComparisonSemantics::Tuple),
+        (KnownClass::Dict, KnownComparisonSemantics::Dict),
+    ] {
+        if dunder == lookup_dunder(db, known_class.to_class_literal(db), operator.dunder()) {
+            return Some(semantics);
+        }
+    }
+    None
+}
+
+fn known_enum_semantics<'db>(
+    db: &'db dyn Db,
+    instance: Type<'db>,
+    operator: ComparisonOperator,
+) -> Option<KnownComparisonSemantics> {
+    let base_semantics = if instance.is_subtype_of(db, KnownClass::Str.to_instance(db)) {
+        KnownComparisonSemantics::Str
+    } else if instance.is_subtype_of(db, KnownClass::Int.to_instance(db)) {
+        KnownComparisonSemantics::Int
+    } else if instance.is_subtype_of(db, KnownClass::Bytes.to_instance(db)) {
+        KnownComparisonSemantics::Bytes
+    } else {
+        KnownComparisonSemantics::Object
+    };
+
+    let has_custom_dunder = |name| {
+        let class = instance.to_meta_type(db);
+        let dunder = class.member_lookup_with_policy(
+            db,
+            Name::new_static(name),
+            MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
+                | MemberLookupPolicy::MRO_NO_INT_OR_STR_LOOKUP,
+        );
+        if dunder.place.is_undefined() {
+            return false;
+        }
+        if base_semantics == KnownComparisonSemantics::Bytes
+            && dunder == lookup_dunder(db, KnownClass::Bytes.to_class_literal(db), name)
+        {
+            return false;
+        }
+        true
+    };
+
+    match operator {
+        ComparisonOperator::Equality => (!has_custom_dunder("__eq__")).then_some(base_semantics),
+        ComparisonOperator::Inequality => {
+            if has_custom_dunder("__ne__")
+                || (base_semantics == KnownComparisonSemantics::Object
+                    && has_custom_dunder("__eq__"))
+            {
+                None
+            } else {
+                Some(base_semantics)
+            }
+        }
+    }
+}
+
+fn lookup_dunder<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    name: &'static str,
+) -> PlaceAndQualifiers<'db> {
+    ty.member_lookup_with_policy(
+        db,
+        Name::new_static(name),
+        MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+    )
+}
+
+fn known_literal_equality<'db>(
+    db: &'db dyn Db,
+    left: LiteralValueTypeKind<'db>,
+    right: LiteralValueTypeKind<'db>,
+    operator: ComparisonOperator,
+) -> Option<bool> {
+    match (left, right) {
+        (LiteralValueTypeKind::Int(left), LiteralValueTypeKind::Int(right)) => {
+            Some(left.as_i64() == right.as_i64())
+        }
+        (LiteralValueTypeKind::Bool(left), LiteralValueTypeKind::Bool(right)) => {
+            Some(left == right)
+        }
+        (LiteralValueTypeKind::Int(left), LiteralValueTypeKind::Bool(right))
+        | (LiteralValueTypeKind::Bool(right), LiteralValueTypeKind::Int(left)) => {
+            Some(left.as_i64() == i64::from(right))
+        }
+        (LiteralValueTypeKind::String(left), LiteralValueTypeKind::String(right)) => {
+            Some(left.value(db) == right.value(db))
+        }
+        (LiteralValueTypeKind::Bytes(left), LiteralValueTypeKind::Bytes(right)) => {
+            Some(left.value(db) == right.value(db))
+        }
+        (LiteralValueTypeKind::Enum(left), LiteralValueTypeKind::Enum(right)) => {
+            let left_semantics =
+                known_instance_semantics(db, left.enum_class_instance(db), operator)?;
+            let right_semantics =
+                known_instance_semantics(db, right.enum_class_instance(db), operator)?;
+            if left_semantics != right_semantics {
+                return Some(false);
+            }
+            if left_semantics == KnownComparisonSemantics::Object {
+                return Some(same_enum_member(db, left, right));
+            }
+            known_type_value_equality(
+                db,
+                enum_literal_value(db, left)?,
+                enum_literal_value(db, right)?,
+            )
+        }
+        (LiteralValueTypeKind::Enum(enum_literal), other)
+        | (other, LiteralValueTypeKind::Enum(enum_literal)) => {
+            let enum_semantics =
+                known_instance_semantics(db, enum_literal.enum_class_instance(db), operator)?;
+            if enum_semantics != literal_semantics(db, other, operator)? {
+                return Some(false);
+            }
+            known_literal_equality(
+                db,
+                enum_literal_value(db, enum_literal)?.as_literal_value_kind()?,
+                other,
+                ComparisonOperator::Equality,
+            )
+        }
+        (
+            LiteralValueTypeKind::LiteralString,
+            LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::String(_),
+        )
+        | (LiteralValueTypeKind::String(_), LiteralValueTypeKind::LiteralString) => None,
+        (left, right) => {
+            let left_semantics = literal_semantics(db, left, operator)?;
+            let right_semantics = literal_semantics(db, right, operator)?;
+            (left_semantics != right_semantics).then_some(false)
+        }
+    }
+}
+
+fn known_type_value_equality<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+) -> Option<bool> {
+    known_literal_equality(
+        db,
+        left.as_literal_value_kind()?,
+        right.as_literal_value_kind()?,
+        ComparisonOperator::Equality,
+    )
+}
+
+fn enum_literal_value<'db>(db: &'db dyn Db, literal: EnumLiteralType<'db>) -> Option<Type<'db>> {
+    let metadata = enum_metadata(db, literal.enum_class(db))?;
+    let name = metadata.resolve_member(literal.name(db))?;
+    if metadata.init_function.is_some()
+        || metadata.new_function.is_some()
+        || metadata.custom_enum_metaclass_new
+    {
+        return None;
+    }
+    if metadata.auto_members.contains(name) {
+        metadata.value_type(db, name)
+    } else {
+        metadata.members.get(name).copied()
+    }
+}
+
+fn same_enum_member<'db>(
+    db: &'db dyn Db,
+    left: EnumLiteralType<'db>,
+    right: EnumLiteralType<'db>,
+) -> bool {
+    if left.enum_class(db) != right.enum_class(db) {
+        return false;
+    }
+    let Some(metadata) = enum_metadata(db, left.enum_class(db)) else {
+        return left == right;
+    };
+    metadata.resolve_member(left.name(db)) == metadata.resolve_member(right.name(db))
+}
+
+fn call_comparison_dunder<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    dunder: &'static str,
+) -> ComparisonResult<'db> {
+    let Ok(bindings) = left.try_call_dunder(
+        db,
+        dunder,
+        CallArguments::positional([right]),
+        TypeContext::default(),
+    ) else {
+        return ComparisonResult::Ambiguous;
+    };
+    match bindings.return_type(db).bool(db) {
+        Truthiness::AlwaysTrue => ComparisonResult::AlwaysTrue,
+        Truthiness::AlwaysFalse => ComparisonResult::AlwaysFalse,
+        Truthiness::Ambiguous => ComparisonResult::Ambiguous,
+    }
+}

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -257,7 +257,9 @@ fn comparison_result<'db>(
         ) => ComparisonResult::Ambiguous,
 
         (Type::Dynamic(_), other) => {
-            if !operator.condition_expects_equality(branch) && other.is_single_valued(db) {
+            if !operator.condition_expects_equality(branch)
+                && all_values_compare_equal(db, other, operator)
+            {
                 ComparisonResult::CanNarrow(
                     IntersectionBuilder::new(db)
                         .add_positive(left)
@@ -273,7 +275,9 @@ fn comparison_result<'db>(
         (Type::TypeVar(var), other) => match var.typevar(db).bound_or_constraints(db) {
             None => ComparisonResult::Ambiguous,
             Some(TypeVarBoundOrConstraints::UpperBound(_)) => {
-                if !operator.condition_expects_equality(branch) && other.is_single_valued(db) {
+                if !operator.condition_expects_equality(branch)
+                    && all_values_compare_equal(db, other, operator)
+                {
                     ComparisonResult::CanNarrow(other.negate(db))
                 } else {
                     ComparisonResult::Ambiguous
@@ -396,6 +400,23 @@ fn comparison_result<'db>(
 
         _ => ComparisonResult::Ambiguous,
     }
+}
+
+/// Return whether every value represented by `ty` compares equal to every other represented value.
+///
+/// Dynamic and type-variable types are excluded to avoid recursive comparison through the special
+/// cases that call this helper.
+fn all_values_compare_equal<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    operator: ComparisonOperator,
+) -> bool {
+    let ty = ty.resolve_type_alias(db);
+    if matches!(ty, Type::Dynamic(_) | Type::TypeVar(_)) {
+        return false;
+    }
+    comparison_result(db, ty, ty, ComparisonBranch::Positive, operator)
+        == operator.result_from_equality(true)
 }
 
 /// Return whether `ty` is handled by [`builtin_literal_constraint`].

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -723,14 +723,9 @@ fn finite_alternatives<'db>(
             Some(vec![Type::bool_literal(true), Type::bool_literal(false)])
         }
         Type::NominalInstance(instance)
-            if enum_metadata(db, instance.class_literal(db)).is_some()
-                && KnownComparisonSemantics::of_type(db, ty, operator).is_some() =>
+            if KnownComparisonSemantics::of_type(db, ty, operator).is_some() =>
         {
-            Some(
-                enum_member_literals(db, instance.class_literal(db), None)
-                    .expect("enum metadata is available")
-                    .collect(),
-            )
+            enum_member_literals(db, instance.class_literal(db), None).map(Iterator::collect)
         }
         _ => None,
     }

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -613,13 +613,11 @@ fn evaluate_target_union<'db>(
 
     let removed = removed_any.then(|| removed.build());
     let mut builder = UnionBuilder::new(db);
-    for (original, narrowed) in elements.iter().zip(narrowed) {
+    for narrowed in narrowed {
         let Some(mut narrowed) = narrowed else {
             continue;
         };
-        if original.is_dynamic()
-            && let Some(removed) = removed
-        {
+        if let Some(removed) = removed {
             narrowed = IntersectionBuilder::new(db)
                 .add_positive(narrowed)
                 .add_negative(removed)

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -459,44 +459,6 @@ fn builtin_literal_constraint<'db>(
         return Some(equal_to_right.negate(db));
     }
 
-    if matches!(
-        right.kind(),
-        LiteralValueTypeKind::String(_) | LiteralValueTypeKind::Bytes(_)
-    ) && let Type::Union(union) = left.resolve_type_alias(db)
-    {
-        let mut excluded = UnionBuilder::new(db);
-        let mut has_dynamic = false;
-
-        for element in union.elements(db) {
-            match element.resolve_type_alias(db) {
-                Type::LiteralValue(left) => {
-                    match known_literal_equality(
-                        db,
-                        left.kind(),
-                        right.kind(),
-                        ComparisonOperator::Equality,
-                    ) {
-                        Some(true) => {}
-                        Some(false) => excluded = excluded.add(*element),
-                        None => return None,
-                    }
-                }
-                Type::Dynamic(_) => has_dynamic = true,
-                Type::Intersection(intersection)
-                    if !intersection.positive(db).is_empty()
-                        && intersection.positive(db).iter().all(Type::is_dynamic) =>
-                {
-                    has_dynamic = true;
-                }
-                _ => return None,
-            }
-        }
-
-        if has_dynamic {
-            return excluded.try_build().map(|excluded| excluded.negate(db));
-        }
-    }
-
     match left.resolve_type_alias(db) {
         Type::Union(union) => union
             .elements(db)

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -276,7 +276,7 @@ fn comparison_result<'db>(
 
         (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::Ambiguous,
         (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
-            match comparison_semantics(db, other, operator) {
+            match KnownComparisonSemantics::of_type(db, other, operator) {
                 Some(KnownComparisonSemantics::Dict) | None => ComparisonResult::Ambiguous,
                 Some(_) => operator.result_from_equality(false),
             }
@@ -421,7 +421,8 @@ fn enum_literal_constraint<'db>(
     let enum_class = right.enum_class(db);
 
     if !is_same_enum_domain(db, left, right)
-        || known_instance_semantics(db, right.enum_class_instance(db), operator).is_none()
+        || KnownComparisonSemantics::of_instance(db, right.enum_class_instance(db), operator)
+            .is_none()
     {
         return None;
     }
@@ -674,12 +675,12 @@ fn finite_alternatives<'db>(
     operator: ComparisonOperator,
 ) -> Option<Vec<Type<'db>>> {
     match ty {
-        Type::EnumComplement(complement) => comparison_semantics(db, ty, operator)
+        Type::EnumComplement(complement) => KnownComparisonSemantics::of_type(db, ty, operator)
             .is_some()
             .then(|| complement.remaining_literal_types(db)),
         Type::Intersection(intersection) => {
             let complement = intersection.enum_complement(db)?;
-            comparison_semantics(db, ty, operator)
+            KnownComparisonSemantics::of_type(db, ty, operator)
                 .is_some()
                 .then(|| complement.remaining_literal_types(db))
         }
@@ -688,7 +689,7 @@ fn finite_alternatives<'db>(
         }
         Type::NominalInstance(instance)
             if enum_metadata(db, instance.class_literal(db)).is_some()
-                && comparison_semantics(db, ty, operator).is_some() =>
+                && KnownComparisonSemantics::of_type(db, ty, operator).is_some() =>
         {
             Some(
                 enum_member_literals(db, instance.class_literal(db), None)
@@ -731,7 +732,7 @@ fn narrow_literal_string_against_enum<'db>(
     enum_literal: EnumLiteralType<'db>,
     equality_is_positive: bool,
 ) -> ComparisonResult<'db> {
-    if comparison_semantics(
+    if KnownComparisonSemantics::of_type(
         db,
         Type::enum_literal(enum_literal),
         ComparisonOperator::Equality,
@@ -763,18 +764,19 @@ fn compare_literal_to_other<'db>(
     literal_is_target: bool,
 ) -> ComparisonResult<'db> {
     if matches!(literal, LiteralValueTypeKind::LiteralString) {
-        return match comparison_semantics(db, other, operator) {
+        return match KnownComparisonSemantics::of_type(db, other, operator) {
             Some(KnownComparisonSemantics::Str) => ComparisonResult::Ambiguous,
             Some(_) => ComparisonResult::from_bool(operator == ComparisonOperator::Inequality),
             None => ComparisonResult::Ambiguous,
         };
     }
 
-    let Some(literal_semantics) = literal_semantics(db, literal, operator) else {
+    let Some(literal_semantics) = KnownComparisonSemantics::of_literal(db, literal, operator)
+    else {
         return ComparisonResult::Ambiguous;
     };
     let condition_expects_equality = operator.condition_expects_equality(is_positive);
-    match comparison_semantics(db, other, operator) {
+    match KnownComparisonSemantics::of_type(db, other, operator) {
         Some(other_semantics) if literal_semantics != other_semantics => {
             ComparisonResult::from_bool(operator == ComparisonOperator::Inequality)
         }
@@ -800,10 +802,10 @@ fn compare_nominal_instances<'db>(
 ) -> ComparisonResult<'db> {
     let left = Type::NominalInstance(left_instance);
     let right = Type::NominalInstance(right_instance);
-    let Some(left_semantics) = comparison_semantics(db, left, operator) else {
+    let Some(left_semantics) = KnownComparisonSemantics::of_type(db, left, operator) else {
         return ComparisonResult::Ambiguous;
     };
-    let Some(right_semantics) = comparison_semantics(db, right, operator) else {
+    let Some(right_semantics) = KnownComparisonSemantics::of_type(db, right, operator) else {
         return ComparisonResult::Ambiguous;
     };
 
@@ -865,6 +867,152 @@ enum KnownComparisonSemantics {
     Dict,
 }
 
+impl KnownComparisonSemantics {
+    /// Determine the builtin comparison implementation inherited by `ty`.
+    ///
+    /// Returns `None` when dunder lookup finds custom or conflicting comparison behavior.
+    fn of_type<'db>(db: &'db dyn Db, ty: Type<'db>, operator: ComparisonOperator) -> Option<Self> {
+        match ty {
+            Type::LiteralValue(literal) => Self::of_literal(db, literal.kind(), operator),
+            Type::TypedDict(_) => Some(Self::Dict),
+            Type::EnumComplement(complement) => Self::of_instance(
+                db,
+                complement.enum_class(db).to_non_generic_instance(db),
+                operator,
+            ),
+            Type::Intersection(intersection) => {
+                if let Some(complement) = intersection.enum_complement(db) {
+                    return Self::of_instance(
+                        db,
+                        complement.enum_class(db).to_non_generic_instance(db),
+                        operator,
+                    );
+                }
+                let mut semantics = intersection
+                    .positive(db)
+                    .iter()
+                    .filter_map(|element| Self::of_type(db, *element, operator));
+                let first = semantics.next()?;
+                semantics
+                    .all(|semantics| semantics == first)
+                    .then_some(first)
+            }
+            Type::NominalInstance(instance)
+                if instance.class(db).is_final(db)
+                    || instance.tuple_spec(db).is_some()
+                    || enum_metadata(db, instance.class_literal(db)).is_some() =>
+            {
+                Self::of_instance(db, ty, operator)
+            }
+            _ => None,
+        }
+    }
+
+    fn of_literal<'db>(
+        db: &'db dyn Db,
+        literal: LiteralValueTypeKind<'db>,
+        operator: ComparisonOperator,
+    ) -> Option<Self> {
+        match literal {
+            LiteralValueTypeKind::Int(_) | LiteralValueTypeKind::Bool(_) => Some(Self::Int),
+            LiteralValueTypeKind::String(_) | LiteralValueTypeKind::LiteralString => {
+                Some(Self::Str)
+            }
+            LiteralValueTypeKind::Bytes(_) => Some(Self::Bytes),
+            LiteralValueTypeKind::Enum(enum_literal) => {
+                Self::of_instance(db, enum_literal.enum_class_instance(db), operator)
+            }
+        }
+    }
+
+    fn of_instance<'db>(
+        db: &'db dyn Db,
+        instance: Type<'db>,
+        operator: ComparisonOperator,
+    ) -> Option<Self> {
+        if let Some(nominal) = instance.as_nominal_instance()
+            && enum_metadata(db, nominal.class_literal(db)).is_some()
+        {
+            return Self::of_enum(db, instance, operator);
+        }
+
+        let class = instance.to_meta_type(db);
+        let dunder = lookup_dunder(db, class, operator.dunder());
+
+        if dunder.place.is_undefined() {
+            if operator == ComparisonOperator::Inequality
+                && !lookup_dunder(db, class, "__eq__").place.is_undefined()
+            {
+                return None;
+            }
+            return Some(Self::Object);
+        }
+
+        for (known_class, semantics) in [
+            (KnownClass::Int, Self::Int),
+            (KnownClass::Str, Self::Str),
+            (KnownClass::Bytes, Self::Bytes),
+            (KnownClass::Tuple, Self::Tuple),
+            (KnownClass::Dict, Self::Dict),
+        ] {
+            if dunder == lookup_dunder(db, known_class.to_class_literal(db), operator.dunder()) {
+                return Some(semantics);
+            }
+        }
+        None
+    }
+
+    fn of_enum<'db>(
+        db: &'db dyn Db,
+        instance: Type<'db>,
+        operator: ComparisonOperator,
+    ) -> Option<Self> {
+        let base_semantics = if instance.is_subtype_of(db, KnownClass::Str.to_instance(db)) {
+            Self::Str
+        } else if instance.is_subtype_of(db, KnownClass::Int.to_instance(db)) {
+            Self::Int
+        } else if instance.is_subtype_of(db, KnownClass::Bytes.to_instance(db)) {
+            Self::Bytes
+        } else {
+            Self::Object
+        };
+
+        let class = instance.to_meta_type(db);
+        let has_custom_dunder = |name| {
+            let dunder = class.member_lookup_with_policy(
+                db,
+                Name::new_static(name),
+                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
+                    | MemberLookupPolicy::MRO_NO_INT_OR_STR_LOOKUP,
+            );
+            if dunder.place.is_undefined() {
+                return false;
+            }
+            if base_semantics == Self::Bytes
+                && dunder == lookup_dunder(db, KnownClass::Bytes.to_class_literal(db), name)
+            {
+                return false;
+            }
+            true
+        };
+
+        match operator {
+            ComparisonOperator::Equality => {
+                (!has_custom_dunder("__eq__")).then_some(base_semantics)
+            }
+            ComparisonOperator::Inequality => {
+                if has_custom_dunder("__ne__")
+                    || (base_semantics == Self::Object && has_custom_dunder("__eq__"))
+                {
+                    None
+                } else {
+                    Some(base_semantics)
+                }
+            }
+        }
+    }
+}
+
 /// Whether the non-target operand has a comparison domain that can safely constrain the target.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum ComparisonDomain {
@@ -909,7 +1057,8 @@ fn comparison_domain<'db>(
                     .class(db)
                     .known(db)
                     .is_some_and(|known| known == KnownClass::Bool || known.is_singleton())
-                || target.is_union() && comparison_semantics(db, ty, operator).is_some()
+                || target.is_union()
+                    && KnownComparisonSemantics::of_type(db, ty, operator).is_some()
             {
                 ComparisonDomain::Known
             } else {
@@ -918,50 +1067,6 @@ fn comparison_domain<'db>(
         }
         _ if ty.is_single_valued(db) => ComparisonDomain::Known,
         _ => ComparisonDomain::Unknown,
-    }
-}
-
-/// Determine the builtin comparison implementation inherited by `ty`.
-///
-/// Returns `None` when dunder lookup finds custom or conflicting comparison behavior.
-fn comparison_semantics<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    operator: ComparisonOperator,
-) -> Option<KnownComparisonSemantics> {
-    match ty {
-        Type::LiteralValue(literal) => literal_semantics(db, literal.kind(), operator),
-        Type::TypedDict(_) => Some(KnownComparisonSemantics::Dict),
-        Type::EnumComplement(complement) => known_instance_semantics(
-            db,
-            complement.enum_class(db).to_non_generic_instance(db),
-            operator,
-        ),
-        Type::Intersection(intersection) => {
-            if let Some(complement) = intersection.enum_complement(db) {
-                return known_instance_semantics(
-                    db,
-                    complement.enum_class(db).to_non_generic_instance(db),
-                    operator,
-                );
-            }
-            let mut semantics = intersection
-                .positive(db)
-                .iter()
-                .filter_map(|element| comparison_semantics(db, *element, operator));
-            let first = semantics.next()?;
-            semantics
-                .all(|semantics| semantics == first)
-                .then_some(first)
-        }
-        Type::NominalInstance(instance)
-            if instance.class(db).is_final(db)
-                || instance.tuple_spec(db).is_some()
-                || enum_metadata(db, instance.class_literal(db)).is_some() =>
-        {
-            known_instance_semantics(db, ty, operator)
-        }
-        _ => None,
     }
 }
 
@@ -974,117 +1079,13 @@ fn has_known_identity_comparison_semantics<'db>(
     match ty {
         Type::FunctionLiteral(_) | Type::ModuleLiteral(_) | Type::SpecialForm(_) => true,
         Type::ClassLiteral(class) => {
-            known_instance_semantics(db, class.metaclass_instance_type(db), operator)
+            KnownComparisonSemantics::of_instance(db, class.metaclass_instance_type(db), operator)
                 == Some(KnownComparisonSemantics::Object)
         }
         _ => {
             ty.is_singleton(db)
-                && comparison_semantics(db, ty, operator) == Some(KnownComparisonSemantics::Object)
-        }
-    }
-}
-
-fn literal_semantics<'db>(
-    db: &'db dyn Db,
-    literal: LiteralValueTypeKind<'db>,
-    operator: ComparisonOperator,
-) -> Option<KnownComparisonSemantics> {
-    match literal {
-        LiteralValueTypeKind::Int(_) | LiteralValueTypeKind::Bool(_) => {
-            Some(KnownComparisonSemantics::Int)
-        }
-        LiteralValueTypeKind::String(_) | LiteralValueTypeKind::LiteralString => {
-            Some(KnownComparisonSemantics::Str)
-        }
-        LiteralValueTypeKind::Bytes(_) => Some(KnownComparisonSemantics::Bytes),
-        LiteralValueTypeKind::Enum(enum_literal) => {
-            known_instance_semantics(db, enum_literal.enum_class_instance(db), operator)
-        }
-    }
-}
-
-fn known_instance_semantics<'db>(
-    db: &'db dyn Db,
-    instance: Type<'db>,
-    operator: ComparisonOperator,
-) -> Option<KnownComparisonSemantics> {
-    if let Some(nominal) = instance.as_nominal_instance()
-        && enum_metadata(db, nominal.class_literal(db)).is_some()
-    {
-        return known_enum_semantics(db, instance, operator);
-    }
-
-    let class = instance.to_meta_type(db);
-    let dunder = lookup_dunder(db, class, operator.dunder());
-
-    if dunder.place.is_undefined() {
-        if operator == ComparisonOperator::Inequality
-            && !lookup_dunder(db, class, "__eq__").place.is_undefined()
-        {
-            return None;
-        }
-        return Some(KnownComparisonSemantics::Object);
-    }
-
-    for (known_class, semantics) in [
-        (KnownClass::Int, KnownComparisonSemantics::Int),
-        (KnownClass::Str, KnownComparisonSemantics::Str),
-        (KnownClass::Bytes, KnownComparisonSemantics::Bytes),
-        (KnownClass::Tuple, KnownComparisonSemantics::Tuple),
-        (KnownClass::Dict, KnownComparisonSemantics::Dict),
-    ] {
-        if dunder == lookup_dunder(db, known_class.to_class_literal(db), operator.dunder()) {
-            return Some(semantics);
-        }
-    }
-    None
-}
-
-fn known_enum_semantics<'db>(
-    db: &'db dyn Db,
-    instance: Type<'db>,
-    operator: ComparisonOperator,
-) -> Option<KnownComparisonSemantics> {
-    let base_semantics = if instance.is_subtype_of(db, KnownClass::Str.to_instance(db)) {
-        KnownComparisonSemantics::Str
-    } else if instance.is_subtype_of(db, KnownClass::Int.to_instance(db)) {
-        KnownComparisonSemantics::Int
-    } else if instance.is_subtype_of(db, KnownClass::Bytes.to_instance(db)) {
-        KnownComparisonSemantics::Bytes
-    } else {
-        KnownComparisonSemantics::Object
-    };
-
-    let class = instance.to_meta_type(db);
-    let has_custom_dunder = |name| {
-        let dunder = class.member_lookup_with_policy(
-            db,
-            Name::new_static(name),
-            MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
-                | MemberLookupPolicy::MRO_NO_INT_OR_STR_LOOKUP,
-        );
-        if dunder.place.is_undefined() {
-            return false;
-        }
-        if base_semantics == KnownComparisonSemantics::Bytes
-            && dunder == lookup_dunder(db, KnownClass::Bytes.to_class_literal(db), name)
-        {
-            return false;
-        }
-        true
-    };
-
-    match operator {
-        ComparisonOperator::Equality => (!has_custom_dunder("__eq__")).then_some(base_semantics),
-        ComparisonOperator::Inequality => {
-            if has_custom_dunder("__ne__")
-                || (base_semantics == KnownComparisonSemantics::Object
-                    && has_custom_dunder("__eq__"))
-            {
-                None
-            } else {
-                Some(base_semantics)
-            }
+                && KnownComparisonSemantics::of_type(db, ty, operator)
+                    == Some(KnownComparisonSemantics::Object)
         }
     }
 }
@@ -1130,26 +1131,30 @@ fn known_literal_equality<'db>(
         }
         (LiteralValueTypeKind::Enum(left), LiteralValueTypeKind::Enum(right)) => {
             let left_semantics =
-                known_instance_semantics(db, left.enum_class_instance(db), operator)?;
+                KnownComparisonSemantics::of_instance(db, left.enum_class_instance(db), operator)?;
             let right_semantics =
-                known_instance_semantics(db, right.enum_class_instance(db), operator)?;
+                KnownComparisonSemantics::of_instance(db, right.enum_class_instance(db), operator)?;
             if left_semantics != right_semantics {
                 return Some(false);
             }
             if left_semantics == KnownComparisonSemantics::Object {
                 return Some(same_enum_member(db, left, right));
             }
-            known_type_value_equality(
+            known_literal_equality(
                 db,
-                enum_literal_value(db, left)?,
-                enum_literal_value(db, right)?,
+                enum_literal_value(db, left)?.as_literal_value_kind()?,
+                enum_literal_value(db, right)?.as_literal_value_kind()?,
+                ComparisonOperator::Equality,
             )
         }
         (LiteralValueTypeKind::Enum(enum_literal), other)
         | (other, LiteralValueTypeKind::Enum(enum_literal)) => {
-            let enum_semantics =
-                known_instance_semantics(db, enum_literal.enum_class_instance(db), operator)?;
-            if enum_semantics != literal_semantics(db, other, operator)? {
+            let enum_semantics = KnownComparisonSemantics::of_instance(
+                db,
+                enum_literal.enum_class_instance(db),
+                operator,
+            )?;
+            if enum_semantics != KnownComparisonSemantics::of_literal(db, other, operator)? {
                 return Some(false);
             }
             known_literal_equality(
@@ -1165,24 +1170,11 @@ fn known_literal_equality<'db>(
         )
         | (LiteralValueTypeKind::String(_), LiteralValueTypeKind::LiteralString) => None,
         (left, right) => {
-            let left_semantics = literal_semantics(db, left, operator)?;
-            let right_semantics = literal_semantics(db, right, operator)?;
+            let left_semantics = KnownComparisonSemantics::of_literal(db, left, operator)?;
+            let right_semantics = KnownComparisonSemantics::of_literal(db, right, operator)?;
             (left_semantics != right_semantics).then_some(false)
         }
     }
-}
-
-fn known_type_value_equality<'db>(
-    db: &'db dyn Db,
-    left: Type<'db>,
-    right: Type<'db>,
-) -> Option<bool> {
-    known_literal_equality(
-        db,
-        left.as_literal_value_kind()?,
-        right.as_literal_value_kind()?,
-        ComparisonOperator::Equality,
-    )
 }
 
 /// Return the statically known runtime value of an enum member.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -3,8 +3,8 @@ use ruff_python_ast::name::Name;
 use crate::{Db, place::PlaceAndQualifiers};
 
 use super::{
-    EnumLiteralType, IntersectionBuilder, KnownClass, LiteralValueTypeKind, MemberLookupPolicy,
-    Truthiness, Type, TypeVarBoundOrConstraints, UnionBuilder,
+    EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass, LiteralValueTypeKind,
+    MemberLookupPolicy, Truthiness, Type, TypeVarBoundOrConstraints, UnionBuilder,
     enums::{enum_member_literals, enum_metadata},
 };
 
@@ -308,6 +308,31 @@ fn comparison_result<'db>(
 
         (Type::ModuleLiteral(left_module), Type::ModuleLiteral(right_module)) => {
             operator.result_from_equality(left_module.module(db) == right_module.module(db))
+        }
+        (Type::GenericAlias(left_alias), Type::GenericAlias(right_alias))
+            if left_alias == right_alias =>
+        {
+            operator.result_from_equality(true)
+        }
+        (Type::WrapperDescriptor(left_descriptor), Type::WrapperDescriptor(right_descriptor))
+            if left_descriptor == right_descriptor =>
+        {
+            operator.result_from_equality(true)
+        }
+        (
+            Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(left_function)),
+            Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(right_function)),
+        )
+        | (
+            Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(left_function)),
+            Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(right_function)),
+        ) if left_function == right_function => operator.result_from_equality(true),
+        (Type::KnownInstance(left_instance), Type::KnownInstance(right_instance))
+            if left_instance == right_instance
+                && left.is_single_valued(db)
+                && operator == ComparisonOperator::Equality =>
+        {
+            ComparisonResult::AlwaysTrue
         }
         (left, right)
             if has_known_identity_comparison_semantics(db, left, operator)

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -1,6 +1,3 @@
-use std::fmt::Write as _;
-use std::time::{Duration, Instant};
-
 use super::builder::TypeInferenceBuilder;
 use crate::db::tests::{TestDb, setup_db};
 use crate::place::symbol;
@@ -96,61 +93,6 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
     assert_eq!(
         non_owner.bindings(first).collect::<Vec<_>>(),
         [(second, owner_type)]
-    );
-
-    Ok(())
-}
-
-#[test]
-fn enum_discriminated_typed_dict_chain_avoids_constraint_explosion() -> anyhow::Result<()> {
-    let mut db = setup_db();
-    let mut members = String::new();
-    let mut typed_dicts = String::new();
-    let mut branches = String::new();
-
-    for index in 0..16 {
-        writeln!(&mut members, "    K{index} = \"{index}\"")
-            .expect("writing to a String cannot fail");
-    }
-    for index in 0..8 {
-        let first = index * 2;
-        let second = first + 1;
-        writeln!(
-            &mut typed_dicts,
-            "class M{index}(TypedDict):\n    type: Literal[Kind.K{first}, Kind.K{second}]\n"
-        )
-        .expect("writing to a String cannot fail");
-        writeln!(
-            &mut branches,
-            "    {} message[\"type\"] == Kind.K{first} or message[\"type\"] == Kind.K{second}:\n        return {index}",
-            if index == 0 { "if" } else { "elif" },
-        )
-        .expect("writing to a String cannot fail");
-    }
-
-    let source = format!(
-        r#"
-from enum import Enum
-from typing import Literal, TypedDict
-
-class Kind(str, Enum):
-{members}
-{typed_dicts}
-Message = M0 | M1 | M2 | M3 | M4 | M5 | M6 | M7
-
-def classify(message: Message) -> int:
-{branches}
-    return -1
-"#
-    );
-    db.write_file("/src/a.py", source)?;
-
-    let start = Instant::now();
-    assert_file_diagnostics(&db, "/src/a.py", &[]);
-    assert!(
-        start.elapsed() < Duration::from_secs(10),
-        "enum-discriminated TypedDict narrowing took {:?}",
-        start.elapsed()
     );
 
     Ok(())

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -1,3 +1,6 @@
+use std::fmt::Write as _;
+use std::time::{Duration, Instant};
+
 use super::builder::TypeInferenceBuilder;
 use crate::db::tests::{TestDb, setup_db};
 use crate::place::symbol;
@@ -93,6 +96,61 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
     assert_eq!(
         non_owner.bindings(first).collect::<Vec<_>>(),
         [(second, owner_type)]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn enum_discriminated_typed_dict_chain_avoids_constraint_explosion() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    let mut members = String::new();
+    let mut typed_dicts = String::new();
+    let mut branches = String::new();
+
+    for index in 0..16 {
+        writeln!(&mut members, "    K{index} = \"{index}\"")
+            .expect("writing to a String cannot fail");
+    }
+    for index in 0..8 {
+        let first = index * 2;
+        let second = first + 1;
+        writeln!(
+            &mut typed_dicts,
+            "class M{index}(TypedDict):\n    type: Literal[Kind.K{first}, Kind.K{second}]\n"
+        )
+        .expect("writing to a String cannot fail");
+        writeln!(
+            &mut branches,
+            "    {} message[\"type\"] == Kind.K{first} or message[\"type\"] == Kind.K{second}:\n        return {index}",
+            if index == 0 { "if" } else { "elif" },
+        )
+        .expect("writing to a String cannot fail");
+    }
+
+    let source = format!(
+        r#"
+from enum import Enum
+from typing import Literal, TypedDict
+
+class Kind(str, Enum):
+{members}
+{typed_dicts}
+Message = M0 | M1 | M2 | M3 | M4 | M5 | M6 | M7
+
+def classify(message: Message) -> int:
+{branches}
+    return -1
+"#
+    );
+    db.write_file("/src/a.py", source)?;
+
+    let start = Instant::now();
+    assert_file_diagnostics(&db, "/src/a.py", &[]);
+    assert!(
+        start.elapsed() < Duration::from_secs(10),
+        "enum-discriminated TypedDict narrowing took {:?}",
+        start.elapsed()
     );
 
     Ok(())

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -1,5 +1,6 @@
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
+use ty_python_core::Truthiness;
 use ty_python_core::predicate::{PatternPredicateKind, SequencePatternPredicateKind};
 
 use crate::Db;
@@ -8,7 +9,8 @@ use crate::types::signatures::CallableSignature;
 use crate::types::tuple::TupleType;
 use crate::types::{
     CallableType, IntersectionBuilder, KnownClass, Parameter, Parameters, Signature,
-    SpecialFormType, Type, TypeContext, UnionType, infer_same_file_expression_type,
+    SpecialFormType, Type, TypeContext, UnionType, equality_truthiness,
+    infer_same_file_expression_type,
 };
 
 pub(crate) fn singleton_pattern_type(db: &dyn Db, singleton: ast::Singleton) -> Type<'_> {
@@ -173,10 +175,10 @@ pub(crate) fn definite_match_pattern_type<'db>(
         PatternPredicateKind::Singleton(singleton) => singleton_pattern_type(db, *singleton),
         PatternPredicateKind::Value(value) => {
             let ty = infer_same_file_expression_type(db, *value, TypeContext::default());
-            // Only return the type if it's single-valued. For non-single-valued types
-            // (like `str`), we can't definitively exclude any specific type from
-            // subsequent patterns because the pattern could match any value of that type.
-            if ty.is_single_valued(db) {
+            // Only return the type if it's single-valued and guaranteed to match itself.
+            // Otherwise, we can't definitively exclude it from subsequent patterns.
+            if ty.is_single_valued(db) && equality_truthiness(db, ty, ty) == Truthiness::AlwaysTrue
+            {
                 ty
             } else {
                 Type::Never

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -31,6 +31,7 @@ use ruff_python_stdlib::identifiers::is_identifier;
 
 use super::UnionType;
 use super::enums::{enum_member_literals, enum_metadata};
+use super::equality::{evaluate_type_equality, evaluate_type_inequality};
 use itertools::Itertools;
 use ruff_python_ast as ast;
 use ruff_python_ast::{BoolOp, ExprBoolOp};
@@ -1247,109 +1248,6 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
-    fn evaluate_expr_eq(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
-        let rhs_ty = rhs_ty.resolve_type_alias(self.db);
-
-        // We can only narrow on equality checks against single-valued types.
-        if is_union_of_single_valued(self.db, rhs_ty) {
-            // The fully-general (and more efficient) approach here would be to introduce a
-            // `NeverEqualTo` type that can wrap a single-valued type, and then simply return
-            // `~NeverEqualTo(rhs_ty)` here and let union/intersection builder sort it out. This is
-            // how we handle `AlwaysTruthy` and `AlwaysFalsy`. But this means we have to deal with
-            // this type everywhere, and possibly have it show up unsimplified in some cases, and
-            // so we instead prefer to just do the simplification here. (Another hybrid option that
-            // would be similar to this, but more efficient, would be to allow narrowing to return
-            // something that is not a type, and handle this not-a-type in `symbol_from_bindings`,
-            // instead of intersecting with a type.)
-
-            // Return `true` if `lhs_ty` consists only of `LiteralString` and types that cannot
-            // compare equal to `rhs_ty`.
-            fn can_narrow_to_rhs<'db>(
-                db: &'db dyn Db,
-                lhs_ty: Type<'db>,
-                rhs_ty: Type<'db>,
-            ) -> bool {
-                if let Type::Union(union) = lhs_ty {
-                    return union
-                        .elements(db)
-                        .iter()
-                        .all(|ty| can_narrow_to_rhs(db, *ty, rhs_ty));
-                }
-
-                if let Some(alternatives) = finite_single_valued_union_alternatives(db, lhs_ty) {
-                    return alternatives
-                        .into_iter()
-                        .all(|ty| can_narrow_to_rhs(db, ty, rhs_ty));
-                }
-
-                // Either `rhs_ty` is a string literal, in which case we can narrow to it (no other
-                // string literal could compare equal to it), or it is not a string literal, in which
-                // case (given that it is single-valued), LiteralString cannot compare equal to it.
-                if lhs_ty.is_subtype_of(db, Type::literal_string()) {
-                    return true;
-                }
-
-                !could_compare_equal(db, lhs_ty, rhs_ty)
-            }
-
-            // Filter `ty` to just the types that cannot be equal to `rhs_ty`.
-            fn filter_to_cannot_be_equal<'db>(
-                db: &'db dyn Db,
-                ty: Type<'db>,
-                rhs_ty: Type<'db>,
-            ) -> Type<'db> {
-                if let Type::Union(union) = ty {
-                    return union.map(db, |ty| filter_to_cannot_be_equal(db, *ty, rhs_ty));
-                }
-
-                if let Some(alternatives) = finite_single_valued_union_alternatives(db, ty) {
-                    return UnionType::from_elements(
-                        db,
-                        alternatives
-                            .into_iter()
-                            .map(|ty| filter_to_cannot_be_equal(db, ty, rhs_ty)),
-                    );
-                }
-
-                if !could_compare_equal(db, ty, rhs_ty) {
-                    // Cannot compare equal to rhs, so keep this type
-                    ty
-                } else {
-                    Type::Never
-                }
-            }
-            Some(if can_narrow_to_rhs(self.db, lhs_ty, rhs_ty) {
-                rhs_ty
-            } else {
-                filter_to_cannot_be_equal(self.db, lhs_ty, rhs_ty).negate(self.db)
-            })
-        } else {
-            None
-        }
-    }
-
-    fn evaluate_expr_ne(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
-        match (lhs_ty, rhs_ty.as_literal_value_kind()) {
-            (Type::NominalInstance(instance), Some(LiteralValueTypeKind::Int(i)))
-                if instance.has_known_class(self.db, KnownClass::Bool) =>
-            {
-                if i.as_i64() == 0 {
-                    Some(Type::bool_literal(false).negate(self.db))
-                } else if i.as_i64() == 1 {
-                    Some(Type::bool_literal(true).negate(self.db))
-                } else {
-                    None
-                }
-            }
-            (_, Some(LiteralValueTypeKind::Bool(b))) => Some(
-                UnionType::from_two_elements(self.db, rhs_ty, Type::int_literal(i64::from(b)))
-                    .negate(self.db),
-            ),
-            _ if rhs_ty.is_single_valued(self.db) => Some(rhs_ty.negate(self.db)),
-            _ => None,
-        }
-    }
-
     fn exact_fixed_length_membership_values(&self, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         let iterable = rhs_ty.try_iterate(self.db).ok()?;
         let fixed_length = iterable.as_fixed_length()?;
@@ -1454,6 +1352,13 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         op: ast::CmpOp,
         is_positive: bool,
     ) -> Option<Type<'db>> {
+        if op == ast::CmpOp::Eq {
+            return evaluate_type_equality(self.db, lhs_ty, rhs_ty, is_positive);
+        }
+        if op == ast::CmpOp::NotEq {
+            return evaluate_type_inequality(self.db, lhs_ty, rhs_ty, is_positive);
+        }
+
         let op = if is_positive { op } else { op.negate() };
 
         match op {
@@ -1466,8 +1371,6 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 }
             }
             ast::CmpOp::Is => Some(rhs_ty),
-            ast::CmpOp::Eq => self.evaluate_expr_eq(lhs_ty, rhs_ty),
-            ast::CmpOp::NotEq => self.evaluate_expr_ne(lhs_ty, rhs_ty),
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
             ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty),
             _ => None,


### PR DESCRIPTION
## Summary

This revives equality narrowing from #22799 and makes narrowing follow Python's `==` and `!=` behavior more closely. We narrow only when the result is predictable; when custom comparison code could produce either result, we leave the type unchanged.

Python allows `==` and `!=` to behave independently. Here `!=` is customized, but `==` still uses normal enum equality and can narrow `answer`:

```python
from enum import Enum
from typing import reveal_type

class Answer(Enum):
    NO = 0
    YES = 1

    def __ne__(self, other: object) -> bool:
        return True

def handle(answer: Answer) -> None:
    if answer == Answer.NO:
        reveal_type(answer)  # Literal[Answer.NO]
    else:
        reveal_type(answer)  # Literal[Answer.YES]
```

`match` value patterns are equality comparisons too, so we use the same rules when deciding which cases are reachable:

```python
from enum import StrEnum
from typing import Literal, assert_never, reveal_type

class Color(StrEnum):
    GREEN = "g"

def handle(color: Literal[Color.GREEN]) -> None:
    match color:
        case "g":
            reveal_type(color)  # Literal[Color.GREEN]
        case _:
            assert_never(color)
```

Closes https://github.com/astral-sh/ty/issues/1454.
