### PR TITLE
Update zip dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,13 +69,6 @@
       enabled: false,
     },
     {
-      // Disable updates of `zip-rs`; intentionally pinned for now due to ownership change
-      // See: https://github.com/astral-sh/uv/issues/3642
-      matchPackageNames: ["zip"],
-      matchManagers: ["cargo"],
-      enabled: false,
-    },
-    {
       groupName: "prek dependencies",
       matchManagers: ["pre-commit"],
       description: "Weekly update of prek dependencies",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3949,12 +3949,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5782,7 +5776,6 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "zopfli",
  "zstd",
 ]
 
@@ -5797,18 +5790,6 @@ name = "zmij"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e0d8dffbae3d840f64bda38e28391faef673a7b5a6017840f2a106c8145868"
-
-[[package]]
-name = "zopfli"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,12 +354,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cachedir"
@@ -539,7 +542,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -668,7 +671,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -983,6 +986,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,7 +1036,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1102,7 +1116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1181,6 +1195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1950,6 +1965,15 @@ dependencies = [
  "anstyle",
  "clap",
  "escape8259",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3672,7 +3696,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3925,6 +3949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4079,10 +4109,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5275,7 +5305,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5743,16 +5773,24 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "2f852905151ac8d4d06fdca66520a661c09730a74c6d4e2b0f27b436b382e532"
 dependencies = [
- "byteorder",
+ "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
@@ -5761,21 +5799,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e0d8dffbae3d840f64bda38e28391faef673a7b5a6017840f2a106c8145868"
 
 [[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+name = "zopfli"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ wasm-bindgen = { version = "0.2.92" }
 wasm-bindgen-test = { version = "0.3.42" }
 which = { version = "8.0.0" }
 wild = { version = "2" }
-zip = { version = "0.6.6", default-features = false }
+zip = { version = "5.1", default-features = false }
 
 [workspace.metadata.cargo-shear]
 ignored = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ wasm-bindgen = { version = "0.2.92" }
 wasm-bindgen-test = { version = "0.3.42" }
 which = { version = "8.0.0" }
 wild = { version = "2" }
-zip = { version = "5.1", default-features = false }
+zip = { version = "5.1", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 
 [workspace.metadata.cargo-shear]
 ignored = [

--- a/crates/ruff_db/src/vendored.rs
+++ b/crates/ruff_db/src/vendored.rs
@@ -5,7 +5,7 @@ use std::io::{self, Read, Write};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use zip::result::ZipResult;
-use zip::write::FileOptions;
+use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter, read::ZipFile};
 
 pub use self::path::{VendoredPath, VendoredPathBuf};
@@ -232,7 +232,7 @@ impl Default for VendoredFileSystem {
         let mut cursor = io::Cursor::new(&mut bytes);
 
         {
-            let mut writer = ZipWriter::new(&mut cursor);
+            let writer = ZipWriter::new(&mut cursor);
             writer.finish().unwrap();
         }
 
@@ -256,8 +256,8 @@ struct ZipFileDebugInfo {
     kind: FileType,
 }
 
-impl<'a> From<ZipFile<'a>> for ZipFileDebugInfo {
-    fn from(value: ZipFile<'a>) -> Self {
+impl<'a, R: Read> From<ZipFile<'a, R>> for ZipFileDebugInfo {
+    fn from(value: ZipFile<'a, R>) -> Self {
         Self {
             crc32_hash: value.crc32(),
             compressed_size: value.compressed_size(),
@@ -305,7 +305,7 @@ pub struct Metadata {
 }
 
 impl Metadata {
-    fn from_zip_file(zip_file: ZipFile) -> Self {
+    fn from_zip_file<R: Read>(zip_file: ZipFile<'_, R>) -> Self {
         let kind = if zip_file.is_dir() {
             FileType::Directory
         } else {
@@ -360,7 +360,10 @@ impl VendoredZipArchive {
         Ok(Self(ZipArchive::new(io::Cursor::new(data))?))
     }
 
-    fn lookup_path(&mut self, path: &NormalizedVendoredPath) -> Result<ZipFile<'_>> {
+    fn lookup_path(
+        &mut self,
+        path: &NormalizedVendoredPath,
+    ) -> Result<ZipFile<'_, io::Cursor<Cow<'static, [u8]>>>> {
         Ok(self.0.by_name(path.as_str())?)
     }
 
@@ -477,14 +480,14 @@ impl VendoredFileSystemBuilder {
             .add_directory(path.as_ref().as_str(), self.options())
     }
 
-    pub fn finish(mut self) -> Result<VendoredFileSystem> {
+    pub fn finish(self) -> Result<VendoredFileSystem> {
         let buffer = self.writer.finish()?;
 
         VendoredFileSystem::new(buffer.into_inner())
     }
 
-    fn options(&self) -> FileOptions {
-        FileOptions::default()
+    fn options(&self) -> SimpleFileOptions {
+        SimpleFileOptions::default()
             .compression_method(self.compression_method)
             .unix_permissions(0o644)
     }

--- a/crates/ruff_db/src/vendored.rs
+++ b/crates/ruff_db/src/vendored.rs
@@ -81,11 +81,10 @@ impl VendoredFileSystem {
             // different paths in a zip file, but we want to abstract over that difference here
             // so that paths relative to the `VendoredFileSystem`
             // work the same as other paths in Ruff.
-            if let Ok(zip_file) = archive.lookup_path_raw(&normalized) {
-                return Ok(Metadata::from_zip_file(zip_file));
+            if let Ok(metadata) = archive.metadata_for_path(&normalized) {
+                return Ok(metadata);
             }
-            let zip_file = archive.lookup_path_raw(&normalized.with_trailing_slash())?;
-            Ok(Metadata::from_zip_file(zip_file))
+            archive.metadata_for_path(&normalized.with_trailing_slash())
         }
 
         metadata(self, path.as_ref())
@@ -371,12 +370,9 @@ impl VendoredZipArchive {
         Ok(self.0.by_name(path.as_str())?)
     }
 
-    fn lookup_path_raw(
-        &mut self,
-        path: &NormalizedVendoredPath,
-    ) -> Result<ZipFile<'_, io::Cursor<Cow<'static, [u8]>>>> {
+    fn metadata_for_path(&mut self, path: &NormalizedVendoredPath) -> Result<Metadata> {
         let index = self.index_for_path(path).ok_or(ZipError::FileNotFound)?;
-        Ok(self.0.by_index_raw(index)?)
+        Ok(Metadata::from_zip_file(self.0.by_index_raw(index)?))
     }
 
     fn len(&self) -> usize {

--- a/crates/ruff_db/src/vendored.rs
+++ b/crates/ruff_db/src/vendored.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Debug};
 use std::io::{self, Read, Write};
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use zip::result::ZipResult;
+use zip::result::{ZipError, ZipResult};
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter, read::ZipFile};
 
@@ -57,16 +57,16 @@ impl VendoredFileSystem {
     pub fn exists(&self, path: impl AsRef<VendoredPath>) -> bool {
         fn exists(fs: &VendoredFileSystem, path: &VendoredPath) -> bool {
             let normalized = NormalizedVendoredPath::from(path);
-            let mut archive = fs.lock_archive();
+            let archive = fs.lock_archive();
 
             // Must probe the zipfile twice, as "stdlib" and "stdlib/" are considered
             // different paths in a zip file, but we want to abstract over that difference here
             // so that paths relative to the `VendoredFileSystem`
             // work the same as other paths in Ruff.
-            archive.lookup_path(&normalized).is_ok()
+            archive.index_for_path(&normalized).is_some()
                 || archive
-                    .lookup_path(&normalized.with_trailing_slash())
-                    .is_ok()
+                    .index_for_path(&normalized.with_trailing_slash())
+                    .is_some()
         }
 
         exists(self, path.as_ref())
@@ -81,10 +81,10 @@ impl VendoredFileSystem {
             // different paths in a zip file, but we want to abstract over that difference here
             // so that paths relative to the `VendoredFileSystem`
             // work the same as other paths in Ruff.
-            if let Ok(zip_file) = archive.lookup_path(&normalized) {
+            if let Ok(zip_file) = archive.lookup_path_raw(&normalized) {
                 return Ok(Metadata::from_zip_file(zip_file));
             }
-            let zip_file = archive.lookup_path(&normalized.with_trailing_slash())?;
+            let zip_file = archive.lookup_path_raw(&normalized.with_trailing_slash())?;
             Ok(Metadata::from_zip_file(zip_file))
         }
 
@@ -360,11 +360,23 @@ impl VendoredZipArchive {
         Ok(Self(ZipArchive::new(io::Cursor::new(data))?))
     }
 
+    fn index_for_path(&self, path: &NormalizedVendoredPath) -> Option<usize> {
+        self.0.index_for_name(path.as_str())
+    }
+
     fn lookup_path(
         &mut self,
         path: &NormalizedVendoredPath,
     ) -> Result<ZipFile<'_, io::Cursor<Cow<'static, [u8]>>>> {
         Ok(self.0.by_name(path.as_str())?)
+    }
+
+    fn lookup_path_raw(
+        &mut self,
+        path: &NormalizedVendoredPath,
+    ) -> Result<ZipFile<'_, io::Cursor<Cow<'static, [u8]>>>> {
+        let index = self.index_for_path(path).ok_or(ZipError::FileNotFound)?;
+        Ok(self.0.by_index_raw(index)?)
     }
 
     fn len(&self) -> usize {

--- a/crates/ty_vendored/Cargo.toml
+++ b/crates/ty_vendored/Cargo.toml
@@ -18,14 +18,14 @@ zip = { workspace = true }
 [build-dependencies]
 path-slash = { workspace = true }
 walkdir = { workspace = true }
-zip = { workspace = true, features = ["zstd", "deflate"] }
+zip = { workspace = true, features = ["zstd", "deflate-flate2-zlib-rs"] }
 
 [dev-dependencies]
 walkdir = { workspace = true }
 
 [features]
 zstd = ["zip/zstd"]
-deflate = ["zip/deflate"]
+deflate = ["zip/deflate-flate2-zlib-rs"]
 
 [lints]
 workspace = true

--- a/crates/ty_vendored/build.rs
+++ b/crates/ty_vendored/build.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use path_slash::PathExt;
 use zip::CompressionMethod;
 use zip::result::ZipResult;
-use zip::write::{FileOptions, ZipWriter};
+use zip::write::{SimpleFileOptions, ZipWriter};
 
 const TYPESHED_SOURCE_DIR: &str = "vendor/typeshed";
 const TY_EXTENSIONS_STUBS: &str = "ty_extensions/ty_extensions.pyi";
@@ -41,7 +41,7 @@ fn write_zipped_typeshed_to(writer: File) -> ZipResult<File> {
         CompressionMethod::Stored
     };
 
-    let options = FileOptions::default()
+    let options = SimpleFileOptions::default()
         .compression_method(method)
         .unix_permissions(0o644);
 


### PR DESCRIPTION
## Summary

Use the new api of zip, bump version to match the version currently available in Debian.

Aiming to version 5.1 as that's the version currently available version in Debian and we are trying to package a newer version of ruff for Debian.

## Test Plan

Test pass
