### PR TITLE
[ty] Restore builder-local constraint subtype cache

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -708,6 +708,7 @@ struct ConstraintSetStorage<'db> {
 
     single_sequent_cache: FxHashMap<ConstraintId, SequentMap>,
     pair_sequent_cache: FxHashMap<(ConstraintId, ConstraintId), SequentMap>,
+    constraint_set_subtype_cache: FxHashMap<(Type<'db>, Type<'db>), bool>,
 }
 
 impl<'db> ConstraintSetBuilder<'db> {
@@ -935,6 +936,25 @@ impl<'db> ConstraintSetBuilder<'db> {
         self.storage
             .borrow_mut()
             .constraint_implication_cache
+            .insert(key, result);
+        result
+    }
+
+    fn cached_is_constraint_set_subtype_of(
+        &self,
+        db: &'db dyn Db,
+        source: Type<'db>,
+        target: Type<'db>,
+    ) -> bool {
+        let key = (source, target);
+        if let Some(result) = self.storage.borrow().constraint_set_subtype_cache.get(&key) {
+            return *result;
+        }
+
+        let result = source.is_constraint_set_subtype_of(db, target);
+        self.storage
+            .borrow_mut()
+            .constraint_set_subtype_cache
             .insert(key, result);
         result
     }
@@ -5039,12 +5059,11 @@ impl SequentMap {
             (constrained_lower, Some(constrained_upper), Some(bound_lower), _)
                 if !constrained_upper.is_never()
                     && !constrained_upper.is_object()
-                    && constrained_upper
-                        .top_materialization(db)
-                        .is_constraint_set_subtype_of(
-                            db,
-                            bound_lower.bottom_materialization(db),
-                        ) =>
+                    && builder.cached_is_constraint_set_subtype_of(
+                        db,
+                        constrained_upper.top_materialization(db),
+                        bound_lower.bottom_materialization(db),
+                    ) =>
             {
                 (constrained_lower, Some(Type::TypeVar(bound_typevar)))
             }
@@ -5053,12 +5072,11 @@ impl SequentMap {
             (Some(constrained_lower), constrained_upper, _, Some(bound_upper))
                 if !constrained_lower.is_never()
                     && !constrained_lower.is_object()
-                    && bound_upper
-                        .top_materialization(db)
-                        .is_constraint_set_subtype_of(
-                            db,
-                            constrained_lower.bottom_materialization(db),
-                        ) =>
+                    && builder.cached_is_constraint_set_subtype_of(
+                        db,
+                        bound_upper.top_materialization(db),
+                        constrained_lower.bottom_materialization(db),
+                    ) =>
             {
                 (Some(Type::TypeVar(bound_typevar)), constrained_upper)
             }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -401,7 +401,6 @@ impl<'db> Type<'db> {
     }
 
     /// Return true if this type is a subtype of `target` using constraint-set typevar rules.
-    #[salsa::tracked(cycle_initial=|_, _, _, _| true, heap_size=ruff_memory_usage::heap_size)]
     pub(super) fn is_constraint_set_subtype_of(self, db: &'db dyn Db, target: Type<'db>) -> bool {
         let constraints = ConstraintSetBuilder::new();
         self.when_constraint_set_subtype_of(db, target, &constraints)


### PR DESCRIPTION
## Summary

PR #25786 originally cached repeated constraint-set subtype checks on `ConstraintSetBuilder`. [During review](https://github.com/astral-sh/ruff/pull/25786#discussion_r3383378278), that cache was replaced with a Salsa-tracked query to allow reuse across builders. On pytest-robotframework, the tracked query does not recover the same performance: current main remains roughly 25% slower than the commit immediately before #25778.

This restores the builder-local `FxHashMap` cache and routes the two transitive-pivot subtype checks through it. The separate type-variable-bound precheck from #25786 remains unchanged.

In 80 balanced, interleaved runs of pytest-robotframework using clean profiling builds, the results were:

| Revision | Median | Paired change vs. pre-#25778 |
| --- | ---: | ---: |
| Pre-#25778 (`1676ec8013`) | 103.2 ms | — |
| Current main (`8f2caa6a04`) | 128.3 ms | +24.9% |
| This PR | 106.9 ms | +3.7% |

This PR is 16.9% faster than current main. All three revisions produced byte-for-byte identical diagnostics. The full `ty_python_semantic` suite (558 tests), focused Clippy, and repository hooks pass.
