### PR TITLE
[ty] Combine definition annotation queries

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -248,23 +248,33 @@ fn definition_expression_type<'db>(
     }
 }
 
-/// Return the qualifiers for a deferred annotation expression that is a sub-expression of a
-/// [`Definition`].
+/// Infer the type and qualifiers of a deferred annotation expression that is a sub-expression of
+/// a [`Definition`].
 ///
 /// Supports expressions that are evaluated within a type-params sub-scope.
-fn definition_expression_qualifiers<'db>(
+fn definition_expression_annotation<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
     expression: &ast::Expr,
-) -> TypeQualifiers {
+) -> TypeAndQualifiers<'db> {
     let file = definition.file(db);
     let index = semantic_index(db, file);
     let file_scope = index.expression_scope_id(expression);
     let scope = file_scope.to_scope_id(db, file);
     if scope == definition.scope(db) {
-        infer_deferred_types(db, definition).qualifiers(expression)
+        let inference = infer_deferred_types(db, definition);
+        TypeAndQualifiers::new(
+            inference.expression_type(expression),
+            TypeOrigin::Declared,
+            inference.qualifiers(expression),
+        )
     } else {
-        infer_complete_scope_types(db, scope).qualifiers(expression)
+        let inference = infer_complete_scope_types(db, scope);
+        TypeAndQualifiers::new(
+            inference.expression_type(expression),
+            TypeOrigin::Declared,
+            inference.qualifiers(expression),
+        )
     }
 }
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -19,7 +19,7 @@ use super::diagnostic::{
 use super::infer::{TypeExpressionFlags, infer_deferred_types};
 use super::{
     ApplyTypeMappingVisitor, ErrorContext, IntersectionType, Type, TypeMapping, TypeQualifiers,
-    UnionBuilder, definition_expression_qualifiers, definition_expression_type, visitor,
+    UnionBuilder, definition_expression_annotation, definition_expression_type, visitor,
 };
 use crate::Db;
 use crate::types::TypeContext;
@@ -263,15 +263,13 @@ impl<'db> TypedDictType<'db> {
 
             if let Some(arguments) = &class_stmt.arguments {
                 if let Some(extra_items) = arguments.find_keyword("extra_items") {
-                    let declared_ty =
-                        definition_expression_type(db, class_definition, &extra_items.value)
-                            .apply_optional_specialization(db, specialization);
-                    let qualifiers =
-                        definition_expression_qualifiers(db, class_definition, &extra_items.value);
+                    let annotation =
+                        definition_expression_annotation(db, class_definition, &extra_items.value)
+                            .map_type(|ty| ty.apply_optional_specialization(db, specialization));
                     return TypedDictOpenness::extra(
                         db,
-                        declared_ty,
-                        qualifiers.contains(TypeQualifiers::READ_ONLY),
+                        annotation.inner_type(),
+                        annotation.qualifiers().contains(TypeQualifiers::READ_ONLY),
                     );
                 }
 


### PR DESCRIPTION
## Summary

This follows up on [the post-merge review](https://github.com/astral-sh/ruff/pull/25591#discussion_r3384620120) of #25591.

The `extra_items` path previously queried a definition expression's type and qualifiers separately, even though both values come from the same inference result. This adds `definition_expression_annotation`, which returns `TypeAndQualifiers` from that shared result for both definition scopes and type-parameter scopes.

TypedDict extra-items construction now uses the combined annotation result and applies specialization only to its inner type, preserving qualifiers such as `ReadOnly`.
