### PR TITLE
[ty] Avoid caching specialization-invariant known instances

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5856,6 +5856,21 @@ impl<'db> Type<'db> {
                 | Type::AlwaysFalsy
                 | Type::LiteralValue(_)
                 | Type::BoundSuper(_)
+                | Type::KnownInstance(
+                    KnownInstanceType::SubscriptedProtocol(_)
+                        | KnownInstanceType::SubscriptedGeneric(_)
+                        | KnownInstanceType::TypeAliasType(_)
+                        | KnownInstanceType::Deprecated(_)
+                        | KnownInstanceType::Field(_)
+                        | KnownInstanceType::ConstraintSet(_)
+                        | KnownInstanceType::GenericContext(_)
+                        | KnownInstanceType::Specialization(_)
+                        | KnownInstanceType::Literal(_)
+                        | KnownInstanceType::LiteralStringAlias(_)
+                        | KnownInstanceType::NewType(_)
+                        | KnownInstanceType::Sentinel(_)
+                        | KnownInstanceType::NamedTupleSpec(_),
+                )
                 | Type::KnownBoundMethod(
                     KnownBoundMethodType::StrStartswith(_)
                         | KnownBoundMethodType::ConstraintSetRange


### PR DESCRIPTION
## Summary

`apply_specialization` already handles atomic types before entering its tracked query, but several `KnownInstanceType` variants still create and retain query entries even though specialization always returns the original type.

This handles those specialization-invariant known instances directly. Variants that can depend on type variables continue through the existing tracked implementation.
