### PR TITLE
Fix handling of `ignore` comments within a `disable`/`enable` pair

### DIFF
--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -220,3 +220,37 @@ values = [
 ```
 
 <!-- fmt:on -->
+
+## `ruff:ignore` comments with a `disable`/`enable` pair
+
+```toml
+[lint]
+preview = true
+select = ["F401", "RUF10"]
+```
+
+An intervening `ruff:ignore` directive shouldn't cause a `disable`/`enable` pair to be reported as
+unmatched. Instead, the range suppression should take precedence, and the inner `ruff:ignore` should
+be unused, just like a `noqa` comment:
+
+```py
+# ruff:disable[F401]
+# error: [unused-noqa]
+import os  # ruff:ignore[F401]
+# ruff:enable[F401]
+
+# ruff:disable[F401]
+# error: [unused-noqa]
+import sys  # noqa: F401
+# ruff:enable[F401]
+```
+
+This applies to own-line comments too:
+
+```py
+# ruff:disable[F401]
+# error: [unused-noqa]
+# ruff:ignore[F401]
+import os
+# ruff:enable[F401]
+```

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -221,12 +221,12 @@ values = [
 
 <!-- fmt:on -->
 
-## `ruff:ignore` comments with a `disable`/`enable` pair
+## `ruff:ignore` comments within a `disable`/`enable` pair
 
 ```toml
 [lint]
 preview = true
-select = ["F401", "RUF10"]
+select = ["E501", "F401", "RUF10"]
 ```
 
 An intervening `ruff:ignore` directive shouldn't cause a `disable`/`enable` pair to be reported as
@@ -252,5 +252,33 @@ This applies to own-line comments too:
 # error: [unused-noqa]
 # ruff:ignore[F401]
 import os
+# ruff:enable[F401]
+```
+
+and cases where the `disable` and `ignore` suppress different codes:
+
+```py
+# ruff:disable[E501]
+import os  # ruff:ignore[F401]
+message = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+# ruff:enable[E501]
+```
+
+## `file-ignore` comments within a `disable`/`enable` pair
+
+```toml
+[lint]
+preview = true
+select = ["F401", "RUF10"]
+```
+
+A `file-ignore` within a range suppression takes precedence and marks the `disable` as unused:
+
+```py
+# error: [unused-noqa]
+# ruff:disable[F401]
+# ruff:file-ignore[F401]
+import os
+message = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 # ruff:enable[F401]
 ```

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -575,76 +575,15 @@ impl<'a> SuppressionsBuilder<'a> {
 
         'comments: while let Some(suppression) = suppressions.peek() {
             indents.clear();
-            let (before, after) = tokens.split_at(suppression.range.start());
 
             // Standalone suppression comments
-
-            if suppression.action == SuppressionAction::Ignore {
-                if is_ruff_ignore_enabled(self.settings) {
-                    let range = if indentation_at_offset(suppression.range.start(), self.source)
-                        .is_some()
-                    {
-                        // own-line ignore
-                        Self::standalone_comment_range(suppression.range, before, after)
-                    } else {
-                        // trailing ignore
-                        self.trailing_comment_range(suppression.range, before)
-                    };
-                    for code in suppression.codes_as_str(self.source) {
-                        self.valid.push(Suppression {
-                            code: code.into(),
-                            range,
-                            used: false.into(),
-                            comments: SuppressionComments::Single(suppression.clone()),
-                        });
-                    }
-                } else {
-                    warn_user_once!(
-                        "#ruff:ignore comment found but not active, enable preview mode"
-                    );
-                }
-                suppressions.next();
-                continue;
-            } else if suppression.action == SuppressionAction::FileIgnore {
-                if is_ruff_ignore_enabled(self.settings) {
-                    match indentation_at_offset(suppression.range.start(), self.source) {
-                        // Module scope
-                        Some("") => {
-                            let range = TextRange::up_to(self.source.text_len());
-                            for code in suppression.codes_as_str(self.source) {
-                                self.valid.push(Suppression {
-                                    code: code.into(),
-                                    range,
-                                    used: false.into(),
-                                    comments: SuppressionComments::Single(suppression.clone()),
-                                });
-                            }
-                        }
-                        // Indented/inside block
-                        Some(_) => {
-                            self.invalid.push(InvalidSuppression {
-                                kind: InvalidSuppressionKind::NotModuleScope,
-                                comment: suppression.clone(),
-                            });
-                        }
-                        // Trailing
-                        None => {
-                            self.invalid.push(InvalidSuppression {
-                                kind: InvalidSuppressionKind::Trailing,
-                                comment: suppression.clone(),
-                            });
-                        }
-                    }
-                } else {
-                    warn_user_once!(
-                        "#ruff:file-ignore comment found but not active, enable preview mode"
-                    );
-                }
+            if self.register_standalone_suppression(suppression, tokens) {
                 suppressions.next();
                 continue;
             }
 
             // Matched suppression comments
+            let (before, after) = tokens.split_at(suppression.range.start());
 
             let mut count = 0;
             let last_indent = before
@@ -686,6 +625,10 @@ impl<'a> SuppressionsBuilder<'a> {
                         else {
                             continue;
                         };
+
+                        if self.register_standalone_suppression(&suppression, tokens) {
+                            continue;
+                        }
 
                         let Some(indent) =
                             indentation_at_offset(suppression.range.start(), self.source)
@@ -743,6 +686,82 @@ impl<'a> SuppressionsBuilder<'a> {
             valid: self.valid,
             invalid: self.invalid,
             errors,
+        }
+    }
+
+    /// Handles a single-comment suppression like `ruff:ignore` or `ruff:file-ignore` and returns
+    /// `true` if such a comment was found.
+    fn register_standalone_suppression(
+        &mut self,
+        suppression: &SuppressionComment,
+        tokens: &Tokens,
+    ) -> bool {
+        match suppression.action {
+            SuppressionAction::Ignore => {
+                if is_ruff_ignore_enabled(self.settings) {
+                    let (before, after) = tokens.split_at(suppression.range.start());
+                    let range = if indentation_at_offset(suppression.range.start(), self.source)
+                        .is_some()
+                    {
+                        // own-line ignore
+                        Self::standalone_comment_range(suppression.range, before, after)
+                    } else {
+                        // trailing ignore
+                        self.trailing_comment_range(suppression.range, before)
+                    };
+                    for code in suppression.codes_as_str(self.source) {
+                        self.valid.push(Suppression {
+                            code: code.into(),
+                            range,
+                            used: false.into(),
+                            comments: SuppressionComments::Single(suppression.clone()),
+                        });
+                    }
+                } else {
+                    warn_user_once!(
+                        "#ruff:ignore comment found but not active, enable preview mode"
+                    );
+                }
+                true
+            }
+            SuppressionAction::FileIgnore => {
+                if is_ruff_ignore_enabled(self.settings) {
+                    match indentation_at_offset(suppression.range.start(), self.source) {
+                        // Module scope
+                        Some("") => {
+                            let range = TextRange::up_to(self.source.text_len());
+                            for code in suppression.codes_as_str(self.source) {
+                                self.valid.push(Suppression {
+                                    code: code.into(),
+                                    range,
+                                    used: false.into(),
+                                    comments: SuppressionComments::Single(suppression.clone()),
+                                });
+                            }
+                        }
+                        // Indented/inside block
+                        Some(_) => {
+                            self.invalid.push(InvalidSuppression {
+                                kind: InvalidSuppressionKind::NotModuleScope,
+                                comment: suppression.clone(),
+                            });
+                        }
+                        // Trailing
+                        None => {
+                            self.invalid.push(InvalidSuppression {
+                                kind: InvalidSuppressionKind::Trailing,
+                                comment: suppression.clone(),
+                            });
+                        }
+                    }
+                } else {
+                    warn_user_once!(
+                        "#ruff:file-ignore comment found but not active, enable preview mode"
+                    );
+                }
+                true
+            }
+            SuppressionAction::Disable | SuppressionAction::Enable => false,
         }
     }
 


### PR DESCRIPTION
Summary
--

This PR addresses the part of https://github.com/astral-sh/ruff/pull/25791#pullrequestreview-4469517385 that reproduced on main.

Both of these cases were mishandled:

```py
# ruff:disable[F401, F402]
# ruff:ignore[F401]
# ruff:enable[F401, F402]

# ruff:disable[E501]
import os  # ruff:ignore[F401]
# ruff:enable[E501]
```

[Playground](https://play.ruff.rs/9095ff69-5a67-45f2-bb96-81b9d36a361c)

with both `ruff:ignore` comments generating a `RUF103` diagnostic and with a particularly strange
error message in the second case:

```
Invalid suppression comment: trailing comments are only support for ruff:ignore suppressions
```

The fix was to factor out the code for handling standalone `ruff:ignore` and `ruff:file-ignore`
comments to allow also calling back into it while looking ahead for the the `enable` comment that
matches a `disable` comment.

Test Plan
--

New mdtests based on the examples in Micha's comment
