### PR TITLE
[ty] Synthesize PEP 728 TypedDict class attributes

### DIFF
--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -10,8 +10,8 @@ use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_text_size::{Ranged, TextRange};
 use ty_module_resolver::KnownModule;
 
-use crate::place::PlaceAndQualifiers;
 use crate::place::known_module_symbol;
+use crate::place::{Place, PlaceAndQualifiers};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::generics::GenericContext;
 use crate::types::member::Member;
@@ -23,8 +23,8 @@ use crate::types::typed_dict::{
 };
 use crate::types::{
     BoundTypeVarInstance, CallableType, ClassBase, ClassLiteral, ClassType, KnownClass,
-    MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeVarVariance, TypedDictType, UnionType,
-    determine_upper_bound,
+    MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeQualifiers, TypeVarVariance,
+    TypedDictType, UnionType, determine_upper_bound,
 };
 use crate::{Db, FxIndexMap};
 use ty_python_core::definition::Definition;
@@ -1010,6 +1010,21 @@ pub(super) fn typed_dict_class_member<'db>(
         });
     if !fallback_member.is_undefined() {
         return fallback_member;
+    }
+
+    // TODO: Remove this fallback once typeshed's `TypedDictFallback` includes these PEP 728
+    // attributes.
+    let synthesized_member = match name {
+        "__closed__" => Some(UnionType::from_two_elements(
+            db,
+            KnownClass::Bool.to_instance(db),
+            Type::none(db),
+        )),
+        "__extra_items__" => Some(Type::any()),
+        _ => None,
+    };
+    if let Some(member) = synthesized_member {
+        return Place::declared(member).with_qualifiers(TypeQualifiers::CLASS_VAR);
     }
 
     if let Some(value_ty) = typed_dict.dict_value_type(db)

--- a/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/_typeshed/_type_checker_internals.pyi
@@ -28,8 +28,6 @@ class TypedDictFallback(Mapping[str, object], metaclass=ABCMeta):
     if sys.version_info >= (3, 13):
         __readonly_keys__: ClassVar[frozenset[str]]
         __mutable_keys__: ClassVar[frozenset[str]]
-    __closed__: ClassVar[bool | None]
-    __extra_items__: ClassVar[Any]
 
     def copy(self) -> typing_extensions.Self: ...
     # Using Never so that only calls using mypy plugin hook that specialize the signature


### PR DESCRIPTION
## Summary

This follows up on [the post-merge review](https://github.com/astral-sh/ruff/pull/25591#discussion_r3389547485) of #25591.

The PEP 728 implementation added `__closed__` and `__extra_items__` directly to the vendored `TypedDictFallback` stub, but the next automated typeshed sync would overwrite those declarations.

This removes the vendored changes and synthesizes the attributes during TypedDict class-member lookup when the typeshed fallback does not provide them. The synthesized members retain their `ClassVar` qualifier, so they remain available on TypedDict classes and `type[TypedDict]` while staying unavailable on TypedDict instances.
