### PR TITLE
[ty] Avoid rebuilding unchanged specializations

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -245,12 +245,14 @@ impl<'db> GenericAlias<'db> {
             .map(|specialization| specialization.types(db))
             .unwrap_or(&[]);
 
-        Self::new(
-            db,
-            self.origin(db),
-            self.specialization(db)
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-        )
+        let original_specialization = self.specialization(db);
+        let specialization =
+            original_specialization.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+        if specialization == original_specialization {
+            self
+        } else {
+            Self::new(db, self.origin(db), specialization)
+        }
     }
 
     pub(super) fn find_legacy_typevars_impl(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1261,15 +1261,19 @@ impl<'db> Specialization<'db> {
             tuple.apply_type_mapping_impl(db, type_mapping, TypeContext::default(), visitor)
         });
 
-        match types {
-            Cow::Borrowed(_) if tuple_inner == original_tuple_inner => self,
-            types => Specialization::new(
+        // Keep this check in sync with every field that can be transformed above.
+        let specialization_unchanged =
+            matches!(&types, Cow::Borrowed(_)) && tuple_inner == original_tuple_inner;
+        if specialization_unchanged {
+            self
+        } else {
+            Specialization::new(
                 db,
                 self.generic_context(db),
                 types,
                 self.materialization_kind(db),
                 tuple_inner,
-            ),
+            )
         }
     }
 
@@ -1397,17 +1401,20 @@ impl<'db> Specialization<'db> {
         } else {
             None
         };
-        let metadata_unchanged = tuple_inner == original_tuple_inner
+        // Keep this check in sync with every field that can be transformed above.
+        let specialization_unchanged = matches!(&types, Cow::Borrowed(_))
+            && tuple_inner == original_tuple_inner
             && new_materialization_kind == self.materialization_kind(db);
-        match types {
-            Cow::Borrowed(_) if metadata_unchanged => self,
-            types => Specialization::new(
+        if specialization_unchanged {
+            self
+        } else {
+            Specialization::new(
                 db,
                 self.generic_context(db),
                 types,
                 new_materialization_kind,
                 tuple_inner,
-            ),
+            )
         }
     }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1112,6 +1112,35 @@ pub(super) fn walk_specialization<'db, V: TypeVisitor<'db> + ?Sized>(
 }
 
 impl<'db> Specialization<'db> {
+    /// Maps the specialization's types without allocating if every type is unchanged.
+    fn map_types(
+        self,
+        db: &'db dyn Db,
+        mut map: impl FnMut(usize, BoundTypeVarInstance<'db>, Type<'db>) -> Type<'db>,
+    ) -> Cow<'db, [Type<'db>]> {
+        let types = self.types(db);
+        let mut mapped_types: Option<Vec<Type<'db>>> = None;
+
+        for (index, (typevar, ty)) in self
+            .generic_context(db)
+            .variables(db)
+            .zip(types.iter().copied())
+            .enumerate()
+        {
+            let mapped_ty = map(index, typevar, ty);
+            if let Some(mapped_types) = &mut mapped_types {
+                mapped_types.push(mapped_ty);
+            } else if mapped_ty != ty {
+                let mut changed_types = Vec::with_capacity(types.len());
+                changed_types.extend_from_slice(&types[..index]);
+                changed_types.push(mapped_ty);
+                mapped_types = Some(changed_types);
+            }
+        }
+
+        mapped_types.map_or(Cow::Borrowed(types), Cow::Owned)
+    }
+
     /// Restricts this specialization to only include the typevars in a generic context. If the
     /// specialization does not include all of those typevars, returns `None`.
     pub(crate) fn restrict(
@@ -1217,32 +1246,31 @@ impl<'db> Specialization<'db> {
             return self.materialize_impl(db, *materialization_kind, visitor);
         }
 
-        let types: Box<[_]> = self
-            .types(db)
-            .iter()
-            .zip(self.generic_context(db).variables(db))
-            .enumerate()
-            .map(|(i, (ty, typevar))| {
-                let tcx = TypeContext::new(tcx.get(i).copied());
-                if typevar.variance(db).is_covariant() {
-                    ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
-                } else {
-                    ty.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor)
-                }
-            })
-            .collect();
+        let types = self.map_types(db, |i, typevar, ty| {
+            let tcx = TypeContext::new(tcx.get(i).copied());
+            if typevar.variance(db).is_covariant() {
+                ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+            } else {
+                ty.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor)
+            }
+        });
 
-        let tuple_inner = self.tuple_inner(db).and_then(|tuple| {
+        let original_tuple_inner = self.tuple_inner(db);
+        let tuple_inner = original_tuple_inner.and_then(|tuple| {
             tuple.apply_type_mapping_impl(db, type_mapping, TypeContext::default(), visitor)
         });
 
-        Specialization::new(
-            db,
-            self.generic_context(db),
-            types,
-            self.materialization_kind(db),
-            tuple_inner,
-        )
+        if matches!(types, Cow::Borrowed(_)) && tuple_inner == original_tuple_inner {
+            self
+        } else {
+            Specialization::new(
+                db,
+                self.generic_context(db),
+                types,
+                self.materialization_kind(db),
+                tuple_inner,
+            )
+        }
     }
 
     /// Applies an optional specialization to this specialization.
@@ -1331,39 +1359,31 @@ impl<'db> Specialization<'db> {
             return self;
         }
         let mut has_dynamic_invariant_typevar = false;
-        let types: Box<[_]> = self
-            .generic_context(db)
-            .variables(db)
-            .zip(self.types(db))
-            .map(|(bound_typevar, vartype)| {
-                match specialization_variance(db, bound_typevar) {
-                    TypeVarVariance::Bivariant => {
-                        // With bivariance, all specializations are subtypes of each other,
-                        // so any materialization is acceptable.
-                        vartype.materialize(db, MaterializationKind::Top, visitor)
-                    }
-                    TypeVarVariance::Covariant => {
-                        vartype.materialize(db, materialization_kind, visitor)
-                    }
-                    TypeVarVariance::Contravariant => {
-                        vartype.materialize(db, materialization_kind.flip(), visitor)
-                    }
-                    TypeVarVariance::Invariant => {
-                        let top_materialization =
-                            vartype.materialize(db, MaterializationKind::Top, visitor);
-                        if !visitor.is_equivalent_to_materialization(
-                            db,
-                            *vartype,
-                            top_materialization,
-                        ) {
-                            has_dynamic_invariant_typevar = true;
-                        }
-                        *vartype
-                    }
+        let types = self.map_types(db, |_, bound_typevar, vartype| {
+            match specialization_variance(db, bound_typevar) {
+                TypeVarVariance::Bivariant => {
+                    // With bivariance, all specializations are subtypes of each other,
+                    // so any materialization is acceptable.
+                    vartype.materialize(db, MaterializationKind::Top, visitor)
                 }
-            })
-            .collect();
-        let tuple_inner = self.tuple_inner(db).and_then(|tuple| {
+                TypeVarVariance::Covariant => {
+                    vartype.materialize(db, materialization_kind, visitor)
+                }
+                TypeVarVariance::Contravariant => {
+                    vartype.materialize(db, materialization_kind.flip(), visitor)
+                }
+                TypeVarVariance::Invariant => {
+                    let top_materialization =
+                        vartype.materialize(db, MaterializationKind::Top, visitor);
+                    if !visitor.is_equivalent_to_materialization(db, vartype, top_materialization) {
+                        has_dynamic_invariant_typevar = true;
+                    }
+                    vartype
+                }
+            }
+        });
+        let original_tuple_inner = self.tuple_inner(db);
+        let tuple_inner = original_tuple_inner.and_then(|tuple| {
             // Tuples are immutable, so tuple element types are always in covariant position.
             tuple.apply_type_mapping_impl(
                 db,
@@ -1377,13 +1397,20 @@ impl<'db> Specialization<'db> {
         } else {
             None
         };
-        Specialization::new(
-            db,
-            self.generic_context(db),
-            types,
-            new_materialization_kind,
-            tuple_inner,
-        )
+        if matches!(types, Cow::Borrowed(_))
+            && tuple_inner == original_tuple_inner
+            && new_materialization_kind == self.materialization_kind(db)
+        {
+            self
+        } else {
+            Specialization::new(
+                db,
+                self.generic_context(db),
+                types,
+                new_materialization_kind,
+                tuple_inner,
+            )
+        }
     }
 
     pub(crate) fn is_disjoint_from<'c>(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1112,7 +1112,8 @@ pub(super) fn walk_specialization<'db, V: TypeVisitor<'db> + ?Sized>(
 }
 
 impl<'db> Specialization<'db> {
-    /// Maps the specialization's types without allocating if every type is unchanged.
+    /// Maps the specialization's types, returning [`Cow::Borrowed`] without allocating if every
+    /// type is unchanged and [`Cow::Owned`] otherwise.
     fn map_types(
         self,
         db: &'db dyn Db,
@@ -1260,16 +1261,15 @@ impl<'db> Specialization<'db> {
             tuple.apply_type_mapping_impl(db, type_mapping, TypeContext::default(), visitor)
         });
 
-        if matches!(types, Cow::Borrowed(_)) && tuple_inner == original_tuple_inner {
-            self
-        } else {
-            Specialization::new(
+        match types {
+            Cow::Borrowed(_) if tuple_inner == original_tuple_inner => self,
+            types => Specialization::new(
                 db,
                 self.generic_context(db),
                 types,
                 self.materialization_kind(db),
                 tuple_inner,
-            )
+            ),
         }
     }
 
@@ -1397,19 +1397,17 @@ impl<'db> Specialization<'db> {
         } else {
             None
         };
-        if matches!(types, Cow::Borrowed(_))
-            && tuple_inner == original_tuple_inner
-            && new_materialization_kind == self.materialization_kind(db)
-        {
-            self
-        } else {
-            Specialization::new(
+        let metadata_unchanged = tuple_inner == original_tuple_inner
+            && new_materialization_kind == self.materialization_kind(db);
+        match types {
+            Cow::Borrowed(_) if metadata_unchanged => self,
+            types => Specialization::new(
                 db,
                 self.generic_context(db),
                 types,
                 new_materialization_kind,
                 tuple_inner,
-            )
+            ),
         }
     }
 


### PR DESCRIPTION
## Summary

Applying a type mapping currently collects a new boxed type list and re-enters `Specialization` interning even when none of the mapped types or tuple metadata change. A surrounding `GenericAlias` then performs another redundant interner lookup for the unchanged specialization.

This maps specialization types lazily, allocating only after the first changed type, and returns the existing specialization when mapping or materialization leaves its fields unchanged. `GenericAlias` now preserves its identity when the mapped specialization is unchanged as well.
