### PR TITLE
[ty] Avoid caching parameter inference

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -30,8 +30,8 @@ pub use self::diagnostic::{TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_RE
 pub(crate) use self::infer::{
     InferredDeclaration, TypeContext, infer_complete_scope_types, infer_deferred_types,
     infer_definition_types, infer_expression_type, infer_expression_types,
-    infer_parameter_types_untracked, infer_same_file_expression_type, infer_scope_types,
-    is_discarded_dict_key_assignment,
+    infer_same_file_expression_type, infer_scope_types, is_discarded_dict_key_assignment,
+    parameter_inference_key,
 };
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
@@ -211,7 +211,8 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
 /// Infer the type of a binding.
 pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     if matches!(definition.kind(db), DefinitionKind::Parameter(_)) {
-        return infer_parameter_types_untracked(db, definition).binding_type(definition);
+        return infer_definition_types(db, parameter_inference_key(db, definition))
+            .binding_type(definition);
     }
 
     let inference = infer_definition_types(db, definition);
@@ -224,7 +225,8 @@ pub(crate) fn inferred_declaration<'db>(
     definition: Definition<'db>,
 ) -> InferredDeclaration<'db> {
     if matches!(definition.kind(db), DefinitionKind::Parameter(_)) {
-        return infer_parameter_types_untracked(db, definition).inferred_declaration(definition);
+        return infer_definition_types(db, parameter_inference_key(db, definition))
+            .inferred_declaration(definition);
     }
 
     let inference = infer_definition_types(db, definition);

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -30,7 +30,8 @@ pub use self::diagnostic::{TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_RE
 pub(crate) use self::infer::{
     InferredDeclaration, TypeContext, infer_complete_scope_types, infer_deferred_types,
     infer_definition_types, infer_expression_type, infer_expression_types,
-    infer_same_file_expression_type, infer_scope_types, is_discarded_dict_key_assignment,
+    infer_parameter_types_untracked, infer_same_file_expression_type, infer_scope_types,
+    is_discarded_dict_key_assignment,
 };
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
@@ -106,7 +107,7 @@ pub(crate) use literal::{
     BytesLiteralType, EnumLiteralType, LiteralValueType, LiteralValueTypeKind, StringLiteralType,
 };
 pub use special_form::SpecialFormType;
-use ty_python_core::definition::Definition;
+use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{Truthiness, place_table, semantic_index};
@@ -209,6 +210,10 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
 
 /// Infer the type of a binding.
 pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
+    if matches!(definition.kind(db), DefinitionKind::Parameter(_)) {
+        return infer_parameter_types_untracked(db, definition).binding_type(definition);
+    }
+
     let inference = infer_definition_types(db, definition);
     inference.binding_type(definition)
 }
@@ -218,6 +223,10 @@ pub(crate) fn inferred_declaration<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> InferredDeclaration<'db> {
+    if matches!(definition.kind(db), DefinitionKind::Parameter(_)) {
+        return infer_parameter_types_untracked(db, definition).inferred_declaration(definition);
+    }
+
     let inference = infer_definition_types(db, definition);
     inference.inferred_declaration(definition)
 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -30,8 +30,8 @@ pub use self::diagnostic::{TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_RE
 pub(crate) use self::infer::{
     InferredDeclaration, TypeContext, infer_complete_scope_types, infer_deferred_types,
     infer_definition_types, infer_expression_type, infer_expression_types,
-    infer_same_file_expression_type, infer_scope_types, is_discarded_dict_key_assignment,
-    parameter_inference_key,
+    infer_parameter_types_untracked, infer_same_file_expression_type, infer_scope_types,
+    is_discarded_dict_key_assignment,
 };
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
@@ -211,8 +211,7 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
 /// Infer the type of a binding.
 pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     if matches!(definition.kind(db), DefinitionKind::Parameter(_)) {
-        return infer_definition_types(db, parameter_inference_key(db, definition))
-            .binding_type(definition);
+        return infer_parameter_types_untracked(db, definition).binding_type(definition);
     }
 
     let inference = infer_definition_types(db, definition);
@@ -225,8 +224,7 @@ pub(crate) fn inferred_declaration<'db>(
     definition: Definition<'db>,
 ) -> InferredDeclaration<'db> {
     if matches!(definition.kind(db), DefinitionKind::Parameter(_)) {
-        return infer_definition_types(db, parameter_inference_key(db, definition))
-            .inferred_declaration(definition);
+        return infer_parameter_types_untracked(db, definition).inferred_declaration(definition);
     }
 
     let inference = infer_definition_types(db, definition);

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -124,28 +124,22 @@ pub(crate) fn infer_definition_types<'db>(
         .finish_definition(definition)
 }
 
-/// Return the definition used to cache parameter inference for a function.
+/// Infer a parameter without retaining a separate Salsa memo for its definition.
 ///
-/// All parameters in a function are inferred together and cached using the first parameter's
-/// definition. This avoids retaining a separate Salsa memo for every parameter.
-pub(crate) fn parameter_inference_key<'db>(
+/// Parameter inference is small and is already repeated when function-body inference merges the
+/// parameter diagnostics, so retaining every result costs more than recomputing it.
+pub(crate) fn infer_parameter_types_untracked<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
-) -> Definition<'db> {
+) -> DefinitionInference<'db> {
     debug_assert!(matches!(definition.kind(db), DefinitionKind::Parameter(_)));
 
-    let scope = definition.scope(db);
     let file = definition.file(db);
     let module = parsed_module(db, file).load(db);
     let index = semantic_index(db, file);
-    let function = scope.node(db).expect_function().node(&module);
-    let first_parameter = function
-        .parameters
-        .iter()
-        .next()
-        .expect("a parameter definition must belong to a function with parameters");
 
-    index.expect_single_definition(first_parameter)
+    TypeInferenceBuilder::new(db, InferenceRegion::Definition(definition), index, &module)
+        .finish_definition()
 }
 
 /// Returns `true` if the definition refers to a dictionary-key binding that should be discarded.

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -124,6 +124,24 @@ pub(crate) fn infer_definition_types<'db>(
         .finish_definition(definition)
 }
 
+/// Infer a parameter without retaining a separate Salsa memo for its definition.
+///
+/// Parameter inference is small and is already repeated when function-body inference merges the
+/// parameter diagnostics, so retaining every result costs more than recomputing it.
+pub(crate) fn infer_parameter_types_untracked<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+) -> DefinitionInference<'db> {
+    debug_assert!(matches!(definition.kind(db), DefinitionKind::Parameter(_)));
+
+    let file = definition.file(db);
+    let module = parsed_module(db, file).load(db);
+    let index = semantic_index(db, file);
+
+    TypeInferenceBuilder::new(db, InferenceRegion::Definition(definition), index, &module)
+        .finish_definition()
+}
+
 /// Returns `true` if the definition refers to a dictionary-key binding that should be discarded.
 ///
 /// For example, inference synthesizes an `x["a"] = "bad"` binding for:

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -139,7 +139,7 @@ pub(crate) fn infer_parameter_types_untracked<'db>(
     let index = semantic_index(db, file);
 
     TypeInferenceBuilder::new(db, InferenceRegion::Definition(definition), index, &module)
-        .finish_definition()
+        .finish_definition(definition)
 }
 
 /// Returns `true` if the definition refers to a dictionary-key binding that should be discarded.

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -124,22 +124,28 @@ pub(crate) fn infer_definition_types<'db>(
         .finish_definition(definition)
 }
 
-/// Infer a parameter without retaining a separate Salsa memo for its definition.
+/// Return the definition used to cache parameter inference for a function.
 ///
-/// Parameter inference is small and is already repeated when function-body inference merges the
-/// parameter diagnostics, so retaining every result costs more than recomputing it.
-pub(crate) fn infer_parameter_types_untracked<'db>(
+/// All parameters in a function are inferred together and cached using the first parameter's
+/// definition. This avoids retaining a separate Salsa memo for every parameter.
+pub(crate) fn parameter_inference_key<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
-) -> DefinitionInference<'db> {
+) -> Definition<'db> {
     debug_assert!(matches!(definition.kind(db), DefinitionKind::Parameter(_)));
 
+    let scope = definition.scope(db);
     let file = definition.file(db);
     let module = parsed_module(db, file).load(db);
     let index = semantic_index(db, file);
+    let function = scope.node(db).expect_function().node(&module);
+    let first_parameter = function
+        .parameters
+        .iter()
+        .next()
+        .expect("a parameter definition must belong to a function with parameters");
 
-    TypeInferenceBuilder::new(db, InferenceRegion::Definition(definition), index, &module)
-        .finish_definition()
+    index.expect_single_definition(first_parameter)
 }
 
 /// Returns `true` if the definition refers to a dictionary-key binding that should be discarded.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -997,7 +997,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_statement(statement.node_ref(self.db()).node(self.module()));
     }
 
+    fn infer_region_function_parameters(&mut self, scope: ScopeId<'db>) {
+        let function = scope.node(self.db()).expect_function().node(self.module());
+        for parameter in &function.parameters {
+            let definition = self.index.expect_single_definition(parameter);
+            self.infer_single_definition(definition);
+        }
+    }
+
     fn infer_region_definition(&mut self, definition: Definition<'db>) {
+        if matches!(definition.kind(self.db()), DefinitionKind::Parameter(_)) {
+            self.infer_region_function_parameters(definition.scope(self.db()));
+        } else {
+            self.infer_single_definition(definition);
+        }
+    }
+
+    fn infer_single_definition(&mut self, definition: Definition<'db>) {
         match definition.kind(self.db()) {
             DefinitionKind::Function(function) => {
                 self.infer_function_definition(function.node(self.module()), definition);

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -997,23 +997,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_statement(statement.node_ref(self.db()).node(self.module()));
     }
 
-    fn infer_region_function_parameters(&mut self, scope: ScopeId<'db>) {
-        let function = scope.node(self.db()).expect_function().node(self.module());
-        for parameter in &function.parameters {
-            let definition = self.index.expect_single_definition(parameter);
-            self.infer_single_definition(definition);
-        }
-    }
-
     fn infer_region_definition(&mut self, definition: Definition<'db>) {
-        if matches!(definition.kind(self.db()), DefinitionKind::Parameter(_)) {
-            self.infer_region_function_parameters(definition.scope(self.db()));
-        } else {
-            self.infer_single_definition(definition);
-        }
-    }
-
-    fn infer_single_definition(&mut self, definition: Definition<'db>) {
         match definition.kind(self.db()) {
             DefinitionKind::Function(function) => {
                 self.infer_function_definition(function.node(self.module()), definition);

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -23,8 +23,8 @@ use crate::{
                 DeclaredAndInferredType, DeferredExpressionState, TypeAndRange,
                 validate_paramspec_components,
             },
-            function_known_decorators, infer_statement_types, nearest_enclosing_function,
-            original_class_type,
+            function_known_decorators, infer_parameter_types_untracked, infer_statement_types,
+            nearest_enclosing_function, original_class_type,
         },
         infer_definition_types, infer_scope_types,
         signatures::ReturnCallableTypeVarScope,
@@ -133,7 +133,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // constituent nodes that are part of the function body. In order to get diagnostics
         // merged/emitted for them, we need to explicitly infer their definitions here.
         for parameter in &function.parameters {
-            self.infer_definition(parameter);
+            let definition = self.index.expect_single_definition(parameter);
+            let inference = infer_parameter_types_untracked(db, definition);
+            self.extend_definition(&inference);
         }
 
         validate_paramspec_components(&self.context, &function.parameters, |expr| {

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -135,7 +135,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         for parameter in &function.parameters {
             let definition = self.index.expect_single_definition(parameter);
             let inference = infer_parameter_types_untracked(db, definition);
-            self.extend_definition(&inference);
+            self.extend_definition(definition, &inference);
         }
 
         validate_paramspec_components(&self.context, &function.parameters, |expr| {

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -23,8 +23,8 @@ use crate::{
                 DeclaredAndInferredType, DeferredExpressionState, TypeAndRange,
                 validate_paramspec_components,
             },
-            function_known_decorators, infer_statement_types, nearest_enclosing_function,
-            original_class_type,
+            function_known_decorators, infer_parameter_types_untracked, infer_statement_types,
+            nearest_enclosing_function, original_class_type,
         },
         infer_definition_types, infer_scope_types,
         signatures::ReturnCallableTypeVarScope,
@@ -129,11 +129,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let db = self.db();
 
-        // Parameters are Definitions in the function body scope, but have no constituent nodes in
-        // the body. Explicitly merge their grouped inference result to include diagnostics.
-        if let Some(first_parameter) = function.parameters.iter().next() {
-            let definition = self.index.expect_single_definition(first_parameter);
-            self.extend_definition(infer_definition_types(db, definition));
+        // Parameters are odd: they are Definitions in the function body scope, but have no
+        // constituent nodes that are part of the function body. In order to get diagnostics
+        // merged/emitted for them, we need to explicitly infer their definitions here.
+        for parameter in &function.parameters {
+            let definition = self.index.expect_single_definition(parameter);
+            let inference = infer_parameter_types_untracked(db, definition);
+            self.extend_definition(&inference);
         }
 
         validate_paramspec_components(&self.context, &function.parameters, |expr| {

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -23,8 +23,8 @@ use crate::{
                 DeclaredAndInferredType, DeferredExpressionState, TypeAndRange,
                 validate_paramspec_components,
             },
-            function_known_decorators, infer_parameter_types_untracked, infer_statement_types,
-            nearest_enclosing_function, original_class_type,
+            function_known_decorators, infer_statement_types, nearest_enclosing_function,
+            original_class_type,
         },
         infer_definition_types, infer_scope_types,
         signatures::ReturnCallableTypeVarScope,
@@ -129,13 +129,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let db = self.db();
 
-        // Parameters are odd: they are Definitions in the function body scope, but have no
-        // constituent nodes that are part of the function body. In order to get diagnostics
-        // merged/emitted for them, we need to explicitly infer their definitions here.
-        for parameter in &function.parameters {
-            let definition = self.index.expect_single_definition(parameter);
-            let inference = infer_parameter_types_untracked(db, definition);
-            self.extend_definition(&inference);
+        // Parameters are Definitions in the function body scope, but have no constituent nodes in
+        // the body. Explicitly merge their grouped inference result to include diagnostics.
+        if let Some(first_parameter) = function.parameters.iter().next() {
+            let definition = self.index.expect_single_definition(first_parameter);
+            self.extend_definition(infer_definition_types(db, definition));
         }
 
         validate_paramspec_components(&self.context, &function.parameters, |expr| {

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -2,7 +2,7 @@ use super::builder::TypeInferenceBuilder;
 use crate::db::tests::{TestDb, setup_db};
 use crate::place::symbol;
 use crate::place::{ConsideredDefinitions, Place, global_symbol};
-use crate::types::{KnownClass, KnownInstanceType, check_types};
+use crate::types::{KnownClass, KnownInstanceType, binding_type, check_types};
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::DbWithWritableSystem as _;
@@ -94,6 +94,48 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
         non_owner.bindings(first).collect::<Vec<_>>(),
         [(second, owner_type)]
     );
+
+    Ok(())
+}
+
+#[test]
+fn parameter_inference_is_not_memoized_per_definition() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented(
+        "/src/a.py",
+        r#"
+        def f(
+            positional: int,
+            *args: str,
+            keyword_only: bool,
+            **kwargs: bytes,
+        ) -> None:
+            pass
+        "#,
+    )?;
+
+    let file = system_path_to_file(&db, "/src/a.py").unwrap();
+    for (parameter_index, expected) in ["int", "tuple[str, ...]", "bool", "dict[str, bytes]"]
+        .into_iter()
+        .enumerate()
+    {
+        db.clear_salsa_events();
+        let actual = {
+            let module = parsed_module(&db, file).load(&db);
+            let function = module.syntax().body[0].as_function_def_stmt().unwrap();
+            let parameter = function.parameters.iter().nth(parameter_index).unwrap();
+            let definition = semantic_index(&db, file).expect_single_definition(parameter);
+            binding_type(&db, definition).display(&db).to_string()
+        };
+        assert_eq!(actual, expected);
+        let events = db.take_salsa_events();
+
+        let module = parsed_module(&db, file).load(&db);
+        let function = module.syntax().body[0].as_function_def_stmt().unwrap();
+        let parameter = function.parameters.iter().nth(parameter_index).unwrap();
+        let definition = semantic_index(&db, file).expect_single_definition(parameter);
+        assert_function_query_was_not_run(&db, infer_definition_types, definition, &events);
+    }
 
     Ok(())
 }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -99,7 +99,7 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
 }
 
 #[test]
-fn parameter_inference_is_memoized_per_function() -> anyhow::Result<()> {
+fn parameter_inference_is_not_memoized_per_definition() -> anyhow::Result<()> {
     let mut db = setup_db();
     db.write_dedented(
         "/src/a.py",
@@ -134,15 +134,7 @@ fn parameter_inference_is_memoized_per_function() -> anyhow::Result<()> {
         let function = module.syntax().body[0].as_function_def_stmt().unwrap();
         let parameter = function.parameters.iter().nth(parameter_index).unwrap();
         let definition = semantic_index(&db, file).expect_single_definition(parameter);
-        let key = parameter_inference_key(&db, definition);
-        if parameter_index == 0 {
-            assert_eq!(key, definition);
-            assert_function_query_was_run(&db, infer_definition_types, key, &events);
-        } else {
-            assert_ne!(key, definition);
-            assert_function_query_was_not_run(&db, infer_definition_types, definition, &events);
-            assert_function_query_was_not_run(&db, infer_definition_types, key, &events);
-        }
+        assert_function_query_was_not_run(&db, infer_definition_types, definition, &events);
     }
 
     Ok(())

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -99,7 +99,7 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
 }
 
 #[test]
-fn parameter_inference_is_not_memoized_per_definition() -> anyhow::Result<()> {
+fn parameter_inference_is_memoized_per_function() -> anyhow::Result<()> {
     let mut db = setup_db();
     db.write_dedented(
         "/src/a.py",
@@ -134,7 +134,15 @@ fn parameter_inference_is_not_memoized_per_definition() -> anyhow::Result<()> {
         let function = module.syntax().body[0].as_function_def_stmt().unwrap();
         let parameter = function.parameters.iter().nth(parameter_index).unwrap();
         let definition = semantic_index(&db, file).expect_single_definition(parameter);
-        assert_function_query_was_not_run(&db, infer_definition_types, definition, &events);
+        let key = parameter_inference_key(&db, definition);
+        if parameter_index == 0 {
+            assert_eq!(key, definition);
+            assert_function_query_was_run(&db, infer_definition_types, key, &events);
+        } else {
+            assert_ne!(key, definition);
+            assert_function_query_was_not_run(&db, infer_definition_types, definition, &events);
+            assert_function_query_was_not_run(&db, infer_definition_types, key, &events);
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Function parameters are definitions in the function body scope, but their types are small and parameter diagnostics are already inferred while checking the function body. `infer_definition_types` nevertheless retained a Salsa memo for every parameter.

This routes parameter binding and declaration lookup through an untracked inference helper, and uses the same helper when merging parameter diagnostics into function-body inference. Other definition kinds continue to use tracked inference.

On a large project, this reduced retained memory from 86,692,332,002 bytes to 85,899,041,802 bytes, saving 793,290,200 bytes (0.92%) without diagnostic changes.
