### PR TITLE
[ty] Restrict length narrowing to types that encode their length

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/len.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/len.md
@@ -65,8 +65,8 @@ def _(x: tuple[int, ...]):
 
 ## Exact length comparisons
 
-Exact length constraints eliminate incompatible fixed-length tuples. Variable-length tuples remain
-intersected with `ExactlySized` until tuple/protocol intersections can be simplified generally:
+Exact length constraints eliminate types whose encoded length is incompatible with the comparison.
+Types that do not encode their length remain unchanged:
 
 ```toml
 [environment]
@@ -74,19 +74,14 @@ python-version = "3.11"
 ```
 
 ```py
-from typing import Literal
+from typing import Literal, assert_never
 
 def _(val: tuple[int] | tuple[str, str] | tuple[int, *tuple[str, ...], int]):
     if len(val) == 1:
-        # revealed: tuple[int] | (tuple[int, *tuple[str, ...], int] & ExactlySized[Literal[1, True]])
-        reveal_type(val)
+        reveal_type(val)  # revealed: tuple[int]
 
     if len(val) == 2:
-        # revealed: tuple[str, str] | (tuple[int, *tuple[str, ...], int] & ExactlySized[Literal[2]])
-        reveal_type(val)
-
-    if len(val) == 3:
-        # revealed: tuple[int, *tuple[str, ...], int] & ExactlySized[Literal[3]]
+        # revealed: tuple[str, str] | tuple[int, *tuple[str, ...], int]
         reveal_type(val)
 
 def _(val: tuple[int] | tuple[str, str]):
@@ -97,7 +92,7 @@ def _(val: tuple[int] | tuple[str, str]):
 
 def _(val: tuple[int, ...]):
     if val and len(val) == 2:
-        reveal_type(val)  # revealed: tuple[int, ...] & ExactlySized[Literal[2]] & ~AlwaysFalsy
+        reveal_type(val)  # revealed: tuple[int, ...] & ~AlwaysFalsy
 
 def _(val: tuple[int] | tuple[str, str]):
     if len(val) == True:
@@ -108,6 +103,10 @@ def _(val: tuple[()] | tuple[int]):
     if False == len(val):
         reveal_type(val)  # revealed: tuple[()]
         empty: tuple[()] = val
+
+def _(val: tuple[int]):
+    if len(val) == 2:
+        assert_never(val)
 
 def _(x: Literal[b"", b"a"], y: Literal["a", "ab"]):
     if len(x) == 1:
@@ -121,11 +120,25 @@ def _(x: Literal[b"", b"a"], y: Literal["a", "ab"]):
         reveal_type(y)  # revealed: Literal["ab"]
 ```
 
-Exact length comparisons intersect arbitrary `Sized` values with `ExactlySized`. This persists the
-observed length even for mutable or stateful values, consistent with other forms of narrowing:
+Tuple subclasses are filtered using their tuple spec while preserving the subclass:
 
 ```py
-from typing import Literal, Sized
+class One(tuple[int]): ...
+class Two(tuple[int, int]): ...
+class Variable(tuple[int, ...]): ...
+
+def _(value: One | Two | Variable):
+    if len(value) == 1:
+        reveal_type(value)  # revealed: One | Variable
+    else:
+        reveal_type(value)  # revealed: Two | Variable
+```
+
+Types whose `__len__` return types encode one or more possible lengths are filtered while
+unknown-length alternatives are preserved:
+
+```py
+from typing import Literal
 
 class LengthThree:
     def __len__(self) -> Literal[3]:
@@ -135,11 +148,34 @@ class LengthFour:
     def __len__(self) -> Literal[4]:
         return 4
 
-def _(value: LengthThree | LengthFour):
+class LengthOneOrTwo:
+    def __len__(self) -> Literal[1, 2]:
+        return 1
+
+def _(value: LengthThree | LengthFour | list[int]):
     if len(value) == 3:
-        reveal_type(value)  # revealed: LengthThree & ExactlySized[Literal[3]]
+        reveal_type(value)  # revealed: LengthThree | list[int]
     else:
-        reveal_type(value)  # revealed: LengthFour
+        reveal_type(value)  # revealed: LengthFour | list[int]
+
+def _(value: LengthOneOrTwo | LengthThree):
+    if len(value) == 3:
+        reveal_type(value)  # revealed: LengthThree
+    else:
+        reveal_type(value)  # revealed: LengthOneOrTwo
+
+def _(value: LengthOneOrTwo | LengthThree):
+    if len(value) == 1:
+        reveal_type(value)  # revealed: LengthOneOrTwo
+    else:
+        reveal_type(value)  # revealed: LengthOneOrTwo | LengthThree
+```
+
+Boolean-valued `__len__` return types are normalized to their corresponding integer lengths before
+filtering:
+
+```py
+from typing import Literal
 
 class TrueLength:
     def __len__(self) -> Literal[True]:
@@ -151,33 +187,20 @@ class FalseLength:
 
 def _(value: TrueLength | FalseLength):
     if len(value) == 1:
-        reveal_type(value)  # revealed: TrueLength & ExactlySized[Literal[1, True]]
+        reveal_type(value)  # revealed: TrueLength
     else:
         reveal_type(value)  # revealed: FalseLength
-
-def _(value: LengthThree | list[int]):
-    if len(value) == 3:
-        # revealed: (LengthThree & ExactlySized[Literal[3]]) | (list[int] & ExactlySized[Literal[3]])
-        reveal_type(value)
-    else:
-        reveal_type(value)  # revealed: list[int] & ~ExactlySized[Literal[3]]
 ```
 
-The length constraint remains after mutation. This is an accepted limitation:
+## Regression tests
+
+Length constraints must not become stale after mutating a value that does not encode its length:
 
 ```py
-def _(value: Sized):
-    if len(value) == 3:
-        reveal_type(value)  # revealed: ExactlySized[Literal[3]]
-        reveal_type(len(value))  # revealed: Literal[3]
-    else:
-        reveal_type(value)  # revealed: Sized & ~ExactlySized[Literal[3]]
-
 def _(items: list[int]):
-    if len(items) == 3:
-        reveal_type(items)  # revealed: list[int] & ExactlySized[Literal[3]]
-        items.clear()
-        reveal_type(len(items))  # revealed: Literal[3]
+    if len(items) == 0:
+        items.append(1)
+        reveal_type(len(items))  # revealed: int
 ```
 
 ## Aliased exact lengths
@@ -194,9 +217,9 @@ from typing import Literal
 
 type Two = Literal[2]
 
-def _(val: tuple[int, ...], n: Two):
+def _(val: tuple[int] | tuple[str, str], n: Two):
     if len(val) == n:
-        reveal_type(val)  # revealed: tuple[int, ...] & ExactlySized[Literal[2]]
+        reveal_type(val)  # revealed: tuple[str, str]
 ```
 
 ## Unions of narrowable types

--- a/crates/ty_python_semantic/resources/mdtest/narrow/len.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/len.md
@@ -65,8 +65,9 @@ def _(x: tuple[int, ...]):
 
 ## Exact length comparisons
 
-Exact length constraints eliminate types whose encoded length is incompatible with the comparison.
-Types that do not encode their length remain unchanged:
+Exact length constraints specialize exact tuple types to the observed length and eliminate types
+whose encoded length is incompatible with the comparison. Types that do not encode their length
+remain unchanged:
 
 ```toml
 [environment]
@@ -81,8 +82,10 @@ def _(val: tuple[int] | tuple[str, str] | tuple[int, *tuple[str, ...], int]):
         reveal_type(val)  # revealed: tuple[int]
 
     if len(val) == 2:
-        # revealed: tuple[str, str] | tuple[int, *tuple[str, ...], int]
-        reveal_type(val)
+        reveal_type(val)  # revealed: tuple[str, str] | tuple[int, int]
+
+    if len(val) == 3:
+        reveal_type(val)  # revealed: tuple[int, str, int]
 
 def _(val: tuple[int] | tuple[str, str]):
     if 1 != len(val):
@@ -92,7 +95,13 @@ def _(val: tuple[int] | tuple[str, str]):
 
 def _(val: tuple[int, ...]):
     if val and len(val) == 2:
-        reveal_type(val)  # revealed: tuple[int, ...] & ~AlwaysFalsy
+        reveal_type(val)  # revealed: tuple[int, int]
+
+def _(val: tuple[int, ...]):
+    if len(val) != 2:
+        reveal_type(val)  # revealed: tuple[int, ...]
+    else:
+        reveal_type(val)  # revealed: tuple[int, int]
 
 def _(val: tuple[int] | tuple[str, str]):
     if len(val) == True:

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -141,7 +141,6 @@ pub enum KnownClass {
     // functools
     FunctoolsPartial,
     // ty_extensions
-    ExactlySized,
     ConstraintSet,
     GenericContext,
     Specialization,
@@ -265,7 +264,6 @@ impl KnownClass {
             | Self::KwOnly
             | Self::NamedTupleFallback
             | Self::NamedTupleLike
-            | Self::ExactlySized
             | Self::ConstraintSet
             | Self::GenericContext
             | Self::Specialization
@@ -366,7 +364,6 @@ impl KnownClass {
             | KnownClass::KwOnly
             | KnownClass::NamedTupleFallback
             | KnownClass::NamedTupleLike
-            | KnownClass::ExactlySized
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
             | KnownClass::Specialization
@@ -467,7 +464,6 @@ impl KnownClass {
             | KnownClass::KwOnly
             | KnownClass::NamedTupleFallback
             | KnownClass::NamedTupleLike
-            | KnownClass::ExactlySized
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
             | KnownClass::Specialization
@@ -567,7 +563,6 @@ impl KnownClass {
             | KnownClass::KwOnly
             | KnownClass::TypedDictFallback
             | KnownClass::NamedTupleLike
-            | KnownClass::ExactlySized
             | KnownClass::NamedTupleFallback
             | KnownClass::ConstraintSet
             | KnownClass::GenericContext
@@ -604,7 +599,6 @@ impl KnownClass {
             | Self::AsyncIterator
             | Self::Awaitable
             | Self::NamedTupleLike
-            | Self::ExactlySized
             | Self::AsyncGenerator
             | Self::Generator => true,
 
@@ -786,7 +780,6 @@ impl KnownClass {
             | KnownClass::Field
             | KnownClass::KwOnly
             | KnownClass::NamedTupleLike
-            | KnownClass::ExactlySized
             | KnownClass::Template
             | KnownClass::Path
             | KnownClass::FunctoolsPartial
@@ -897,7 +890,6 @@ impl KnownClass {
             Self::KwOnly => "KW_ONLY",
             Self::NamedTupleFallback => "NamedTupleFallback",
             Self::NamedTupleLike => "NamedTupleLike",
-            Self::ExactlySized => "ExactlySized",
             Self::ConstraintSet => "ConstraintSet",
             Self::GenericContext => "GenericContext",
             Self::Specialization => "Specialization",
@@ -1255,7 +1247,6 @@ impl KnownClass {
             Self::Field | Self::KwOnly => KnownModule::Dataclasses,
             Self::NamedTupleFallback | Self::TypedDictFallback => KnownModule::TypeCheckerInternals,
             Self::NamedTupleLike
-            | Self::ExactlySized
             | Self::ConstraintSet
             | Self::GenericContext
             | Self::Specialization
@@ -1358,7 +1349,6 @@ impl KnownClass {
             | Self::Mapping
             | Self::NamedTupleFallback
             | Self::NamedTupleLike
-            | Self::ExactlySized
             | Self::ConstraintSet
             | Self::GenericContext
             | Self::Specialization
@@ -1465,7 +1455,6 @@ impl KnownClass {
             | Self::Mapping
             | Self::NamedTupleFallback
             | Self::NamedTupleLike
-            | Self::ExactlySized
             | Self::ConstraintSet
             | Self::GenericContext
             | Self::Specialization
@@ -1571,7 +1560,6 @@ impl KnownClass {
             "KW_ONLY" => &[Self::KwOnly],
             "NamedTupleFallback" => &[Self::NamedTupleFallback],
             "NamedTupleLike" => &[Self::NamedTupleLike],
-            "ExactlySized" => &[Self::ExactlySized],
             "ConstraintSet" => &[Self::ConstraintSet],
             "GenericContext" => &[Self::GenericContext],
             "Specialization" => &[Self::Specialization],
@@ -1659,7 +1647,6 @@ impl KnownClass {
             | Self::ExtensionsParamSpec
             | Self::Sentinel
             | Self::NamedTupleLike
-            | Self::ExactlySized
             | Self::ConstraintSet
             | Self::GenericContext
             | Self::Specialization

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1058,6 +1058,67 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
+    /// Filter a type based on an equality or inequality comparison against an exact length.
+    ///
+    /// Only types that encode their possible lengths are filtered. Other types are left unchanged
+    /// because persisting an observed length would become stale after mutation.
+    fn narrow_type_by_exact_len(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        length: usize,
+        is_equality: bool,
+    ) -> Type<'db> {
+        let resolved = ty.resolve_type_alias(db);
+
+        let narrowed = match resolved {
+            Type::Union(union) => union.map(db, |element| {
+                Self::narrow_type_by_exact_len(db, *element, length, is_equality)
+            }),
+            Type::Intersection(intersection) => intersection.map_positive(db, |element| {
+                Self::narrow_type_by_exact_len(db, *element, length, is_equality)
+            }),
+            _ => {
+                let tuple_length = resolved
+                    .as_nominal_instance()
+                    .and_then(|instance| instance.tuple_spec(db))
+                    .map(|spec| spec.len());
+                let satisfies_comparison = |length_type: Type<'db>| {
+                    length_type
+                        .as_int_literal()
+                        .and_then(|actual| usize::try_from(actual).ok())
+                        .is_some_and(|actual| (actual == length) == is_equality)
+                };
+                let comparison_possible = resolved
+                    .len(db)
+                    .map(|length_type| match length_type {
+                        Type::Union(union) => union
+                            .elements(db)
+                            .iter()
+                            .any(|element| satisfies_comparison(*element)),
+                        _ => satisfies_comparison(length_type),
+                    })
+                    .or_else(|| {
+                        tuple_length
+                            .and_then(|length| length.into_fixed_length())
+                            .map(|actual| (actual == length) == is_equality)
+                    });
+
+                match comparison_possible {
+                    Some(false) => Type::Never,
+                    None if is_equality
+                        && tuple_length
+                            .is_some_and(|tuple_length| length < tuple_length.minimum()) =>
+                    {
+                        Type::Never
+                    }
+                    _ => resolved,
+                }
+            }
+        };
+
+        if narrowed == resolved { ty } else { narrowed }
+    }
+
     fn evaluate_simple_expr(
         &mut self,
         expr: &ast::Expr,
@@ -1495,7 +1556,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         if matches!(&**ops, [ast::CmpOp::Eq | ast::CmpOp::NotEq]) {
             // For `==`, we use equality semantics on the `if` branch (is_positive=true).
             // For `!=`, we use equality semantics on the `else` branch (is_positive=false).
-            let constrain_with_equality = is_positive == (ops[0] == ast::CmpOp::Eq);
+            let is_equality = is_positive == (ops[0] == ast::CmpOp::Eq);
 
             let mut narrow_len_call = |call: &ast::ExprCall, length_type: Type<'db>| {
                 let Type::FunctionLiteral(function_type) = inference.expression_type(&*call.func)
@@ -1516,38 +1577,23 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 else {
                     return;
                 };
-                if length_literal < 0 {
+                let Ok(length) = usize::try_from(length_literal) else {
                     return;
-                }
+                };
                 let Some(target) = PlaceExpr::try_from_expr(arg) else {
                     return;
                 };
 
-                // `False == 0` and `True == 1`, so the protocol must accept both literals.
-                let protocol_length = match length_literal {
-                    0 => UnionType::from_two_elements(
-                        self.db,
-                        Type::int_literal(0),
-                        Type::bool_literal(false),
-                    ),
-                    1 => UnionType::from_two_elements(
-                        self.db,
-                        Type::int_literal(1),
-                        Type::bool_literal(true),
-                    ),
-                    _ => Type::int_literal(length_literal),
-                };
-                let exactly_sized =
-                    KnownClass::ExactlySized.to_specialized_instance(self.db, &[protocol_length]);
-                let constraint = NarrowingConstraint::intersection(
-                    exactly_sized.negate_if(self.db, !constrain_with_equality),
-                );
-                constraints
-                    .entry(self.expect_place(&target))
-                    .and_modify(|existing| {
-                        *existing = existing.merge_constraint_and(constraint.clone());
-                    })
-                    .or_insert(constraint);
+                let arg_type = inference.expression_type(arg);
+                let narrowed =
+                    Self::narrow_type_by_exact_len(self.db, arg_type, length, is_equality);
+                if narrowed != arg_type {
+                    insert_narrowing_constraint(
+                        &mut constraints,
+                        self.expect_place(&target),
+                        NarrowingConstraint::replacement(narrowed),
+                    );
+                }
             };
 
             // E.g., `len(items) == 2`
@@ -1569,7 +1615,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     &subscript.value,
                     slice_type,
                     other_type,
-                    constrain_with_equality,
+                    is_equality,
                 ) {
                     insert_narrowing_constraint(&mut constraints, place, constraint);
                 } else if let Some((place, constraint)) = self.narrow_tuple_subscript(
@@ -1577,7 +1623,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     &subscript.value,
                     slice_type,
                     other_type,
-                    constrain_with_equality,
+                    is_equality,
                 ) {
                     insert_narrowing_constraint(&mut constraints, place, constraint);
                 }
@@ -1599,7 +1645,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     &attribute.value,
                     attribute.attr.id(),
                     other_type,
-                    constrain_with_equality,
+                    is_equality,
                 ) {
                     insert_narrowing_constraint(&mut constraints, place, constraint);
                 }
@@ -2296,7 +2342,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         subscript_value_expr: &ast::Expr,
         subscript_key_type: Type<'db>,
         rhs_type: Type<'db>,
-        constrain_with_equality: bool,
+        is_equality: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
         // Check preconditions: we need a TypedDict, a string key, and a supported tag literal.
         if !is_or_contains_typeddict(self.db, subscript_value_type) {
@@ -2315,7 +2361,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         // implement `__eq__` in any perverse way they like. On the other hand, if this is an
         // *inequality* constraint, then we can go ahead and assert "you can't be this exact
         // literal type" without worrying about what other types might be present.
-        if constrain_with_equality
+        if is_equality
             && !all_matching_typeddict_fields_have_literal_types(
                 self.db,
                 subscript_value_type,
@@ -2328,10 +2374,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         let field_name = Name::from(key_literal.value(self.db));
         // To avoid excluding non-`TypedDict` types, our constraints are always expressed
         // as a negative intersection (i.e. "you're *not* this kind of `TypedDict`"). If
-        // `constrain_with_equality` is true, the whole constraint is going to be a double
+        // `is_equality` is true, the whole constraint is going to be a double
         // negative, i.e. "you're *not* a `TypedDict` *without* this literal field". As the
         // first step of building that, we negate the right hand side.
-        let field_type = rhs_type.negate_if(self.db, constrain_with_equality);
+        let field_type = rhs_type.negate_if(self.db, is_equality);
         // Create the synthesized `TypedDict` with that (possibly negated) field. We don't
         // want to constrain the mutability or required-ness of the field, so the most
         // compatible form is not-required and read-only.
@@ -2391,7 +2437,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         subscript_value_expr: &ast::Expr,
         subscript_index_type: Type<'db>,
         rhs_type: Type<'db>,
-        constrain_with_equality: bool,
+        is_equality: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
         // We need a union type for narrowing to be useful.
         let Type::Union(union) = subscript_value_type.resolve_type_alias(self.db) else {
@@ -2417,9 +2463,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
         // For equality constraints, all matching elements must have literal types to safely narrow.
         // For inequality constraints, we can narrow even with non-literal element types.
-        if constrain_with_equality
-            && !all_matching_tuple_elements_have_literal_types(self.db, union, index)
-        {
+        if is_equality && !all_matching_tuple_elements_have_literal_types(self.db, union, index) {
             return None;
         }
 
@@ -2429,7 +2473,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 .and_then(|inst| inst.tuple_spec(self.db))
                 .and_then(|spec| spec.py_index(self.db, index).ok())
                 .is_none_or(|el_ty| {
-                    if constrain_with_equality {
+                    if is_equality {
                         // Keep tuples where element could be equal to rhs.
                         !el_ty.is_disjoint_from(self.db, rhs_type)
                     } else {
@@ -2454,7 +2498,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         attribute_value_expr: &ast::Expr,
         attribute_name: &str,
         rhs_type: Type<'db>,
-        constrain_with_equality: bool,
+        is_equality: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
         let Type::Union(union) = attribute_value_type.resolve_type_alias(self.db) else {
             return None;
@@ -2465,7 +2509,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
         let narrowed = union.filter(self.db, |element| {
             nominal_attribute_type(self.db, *element, attribute_name).is_none_or(|attribute_type| {
-                if constrain_with_equality {
+                if is_equality {
                     !is_supported_tag_literal(attribute_type)
                         || !attribute_type.is_disjoint_from(self.db, rhs_type)
                 } else {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4,6 +4,7 @@ use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
 use crate::types::special_form::TypeQualifier;
+use crate::types::tuple::{TupleLength, TupleType};
 use crate::types::typed_dict::{
     TypedDictField, TypedDictFieldBuilder, TypedDictSchema, TypedDictType,
 };
@@ -1060,8 +1061,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
     /// Filter a type based on an equality or inequality comparison against an exact length.
     ///
-    /// Only types that encode their possible lengths are filtered. Other types are left unchanged
-    /// because persisting an observed length would become stale after mutation.
+    /// Exact tuple types are specialized to the observed length. Other types that encode their
+    /// possible lengths are filtered. Unknown-length types are left unchanged because persisting
+    /// an observed length would become stale after mutation.
     fn narrow_type_by_exact_len(
         db: &'db dyn Db,
         ty: Type<'db>,
@@ -1078,40 +1080,47 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 Self::narrow_type_by_exact_len(db, *element, length, is_equality)
             }),
             _ => {
-                let tuple_length = resolved
-                    .as_nominal_instance()
-                    .and_then(|instance| instance.tuple_spec(db))
-                    .map(|spec| spec.len());
-                let satisfies_comparison = |length_type: Type<'db>| {
-                    length_type
-                        .as_int_literal()
-                        .and_then(|actual| usize::try_from(actual).ok())
-                        .is_some_and(|actual| (actual == length) == is_equality)
-                };
-                let comparison_possible = resolved
-                    .len(db)
-                    .map(|length_type| match length_type {
-                        Type::Union(union) => union
-                            .elements(db)
-                            .iter()
-                            .any(|element| satisfies_comparison(*element)),
-                        _ => satisfies_comparison(length_type),
-                    })
-                    .or_else(|| {
-                        tuple_length
-                            .and_then(|length| length.into_fixed_length())
-                            .map(|actual| (actual == length) == is_equality)
-                    });
-
-                match comparison_possible {
-                    Some(false) => Type::Never,
-                    None if is_equality
-                        && tuple_length
-                            .is_some_and(|tuple_length| length < tuple_length.minimum()) =>
-                    {
-                        Type::Never
+                if is_equality && let Some(tuple) = resolved.exact_tuple_instance_spec(db) {
+                    match tuple.resize(db, TupleLength::Fixed(length)) {
+                        Ok(tuple) => Type::tuple(TupleType::new(db, &tuple)),
+                        Err(_) => Type::Never,
                     }
-                    _ => resolved,
+                } else {
+                    let tuple_length = resolved
+                        .as_nominal_instance()
+                        .and_then(|instance| instance.tuple_spec(db))
+                        .map(|spec| spec.len());
+                    let satisfies_comparison = |length_type: Type<'db>| {
+                        length_type
+                            .as_int_literal()
+                            .and_then(|actual| usize::try_from(actual).ok())
+                            .is_some_and(|actual| (actual == length) == is_equality)
+                    };
+                    let comparison_possible = resolved
+                        .len(db)
+                        .map(|length_type| match length_type {
+                            Type::Union(union) => union
+                                .elements(db)
+                                .iter()
+                                .any(|element| satisfies_comparison(*element)),
+                            _ => satisfies_comparison(length_type),
+                        })
+                        .or_else(|| {
+                            tuple_length
+                                .and_then(TupleLength::into_fixed_length)
+                                .map(|actual| (actual == length) == is_equality)
+                        });
+
+                    match comparison_possible {
+                        Some(false) => Type::Never,
+                        None if is_equality
+                            && tuple_length
+                                .is_some_and(|tuple_length| length < tuple_length.minimum()) =>
+                        {
+                            Type::Never
+                        }
+                        _ => resolved,
+                    }
                 }
             }
         };

--- a/crates/ty_vendored/ty_extensions/ty_extensions.pyi
+++ b/crates/ty_vendored/ty_extensions/ty_extensions.pyi
@@ -319,11 +319,6 @@ class NamedTupleLike(Protocol):
     if sys.version_info >= (3, 13):
         def __replace__(self, *args, **kwargs) -> Self: ...
 
-class ExactlySized[Length: int](Protocol):
-    """A protocol for objects whose length is statically known."""
-
-    def __len__(self) -> Length: ...
-
 # Special variants of the corresponding protocols in `typing`, but without the
 # `__iter__`/`__aiter__` on Iterator/AsyncIterator, which is often omitted in
 # practice. These protocols are used for generating better `non-iterable` error


### PR DESCRIPTION
## Summary

Restrict exact `len()` narrowing to types that actually encode their possible lengths, so that we don't wrongly preserve length-narrowings on types with mutable length.

Closes astral-sh/ty#3710.

## Test plan

Added/updated mdtests.

### Ecosystem analysis

72 of the added diagnostics (48 in apprise, 19 in scrapy, plus some others) are from restoring correct reachability to code that was previously erroneously marked unreachable.

33 new diagnostics involve cases where we previously narrowed `None` out of a type after a `len` call (which itself errors since `None` is not `Sized`), since `None` is disjoint from `ExactlySized`. We could easily continue to do this (remove any non `Sized` types when narrowing from a `len` check), and I don't think it's wrong to do so? But it's kind of odd to narrow from a failed call, and no other type checker does it, so I haven't done it in this PR.

12 new diagnostics (all in packaging, or pip from its vendored packaging) come from a case where we are length-narrowing correctly, it's just we top-materialize `isinstance` and `object` is not assignable where a value from that tuple is used. This was silenced on main because we don't support exact unpacking from an intersection at all, and we previously had an intersection with `ExactlySized` here.

Four new diagnostics in `ppb-vector` come from code like this:

```py
def unpack(value: Sequence[int] | Mapping[str, int]):
    if isinstance(value, Sequence) and len(value) == 2:
        return value[0]
    if isinstance(value, Mapping) and "x" in value and len(value) == 2:
        return value["x"]
    raise ValueError
```

Where retaining the intersection with `~ExactlySized[2]` allowed us to rule out the "both a Sequence and a Mapping" case in the second branch (since if it were a sequence of length 2 it would have already taken the first branch). This is the only case where this PR regresses results. We could keep this by restoring `ExactlySized` and continuing to use it with `Sequence` and `Mapping` types -- but that would add a lot of code for something that has a very small ecosystem impact.
