### PR TITLE
[`flake8-type-checking`] Avoid escape sequences in the TC006 fix

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-type-checking/runtime-cast-value.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-type-checking/runtime-cast-value.md
@@ -1,0 +1,153 @@
+# `runtime-cast-value` (`TC006`)
+
+Add quotes to the type expression passed as the first argument to `typing.cast()`.
+
+```toml
+[lint]
+select = ["TC006"]
+```
+
+## Nested quotes that would need escaping
+
+A type checker rejects an escape sequence in a forward reference, so a nested quote is
+wrapped in triple quotes rather than escaped.
+
+```py
+from typing import Literal, cast
+
+cast(Literal["'"], "'")  # snapshot: runtime-cast-value
+cast(Literal['"'], '"')  # snapshot: runtime-cast-value
+cast(Literal['"""'], "")  # snapshot: runtime-cast-value
+```
+
+```snapshot
+error[TC006]: Add quotes to type expression in `typing.cast()`
+ --> src/mdtest_snippet.py:3:6
+  |
+3 | cast(Literal["'"], "'")  # snapshot: runtime-cast-value
+  |      ^^^^^^^^^^^^
+help: Add quotes
+  |
+2 |
+  - cast(Literal["'"], "'")  # snapshot: runtime-cast-value
+3 + cast("""Literal["'"]""", "'")  # snapshot: runtime-cast-value
+4 | cast(Literal['"'], '"')  # snapshot: runtime-cast-value
+  |
+
+
+error[TC006]: Add quotes to type expression in `typing.cast()`
+ --> src/mdtest_snippet.py:4:6
+  |
+4 | cast(Literal['"'], '"')  # snapshot: runtime-cast-value
+  |      ^^^^^^^^^^^^
+help: Add quotes
+  |
+3 | cast(Literal["'"], "'")  # snapshot: runtime-cast-value
+  - cast(Literal['"'], '"')  # snapshot: runtime-cast-value
+4 + cast("""Literal['"']""", '"')  # snapshot: runtime-cast-value
+5 | cast(Literal['"""'], "")  # snapshot: runtime-cast-value
+  |
+
+
+error[TC006]: Add quotes to type expression in `typing.cast()`
+ --> src/mdtest_snippet.py:5:6
+  |
+5 | cast(Literal['"""'], "")  # snapshot: runtime-cast-value
+  |      ^^^^^^^^^^^^^^
+help: Add quotes
+  |
+4 | cast(Literal['"'], '"')  # snapshot: runtime-cast-value
+  - cast(Literal['"""'], "")  # snapshot: runtime-cast-value
+5 + cast('''Literal['"""']''', "")  # snapshot: runtime-cast-value
+  |
+```
+
+## No fix when every quote style is used
+
+Every quote style already appears in the type expression, so no wrapper can avoid an
+escape and no fix is offered.
+
+```py
+from typing import Literal, cast
+
+cast(Literal["'", '"', "'''", '"""'], "")  # snapshot: runtime-cast-value
+```
+
+```snapshot
+error[TC006]: Add quotes to type expression in `typing.cast()`
+ --> src/mdtest_snippet.py:3:6
+  |
+3 | cast(Literal["'", '"', "'''", '"""'], "")  # snapshot: runtime-cast-value
+  |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Add quotes
+```
+
+## No fix when an escape is not a quote
+
+Changing the wrapper cannot remove a `\n`, so no fix is offered here either. This case
+asserts only the diagnostic because mdtest renders a backslash as `/`; the `TC006.py`
+fixture snapshots the absent fix.
+
+```py
+from typing import Literal, cast
+
+cast(Literal["\n"], "\n")  # error: [runtime-cast-value]
+```
+
+## Inside an f-string before PEP 701
+
+```toml
+target-version = "py311"
+
+[lint]
+select = ["TC006"]
+```
+
+Before Python 3.12 an f-string cannot reuse its own quote character, so a wrapper that
+would collide with the enclosing delimiter is not available and no fix is offered.
+
+```py
+from typing import Literal, cast
+
+x = f"""{cast(Literal["'''"], "")}"""  # snapshot: runtime-cast-value
+```
+
+```snapshot
+error[TC006]: Add quotes to type expression in `typing.cast()`
+ --> src/mdtest_snippet.py:3:15
+  |
+3 | x = f"""{cast(Literal["'''"], "")}"""  # snapshot: runtime-cast-value
+  |               ^^^^^^^^^^^^^^
+help: Add quotes
+```
+
+## Inside an f-string from PEP 701 on
+
+```toml
+target-version = "py312"
+
+[lint]
+select = ["TC006"]
+```
+
+PEP 701 lifts that restriction, so the same expression is quoted normally.
+
+```py
+from typing import Literal, cast
+
+x = f"""{cast(Literal["'''"], "")}"""  # snapshot: runtime-cast-value
+```
+
+```snapshot
+error[TC006]: Add quotes to type expression in `typing.cast()`
+ --> src/mdtest_snippet.py:3:15
+  |
+3 | x = f"""{cast(Literal["'''"], "")}"""  # snapshot: runtime-cast-value
+  |               ^^^^^^^^^^^^^^
+help: Add quotes
+  |
+2 |
+  - x = f"""{cast(Literal["'''"], "")}"""  # snapshot: runtime-cast-value
+3 + x = f"""{cast("""Literal["'''"]""", "")}"""  # snapshot: runtime-cast-value
+  |
+```

--- a/crates/ruff_linter/resources/mdtest/flake8-type-checking/runtime-import-in-type-checking-block.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-type-checking/runtime-import-in-type-checking-block.md
@@ -1,0 +1,77 @@
+# `runtime-import-in-type-checking-block` (`TC004`)
+
+With \[`lint.flake8-type-checking.quote-annotations`\] enabled, an import inside an
+`if TYPE_CHECKING:` block that is used at runtime can be kept in place by quoting its runtime
+references instead of moving the import out of the block.
+
+Quoting is all-or-nothing across the import's references. If any runtime reference cannot be
+quoted without leaving an escape, no fix is offered. Quoting only some references would leave
+the others referring to a name that the type-checking import does not provide at runtime.
+
+```toml
+[lint]
+select = ["TC004"]
+
+[lint.flake8-type-checking]
+quote-annotations = true
+```
+
+## Every reference can be quoted
+
+```py
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from third_party import Type  # snapshot: runtime-import-in-type-checking-block
+
+def f(x: Type[int]): ...
+def g(x: Type[str]): ...
+```
+
+```snapshot
+error[TC004]: Quote references to `third_party.Type`. Import is in a type-checking block.
+ --> src/mdtest_snippet.py:4:29
+  |
+4 |     from third_party import Type  # snapshot: runtime-import-in-type-checking-block
+  |                             ^^^^
+5 |
+6 | def f(x: Type[int]): ...
+  |          ---- Used at runtime here
+help: Quote references
+  |
+5 |
+  - def f(x: Type[int]): ...
+  - def g(x: Type[str]): ...
+6 + def f(x: "Type[int]"): ...
+7 + def g(x: "Type[str]"): ...
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## A reference cannot be quoted
+
+`Type[Literal["'", '"', "'''", '"""']]` uses every quote style, so it has no escape-free
+wrapper. The diagnostic is still reported, but Ruff leaves every reference unquoted rather
+than quoting the ones it can.
+
+```py
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from third_party import Type  # snapshot: runtime-import-in-type-checking-block
+
+def f(x: Type[int]): ...
+def g(x: Type[Literal["'", '"', "'''", '"""']]): ...
+```
+
+```snapshot
+error[TC004]: Quote references to `third_party.Type`. Import is in a type-checking block.
+ --> src/mdtest_snippet.py:4:29
+  |
+4 |     from third_party import Type  # snapshot: runtime-import-in-type-checking-block
+  |                             ^^^^
+5 |
+6 | def f(x: Type[int]): ...
+  |          ---- Used at runtime here
+help: Quote references
+```

--- a/crates/ruff_linter/resources/mdtest/flake8-type-checking/typing-only-third-party-import.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-type-checking/typing-only-third-party-import.md
@@ -1,0 +1,74 @@
+# `typing-only-third-party-import` (`TC002`)
+
+With \[`lint.flake8-type-checking.quote-annotations`\] enabled, a third-party import that is
+used only in annotations is moved into an `if TYPE_CHECKING:` block and its runtime
+references are quoted.
+
+Quoting is all-or-nothing across the import's references. If any runtime reference cannot be
+quoted without leaving an escape, the import is left in place. Quoting only some references
+while moving the import would leave the others pointing at a name that is no longer available
+at runtime.
+
+```toml
+[lint]
+select = ["TC002"]
+
+[lint.flake8-type-checking]
+quote-annotations = true
+```
+
+## Every reference can be quoted
+
+The import moves into the type-checking block and both references are quoted.
+
+```py
+from third_party import Type  # snapshot: typing-only-third-party-import
+
+def f(x: Type[int]): ...
+def g(x: Type[str]): ...
+```
+
+```snapshot
+error[TC002]: Move third-party import `third_party.Type` into a type-checking block
+ --> src/mdtest_snippet.py:1:25
+  |
+1 | from third_party import Type  # snapshot: typing-only-third-party-import
+  |                         ^^^^
+help: Move into type-checking block
+  |
+  - from third_party import Type  # snapshot: typing-only-third-party-import
+1 + from typing import TYPE_CHECKING
+2 |
+  - def f(x: Type[int]): ...
+  - def g(x: Type[str]): ...
+3 + if TYPE_CHECKING:
+4 +     from third_party import Type
+5 +
+6 + def f(x: "Type[int]"): ...
+7 + def g(x: "Type[str]"): ...
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## A reference cannot be quoted
+
+`Type[Literal["'", '"', "'''", '"""']]` uses every quote style, so it has no escape-free
+wrapper. The diagnostic is still reported, but Ruff leaves the import where it is rather
+than moving it and quoting only some of the references.
+
+```py
+from typing import Literal
+from third_party import Type  # snapshot: typing-only-third-party-import
+
+def f(x: Type[int]): ...
+def g(x: Type[Literal["'", '"', "'''", '"""']]): ...
+```
+
+```snapshot
+error[TC002]: Move third-party import `third_party.Type` into a type-checking block
+ --> src/mdtest_snippet.py:2:25
+  |
+2 | from third_party import Type  # snapshot: typing-only-third-party-import
+  |                         ^^^^
+help: Move into type-checking block
+```

--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC006.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC006.py
@@ -97,3 +97,24 @@ def f():
 
     cast(typ=int, val=3.0)  # TC006
     cast(val=3.0, typ=int)  # TC006
+
+
+def f():
+    # No fix: the escape survives every quote style
+    from typing import cast, Literal
+
+    cast(Literal["\n"], "\n")  # TC006
+
+
+def f():
+    # A trailing quote would run into a `"""` closing delimiter, so this falls back to `'''`
+    from typing import cast, Literal
+
+    cast(Literal["it's"] | "(", "")  # TC006
+
+
+def f():
+    # No fix: the trailing quote rules out `"""` and the content already holds `'''`
+    from typing import cast, Literal
+
+    cast(Literal["'''"] | "(", "")  # TC006

--- a/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC007.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_type_checking/TC007.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, TypeAlias, TYPE_CHECKING
+from typing import Dict, Literal, TypeAlias, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Dict
@@ -20,6 +20,7 @@ g: TypeAlias = Foo | Bar  # TC007 x2
 h: TypeAlias = Foo[str]  # TC007
 i: TypeAlias = (Foo |  # TC007 x2 (fix removes comment currently)
     Bar)
+j: TypeAlias = Foo | Literal["\n"]  # TC007 (no fix: quoting would leave a non-quote escape)
 
 type C = Foo   # OK
 type D = Foo | None  # OK

--- a/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
@@ -1,8 +1,10 @@
 use std::cmp::Reverse;
 
+use ruff_python_ast::PythonVersion;
+use ruff_python_ast::StringFlags;
 use ruff_python_ast::helpers::{map_callable, map_subscript};
 use ruff_python_ast::name::QualifiedName;
-use ruff_python_ast::str::Quote;
+use ruff_python_ast::str::{Quote, TripleQuotes};
 use ruff_python_ast::visitor::transformer::{Transformer, walk_expr};
 use ruff_python_ast::{self as ast, Decorator, Expr, StringLiteralFlags};
 use ruff_python_codegen::{Generator, Stylist};
@@ -10,7 +12,7 @@ use ruff_python_parser::typing::parse_type_annotation;
 use ruff_python_semantic::{
     Binding, BindingKind, Modules, NodeId, ScopeKind, SemanticModel, analyze,
 };
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::Ranged;
 
 use crate::Edit;
 use crate::Locator;
@@ -314,13 +316,16 @@ pub(crate) fn is_singledispatch_implementation(
 /// - When quoting `Series` in `Series[Literal["pd.Timestamp"]]`, we want `"Series[Literal['pd.Timestamp']]"`.
 ///
 /// In general, when expanding a component of a call chain, we want to quote the entire call chain.
+///
+/// Returns `None` when the annotation has no escape-free quoted form.
 pub(crate) fn quote_annotation(
     node_id: NodeId,
     semantic: &SemanticModel,
     stylist: &Stylist,
     locator: &Locator,
     flags: StringLiteralFlags,
-) -> Edit {
+    target_version: PythonVersion,
+) -> Option<Edit> {
     let expr = semantic.expression(node_id).expect("Expression not found");
     if let Some(parent_id) = semantic.parent_expression_id(node_id) {
         match semantic.expression(parent_id) {
@@ -328,31 +333,59 @@ pub(crate) fn quote_annotation(
                 // If we're quoting the value of a subscript, we need to quote the entire
                 // expression. For example, when quoting `DataFrame` in `DataFrame[int]`, we
                 // should generate `"DataFrame[int]"`.
-                return quote_annotation(parent_id, semantic, stylist, locator, flags);
+                return quote_annotation(
+                    parent_id,
+                    semantic,
+                    stylist,
+                    locator,
+                    flags,
+                    target_version,
+                );
             }
             Some(Expr::Attribute(parent)) if expr == parent.value.as_ref() => {
                 // If we're quoting the value of an attribute, we need to quote the entire
                 // expression. For example, when quoting `DataFrame` in `pd.DataFrame`, we
                 // should generate `"pd.DataFrame"`.
-                return quote_annotation(parent_id, semantic, stylist, locator, flags);
+                return quote_annotation(
+                    parent_id,
+                    semantic,
+                    stylist,
+                    locator,
+                    flags,
+                    target_version,
+                );
             }
             Some(Expr::Call(parent)) if expr == parent.func.as_ref() => {
                 // If we're quoting the function of a call, we need to quote the entire
                 // expression. For example, when quoting `DataFrame` in `DataFrame()`, we
                 // should generate `"DataFrame()"`.
-                return quote_annotation(parent_id, semantic, stylist, locator, flags);
+                return quote_annotation(
+                    parent_id,
+                    semantic,
+                    stylist,
+                    locator,
+                    flags,
+                    target_version,
+                );
             }
             Some(Expr::BinOp(parent)) if parent.op.is_bit_or() => {
                 // If we're quoting the left or right side of a binary operation, we need to
                 // quote the entire expression. For example, when quoting `DataFrame` in
                 // `DataFrame | Series`, we should generate `"DataFrame | Series"`.
-                return quote_annotation(parent_id, semantic, stylist, locator, flags);
+                return quote_annotation(
+                    parent_id,
+                    semantic,
+                    stylist,
+                    locator,
+                    flags,
+                    target_version,
+                );
             }
             _ => {}
         }
     }
 
-    quote_type_expression(expr, semantic, stylist, locator, flags)
+    quote_type_expression(expr, semantic, stylist, locator, flags, target_version)
 }
 
 /// Wrap a type expression in quotes.
@@ -363,17 +396,25 @@ pub(crate) fn quote_annotation(
 ///
 /// In most cases you want to call [`quote_annotation`] instead, which provides
 /// that guarantee by expanding the expression before calling into this function.
+///
+/// Returns `None` when no quote style wraps the expression without an escape.
 pub(crate) fn quote_type_expression(
     expr: &Expr,
     semantic: &SemanticModel,
     stylist: &Stylist,
     locator: &Locator,
     flags: StringLiteralFlags,
-) -> Edit {
+    target_version: PythonVersion,
+) -> Option<Edit> {
     // Quote the entire expression.
-    let quote_annotator = QuoteAnnotator::new(semantic, stylist, locator, flags);
-
-    Edit::range_replacement(quote_annotator.into_annotation(expr), expr.range())
+    let quote_annotator = QuoteAnnotator::new(semantic, stylist, locator, flags, target_version);
+    let annotation = quote_annotator.into_annotation(expr)?;
+    // No wrapper removes an escape like the `\n` in `Literal["\n"]`, and a type checker
+    // rejects any escape in a forward reference.
+    if annotation.contains('\\') {
+        return None;
+    }
+    Some(Edit::range_replacement(annotation, expr.range()))
 }
 
 /// Filter out any [`Edit`]s that are completely contained by any other [`Edit`].
@@ -396,11 +437,62 @@ pub(crate) fn filter_contained(edits: Vec<Edit>) -> Vec<Edit> {
     filtered
 }
 
+/// Pick string flags that wrap `annotation` without escaping any quote character.
+///
+/// Tries the preferred quote, then the opposite, then each of those triple-quoted.
+/// Returns `None` when none of the candidates fit, as for `Literal["'", '"', "'''", '"""']`.
+///
+/// `opposite_allowed` is `false` where a triple-quoted opposite wrapper would reuse an
+/// enclosing interpolated string's own quote character.
+fn flags_avoiding_escape_sequences(
+    annotation: &str,
+    preferred: StringLiteralFlags,
+    opposite_allowed: bool,
+) -> Option<StringLiteralFlags> {
+    let quote = preferred.quote_style();
+
+    if !annotation.contains(quote.as_char()) {
+        return Some(preferred);
+    }
+
+    let opposite = quote.opposite();
+    if !annotation.contains(opposite.as_char()) {
+        return Some(preferred.with_quote_style(opposite));
+    }
+
+    let triple = preferred.with_triple_quotes(TripleQuotes::Yes);
+    if fits_in_triple_quotes(annotation, triple) {
+        return Some(triple);
+    }
+
+    if !opposite_allowed {
+        return None;
+    }
+
+    let triple_opposite = preferred
+        .with_quote_style(opposite)
+        .with_triple_quotes(TripleQuotes::Yes);
+    if fits_in_triple_quotes(annotation, triple_opposite) {
+        return Some(triple_opposite);
+    }
+
+    None
+}
+
+/// Returns `true` if `annotation` fits between the triple-quoted delimiters of `flags`.
+///
+/// A trailing quote of the same character runs into the closing delimiter and leaves the
+/// string unterminated, so `Foo | "("` cannot go inside `"""`.
+fn fits_in_triple_quotes(annotation: &str, flags: StringLiteralFlags) -> bool {
+    !annotation.contains(flags.quote_str()) && !annotation.ends_with(flags.quote_style().as_char())
+}
+
 pub(crate) struct QuoteAnnotator<'a> {
     semantic: &'a SemanticModel<'a>,
     stylist: &'a Stylist<'a>,
     locator: &'a Locator<'a>,
     flags: StringLiteralFlags,
+    target_version: PythonVersion,
 }
 
 impl<'a> QuoteAnnotator<'a> {
@@ -409,29 +501,33 @@ impl<'a> QuoteAnnotator<'a> {
         stylist: &'a Stylist<'a>,
         locator: &'a Locator<'a>,
         flags: StringLiteralFlags,
+        target_version: PythonVersion,
     ) -> Self {
         Self {
             semantic,
             stylist,
             locator,
             flags,
+            target_version,
         }
     }
 
-    fn into_annotation(self, expr: &Expr) -> String {
+    fn into_annotation(self, expr: &Expr) -> Option<String> {
         let mut expr_without_forward_references = expr.clone();
         self.visit_expr(&mut expr_without_forward_references);
-        let generator = Generator::from(self.stylist);
-        // we first generate the annotation with the inverse quote, so we can
-        // generate the string literal with the preferred quote
         let subgenerator = Generator::new(self.stylist.indentation(), self.stylist.line_ending());
         let annotation = subgenerator.expr(&expr_without_forward_references);
-        generator.expr(&Expr::from(ast::StringLiteral {
-            range: TextRange::default(),
-            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-            value: annotation.into_boxed_str(),
-            flags: self.flags,
-        }))
+        // Before PEP 701 an interpolated string cannot reuse its own quote character. `flags`
+        // already holds the reversed quote inside one, so only the opposite-quote wrapper
+        // would collide with the enclosing delimiter.
+        let opposite_allowed =
+            !self.semantic.in_interpolated_string() || self.target_version.supports_pep_701();
+        // Wrap by hand instead of generating a string literal. The generator escapes a quote
+        // character even inside `"""..."""`, and a type checker rejects that escape in a
+        // forward reference.
+        let flags = flags_avoiding_escape_sequences(&annotation, self.flags, opposite_allowed)?;
+        let quote = flags.quote_str();
+        Some(format!("{quote}{annotation}{quote}"))
     }
 
     fn visit_annotated_slice(&self, slice: &mut Expr) {

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_cast_value.rs
@@ -5,7 +5,7 @@ use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
 use crate::rules::flake8_type_checking::helpers::quote_type_expression;
-use crate::{AlwaysFixableViolation, Fix};
+use crate::{Fix, FixAvailability, Violation};
 
 /// ## What it does
 /// Checks for unquoted type expressions in `typing.cast()` calls.
@@ -40,20 +40,25 @@ use crate::{AlwaysFixableViolation, Fix};
 /// ```
 ///
 /// ## Fix safety
-/// This fix is safe as long as the type expression doesn't span multiple
-/// lines and includes comments on any of the lines apart from the last one.
+/// This rule's fix is marked as unsafe when the type expression contains a comment,
+/// since quoting it would drop the comment.
+///
+/// No fix is offered when the type expression cannot be quoted without an escape
+/// sequence, which a type checker rejects in a forward reference.
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "0.10.0")]
 pub(crate) struct RuntimeCastValue;
 
-impl AlwaysFixableViolation for RuntimeCastValue {
+impl Violation for RuntimeCastValue {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         "Add quotes to type expression in `typing.cast()`".to_string()
     }
 
-    fn fix_title(&self) -> String {
-        "Add quotes".to_string()
+    fn fix_title(&self) -> Option<String> {
+        Some("Add quotes".to_string())
     }
 }
 
@@ -64,13 +69,17 @@ pub(crate) fn runtime_cast_value(checker: &Checker, type_expr: &Expr) {
     }
 
     let mut diagnostic = checker.report_diagnostic(RuntimeCastValue, type_expr.range());
-    let edit = quote_type_expression(
+    let Some(edit) = quote_type_expression(
         type_expr,
         checker.semantic(),
         checker.stylist(),
         checker.locator(),
         checker.default_string_flags(),
-    );
+        checker.target_version(),
+    ) else {
+        return;
+    };
+    // Quoting drops any comment inside the type expression.
     if checker.comment_ranges().intersects(type_expr.range()) {
         diagnostic.set_fix(Fix::unsafe_edit(edit));
     } else {

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -252,7 +252,9 @@ pub(crate) fn runtime_import_in_type_checking_block(checker: &Checker, scope: &S
                     if let Some(range) = parent_range {
                         diagnostic.set_parent(range.start());
                     }
-                    diagnostic.set_fix(fix.clone());
+                    if let Some(fix) = fix.as_ref() {
+                        diagnostic.set_fix(fix.clone());
+                    }
                 }
             }
 
@@ -283,34 +285,39 @@ pub(crate) fn runtime_import_in_type_checking_block(checker: &Checker, scope: &S
 }
 
 /// Generate a [`Fix`] to quote runtime usages for imports in a type-checking block.
-fn quote_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) -> Fix {
-    let quote_reference_edits = filter_contained(
-        imports
-            .iter()
-            .flat_map(|ImportBinding { binding, .. }| {
-                binding.references.iter().filter_map(|reference_id| {
-                    let reference = checker.semantic().reference(*reference_id);
-                    if reference.in_runtime_context() {
-                        Some(quote_annotation(
-                            reference.expression_id()?,
-                            checker.semantic(),
-                            checker.stylist(),
-                            checker.locator(),
-                            checker.default_string_flags(),
-                        ))
-                    } else {
-                        None
-                    }
-                })
-            })
-            .collect::<Vec<_>>(),
-    );
+fn quote_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) -> Option<Fix> {
+    let quote_reference_edits = imports
+        .iter()
+        .flat_map(|ImportBinding { binding, .. }| binding.references.iter())
+        .filter_map(|reference_id| {
+            let reference = checker.semantic().reference(*reference_id);
+            if reference.in_runtime_context() {
+                reference.expression_id()
+            } else {
+                None
+            }
+        })
+        .map(|expression_id| {
+            quote_annotation(
+                expression_id,
+                checker.semantic(),
+                checker.stylist(),
+                checker.locator(),
+                checker.default_string_flags(),
+                checker.target_version(),
+            )
+        })
+        // All or nothing: quoting only some of the references would leave the rest naming
+        // something that does not exist at runtime.
+        .collect::<Option<Vec<_>>>()?;
+
+    let quote_reference_edits = filter_contained(quote_reference_edits);
 
     let mut rest = quote_reference_edits.into_iter();
-    let head = rest.next().expect("Expected at least one reference");
-    Fix::unsafe_edits(head, rest).isolate(Checker::isolation(
+    let head = rest.next()?;
+    Some(Fix::unsafe_edits(head, rest).isolate(Checker::isolation(
         checker.semantic().parent_statement_id(node_id),
-    ))
+    )))
 }
 
 /// Generate a [`Fix`] to remove runtime imports from a type-checking block.

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
@@ -39,10 +39,12 @@ use ruff_python_ast::token::parenthesized_range;
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is currently always marked as unsafe, since runtime
-/// typing libraries may try to access/resolve the type alias in a way
-/// that we can't statically determine during analysis and relies on the
-/// type alias not containing any forward references.
+/// This rule's fix is marked as unsafe, since runtime typing libraries may try to
+/// access/resolve the type alias in a way that we can't statically determine during
+/// analysis and relies on the type alias not containing any forward references.
+///
+/// No fix is offered when the type alias cannot be quoted without an escape sequence,
+/// which a type checker rejects in a forward reference.
 ///
 /// ## References
 /// - [PEP 613 – Explicit Type Aliases](https://peps.python.org/pep-0613/)
@@ -53,7 +55,7 @@ use ruff_python_ast::token::parenthesized_range;
 pub(crate) struct UnquotedTypeAlias;
 
 impl Violation for UnquotedTypeAlias {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {
@@ -184,11 +186,14 @@ pub(crate) fn unquoted_type_alias(checker: &Checker, binding: &Binding) {
         checker.stylist(),
         checker.locator(),
         checker.default_string_flags(),
+        checker.target_version(),
     );
     for name in names {
         let mut diagnostic = checker.report_diagnostic(UnquotedTypeAlias, name.range());
         diagnostic.set_parent(parent);
-        diagnostic.set_fix(Fix::unsafe_edit(edit.clone()));
+        if let Some(edit) = &edit {
+            diagnostic.set_fix(Fix::unsafe_edit(edit.clone()));
+        }
     }
 }
 

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -401,7 +401,7 @@ pub(crate) fn typing_only_runtime_import(
         reason = "each statement group produces diagnostics and a fix independently"
     )]
     for ((node_id, import_type), imports) in errors_by_statement {
-        let fix = fix_imports(checker, node_id, &imports).ok();
+        let fix = fix_imports(checker, node_id, &imports).ok().flatten();
 
         for ImportBinding {
             import,
@@ -511,7 +511,14 @@ fn is_exempt(name: &str, exempt_modules: &[&str]) -> bool {
 }
 
 /// Generate a [`Fix`] to remove typing-only imports from a runtime context.
-fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) -> Result<Fix> {
+///
+/// Returns `Ok(None)` when a runtime reference cannot be quoted without an escape
+/// sequence, since the import cannot then move under `TYPE_CHECKING` safely.
+fn fix_imports(
+    checker: &Checker,
+    node_id: NodeId,
+    imports: &[ImportBinding],
+) -> Result<Option<Fix>> {
     let statement = checker.semantic().statement(node_id);
     let parent = checker.semantic().parent_statement(node_id);
 
@@ -570,27 +577,35 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
                 .chain(std::iter::once(remove_import_edit)),
         )
     } else {
-        let quote_reference_edits = filter_contained(
-            imports
-                .iter()
-                .flat_map(|ImportBinding { binding, .. }| {
-                    binding.references.iter().filter_map(|reference_id| {
-                        let reference = checker.semantic().reference(*reference_id);
-                        if reference.in_runtime_context() {
-                            Some(quote_annotation(
-                                reference.expression_id()?,
-                                checker.semantic(),
-                                checker.stylist(),
-                                checker.locator(),
-                                checker.default_string_flags(),
-                            ))
-                        } else {
-                            None
-                        }
-                    })
-                })
-                .collect::<Vec<_>>(),
-        );
+        let Some(quote_reference_edits) = imports
+            .iter()
+            .flat_map(|ImportBinding { binding, .. }| binding.references.iter())
+            .filter_map(|reference_id| {
+                let reference = checker.semantic().reference(*reference_id);
+                if reference.in_runtime_context() {
+                    reference.expression_id()
+                } else {
+                    None
+                }
+            })
+            .map(|expression_id| {
+                quote_annotation(
+                    expression_id,
+                    checker.semantic(),
+                    checker.stylist(),
+                    checker.locator(),
+                    checker.default_string_flags(),
+                    checker.target_version(),
+                )
+            })
+            // All or nothing: moving the import under `TYPE_CHECKING` while one reference
+            // stays unquoted would leave that reference naming something unavailable at
+            // runtime.
+            .collect::<Option<Vec<_>>>()
+        else {
+            return Ok(None);
+        };
+        let quote_reference_edits = filter_contained(quote_reference_edits);
         Fix::unsafe_edits(
             type_checking_edit,
             add_import_edit
@@ -600,7 +615,7 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
         )
     };
 
-    Ok(fix.isolate(Checker::isolation(
+    Ok(Some(fix.isolate(Checker::isolation(
         checker.semantic().parent_statement_id(node_id),
-    )))
+    ))))
 }

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-cast-value_TC006.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__runtime-cast-value_TC006.py.snap
@@ -197,8 +197,42 @@ TC006 [*] Add quotes to type expression in `typing.cast()`
 99 |     cast(val=3.0, typ=int)  # TC006
    |                       ^^^
 help: Add quotes
-   |
-98 |     cast(typ=int, val=3.0)  # TC006
-   -     cast(val=3.0, typ=int)  # TC006
-99 +     cast(val=3.0, typ="int")  # TC006
-   |
+    |
+98  |     cast(typ=int, val=3.0)  # TC006
+    -     cast(val=3.0, typ=int)  # TC006
+99  +     cast(val=3.0, typ="int")  # TC006
+100 |
+    |
+
+TC006 Add quotes to type expression in `typing.cast()`
+   --> TC006.py:106:10
+    |
+104 |     from typing import cast, Literal
+105 |
+106 |     cast(Literal["\n"], "\n")  # TC006
+    |          ^^^^^^^^^^^^^
+help: Add quotes
+
+TC006 [*] Add quotes to type expression in `typing.cast()`
+   --> TC006.py:113:10
+    |
+111 |     from typing import cast, Literal
+112 |
+113 |     cast(Literal["it's"] | "(", "")  # TC006
+    |          ^^^^^^^^^^^^^^^^^^^^^
+help: Add quotes
+    |
+112 |
+    -     cast(Literal["it's"] | "(", "")  # TC006
+113 +     cast('''Literal["it's"] | "("''', "")  # TC006
+114 |
+    |
+
+TC006 Add quotes to type expression in `typing.cast()`
+   --> TC006.py:120:10
+    |
+118 |     from typing import cast, Literal
+119 |
+120 |     cast(Literal["'''"] | "(", "")  # TC006
+    |          ^^^^^^^^^^^^^^^^^^^^
+help: Add quotes

--- a/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__unquoted-type-alias_TC007.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/snapshots/ruff_linter__rules__flake8_type_checking__tests__unquoted-type-alias_TC007.py.snap
@@ -142,6 +142,7 @@ TC007 [*] Add quotes to type alias
 21 | i: TypeAlias = (Foo |  # TC007 x2 (fix removes comment currently)
    |                 ^^^
 22 |     Bar)
+23 | j: TypeAlias = Foo | Literal["\n"]  # TC007 (no fix: quoting would leave a non-quote escape)
    |
 help: Add quotes
    |
@@ -149,7 +150,7 @@ help: Add quotes
    - i: TypeAlias = (Foo |  # TC007 x2 (fix removes comment currently)
    -     Bar)
 21 + i: TypeAlias = ("Foo | Bar")
-22 |
+22 | j: TypeAlias = Foo | Literal["\n"]  # TC007 (no fix: quoting would leave a non-quote escape)
    |
 note: This is an unsafe fix and may change runtime behavior
 
@@ -160,8 +161,7 @@ TC007 [*] Add quotes to type alias
 21 | i: TypeAlias = (Foo |  # TC007 x2 (fix removes comment currently)
 22 |     Bar)
    |     ^^^
-23 |
-24 | type C = Foo   # OK
+23 | j: TypeAlias = Foo | Literal["\n"]  # TC007 (no fix: quoting would leave a non-quote escape)
    |
 help: Add quotes
    |
@@ -169,6 +169,18 @@ help: Add quotes
    - i: TypeAlias = (Foo |  # TC007 x2 (fix removes comment currently)
    -     Bar)
 21 + i: TypeAlias = ("Foo | Bar")
-22 |
+22 | j: TypeAlias = Foo | Literal["\n"]  # TC007 (no fix: quoting would leave a non-quote escape)
    |
 note: This is an unsafe fix and may change runtime behavior
+
+TC007 Add quotes to type alias
+  --> TC007.py:23:16
+   |
+21 | i: TypeAlias = (Foo |  # TC007 x2 (fix removes comment currently)
+22 |     Bar)
+23 | j: TypeAlias = Foo | Literal["\n"]  # TC007 (no fix: quoting would leave a non-quote escape)
+   |                ^^^
+24 |
+25 | type C = Foo   # OK
+   |
+help: Add quotes


### PR DESCRIPTION
## Summary

Fixes #22131.

The `TC006` fix quotes the type expression in `typing.cast()` to make it a forward reference.
The old output escaped a quote character when an inner string used the same quote as the wrapper, so `cast(Literal["'"], "'")` became `cast("Literal[\"'\"]", "'")`.
ty rejects escape sequences in forward references, so the autofix produced code that fails type checking.

The fix picks a quote style that avoids the escape.
It tries the preferred quote, the opposite, then the triple-quoted forms, wrapping by hand because the generator escapes the inner quote even inside triple quotes.
A triple-quoted candidate is rejected when the expression ends with that quote character, and inside an f-string before Python 3.12 a candidate that reuses the enclosing quote is skipped.

`cast(Literal["'"], "'")` now becomes `cast("""Literal["'"]""", "'")`, which ty accepts.
When no wrapper avoids an escape, because the expression uses every quote style or contains a non-quote escape like `\n`, the helpers return `None` and no fix is offered.

The quote helpers are shared, so `TC001`/`TC002`/`TC003` and `TC004` now drop their whole fix when any runtime reference has no escape-free form.
Previously they quoted the other references and moved the import into `TYPE_CHECKING`, leaving the unquoted name to fail at runtime.
`RuntimeCastValue` and `UnquotedTypeAlias` move to sometimes-available fixes.
Flagging that as a rule behavior change for the changelog label.

## Test Plan

New cases in the `TC006.py` fixture (nested quotes, `"""`, every quote style, `\n`) with the snapshot showing the triple-quoted fixes and the cases that get no fix.
mdtests cover the new all-or-nothing behavior for `TC002`/`TC004` and the f-string cases on Python 3.11 vs 3.12.
Built the patched binaries and ran ty on the fix output. The reporter's cases go from 5 escape-character errors to 0.
Applied fixes with both binaries across 513 files that carry a TC diagnostic in real projects. The output is byte-identical, so only the escape cases change.
