### PR TITLE
[pyupgrade] Document constrained TypeVars for UP047

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs
@@ -59,6 +59,25 @@ use super::{DisplayTypeVars, TypeVarReferenceVisitor, check_type_vars, in_nested
 ///     return var
 /// ```
 ///
+/// Type variables with constraints are converted to constrained type parameters:
+///
+/// ```python
+/// from typing import TypeVar
+///
+/// AnyStr = TypeVar("AnyStr", str, bytes)
+///
+///
+/// def concat(x: AnyStr, y: AnyStr) -> AnyStr:
+///     return x + y
+/// ```
+///
+/// Use instead:
+///
+/// ```python
+/// def concat[AnyStr: (str, bytes)](x: AnyStr, y: AnyStr) -> AnyStr:
+///     return x + y
+/// ```
+///
 /// ## See also
 ///
 /// This rule replaces standalone type variables in function signatures but doesn't remove


### PR DESCRIPTION
## Summary

- Add a `non-pep695-generic-function` (UP047) documentation example for constrained `TypeVar` values.
- Show that UP047 preserves constraints by converting them to constrained PEP 695 type parameters.

Addresses #19155.

## Reproduction

- The existing UP047 docs showed an unconstrained `TypeVar` example.
- In #19155, users noted that the docs did not show how constrained type variables are handled, making the safe manual migration less obvious without running the unsafe fix diff.

## Root cause

- UP047 already preserves constrained `TypeVar` definitions in its fix, but the rule documentation did not include an example for that case.

## Changes

- Add a constrained `TypeVar("AnyStr", str, bytes)` example to the UP047 rule docs.
- Show the corresponding PEP 695 form: `def concat[AnyStr: (str, bytes)](...)`.

## Tests

- `git diff --check`
- `rustfmt --check crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs`
- `/tmp/ruff-prek-venv/bin/prek run --files crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_generic_function.rs`
- `cargo run -p ruff_dev -- generate-docs`

## Screenshots/Logs

N/A, documentation-only change. `generate-docs` completed successfully and printed the existing warning: `Rule F401 references deprecated option lint.ignore-init-module-imports.`
