### PR TITLE
[ty] Store common definition inference results inline

### DIFF
--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -897,15 +897,14 @@ pub(crate) struct DefinitionInference<'db> {
 /// The binding and declaration types inferred for a definition region.
 ///
 /// Almost all regions contain a single binding, optionally paired with a declaration for the same
-/// definition and type. Keep those cases in a single allocation instead of retaining two separate
-/// allocations.
+/// definition and type. Keep those cases inline instead of retaining separate allocations.
 #[derive(Debug, Default, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 enum DefinitionTypes<'db> {
     #[default]
     Empty,
-    Binding(Box<DefinitionBinding<'db>>),
-    Declaration(Box<DefinitionDeclaration<'db>>),
-    BindingAndDeclaration(Box<DefinitionDeclaration<'db>>),
+    Binding(DefinitionBinding<'db>),
+    Declaration(DefinitionDeclaration<'db>),
+    BindingAndDeclaration(DefinitionDeclaration<'db>),
     Other(Box<OtherDefinitionTypes<'db>>),
 }
 
@@ -925,12 +924,12 @@ impl<'db> DefinitionTypes<'db> {
     ) -> Self {
         match (&*bindings, &*declarations) {
             ([], []) => Self::Empty,
-            ([binding], []) => Self::Binding(Box::new(*binding)),
-            ([], [declaration]) => Self::Declaration(Box::new(*declaration)),
+            ([binding], []) => Self::Binding(*binding),
+            ([], [declaration]) => Self::Declaration(*declaration),
             ([(binding, binding_ty)], [(declaration, declaration_ty)])
                 if binding == declaration && *binding_ty == declaration_ty.inner_type() =>
             {
-                Self::BindingAndDeclaration(Box::new((*declaration, *declaration_ty)))
+                Self::BindingAndDeclaration((*declaration, *declaration_ty))
             }
             _ => Self::Other(Box::new(OtherDefinitionTypes {
                 bindings: bindings.into_boxed_slice(),
@@ -986,17 +985,17 @@ impl<'db> DefinitionTypes<'db> {
         match self {
             Self::Empty => Self::Empty,
             Self::Binding(mut binding) => {
-                let (definition, ty) = &mut *binding;
+                let (definition, ty) = &mut binding;
                 *ty = Self::normalize_binding(db, previous, cycle, *definition, *ty);
                 Self::Binding(binding)
             }
             Self::Declaration(mut declaration) => {
-                let (definition, ty) = &mut *declaration;
+                let (definition, ty) = &mut declaration;
                 *ty = Self::normalize_declaration(db, previous, cycle, *definition, *ty);
                 Self::Declaration(declaration)
             }
             Self::BindingAndDeclaration(mut declaration) => {
-                let (definition, declaration_ty) = *declaration;
+                let (definition, declaration_ty) = declaration;
                 let binding_ty = Self::normalize_binding(
                     db,
                     previous,
@@ -1029,7 +1028,7 @@ impl<'db> DefinitionTypes<'db> {
                     ([(binding, binding_ty)], [(declaration, declaration_ty)])
                         if binding == declaration && *binding_ty == declaration_ty.inner_type() =>
                     {
-                        Self::BindingAndDeclaration(Box::new((*declaration, *declaration_ty)))
+                        Self::BindingAndDeclaration((*declaration, *declaration_ty))
                     }
                     _ => Self::Other(other),
                 }
@@ -1039,7 +1038,7 @@ impl<'db> DefinitionTypes<'db> {
 
     fn bindings(&self) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> {
         match self {
-            Self::Binding(binding) => Either::Left(std::iter::once(**binding)),
+            Self::Binding(binding) => Either::Left(std::iter::once(*binding)),
             Self::BindingAndDeclaration(declaration) => {
                 Either::Left(std::iter::once((declaration.0, declaration.1.inner_type())))
             }
@@ -1053,7 +1052,7 @@ impl<'db> DefinitionTypes<'db> {
     ) -> impl ExactSizeIterator<Item = (Definition<'db>, TypeAndQualifiers<'db>)> {
         match self {
             Self::Declaration(declaration) | Self::BindingAndDeclaration(declaration) => {
-                Either::Left(std::iter::once(**declaration))
+                Either::Left(std::iter::once(*declaration))
             }
             Self::Other(other) => Either::Right(other.declarations.iter().copied()),
             Self::Empty | Self::Binding(..) => Either::Right([].iter().copied()),
@@ -1126,10 +1125,10 @@ impl<'db> DefinitionInference<'db> {
                         generic_context.repeat_specialization(db, cycle_recovery)
                     });
 
-                types = DefinitionTypes::Binding(Box::new((
+                types = DefinitionTypes::Binding((
                     definition,
                     Type::instance(db, divergent_collection),
-                )));
+                ));
             }
         }
 


### PR DESCRIPTION
## Summary

`DefinitionInference` almost always retains either one binding, one declaration, or a binding and declaration for the same definition and type. `DefinitionTypes` stored each of these common cases in a separate `Box`, adding a heap allocation for every cached result, while only the uncommon multi-result case needs out-of-line storage.

This stores the common singleton payloads directly in the enum and keeps the `Other` variant boxed. The cycle-normalization and iteration paths preserve the existing behavior while operating on the inline payloads.

On a representative project, this reduced retained memory from 287,972,361 bytes to 286,861,193 bytes, saving 1,111,168 bytes (0.39%) without diagnostic changes.
