### PR TITLE
[ty] Address intersection receiver review feedback

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1863,10 +1863,10 @@ def _(a_and_b: Intersection[type[A], type[B]]):
     a_and_b.x = R()
 ```
 
-For `Intersection[A, B]`, member lookup searches `A` and `B` separately to find the attribute. Once
-found, however, descriptors and `Self` must be bound using the full `A & B` receiver.
-
 ### Method binding uses the full intersection type
+
+For `Intersection[A, B]`, member lookup searches `A` and `B` separately to find the method. Once
+found, however, `Self` must be bound using the full `A & B` receiver.
 
 ```py
 from typing_extensions import Self
@@ -1884,19 +1884,18 @@ def _(a_and_b: Intersection[A, B]):
 
 ### Descriptor binding uses the full intersection type
 
+Descriptors found while searching the individual elements of an intersection must also be bound
+using the full intersection as the receiver.
+
 ```py
-from typing import Any, TypeVar, overload
-from typing_extensions import Self
+from typing import TypeVar
 from ty_extensions import Intersection
 
-T = TypeVar("T")
+T = TypeVar(name="T")
 
 class Descriptor:
-    @overload
-    def __get__(self, instance: None, owner: type, /) -> Self: ...
-    @overload
-    def __get__(self, instance: T, owner: type | None = None, /) -> T: ...
-    def __get__(self, instance: object, owner: type | None = None, /) -> Any: ...
+    def __get__(self, instance: T, owner: type | None = None, /) -> T:
+        return instance
 
 class A:
     desc = Descriptor()

--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -1573,9 +1573,9 @@ reveal_type(p.__call__("hello"))  # revealed: bool
 
 ### Attribute access on partial results
 
-Standard `partial` attributes like `.func`, `.args`, and `.keywords` should be accessible. Runtime
-protocol narrowing can add a refinement to the concrete `partial` object, but attributes provided by
-`partial` must remain precise when looked up through that intersection.
+Standard `partial` attributes like `.func`, `.args`, and `.keywords` should be accessible. As with
+other intersection types, runtime protocol narrowing preserves the full receiver while looking up
+attributes provided by `partial`.
 
 ```py
 from functools import partial
@@ -1595,6 +1595,9 @@ class PartialMarker(Protocol):
     def __call__(self, value: str) -> bool: ...
 
 if isinstance(p, PartialMarker):
+    reveal_type(p)  # revealed: partial[(b: str) -> bool] & PartialMarker
+    # revealed: bound method (partial[(b: str) -> bool] & PartialMarker).__str__() -> str
+    reveal_type(p.__str__)
     reveal_type(p.args)  # revealed: tuple[Any, ...]
     reveal_type(p.keywords)  # revealed: dict[str, Any]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -100,24 +100,6 @@ methods, even though it is not available on `types.MethodType`:
 reveal_type(bound_method.__kwdefaults__)  # revealed: dict[str, Any] | None
 ```
 
-Bound-method attributes are resolved in two stages: first on `types.MethodType`, then, if absent, on
-the underlying function object. A protocol refinement of the bound method must not be used as the
-receiver for that underlying-function fallback:
-
-```py
-from typing import Protocol, runtime_checkable
-
-@runtime_checkable
-class ReturnsStr(Protocol):
-    def __call__(self, x: str) -> str: ...
-
-def narrowed_bound_method_attribute():
-    method = C().f
-    if isinstance(method, ReturnsStr):
-        reveal_type(method)  # revealed: (bound method C.f(x: int) -> str) & ReturnsStr
-        reveal_type(method.__globals__)  # revealed: dict[str, Any]
-```
-
 ## Basic method calls on class objects and instances
 
 ```py
@@ -977,6 +959,30 @@ class X:
     def make_another(self) -> Self:
         reveal_type(self.__new__)  # revealed: def __new__[Self](cls) -> Self
         return self.__new__(type(self))
+```
+
+## Bound-method attribute fallback
+
+Bound-method attributes are resolved first on `types.MethodType`, then, if absent, on the underlying
+function object. A protocol refinement of the bound method must not be used as the receiver for that
+underlying-function fallback:
+
+```py
+from typing import Protocol, runtime_checkable
+
+class C:
+    def f(self, x: int) -> str:
+        return "a"
+
+@runtime_checkable
+class ReturnsStr(Protocol):
+    def __call__(self, x: str) -> str: ...
+
+def narrowed_bound_method_attribute():
+    method = C().f
+    if isinstance(method, ReturnsStr):
+        reveal_type(method)  # revealed: (bound method C.f(x: int) -> str) & ReturnsStr
+        reveal_type(method.__globals__)  # revealed: dict[str, Any]
 ```
 
 ## Builtin functions and methods

--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -1343,7 +1343,7 @@ class Y(Base):
     pass
 
 def test(x: Intersection[X, Y]) -> None:
-    reveal_type(x.f)  # revealed: bound method X & Y.f() -> int
+    reveal_type(x.f)  # revealed: bound method (X & Y).f() -> int
     reveal_type(x.f())  # revealed: int
 
 # Example subclass that inhabits that intersection:

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1424,11 +1424,11 @@ satisfy:
 def expects_named_tuple(x: typing.NamedTuple):
     reveal_type(x)  # revealed: tuple[object, ...] & NamedTupleLike
     reveal_type(x._make)  # revealed: bound method type[NamedTupleLike]._make(iterable: Iterable[Any]) -> NamedTupleLike
-    # revealed: bound method tuple[object, ...] & NamedTupleLike._replace(...) -> tuple[object, ...] & NamedTupleLike
+    # revealed: bound method (tuple[object, ...] & NamedTupleLike)._replace(...) -> tuple[object, ...] & NamedTupleLike
     reveal_type(x._replace)
     # revealed: Overload[(value: tuple[object, ...], /) -> tuple[object, ...], [_T](value: tuple[_T, ...], /) -> tuple[object, ...]]
     reveal_type(x.__add__)
-    # revealed: bound method tuple[object, ...] & NamedTupleLike.__iter__() -> Iterator[object]
+    # revealed: bound method (tuple[object, ...] & NamedTupleLike).__iter__() -> Iterator[object]
     reveal_type(x.__iter__)
 
 def _(y: type[typing.NamedTuple]):

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3557,7 +3557,9 @@ impl<'db> Type<'db> {
                             )
                             .or_fall_back_to(db, || {
                                 // If an attribute is not available on the bound method object,
-                                // it will be looked up on the underlying function object:
+                                // it will be looked up on the underlying function object. This
+                                // changes the lookup object, so do not forward the bound-method
+                                // receiver.
                                 Type::FunctionLiteral(bound_method.function(db))
                                     .member_lookup_with_policy(db, name, policy)
                             })
@@ -3748,7 +3750,7 @@ impl<'db> Type<'db> {
                     let nominal_lookup = partial
                         .partial(db)
                         .into_functools_partial_instance(db)
-                        .member_lookup_with_policy(db, name.clone(), policy);
+                        .member_lookup_with_policy_and_receiver(db, name.clone(), policy, receiver);
                     if name_str == "func" {
                         match nominal_lookup.place {
                             Place::Defined(DefinedPlace {

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1094,9 +1094,12 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         };
                         f.set_invalid_type_annotation();
                         f.write_str("bound method ")?;
-                        self_ty
-                            .display_with(self.db, self.settings.singleline())
-                            .fmt_detailed(f)?;
+                        DisplayMaybeParenthesizedType {
+                            ty: self_ty,
+                            db: self.db,
+                            settings: self.settings.singleline(),
+                        }
+                        .fmt_detailed(f)?;
                         f.write_char('.')?;
                         f.with_type(self.ty).write_str(function.name(self.db))?;
                         type_parameters.fmt_detailed(f)?;


### PR DESCRIPTION
## Summary

This follows up on [the post-merge review](https://github.com/astral-sh/ruff/pull/25626#pullrequestreview-4466748160) of #25626.

`functools.partial` now preserves the full intersection receiver when delegating member lookup to its nominal `partial[T]` view. Bound-method fallback still resets the receiver when lookup switches to the separate underlying function object; the implementation and regression coverage now make that distinction explicit.

This also parenthesizes compound bound-method receivers in displayed types and clarifies and relocates the related intersection receiver documentation and tests.
