### PR TITLE
[ty] Preserve overloads through callable protocol decorators

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1001,6 +1001,43 @@ reveal_type(decorated_factory(1))  # revealed: int
 reveal_type(decorated_factory(y="x"))  # revealed: str
 ```
 
+A callable protocol can also describe a transparent decorator returned by a factory. Stacked
+decorators of this form preserve overload signatures independently.
+
+```py
+from typing import Callable, Literal, ParamSpec, Protocol, TypeVar, overload
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+class IdentityFunction(Protocol):
+    def __call__(self, func: Callable[P, R], /) -> Callable[P, R]: ...
+
+def deprecate_streaming_parameter() -> IdentityFunction:
+    raise NotImplementedError
+
+def forward_old_opt_flags() -> IdentityFunction:
+    raise NotImplementedError
+
+class DataFrame: ...
+class InProcessQuery: ...
+
+class LazyFrame:
+    @overload
+    def collect(self, *, background: Literal[True]) -> InProcessQuery: ...
+    @overload
+    def collect(self, *, background: Literal[False] = False) -> DataFrame: ...
+    @deprecate_streaming_parameter()
+    @forward_old_opt_flags()
+    def collect(self, *, background: bool = False) -> DataFrame | InProcessQuery:
+        raise NotImplementedError
+
+lazy_frame = LazyFrame()
+reveal_type(lazy_frame.collect())  # revealed: DataFrame
+reveal_type(lazy_frame.collect(background=False))  # revealed: DataFrame
+reveal_type(lazy_frame.collect(background=True))  # revealed: InProcessQuery
+```
+
 ### Overloads
 
 #### Return type filtering

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5312,11 +5312,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
                 return false;
             }
-            let decorator_signatures = match decorator_ty {
-                Type::FunctionLiteral(decorator_function) => decorator_function.signature(db),
-                Type::Callable(decorator_callable) => decorator_callable.signatures(db),
-                _ => return false,
+            let Some(decorator_callable) = decorator_ty
+                .try_upcast_to_callable(db)
+                .and_then(CallableTypes::exactly_one)
+            else {
+                return false;
             };
+            let decorator_signatures = decorator_callable.signatures(db);
             let [decorator_signature] = decorator_signatures.overloads.as_slice() else {
                 return false;
             };


### PR DESCRIPTION
## Summary

The workaround from #25030 only inspected function literals and direct `Callable` types. Polars types both decorators on `LazyFrame.collect` as an `IdentityFunction` protocol, so ty represented the decorator expressions as protocol instances and discarded the overload signatures.

This follow-up resolves the protocol's bound `__call__` method through the existing callable upcast path, while retaining the strict `Callable[P, R] -> Callable[P, R]` signature check.

Fixes the remaining Polars example reported in astral-sh/ty#2278.

## Test plan

Add a regression test case for it.
