### PR TITLE
[ty] Add cofactor absorption for narrowing TDDs

### DIFF
--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -192,6 +192,35 @@ impl NarrowingConstraintsBuilder {
             return self.add_or_constraint(node.if_true, node.if_uncertain);
         }
 
+        // `if_uncertain` contributes to both cofactors. If either cofactor is already true,
+        // then the remaining cofactor can be lifted into `if_uncertain`, avoiding shapes like
+        // `A or (not A and B)`.
+        let when_true = self.add_or_constraint(node.if_true, node.if_uncertain);
+        let when_false = self.add_or_constraint(node.if_false, node.if_uncertain);
+        if when_true == when_false {
+            return when_true;
+        }
+        if when_true == ALWAYS_TRUE
+            && !(node.if_true == ALWAYS_TRUE && node.if_false == ALWAYS_FALSE)
+        {
+            return self.add_interior(InteriorNode {
+                atom: node.atom,
+                if_true: ALWAYS_TRUE,
+                if_uncertain: when_false,
+                if_false: ALWAYS_FALSE,
+            });
+        }
+        if when_false == ALWAYS_TRUE
+            && !(node.if_true == ALWAYS_FALSE && node.if_false == ALWAYS_TRUE)
+        {
+            return self.add_interior(InteriorNode {
+                atom: node.atom,
+                if_true: ALWAYS_FALSE,
+                if_uncertain: when_true,
+                if_false: ALWAYS_TRUE,
+            });
+        }
+
         *self.interior_cache.entry(node).or_insert_with(|| {
             self.interior_used.push(false);
             self.interiors.push(node)
@@ -438,5 +467,52 @@ mod tests {
         assert_eq!(root.if_true, ALWAYS_TRUE);
         assert_eq!(root.if_uncertain, a);
         assert_eq!(root.if_false, ALWAYS_FALSE);
+    }
+
+    #[test]
+    fn absorption_drops_failed_check_when_preceding_branch_reaches_merge() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let a = constraints.add_atom(predicate(0));
+        let b = constraints.add_atom(predicate(1));
+        let not_a = constraints.add_negated_atom(predicate(0));
+        let later_branch = constraints.add_and_constraint(not_a, b);
+
+        let merged = constraints.add_or_constraint(a, later_branch);
+        let root = constraints.interiors[merged];
+
+        assert_eq!(root.atom, predicate(1));
+        assert_eq!(root.if_true, ALWAYS_TRUE);
+        assert_eq!(root.if_uncertain, a);
+        assert_eq!(root.if_false, ALWAYS_FALSE);
+
+        for mask in 0_u8..4 {
+            let values = [mask & 0b01 != 0, mask & 0b10 != 0];
+            assert_eq!(
+                evaluate(&constraints, merged, &values),
+                values[0] || values[1]
+            );
+        }
+    }
+
+    #[test]
+    fn absorption_keeps_common_failed_check_from_terminal_branch() {
+        let mut constraints = NarrowingConstraintsBuilder::default();
+        let not_a = constraints.add_negated_atom(predicate(0));
+        let b = constraints.add_atom(predicate(1));
+        let not_b = constraints.add_negated_atom(predicate(1));
+        let c = constraints.add_atom(predicate(2));
+
+        let b_branch = constraints.add_and_constraint(not_a, b);
+        let c_branch = constraints.add_and_constraint(not_a, not_b);
+        let c_branch = constraints.add_and_constraint(c_branch, c);
+        let merged = constraints.add_or_constraint(b_branch, c_branch);
+
+        for mask in 0_u8..8 {
+            let values = [mask & 0b001 != 0, mask & 0b010 != 0, mask & 0b100 != 0];
+            assert_eq!(
+                evaluate(&constraints, merged, &values),
+                !values[0] && (values[1] || values[2]),
+            );
+        }
     }
 }

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -518,7 +518,7 @@ match x:
     case "foo" if (x := "bar") and reveal_type(x):  #  revealed: Literal["bar"]
         pass
 
-reveal_type(x)  # revealed: int | str | (~str & ~float & ~Literal[False]) | float
+reveal_type(x)  # revealed: object
 ```
 
 ## Narrowing on `Self` in `match` statements
@@ -613,7 +613,7 @@ def _(x: A | B | C):
         case _:
             raise ValueError()
 
-    reveal_type(x)  # revealed: (B & ~A) | A
+    reveal_type(x)  # revealed: B | A
 ```
 
 Reassignment in non-terminal branches is also preserved when the default branch is terminal:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -70,7 +70,7 @@ def _(x: A | B | C):
 
     # Only the if-branch (A) and elif-branch (B) flow through.
     # The else-branch returned, so its narrowing doesn't participate.
-    reveal_type(x)  # revealed: (B & ~A) | A
+    reveal_type(x)  # revealed: B | A
 ```
 
 ## Narrowing is preserved with multiple terminal branches

--- a/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/truthiness.md
@@ -228,8 +228,8 @@ def f(x: Literal[0, 1], y: Literal["", "hello"]):
         reveal_type(y)  # revealed: Never
     else:
         # ~(x or not x) or ~(y and not y)
-        reveal_type(x)  # revealed: Literal[1, 0]
-        reveal_type(y)  # revealed: Literal["hello", ""]
+        reveal_type(x)  # revealed: Literal[0, 1]
+        reveal_type(y)  # revealed: Literal["", "hello"]
 ```
 
 ## Control Flow Merging

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -637,6 +637,37 @@ impl ProjectedNarrowingGraph<'_> {
             return self.or(node.if_true, node.if_uncertain);
         }
 
+        // `if_uncertain` contributes to both cofactors. If either cofactor is already true,
+        // then the remaining cofactor can be lifted into `if_uncertain`, avoiding shapes like
+        // `A or (not A and B)`.
+        let when_true = self.or(node.if_true, node.if_uncertain);
+        let when_false = self.or(node.if_false, node.if_uncertain);
+        if when_true == when_false {
+            return when_true;
+        }
+        if when_true == ProjectedNarrowingNodeId::ALWAYS_TRUE
+            && !(node.if_true == ProjectedNarrowingNodeId::ALWAYS_TRUE
+                && node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE)
+        {
+            return self.add_node(ProjectedNarrowingNode {
+                atom: node.atom,
+                if_true: ProjectedNarrowingNodeId::ALWAYS_TRUE,
+                if_uncertain: when_false,
+                if_false: ProjectedNarrowingNodeId::ALWAYS_FALSE,
+            });
+        }
+        if when_false == ProjectedNarrowingNodeId::ALWAYS_TRUE
+            && !(node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE
+                && node.if_false == ProjectedNarrowingNodeId::ALWAYS_TRUE)
+        {
+            return self.add_node(ProjectedNarrowingNode {
+                atom: node.atom,
+                if_true: ProjectedNarrowingNodeId::ALWAYS_FALSE,
+                if_uncertain: when_true,
+                if_false: ProjectedNarrowingNodeId::ALWAYS_TRUE,
+            });
+        }
+
         if let Some(cached) = self.node_cache.get(&node) {
             return *cached;
         }


### PR DESCRIPTION
Adds absorption rules using a simple reduction rule when creating narrowing constraint nodes.

This implements a new reduction rule when constructing a TDD interior node:

If the new node is

```text
N = U ∨ (P ∧ T) ∨ (¬P ∧ F)
```

(That is, `P` is the BDD variable, `T` is the `if_true` branch, `U` is the `if_uncertain` branch, `F` is the `if_false` branch)

If:

```text
T ∨ U = TRUE
```

then:

```text
N = P ∨ U ∨ F
```

so represent it as:

```text
P ? TRUE : (U ∨ F) : FALSE
```

Symmetrically, if:

```text
F ∨ U = TRUE
```

then:

```text
P ? FALSE : (U ∨ T) : TRUE
```

This reduction rule should be enough to handle `elif` chains correctly. For an `elif` chain, when merging:

```text
A ∨ B ∨ ...      // accumulated
```

with:

```text
¬A ∧ ¬B ∧ ... ∧ X
```

Duboc OR creates a node like:

```text
X ? (¬A ∧ ¬B ∧ ...) : (A ∨ B ∨ ...) : FALSE
```

Then the true cofactor is:

```text
(¬A ∧ ¬B ∧ ...) ∨ (A ∨ B ∨ ...) = TRUE
```

And that should reduce to:

```text
X ? TRUE : (A ∨ B ∨ ...) : FALSE
```

i.e. A ∨ B ∨ ... ∨ X.