### PR TITLE
[ty] Bound equality comparison expansion

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -598,14 +598,12 @@ fn benchmark_many_enum_members(criterion: &mut Criterion) {
     });
 }
 
-fn benchmark_enum_equality_with_aliased_open_union(criterion: &mut Criterion) {
+fn benchmark_intersection_enum_equality_with_aliased_open_union(criterion: &mut Criterion) {
     const DOMAIN_SIZE: usize = 128;
 
     setup_rayon();
 
-    let mut code =
-        "from enum import Enum\nfrom typing import TypeAlias\n\nclass LargeEnum(Enum):\n"
-            .to_string();
+    let mut code = "from enum import Enum\nfrom typing import Any, TypeAlias\n\nfrom ty_extensions import Intersection\n\nclass LargeEnum(Enum):\n".to_string();
     for index in 0..DOMAIN_SIZE {
         writeln!(&mut code, "    MEMBER_{index} = {index}").ok();
     }
@@ -620,20 +618,23 @@ fn benchmark_enum_equality_with_aliased_open_union(criterion: &mut Criterion) {
         write!(&mut code, "A{index}").ok();
     }
     code.push_str(
-        "\n\ndef consume(value: LargeEnum) -> None: ...\n\ndef compare(left: LargeEnum, right: LargeEnum | Open) -> None:\n    if left != right:\n        consume(left)\n",
+        "\n\ndef consume(value: LargeEnum) -> None: ...\n\ndef compare(left: Intersection[LargeEnum, Any], right: LargeEnum | Open) -> None:\n    if left != right:\n        consume(left)\n",
     );
 
-    criterion.bench_function("ty_micro[enum_equality_aliased_open_union]", |b| {
-        b.iter_batched_ref(
-            || setup_micro_case(&code),
-            |case| {
-                let Case { db, .. } = case;
-                let result = db.check();
-                assert_eq!(result.len(), 0);
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    criterion.bench_function(
+        "ty_micro[intersection_enum_equality_aliased_open_union]",
+        |b| {
+            b.iter_batched_ref(
+                || setup_micro_case(&code),
+                |case| {
+                    let Case { db, .. } = case;
+                    let result = db.check();
+                    assert_eq!(result.len(), 0);
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
 }
 
 /// Micro-benchmark that tests our performance when slicing and unpacking
@@ -1549,7 +1550,7 @@ criterion_group!(
     benchmark_complex_constrained_attributes_2,
     benchmark_complex_constrained_attributes_3,
     benchmark_many_enum_members,
-    benchmark_enum_equality_with_aliased_open_union,
+    benchmark_intersection_enum_equality_with_aliased_open_union,
     benchmark_many_enum_members_2,
     benchmark_many_protocol_members_mismatch,
     benchmark_gradual_vararg_call,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -637,6 +637,47 @@ fn benchmark_intersection_enum_equality_with_aliased_open_union(criterion: &mut 
     );
 }
 
+fn benchmark_disjoint_final_class_union_equality(criterion: &mut Criterion) {
+    const DOMAIN_SIZE: usize = 128;
+
+    setup_rayon();
+
+    let mut code = "from typing import TypeAlias, final\n".to_string();
+    for index in 0..DOMAIN_SIZE {
+        writeln!(&mut code, "\n@final\nclass Left{index}: ...").ok();
+        writeln!(&mut code, "\n@final\nclass Right{index}: ...").ok();
+    }
+    code.push_str("\nLeft: TypeAlias = ");
+    for index in 0..DOMAIN_SIZE {
+        if index > 0 {
+            code.push_str(" | ");
+        }
+        write!(&mut code, "Left{index}").ok();
+    }
+    code.push_str("\nRight: TypeAlias = ");
+    for index in 0..DOMAIN_SIZE {
+        if index > 0 {
+            code.push_str(" | ");
+        }
+        write!(&mut code, "Right{index}").ok();
+    }
+    code.push_str(
+        "\n\ndef consume(value: Left) -> None: ...\n\ndef compare(left: Left, right: Right) -> None:\n    if left != right:\n        consume(left)\n",
+    );
+
+    criterion.bench_function("ty_micro[disjoint_final_class_union_equality]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 /// Micro-benchmark that tests our performance when slicing and unpacking
 /// a very large tuple that has many varied literal strings inside it.
 ///
@@ -1551,6 +1592,7 @@ criterion_group!(
     benchmark_complex_constrained_attributes_3,
     benchmark_many_enum_members,
     benchmark_intersection_enum_equality_with_aliased_open_union,
+    benchmark_disjoint_final_class_union_equality,
     benchmark_many_enum_members_2,
     benchmark_many_protocol_members_mismatch,
     benchmark_gradual_vararg_call,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -598,6 +598,44 @@ fn benchmark_many_enum_members(criterion: &mut Criterion) {
     });
 }
 
+fn benchmark_enum_equality_with_aliased_open_union(criterion: &mut Criterion) {
+    const DOMAIN_SIZE: usize = 128;
+
+    setup_rayon();
+
+    let mut code =
+        "from enum import Enum\nfrom typing import TypeAlias\n\nclass LargeEnum(Enum):\n"
+            .to_string();
+    for index in 0..DOMAIN_SIZE {
+        writeln!(&mut code, "    MEMBER_{index} = {index}").ok();
+    }
+    for index in 0..DOMAIN_SIZE {
+        writeln!(&mut code, "\nclass A{index}: ...").ok();
+    }
+    code.push_str("\nOpen: TypeAlias = ");
+    for index in 0..DOMAIN_SIZE {
+        if index > 0 {
+            code.push_str(" | ");
+        }
+        write!(&mut code, "A{index}").ok();
+    }
+    code.push_str(
+        "\n\ndef consume(value: LargeEnum) -> None: ...\n\ndef compare(left: LargeEnum, right: LargeEnum | Open) -> None:\n    if left != right:\n        consume(left)\n",
+    );
+
+    criterion.bench_function("ty_micro[enum_equality_aliased_open_union]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 /// Micro-benchmark that tests our performance when slicing and unpacking
 /// a very large tuple that has many varied literal strings inside it.
 ///
@@ -1511,6 +1549,7 @@ criterion_group!(
     benchmark_complex_constrained_attributes_2,
     benchmark_complex_constrained_attributes_3,
     benchmark_many_enum_members,
+    benchmark_enum_equality_with_aliased_open_union,
     benchmark_many_enum_members_2,
     benchmark_many_protocol_members_mismatch,
     benchmark_gradual_vararg_call,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -598,6 +598,16 @@ fn benchmark_many_enum_members(criterion: &mut Criterion) {
     });
 }
 
+fn write_union_type_alias(code: &mut String, name: &str, member_prefix: &str, size: usize) {
+    write!(code, "\n{name}: TypeAlias = ").ok();
+    for index in 0..size {
+        if index > 0 {
+            code.push_str(" | ");
+        }
+        write!(code, "{member_prefix}{index}").ok();
+    }
+}
+
 fn benchmark_intersection_enum_equality_with_aliased_open_union(criterion: &mut Criterion) {
     const DOMAIN_SIZE: usize = 128;
 
@@ -610,13 +620,7 @@ fn benchmark_intersection_enum_equality_with_aliased_open_union(criterion: &mut 
     for index in 0..DOMAIN_SIZE {
         writeln!(&mut code, "\nclass A{index}: ...").ok();
     }
-    code.push_str("\nOpen: TypeAlias = ");
-    for index in 0..DOMAIN_SIZE {
-        if index > 0 {
-            code.push_str(" | ");
-        }
-        write!(&mut code, "A{index}").ok();
-    }
+    write_union_type_alias(&mut code, "Open", "A", DOMAIN_SIZE);
     code.push_str(
         "\n\ndef consume(value: LargeEnum) -> None: ...\n\ndef compare(left: Intersection[LargeEnum, Any], right: LargeEnum | Open) -> None:\n    if left != right:\n        consume(left)\n",
     );
@@ -647,20 +651,8 @@ fn benchmark_disjoint_final_class_union_equality(criterion: &mut Criterion) {
         writeln!(&mut code, "\n@final\nclass Left{index}: ...").ok();
         writeln!(&mut code, "\n@final\nclass Right{index}: ...").ok();
     }
-    code.push_str("\nLeft: TypeAlias = ");
-    for index in 0..DOMAIN_SIZE {
-        if index > 0 {
-            code.push_str(" | ");
-        }
-        write!(&mut code, "Left{index}").ok();
-    }
-    code.push_str("\nRight: TypeAlias = ");
-    for index in 0..DOMAIN_SIZE {
-        if index > 0 {
-            code.push_str(" | ");
-        }
-        write!(&mut code, "Right{index}").ok();
-    }
+    write_union_type_alias(&mut code, "Left", "Left", DOMAIN_SIZE);
+    write_union_type_alias(&mut code, "Right", "Right", DOMAIN_SIZE);
     code.push_str(
         "\n\ndef consume(value: Left) -> None: ...\n\ndef compare(left: Left, right: Right) -> None:\n    if left != right:\n        consume(left)\n",
     );

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -261,7 +261,7 @@ keeps large comparisons from requiring a Cartesian comparison of every possible 
 
 ```py
 from enum import Enum
-from typing import Literal, TypeVar, final
+from typing import Generic, Literal, TypeVar, final
 
 class Budgeted(Enum):
     M0 = 0
@@ -338,6 +338,21 @@ def disjoint_union_over_budget(value: Budgeted | None, other: Disjoint):
     if value == other:
         reveal_type(value)  # revealed: Never
         value.name
+
+BoxT = TypeVar("BoxT")
+
+@final
+class Box(Generic[BoxT]): ...
+
+@final
+class Unrelated: ...
+
+def generic_identity_overlap(
+    value: Budgeted | Box[int] | Unrelated,
+    other: Disjoint | Box[str],
+):
+    if value == other:
+        reveal_type(value)  # revealed: Budgeted | Box[int] | Unrelated
 
 class Shared(Enum):
     A = 1

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -320,109 +320,41 @@ WithinBudget = Literal[
 ]
 OverBudget = Literal[WithinBudget, Budgeted.M15]
 
-def within_budget(value: Budgeted, other: WithinBudget):
-    if value == other:
+def comparison_budget(value: Budgeted, within: WithinBudget, over: OverBudget):
+    if value == within:
         assert_type(value, WithinBudget)
 
-def over_budget(value: Budgeted, other: OverBudget | None):
-    if value == other:
+    if value == over:
         assert_type(value, Budgeted)
 
-def disjoint_over_budget(value: Budgeted, other: Disjoint):
+def disjoint_union_over_budget(value: Budgeted | None, other: Disjoint):
     if value != other:
         pass
     else:
         reveal_type(value)  # revealed: Never
 
-def disjoint_union_over_budget(value: Budgeted | None, other: Disjoint):
-    if value == other:
-        reveal_type(value)  # revealed: Never
-        value.name
-
 @final
 class LeftExtra: ...
 
-@final
-class RightExtra: ...
-
-LeftNewType0 = NewType("LeftNewType0", LeftExtra)
-LeftNewType1 = NewType("LeftNewType1", LeftExtra)
-LeftNewType2 = NewType("LeftNewType2", LeftExtra)
-LeftNewType3 = NewType("LeftNewType3", LeftExtra)
-LeftNewType4 = NewType("LeftNewType4", LeftExtra)
-LeftNewType5 = NewType("LeftNewType5", LeftExtra)
-LeftNewType6 = NewType("LeftNewType6", LeftExtra)
-LeftNewType7 = NewType("LeftNewType7", LeftExtra)
-LeftNewType8 = NewType("LeftNewType8", LeftExtra)
-LeftNewType9 = NewType("LeftNewType9", LeftExtra)
-LeftNewType10 = NewType("LeftNewType10", LeftExtra)
-LeftNewType11 = NewType("LeftNewType11", LeftExtra)
-LeftNewType12 = NewType("LeftNewType12", LeftExtra)
-LeftNewType13 = NewType("LeftNewType13", LeftExtra)
-LeftNewType14 = NewType("LeftNewType14", LeftExtra)
-LeftNewType15 = NewType("LeftNewType15", LeftExtra)
-LeftNewType16 = NewType("LeftNewType16", LeftExtra)
-
-LeftNewTypes = (
-    LeftNewType0
-    | LeftNewType1
-    | LeftNewType2
-    | LeftNewType3
-    | LeftNewType4
-    | LeftNewType5
-    | LeftNewType6
-    | LeftNewType7
-    | LeftNewType8
-    | LeftNewType9
-    | LeftNewType10
-    | LeftNewType11
-    | LeftNewType12
-    | LeftNewType13
-    | LeftNewType14
-    | LeftNewType15
-    | LeftNewType16
-)
-
-def newtype_wrapped_domains(value: LeftNewTypes, other: Disjoint):
-    if value == other:
-        reveal_type(value)  # revealed: Never
-
-RightConstraint = TypeVar("RightConstraint", Disjoint, RightExtra)
-
-def constrained_typevar_domains(value: Budgeted | LeftExtra, other: RightConstraint):
-    if value == other:
-        reveal_type(value)  # revealed: Never
+LeftNewType = NewType("LeftNewType", LeftExtra)
 
 BoxT = TypeVar("BoxT")
 
 @final
 class Box(Generic[BoxT]): ...
 
-@final
-class Unrelated: ...
+RightConstraint = TypeVar("RightConstraint", Disjoint, Box[str])
+
+def wrapped_domains(value: Budgeted | LeftNewType, other: RightConstraint):
+    if value == other:
+        reveal_type(value)  # revealed: Never
 
 def generic_identity_overlap(
-    value: Budgeted | Box[int] | Unrelated,
+    value: Budgeted | Box[int],
     other: Disjoint | Box[str],
 ):
     if value == other:
-        reveal_type(value)  # revealed: Budgeted | Box[int] | Unrelated
-
-class Shared(Enum):
-    A = 1
-    B = 2
-
-@final
-class Other: ...
-
-T = TypeVar("T", Literal[Shared.A], Other)
-U = TypeVar("U", Literal[Shared.A], Other)
-
-def shared_constraint_domain(value: Shared, other: T | U):
-    if value != other:
-        pass
-    else:
-        reveal_type(value)  # revealed: Literal[Shared.A]
+        reveal_type(value)  # revealed: Budgeted | Box[int]
 ```
 
 An assignment to `__new__`, `__init__`, or other methods can replace the value declared in the class

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -334,6 +334,11 @@ def disjoint_over_budget(value: Budgeted, other: Disjoint):
     else:
         reveal_type(value)  # revealed: Never
 
+def disjoint_union_over_budget(value: Budgeted | None, other: Disjoint):
+    if value == other:
+        reveal_type(value)  # revealed: Never
+        value.name
+
 class Shared(Enum):
     A = 1
     B = 2

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -59,6 +59,7 @@ def _(x: bool):
 ```py
 from enum import Enum
 from typing import Literal
+from typing_extensions import assert_type
 
 from ty_extensions import Intersection, Not
 
@@ -253,6 +254,101 @@ reveal_type(Generated.ONE.value)  # revealed: int
 def _(value: Generated | Other):
     if value == Generated.ONE:
         reveal_type(value)  # revealed: Generated | Other
+```
+
+Finite-domain narrowing has a work limit when both operands contain multiple alternatives. This
+keeps large comparisons from requiring a Cartesian comparison of every possible pair:
+
+```py
+from enum import Enum
+from typing import Literal, TypeVar, final
+
+class Budgeted(Enum):
+    M0 = 0
+    M1 = 1
+    M2 = 2
+    M3 = 3
+    M4 = 4
+    M5 = 5
+    M6 = 6
+    M7 = 7
+    M8 = 8
+    M9 = 9
+    M10 = 10
+    M11 = 11
+    M12 = 12
+    M13 = 13
+    M14 = 14
+    M15 = 15
+    M16 = 16
+
+class Disjoint(Enum):
+    M0 = 0
+    M1 = 1
+    M2 = 2
+    M3 = 3
+    M4 = 4
+    M5 = 5
+    M6 = 6
+    M7 = 7
+    M8 = 8
+    M9 = 9
+    M10 = 10
+    M11 = 11
+    M12 = 12
+    M13 = 13
+    M14 = 14
+    M15 = 15
+    M16 = 16
+
+WithinBudget = Literal[
+    Budgeted.M0,
+    Budgeted.M1,
+    Budgeted.M2,
+    Budgeted.M3,
+    Budgeted.M4,
+    Budgeted.M5,
+    Budgeted.M6,
+    Budgeted.M7,
+    Budgeted.M8,
+    Budgeted.M9,
+    Budgeted.M10,
+    Budgeted.M11,
+    Budgeted.M12,
+    Budgeted.M13,
+    Budgeted.M14,
+]
+OverBudget = Literal[WithinBudget, Budgeted.M15]
+
+def within_budget(value: Budgeted, other: WithinBudget):
+    if value == other:
+        assert_type(value, WithinBudget)
+
+def over_budget(value: Budgeted, other: OverBudget | None):
+    if value == other:
+        assert_type(value, Budgeted)
+
+def disjoint_over_budget(value: Budgeted, other: Disjoint):
+    if value != other:
+        pass
+    else:
+        reveal_type(value)  # revealed: Never
+
+class Shared(Enum):
+    A = 1
+    B = 2
+
+@final
+class Other: ...
+
+T = TypeVar("T", Literal[Shared.A], Other)
+U = TypeVar("U", Literal[Shared.A], Other)
+
+def shared_constraint_domain(value: Shared, other: T | U):
+    if value != other:
+        pass
+    else:
+        reveal_type(value)  # revealed: Literal[Shared.A]
 ```
 
 An assignment to `__new__`, `__init__`, or other methods can replace the value declared in the class

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -261,7 +261,7 @@ keeps large comparisons from requiring a Cartesian comparison of every possible 
 
 ```py
 from enum import Enum
-from typing import Generic, Literal, TypeVar, final
+from typing import Generic, Literal, NewType, TypeVar, final
 
 class Budgeted(Enum):
     M0 = 0
@@ -338,6 +338,60 @@ def disjoint_union_over_budget(value: Budgeted | None, other: Disjoint):
     if value == other:
         reveal_type(value)  # revealed: Never
         value.name
+
+@final
+class LeftExtra: ...
+
+@final
+class RightExtra: ...
+
+LeftNewType0 = NewType("LeftNewType0", LeftExtra)
+LeftNewType1 = NewType("LeftNewType1", LeftExtra)
+LeftNewType2 = NewType("LeftNewType2", LeftExtra)
+LeftNewType3 = NewType("LeftNewType3", LeftExtra)
+LeftNewType4 = NewType("LeftNewType4", LeftExtra)
+LeftNewType5 = NewType("LeftNewType5", LeftExtra)
+LeftNewType6 = NewType("LeftNewType6", LeftExtra)
+LeftNewType7 = NewType("LeftNewType7", LeftExtra)
+LeftNewType8 = NewType("LeftNewType8", LeftExtra)
+LeftNewType9 = NewType("LeftNewType9", LeftExtra)
+LeftNewType10 = NewType("LeftNewType10", LeftExtra)
+LeftNewType11 = NewType("LeftNewType11", LeftExtra)
+LeftNewType12 = NewType("LeftNewType12", LeftExtra)
+LeftNewType13 = NewType("LeftNewType13", LeftExtra)
+LeftNewType14 = NewType("LeftNewType14", LeftExtra)
+LeftNewType15 = NewType("LeftNewType15", LeftExtra)
+LeftNewType16 = NewType("LeftNewType16", LeftExtra)
+
+LeftNewTypes = (
+    LeftNewType0
+    | LeftNewType1
+    | LeftNewType2
+    | LeftNewType3
+    | LeftNewType4
+    | LeftNewType5
+    | LeftNewType6
+    | LeftNewType7
+    | LeftNewType8
+    | LeftNewType9
+    | LeftNewType10
+    | LeftNewType11
+    | LeftNewType12
+    | LeftNewType13
+    | LeftNewType14
+    | LeftNewType15
+    | LeftNewType16
+)
+
+def newtype_wrapped_domains(value: LeftNewTypes, other: Disjoint):
+    if value == other:
+        reveal_type(value)  # revealed: Never
+
+RightConstraint = TypeVar("RightConstraint", Disjoint, RightExtra)
+
+def constrained_typevar_domains(value: Budgeted | LeftExtra, other: RightConstraint):
+    if value == other:
+        reveal_type(value)  # revealed: Never
 
 BoxT = TypeVar("BoxT")
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -513,17 +513,29 @@ fn known_comparison_domains_are_disjoint(
     let Some(right_semantics) = KnownComparisonSemantics::of_type(db, right, operator) else {
         return false;
     };
-    left_semantics != right_semantics
-        || (left_semantics == KnownComparisonSemantics::Object
-            && left.is_disjoint_from(db, right)
-            && nominal_runtime_classes(db, left).is_disjoint(&nominal_runtime_classes(db, right)))
+    if left_semantics != right_semantics {
+        return true;
+    }
+    if left_semantics != KnownComparisonSemantics::Object {
+        return false;
+    }
+    let Some(left_classes) = object_identity_runtime_classes(db, left) else {
+        return false;
+    };
+    let Some(right_classes) = object_identity_runtime_classes(db, right) else {
+        return false;
+    };
+    left_classes.is_disjoint(&right_classes)
 }
 
-/// Collect the runtime classes of nominal instances represented by `ty`.
+/// Collect the runtime classes represented by a domain with object identity semantics.
 ///
 /// Generic arguments are erased at runtime, so different specializations contribute the same
 /// class even when they are statically disjoint.
-fn nominal_runtime_classes<'db>(db: &'db dyn Db, ty: Type<'db>) -> FxHashSet<ClassLiteral<'db>> {
+fn object_identity_runtime_classes<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+) -> Option<FxHashSet<ClassLiteral<'db>>> {
     let mut classes = FxHashSet::default();
     let mut pending = vec![ty];
     let mut visited = FxHashSet::default();
@@ -535,15 +547,26 @@ fn nominal_runtime_classes<'db>(db: &'db dyn Db, ty: Type<'db>) -> FxHashSet<Cla
         }
         match ty {
             Type::Union(union) => pending.extend(union.elements(db)),
-            Type::Intersection(intersection) => pending.extend(intersection.positive(db)),
             Type::NominalInstance(instance) => {
                 classes.insert(instance.class_literal(db));
             }
-            _ => {}
+            Type::LiteralValue(literal) => {
+                let LiteralValueTypeKind::Enum(enum_literal) = literal.kind() else {
+                    return None;
+                };
+                classes.insert(enum_literal.enum_class(db));
+            }
+            Type::EnumComplement(complement) => {
+                classes.insert(complement.enum_class(db));
+            }
+            Type::Intersection(intersection) => {
+                classes.insert(intersection.enum_complement(db)?.enum_class(db));
+            }
+            _ => return None,
         }
     }
 
-    classes
+    Some(classes)
 }
 
 /// Return whether every value represented by `ty` is known to compare equal to every other value.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -286,9 +286,6 @@ impl<'db> ComparisonEvaluator<'db> {
         alternatives: usize,
         evaluate: impl FnOnce(&mut Self) -> ComparisonResult<'db>,
     ) -> ComparisonResult<'db> {
-        if self.exhausted {
-            return ComparisonResult::Ambiguous;
-        }
         if alternatives <= 1 {
             return evaluate(self);
         }

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -528,6 +528,22 @@ fn known_comparison_domains_are_disjoint(
     left_classes.is_disjoint(&right_classes)
 }
 
+/// Return the comparison-equivalent inner type of a transparent wrapper.
+fn comparison_wrapper_inner_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
+    match ty {
+        Type::TypeVar(var) => {
+            let TypeVarBoundOrConstraints::Constraints(constraints) =
+                var.typevar(db).bound_or_constraints(db)?
+            else {
+                return None;
+            };
+            Some(constraints.as_type(db))
+        }
+        Type::NewTypeInstance(newtype) => Some(newtype.concrete_base_type(db)),
+        _ => None,
+    }
+}
+
 /// Collect the runtime classes represented by a domain with object identity semantics.
 ///
 /// Generic arguments are erased at runtime, so different specializations contribute the same
@@ -543,6 +559,10 @@ fn object_identity_runtime_classes<'db>(
     while let Some(ty) = pending.pop() {
         let ty = ty.resolve_type_alias(db);
         if !visited.insert(ty) {
+            continue;
+        }
+        if let Some(inner) = comparison_wrapper_inner_type(db, ty) {
+            pending.push(inner);
             continue;
         }
         match ty {
@@ -1046,22 +1066,12 @@ fn comparison_operand_branch_count(
 
         if let Some(alternatives) = finite_alternatives(db, ty, operator) {
             count = count.saturating_add(alternatives.len());
+        } else if let Some(inner) = comparison_wrapper_inner_type(db, ty) {
+            pending.push((inner, false));
         } else {
             match ty {
                 Type::Union(union) => {
                     pending.extend(union.elements(db).iter().map(|element| (*element, false)));
-                }
-                Type::TypeVar(var) => {
-                    if let Some(TypeVarBoundOrConstraints::Constraints(constraints)) =
-                        var.typevar(db).bound_or_constraints(db)
-                    {
-                        pending.push((constraints.as_type(db), false));
-                    } else {
-                        count += 1;
-                    }
-                }
-                Type::NewTypeInstance(newtype) => {
-                    pending.push((newtype.concrete_base_type(db), false));
                 }
                 Type::Intersection(intersection) if is_target => {
                     pending.extend(
@@ -1280,6 +1290,9 @@ impl KnownComparisonSemantics {
     ///
     /// Returns `None` when dunder lookup finds custom or conflicting comparison behavior.
     fn of_type<'db>(db: &'db dyn Db, ty: Type<'db>, operator: ComparisonOperator) -> Option<Self> {
+        if let Some(inner) = comparison_wrapper_inner_type(db, ty) {
+            return Self::of_type(db, inner, operator);
+        }
         match ty {
             Type::Union(union) => {
                 let mut elements = union.elements(db).iter().copied();
@@ -1395,6 +1408,10 @@ fn comparison_domain<'db>(
 ) -> ComparisonDomain {
     let target = target.resolve_type_alias(db);
     let ty = ty.resolve_type_alias(db);
+
+    if let Some(inner) = comparison_wrapper_inner_type(db, ty) {
+        return comparison_domain(db, target, inner, operator);
+    }
 
     match ty {
         Type::Union(union) => {

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -240,6 +240,12 @@ struct ComparisonKey<'db> {
     operator: ComparisonOperator,
 }
 
+/// Maximum number of pairwise checks introduced by expanding a finite comparison domain.
+///
+/// A large finite domain can still be compared with a single alternative because that work is
+/// linear. This limit only prevents Cartesian expansion when both operands can branch.
+const MAX_FINITE_COMPARISON_PAIRS: usize = 256;
+
 /// Tracks comparisons that are already in progress so recursive evaluation terminates.
 struct ComparisonEvaluator<'db> {
     db: &'db dyn Db,
@@ -313,9 +319,33 @@ fn evaluate_comparison_once<'db>(
     let db = evaluator.db;
 
     if let Some(alternatives) = finite_alternatives(db, left, operator) {
+        if !finite_comparison_expansion_is_within_limit(
+            db,
+            alternatives.len(),
+            right,
+            false,
+            operator,
+        ) {
+            if known_comparison_domains_are_disjoint(db, left, right, operator) {
+                return operator.result_from_equality(false);
+            }
+            return ComparisonResult::Ambiguous;
+        }
         return evaluate_union_left(evaluator, &alternatives, right, branch, operator);
     }
     if let Some(alternatives) = finite_alternatives(db, right, operator) {
+        if !finite_comparison_expansion_is_within_limit(
+            db,
+            alternatives.len(),
+            left,
+            true,
+            operator,
+        ) {
+            if known_comparison_domains_are_disjoint(db, left, right, operator) {
+                return operator.result_from_equality(false);
+            }
+            return ComparisonResult::Ambiguous;
+        }
         return evaluate_union_right(evaluator, left, &alternatives, branch, operator);
     }
 
@@ -485,6 +515,22 @@ fn evaluate_comparison_once<'db>(
 
         _ => ComparisonResult::Ambiguous,
     }
+}
+
+fn known_comparison_domains_are_disjoint(
+    db: &dyn Db,
+    left: Type,
+    right: Type,
+    operator: ComparisonOperator,
+) -> bool {
+    let Some(left_semantics) = KnownComparisonSemantics::of_type(db, left, operator) else {
+        return false;
+    };
+    let Some(right_semantics) = KnownComparisonSemantics::of_type(db, right, operator) else {
+        return false;
+    };
+    left_semantics != right_semantics
+        || (left_semantics == KnownComparisonSemantics::Object && left.is_disjoint_from(db, right))
 }
 
 /// Return whether every value represented by `ty` is known to compare equal to every other value.
@@ -917,6 +963,91 @@ fn finite_alternatives<'db>(
         }
         _ => None,
     }
+}
+
+/// Return whether expanding `alternatives` stays within the finite-comparison work budget.
+fn finite_comparison_expansion_is_within_limit(
+    db: &dyn Db,
+    alternatives: usize,
+    other: Type,
+    other_is_target: bool,
+    operator: ComparisonOperator,
+) -> bool {
+    if alternatives <= 1 {
+        return true;
+    }
+
+    let other_alternatives = comparison_operand_branch_count(db, other, other_is_target, operator);
+    other_alternatives <= 1
+        || alternatives
+            .checked_mul(other_alternatives)
+            .is_some_and(|pairs| pairs <= MAX_FINITE_COMPARISON_PAIRS)
+}
+
+/// Estimate how many alternatives the evaluator visits after recursively unpacking `ty`.
+///
+/// The count stops once it exceeds the finite-comparison work budget. Re-entering a type that is
+/// still active also exceeds the estimate conservatively so recursive types cannot make this walk
+/// cycle. Completed shared subgraphs are counted again because the evaluator revisits them.
+fn comparison_operand_branch_count(
+    db: &dyn Db,
+    ty: Type,
+    is_target: bool,
+    operator: ComparisonOperator,
+) -> usize {
+    let over_limit = MAX_FINITE_COMPARISON_PAIRS + 1;
+    let mut pending = vec![(ty, false)];
+    let mut active = FxHashSet::default();
+    let mut count = 0usize;
+
+    while let Some((ty, exiting)) = pending.pop() {
+        let ty = ty.resolve_type_alias(db);
+        if exiting {
+            active.remove(&ty);
+            continue;
+        }
+        if !active.insert(ty) {
+            return over_limit;
+        }
+        pending.push((ty, true));
+
+        if let Some(alternatives) = finite_alternatives(db, ty, operator) {
+            count = count.saturating_add(alternatives.len());
+        } else {
+            match ty {
+                Type::Union(union) => {
+                    pending.extend(union.elements(db).iter().map(|element| (*element, false)));
+                }
+                Type::TypeVar(var) => {
+                    if let Some(TypeVarBoundOrConstraints::Constraints(constraints)) =
+                        var.typevar(db).bound_or_constraints(db)
+                    {
+                        pending.push((constraints.as_type(db), false));
+                    } else {
+                        count += 1;
+                    }
+                }
+                Type::NewTypeInstance(newtype) => {
+                    pending.push((newtype.concrete_base_type(db), false));
+                }
+                Type::Intersection(intersection) if is_target => {
+                    pending.extend(
+                        intersection
+                            .positive(db)
+                            .iter()
+                            .map(|element| (*element, false)),
+                    );
+                }
+                _ => count += 1,
+            }
+        }
+
+        if count > MAX_FINITE_COMPARISON_PAIRS {
+            return over_limit;
+        }
+    }
+
+    count
 }
 
 /// Return a constraint for literal pairs whose equality cannot be decided statically.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -10,8 +10,9 @@ use rustc_hash::FxHashSet;
 use crate::{Db, place::PlaceAndQualifiers};
 
 use super::{
-    EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass, LiteralValueTypeKind,
-    MemberLookupPolicy, Truthiness, Type, TypeVarBoundOrConstraints, UnionBuilder,
+    ClassLiteral, EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass,
+    LiteralValueTypeKind, MemberLookupPolicy, Truthiness, Type, TypeVarBoundOrConstraints,
+    UnionBuilder,
     enums::{enum_member_literals, enum_metadata},
 };
 
@@ -513,7 +514,36 @@ fn known_comparison_domains_are_disjoint(
         return false;
     };
     left_semantics != right_semantics
-        || (left_semantics == KnownComparisonSemantics::Object && left.is_disjoint_from(db, right))
+        || (left_semantics == KnownComparisonSemantics::Object
+            && left.is_disjoint_from(db, right)
+            && nominal_runtime_classes(db, left).is_disjoint(&nominal_runtime_classes(db, right)))
+}
+
+/// Collect the runtime classes of nominal instances represented by `ty`.
+///
+/// Generic arguments are erased at runtime, so different specializations contribute the same
+/// class even when they are statically disjoint.
+fn nominal_runtime_classes<'db>(db: &'db dyn Db, ty: Type<'db>) -> FxHashSet<ClassLiteral<'db>> {
+    let mut classes = FxHashSet::default();
+    let mut pending = vec![ty];
+    let mut visited = FxHashSet::default();
+
+    while let Some(ty) = pending.pop() {
+        let ty = ty.resolve_type_alias(db);
+        if !visited.insert(ty) {
+            continue;
+        }
+        match ty {
+            Type::Union(union) => pending.extend(union.elements(db)),
+            Type::Intersection(intersection) => pending.extend(intersection.positive(db)),
+            Type::NominalInstance(instance) => {
+                classes.insert(instance.class_literal(db));
+            }
+            _ => {}
+        }
+    }
+
+    classes
 }
 
 /// Return whether every value represented by `ty` is known to compare equal to every other value.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1248,6 +1248,13 @@ impl KnownComparisonSemantics {
     /// Returns `None` when dunder lookup finds custom or conflicting comparison behavior.
     fn of_type<'db>(db: &'db dyn Db, ty: Type<'db>, operator: ComparisonOperator) -> Option<Self> {
         match ty {
+            Type::Union(union) => {
+                let mut elements = union.elements(db).iter().copied();
+                let first = Self::of_type(db, elements.next()?, operator)?;
+                elements
+                    .all(|element| Self::of_type(db, element, operator) == Some(first))
+                    .then_some(first)
+            }
             Type::LiteralValue(literal) => Self::of_literal(db, literal.kind(), operator),
             Type::TypedDict(_) => Some(Self::Dict),
             Type::EnumComplement(complement) => Self::of_instance(

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -318,34 +318,17 @@ fn evaluate_comparison_once<'db>(
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
 
-    if let Some(alternatives) = finite_alternatives(db, left, operator) {
-        if !finite_comparison_expansion_is_within_limit(
-            db,
-            alternatives.len(),
-            right,
-            false,
-            operator,
-        ) {
-            if known_comparison_domains_are_disjoint(db, left, right, operator) {
-                return operator.result_from_equality(false);
-            }
-            return ComparisonResult::Ambiguous;
+    if !comparison_expansion_is_within_limit(db, left, right, operator) {
+        if known_comparison_domains_are_disjoint(db, left, right, operator) {
+            return operator.result_from_equality(false);
         }
+        return ComparisonResult::Ambiguous;
+    }
+
+    if let Some(alternatives) = finite_alternatives(db, left, operator) {
         return evaluate_union_left(evaluator, &alternatives, right, branch, operator);
     }
     if let Some(alternatives) = finite_alternatives(db, right, operator) {
-        if !finite_comparison_expansion_is_within_limit(
-            db,
-            alternatives.len(),
-            left,
-            true,
-            operator,
-        ) {
-            if known_comparison_domains_are_disjoint(db, left, right, operator) {
-                return operator.result_from_equality(false);
-            }
-            return ComparisonResult::Ambiguous;
-        }
         return evaluate_union_right(evaluator, left, &alternatives, branch, operator);
     }
 
@@ -965,22 +948,19 @@ fn finite_alternatives<'db>(
     }
 }
 
-/// Return whether expanding `alternatives` stays within the finite-comparison work budget.
-fn finite_comparison_expansion_is_within_limit(
+/// Return whether recursively expanding both operands stays within the comparison work budget.
+fn comparison_expansion_is_within_limit(
     db: &dyn Db,
-    alternatives: usize,
-    other: Type,
-    other_is_target: bool,
+    left: Type,
+    right: Type,
     operator: ComparisonOperator,
 ) -> bool {
-    if alternatives <= 1 {
-        return true;
-    }
-
-    let other_alternatives = comparison_operand_branch_count(db, other, other_is_target, operator);
-    other_alternatives <= 1
-        || alternatives
-            .checked_mul(other_alternatives)
+    let left_alternatives = comparison_operand_branch_count(db, left, true, operator);
+    let right_alternatives = comparison_operand_branch_count(db, right, false, operator);
+    left_alternatives <= 1
+        || right_alternatives <= 1
+        || left_alternatives
+            .checked_mul(right_alternatives)
             .is_some_and(|pairs| pairs <= MAX_FINITE_COMPARISON_PAIRS)
 }
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -241,16 +241,31 @@ struct ComparisonKey<'db> {
     operator: ComparisonOperator,
 }
 
-/// Maximum number of pairwise checks introduced by expanding a finite comparison domain.
+/// Maximum number of recursive evaluations after both comparison operands branch.
 ///
 /// A large finite domain can still be compared with a single alternative because that work is
-/// linear. This limit only prevents Cartesian expansion when both operands can branch.
-const MAX_FINITE_COMPARISON_PAIRS: usize = 256;
+/// linear. This limit only bounds Cartesian work after both operands expand into alternatives.
+const MAX_CARTESIAN_EVALUATIONS: usize = 256;
 
-/// Tracks comparisons that are already in progress so recursive evaluation terminates.
+#[derive(Copy, Clone)]
+enum ComparisonOperand {
+    Target,
+    Other,
+}
+
+#[derive(Copy, Clone, Default)]
+struct ComparisonExpansion {
+    target: bool,
+    other: bool,
+}
+
+/// Tracks active comparisons and bounds recursive work after both operands branch.
 struct ComparisonEvaluator<'db> {
     db: &'db dyn Db,
     active: FxHashSet<ComparisonKey<'db>>,
+    expansion: ComparisonExpansion,
+    cartesian_evaluations: usize,
+    exhausted: bool,
 }
 
 impl<'db> ComparisonEvaluator<'db> {
@@ -258,7 +273,34 @@ impl<'db> ComparisonEvaluator<'db> {
         Self {
             db,
             active: FxHashSet::default(),
+            expansion: ComparisonExpansion::default(),
+            cartesian_evaluations: 0,
+            exhausted: false,
         }
+    }
+
+    /// Evaluate with one operand expanded into multiple alternatives.
+    fn with_expansion(
+        &mut self,
+        operand: ComparisonOperand,
+        alternatives: usize,
+        evaluate: impl FnOnce(&mut Self) -> ComparisonResult<'db>,
+    ) -> ComparisonResult<'db> {
+        if self.exhausted {
+            return ComparisonResult::Ambiguous;
+        }
+        if alternatives <= 1 {
+            return evaluate(self);
+        }
+
+        let previous = self.expansion;
+        match operand {
+            ComparisonOperand::Target => self.expansion.target = true,
+            ComparisonOperand::Other => self.expansion.other = true,
+        }
+        let result = evaluate(self);
+        self.expansion = previous;
+        result
     }
 
     /// Evaluate a comparison recursively, treating `left` as the operand being constrained.
@@ -288,6 +330,15 @@ impl<'db> ComparisonEvaluator<'db> {
     ) -> ComparisonResult<'db> {
         let left = left.resolve_type_alias(self.db);
         let right = right.resolve_type_alias(self.db);
+        let is_root = self.active.is_empty();
+
+        if is_root && known_comparison_domains_are_disjoint(self.db, left, right, operator) {
+            return operator.result_from_equality(false);
+        }
+        if self.exhausted {
+            return ComparisonResult::Ambiguous;
+        }
+
         let key = ComparisonKey {
             left,
             right,
@@ -301,9 +352,24 @@ impl<'db> ComparisonEvaluator<'db> {
             return ComparisonResult::Ambiguous;
         }
 
+        if self.expansion.target && self.expansion.other {
+            if self.cartesian_evaluations == MAX_CARTESIAN_EVALUATIONS {
+                self.exhausted = true;
+                self.active.remove(&key);
+                return ComparisonResult::Ambiguous;
+            }
+            self.cartesian_evaluations += 1;
+        }
+
         let result = evaluate_comparison_once(self, left, right, branch, operator);
         self.active.remove(&key);
-        result
+        // Exhaustion can happen after an outer union has accumulated partial results. Discard the
+        // entire root result so traversal order cannot affect narrowing.
+        if is_root && self.exhausted {
+            ComparisonResult::Ambiguous
+        } else {
+            result
+        }
     }
 }
 
@@ -318,13 +384,6 @@ fn evaluate_comparison_once<'db>(
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
-
-    if !comparison_expansion_is_within_limit(db, left, right, operator) {
-        if known_comparison_domains_are_disjoint(db, left, right, operator) {
-            return operator.result_from_equality(false);
-        }
-        return ComparisonResult::Ambiguous;
-    }
 
     if let Some(alternatives) = finite_alternatives(db, left, operator) {
         return evaluate_union_left(evaluator, &alternatives, right, branch, operator);
@@ -408,13 +467,19 @@ fn evaluate_comparison_once<'db>(
         (other, Type::Union(union)) => {
             evaluate_union_right(evaluator, other, union.elements(db), branch, operator)
         }
-        (Type::Intersection(intersection), other) => evaluate_intersection_left(
-            evaluator,
-            Type::Intersection(intersection),
-            intersection.positive(db),
-            other,
-            branch,
-            operator,
+        (Type::Intersection(intersection), other) => evaluator.with_expansion(
+            ComparisonOperand::Target,
+            intersection.positive(db).len(),
+            |evaluator| {
+                evaluate_intersection_left(
+                    evaluator,
+                    Type::Intersection(intersection),
+                    intersection.positive(db),
+                    other,
+                    branch,
+                    operator,
+                )
+            },
         ),
 
         (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
@@ -793,8 +858,10 @@ fn evaluate_union_left<'db>(
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
-    evaluate_target_union(db, elements, branch, |element| {
-        evaluator.evaluate(element, other, branch, operator)
+    evaluator.with_expansion(ComparisonOperand::Target, elements.len(), |evaluator| {
+        evaluate_target_union(db, elements, branch, |element| {
+            evaluator.evaluate(element, other, branch, operator)
+        })
     })
 }
 
@@ -886,14 +953,16 @@ fn evaluate_union_right<'db>(
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
-    evaluate_against_results(
-        db,
-        left,
-        branch,
-        elements
-            .iter()
-            .map(|element| evaluator.evaluate(left, *element, branch, operator)),
-    )
+    evaluator.with_expansion(ComparisonOperand::Other, elements.len(), |evaluator| {
+        evaluate_against_results(
+            db,
+            left,
+            branch,
+            elements
+                .iter()
+                .map(|element| evaluator.evaluate(left, *element, branch, operator)),
+        )
+    })
 }
 
 /// Combine comparison results produced by alternatives of the non-target operand.
@@ -1019,78 +1088,6 @@ fn finite_alternatives<'db>(
         }
         _ => None,
     }
-}
-
-/// Return whether recursively expanding both operands stays within the comparison work budget.
-fn comparison_expansion_is_within_limit(
-    db: &dyn Db,
-    left: Type,
-    right: Type,
-    operator: ComparisonOperator,
-) -> bool {
-    let left_alternatives = comparison_operand_branch_count(db, left, true, operator);
-    let right_alternatives = comparison_operand_branch_count(db, right, false, operator);
-    left_alternatives <= 1
-        || right_alternatives <= 1
-        || left_alternatives
-            .checked_mul(right_alternatives)
-            .is_some_and(|pairs| pairs <= MAX_FINITE_COMPARISON_PAIRS)
-}
-
-/// Estimate how many alternatives the evaluator visits after recursively unpacking `ty`.
-///
-/// The count stops once it exceeds the finite-comparison work budget. Re-entering a type that is
-/// still active also exceeds the estimate conservatively so recursive types cannot make this walk
-/// cycle. Completed shared subgraphs are counted again because the evaluator revisits them.
-fn comparison_operand_branch_count(
-    db: &dyn Db,
-    ty: Type,
-    is_target: bool,
-    operator: ComparisonOperator,
-) -> usize {
-    let over_limit = MAX_FINITE_COMPARISON_PAIRS + 1;
-    let mut pending = vec![(ty, false)];
-    let mut active = FxHashSet::default();
-    let mut count = 0usize;
-
-    while let Some((ty, exiting)) = pending.pop() {
-        let ty = ty.resolve_type_alias(db);
-        if exiting {
-            active.remove(&ty);
-            continue;
-        }
-        if !active.insert(ty) {
-            return over_limit;
-        }
-        pending.push((ty, true));
-
-        if let Some(alternatives) = finite_alternatives(db, ty, operator) {
-            count = count.saturating_add(alternatives.len());
-        } else if let Some(inner) = comparison_wrapper_inner_type(db, ty) {
-            pending.push((inner, false));
-        } else {
-            match ty {
-                Type::Union(union) => {
-                    pending.extend(union.elements(db).iter().map(|element| (*element, false)));
-                }
-                Type::Intersection(intersection) if is_target => {
-                    pending.extend(
-                        intersection
-                            .positive(db)
-                            .iter()
-                            .map(|element| (*element, false)),
-                    );
-                }
-                _ => count += 1,
-            }
-        }
-
-        if count > MAX_FINITE_COMPARISON_PAIRS {
-            return over_limit;
-        }
-    }
-
-    count
 }
 
 /// Return a constraint for literal pairs whose equality cannot be decided statically.


### PR DESCRIPTION
## Summary

Follow-up to #25788.

Equality narrowing recursively expands finite types such as enums and unions. When both operands contain many alternatives, we could compare every pair, making large comparisons quadratic. Aliases and intersections could also hide that expansion until recursion, bypassing top-level guards.

This moves the work limit into the existing `ComparisonEvaluator`, where we can bound the actual recursive evaluation instead of estimating domain sizes in a separate traversal. Expanding one operand remains linear; after both operands branch, we allow up to 256 evaluations before conservatively returning an ambiguous result. If exhaustion occurs after accumulating partial results, we discard the entire root result so narrowing does not depend on traversal order.

We still preserve inexpensive definite results for domains with known comparison semantics. Disjoint object-identity domains can be recognized from their runtime classes without comparing every pair, including domains exposed through aliases, unions, `NewType`, and constrained `TypeVar`s. Generic specializations of the same runtime class continue to overlap because their type arguments are erased at runtime.

The added mdtests cover narrowing within and beyond the budget, disjoint domains, transparent wrappers, and generic identity overlap. Two microbenchmarks exercise hidden finite-domain expansion and large disjoint final-class unions.
