### PR TITLE
[ty] Distinguish typing.TypedDict from typing_extensions.TypedDict

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -459,7 +459,7 @@ impl<'db> CompletionBuilder<'db> {
                         Type::SpecialForm(
                             SpecialFormType::Protocol
                                 | SpecialFormType::Generic
-                                | SpecialFormType::TypedDict
+                                | SpecialFormType::TypedDict(_)
                                 | SpecialFormType::NamedTuple
                         )
                     );

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2626,24 +2626,67 @@ def _(p: Person) -> None:
 
 ## Special properties
 
+### Python 3.12
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
 `TypedDict` class definitions have some special properties that can be used for introspection:
 
 ```py
+from typing import Generic, TypeVar, TypedDict as TypingTypedDict
 from typing_extensions import TypedDict
+
+T = TypeVar("T")
+
+class StdlibPerson(TypingTypedDict):
+    name: str
+
+StdlibFunctionalPerson = TypingTypedDict("StdlibFunctionalPerson", {"name": str})
+DynamicStdlibPerson = type("DynamicStdlibPerson", (StdlibPerson,), {})
 
 class Person(TypedDict):
     name: str
     age: int | None
 
 FunctionalPerson = TypedDict("FunctionalPerson", {"name": str, "age": int | None})
+DynamicPerson = type("DynamicPerson", (Person,), {})
+
+class Employee(Person):
+    employee_id: int
+
+class GenericPerson(TypedDict, Generic[T]):
+    value: T
+
+class SpecializedPerson(GenericPerson[int]):
+    pass
+
+StdlibPerson.__closed__  # error: [unresolved-attribute]
+StdlibPerson.__extra_items__  # error: [unresolved-attribute]
+StdlibPerson.__readonly_keys__  # error: [unresolved-attribute]
+StdlibPerson.__mutable_keys__  # error: [unresolved-attribute]
+StdlibFunctionalPerson.__closed__  # error: [unresolved-attribute]
+StdlibFunctionalPerson.__extra_items__  # error: [unresolved-attribute]
+DynamicStdlibPerson.__closed__  # error: [unresolved-attribute]
+DynamicStdlibPerson.__extra_items__  # error: [unresolved-attribute]
 
 reveal_type(Person.__total__)  # revealed: bool
 reveal_type(Person.__required_keys__)  # revealed: frozenset[str]
 reveal_type(Person.__optional_keys__)  # revealed: frozenset[str]
 reveal_type(Person.__closed__)  # revealed: bool | None
 reveal_type(Person.__extra_items__)  # revealed: Any
+reveal_type(Person.__readonly_keys__)  # revealed: frozenset[str]
+reveal_type(Person.__mutable_keys__)  # revealed: frozenset[str]
 reveal_type(FunctionalPerson.__closed__)  # revealed: bool | None
 reveal_type(FunctionalPerson.__extra_items__)  # revealed: Any
+reveal_type(Employee.__closed__)  # revealed: bool | None
+reveal_type(Employee.__extra_items__)  # revealed: Any
+reveal_type(DynamicPerson.__closed__)  # revealed: bool | None
+reveal_type(DynamicPerson.__extra_items__)  # revealed: Any
+reveal_type(SpecializedPerson.__closed__)  # revealed: bool | None
+reveal_type(SpecializedPerson.__readonly_keys__)  # revealed: frozenset[str]
 ```
 
 These attributes cannot be accessed on inhabitants:
@@ -2680,9 +2723,48 @@ def accepts_typed_dict_class(t_person: type[Person]) -> None:
     reveal_type(t_person.__extra_items__)  # revealed: Any
 
 accepts_typed_dict_class(Person)
+
+def accepts_stdlib_typed_dict_class(t_person: type[StdlibPerson]) -> None:
+    t_person.__closed__  # error: [unresolved-attribute]
+    t_person.__extra_items__  # error: [unresolved-attribute]
+```
+
+### Python 3.15
+
+On Python 3.15 and newer, classes defined using the standard-library `TypedDict` also have the PEP
+728 attributes:
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+```py
+from typing import TypedDict
+from typing_extensions import TypedDict as ExtensionsTypedDict
+
+class Person(TypedDict):
+    name: str
+
+FunctionalPerson = TypedDict("FunctionalPerson", {"name": str})
+
+class ExtensionsPerson(ExtensionsTypedDict):
+    name: str
+
+reveal_type(Person.__closed__)  # revealed: bool | None
+reveal_type(Person.__extra_items__)  # revealed: Any
+reveal_type(FunctionalPerson.__closed__)  # revealed: bool | None
+reveal_type(FunctionalPerson.__extra_items__)  # revealed: Any
+reveal_type(ExtensionsPerson.__closed__)  # revealed: bool | None
+reveal_type(ExtensionsPerson.__extra_items__)  # revealed: Any
 ```
 
 ## Subclassing
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 `TypedDict` types can be subclassed. The subclass can add new keys:
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -103,7 +103,7 @@ pub use instance::{NominalInstanceType, ProtocolInstanceType};
 pub(crate) use literal::{
     BytesLiteralType, EnumLiteralType, LiteralValueType, LiteralValueTypeKind, StringLiteralType,
 };
-pub use special_form::SpecialFormType;
+pub use special_form::{SpecialFormType, TypedDictModule};
 use ty_python_core::definition::Definition;
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -541,7 +541,7 @@ impl<'db> BoundSuperType<'db> {
             },
             Type::SpecialForm(SpecialFormType::Protocol) => ClassBase::Protocol,
             Type::SpecialForm(SpecialFormType::Generic) => ClassBase::Generic,
-            Type::SpecialForm(SpecialFormType::TypedDict) => ClassBase::TypedDict,
+            Type::SpecialForm(SpecialFormType::TypedDict(_)) => ClassBase::TypedDict,
             Type::Dynamic(dynamic) => ClassBase::Dynamic(dynamic),
             Type::Divergent(divergent) => ClassBase::Divergent(divergent),
             _ => {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -39,8 +39,8 @@ use crate::types::signatures::{
 use crate::types::tuple::TupleSpec;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, CallableTypes, DataclassParams,
-    FindLegacyTypeVarsVisitor, IntersectionType, TypeContext, TypeMapping, UnionBuilder,
-    VarianceInferable,
+    FindLegacyTypeVarsVisitor, IntersectionType, TypeContext, TypeMapping, TypedDictModule,
+    UnionBuilder, VarianceInferable,
 };
 use crate::{
     Db, FxIndexMap, FxOrderSet,
@@ -334,6 +334,31 @@ pub enum ClassLiteral<'db> {
     DynamicEnum(DynamicEnumLiteral<'db>),
 }
 
+fn typed_dict_module_from_bases<'db>(
+    db: &'db dyn Db,
+    bases: &[Type<'db>],
+) -> Option<TypedDictModule> {
+    let mut module = None;
+
+    for base in bases {
+        let base_module = match base {
+            Type::SpecialForm(SpecialFormType::TypedDict(module)) => Some(*module),
+            Type::ClassLiteral(base) => base.typed_dict_module(db),
+            Type::GenericAlias(alias) => alias.origin(db).typed_dict_module(db),
+            _ => None,
+        };
+
+        if let Some(base_module) = base_module {
+            if module.is_some_and(|module| module != base_module) {
+                return None;
+            }
+            module = Some(base_module);
+        }
+    }
+
+    module
+}
+
 impl<'db> ClassLiteral<'db> {
     /// Return a `ClassLiteral` representing the class `builtins.object`
     pub(super) fn object(db: &'db dyn Db) -> Self {
@@ -380,6 +405,15 @@ impl<'db> ClassLiteral<'db> {
     /// Returns the known class, if any.
     pub(crate) fn known(self, db: &'db dyn Db) -> Option<KnownClass> {
         self.as_static()?.known(db)
+    }
+
+    pub(crate) fn typed_dict_module(self, db: &'db dyn Db) -> Option<TypedDictModule> {
+        match self {
+            Self::Static(class) => class.typed_dict_module(db),
+            Self::Dynamic(class) => class.typed_dict_module(db),
+            Self::DynamicTypedDict(typed_dict) => Some(typed_dict.typed_dict_module(db)),
+            Self::DynamicNamedTuple(_) | Self::DynamicEnum(_) => None,
+        }
     }
 
     /// Returns whether this class has PEP 695 type parameters.

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -1,13 +1,14 @@
 use ruff_db::{diagnostic::Span, parsed::parsed_module};
 use ruff_python_ast::{self as ast, NodeIndex, name::Name};
 use ruff_text_size::{Ranged, TextRange};
+use ty_module_resolver::KnownModule;
 
 use crate::{
     Db, TypeQualifiers,
-    place::{Place, PlaceAndQualifiers},
+    place::{Place, PlaceAndQualifiers, known_module_symbol},
     types::{
         ClassBase, ClassLiteral, ClassType, DataclassParams, KnownClass, MemberLookupPolicy,
-        SubclassOfType, Type,
+        SubclassOfType, Type, TypedDictModule,
         class::{
             ClassMemberResult, CodeGeneratorKind, DisjointBase, InstanceMemberResult, MroLookup,
         },
@@ -225,6 +226,18 @@ impl<'db> DynamicClassLiteral<'db> {
         }
     }
 
+    pub(crate) fn typed_dict_module(self, db: &'db dyn Db) -> Option<TypedDictModule> {
+        #[salsa::tracked(cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+        fn typed_dict_module_inner<'db>(
+            db: &'db dyn Db,
+            class: DynamicClassLiteral<'db>,
+        ) -> Option<TypedDictModule> {
+            super::typed_dict_module_from_bases(db, class.explicit_bases(db))
+        }
+
+        typed_dict_module_inner(db, self)
+    }
+
     /// Returns a [`Span`] with the range of the `type()` call expression.
     ///
     /// See [`Self::header_range`] for more details.
@@ -423,10 +436,30 @@ impl<'db> DynamicClassLiteral<'db> {
             ClassMemberResult::Done(result) => result.finalize(db),
             ClassMemberResult::TypedDict => {
                 // Simplified `TypedDict` handling without type mapping.
-                KnownClass::TypedDictFallback
+                let fallback_member = KnownClass::TypedDictFallback
                     .to_class_literal(db)
                     .find_name_in_mro_with_policy(db, name, policy)
-                    .expect("Will return Some() when called on class literal")
+                    .expect("Will return Some() when called on class literal");
+                if !fallback_member.is_undefined() {
+                    return fallback_member;
+                }
+
+                if self.typed_dict_module(db) == Some(TypedDictModule::TypingExtensions)
+                    && let Some(typing_extensions_fallback) =
+                        known_module_symbol(db, KnownModule::TypingExtensions, "_TypedDict")
+                            .place
+                            .ignore_possibly_undefined()
+                            .filter(|ty| ty.as_class_literal().is_some())
+                {
+                    let member = typing_extensions_fallback
+                        .find_name_in_mro_with_policy(db, name, policy)
+                        .expect("Will return Some() when called on class literal");
+                    if !member.is_undefined() {
+                        return member;
+                    }
+                }
+
+                fallback_member
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -22,7 +22,7 @@ use crate::{
         GenericContext, KnownClass, KnownInstanceType, MaterializationKind, MemberLookupPolicy,
         MetaclassCandidate, MetaclassTransformInfo, Parameter, Parameters, PropertyInstanceType,
         Signature, SpecialFormType, StaticMroError, SubclassOfType, Truthiness, Type, TypeContext,
-        TypeMapping, TypeVarVariance, UnionBuilder, UnionType,
+        TypeMapping, TypeVarVariance, TypedDictModule, UnionBuilder, UnionType,
         call::{CallError, CallErrorKind},
         callable::{CallableFunctionProvenance, CallableTypeKind},
         class::{
@@ -702,6 +702,21 @@ impl<'db> StaticClassLiteral<'db> {
             return false;
         }
         is_typed_dict_inner(db, self)
+    }
+
+    pub(crate) fn typed_dict_module(self, db: &'db dyn Db) -> Option<TypedDictModule> {
+        #[salsa::tracked(cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+        fn typed_dict_module_inner<'db>(
+            db: &'db dyn Db,
+            class: StaticClassLiteral<'db>,
+        ) -> Option<TypedDictModule> {
+            super::typed_dict_module_from_bases(db, class.explicit_bases(db))
+        }
+
+        if !self.has_explicit_bases(db) {
+            return None;
+        }
+        typed_dict_module_inner(db, self)
     }
 
     /// Return `true` if this class is, or inherits from, a `NamedTuple` (inherits from

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -23,8 +23,8 @@ use crate::types::typed_dict::{
 };
 use crate::types::{
     BoundTypeVarInstance, CallableType, ClassBase, ClassLiteral, ClassType, KnownClass,
-    MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeVarVariance, TypedDictType, UnionType,
-    determine_upper_bound,
+    MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeVarVariance, TypedDictModule,
+    TypedDictType, UnionType, determine_upper_bound,
 };
 use crate::{Db, FxIndexMap};
 use ty_python_core::definition::Definition;
@@ -841,6 +841,8 @@ pub struct DynamicTypedDictLiteral<'db> {
     ///   eagerly computed spec is stored on the anchor.
     #[returns(ref)]
     pub(crate) anchor: DynamicTypedDictAnchor<'db>,
+
+    pub(crate) typed_dict_module: TypedDictModule,
 }
 
 impl get_size2::GetSize for DynamicTypedDictLiteral<'_> {}
@@ -857,6 +859,7 @@ impl<'db> DynamicTypedDictLiteral<'db> {
             self.name(db).clone(),
             self.anchor(db)
                 .recursive_type_normalized_impl(db, div, nested)?,
+            self.typed_dict_module(db),
         ))
     }
 }
@@ -1017,16 +1020,22 @@ pub(super) fn typed_dict_class_member<'db>(
         return fallback_member;
     }
 
-    // `typing_extensions.TypedDict` backports these attributes to Python versions before 3.15,
-    // where the stdlib fallback intentionally omits them.
-    if matches!(name, "__closed__" | "__extra_items__")
+    if self_class.typed_dict_module(db) == Some(TypedDictModule::TypingExtensions)
         && let Some(typing_extensions_fallback) =
             known_module_symbol(db, KnownModule::TypingExtensions, "_TypedDict")
                 .place
                 .ignore_possibly_undefined()
-                .and_then(Type::as_class_literal)
+                .filter(|ty| ty.as_class_literal().is_some())
     {
-        let member = typing_extensions_fallback.class_member(db, name, lookup_policy);
+        let member = typing_extensions_fallback
+            .find_name_in_mro_with_policy(db, name, lookup_policy)
+            .expect("Will return Some() when called on class literal")
+            .map_type(|ty| {
+                let new_upper_bound =
+                    determine_upper_bound(db, self_class, ClassBase::is_typed_dict);
+                let mapping = TypeMapping::ReplaceSelf { new_upper_bound };
+                ty.apply_type_mapping(db, &mapping, TypeContext::default())
+            });
         if !member.is_undefined() {
             return member;
         }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -5,7 +5,7 @@ use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, ClassLiteral, ClassType, DivergentType, DynamicType, KnownClass,
     KnownInstanceType, MaterializationKind, SpecialFormType, StaticMroError, Type, TypeContext,
-    TypeMapping, todo_type,
+    TypeMapping, TypedDictModule, todo_type,
 };
 use crate::{Db, DisplaySettings};
 
@@ -246,7 +246,7 @@ impl<'db> ClassBase<'db> {
                 SpecialFormType::Unknown => Some(Self::unknown()),
                 SpecialFormType::Protocol => Some(Self::Protocol),
                 SpecialFormType::Generic => Some(Self::Generic),
-                SpecialFormType::TypedDict => Some(Self::TypedDict),
+                SpecialFormType::TypedDict(_) => Some(Self::TypedDict),
 
                 SpecialFormType::NamedTuple => {
                     let class = subclass?.as_static()?;
@@ -452,7 +452,9 @@ impl<'db> From<ClassBase<'db>> for Type<'db> {
             ClassBase::Class(class) => class.into(),
             ClassBase::Protocol => Type::SpecialForm(SpecialFormType::Protocol),
             ClassBase::Generic => Type::SpecialForm(SpecialFormType::Generic),
-            ClassBase::TypedDict => Type::SpecialForm(SpecialFormType::TypedDict),
+            ClassBase::TypedDict => {
+                Type::SpecialForm(SpecialFormType::TypedDict(TypedDictModule::Typing))
+            }
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -34,7 +34,7 @@ use crate::types::{
     CallableType, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
     LiteralValueType, LiteralValueTypeKind, MaterializationKind, Protocol, ProtocolInstanceType,
     SpecialFormType, StringLiteralType, SubclassOfInner, SubclassOfType, Type, TypeAliasType,
-    TypeGuardLike, TypedDictType, UnionType, WrapperDescriptorKind, visitor,
+    TypeGuardLike, TypedDictModule, TypedDictType, UnionType, WrapperDescriptorKind, visitor,
 };
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::{FileScopeId, ScopeKind};
@@ -1381,8 +1381,10 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
             Type::TypedDict(TypedDictType::Synthesized(synthesized)) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
-                f.with_type(Type::SpecialForm(SpecialFormType::TypedDict))
-                    .write_str("TypedDict")?;
+                f.with_type(Type::SpecialForm(SpecialFormType::TypedDict(
+                    TypedDictModule::Typing,
+                )))
+                .write_str("TypedDict")?;
                 f.write_str(" with items ")?;
                 let items = synthesized.items(self.db);
                 for (i, name) in items.keys().enumerate() {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3665,8 +3665,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             Some(definition),
                             namedtuple_kind,
                         )
-                    } else if callable_type == Type::SpecialForm(SpecialFormType::TypedDict) {
-                        self.infer_typeddict_call_expression(call_expr, Some(definition))
+                    } else if let Type::SpecialForm(special_form) = callable_type
+                        && let Some(typed_dict_module) = special_form.typed_dict_module()
+                    {
+                        self.infer_typeddict_call_expression(
+                            call_expr,
+                            Some(definition),
+                            typed_dict_module,
+                        )
                     } else if let Some(function) = callable_type.as_function_literal()
                         && function.is_known(self.db(), KnownFunction::NewClass)
                     {
@@ -3972,7 +3978,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             _ => {}
         }
-        if func_ty == Type::SpecialForm(SpecialFormType::TypedDict) {
+        if func_ty
+            .as_special_form()
+            .is_some_and(SpecialFormType::is_typed_dict)
+        {
             self.infer_functional_typeddict_deferred(arguments);
             return;
         }
@@ -8130,8 +8139,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return ty;
         }
 
-        if callable_type == Type::SpecialForm(SpecialFormType::TypedDict) {
-            return self.infer_typeddict_call_expression(call_expression, None);
+        if let Type::SpecialForm(special_form) = callable_type
+            && let Some(typed_dict_module) = special_form.typed_dict_module()
+        {
+            return self.infer_typeddict_call_expression(call_expression, None, typed_dict_module);
         }
 
         if callable_type == Type::SpecialForm(SpecialFormType::TypeForm) {

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -54,7 +54,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.infer_expression(base, TypeContext::default())
                 };
                 is_typed_dict |= match ty {
-                    Type::SpecialForm(SpecialFormType::TypedDict) => true,
+                    Type::SpecialForm(special_form) if special_form.is_typed_dict() => true,
                     Type::ClassLiteral(class) => class.is_typed_dict(self.db()),
                     Type::GenericAlias(alias) => alias.is_typed_dict(self.db()),
                     _ => false,

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2376,7 +2376,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             SpecialFormType::TypingSelf
             | SpecialFormType::TypeAlias
-            | SpecialFormType::TypedDict
+            | SpecialFormType::TypedDict(_)
             | SpecialFormType::Unknown
             | SpecialFormType::Any
             | SpecialFormType::NamedTuple => {

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -19,7 +19,8 @@ use crate::types::typed_dict::{
     validate_typed_dict_constructor, validate_typed_dict_dict_literal,
 };
 use crate::types::{
-    IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictType,
+    IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictModule,
+    TypedDictType,
 };
 use ty_python_core::definition::Definition;
 
@@ -72,6 +73,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         &mut self,
         call_expr: &ast::ExprCall,
         definition: Option<Definition<'db>>,
+        typed_dict_module: TypedDictModule,
     ) -> Type<'db> {
         let db = self.db();
 
@@ -314,7 +316,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         };
 
-        let typeddict = DynamicTypedDictLiteral::new(db, name, anchor);
+        let typeddict = DynamicTypedDictLiteral::new(db, name, anchor, typed_dict_module);
         Type::ClassLiteral(ClassLiteral::DynamicTypedDict(typeddict))
     }
 

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -105,8 +105,8 @@ pub enum SpecialFormType {
     TypeAlias,
     /// The symbol `typing.TypeGuard` (which can also be found as `typing_extensions.TypeGuard`)
     TypeGuard,
-    /// The symbol `typing.TypedDict` (which can also be found as `typing_extensions.TypedDict`)
-    TypedDict,
+    /// The symbol `typing.TypedDict` or `typing_extensions.TypedDict`.
+    TypedDict(TypedDictModule),
     /// The symbol `typing.TypeIs` (which can also be found as `typing_extensions.TypeIs`)
     TypeIs,
 
@@ -128,7 +128,27 @@ pub enum SpecialFormType {
     NamedTuple,
 }
 
+/// The module from which `TypedDict` was imported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]
+pub enum TypedDictModule {
+    /// `typing.TypedDict`.
+    Typing,
+    /// `typing_extensions.TypedDict`.
+    TypingExtensions,
+}
+
 impl SpecialFormType {
+    pub(crate) const fn typed_dict_module(self) -> Option<TypedDictModule> {
+        match self {
+            Self::TypedDict(module) => Some(module),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn is_typed_dict(self) -> bool {
+        self.typed_dict_module().is_some()
+    }
+
     /// Return the [`KnownClass`] which this symbol is an instance of
     pub(crate) const fn class(self) -> KnownClass {
         match self {
@@ -149,7 +169,7 @@ impl SpecialFormType {
             | Self::Unpack
             | Self::TypeAlias
             | Self::TypeGuard
-            | Self::TypedDict
+            | Self::TypedDict(_)
             | Self::TypeIs
             | Self::TypeOf
             | Self::Not
@@ -232,12 +252,10 @@ impl SpecialFormType {
     /// imported the symbol from (`import_module`), return the variant that matches the
     /// import path — or `self` if there's no better match.
     ///
-    /// This exists because typeshed defines `_collections_abc.Callable` as
-    /// `from typing import Callable as Callable`, then re-exports it from `collections.abc`.
-    /// Following the alias chain to the definition site lands on `SpecialFormType::TypingCallable`
-    /// for both `from typing import Callable` and `from collections.abc import Callable`, erasing
-    /// the distinction. This method substitutes `CollectionsAbcCallable` at the `_collections_abc`
-    /// module boundary, restoring it before `collections.abc` star-reexports it.
+    /// This exists because typeshed defines some special forms as re-exports from other modules.
+    /// Following the alias chain to the definition site would otherwise erase distinctions such as
+    /// `typing.Callable` versus `collections.abc.Callable`, or `typing.TypedDict` versus
+    /// `typing_extensions.TypedDict`.
     ///
     /// Called at module-attribute resolution — the one boundary where the import-path
     /// module is still observable.
@@ -245,6 +263,12 @@ impl SpecialFormType {
         match (self, name, import_module) {
             (Self::TypingCallable, "Callable", KnownModule::CollectionsAbcInternal) => {
                 Self::CollectionsAbcCallable
+            }
+            (Self::TypedDict(_), "TypedDict", KnownModule::Typing) => {
+                Self::TypedDict(TypedDictModule::Typing)
+            }
+            (Self::TypedDict(_), "TypedDict", KnownModule::TypingExtensions) => {
+                Self::TypedDict(TypedDictModule::TypingExtensions)
             }
             _ => self,
         }
@@ -346,7 +370,7 @@ impl SpecialFormType {
                     SpecialFormType::Top => Self::Top,
                     SpecialFormType::Unpack => Self::Unpack,
                     SpecialFormType::Tuple => Self::Tuple,
-                    SpecialFormType::TypedDict => Self::TypedDict,
+                    SpecialFormType::TypedDict(_) => Self::TypedDict,
                     SpecialFormType::TypeOf => Self::TypeOf,
                     SpecialFormType::LegacyStdlibAlias(alias) => match alias {
                         LegacyStdlibAlias::List => Self::List,
@@ -404,7 +428,7 @@ impl SpecialFormType {
                 SpecialFormTypeBuilder::Top => Self::Top,
                 SpecialFormTypeBuilder::Unpack => Self::Unpack,
                 SpecialFormTypeBuilder::Tuple => Self::Tuple,
-                SpecialFormTypeBuilder::TypedDict => Self::TypedDict,
+                SpecialFormTypeBuilder::TypedDict => Self::TypedDict(TypedDictModule::Typing),
                 SpecialFormTypeBuilder::TypeOf => Self::TypeOf,
                 SpecialFormTypeBuilder::List => Self::LegacyStdlibAlias(LegacyStdlibAlias::List),
                 SpecialFormTypeBuilder::Dict => Self::LegacyStdlibAlias(LegacyStdlibAlias::Dict),
@@ -460,7 +484,7 @@ impl SpecialFormType {
             | Self::Unpack
             | Self::TypeAlias
             | Self::TypeGuard
-            | Self::TypedDict
+            | Self::TypedDict(_)
             | Self::TypeIs
             | Self::TypeForm
             | Self::TypingSelf
@@ -498,7 +522,7 @@ impl SpecialFormType {
     pub(super) const fn is_callable(self) -> bool {
         match self {
             // TypedDict can be called as a constructor to create TypedDict types
-            Self::TypedDict
+            Self::TypedDict(_)
 
             // Collection constructors are callable
             // TODO actually implement support for calling them
@@ -590,7 +614,7 @@ impl SpecialFormType {
             | Self::Optional
             | Self::Top
             | Self::TypeIs
-            | Self::TypedDict
+            | Self::TypedDict(_)
             | Self::TypingSelf
             | Self::Union
             | Self::Unknown
@@ -622,7 +646,7 @@ impl SpecialFormType {
             SpecialFormType::Unpack => "Unpack",
             SpecialFormType::TypeAlias => "TypeAlias",
             SpecialFormType::TypeGuard => "TypeGuard",
-            SpecialFormType::TypedDict => "TypedDict",
+            SpecialFormType::TypedDict(_) => "TypedDict",
             SpecialFormType::TypeIs => "TypeIs",
             SpecialFormType::LegacyStdlibAlias(LegacyStdlibAlias::List) => "List",
             SpecialFormType::LegacyStdlibAlias(LegacyStdlibAlias::Dict) => "Dict",
@@ -669,7 +693,7 @@ impl SpecialFormType {
             | SpecialFormType::Unpack
             | SpecialFormType::TypeAlias
             | SpecialFormType::TypeGuard
-            | SpecialFormType::TypedDict
+            | SpecialFormType::TypedDict(_)
             | SpecialFormType::TypeIs
             | SpecialFormType::Protocol
             | SpecialFormType::Generic
@@ -796,7 +820,7 @@ impl SpecialFormType {
             // annotated assignment statement) doesn't reach here. Using it in any other type
             // expression is an error.
             Self::TypeAlias => Err(InvalidTypeExpression::TypeAlias),
-            Self::TypedDict => Err(InvalidTypeExpression::TypedDict),
+            Self::TypedDict(_) => Err(InvalidTypeExpression::TypedDict),
 
             Self::Literal | Self::Union | Self::Intersection => {
                 Err(InvalidTypeExpression::RequiresArguments(self))


### PR DESCRIPTION
## Summary

This follows up on #25833. On Python 3.12, classes defined using `typing_extensions.TypedDict` have runtime attributes that classes defined using `typing.TypedDict` do not, but we currently treat both definitions as the same special form.

This keeps track of which `TypedDict` definition was used for class-based, functional, inherited, generic, and dynamically created TypedDicts. Member lookup still uses the shared typeshed declarations first, then consults `typing_extensions._TypedDict` only for TypedDicts defined using `typing_extensions.TypedDict`. Their MRO and type relationships remain unchanged.

The regression tests cover the stdlib and extensions distinction on Python 3.12, along with the standard-library attributes available on Python 3.15.
