### PR TITLE
[ty] Add dedicated TDDs for narrowing constraints

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1623,7 +1623,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     .reachability_constraints
                     .mark_used(live_binding.reachability_constraint());
                 use_def
-                    .reachability_constraints
+                    .narrowing_constraints
                     .mark_used(live_binding.narrowing_constraint());
             }
         }
@@ -1773,7 +1773,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     /// Adds and records a narrowing constraint for only the places that could possibly be narrowed.
     ///
     /// Returns the `ScopedPredicateId` for the positive predicate, which can later be passed to
-    /// `record_negated_narrowing_constraint` for TDD-level negation.
+    /// `record_negated_narrowing_constraint` to record the opposite result of the same check.
     fn record_narrowing_constraint(
         &mut self,
         predicate: PredicateOrLiteral<'db>,
@@ -1824,9 +1824,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     /// Negates the given predicate and then adds it as a narrowing constraint to the places
     /// that could possibly be narrowed.
     ///
-    /// Takes the `ScopedPredicateId` from the positive recording so that TDD-level negation
-    /// (`add_not_constraint`) uses the same atom. This ensures `atom(P) OR NOT(atom(P))`
-    /// simplifies to `ALWAYS_TRUE`, correctly cancelling narrowing after complete if/else blocks.
+    /// Takes the `ScopedPredicateId` from the positive recording so that both constraints refer to
+    /// the same check. This lets the positive and negative cases cancel after a complete
+    /// `if`/`else`.
     fn record_negated_narrowing_constraint(
         &mut self,
         predicate: PredicateOrLiteral<'db>,
@@ -3422,8 +3422,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             node: PredicateNode::Expression(guard_expr),
                             is_positive: true,
                         });
-                        // Add the predicate once, then use TDD-level negation for the failure
-                        // path. This ensures the positive and negative atoms share the same ID.
+                        // Use the same predicate ID for the successful and failed checks.
                         let guard_predicate_id = self.add_predicate(predicate);
                         let possibly_narrowed = self.compute_possibly_narrowed_places(&predicate);
                         self.flow_restore(condition_flow_snapshot.falsy());
@@ -3857,10 +3856,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             is_positive: true,
                         };
 
+                        let predicate_id =
+                            self.add_predicate(PredicateOrLiteral::Predicate(predicate));
+                        let narrowing_constraint = self
+                            .current_use_def_map_mut()
+                            .narrowing_constraints
+                            .add_atom(predicate_id);
+
                         if self.in_function_scope() {
-                            let constraint = self.record_reachability_constraint(
-                                PredicateOrLiteral::Predicate(predicate),
-                            );
+                            self.record_reachability_constraint_id(predicate_id);
 
                             // Also gate narrowing by this constraint: if the call returns
                             // `Never`, any narrowing in the current branch should be
@@ -3868,19 +3872,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             // narrowing to be preserved after if-statements where one branch
                             // calls a `NoReturn` function like `sys.exit()`.
                             self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(constraint);
+                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
                         } else {
                             // In non-function scopes, we only record a narrowing constraint
                             // (not a reachability constraint). Recording reachability for
                             // calls in module scope is simply too expensive, and it's not
                             // too important of a use case.
-                            let predicate_id =
-                                self.add_predicate(PredicateOrLiteral::Predicate(predicate));
-                            let constraint = self
-                                .current_reachability_constraints_mut()
-                                .add_atom(predicate_id);
                             self.current_use_def_map_mut()
-                                .record_narrowing_constraint_for_all_places(constraint);
+                                .record_narrowing_constraint_for_all_places(narrowing_constraint);
                         }
                     }
                 }

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -192,6 +192,35 @@ impl NarrowingConstraintsBuilder {
             return self.add_or_constraint(node.if_true, node.if_uncertain);
         }
 
+        // `if_uncertain` contributes to both cofactors. If either cofactor is already true,
+        // then the remaining cofactor can be lifted into `if_uncertain`, avoiding shapes like
+        // `A or (not A and B)`.
+        let when_true = self.add_or_constraint(node.if_true, node.if_uncertain);
+        let when_false = self.add_or_constraint(node.if_false, node.if_uncertain);
+        if when_true == when_false {
+            return when_true;
+        }
+        if when_true == ALWAYS_TRUE
+            && !(node.if_true == ALWAYS_TRUE && node.if_false == ALWAYS_FALSE)
+        {
+            return self.add_interior(InteriorNode {
+                atom: node.atom,
+                if_true: ALWAYS_TRUE,
+                if_uncertain: when_false,
+                if_false: ALWAYS_FALSE,
+            });
+        }
+        if when_false == ALWAYS_TRUE
+            && !(node.if_true == ALWAYS_FALSE && node.if_false == ALWAYS_TRUE)
+        {
+            return self.add_interior(InteriorNode {
+                atom: node.atom,
+                if_true: ALWAYS_FALSE,
+                if_uncertain: when_true,
+                if_false: ALWAYS_TRUE,
+            });
+        }
+
         *self.interior_cache.entry(node).or_insert_with(|| {
             self.interior_used.push(false);
             self.interiors.push(node)
@@ -438,5 +467,52 @@ mod tests {
         assert_eq!(root.if_true, ALWAYS_TRUE);
         assert_eq!(root.if_uncertain, a);
         assert_eq!(root.if_false, ALWAYS_FALSE);
+    }
+
+    #[test]
+    fn absorption_drops_failed_check_when_preceding_branch_reaches_merge() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let a = constraints.add_atom(predicate(0));
+        let b = constraints.add_atom(predicate(1));
+        let not_a = constraints.add_negated_atom(predicate(0));
+        let later_branch = constraints.add_and_constraint(not_a, b);
+
+        let merged = constraints.add_or_constraint(a, later_branch);
+        let root = constraints.interiors[merged];
+
+        assert_eq!(root.atom, predicate(1));
+        assert_eq!(root.if_true, ALWAYS_TRUE);
+        assert_eq!(root.if_uncertain, a);
+        assert_eq!(root.if_false, ALWAYS_FALSE);
+
+        for mask in 0_u8..4 {
+            let values = [mask & 0b01 != 0, mask & 0b10 != 0];
+            assert_eq!(
+                evaluate(&constraints, merged, &values),
+                values[0] || values[1]
+            );
+        }
+    }
+
+    #[test]
+    fn absorption_keeps_common_failed_check_from_terminal_branch() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let not_a = constraints.add_negated_atom(predicate(0));
+        let b = constraints.add_atom(predicate(1));
+        let not_b = constraints.add_negated_atom(predicate(1));
+        let c = constraints.add_atom(predicate(2));
+
+        let b_branch = constraints.add_and_constraint(not_a, b);
+        let c_branch = constraints.add_and_constraint(not_a, not_b);
+        let c_branch = constraints.add_and_constraint(c_branch, c);
+        let merged = constraints.add_or_constraint(b_branch, c_branch);
+
+        for mask in 0_u8..8 {
+            let values = [mask & 0b001 != 0, mask & 0b010 != 0, mask & 0b100 != 0];
+            assert_eq!(
+                evaluate(&constraints, merged, &values),
+                !values[0] && (values[1] || values[2]),
+            );
+        }
     }
 }

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -262,6 +262,9 @@ impl NarrowingConstraintsBuilder {
             return ALWAYS_TRUE;
         }
 
+        // See the "BDDs with lazy unions (or ternary decision diagrams)" section for the edge
+        // calculations below:
+        // https://elixir-lang.org/blog/2025/12/02/lazier-bdds-for-set-theoretic-types/#bdds-with-lazy-unions-or-ternary-decision-diagrams
         let result = match self.cmp_atoms(a, b) {
             Ordering::Equal => {
                 let a_node = self.interiors[a];
@@ -322,6 +325,8 @@ impl NarrowingConstraintsBuilder {
             return ALWAYS_TRUE;
         }
 
+        // See the "Lazier BDDs (for intersections)" section for the edge calculations below:
+        // https://elixir-lang.org/blog/2025/12/02/lazier-bdds-for-set-theoretic-types/#lazier-bdds-for-intersections
         let result = match self.cmp_atoms(a, b) {
             Ordering::Equal => {
                 let a_node = self.interiors[a];

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -1,30 +1,442 @@
 //! # Narrowing constraints
 //!
-//! When building a semantic index for a file, we associate each binding with a _narrowing
-//! constraint_, which constrains the type of the binding's place. Note that a binding can be
-//! associated with a different narrowing constraint at different points in a file. See the
-//! `use_def` module for more details.
+//! When building a semantic index for a file, we associate each binding with a narrowing
+//! constraint, which constrains the type of the binding's place. A binding can be associated with
+//! a different narrowing constraint at different points in a file. See the `use_def` module for
+//! more details.
 //!
-//! Narrowing constraints are represented as TDD (ternary decision diagram) nodes, sharing the
-//! same graph as reachability constraints. This allows narrowing constraints to support AND, OR,
-//! and NOT operations, which is essential for correctly preserving narrowing information across
-//! control flow merges (e.g. after if/elif/else with terminal branches).
+//! A narrowing constraint is a boolean formula over predicates such as `isinstance(x, A)`.
+//! Internally, we store these formulas in a ternary decision diagram (TDD). Each interior node has
+//! three outgoing edges:
 //!
-//! [`Predicate`]: crate::predicate::Predicate
+//! - `if_true` applies when the predicate is true.
+//! - `if_false` applies when the predicate is false.
+//! - `if_uncertain` applies either way.
+//!
+//! Despite its name, `if_uncertain` does not mean that the predicate's value is unknown. It is a
+//! "don't care" edge: the formula on that edge does not depend on the predicate. A node represents
+//! this formula:
+//!
+//! ```text
+//! if_uncertain OR (predicate AND if_true) OR (NOT predicate AND if_false)
+//! ```
+//!
+//! The extra edge keeps repeated unions small. For example, `A OR B` can store `A` once on `B`'s
+//! `if_uncertain` edge instead of copying `A` into both of `B`'s other edges.
+
+use std::cmp::Ordering;
+
+use ruff_index::{Idx, IndexVec};
+use rustc_hash::FxHashMap;
 
 use crate::ast_ids::ScopedUseId;
-use crate::reachability_constraints::ScopedReachabilityConstraintId;
+use crate::predicate::ScopedPredicateId;
+use crate::rank::RankBitBox;
 use crate::scope::FileScopeId;
 
-/// A narrowing constraint associated with a live binding.
+/// The ID of a narrowing formula within one scope.
 ///
-/// This is a TDD node ID in the shared reachability constraints graph.
-/// `ALWAYS_TRUE` means "no narrowing constraint" (the base type is unchanged).
-pub type ScopedNarrowingConstraint = ScopedReachabilityConstraintId;
+/// `ALWAYS_TRUE` means that no narrowing applies. `ALWAYS_FALSE` means that the path is
+/// impossible.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct ScopedNarrowingConstraint(u32);
+
+impl ScopedNarrowingConstraint {
+    pub const ALWAYS_TRUE: Self = Self(u32::MAX);
+    pub const ALWAYS_FALSE: Self = Self(u32::MAX - 1);
+
+    pub fn is_terminal(self) -> bool {
+        self.0 >= Self::ALWAYS_FALSE.0
+    }
+}
+
+impl Idx for ScopedNarrowingConstraint {
+    fn new(value: usize) -> Self {
+        assert!(value <= Self::ALWAYS_FALSE.0 as usize);
+        #[expect(clippy::cast_possible_truncation)]
+        Self(value as u32)
+    }
+
+    fn index(self) -> usize {
+        debug_assert!(!self.is_terminal());
+        self.0 as usize
+    }
+}
+
+const ALWAYS_TRUE: ScopedNarrowingConstraint = ScopedNarrowingConstraint::ALWAYS_TRUE;
+const ALWAYS_FALSE: ScopedNarrowingConstraint = ScopedNarrowingConstraint::ALWAYS_FALSE;
+
+/// Once a scope reaches this limit, operations return `ALWAYS_TRUE`. Dropping narrowing is less
+/// precise, but avoids exponential growth on pathological input.
+const MAX_INTERIOR_NODES: usize = 512 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize)]
+pub struct InteriorNode {
+    /// The predicate tested by this node.
+    atom: ScopedPredicateId,
+    /// The remaining formula when the predicate is true.
+    if_true: ScopedNarrowingConstraint,
+    /// The part of the formula that applies regardless of the predicate.
+    if_uncertain: ScopedNarrowingConstraint,
+    /// The remaining formula when the predicate is false.
+    if_false: ScopedNarrowingConstraint,
+}
+
+impl InteriorNode {
+    pub const fn atom(self) -> ScopedPredicateId {
+        self.atom
+    }
+
+    pub const fn if_true(self) -> ScopedNarrowingConstraint {
+        self.if_true
+    }
+
+    pub const fn if_uncertain(self) -> ScopedNarrowingConstraint {
+        self.if_uncertain
+    }
+
+    pub const fn if_false(self) -> ScopedNarrowingConstraint {
+        self.if_false
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+pub struct NarrowingConstraints {
+    used_interiors: Box<[InteriorNode]>,
+    used_indices: Option<Box<RankBitBox>>,
+}
+
+impl NarrowingConstraints {
+    pub fn get_interior_node(&self, id: ScopedNarrowingConstraint) -> InteriorNode {
+        debug_assert!(!id.is_terminal());
+        let raw_index = id.0 as usize;
+        if let Some(used_indices) = &self.used_indices {
+            debug_assert!(
+                used_indices.get_bit(raw_index).unwrap_or(false),
+                "all used narrowing constraints should have been marked as used",
+            );
+            self.used_interiors[used_indices.rank(raw_index) as usize]
+        } else {
+            self.used_interiors[raw_index]
+        }
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct NarrowingConstraintsBuilder {
+    interiors: IndexVec<ScopedNarrowingConstraint, InteriorNode>,
+    interior_used: IndexVec<ScopedNarrowingConstraint, bool>,
+    interior_cache: FxHashMap<InteriorNode, ScopedNarrowingConstraint>,
+    and_cache: FxHashMap<
+        (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
+        ScopedNarrowingConstraint,
+    >,
+    or_cache: FxHashMap<
+        (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
+        ScopedNarrowingConstraint,
+    >,
+}
+
+impl NarrowingConstraintsBuilder {
+    pub(crate) fn build(self) -> NarrowingConstraints {
+        if self.interior_used.iter().all(|used| *used) {
+            NarrowingConstraints {
+                used_interiors: self.interiors.raw.into_boxed_slice(),
+                used_indices: None,
+            }
+        } else {
+            let used_indices = RankBitBox::from_bits(self.interior_used.iter().copied());
+            let used_interiors = self
+                .interiors
+                .into_iter()
+                .zip(self.interior_used)
+                .filter_map(|(interior, used)| used.then_some(interior))
+                .collect();
+            NarrowingConstraints {
+                used_interiors,
+                used_indices: Some(Box::new(used_indices)),
+            }
+        }
+    }
+
+    pub(crate) fn mark_used(&mut self, node: ScopedNarrowingConstraint) {
+        if !node.is_terminal() && !self.interior_used[node] {
+            self.interior_used[node] = true;
+            let node = self.interiors[node];
+            self.mark_used(node.if_true);
+            self.mark_used(node.if_uncertain);
+            self.mark_used(node.if_false);
+        }
+    }
+
+    fn cmp_atoms(&self, a: ScopedNarrowingConstraint, b: ScopedNarrowingConstraint) -> Ordering {
+        if a == b || (a.is_terminal() && b.is_terminal()) {
+            Ordering::Equal
+        } else if a.is_terminal() {
+            Ordering::Greater
+        } else if b.is_terminal() {
+            Ordering::Less
+        } else {
+            self.interiors[a]
+                .atom
+                .cmp(&self.interiors[b].atom)
+                .reverse()
+        }
+    }
+
+    fn add_interior(&mut self, node: InteriorNode) -> ScopedNarrowingConstraint {
+        if node.if_uncertain == ALWAYS_TRUE {
+            return ALWAYS_TRUE;
+        }
+        if node.if_true == node.if_false {
+            return self.add_or_constraint(node.if_true, node.if_uncertain);
+        }
+
+        *self.interior_cache.entry(node).or_insert_with(|| {
+            self.interior_used.push(false);
+            self.interiors.push(node)
+        })
+    }
+
+    pub(crate) fn add_atom(&mut self, predicate: ScopedPredicateId) -> ScopedNarrowingConstraint {
+        if predicate == ScopedPredicateId::ALWAYS_FALSE {
+            ALWAYS_FALSE
+        } else if predicate == ScopedPredicateId::ALWAYS_TRUE {
+            ALWAYS_TRUE
+        } else {
+            self.add_interior(InteriorNode {
+                atom: predicate,
+                if_true: ALWAYS_TRUE,
+                if_uncertain: ALWAYS_FALSE,
+                if_false: ALWAYS_FALSE,
+            })
+        }
+    }
+
+    pub(crate) fn add_negated_atom(
+        &mut self,
+        predicate: ScopedPredicateId,
+    ) -> ScopedNarrowingConstraint {
+        if predicate == ScopedPredicateId::ALWAYS_FALSE {
+            ALWAYS_TRUE
+        } else if predicate == ScopedPredicateId::ALWAYS_TRUE {
+            ALWAYS_FALSE
+        } else {
+            self.add_interior(InteriorNode {
+                atom: predicate,
+                if_true: ALWAYS_FALSE,
+                if_uncertain: ALWAYS_FALSE,
+                if_false: ALWAYS_TRUE,
+            })
+        }
+    }
+
+    pub(crate) fn add_or_constraint(
+        &mut self,
+        a: ScopedNarrowingConstraint,
+        b: ScopedNarrowingConstraint,
+    ) -> ScopedNarrowingConstraint {
+        match (a, b) {
+            (ALWAYS_TRUE, _) | (_, ALWAYS_TRUE) => return ALWAYS_TRUE,
+            (ALWAYS_FALSE, other) | (other, ALWAYS_FALSE) => return other,
+            _ if a == b => return a,
+            _ => {}
+        }
+
+        let (a, b) = if b.0 < a.0 { (b, a) } else { (a, b) };
+        if let Some(cached) = self.or_cache.get(&(a, b)) {
+            return *cached;
+        }
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return ALWAYS_TRUE;
+        }
+
+        let result = match self.cmp_atoms(a, b) {
+            Ordering::Equal => {
+                let a_node = self.interiors[a];
+                let b_node = self.interiors[b];
+                let if_true = self.add_or_constraint(a_node.if_true, b_node.if_true);
+                let if_uncertain = self.add_or_constraint(a_node.if_uncertain, b_node.if_uncertain);
+                let if_false = self.add_or_constraint(a_node.if_false, b_node.if_false);
+                self.add_interior(InteriorNode {
+                    atom: a_node.atom,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                })
+            }
+            Ordering::Less => {
+                let node = self.interiors[a];
+                let if_uncertain = self.add_or_constraint(node.if_uncertain, b);
+                self.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true: node.if_true,
+                    if_uncertain,
+                    if_false: node.if_false,
+                })
+            }
+            Ordering::Greater => {
+                let node = self.interiors[b];
+                let if_uncertain = self.add_or_constraint(a, node.if_uncertain);
+                self.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true: node.if_true,
+                    if_uncertain,
+                    if_false: node.if_false,
+                })
+            }
+        };
+
+        self.or_cache.insert((a, b), result);
+        result
+    }
+
+    pub(crate) fn add_and_constraint(
+        &mut self,
+        a: ScopedNarrowingConstraint,
+        b: ScopedNarrowingConstraint,
+    ) -> ScopedNarrowingConstraint {
+        match (a, b) {
+            (ALWAYS_FALSE, _) | (_, ALWAYS_FALSE) => return ALWAYS_FALSE,
+            (ALWAYS_TRUE, other) | (other, ALWAYS_TRUE) => return other,
+            _ if a == b => return a,
+            _ => {}
+        }
+
+        let (a, b) = if b.0 < a.0 { (b, a) } else { (a, b) };
+        if let Some(cached) = self.and_cache.get(&(a, b)) {
+            return *cached;
+        }
+        if self.interiors.len() >= MAX_INTERIOR_NODES {
+            return ALWAYS_TRUE;
+        }
+
+        let result = match self.cmp_atoms(a, b) {
+            Ordering::Equal => {
+                let a_node = self.interiors[a];
+                let b_node = self.interiors[b];
+
+                let b_true_or_uncertain =
+                    self.add_or_constraint(b_node.if_true, b_node.if_uncertain);
+                let true_from_a = self.add_and_constraint(a_node.if_true, b_true_or_uncertain);
+                let true_from_uncertain =
+                    self.add_and_constraint(a_node.if_uncertain, b_node.if_true);
+                let if_true = self.add_or_constraint(true_from_a, true_from_uncertain);
+
+                let if_uncertain =
+                    self.add_and_constraint(a_node.if_uncertain, b_node.if_uncertain);
+
+                let b_false_or_uncertain =
+                    self.add_or_constraint(b_node.if_false, b_node.if_uncertain);
+                let false_from_a = self.add_and_constraint(a_node.if_false, b_false_or_uncertain);
+                let false_from_uncertain =
+                    self.add_and_constraint(a_node.if_uncertain, b_node.if_false);
+                let if_false = self.add_or_constraint(false_from_a, false_from_uncertain);
+
+                self.add_interior(InteriorNode {
+                    atom: a_node.atom,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                })
+            }
+            Ordering::Less => {
+                let node = self.interiors[a];
+                let if_true = self.add_and_constraint(node.if_true, b);
+                let if_uncertain = self.add_and_constraint(node.if_uncertain, b);
+                let if_false = self.add_and_constraint(node.if_false, b);
+                self.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                })
+            }
+            Ordering::Greater => {
+                let node = self.interiors[b];
+                let if_true = self.add_and_constraint(a, node.if_true);
+                let if_uncertain = self.add_and_constraint(a, node.if_uncertain);
+                let if_false = self.add_and_constraint(a, node.if_false);
+                self.add_interior(InteriorNode {
+                    atom: node.atom,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                })
+            }
+        };
+
+        self.and_cache.insert((a, b), result);
+        result
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ConstraintKey {
     NarrowingConstraint(ScopedNarrowingConstraint),
     NestedScope(FileScopeId),
     UseId(ScopedUseId),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn predicate(index: usize) -> ScopedPredicateId {
+        ScopedPredicateId::new(index)
+    }
+
+    fn evaluate(
+        constraints: &NarrowingConstraintsBuilder,
+        constraint: ScopedNarrowingConstraint,
+        values: &[bool],
+    ) -> bool {
+        match constraint {
+            ALWAYS_TRUE => true,
+            ALWAYS_FALSE => false,
+            _ => {
+                let node = constraints.interiors[constraint];
+                evaluate(constraints, node.if_uncertain, values)
+                    || if values[node.atom.index()] {
+                        evaluate(constraints, node.if_true, values)
+                    } else {
+                        evaluate(constraints, node.if_false, values)
+                    }
+            }
+        }
+    }
+
+    #[test]
+    fn boolean_operations_match_their_truth_tables() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let a = constraints.add_atom(predicate(0));
+        let b = constraints.add_atom(predicate(1));
+
+        let a_or_b = constraints.add_or_constraint(a, b);
+        let not_c = constraints.add_negated_atom(predicate(2));
+        let formula = constraints.add_and_constraint(a_or_b, not_c);
+
+        for mask in 0_u8..8 {
+            let values = [mask & 0b001 != 0, mask & 0b010 != 0, mask & 0b100 != 0];
+            assert_eq!(
+                evaluate(&constraints, formula, &values),
+                (values[0] || values[1]) && !values[2],
+            );
+        }
+    }
+
+    #[test]
+    fn union_parks_the_other_operand_in_the_uncertain_branch() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let a = constraints.add_atom(predicate(0));
+        let b = constraints.add_atom(predicate(1));
+
+        let union = constraints.add_or_constraint(a, b);
+        let root = constraints.interiors[union];
+
+        assert_eq!(root.atom, predicate(1));
+        assert_eq!(root.if_true, ALWAYS_TRUE);
+        assert_eq!(root.if_uncertain, a);
+        assert_eq!(root.if_false, ALWAYS_FALSE);
+    }
 }

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -52,7 +52,7 @@ impl ScopedNarrowingConstraint {
 
 impl Idx for ScopedNarrowingConstraint {
     fn new(value: usize) -> Self {
-        assert!(value <= Self::ALWAYS_FALSE.0 as usize);
+        assert!(value < Self::ALWAYS_FALSE.0 as usize);
         #[expect(clippy::cast_possible_truncation)]
         Self(value as u32)
     }
@@ -73,31 +73,13 @@ const MAX_INTERIOR_NODES: usize = 512 * 1024;
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize)]
 pub struct InteriorNode {
     /// The predicate tested by this node.
-    atom: ScopedPredicateId,
+    pub atom: ScopedPredicateId,
     /// The remaining formula when the predicate is true.
-    if_true: ScopedNarrowingConstraint,
+    pub if_true: ScopedNarrowingConstraint,
     /// The part of the formula that applies regardless of the predicate.
-    if_uncertain: ScopedNarrowingConstraint,
+    pub if_uncertain: ScopedNarrowingConstraint,
     /// The remaining formula when the predicate is false.
-    if_false: ScopedNarrowingConstraint,
-}
-
-impl InteriorNode {
-    pub const fn atom(self) -> ScopedPredicateId {
-        self.atom
-    }
-
-    pub const fn if_true(self) -> ScopedNarrowingConstraint {
-        self.if_true
-    }
-
-    pub const fn if_uncertain(self) -> ScopedNarrowingConstraint {
-        self.if_uncertain
-    }
-
-    pub const fn if_false(self) -> ScopedNarrowingConstraint {
-        self.if_false
-    }
+    pub if_false: ScopedNarrowingConstraint,
 }
 
 #[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
@@ -188,8 +170,8 @@ impl NarrowingConstraintsBuilder {
         if node.if_uncertain == ALWAYS_TRUE {
             return ALWAYS_TRUE;
         }
-        if node.if_true == node.if_false {
-            return self.add_or_constraint(node.if_true, node.if_uncertain);
+        if node.if_true == node.if_false && node.if_true == node.if_uncertain {
+            return node.if_true;
         }
 
         // `if_uncertain` contributes to both cofactors. If either cofactor is already true,

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -23,6 +23,14 @@
 //!
 //! The extra edge keeps repeated unions small. For example, `A OR B` can store `A` once on `B`'s
 //! `if_uncertain` edge instead of copying `A` into both of `B`'s other edges.
+//!
+//! We also absorb redundant cofactors when constructing TDD nodes. This is especially useful for
+//! the continuation of a large `if`/`elif` chain. Each branch has narrowing constraints of the
+//! form `A`, `NOT A AND B`, `NOT A AND NOT B AND C`, and so on. The continuation combines those
+//! branch constraints with `OR`. The negative part of each branch constraint is redundant in that
+//! union because it is already covered by the earlier positive branches. These negative prefixes
+//! are cofactors of the earlier positive alternatives and can be absorbed. For example,
+//! `A OR (NOT A AND B)` simplifies to `A OR B`.
 
 use std::cmp::Ordering;
 
@@ -174,6 +182,7 @@ impl NarrowingConstraintsBuilder {
             return node.if_true;
         }
 
+        // Find and absorb cofactors if we can. (See module documentation for more details.)
         // `if_uncertain` contributes to both cofactors. If either cofactor is already true,
         // then the remaining cofactor can be lifted into `if_uncertain`, avoiding shapes like
         // `A or (not A and B)`.

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -250,7 +250,9 @@ use thin_vec::ThinVec;
 use crate::ast_ids::ScopedUseId;
 use crate::definition::{Definition, DefinitionState};
 use crate::member::ScopedMemberId;
-use crate::narrowing_constraints::{ConstraintKey, ScopedNarrowingConstraint};
+use crate::narrowing_constraints::{
+    ConstraintKey, NarrowingConstraints, NarrowingConstraintsBuilder, ScopedNarrowingConstraint,
+};
 use crate::place::{PlaceExprRef, ScopedPlaceId};
 use crate::predicate::{PredicateOrLiteral, Predicates, PredicatesBuilder, ScopedPredicateId};
 use crate::reachability_constraints::{
@@ -447,11 +449,12 @@ impl RetainedBindingsBuilder {
 
     fn finish(
         self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) -> RetainedBindings {
         for binding in &self.live_bindings {
             reachability_constraints.mark_used(binding.reachability_constraint());
-            reachability_constraints.mark_used(binding.narrowing_constraint());
+            narrowing_constraints.mark_used(binding.narrowing_constraint());
         }
         RetainedBindings {
             ranges: self.ranges.into(),
@@ -504,6 +507,9 @@ pub struct UseDefMap<'db> {
 
     /// Array of reachability constraints in this scope.
     reachability_constraints: ReachabilityConstraints,
+
+    /// Array of narrowing constraints in this scope.
+    narrowing_constraints: NarrowingConstraints,
 
     /// Interned [`Bindings`] values.
     interned_bindings: RetainedBindings,
@@ -610,6 +616,10 @@ impl<'db> UseDefMap<'db> {
         &self.reachability_constraints
     }
 
+    pub fn narrowing_constraints(&self) -> &NarrowingConstraints {
+        &self.narrowing_constraints
+    }
+
     pub fn predicates(&self) -> &Predicates<'db> {
         &self.predicates
     }
@@ -672,7 +682,7 @@ impl<'db> UseDefMap<'db> {
                 ApplicableConstraints::UnboundBinding(NarrowingEvaluator {
                     constraint,
                     predicates: &self.predicates,
-                    reachability_constraints: &self.reachability_constraints,
+                    narrowing_constraints: &self.narrowing_constraints,
                 })
             }
             ConstraintKey::NestedScope(nested_scope) => {
@@ -702,7 +712,7 @@ impl<'db> UseDefMap<'db> {
         NarrowingEvaluator {
             constraint,
             predicates: &self.predicates,
-            reachability_constraints: &self.reachability_constraints,
+            narrowing_constraints: &self.narrowing_constraints,
         }
     }
 
@@ -928,6 +938,7 @@ impl<'db> UseDefMap<'db> {
         BindingWithConstraintsIterator {
             all_definitions: &self.all_definitions,
             predicates: &self.predicates,
+            narrowing_constraints: &self.narrowing_constraints,
             reachability_constraints: &self.reachability_constraints,
             boundness_analysis,
             inner: bindings.iter(),
@@ -983,6 +994,7 @@ type EnclosingSnapshots = IndexVec<ScopedEnclosingSnapshotId, EnclosingSnapshot>
 pub struct BindingWithConstraintsIterator<'map, 'db> {
     all_definitions: &'map IndexSlice<ScopedDefinitionId, DefinitionState<'db>>,
     predicates: &'map Predicates<'db>,
+    narrowing_constraints: &'map NarrowingConstraints,
     reachability_constraints: &'map ReachabilityConstraints,
     boundness_analysis: BoundnessAnalysis,
     inner: LiveBindingsIterator<'map>,
@@ -1007,7 +1019,7 @@ impl<'map, 'db> Iterator for BindingWithConstraintsIterator<'map, 'db> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let predicates = self.predicates;
-        let reachability_constraints = self.reachability_constraints;
+        let narrowing_constraints = self.narrowing_constraints;
 
         self.inner
             .next()
@@ -1016,7 +1028,7 @@ impl<'map, 'db> Iterator for BindingWithConstraintsIterator<'map, 'db> {
                 narrowing_constraint: NarrowingEvaluator {
                     constraint: live_binding.narrowing_constraint(),
                     predicates,
-                    reachability_constraints,
+                    narrowing_constraints,
                 },
                 reachability_constraint: live_binding.reachability_constraint(),
             })
@@ -1034,7 +1046,7 @@ pub struct BindingWithConstraints<'map, 'db> {
 pub struct NarrowingEvaluator<'map, 'db> {
     constraint: ScopedNarrowingConstraint,
     predicates: &'map Predicates<'db>,
-    reachability_constraints: &'map ReachabilityConstraints,
+    narrowing_constraints: &'map NarrowingConstraints,
 }
 
 impl<'map, 'db> NarrowingEvaluator<'map, 'db> {
@@ -1046,8 +1058,8 @@ impl<'map, 'db> NarrowingEvaluator<'map, 'db> {
         self.predicates
     }
 
-    pub fn reachability_constraints(&self) -> &'map ReachabilityConstraints {
-        self.reachability_constraints
+    pub fn narrowing_constraints(&self) -> &'map NarrowingConstraints {
+        self.narrowing_constraints
     }
 }
 
@@ -1146,6 +1158,9 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// Builder of reachability constraints.
     pub(super) reachability_constraints: ReachabilityConstraintsBuilder,
 
+    /// Builder of narrowing constraints.
+    pub(super) narrowing_constraints: NarrowingConstraintsBuilder,
+
     /// Live bindings at each so-far-recorded use.
     bindings_by_use: IndexVec<ScopedUseId, Bindings>,
 
@@ -1194,6 +1209,7 @@ impl<'db> UseDefMapBuilder<'db> {
             used_bindings: IndexVec::from_iter([false]),
             predicates: PredicatesBuilder::default(),
             reachability_constraints: ReachabilityConstraintsBuilder::default(),
+            narrowing_constraints: NarrowingConstraintsBuilder::default(),
             bindings_by_use: IndexVec::new(),
             multi_bindings_by_use: FxHashMap::default(),
             reachability: ScopedReachabilityConstraintId::ALWAYS_TRUE,
@@ -1356,16 +1372,14 @@ impl<'db> UseDefMapBuilder<'db> {
             return;
         }
 
-        let atom = self.reachability_constraints.add_atom(predicate);
+        let atom = self.narrowing_constraints.add_atom(predicate);
         self.record_narrowing_constraint_node_for_places(atom, places);
     }
 
     /// Records a negated narrowing constraint for only the specified places.
     ///
-    /// Uses TDD-level negation (`add_not_constraint`) rather than creating a new predicate atom
-    /// for the negated predicate. This ensures that `atom(P) OR NOT(atom(P))` simplifies to
-    /// `ALWAYS_TRUE` in the TDD, so narrowing is correctly cancelled out after complete
-    /// if/else blocks.
+    /// The positive and negative constraints use the same predicate ID. This lets `P or not P`
+    /// simplify to `ALWAYS_TRUE`, so narrowing cancels out after a complete `if`/`else`.
     pub(super) fn record_negated_narrowing_constraint_for_places(
         &mut self,
         predicate: ScopedPredicateId,
@@ -1377,12 +1391,11 @@ impl<'db> UseDefMapBuilder<'db> {
             return;
         }
 
-        let atom = self.reachability_constraints.add_atom(predicate);
-        let negated = self.reachability_constraints.add_not_constraint(atom);
+        let negated = self.narrowing_constraints.add_negated_atom(predicate);
         self.record_narrowing_constraint_node_for_places(negated, places);
     }
 
-    /// Records a TDD narrowing constraint node for the specified places.
+    /// Records a narrowing constraint node for the specified places.
     fn record_narrowing_constraint_node_for_places(
         &mut self,
         constraint: ScopedNarrowingConstraint,
@@ -1397,7 +1410,7 @@ impl<'db> UseDefMapBuilder<'db> {
                 ScopedPlaceId::Symbol(symbol_id) => {
                     if let Some(state) = self.symbol_states.get_mut(*symbol_id) {
                         state.record_narrowing_constraint(
-                            &mut self.reachability_constraints,
+                            &mut self.narrowing_constraints,
                             constraint,
                         );
                     }
@@ -1405,7 +1418,7 @@ impl<'db> UseDefMapBuilder<'db> {
                 ScopedPlaceId::Member(member_id) => {
                     if let Some(state) = self.member_states.get_mut(*member_id) {
                         state.record_narrowing_constraint(
-                            &mut self.reachability_constraints,
+                            &mut self.narrowing_constraints,
                             constraint,
                         );
                     }
@@ -1486,7 +1499,11 @@ impl<'db> UseDefMapBuilder<'db> {
             negated_reachability_id,
         );
 
-        self.symbol_states[symbol].merge(post_definition_state, &mut self.reachability_constraints);
+        self.symbol_states[symbol].merge(
+            post_definition_state,
+            &mut self.narrowing_constraints,
+            &mut self.reachability_constraints,
+        );
 
         // And similarly for all associated members:
         #[expect(
@@ -1509,8 +1526,11 @@ impl<'db> UseDefMapBuilder<'db> {
                 negated_reachability_id,
             );
 
-            self.member_states[member_id]
-                .merge(post_definition_state, &mut self.reachability_constraints);
+            self.member_states[member_id].merge(
+                post_definition_state,
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+            );
         }
     }
 
@@ -1524,11 +1544,11 @@ impl<'db> UseDefMapBuilder<'db> {
         constraint: ScopedNarrowingConstraint,
     ) {
         for state in &mut self.symbol_states {
-            state.record_narrowing_constraint(&mut self.reachability_constraints, constraint);
+            state.record_narrowing_constraint(&mut self.narrowing_constraints, constraint);
         }
 
         for state in &mut self.member_states {
-            state.record_narrowing_constraint(&mut self.reachability_constraints, constraint);
+            state.record_narrowing_constraint(&mut self.narrowing_constraints, constraint);
         }
     }
 
@@ -1772,6 +1792,7 @@ impl<'db> UseDefMapBuilder<'db> {
                 let new_symbol_state = &self.symbol_states[enclosing_symbol];
                 bindings.merge(
                     new_symbol_state.bindings().clone(),
+                    &mut self.narrowing_constraints,
                     &mut self.reachability_constraints,
                 );
             }
@@ -1879,28 +1900,28 @@ impl<'db> UseDefMapBuilder<'db> {
 
         let mut snapshot_definitions_iter = snapshot.symbol_states.into_iter();
         for current in &mut self.symbol_states {
-            if let Some(snapshot) = snapshot_definitions_iter.next() {
-                current.merge(snapshot, &mut self.reachability_constraints);
-            } else {
-                current.merge(
-                    PlaceState::undefined(snapshot.reachability),
-                    &mut self.reachability_constraints,
-                );
-                // Place not present in snapshot, so it's unbound/undeclared from that path.
-            }
+            let branch = snapshot_definitions_iter
+                .next()
+                // A place missing from the snapshot was undefined on that path.
+                .unwrap_or_else(|| PlaceState::undefined(snapshot.reachability));
+            current.merge(
+                branch,
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+            );
         }
 
         let mut snapshot_definitions_iter = snapshot.member_states.into_iter();
         for current in &mut self.member_states {
-            if let Some(snapshot) = snapshot_definitions_iter.next() {
-                current.merge(snapshot, &mut self.reachability_constraints);
-            } else {
-                current.merge(
-                    PlaceState::undefined(snapshot.reachability),
-                    &mut self.reachability_constraints,
-                );
-                // Place not present in snapshot, so it's unbound/undeclared from that path.
-            }
+            let branch = snapshot_definitions_iter
+                .next()
+                // A place missing from the snapshot was undefined on that path.
+                .unwrap_or_else(|| PlaceState::undefined(snapshot.reachability));
+            current.merge(
+                branch,
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+            );
         }
 
         self.reachability = self
@@ -1977,12 +1998,18 @@ impl<'db> UseDefMapBuilder<'db> {
 
         // We only walk the fields that are copied through to the UseDefMap when we finish building
         // it.
-        let interned_bindings = interned_bindings.finish(&mut self.reachability_constraints);
+        let interned_bindings = interned_bindings.finish(
+            &mut self.narrowing_constraints,
+            &mut self.reachability_constraints,
+        );
         for declarations in &mut interned_declarations {
             declarations.finish(&mut self.reachability_constraints);
         }
         for bindings in self.multi_bindings_by_use.values_mut().flatten() {
-            bindings.finish(&mut self.reachability_constraints);
+            bindings.finish(
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+            );
         }
         for &(_, RangeInfo { reachability, .. }) in &self.range_reachability {
             self.reachability_constraints.mark_used(reachability);
@@ -1990,7 +2017,7 @@ impl<'db> UseDefMapBuilder<'db> {
         for enclosing_snapshot in &enclosing_snapshots {
             // Bindings are already marked above.
             if let InternedEnclosingSnapshotId::Constraint(constraint) = enclosing_snapshot {
-                self.reachability_constraints.mark_used(*constraint);
+                self.narrowing_constraints.mark_used(*constraint);
             }
         }
         self.reachability_constraints.mark_used(self.reachability);
@@ -2005,6 +2032,7 @@ impl<'db> UseDefMapBuilder<'db> {
             used_bindings: self.used_bindings.into(),
             predicates: self.predicates.build(),
             reachability_constraints: self.reachability_constraints.build(),
+            narrowing_constraints: self.narrowing_constraints.build(),
             interned_bindings,
             interned_declarations: interned_declarations.into(),
             bindings_by_use: bindings_by_use.into(),

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -47,7 +47,7 @@ use ruff_index::newtype_index;
 use smallvec::{SmallVec, smallvec};
 
 use crate::ReachabilityConstraintsBuilder;
-use crate::narrowing_constraints::ScopedNarrowingConstraint;
+use crate::narrowing_constraints::{NarrowingConstraintsBuilder, ScopedNarrowingConstraint};
 use crate::reachability_constraints::ScopedReachabilityConstraintId;
 
 /// A newtype-index for a definition in a particular scope.
@@ -180,9 +180,8 @@ impl Declarations {
 
         // Invariant: merge_join_by consumes the two iterators in sorted order, which ensures that
         // the merged `live_declarations` vec remains sorted. If a definition is found in both `a`
-        // and `b`, we compose the constraints from the two paths in an appropriate way
-        // (intersection for narrowing constraints; ternary OR for reachability constraints). If a
-        // definition is found in only one path, it is used as-is.
+        // and `b`, we combine its reachability constraints. If a definition is found in only one
+        // path, it is used as-is.
         let a = a.live_declarations.into_iter();
         let b = b.live_declarations.into_iter();
         for zipped in a.merge_join_by(b, |a, b| a.declaration.cmp(&b.declaration)) {
@@ -252,11 +251,15 @@ impl Bindings {
             .unwrap_or(self.live_bindings[0].narrowing_constraint)
     }
 
-    pub(super) fn finish(&mut self, reachability_constraints: &mut ReachabilityConstraintsBuilder) {
+    pub(super) fn finish(
+        &mut self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+    ) {
         self.live_bindings.shrink_to_fit();
         for binding in &self.live_bindings {
             reachability_constraints.mark_used(binding.reachability_constraint);
-            reachability_constraints.mark_used(binding.narrowing_constraint);
+            narrowing_constraints.mark_used(binding.narrowing_constraint);
         }
     }
 }
@@ -388,12 +391,12 @@ impl Bindings {
     /// Add given constraint to all live bindings.
     pub(super) fn record_narrowing_constraint(
         &mut self,
-        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         constraint: ScopedNarrowingConstraint,
     ) {
         for binding in &mut self.live_bindings {
-            binding.narrowing_constraint = reachability_constraints
-                .add_and_constraint(binding.narrowing_constraint, constraint);
+            binding.narrowing_constraint =
+                narrowing_constraints.add_and_constraint(binding.narrowing_constraint, constraint);
         }
     }
 
@@ -421,6 +424,7 @@ impl Bindings {
     pub(super) fn merge(
         &mut self,
         b: Self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) {
         let a = std::mem::take(self);
@@ -429,15 +433,13 @@ impl Bindings {
             .unbound_narrowing_constraint
             .zip(b.unbound_narrowing_constraint)
         {
-            self.unbound_narrowing_constraint =
-                Some(reachability_constraints.add_or_constraint(a, b));
+            self.unbound_narrowing_constraint = Some(narrowing_constraints.add_or_constraint(a, b));
         }
 
         // Invariant: merge_join_by consumes the two iterators in sorted order, which ensures that
         // the merged `live_bindings` vec remains sorted. If a definition is found in both `a` and
-        // `b`, we compose the constraints from the two paths using ternary OR for both narrowing
-        // and reachability constraints. If a definition is found in only one path, it is used
-        // as-is.
+        // `b`, we combine its boolean narrowing constraints and its ternary reachability
+        // constraints. If a definition is found in only one path, it is used as-is.
         let a = a.live_bindings.into_iter();
         let b = b.live_bindings.into_iter();
         for zipped in a.merge_join_by(b, |a, b| a.binding().cmp(&b.binding())) {
@@ -445,7 +447,7 @@ impl Bindings {
                 EitherOrBoth::Both(a, b) => {
                     // If the same definition is visible through both paths, we OR the narrowing
                     // constraints: the type should be narrowed by whichever path was taken.
-                    let narrowing_constraint = reachability_constraints
+                    let narrowing_constraint = narrowing_constraints
                         .add_or_constraint(a.narrowing_constraint, b.narrowing_constraint);
 
                     // For reachability constraints, we also merge using a ternary OR operation:
@@ -508,11 +510,11 @@ impl PlaceState {
     /// Add given constraint to all live bindings.
     pub(super) fn record_narrowing_constraint(
         &mut self,
-        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         constraint: ScopedNarrowingConstraint,
     ) {
         self.bindings
-            .record_narrowing_constraint(reachability_constraints, constraint);
+            .record_narrowing_constraint(narrowing_constraints, constraint);
     }
 
     /// Add given reachability constraint to all live bindings.
@@ -544,9 +546,11 @@ impl PlaceState {
     pub(super) fn merge(
         &mut self,
         b: PlaceState,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) {
-        self.bindings.merge(b.bindings, reachability_constraints);
+        self.bindings
+            .merge(b.bindings, narrowing_constraints, reachability_constraints);
         self.declarations
             .merge(b.declarations, reachability_constraints);
     }
@@ -677,7 +681,7 @@ mod tests {
 
     #[test]
     fn record_constraint() {
-        let mut reachability_constraints = ReachabilityConstraintsBuilder::default();
+        let mut narrowing_constraints = NarrowingConstraintsBuilder::default();
         let mut sym = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
         sym.record_binding(
             ScopedDefinitionId::from_u32(1),
@@ -687,14 +691,15 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        let atom = reachability_constraints.add_atom(ScopedPredicateId::new(0));
-        sym.record_narrowing_constraint(&mut reachability_constraints, atom);
+        let atom = narrowing_constraints.add_atom(ScopedPredicateId::new(0));
+        sym.record_narrowing_constraint(&mut narrowing_constraints, atom);
 
         assert_bindings(&sym, &[(1, atom)]);
     }
 
     #[test]
     fn merge() {
+        let mut narrowing_constraints = NarrowingConstraintsBuilder::default();
         let mut reachability_constraints = ReachabilityConstraintsBuilder::default();
 
         // merging the same definition with the same constraint keeps the constraint
@@ -707,8 +712,8 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        let atom0 = reachability_constraints.add_atom(ScopedPredicateId::new(0));
-        sym1a.record_narrowing_constraint(&mut reachability_constraints, atom0);
+        let atom0 = narrowing_constraints.add_atom(ScopedPredicateId::new(0));
+        sym1a.record_narrowing_constraint(&mut narrowing_constraints, atom0);
 
         let mut sym1b = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
         sym1b.record_binding(
@@ -719,9 +724,13 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        sym1b.record_narrowing_constraint(&mut reachability_constraints, atom0);
+        sym1b.record_narrowing_constraint(&mut narrowing_constraints, atom0);
 
-        sym1a.merge(sym1b, &mut reachability_constraints);
+        sym1a.merge(
+            sym1b,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+        );
         let mut sym1 = sym1a;
         // Same constraint on both sides → OR(atom0, atom0) = atom0
         assert_bindings(&sym1, &[(1, atom0)]);
@@ -736,8 +745,8 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        let atom1 = reachability_constraints.add_atom(ScopedPredicateId::new(1));
-        sym2a.record_narrowing_constraint(&mut reachability_constraints, atom1);
+        let atom1 = narrowing_constraints.add_atom(ScopedPredicateId::new(1));
+        sym2a.record_narrowing_constraint(&mut narrowing_constraints, atom1);
 
         let mut sym1b = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
         sym1b.record_binding(
@@ -748,10 +757,14 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        let atom2 = reachability_constraints.add_atom(ScopedPredicateId::new(2));
-        sym1b.record_narrowing_constraint(&mut reachability_constraints, atom2);
+        let atom2 = narrowing_constraints.add_atom(ScopedPredicateId::new(2));
+        sym1b.record_narrowing_constraint(&mut narrowing_constraints, atom2);
 
-        sym2a.merge(sym1b, &mut reachability_constraints);
+        sym2a.merge(
+            sym1b,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+        );
         let sym2 = sym2a;
         // Different constraints: OR(atom1, atom2) produces a new TDD node (not a terminal)
         let merged_constraint = sym2.bindings().iter().next().unwrap().narrowing_constraint;
@@ -770,12 +783,16 @@ mod tests {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
-        let atom3 = reachability_constraints.add_atom(ScopedPredicateId::new(3));
-        sym3a.record_narrowing_constraint(&mut reachability_constraints, atom3);
+        let atom3 = narrowing_constraints.add_atom(ScopedPredicateId::new(3));
+        sym3a.record_narrowing_constraint(&mut narrowing_constraints, atom3);
 
         let sym2b = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
 
-        sym3a.merge(sym2b, &mut reachability_constraints);
+        sym3a.merge(
+            sym2b,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+        );
         let sym3 = sym3a;
         let bindings: Vec<_> = sym3
             .bindings()
@@ -788,7 +805,11 @@ mod tests {
         assert_eq!(bindings[1].1, atom3);
 
         // merging different definitions keeps them each with their existing constraints
-        sym1.merge(sym3, &mut reachability_constraints);
+        sym1.merge(
+            sym3,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+        );
         let sym = sym1;
         let bindings: Vec<_> = sym
             .bindings()
@@ -838,6 +859,7 @@ mod tests {
 
     #[test]
     fn record_declaration_merge() {
+        let mut narrowing_constraints = NarrowingConstraintsBuilder::default();
         let mut reachability_constraints = ReachabilityConstraintsBuilder::default();
         let mut sym = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
         sym.record_declaration(
@@ -851,13 +873,18 @@ mod tests {
             ScopedReachabilityConstraintId::ALWAYS_TRUE,
         );
 
-        sym.merge(sym2, &mut reachability_constraints);
+        sym.merge(
+            sym2,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+        );
 
         assert_declarations(&sym, &["1", "2"]);
     }
 
     #[test]
     fn record_declaration_merge_partial_undeclared() {
+        let mut narrowing_constraints = NarrowingConstraintsBuilder::default();
         let mut reachability_constraints = ReachabilityConstraintsBuilder::default();
         let mut sym = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
         sym.record_declaration(
@@ -867,7 +894,11 @@ mod tests {
 
         let sym2 = PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE);
 
-        sym.merge(sym2, &mut reachability_constraints);
+        sym.merge(
+            sym2,
+            &mut narrowing_constraints,
+            &mut reachability_constraints,
+        );
 
         assert_declarations(&sym, &["undeclared", "1"]);
     }

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -518,7 +518,7 @@ match x:
     case "foo" if (x := "bar") and reveal_type(x):  #  revealed: Literal["bar"]
         pass
 
-reveal_type(x)  # revealed: int | str | (~str & ~float & ~Literal[False]) | float
+reveal_type(x)  # revealed: object
 ```
 
 ## Narrowing on `Self` in `match` statements
@@ -613,7 +613,7 @@ def _(x: A | B | C):
         case _:
             raise ValueError()
 
-    reveal_type(x)  # revealed: (B & ~A) | A
+    reveal_type(x)  # revealed: B | A
 ```
 
 Reassignment in non-terminal branches is also preserved when the default branch is terminal:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -518,7 +518,7 @@ match x:
     case "foo" if (x := "bar") and reveal_type(x):  #  revealed: Literal["bar"]
         pass
 
-reveal_type(x)  # revealed: object
+reveal_type(x)  # revealed: int | str | (~str & ~float & ~Literal[False]) | float
 ```
 
 ## Narrowing on `Self` in `match` statements
@@ -613,7 +613,7 @@ def _(x: A | B | C):
         case _:
             raise ValueError()
 
-    reveal_type(x)  # revealed: B | (A & ~B)
+    reveal_type(x)  # revealed: (B & ~A) | A
 ```
 
 Reassignment in non-terminal branches is also preserved when the default branch is terminal:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -70,7 +70,7 @@ def _(x: A | B | C):
 
     # Only the if-branch (A) and elif-branch (B) flow through.
     # The else-branch returned, so its narrowing doesn't participate.
-    reveal_type(x)  # revealed: B | (A & ~B)
+    reveal_type(x)  # revealed: (B & ~A) | A
 ```
 
 ## Narrowing is preserved with multiple terminal branches
@@ -92,7 +92,7 @@ def _(x: A | B | C | D):
         return
 
     # Only the elif-B and elif-C branches flow through.
-    reveal_type(x)  # revealed: (C & ~A) | (B & ~A & ~C)
+    reveal_type(x)  # revealed: (C & ~A & ~B) | (B & ~A)
 ```
 
 ## Opaque branch predicates should not manufacture narrowing

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -70,7 +70,7 @@ def _(x: A | B | C):
 
     # Only the if-branch (A) and elif-branch (B) flow through.
     # The else-branch returned, so its narrowing doesn't participate.
-    reveal_type(x)  # revealed: (B & ~A) | A
+    reveal_type(x)  # revealed: B | A
 ```
 
 ## Narrowing is preserved with multiple terminal branches

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -228,8 +228,8 @@ def f(x: Literal[0, 1], y: Literal["", "hello"]):
         reveal_type(y)  # revealed: Never
     else:
         # ~(x or not x) or ~(y and not y)
-        reveal_type(x)  # revealed: Literal[0, 1]
-        reveal_type(y)  # revealed: Literal["", "hello"]
+        reveal_type(x)  # revealed: Literal[1, 0]
+        reveal_type(y)  # revealed: Literal["hello", ""]
 ```
 
 ## Control Flow Merging

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -228,8 +228,8 @@ def f(x: Literal[0, 1], y: Literal["", "hello"]):
         reveal_type(y)  # revealed: Never
     else:
         # ~(x or not x) or ~(y and not y)
-        reveal_type(x)  # revealed: Literal[1, 0]
-        reveal_type(y)  # revealed: Literal["hello", ""]
+        reveal_type(x)  # revealed: Literal[0, 1]
+        reveal_type(y)  # revealed: Literal["", "hello"]
 ```
 
 ## Control Flow Merging

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -637,6 +637,8 @@ impl ProjectedNarrowingGraph<'_> {
             return node.if_true;
         }
 
+        // Find and absorb cofactors if we can. (See `ty_python_core::narrowing_constraints` for
+        // more details.)
         // `if_uncertain` contributes to both cofactors. If either cofactor is already true,
         // then the remaining cofactor can be lifted into `if_uncertain`, avoiding shapes like
         // `A or (not A and B)`.

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -212,6 +212,7 @@ use ty_python_core::{
     BindingWithConstraints, DeclarationWithConstraint, DeclarationsIterator, FileScopeId,
     ScopedDefinitionId, SemanticIndex, Truthiness, UseDefMap,
     definition::DefinitionState,
+    narrowing_constraints::{NarrowingConstraints, ScopedNarrowingConstraint},
     place::ScopedPlaceId,
     place_table,
     predicate::{
@@ -512,16 +513,6 @@ fn accumulate_constraint<'db>(
 }
 
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
-    /// Narrow a type by walking a TDD narrowing constraint.
-    fn narrow_by_constraint(
-        &self,
-        db: &'db dyn Db,
-        predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-        id: ScopedReachabilityConstraintId,
-        base_ty: Type<'db>,
-        place: ScopedPlaceId,
-    ) -> Type<'db>;
-
     /// Analyze the statically known reachability for a given constraint.
     fn evaluate(
         &self,
@@ -532,47 +523,6 @@ pub(crate) trait ReachabilityConstraintsExtension<'db> {
 }
 
 impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
-    /// Narrow a type by walking a TDD narrowing constraint.
-    ///
-    /// The TDD represents a ternary formula over predicates that encodes which predicates
-    /// hold along a particular control flow path. We walk from root to leaves, accumulating
-    /// narrowing constraints.
-    ///
-    /// At each interior node, we branch based on whether the predicate is true or false:
-    /// - True branch: apply positive narrowing from the predicate
-    /// - False branch: apply negative narrowing from the predicate
-    ///
-    /// The "ambiguous" branch in the TDD is not followed for narrowing purposes, because
-    /// narrowing constraints record which predicates hold along the control flow path.
-    /// The predicates may be statically ambiguous (we can't determine their truthiness
-    /// at analysis time), but they still hold dynamically at runtime and should be used
-    /// for narrowing.
-    ///
-    /// At leaves:
-    /// - `ALWAYS_TRUE` or `AMBIGUOUS`: apply all accumulated narrowing to the base type
-    /// - `ALWAYS_FALSE`: this path is impossible → Never
-    ///
-    /// The final result is the union of all path results.
-    fn narrow_by_constraint(
-        &self,
-        db: &'db dyn Db,
-        predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-        id: ScopedReachabilityConstraintId,
-        base_ty: Type<'db>,
-        place: ScopedPlaceId,
-    ) -> Type<'db> {
-        let mut projector = NarrowingProjector::new(db, self, predicates, place);
-        let projected_root = projector.project(id);
-        let mut context = ProjectedNarrowingContext {
-            db,
-            base_ty,
-            graph: &projector.graph,
-            joins: projector.graph.joins(projected_root),
-            join_cache: FxHashMap::default(),
-        };
-        context.narrow(projected_root, None)
-    }
-
     /// Analyze the statically known reachability for a given constraint.
     fn evaluate(
         &self,
@@ -597,6 +547,26 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
             }
         }
     }
+}
+
+pub(crate) fn narrow_type_by_constraint<'db>(
+    db: &'db dyn Db,
+    constraints: &NarrowingConstraints,
+    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
+    id: ScopedNarrowingConstraint,
+    base_ty: Type<'db>,
+    place: ScopedPlaceId,
+) -> Type<'db> {
+    let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
+    let projected_root = projector.project(id);
+    let mut context = ProjectedNarrowingContext {
+        db,
+        base_ty,
+        graph: &projector.graph,
+        joins: projector.graph.joins(projected_root),
+        join_cache: FxHashMap::default(),
+    };
+    context.narrow(projected_root, None)
 }
 
 fn apply_accumulated_narrowing<'db>(
@@ -632,10 +602,11 @@ impl ProjectedNarrowingNodeId {
 struct ProjectedNarrowingNode {
     atom: ScopedPredicateId,
     if_true: ProjectedNarrowingNodeId,
+    if_uncertain: ProjectedNarrowingNodeId,
     if_false: ProjectedNarrowingNodeId,
 }
 
-/// Reduced reachability graph containing only predicates relevant to one place.
+/// Narrowing graph containing only predicates that can narrow one place.
 #[derive(Default)]
 struct ProjectedNarrowingGraph<'db> {
     nodes: Vec<ProjectedNarrowingNode>,
@@ -659,8 +630,11 @@ impl ProjectedNarrowingGraph<'_> {
 
     /// Interns a projected node, collapsing nodes with identical branches.
     fn add_node(&mut self, node: ProjectedNarrowingNode) -> ProjectedNarrowingNodeId {
+        if node.if_uncertain == ProjectedNarrowingNodeId::ALWAYS_TRUE {
+            return ProjectedNarrowingNodeId::ALWAYS_TRUE;
+        }
         if node.if_true == node.if_false {
-            return node.if_true;
+            return self.or(node.if_true, node.if_uncertain);
         }
 
         if let Some(cached) = self.node_cache.get(&node) {
@@ -689,7 +663,7 @@ impl ProjectedNarrowingGraph<'_> {
             }
 
             let node = self.node(id);
-            for next in [node.if_true, node.if_false] {
+            for next in [node.if_true, node.if_uncertain, node.if_false] {
                 if !next.is_terminal() {
                     if std::mem::replace(&mut referenced[next.0], true) {
                         joins[next.0] = true;
@@ -702,7 +676,7 @@ impl ProjectedNarrowingGraph<'_> {
         joins
     }
 
-    /// Constructs the canonical disjunction of two projected subgraphs.
+    /// Combines two paths without copying one path into both outcomes of the other's predicate.
     fn or(
         &mut self,
         left: ProjectedNarrowingNodeId,
@@ -735,29 +709,31 @@ impl ProjectedNarrowingGraph<'_> {
         let result = match left_node.atom.cmp(&right_node.atom).reverse() {
             std::cmp::Ordering::Equal => {
                 let if_true = self.or(left_node.if_true, right_node.if_true);
+                let if_uncertain = self.or(left_node.if_uncertain, right_node.if_uncertain);
                 let if_false = self.or(left_node.if_false, right_node.if_false);
                 self.add_node(ProjectedNarrowingNode {
                     atom: left_node.atom,
                     if_true,
+                    if_uncertain,
                     if_false,
                 })
             }
             std::cmp::Ordering::Less => {
-                let if_true = self.or(left_node.if_true, right);
-                let if_false = self.or(left_node.if_false, right);
+                let if_uncertain = self.or(left_node.if_uncertain, right);
                 self.add_node(ProjectedNarrowingNode {
                     atom: left_node.atom,
-                    if_true,
-                    if_false,
+                    if_true: left_node.if_true,
+                    if_uncertain,
+                    if_false: left_node.if_false,
                 })
             }
             std::cmp::Ordering::Greater => {
-                let if_true = self.or(left, right_node.if_true);
-                let if_false = self.or(left, right_node.if_false);
+                let if_uncertain = self.or(left, right_node.if_uncertain);
                 self.add_node(ProjectedNarrowingNode {
                     atom: right_node.atom,
-                    if_true,
-                    if_false,
+                    if_true: right_node.if_true,
+                    if_uncertain,
+                    if_false: right_node.if_false,
                 })
             }
         };
@@ -767,13 +743,13 @@ impl ProjectedNarrowingGraph<'_> {
     }
 }
 
-/// Projects reachability constraints onto the predicates that can narrow one place.
+/// Removes predicates that cannot narrow one place from a narrowing constraint.
 struct NarrowingProjector<'a, 'db> {
     db: &'db dyn Db,
-    constraints: &'a ReachabilityConstraints,
+    constraints: &'a NarrowingConstraints,
     predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
     place: ScopedPlaceId,
-    project_cache: FxHashMap<ScopedReachabilityConstraintId, ProjectedNarrowingNodeId>,
+    project_cache: FxHashMap<ScopedNarrowingConstraint, ProjectedNarrowingNodeId>,
     graph: ProjectedNarrowingGraph<'db>,
 }
 
@@ -781,7 +757,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     /// Creates a projector for narrowing `place`.
     fn new(
         db: &'db dyn Db,
-        constraints: &'a ReachabilityConstraints,
+        constraints: &'a NarrowingConstraints,
         predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
         place: ScopedPlaceId,
     ) -> Self {
@@ -815,40 +791,50 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         constraints
     }
 
-    /// Projects a reachability node into the reduced narrowing graph.
-    fn project(&mut self, id: ScopedReachabilityConstraintId) -> ProjectedNarrowingNodeId {
-        type Id = ScopedReachabilityConstraintId;
+    /// Projects one constraint node into the graph for this place.
+    fn project(&mut self, id: ScopedNarrowingConstraint) -> ProjectedNarrowingNodeId {
+        type Id = ScopedNarrowingConstraint;
 
         if let Some(cached) = self.project_cache.get(&id) {
             return *cached;
         }
 
         let projected = match id {
-            Id::ALWAYS_TRUE | Id::AMBIGUOUS => ProjectedNarrowingNodeId::ALWAYS_TRUE,
+            Id::ALWAYS_TRUE => ProjectedNarrowingNodeId::ALWAYS_TRUE,
             Id::ALWAYS_FALSE => ProjectedNarrowingNodeId::ALWAYS_FALSE,
             _ => {
                 let node = self.constraints.get_interior_node(id);
                 let predicate = self.predicates[node.atom()];
 
                 if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
+                    let if_uncertain = self.project(node.if_uncertain());
                     match analyze_single(self.db, &predicate) {
-                        Truthiness::AlwaysTrue => self.project(node.if_true()),
-                        Truthiness::AlwaysFalse => self.project(node.if_false()),
+                        Truthiness::AlwaysTrue => {
+                            let if_true = self.project(node.if_true());
+                            self.graph.or(if_true, if_uncertain)
+                        }
+                        Truthiness::AlwaysFalse => {
+                            let if_false = self.project(node.if_false());
+                            self.graph.or(if_false, if_uncertain)
+                        }
                         Truthiness::Ambiguous => {
                             unreachable!("`IsNonTerminalCall` predicates should never be Ambiguous")
                         }
                     }
                 } else {
                     let if_true = self.project(node.if_true());
+                    let if_uncertain = self.project(node.if_uncertain());
                     let if_false = self.project(node.if_false());
                     let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom());
 
                     if pos_constraint.is_none() && neg_constraint.is_none() {
-                        self.graph.or(if_true, if_false)
+                        let either = self.graph.or(if_true, if_false);
+                        self.graph.or(either, if_uncertain)
                     } else {
                         self.graph.add_node(ProjectedNarrowingNode {
                             atom: node.atom(),
                             if_true,
+                            if_uncertain,
                             if_false,
                         })
                     }
@@ -921,21 +907,16 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
             let (pos_constraint, neg_constraint) =
                 self.graph.predicate_constraints_cache[&node.atom].clone();
 
-            if node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
-                self.narrow(node.if_false, false_accumulated)
-            } else if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-                let true_accumulated = accumulate_constraint(accumulated, pos_constraint);
-                self.narrow(node.if_true, true_accumulated)
-            } else {
-                let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
-                let true_ty = self.narrow(node.if_true, true_accumulated);
+            let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
+            let true_ty = self.narrow(node.if_true, true_accumulated);
 
-                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
-                let false_ty = self.narrow(node.if_false, false_accumulated);
+            let uncertain_ty = self.narrow(node.if_uncertain, accumulated.clone());
 
-                UnionType::from_two_elements(self.db, true_ty, false_ty)
-            }
+            let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+            let false_ty = self.narrow(node.if_false, false_accumulated);
+
+            let true_or_uncertain = UnionType::from_two_elements(self.db, true_ty, uncertain_ty);
+            UnionType::from_two_elements(self.db, true_or_uncertain, false_ty)
         }
     }
 }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -835,17 +835,17 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             Id::ALWAYS_FALSE => ProjectedNarrowingNodeId::ALWAYS_FALSE,
             _ => {
                 let node = self.constraints.get_interior_node(id);
-                let predicate = self.predicates[node.atom()];
+                let predicate = self.predicates[node.atom];
 
                 if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
-                    let if_uncertain = self.project(node.if_uncertain());
+                    let if_uncertain = self.project(node.if_uncertain);
                     match analyze_single(self.db, &predicate) {
                         Truthiness::AlwaysTrue => {
-                            let if_true = self.project(node.if_true());
+                            let if_true = self.project(node.if_true);
                             self.graph.or(if_true, if_uncertain)
                         }
                         Truthiness::AlwaysFalse => {
-                            let if_false = self.project(node.if_false());
+                            let if_false = self.project(node.if_false);
                             self.graph.or(if_false, if_uncertain)
                         }
                         Truthiness::Ambiguous => {
@@ -853,17 +853,17 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                         }
                     }
                 } else {
-                    let if_true = self.project(node.if_true());
-                    let if_uncertain = self.project(node.if_uncertain());
-                    let if_false = self.project(node.if_false());
-                    let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom());
+                    let if_true = self.project(node.if_true);
+                    let if_uncertain = self.project(node.if_uncertain);
+                    let if_false = self.project(node.if_false);
+                    let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom);
 
                     if pos_constraint.is_none() && neg_constraint.is_none() {
                         let either = self.graph.or(if_true, if_false);
                         self.graph.or(either, if_uncertain)
                     } else {
                         self.graph.add_node(ProjectedNarrowingNode {
-                            atom: node.atom(),
+                            atom: node.atom,
                             if_true,
                             if_uncertain,
                             if_false,

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -633,8 +633,8 @@ impl ProjectedNarrowingGraph<'_> {
         if node.if_uncertain == ProjectedNarrowingNodeId::ALWAYS_TRUE {
             return ProjectedNarrowingNodeId::ALWAYS_TRUE;
         }
-        if node.if_true == node.if_false {
-            return self.or(node.if_true, node.if_uncertain);
+        if node.if_true == node.if_false && node.if_true == node.if_uncertain {
+            return node.if_true;
         }
 
         // `if_uncertain` contributes to both cofactors. If either cofactor is already true,

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -637,6 +637,37 @@ impl ProjectedNarrowingGraph<'_> {
             return self.or(node.if_true, node.if_uncertain);
         }
 
+        // `if_uncertain` contributes to both cofactors. If either cofactor is already true,
+        // then the remaining cofactor can be lifted into `if_uncertain`, avoiding shapes like
+        // `A or (not A and B)`.
+        let when_true = self.or(node.if_true, node.if_uncertain);
+        let when_false = self.or(node.if_false, node.if_uncertain);
+        if when_true == when_false {
+            return when_true;
+        }
+        if when_true == ProjectedNarrowingNodeId::ALWAYS_TRUE
+            && !(node.if_true == ProjectedNarrowingNodeId::ALWAYS_TRUE
+                && node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE)
+        {
+            return self.add_node(ProjectedNarrowingNode {
+                atom: node.atom,
+                if_true: ProjectedNarrowingNodeId::ALWAYS_TRUE,
+                if_uncertain: when_false,
+                if_false: ProjectedNarrowingNodeId::ALWAYS_FALSE,
+            });
+        }
+        if when_false == ProjectedNarrowingNodeId::ALWAYS_TRUE
+            && !(node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE
+                && node.if_false == ProjectedNarrowingNodeId::ALWAYS_TRUE)
+        {
+            return self.add_node(ProjectedNarrowingNode {
+                atom: node.atom,
+                if_true: ProjectedNarrowingNodeId::ALWAYS_FALSE,
+                if_uncertain: when_true,
+                if_false: ProjectedNarrowingNodeId::ALWAYS_TRUE,
+            });
+        }
+
         if let Some(cached) = self.node_cache.get(&node) {
             return *cached;
         }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -938,16 +938,29 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
             let (pos_constraint, neg_constraint) =
                 self.graph.predicate_constraints_cache[&node.atom].clone();
 
-            let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
-            let true_ty = self.narrow(node.if_true, true_accumulated);
+            if node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE
+                && node.if_uncertain == ProjectedNarrowingNodeId::ALWAYS_FALSE
+            {
+                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+                self.narrow(node.if_false, false_accumulated)
+            } else if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE
+                && node.if_uncertain == ProjectedNarrowingNodeId::ALWAYS_FALSE
+            {
+                let true_accumulated = accumulate_constraint(accumulated, pos_constraint);
+                self.narrow(node.if_true, true_accumulated)
+            } else {
+                let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
+                let true_ty = self.narrow(node.if_true, true_accumulated);
 
-            let uncertain_ty = self.narrow(node.if_uncertain, accumulated.clone());
+                let uncertain_ty = self.narrow(node.if_uncertain, accumulated.clone());
 
-            let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
-            let false_ty = self.narrow(node.if_false, false_accumulated);
+                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+                let false_ty = self.narrow(node.if_false, false_accumulated);
 
-            let true_or_uncertain = UnionType::from_two_elements(self.db, true_ty, uncertain_ty);
-            UnionType::from_two_elements(self.db, true_or_uncertain, false_ty)
+                let true_or_uncertain =
+                    UnionType::from_two_elements(self.db, true_ty, uncertain_ty);
+                UnionType::from_two_elements(self.db, true_or_uncertain, false_ty)
+            }
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,5 +1,5 @@
 use crate::Db;
-use crate::reachability::ReachabilityConstraintsExtension;
+use crate::reachability::narrow_type_by_constraint;
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
@@ -2817,8 +2817,9 @@ pub(crate) trait NarrowingEvaluatorExtension<'db> {
 
 impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
     fn narrow(&self, db: &'db dyn Db, base_type: Type<'db>, place: ScopedPlaceId) -> Type<'db> {
-        self.reachability_constraints().narrow_by_constraint(
+        narrow_type_by_constraint(
             db,
+            self.narrowing_constraints(),
             self.predicates(),
             self.constraint(),
             base_type,


### PR DESCRIPTION
## Summary

This started as the structural half of #25787: move narrowing constraints out of the reachability graph into a dedicated ternary decision diagram, where `if_uncertain` is a lazy "don't care" edge. Duboc OR and AND can then combine formulas without copying one path into both outcomes of another predicate, and projected narrowing uses the same representation for each place.

This PR now also includes #25835. Its cofactor-absorption reductions simplify formulas such as `A or (not A and B)` to `A or B`, so successful `if`/`elif` branches stay compact without continuation-specific predicate removal. The same reductions apply when constructing the semantic-index TDD and the projected graph used during narrowing.

#25836 was split out as the continuation-specific follow-up from #25787. With #25835 now incorporated here, its remaining branch-specific reductions and benchmarks need to be reevaluated against this updated base.

## Benchmarks

Using the original `charlie/rebench` structural checkpoint:

- PyTorch: 7.79s -> 1.87s (4.18x faster)

For `isort`, comparing ty binaries on the benchmark project with 5 warmups and 20 runs:

- before PR (`7c645a9a1`): 254.5ms ± 1.6ms
- dedicated TDDs (`698e44a`): 306.9ms ± 2.3ms (1.21x slower)
- cofactor absorption (`4a91655`): 258.9ms ± 2.4ms (1.02x slower)
- restored fast paths (`40a99f3`): 256.1ms ± 1.8ms (1.01x slower)

So the initial structural checkpoint regressed `isort`, but the current PR state is effectively back to baseline.
