### PR TITLE
[ty] Distinguish `typing.TypedDict` from `typing_extensions.TypedDict`

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -465,7 +465,7 @@ impl<'db> CompletionBuilder<'db> {
                         Type::SpecialForm(
                             SpecialFormType::Protocol
                                 | SpecialFormType::Generic
-                                | SpecialFormType::TypedDict
+                                | SpecialFormType::TypedDict(_)
                                 | SpecialFormType::NamedTuple
                         )
                     );

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4486,6 +4486,28 @@ reveal_type(user_empty["name"])  # revealed: str
 reveal_type(user_partial["age"])  # revealed: int
 ```
 
+Compatibility imports that fall back to `typing_extensions.TypedDict` should also preserve
+`TypedDict` semantics:
+
+```py
+try:
+    from typing import TypedDict as CompatTypedDict
+except ImportError:
+    from typing_extensions import TypedDict as CompatTypedDict
+
+class FormattedError(CompatTypedDict, total=False):
+    message: str
+
+class ErrorMessage(CompatTypedDict):
+    payload: FormattedError
+
+error = ErrorMessage(payload={"message": "Subscription limit reached"})
+reveal_type(error["payload"])  # revealed: FormattedError
+
+FunctionalError = CompatTypedDict("FunctionalError", {"message": str}, total=False)
+functional_error: FunctionalError = {"message": "Subscription limit reached"}
+```
+
 ## Shadowing behavior
 
 When a local class shadows the `TypedDict` import, only the actual `TypedDict` import should be

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2810,6 +2810,16 @@ def combine(p: Person, e: Employee):
     reveal_type(e | p)  # revealed: Person
 ```
 
+The `TypedDict` special forms from `typing` and `typing_extensions` cannot both appear in the same
+bases list:
+
+```py
+from typing import TypedDict as TypingTypedDict
+from typing_extensions import TypedDict as TypingExtensionsTypedDict
+
+class MixedTypedDict(TypingTypedDict, TypingExtensionsTypedDict): ...  # error: [duplicate-base]
+```
+
 When inheriting from a `TypedDict` with a different `total` setting, inherited fields maintain their
 original requirement status, while new fields follow the child class's `total` setting:
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2644,24 +2644,59 @@ def _(p: Person) -> None:
 
 ## Special properties
 
+### Python 3.12
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
 `TypedDict` class definitions have some special properties that can be used for introspection:
 
 ```py
+from typing import Generic, TypeVar, TypedDict as TypingTypedDict
 from typing_extensions import TypedDict
+
+T = TypeVar("T")
+
+class StdlibPerson(TypingTypedDict):
+    name: str
+
+StdlibFunctionalPerson = TypingTypedDict("StdlibFunctionalPerson", {"name": str})
+DynamicStdlibPerson = type("DynamicStdlibPerson", (StdlibPerson,), {})
 
 class Person(TypedDict):
     name: str
     age: int | None
 
 FunctionalPerson = TypedDict("FunctionalPerson", {"name": str, "age": int | None})
+DynamicPerson = type("DynamicPerson", (Person,), {})
+
+class Employee(Person):
+    employee_id: int
+
+class GenericPerson(TypedDict, Generic[T]):
+    value: T
+
+class SpecializedPerson(GenericPerson[int]):
+    pass
+
+StdlibPerson.__closed__  # error: [unresolved-attribute]
+StdlibPerson.__readonly_keys__  # error: [unresolved-attribute]
+StdlibFunctionalPerson.__closed__  # error: [unresolved-attribute]
+DynamicStdlibPerson.__closed__  # error: [unresolved-attribute]
 
 reveal_type(Person.__total__)  # revealed: bool
 reveal_type(Person.__required_keys__)  # revealed: frozenset[str]
 reveal_type(Person.__optional_keys__)  # revealed: frozenset[str]
 reveal_type(Person.__closed__)  # revealed: bool | None
 reveal_type(Person.__extra_items__)  # revealed: Any
+reveal_type(Person.__readonly_keys__)  # revealed: frozenset[str]
 reveal_type(FunctionalPerson.__closed__)  # revealed: bool | None
 reveal_type(FunctionalPerson.__extra_items__)  # revealed: Any
+reveal_type(Employee.__closed__)  # revealed: bool | None
+reveal_type(DynamicPerson.__closed__)  # revealed: bool | None
+reveal_type(SpecializedPerson.__readonly_keys__)  # revealed: frozenset[str]
 ```
 
 These attributes cannot be accessed on inhabitants:
@@ -2698,9 +2733,57 @@ def accepts_typed_dict_class(t_person: type[Person]) -> None:
     reveal_type(t_person.__extra_items__)  # revealed: Any
 
 accepts_typed_dict_class(Person)
+
+def accepts_stdlib_typed_dict_class(t_person: type[StdlibPerson]) -> None:
+    t_person.__closed__  # error: [unresolved-attribute]
+```
+
+### Python 3.13
+
+The standard-library `TypedDict` has the PEP 705 attributes on Python 3.13, but not the PEP 728
+attributes:
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import TypedDict
+
+class Foo(TypedDict):
+    x: int
+
+reveal_type(Foo.__readonly_keys__)  # revealed: frozenset[str]
+Foo.__closed__  # error: [unresolved-attribute]
+```
+
+### Python 3.15
+
+On Python 3.15 and newer, classes defined using the standard-library `TypedDict` also have the PEP
+728 attributes:
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+```py
+from typing import TypedDict
+
+class Person(TypedDict):
+    name: str
+
+reveal_type(Person.__closed__)  # revealed: bool | None
+reveal_type(Person.__extra_items__)  # revealed: Any
 ```
 
 ## Subclassing
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 `TypedDict` types can be subclassed. The subclass can add new keys:
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2654,10 +2654,8 @@ python-version = "3.12"
 `TypedDict` class definitions have some special properties that can be used for introspection:
 
 ```py
-from typing import Generic, TypeVar, TypedDict as TypingTypedDict
+from typing import TypedDict as TypingTypedDict
 from typing_extensions import TypedDict
-
-T = TypeVar("T")
 
 class StdlibPerson(TypingTypedDict):
     name: str
@@ -2675,11 +2673,8 @@ DynamicPerson = type("DynamicPerson", (Person,), {})
 class Employee(Person):
     employee_id: int
 
-class GenericPerson(TypedDict, Generic[T]):
+class GenericPerson[T](TypedDict):
     value: T
-
-class SpecializedPerson(GenericPerson[int]):
-    pass
 
 StdlibPerson.__closed__  # error: [unresolved-attribute]
 StdlibPerson.__readonly_keys__  # error: [unresolved-attribute]
@@ -2696,7 +2691,7 @@ reveal_type(FunctionalPerson.__closed__)  # revealed: bool | None
 reveal_type(FunctionalPerson.__extra_items__)  # revealed: Any
 reveal_type(Employee.__closed__)  # revealed: bool | None
 reveal_type(DynamicPerson.__closed__)  # revealed: bool | None
-reveal_type(SpecializedPerson.__readonly_keys__)  # revealed: frozenset[str]
+reveal_type(GenericPerson[int].__readonly_keys__)  # revealed: frozenset[str]
 ```
 
 These attributes cannot be accessed on inhabitants:

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4489,6 +4489,11 @@ reveal_type(user_partial["age"])  # revealed: int
 Compatibility imports that fall back to `typing_extensions.TypedDict` should also preserve
 `TypedDict` semantics:
 
+```toml
+[environment]
+python-version = "3.12"
+```
+
 ```py
 try:
     from typing import TypedDict as CompatTypedDict
@@ -4500,6 +4505,9 @@ class FormattedError(CompatTypedDict, total=False):
 
 class ErrorMessage(CompatTypedDict):
     payload: FormattedError
+
+# `__closed__` is only available on the `typing_extensions` branch for Python 3.12.
+FormattedError.__closed__  # error: [unresolved-attribute]
 
 error = ErrorMessage(payload={"message": "Subscription limit reached"})
 reveal_type(error["payload"])  # revealed: FormattedError

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1623,6 +1623,26 @@ impl<'db> Type<'db> {
         matches!(self, Type::TypedDict(..))
     }
 
+    /// Return the module for a `TypedDict` special form, including a union of the special forms
+    /// exported by `typing` and `typing_extensions`.
+    pub(crate) fn typed_dict_module(self, db: &'db dyn Db) -> Option<TypedDictModule> {
+        match self {
+            Type::SpecialForm(special_form) => special_form.typed_dict_module(),
+            Type::Union(union) => {
+                let mut module: Option<TypedDictModule> = None;
+                for element in union.elements(db) {
+                    let element_module = element.typed_dict_module(db)?;
+                    module = Some(match module {
+                        None => element_module,
+                        Some(module) => module.union(element_module),
+                    });
+                }
+                module
+            }
+            _ => None,
+        }
+    }
+
     pub(crate) const fn as_typed_dict(self) -> Option<TypedDictType<'db>> {
         match self {
             Type::TypedDict(typed_dict) => Some(typed_dict),

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1629,15 +1629,11 @@ impl<'db> Type<'db> {
         match self {
             Type::SpecialForm(special_form) => special_form.typed_dict_module(),
             Type::Union(union) => {
-                let mut module: Option<TypedDictModule> = None;
-                for element in union.elements(db) {
-                    let element_module = element.typed_dict_module(db)?;
-                    module = Some(match module {
-                        None => element_module,
-                        Some(module) => module.union(element_module),
-                    });
-                }
-                module
+                let mut elements = union.elements(db).iter();
+                let module = elements.next()?.as_special_form()?.typed_dict_module()?;
+                elements.try_fold(module, |module, element| {
+                    Some(module.union(element.as_special_form()?.typed_dict_module()?))
+                })
             }
             _ => None,
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -107,7 +107,8 @@ pub use instance::{NominalInstanceType, ProtocolInstanceType};
 pub(crate) use literal::{
     BytesLiteralType, EnumLiteralType, LiteralValueType, LiteralValueTypeKind, StringLiteralType,
 };
-pub use special_form::{SpecialFormType, TypedDictModule};
+pub use special_form::SpecialFormType;
+pub(crate) use special_form::TypedDictModule;
 use ty_python_core::definition::Definition;
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -107,7 +107,7 @@ pub use instance::{NominalInstanceType, ProtocolInstanceType};
 pub(crate) use literal::{
     BytesLiteralType, EnumLiteralType, LiteralValueType, LiteralValueTypeKind, StringLiteralType,
 };
-pub use special_form::SpecialFormType;
+pub use special_form::{SpecialFormType, TypedDictModule};
 use ty_python_core::definition::Definition;
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1623,22 +1623,6 @@ impl<'db> Type<'db> {
         matches!(self, Type::TypedDict(..))
     }
 
-    /// Return the module for a `TypedDict` special form, including a union of the special forms
-    /// exported by `typing` and `typing_extensions`.
-    pub(crate) fn typed_dict_module(self, db: &'db dyn Db) -> Option<TypedDictModule> {
-        match self {
-            Type::SpecialForm(special_form) => special_form.typed_dict_module(),
-            Type::Union(union) => {
-                let mut elements = union.elements(db).iter();
-                let module = elements.next()?.as_special_form()?.typed_dict_module()?;
-                elements.try_fold(module, |module, element| {
-                    Some(module.union(element.as_special_form()?.typed_dict_module()?))
-                })
-            }
-            _ => None,
-        }
-    }
-
     pub(crate) const fn as_typed_dict(self) -> Option<TypedDictType<'db>> {
         match self {
             Type::TypedDict(typed_dict) => Some(typed_dict),

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -381,7 +381,7 @@ impl<'db> BoundSuperType<'db> {
                 class.iter_mro(db).any(|superclass| match superclass {
                     ClassBase::Any | ClassBase::Dynamic(_) | ClassBase::Divergent(_) => true,
                     ClassBase::Class(superclass) => superclass.class_literal(db) == pivot_class,
-                    ClassBase::Generic | ClassBase::Protocol | ClassBase::TypedDict => false,
+                    ClassBase::Generic | ClassBase::Protocol | ClassBase::TypedDict(_) => false,
                 })
             }
             special_form @ (ClassBase::Generic | ClassBase::Protocol) => {
@@ -391,7 +391,7 @@ impl<'db> BoundSuperType<'db> {
                 })
             }
             // typing.TypedDict never stays in a runtime class' MRO
-            ClassBase::TypedDict => false,
+            ClassBase::TypedDict(_) => false,
         }
     }
 
@@ -541,7 +541,7 @@ impl<'db> BoundSuperType<'db> {
             },
             Type::SpecialForm(SpecialFormType::Protocol) => ClassBase::Protocol,
             Type::SpecialForm(SpecialFormType::Generic) => ClassBase::Generic,
-            Type::SpecialForm(SpecialFormType::TypedDict(_)) => ClassBase::TypedDict,
+            Type::SpecialForm(SpecialFormType::TypedDict(module)) => ClassBase::TypedDict(module),
             Type::Dynamic(dynamic) => ClassBase::Dynamic(dynamic),
             Type::Divergent(divergent) => ClassBase::Divergent(divergent),
             _ => {
@@ -999,8 +999,10 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             (ClassBase::Protocol, ClassBase::Protocol) => self.always(),
             (ClassBase::Protocol, _) => self.never(),
 
-            (ClassBase::TypedDict, ClassBase::TypedDict) => self.always(),
-            (ClassBase::TypedDict, _) => self.never(),
+            (ClassBase::TypedDict(left), ClassBase::TypedDict(right)) => {
+                ConstraintSet::from_bool(self.constraints, left == right)
+            }
+            (ClassBase::TypedDict(_), _) => self.never(),
         };
         if class_equivalence.is_never_satisfied(db) {
             return self.never();

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -541,7 +541,7 @@ impl<'db> BoundSuperType<'db> {
             },
             Type::SpecialForm(SpecialFormType::Protocol) => ClassBase::Protocol,
             Type::SpecialForm(SpecialFormType::Generic) => ClassBase::Generic,
-            Type::SpecialForm(SpecialFormType::TypedDict) => ClassBase::TypedDict,
+            Type::SpecialForm(SpecialFormType::TypedDict(_)) => ClassBase::TypedDict,
             Type::Dynamic(dynamic) => ClassBase::Dynamic(dynamic),
             Type::Divergent(divergent) => ClassBase::Divergent(divergent),
             _ => {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -88,7 +88,7 @@ pub(crate) enum CodeGeneratorKind<'db> {
     DataclassLike(Option<DataclassTransformerParams<'db>>),
     /// Classes inheriting from `typing.NamedTuple`
     NamedTuple,
-    /// Classes inheriting from `typing.TypedDict`
+    /// Classes inheriting from `typing.TypedDict` or `typing_extensions.TypedDict`
     TypedDict,
 }
 
@@ -419,18 +419,6 @@ impl<'db> ClassLiteral<'db> {
     /// Returns the known class, if any.
     pub(crate) fn known(self, db: &'db dyn Db) -> Option<KnownClass> {
         self.as_static()?.known(db)
-    }
-
-    pub(crate) fn typed_dict_module(self, db: &'db dyn Db) -> Option<TypedDictModule> {
-        #[salsa::tracked(cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
-        fn typed_dict_module_inner<'db>(
-            db: &'db dyn Db,
-            class: ClassLiteral<'db>,
-        ) -> Option<TypedDictModule> {
-            class.iter_mro(db).find_map(ClassBase::typed_dict_module)
-        }
-
-        typed_dict_module_inner(db, self)
     }
 
     /// Returns whether this class has PEP 695 type parameters.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -519,10 +519,9 @@ impl<'db> ClassLiteral<'db> {
                 let result = MroLookup::new(db, mro_iter).class_member(name, policy, None, false);
                 match result {
                     ClassMemberResult::Done(result) => result.finalize(db),
-                    ClassMemberResult::TypedDict => KnownClass::TypedDictFallback
-                        .to_class_literal(db)
-                        .find_name_in_mro_with_policy(db, name, policy)
-                        .expect("Will return Some() when called on class literal"),
+                    ClassMemberResult::TypedDict(module) => {
+                        typed_dict::typed_dict_fallback_class_member(db, module, policy, name)
+                    }
                 }
             }
         }
@@ -2449,8 +2448,8 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
     /// - `inherited_generic_context`: Generic context for `own_class_member` calls
     /// - `is_self_object`: Whether the class itself is `object` (affects policy filtering)
     ///
-    /// Returns `ClassMemberResult::TypedDict` if a `TypedDict` base is encountered,
-    /// allowing the caller to handle this case specially.
+    /// Returns `ClassMemberResult::TypedDict` with the originating module if a `TypedDict` base is
+    /// encountered, allowing the caller to handle this case specially.
     ///
     /// If we encounter a dynamic type in the MRO, we save it and after traversal:
     /// 1. Use it as the type if no other classes define the attribute, or
@@ -2512,8 +2511,8 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                         )
                     });
                 }
-                ClassBase::TypedDict(_) => {
-                    return ClassMemberResult::TypedDict;
+                ClassBase::TypedDict(module) => {
+                    return ClassMemberResult::TypedDict(module);
                 }
             }
             if lookup_result.is_ok() {
@@ -2622,7 +2621,7 @@ pub(super) enum ClassMemberResult<'db> {
     /// Found the member or exhausted the MRO.
     Done(CompletedMemberLookup<'db>),
     /// Encountered a `TypedDict` base.
-    TypedDict,
+    TypedDict(TypedDictModule),
 }
 
 pub(super) struct CompletedMemberLookup<'db> {

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -39,8 +39,8 @@ use crate::types::signatures::{
 use crate::types::tuple::TupleSpec;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, CallableTypes, DataclassParams,
-    FindLegacyTypeVarsVisitor, IntersectionType, TypeContext, TypeMapping, UnionBuilder,
-    VarianceInferable,
+    FindLegacyTypeVarsVisitor, IntersectionType, TypeContext, TypeMapping, TypedDictModule,
+    UnionBuilder, VarianceInferable,
 };
 use crate::{
     Db, FxIndexMap, FxOrderSet,
@@ -372,6 +372,33 @@ pub enum ClassLiteral<'db> {
     DynamicEnum(DynamicEnumLiteral<'db>),
 }
 
+fn typed_dict_module_from_bases<'db>(
+    db: &'db dyn Db,
+    bases: &[Type<'db>],
+) -> Option<TypedDictModule> {
+    let mut module = None;
+
+    for base in bases {
+        let base_module = match base {
+            Type::SpecialForm(SpecialFormType::TypedDict(module)) => Some(*module),
+            Type::ClassLiteral(base) => base.typed_dict_module(db),
+            Type::GenericAlias(alias) => {
+                ClassLiteral::Static(alias.origin(db)).typed_dict_module(db)
+            }
+            _ => None,
+        };
+
+        if let Some(base_module) = base_module {
+            if module.is_some_and(|module| module != base_module) {
+                return None;
+            }
+            module = Some(base_module);
+        }
+    }
+
+    module
+}
+
 #[salsa::tracked]
 impl<'db> ClassLiteral<'db> {
     /// Return a `ClassLiteral` representing the class `builtins.object`
@@ -419,6 +446,29 @@ impl<'db> ClassLiteral<'db> {
     /// Returns the known class, if any.
     pub(crate) fn known(self, db: &'db dyn Db) -> Option<KnownClass> {
         self.as_static()?.known(db)
+    }
+
+    pub(crate) fn typed_dict_module(self, db: &'db dyn Db) -> Option<TypedDictModule> {
+        #[salsa::tracked(cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+        fn typed_dict_module_inner<'db>(
+            db: &'db dyn Db,
+            class: ClassLiteral<'db>,
+        ) -> Option<TypedDictModule> {
+            match class {
+                ClassLiteral::Static(class) => {
+                    typed_dict_module_from_bases(db, class.explicit_bases(db))
+                }
+                ClassLiteral::Dynamic(class) => {
+                    typed_dict_module_from_bases(db, class.explicit_bases(db))
+                }
+                ClassLiteral::DynamicTypedDict(typed_dict) => {
+                    Some(typed_dict.typed_dict_module(db))
+                }
+                ClassLiteral::DynamicNamedTuple(_) | ClassLiteral::DynamicEnum(_) => None,
+            }
+        }
+
+        typed_dict_module_inner(db, self)
     }
 
     /// Returns whether this class has PEP 695 type parameters.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -372,33 +372,6 @@ pub enum ClassLiteral<'db> {
     DynamicEnum(DynamicEnumLiteral<'db>),
 }
 
-fn typed_dict_module_from_bases<'db>(
-    db: &'db dyn Db,
-    bases: &[Type<'db>],
-) -> Option<TypedDictModule> {
-    let mut module = None;
-
-    for base in bases {
-        let base_module = match base {
-            Type::SpecialForm(SpecialFormType::TypedDict(module)) => Some(*module),
-            Type::ClassLiteral(base) => base.typed_dict_module(db),
-            Type::GenericAlias(alias) => {
-                ClassLiteral::Static(alias.origin(db)).typed_dict_module(db)
-            }
-            _ => None,
-        };
-
-        if let Some(base_module) = base_module {
-            if module.is_some_and(|module| module != base_module) {
-                return None;
-            }
-            module = Some(base_module);
-        }
-    }
-
-    module
-}
-
 #[salsa::tracked]
 impl<'db> ClassLiteral<'db> {
     /// Return a `ClassLiteral` representing the class `builtins.object`
@@ -454,18 +427,7 @@ impl<'db> ClassLiteral<'db> {
             db: &'db dyn Db,
             class: ClassLiteral<'db>,
         ) -> Option<TypedDictModule> {
-            match class {
-                ClassLiteral::Static(class) => {
-                    typed_dict_module_from_bases(db, class.explicit_bases(db))
-                }
-                ClassLiteral::Dynamic(class) => {
-                    typed_dict_module_from_bases(db, class.explicit_bases(db))
-                }
-                ClassLiteral::DynamicTypedDict(typed_dict) => {
-                    Some(typed_dict.typed_dict_module(db))
-                }
-                ClassLiteral::DynamicNamedTuple(_) | ClassLiteral::DynamicEnum(_) => None,
-            }
+            class.iter_mro(db).find_map(ClassBase::typed_dict_module)
         }
 
         typed_dict_module_inner(db, self)
@@ -2303,7 +2265,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 },
 
                 // Protocol, Generic, and TypedDict are special bases that don't match ClassType.
-                ClassBase::Protocol | ClassBase::Generic | ClassBase::TypedDict => self.never(),
+                ClassBase::Protocol | ClassBase::Generic | ClassBase::TypedDict(_) => self.never(),
 
                 ClassBase::Class(source) => match (source, target) {
                     // Two non-generic classes match if they have the same class literal.
@@ -2550,7 +2512,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                         )
                     });
                 }
-                ClassBase::TypedDict => {
+                ClassBase::TypedDict(_) => {
                     return ClassMemberResult::TypedDict;
                 }
             }
@@ -2626,7 +2588,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                         union_qualifiers |= qualifiers;
                     }
                 }
-                ClassBase::TypedDict => {
+                ClassBase::TypedDict(_) => {
                     return InstanceMemberResult::TypedDict;
                 }
             }

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -423,7 +423,6 @@ impl<'db> DynamicClassLiteral<'db> {
         match result {
             ClassMemberResult::Done(result) => result.finalize(db),
             ClassMemberResult::TypedDict(module) => {
-                // Simplified `TypedDict` handling without type mapping.
                 typed_dict_fallback_class_member(db, module, policy, name)
             }
         }

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -10,6 +10,7 @@ use crate::{
         SubclassOfType, Type,
         class::{
             ClassMemberResult, CodeGeneratorKind, DisjointBase, InstanceMemberResult, MroLookup,
+            typed_dict::typing_extensions_typed_dict_class_member,
         },
         definition_expression_type, extract_fixed_length_iterable_element_types,
         member::Member,
@@ -423,10 +424,16 @@ impl<'db> DynamicClassLiteral<'db> {
             ClassMemberResult::Done(result) => result.finalize(db),
             ClassMemberResult::TypedDict => {
                 // Simplified `TypedDict` handling without type mapping.
-                KnownClass::TypedDictFallback
+                let fallback_member = KnownClass::TypedDictFallback
                     .to_class_literal(db)
                     .find_name_in_mro_with_policy(db, name, policy)
-                    .expect("Will return Some() when called on class literal")
+                    .expect("Will return Some() when called on class literal");
+                if !fallback_member.is_undefined() {
+                    return fallback_member;
+                }
+
+                typing_extensions_typed_dict_class_member(db, self.into(), policy, name)
+                    .unwrap_or(fallback_member)
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -10,7 +10,7 @@ use crate::{
         SubclassOfType, Type,
         class::{
             ClassMemberResult, CodeGeneratorKind, DisjointBase, InstanceMemberResult, MroLookup,
-            typed_dict::typing_extensions_typed_dict_class_member,
+            typed_dict::typed_dict_fallback_class_member,
         },
         definition_expression_type, extract_fixed_length_iterable_element_types,
         member::Member,
@@ -422,18 +422,9 @@ impl<'db> DynamicClassLiteral<'db> {
 
         match result {
             ClassMemberResult::Done(result) => result.finalize(db),
-            ClassMemberResult::TypedDict => {
+            ClassMemberResult::TypedDict(module) => {
                 // Simplified `TypedDict` handling without type mapping.
-                let fallback_member = KnownClass::TypedDictFallback
-                    .to_class_literal(db)
-                    .find_name_in_mro_with_policy(db, name, policy)
-                    .expect("Will return Some() when called on class literal");
-                if !fallback_member.is_undefined() {
-                    return fallback_member;
-                }
-
-                typing_extensions_typed_dict_class_member(db, self.into(), policy, name)
-                    .unwrap_or(fallback_member)
+                typed_dict_fallback_class_member(db, module, policy, name)
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1136,10 +1136,11 @@ impl<'db> StaticClassLiteral<'db> {
 
         match result {
             ClassMemberResult::Done(result) => result.finalize(db),
-            ClassMemberResult::TypedDict => typed_dict_class_member(
+            ClassMemberResult::TypedDict(module) => typed_dict_class_member(
                 db,
                 TypedDictType::new(self.identity_specialization(db)),
                 ClassLiteral::Static(self),
+                module,
                 policy,
                 name,
             ),
@@ -1808,7 +1809,18 @@ impl<'db> StaticClassLiteral<'db> {
                 }
                 None => self.identity_specialization(db),
             };
-            typed_dict_class_member(db, TypedDictType::new(class), self.into(), policy, name)
+            let self_class = ClassLiteral::Static(self);
+            let Some(module) = self_class.typed_dict_module(db) else {
+                return Place::Undefined.into();
+            };
+            typed_dict_class_member(
+                db,
+                TypedDictType::new(class),
+                self_class,
+                module,
+                policy,
+                name,
+            )
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -23,7 +23,7 @@ use crate::{
         GenericContext, KnownClass, KnownInstanceType, MaterializationKind, MemberLookupPolicy,
         MetaclassCandidate, MetaclassTransformInfo, Parameter, Parameters, PropertyInstanceType,
         Signature, SpecialFormType, StaticMroError, SubclassOfType, Truthiness, Type, TypeContext,
-        TypeMapping, TypeVarVariance, UnionBuilder, UnionType,
+        TypeMapping, TypeVarVariance, TypedDictModule, UnionBuilder, UnionType,
         call::{CallError, CallErrorKind},
         callable::{CallableFunctionProvenance, CallableTypeKind},
         class::{
@@ -734,8 +734,15 @@ impl<'db> StaticClassLiteral<'db> {
         instance_flags_inner(db, self)
     }
 
+    /// Return the module defining the `TypedDict` base of this class.
+    #[salsa::tracked(cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+    pub(crate) fn typed_dict_module(self, db: &'db dyn Db) -> Option<TypedDictModule> {
+        self.iter_mro(db, None)
+            .find_map(ClassBase::typed_dict_module)
+    }
+
     /// Return `true` if this class constitutes a typed dict specification (inherits from
-    /// `typing.TypedDict`, either directly or indirectly).
+    /// `typing.TypedDict` or `typing_extensions.TypedDict`, either directly or indirectly).
     pub fn is_typed_dict(self, db: &'db dyn Db) -> bool {
         self.instance_flags(db)
             .contains(ClassInstanceFlags::TYPED_DICT)
@@ -1136,14 +1143,9 @@ impl<'db> StaticClassLiteral<'db> {
 
         match result {
             ClassMemberResult::Done(result) => result.finalize(db),
-            ClassMemberResult::TypedDict(module) => typed_dict_class_member(
-                db,
-                TypedDictType::new(self.identity_specialization(db)),
-                ClassLiteral::Static(self),
-                module,
-                policy,
-                name,
-            ),
+            ClassMemberResult::TypedDict(module) => {
+                typed_dict_class_member(db, self.identity_specialization(db), module, policy, name)
+            }
         }
     }
 
@@ -1809,18 +1811,10 @@ impl<'db> StaticClassLiteral<'db> {
                 }
                 None => self.identity_specialization(db),
             };
-            let self_class = ClassLiteral::Static(self);
-            let Some(module) = self_class.typed_dict_module(db) else {
+            let Some(module) = self.typed_dict_module(db) else {
                 return Place::Undefined.into();
             };
-            typed_dict_class_member(
-                db,
-                TypedDictType::new(class),
-                self_class,
-                module,
-                policy,
-                name,
-            )
+            typed_dict_class_member(db, class, module, policy, name)
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -992,8 +992,7 @@ impl<'db> DynamicTypedDictLiteral<'db> {
         // This mirrors the behavior of StaticClassLiteral::typed_dict_member.
         typed_dict_class_member(
             db,
-            TypedDictType::new(ClassType::NonGeneric(ClassLiteral::DynamicTypedDict(self))),
-            ClassLiteral::DynamicTypedDict(self),
+            ClassType::NonGeneric(ClassLiteral::DynamicTypedDict(self)),
             self.typed_dict_module(db),
             policy,
             name,
@@ -1034,28 +1033,23 @@ pub(super) fn typed_dict_fallback_class_member<'db>(
 
 pub(super) fn typed_dict_class_member<'db>(
     db: &'db dyn Db,
-    typed_dict: TypedDictType<'db>,
-    self_class: ClassLiteral<'db>,
+    class: ClassType<'db>,
     module: TypedDictModule,
     lookup_policy: MemberLookupPolicy,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
-    let new_upper_bound = determine_upper_bound(db, self_class, ClassBase::is_typed_dict);
-    let mapping = TypeMapping::ReplaceSelf { new_upper_bound };
-    let apply_self_mapping = |member: PlaceAndQualifiers<'db>| {
-        member.map_type(|ty| ty.apply_type_mapping(db, &mapping, TypeContext::default()))
-    };
-    let fallback_member = apply_self_mapping(typed_dict_fallback_class_member(
-        db,
-        module,
-        lookup_policy,
-        name,
-    ));
+    let self_class = class.class_literal(db);
+    let fallback_member = typed_dict_fallback_class_member(db, module, lookup_policy, name)
+        .map_type(|ty| {
+            let new_upper_bound = determine_upper_bound(db, self_class, ClassBase::is_typed_dict);
+            let mapping = TypeMapping::ReplaceSelf { new_upper_bound };
+            ty.apply_type_mapping(db, &mapping, TypeContext::default())
+        });
     if !fallback_member.is_undefined() {
         return fallback_member;
     }
 
-    if let Some(value_ty) = typed_dict.dict_value_type(db)
+    if let Some(value_ty) = TypedDictType::new(class).dict_value_type(db)
         && let Some(dict_class) = KnownClass::Dict
             .to_specialized_class_type(db, &[KnownClass::Str.to_instance(db), value_ty])
     {

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -23,8 +23,8 @@ use crate::types::typed_dict::{
 };
 use crate::types::{
     BoundTypeVarInstance, CallableType, ClassBase, ClassLiteral, ClassType, KnownClass,
-    MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeVarVariance, TypedDictType, UnionType,
-    determine_upper_bound,
+    MemberLookupPolicy, Type, TypeContext, TypeMapping, TypeVarVariance, TypedDictModule,
+    TypedDictType, UnionType, determine_upper_bound,
 };
 use crate::{Db, FxIndexMap};
 use ty_python_core::definition::Definition;
@@ -841,6 +841,8 @@ pub struct DynamicTypedDictLiteral<'db> {
     ///   eagerly computed spec is stored on the anchor.
     #[returns(ref)]
     pub(crate) anchor: DynamicTypedDictAnchor<'db>,
+
+    pub(crate) typed_dict_module: TypedDictModule,
 }
 
 impl get_size2::GetSize for DynamicTypedDictLiteral<'_> {}
@@ -857,6 +859,7 @@ impl<'db> DynamicTypedDictLiteral<'db> {
             self.name(db),
             self.anchor(db)
                 .recursive_type_normalized_impl(db, div, nested)?,
+            self.typed_dict_module(db),
         ))
     }
 }
@@ -997,6 +1000,26 @@ impl<'db> DynamicTypedDictLiteral<'db> {
     }
 }
 
+pub(super) fn typing_extensions_typed_dict_class_member<'db>(
+    db: &'db dyn Db,
+    self_class: ClassLiteral<'db>,
+    lookup_policy: MemberLookupPolicy,
+    name: &str,
+) -> Option<PlaceAndQualifiers<'db>> {
+    if self_class.typed_dict_module(db) != Some(TypedDictModule::TypingExtensions) {
+        return None;
+    }
+
+    let fallback = known_module_symbol(db, KnownModule::TypingExtensions, "_TypedDict")
+        .place
+        .ignore_possibly_undefined()
+        .filter(|ty| ty.as_class_literal().is_some())?;
+    let member = fallback
+        .find_name_in_mro_with_policy(db, name, lookup_policy)
+        .expect("Will return Some() when called on class literal");
+    (!member.is_undefined()).then_some(member)
+}
+
 pub(super) fn typed_dict_class_member<'db>(
     db: &'db dyn Db,
     typed_dict: TypedDictType<'db>,
@@ -1004,32 +1027,25 @@ pub(super) fn typed_dict_class_member<'db>(
     lookup_policy: MemberLookupPolicy,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
-    let fallback_member = KnownClass::TypedDictFallback
-        .to_class_literal(db)
-        .find_name_in_mro_with_policy(db, name, lookup_policy)
-        .expect("Will return Some() when called on class literal")
-        .map_type(|ty| {
-            let new_upper_bound = determine_upper_bound(db, self_class, ClassBase::is_typed_dict);
-            let mapping = TypeMapping::ReplaceSelf { new_upper_bound };
-            ty.apply_type_mapping(db, &mapping, TypeContext::default())
-        });
+    let new_upper_bound = determine_upper_bound(db, self_class, ClassBase::is_typed_dict);
+    let mapping = TypeMapping::ReplaceSelf { new_upper_bound };
+    let apply_self_mapping = |member: PlaceAndQualifiers<'db>| {
+        member.map_type(|ty| ty.apply_type_mapping(db, &mapping, TypeContext::default()))
+    };
+    let fallback_member = apply_self_mapping(
+        KnownClass::TypedDictFallback
+            .to_class_literal(db)
+            .find_name_in_mro_with_policy(db, name, lookup_policy)
+            .expect("Will return Some() when called on class literal"),
+    );
     if !fallback_member.is_undefined() {
         return fallback_member;
     }
 
-    // `typing_extensions.TypedDict` backports these attributes to Python versions before 3.15,
-    // where the stdlib fallback intentionally omits them.
-    if matches!(name, "__closed__" | "__extra_items__")
-        && let Some(typing_extensions_fallback) =
-            known_module_symbol(db, KnownModule::TypingExtensions, "_TypedDict")
-                .place
-                .ignore_possibly_undefined()
-                .and_then(Type::as_class_literal)
+    if let Some(member) =
+        typing_extensions_typed_dict_class_member(db, self_class, lookup_policy, name)
     {
-        let member = typing_extensions_fallback.class_member(db, name, lookup_policy);
-        if !member.is_undefined() {
-            return member;
-        }
+        return apply_self_mapping(member);
     }
 
     if let Some(value_ty) = typed_dict.dict_value_type(db)

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -951,7 +951,7 @@ impl<'db> DynamicTypedDictLiteral<'db> {
         let object_class = ClassType::object(db);
         Mro::from([
             self_base,
-            ClassBase::TypedDict,
+            ClassBase::TypedDict(self.typed_dict_module(db)),
             ClassBase::Class(object_class),
         ])
     }

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -994,36 +994,49 @@ impl<'db> DynamicTypedDictLiteral<'db> {
             db,
             TypedDictType::new(ClassType::NonGeneric(ClassLiteral::DynamicTypedDict(self))),
             ClassLiteral::DynamicTypedDict(self),
+            self.typed_dict_module(db),
             policy,
             name,
         )
     }
 }
 
-pub(super) fn typing_extensions_typed_dict_class_member<'db>(
+pub(super) fn typed_dict_fallback_class_member<'db>(
     db: &'db dyn Db,
-    self_class: ClassLiteral<'db>,
+    module: TypedDictModule,
     lookup_policy: MemberLookupPolicy,
     name: &str,
-) -> Option<PlaceAndQualifiers<'db>> {
-    if self_class.typed_dict_module(db) != Some(TypedDictModule::TypingExtensions) {
-        return None;
+) -> PlaceAndQualifiers<'db> {
+    let fallback_member = KnownClass::TypedDictFallback
+        .to_class_literal(db)
+        .find_name_in_mro_with_policy(db, name, lookup_policy)
+        .expect("Will return Some() when called on class literal");
+    if !fallback_member.is_undefined() || module != TypedDictModule::TypingExtensions {
+        return fallback_member;
     }
 
-    let fallback = known_module_symbol(db, KnownModule::TypingExtensions, "_TypedDict")
+    let Some(fallback) = known_module_symbol(db, KnownModule::TypingExtensions, "_TypedDict")
         .place
         .ignore_possibly_undefined()
-        .filter(|ty| ty.as_class_literal().is_some())?;
+        .filter(|ty| ty.as_class_literal().is_some())
+    else {
+        return fallback_member;
+    };
     let member = fallback
         .find_name_in_mro_with_policy(db, name, lookup_policy)
         .expect("Will return Some() when called on class literal");
-    (!member.is_undefined()).then_some(member)
+    if member.is_undefined() {
+        fallback_member
+    } else {
+        member
+    }
 }
 
 pub(super) fn typed_dict_class_member<'db>(
     db: &'db dyn Db,
     typed_dict: TypedDictType<'db>,
     self_class: ClassLiteral<'db>,
+    module: TypedDictModule,
     lookup_policy: MemberLookupPolicy,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
@@ -1032,20 +1045,14 @@ pub(super) fn typed_dict_class_member<'db>(
     let apply_self_mapping = |member: PlaceAndQualifiers<'db>| {
         member.map_type(|ty| ty.apply_type_mapping(db, &mapping, TypeContext::default()))
     };
-    let fallback_member = apply_self_mapping(
-        KnownClass::TypedDictFallback
-            .to_class_literal(db)
-            .find_name_in_mro_with_policy(db, name, lookup_policy)
-            .expect("Will return Some() when called on class literal"),
-    );
+    let fallback_member = apply_self_mapping(typed_dict_fallback_class_member(
+        db,
+        module,
+        lookup_policy,
+        name,
+    ));
     if !fallback_member.is_undefined() {
         return fallback_member;
-    }
-
-    if let Some(member) =
-        typing_extensions_typed_dict_class_member(db, self_class, lookup_policy, name)
-    {
-        return apply_self_mapping(member);
     }
 
     if let Some(value_ty) = typed_dict.dict_value_type(db)

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -152,6 +152,10 @@ impl<'db> ClassBase<'db> {
                 }
             }
             Type::Union(union) => {
+                if let Some(module) = ty.typed_dict_module(db) {
+                    return Some(ClassBase::TypedDict(module));
+                }
+
                 // We do not support full unions of MROs (yet). Until we do,
                 // support the cases where one of the types in the union is
                 // a dynamic type such as `Any` or `Unknown`, and all other

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -5,7 +5,7 @@ use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, ClassLiteral, ClassType, DivergentType, DynamicType, KnownClass,
     KnownInstanceType, MaterializationKind, SpecialFormType, StaticMroError, Type, TypeContext,
-    TypeMapping, todo_type,
+    TypeMapping, TypedDictModule, todo_type,
 };
 use crate::{Db, DisplaySettings};
 
@@ -271,7 +271,7 @@ impl<'db> ClassBase<'db> {
                 SpecialFormType::Unknown => Some(Self::unknown()),
                 SpecialFormType::Protocol => Some(Self::Protocol),
                 SpecialFormType::Generic => Some(Self::Generic),
-                SpecialFormType::TypedDict => Some(Self::TypedDict),
+                SpecialFormType::TypedDict(_) => Some(Self::TypedDict),
 
                 SpecialFormType::NamedTuple => {
                     let class = subclass?.as_static()?;
@@ -484,7 +484,9 @@ impl<'db> From<ClassBase<'db>> for Type<'db> {
             ClassBase::Class(class) => class.into(),
             ClassBase::Protocol => Type::SpecialForm(SpecialFormType::Protocol),
             ClassBase::Generic => Type::SpecialForm(SpecialFormType::Generic),
-            ClassBase::TypedDict => Type::SpecialForm(SpecialFormType::TypedDict),
+            ClassBase::TypedDict => {
+                Type::SpecialForm(SpecialFormType::TypedDict(TypedDictModule::Typing))
+            }
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -34,7 +34,7 @@ pub enum ClassBase<'db> {
     /// but nonetheless appears in the MRO of classes that inherit from `Generic[T]`,
     /// `Protocol[T]`, or bare `Protocol`.
     Generic,
-    TypedDict,
+    TypedDict(TypedDictModule),
 }
 
 impl<'db> ClassBase<'db> {
@@ -54,7 +54,7 @@ impl<'db> ClassBase<'db> {
             Self::Class(class) => Some(Self::Class(
                 class.recursive_type_normalized_impl(db, div, nested)?,
             )),
-            Self::Any | Self::Protocol | Self::Generic | Self::TypedDict => Some(self),
+            Self::Any | Self::Protocol | Self::Generic | Self::TypedDict(_) => Some(self),
         }
     }
 
@@ -79,7 +79,7 @@ impl<'db> ClassBase<'db> {
             ClassBase::Divergent(_) => "Divergent",
             ClassBase::Protocol => "Protocol",
             ClassBase::Generic => "Generic",
-            ClassBase::TypedDict => "TypedDict",
+            ClassBase::TypedDict(_) => "TypedDict",
         }
     }
 
@@ -89,7 +89,14 @@ impl<'db> ClassBase<'db> {
     }
 
     pub(super) const fn is_typed_dict(self) -> bool {
-        matches!(self, ClassBase::TypedDict)
+        self.typed_dict_module().is_some()
+    }
+
+    pub(super) const fn typed_dict_module(self) -> Option<TypedDictModule> {
+        match self {
+            ClassBase::TypedDict(module) => Some(module),
+            _ => None,
+        }
     }
 
     /// Return whether this is an explicit `Any` base.
@@ -271,7 +278,7 @@ impl<'db> ClassBase<'db> {
                 SpecialFormType::Unknown => Some(Self::unknown()),
                 SpecialFormType::Protocol => Some(Self::Protocol),
                 SpecialFormType::Generic => Some(Self::Generic),
-                SpecialFormType::TypedDict(_) => Some(Self::TypedDict),
+                SpecialFormType::TypedDict(module) => Some(Self::TypedDict(module)),
 
                 SpecialFormType::NamedTuple => {
                     let class = subclass?.as_static()?;
@@ -320,7 +327,7 @@ impl<'db> ClassBase<'db> {
             | Self::Divergent(_)
             | Self::Generic
             | Self::Protocol
-            | Self::TypedDict => None,
+            | Self::TypedDict(_) => None,
         }
     }
 
@@ -332,7 +339,7 @@ impl<'db> ClassBase<'db> {
             Self::Dynamic(dynamic) => Type::Dynamic(dynamic),
             Self::Divergent(divergent) => Type::Divergent(divergent),
             // TODO: all `Protocol` classes actually have `_ProtocolMeta` as their metaclass.
-            Self::Protocol | Self::Generic | Self::TypedDict => KnownClass::Type.to_instance(db),
+            Self::Protocol | Self::Generic | Self::TypedDict(_) => KnownClass::Type.to_instance(db),
         }
     }
 
@@ -352,7 +359,7 @@ impl<'db> ClassBase<'db> {
             | Self::Divergent(_)
             | Self::Generic
             | Self::Protocol
-            | Self::TypedDict => self,
+            | Self::TypedDict(_) => self,
         }
     }
 
@@ -407,7 +414,7 @@ impl<'db> ClassBase<'db> {
             | ClassBase::Divergent(_)
             | ClassBase::Generic
             | ClassBase::Protocol
-            | ClassBase::TypedDict => false,
+            | ClassBase::TypedDict(_) => false,
         }
     }
 
@@ -423,7 +430,7 @@ impl<'db> ClassBase<'db> {
             | ClassBase::Dynamic(_)
             | ClassBase::Divergent(_)
             | ClassBase::Generic
-            | ClassBase::TypedDict => ClassBaseMroIterator::length_2(db, self),
+            | ClassBase::TypedDict(_) => ClassBaseMroIterator::length_2(db, self),
             ClassBase::Class(class) => {
                 ClassBaseMroIterator::from_class(db, class, additional_specialization)
             }
@@ -456,7 +463,7 @@ impl<'db> ClassBase<'db> {
                         .fmt(f),
                     ClassBase::Protocol => f.write_str("typing.Protocol"),
                     ClassBase::Generic => f.write_str("typing.Generic"),
-                    ClassBase::TypedDict => f.write_str("typing.TypedDict"),
+                    ClassBase::TypedDict(_) => f.write_str("typing.TypedDict"),
                 }
             }
         }
@@ -484,9 +491,7 @@ impl<'db> From<ClassBase<'db>> for Type<'db> {
             ClassBase::Class(class) => class.into(),
             ClassBase::Protocol => Type::SpecialForm(SpecialFormType::Protocol),
             ClassBase::Generic => Type::SpecialForm(SpecialFormType::Generic),
-            ClassBase::TypedDict => {
-                Type::SpecialForm(SpecialFormType::TypedDict(TypedDictModule::Typing))
-            }
+            ClassBase::TypedDict(module) => Type::SpecialForm(SpecialFormType::TypedDict(module)),
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -99,6 +99,17 @@ impl<'db> ClassBase<'db> {
         }
     }
 
+    /// Return the identity of this base for method-resolution-order construction.
+    ///
+    /// The `TypedDict` module affects member lookup, but both special forms represent the same
+    /// pseudo-base when detecting duplicate or conflicting bases.
+    pub(super) const fn mro_identity(self) -> Self {
+        match self {
+            Self::TypedDict(_) => Self::TypedDict(TypedDictModule::Typing),
+            _ => self,
+        }
+    }
+
     /// Return whether this is an explicit `Any` base.
     pub(super) const fn is_explicit_any_base(self) -> bool {
         matches!(self, ClassBase::Any)

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -152,7 +152,7 @@ impl<'db> ClassBase<'db> {
                 }
             }
             Type::Union(union) => {
-                if let Some(module) = ty.typed_dict_module(db) {
+                if let Some(module) = TypedDictModule::from_type(db, ty) {
                     return Some(ClassBase::TypedDict(module));
                 }
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -34,7 +34,8 @@ use crate::types::{
     CallableType, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
     LiteralValueType, LiteralValueTypeKind, MaterializationKind, PropertyInstanceType, Protocol,
     ProtocolInstanceType, SpecialFormType, StringLiteralType, SubclassOfInner, SubclassOfType,
-    Type, TypeAliasType, TypeGuardLike, TypedDictType, UnionType, WrapperDescriptorKind, visitor,
+    Type, TypeAliasType, TypeGuardLike, TypedDictModule, TypedDictType, UnionType,
+    WrapperDescriptorKind, visitor,
 };
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::{FileScopeId, ScopeKind};
@@ -1391,8 +1392,10 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
             Type::TypedDict(TypedDictType::Synthesized(synthesized)) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
-                f.with_type(Type::SpecialForm(SpecialFormType::TypedDict))
-                    .write_str("TypedDict")?;
+                f.with_type(Type::SpecialForm(SpecialFormType::TypedDict(
+                    TypedDictModule::Typing,
+                )))
+                .write_str("TypedDict")?;
                 f.write_str(" with items ")?;
                 let items = synthesized.items(self.db);
                 for (i, name) in items.keys().enumerate() {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -104,8 +104,8 @@ use crate::types::{
     IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueTypeKind,
     MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters, SentinelInstance, Signature,
     SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
-    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType,
-    UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
+    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictModule,
+    TypedDictType, UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
     extract_fixed_length_iterable_element_types, infer_complete_scope_types, infer_scope_types,
     is_discarded_dict_key_assignment, todo_type,
 };
@@ -3866,7 +3866,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             namedtuple_kind,
                         )
                     } else if let Some(typed_dict_module) =
-                        callable_type.typed_dict_module(self.db())
+                        TypedDictModule::from_type(self.db(), callable_type)
                     {
                         self.infer_typeddict_call_expression(
                             call_expr,
@@ -4178,7 +4178,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             _ => {}
         }
-        if func_ty.typed_dict_module(self.db()).is_some() {
+        if TypedDictModule::from_type(self.db(), func_ty).is_some() {
             self.infer_functional_typeddict_deferred(arguments);
             return;
         }
@@ -8534,7 +8534,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return ty;
         }
 
-        if let Some(typed_dict_module) = callable_type.typed_dict_module(self.db()) {
+        if let Some(typed_dict_module) = TypedDictModule::from_type(self.db(), callable_type) {
             return self.infer_typeddict_call_expression(call_expression, None, typed_dict_module);
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3865,8 +3865,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             Some(definition),
                             namedtuple_kind,
                         )
-                    } else if let Type::SpecialForm(special_form) = callable_type
-                        && let Some(typed_dict_module) = special_form.typed_dict_module()
+                    } else if let Some(typed_dict_module) =
+                        callable_type.typed_dict_module(self.db())
                     {
                         self.infer_typeddict_call_expression(
                             call_expr,
@@ -4178,10 +4178,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             _ => {}
         }
-        if func_ty
-            .as_special_form()
-            .is_some_and(SpecialFormType::is_typed_dict)
-        {
+        if func_ty.typed_dict_module(self.db()).is_some() {
             self.infer_functional_typeddict_deferred(arguments);
             return;
         }
@@ -8537,9 +8534,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return ty;
         }
 
-        if let Type::SpecialForm(special_form) = callable_type
-            && let Some(typed_dict_module) = special_form.typed_dict_module()
-        {
+        if let Some(typed_dict_module) = callable_type.typed_dict_module(self.db()) {
             return self.infer_typeddict_call_expression(call_expression, None, typed_dict_module);
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3865,8 +3865,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             Some(definition),
                             namedtuple_kind,
                         )
-                    } else if callable_type == Type::SpecialForm(SpecialFormType::TypedDict) {
-                        self.infer_typeddict_call_expression(call_expr, Some(definition))
+                    } else if let Type::SpecialForm(special_form) = callable_type
+                        && let Some(typed_dict_module) = special_form.typed_dict_module()
+                    {
+                        self.infer_typeddict_call_expression(
+                            call_expr,
+                            Some(definition),
+                            typed_dict_module,
+                        )
                     } else if let Some(function) = callable_type.as_function_literal()
                         && function.is_known(self.db(), KnownFunction::NewClass)
                     {
@@ -4172,7 +4178,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             _ => {}
         }
-        if func_ty == Type::SpecialForm(SpecialFormType::TypedDict) {
+        if func_ty
+            .as_special_form()
+            .is_some_and(SpecialFormType::is_typed_dict)
+        {
             self.infer_functional_typeddict_deferred(arguments);
             return;
         }
@@ -8528,8 +8537,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return ty;
         }
 
-        if callable_type == Type::SpecialForm(SpecialFormType::TypedDict) {
-            return self.infer_typeddict_call_expression(call_expression, None);
+        if let Type::SpecialForm(special_form) = callable_type
+            && let Some(typed_dict_module) = special_form.typed_dict_module()
+        {
+            return self.infer_typeddict_call_expression(call_expression, None, typed_dict_module);
         }
 
         if callable_type == Type::SpecialForm(SpecialFormType::TypeForm) {

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -54,7 +54,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.infer_expression(base, TypeContext::default())
                 };
                 is_typed_dict |= match ty {
-                    Type::SpecialForm(special_form) if special_form.is_typed_dict() => true,
+                    ty if ty.typed_dict_module(self.db()).is_some() => true,
                     Type::ClassLiteral(class) => class.is_typed_dict(self.db()),
                     Type::GenericAlias(alias) => alias.is_typed_dict(self.db()),
                     _ => false,

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -1,7 +1,7 @@
 use crate::place::Place;
 use crate::types::{
     CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
-    SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
+    SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext, TypedDictModule,
     call::CallError,
     callable::CallableFunctionProvenance,
     function::KnownFunction,
@@ -54,7 +54,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.infer_expression(base, TypeContext::default())
                 };
                 is_typed_dict |= match ty {
-                    ty if ty.typed_dict_module(self.db()).is_some() => true,
+                    ty if TypedDictModule::from_type(self.db(), ty).is_some() => true,
                     Type::ClassLiteral(class) => class.is_typed_dict(self.db()),
                     Type::GenericAlias(alias) => alias.is_typed_dict(self.db()),
                     _ => false,

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -54,7 +54,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self.infer_expression(base, TypeContext::default())
                 };
                 is_typed_dict |= match ty {
-                    Type::SpecialForm(SpecialFormType::TypedDict) => true,
+                    Type::SpecialForm(special_form) if special_form.is_typed_dict() => true,
                     Type::ClassLiteral(class) => class.is_typed_dict(self.db()),
                     Type::GenericAlias(alias) => alias.is_typed_dict(self.db()),
                     _ => false,

--- a/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
@@ -106,7 +106,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             };
 
             match class_base {
-                ClassBase::Generic | ClassBase::TypedDict => {
+                ClassBase::Generic | ClassBase::TypedDict(_) => {
                     if let Some(builder) = self.context.report_lint(&INVALID_BASE, diagnostic_node)
                     {
                         let mut diagnostic = builder.into_diagnostic(format_args!(
@@ -123,7 +123,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                     "Consider using `class {name}(Generic[...]): ...` instead"
                                 ));
                             }
-                            ClassBase::TypedDict => {
+                            ClassBase::TypedDict(_) => {
                                 diagnostic.info(format_args!(
                                     "Classes created via `{fn_name}` cannot be TypedDicts"
                                 ));

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2457,7 +2457,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             SpecialFormType::TypingSelf
             | SpecialFormType::TypeAlias
-            | SpecialFormType::TypedDict
+            | SpecialFormType::TypedDict(_)
             | SpecialFormType::Unknown
             | SpecialFormType::Divergent
             | SpecialFormType::Todo

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -19,7 +19,8 @@ use crate::types::typed_dict::{
     validate_typed_dict_constructor, validate_typed_dict_dict_literal,
 };
 use crate::types::{
-    IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictType,
+    IntersectionType, KnownClass, Type, TypeAndQualifiers, TypeContext, TypedDictModule,
+    TypedDictType,
 };
 use ty_python_core::definition::Definition;
 
@@ -72,6 +73,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         &mut self,
         call_expr: &ast::ExprCall,
         definition: Option<Definition<'db>>,
+        typed_dict_module: TypedDictModule,
     ) -> Type<'db> {
         let db = self.db();
 
@@ -314,7 +316,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         };
 
-        let typeddict = DynamicTypedDictLiteral::new(db, name, anchor);
+        let typeddict = DynamicTypedDictLiteral::new(db, name, anchor, typed_dict_module);
         Type::ClassLiteral(ClassLiteral::DynamicTypedDict(typeddict))
     }
 

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -285,7 +285,7 @@ impl<'db> Mro<'db> {
                             ClassBase::Class(_)
                             | ClassBase::Generic
                             | ClassBase::Protocol
-                            | ClassBase::TypedDict => {
+                            | ClassBase::TypedDict(_) => {
                                 errors.push(DuplicateBaseError {
                                     duplicate_base: base,
                                     first_index: *first_index,

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -269,7 +269,10 @@ impl<'db> Mro<'db> {
                         ) else {
                             continue;
                         };
-                        base_to_indices.entry(base).or_default().push(index);
+                        base_to_indices
+                            .entry(base.mro_identity())
+                            .or_default()
+                            .push(index);
                     }
 
                     let mut errors = vec![];
@@ -401,7 +404,7 @@ impl<'db> Mro<'db> {
                 }
                 continue;
             }
-            if !seen.insert(*base) {
+            if !seen.insert(base.mro_identity()) {
                 duplicates.push(*base);
             }
         }
@@ -803,10 +806,14 @@ fn c3_merge(mut sequences: Vec<VecDeque<ClassBase>>) -> Option<Mro> {
         // with the given bases.
         let mro_entry = sequences.iter().find_map(|outer_sequence| {
             let candidate = outer_sequence[0];
+            let candidate_identity = candidate.mro_identity();
 
-            let not_head = sequences
-                .iter()
-                .all(|sequence| sequence.iter().skip(1).all(|base| base != &candidate));
+            let not_head = sequences.iter().all(|sequence| {
+                sequence
+                    .iter()
+                    .skip(1)
+                    .all(|base| base.mro_identity() != candidate_identity)
+            });
 
             not_head.then_some(candidate)
         })?;
@@ -815,7 +822,7 @@ fn c3_merge(mut sequences: Vec<VecDeque<ClassBase>>) -> Option<Mro> {
 
         // Make sure we don't try to add the candidate to the MRO twice:
         for sequence in &mut sequences {
-            if sequence[0] == mro_entry {
+            if sequence[0].mro_identity() == mro_entry.mro_identity() {
                 sequence.pop_front();
             }
         }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -340,7 +340,7 @@ fn check_class_declaration<'db>(
                     has_dynamic_superclass = true;
                     continue;
                 }
-                ClassBase::TypedDict => {
+                ClassBase::TypedDict(_) => {
                     has_typeddict_in_mro = true;
                     continue;
                 }

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -144,6 +144,28 @@ pub enum TypedDictModule {
 }
 
 impl TypedDictModule {
+    /// Return the module for a `TypedDict` special form, including a union of the special forms
+    /// exported by `typing` and `typing_extensions`.
+    pub(crate) fn from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+        match ty {
+            Type::SpecialForm(SpecialFormType::TypedDict(module)) => Some(module),
+            Type::Union(union) => {
+                let mut elements = union.elements(db).iter();
+                let Type::SpecialForm(SpecialFormType::TypedDict(module)) = elements.next()? else {
+                    return None;
+                };
+                elements.try_fold(*module, |module, element| {
+                    let Type::SpecialForm(SpecialFormType::TypedDict(element_module)) = element
+                    else {
+                        return None;
+                    };
+                    Some(module.union(*element_module))
+                })
+            }
+            _ => None,
+        }
+    }
+
     pub(crate) const fn union(self, other: Self) -> Self {
         match (self, other) {
             (Self::Typing, Self::Typing) => Self::Typing,
@@ -154,13 +176,6 @@ impl TypedDictModule {
 }
 
 impl SpecialFormType {
-    pub(crate) const fn typed_dict_module(self) -> Option<TypedDictModule> {
-        match self {
-            Self::TypedDict(module) => Some(module),
-            _ => None,
-        }
-    }
-
     /// Return the [`KnownClass`] which this symbol is an instance of
     pub(crate) const fn class(self) -> KnownClass {
         match self {

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -146,7 +146,7 @@ pub enum TypedDictModule {
 impl TypedDictModule {
     /// Return the module for a `TypedDict` special form, including a union of the special forms
     /// exported by `typing` and `typing_extensions`.
-    pub(crate) fn from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+    pub(super) fn from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
         match ty {
             Type::SpecialForm(SpecialFormType::TypedDict(module)) => Some(module),
             Type::Union(union) => {
@@ -166,7 +166,7 @@ impl TypedDictModule {
         }
     }
 
-    pub(crate) const fn union(self, other: Self) -> Self {
+    const fn union(self, other: Self) -> Self {
         match (self, other) {
             (Self::Typing, Self::Typing) => Self::Typing,
             (Self::TypingExtensions, Self::TypingExtensions) => Self::TypingExtensions,

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -109,8 +109,8 @@ pub enum SpecialFormType {
     TypeAlias,
     /// The symbol `typing.TypeGuard` (which can also be found as `typing_extensions.TypeGuard`)
     TypeGuard,
-    /// The symbol `typing.TypedDict` (which can also be found as `typing_extensions.TypedDict`)
-    TypedDict,
+    /// The symbol `typing.TypedDict` or `typing_extensions.TypedDict`.
+    TypedDict(TypedDictModule),
     /// The symbol `typing.TypeIs` (which can also be found as `typing_extensions.TypeIs`)
     TypeIs,
 
@@ -132,7 +132,27 @@ pub enum SpecialFormType {
     NamedTuple,
 }
 
+/// The module from which `TypedDict` was imported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]
+pub enum TypedDictModule {
+    /// `typing.TypedDict`.
+    Typing,
+    /// `typing_extensions.TypedDict`.
+    TypingExtensions,
+}
+
 impl SpecialFormType {
+    pub(crate) const fn typed_dict_module(self) -> Option<TypedDictModule> {
+        match self {
+            Self::TypedDict(module) => Some(module),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn is_typed_dict(self) -> bool {
+        self.typed_dict_module().is_some()
+    }
+
     /// Return the [`KnownClass`] which this symbol is an instance of
     pub(crate) const fn class(self) -> KnownClass {
         match self {
@@ -153,7 +173,7 @@ impl SpecialFormType {
             | Self::Unpack
             | Self::TypeAlias
             | Self::TypeGuard
-            | Self::TypedDict
+            | Self::TypedDict(_)
             | Self::TypeIs
             | Self::TypeOf
             | Self::Not
@@ -238,12 +258,10 @@ impl SpecialFormType {
     /// imported the symbol from (`import_module`), return the variant that matches the
     /// import path — or `self` if there's no better match.
     ///
-    /// This exists because typeshed defines `_collections_abc.Callable` as
-    /// `from typing import Callable as Callable`, then re-exports it from `collections.abc`.
-    /// Following the alias chain to the definition site lands on `SpecialFormType::TypingCallable`
-    /// for both `from typing import Callable` and `from collections.abc import Callable`, erasing
-    /// the distinction. This method substitutes `CollectionsAbcCallable` at the `_collections_abc`
-    /// module boundary, restoring it before `collections.abc` star-reexports it.
+    /// This exists because typeshed defines some special forms as re-exports from other modules.
+    /// Following the alias chain to the definition site would otherwise erase distinctions such as
+    /// `typing.Callable` versus `collections.abc.Callable`, or `typing.TypedDict` versus
+    /// `typing_extensions.TypedDict`.
     ///
     /// Called at module-attribute resolution — the one boundary where the import-path
     /// module is still observable.
@@ -251,6 +269,12 @@ impl SpecialFormType {
         match (self, name, import_module) {
             (Self::TypingCallable, "Callable", KnownModule::CollectionsAbcInternal) => {
                 Self::CollectionsAbcCallable
+            }
+            (Self::TypedDict(_), "TypedDict", KnownModule::Typing) => {
+                Self::TypedDict(TypedDictModule::Typing)
+            }
+            (Self::TypedDict(_), "TypedDict", KnownModule::TypingExtensions) => {
+                Self::TypedDict(TypedDictModule::TypingExtensions)
             }
             _ => self,
         }
@@ -356,7 +380,7 @@ impl SpecialFormType {
                     SpecialFormType::Top => Self::Top,
                     SpecialFormType::Unpack => Self::Unpack,
                     SpecialFormType::Tuple => Self::Tuple,
-                    SpecialFormType::TypedDict => Self::TypedDict,
+                    SpecialFormType::TypedDict(_) => Self::TypedDict,
                     SpecialFormType::TypeOf => Self::TypeOf,
                     SpecialFormType::LegacyStdlibAlias(alias) => match alias {
                         LegacyStdlibAlias::List => Self::List,
@@ -416,7 +440,7 @@ impl SpecialFormType {
                 SpecialFormTypeBuilder::Top => Self::Top,
                 SpecialFormTypeBuilder::Unpack => Self::Unpack,
                 SpecialFormTypeBuilder::Tuple => Self::Tuple,
-                SpecialFormTypeBuilder::TypedDict => Self::TypedDict,
+                SpecialFormTypeBuilder::TypedDict => Self::TypedDict(TypedDictModule::Typing),
                 SpecialFormTypeBuilder::TypeOf => Self::TypeOf,
                 SpecialFormTypeBuilder::List => Self::LegacyStdlibAlias(LegacyStdlibAlias::List),
                 SpecialFormTypeBuilder::Dict => Self::LegacyStdlibAlias(LegacyStdlibAlias::Dict),
@@ -472,7 +496,7 @@ impl SpecialFormType {
             | Self::Unpack
             | Self::TypeAlias
             | Self::TypeGuard
-            | Self::TypedDict
+            | Self::TypedDict(_)
             | Self::TypeIs
             | Self::TypeForm
             | Self::TypingSelf
@@ -512,7 +536,7 @@ impl SpecialFormType {
     pub(super) const fn is_callable(self) -> bool {
         match self {
             // TypedDict can be called as a constructor to create TypedDict types
-            Self::TypedDict
+            Self::TypedDict(_)
 
             // Collection constructors are callable
             // TODO actually implement support for calling them
@@ -606,7 +630,7 @@ impl SpecialFormType {
             | Self::Optional
             | Self::Top
             | Self::TypeIs
-            | Self::TypedDict
+            | Self::TypedDict(_)
             | Self::TypingSelf
             | Self::Union
             | Self::Unknown
@@ -640,7 +664,7 @@ impl SpecialFormType {
             SpecialFormType::Unpack => "Unpack",
             SpecialFormType::TypeAlias => "TypeAlias",
             SpecialFormType::TypeGuard => "TypeGuard",
-            SpecialFormType::TypedDict => "TypedDict",
+            SpecialFormType::TypedDict(_) => "TypedDict",
             SpecialFormType::TypeIs => "TypeIs",
             SpecialFormType::LegacyStdlibAlias(LegacyStdlibAlias::List) => "List",
             SpecialFormType::LegacyStdlibAlias(LegacyStdlibAlias::Dict) => "Dict",
@@ -689,7 +713,7 @@ impl SpecialFormType {
             | SpecialFormType::Unpack
             | SpecialFormType::TypeAlias
             | SpecialFormType::TypeGuard
-            | SpecialFormType::TypedDict
+            | SpecialFormType::TypedDict(_)
             | SpecialFormType::TypeIs
             | SpecialFormType::Protocol
             | SpecialFormType::Generic
@@ -822,7 +846,7 @@ impl SpecialFormType {
             // annotated assignment statement) doesn't reach here. Using it in any other type
             // expression is an error.
             Self::TypeAlias => Err(InvalidTypeExpression::TypeAlias),
-            Self::TypedDict => Err(InvalidTypeExpression::TypedDict),
+            Self::TypedDict(_) => Err(InvalidTypeExpression::TypedDict),
 
             Self::Literal | Self::Union | Self::Intersection => {
                 Err(InvalidTypeExpression::RequiresArguments(self))

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -132,13 +132,25 @@ pub enum SpecialFormType {
     NamedTuple,
 }
 
-/// The module from which `TypedDict` was imported.
+/// The module or modules from which `TypedDict` may have been imported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub enum TypedDictModule {
     /// `typing.TypedDict`.
     Typing,
     /// `typing_extensions.TypedDict`.
     TypingExtensions,
+    /// `TypedDict` may resolve to the symbol from either module.
+    Either,
+}
+
+impl TypedDictModule {
+    pub(crate) const fn union(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Typing, Self::Typing) => Self::Typing,
+            (Self::TypingExtensions, Self::TypingExtensions) => Self::TypingExtensions,
+            _ => Self::Either,
+        }
+    }
 }
 
 impl SpecialFormType {
@@ -147,10 +159,6 @@ impl SpecialFormType {
             Self::TypedDict(module) => Some(module),
             _ => None,
         }
-    }
-
-    pub(crate) const fn is_typed_dict(self) -> bool {
-        self.typed_dict_module().is_some()
     }
 
     /// Return the [`KnownClass`] which this symbol is an instance of


### PR DESCRIPTION
## Summary

This follows up on #25833. On Python 3.12, classes defined using `typing_extensions.TypedDict` have runtime attributes that classes defined using `typing.TypedDict` do not, but we currently treat both definitions as the same special form.

This keeps track of which `TypedDict` definition was used for class-based, functional, inherited, generic, and dynamically created TypedDicts. Member lookup still uses the shared typeshed declarations first, then consults `typing_extensions._TypedDict` only for TypedDicts defined using `typing_extensions.TypedDict`. Their MRO and type relationships remain unchanged.

The regression tests cover `typing.TypedDict` versus `typing_extensions.TypedDict` on Python 3.12, verify that `typing.TypedDict.__closed__` is unavailable on Python 3.13, and cover the standard-library attributes available on Python 3.15.
