### PR TITLE
[ty] Deduplicate retained scope inference types

### DIFF
--- a/crates/ty_python_core/src/frozen.rs
+++ b/crates/ty_python_core/src/frozen.rs
@@ -1,3 +1,8 @@
+use std::hash::Hash;
+
+use ruff_index::{FrozenIndexVec, IndexVec, newtype_index};
+use rustc_hash::FxHashMap;
+
 /// Compact immutable key-value entries stored in key order.
 ///
 /// Analysis builds these tables with hash maps, but after construction they only need keyed
@@ -100,6 +105,113 @@ impl<'a, K, V> IntoIterator for &'a mut FrozenMap<K, V> {
     }
 }
 
+#[newtype_index]
+#[derive(get_size2::GetSize, salsa::Update)]
+struct FrozenValueIndex;
+
+fn index_values<K, V>(
+    entries: impl IntoIterator<Item = (K, V)>,
+) -> (Vec<(K, FrozenValueIndex)>, IndexVec<FrozenValueIndex, V>)
+where
+    V: Copy + Eq + Hash,
+{
+    let mut values = IndexVec::new();
+    let mut value_indices = FxHashMap::default();
+    let entries = entries
+        .into_iter()
+        .map(|(key, value)| {
+            let index = *value_indices
+                .entry(value)
+                .or_insert_with(|| values.push(value));
+            (key, index)
+        })
+        .collect();
+
+    (entries, values)
+}
+
+/// Compact immutable key-value entries that deduplicate repeated values.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct FrozenValueMap<K, V> {
+    entries: FrozenMap<K, FrozenValueIndex>,
+    values: FrozenIndexVec<FrozenValueIndex, V>,
+}
+
+impl<K, V> FrozenValueMap<K, V> {
+    pub fn get(&self, key: &K) -> Option<&V>
+    where
+        K: Ord,
+    {
+        self.entries.get(key).map(|index| &self.values[*index])
+    }
+
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (K, V)> + ExactSizeIterator + '_
+    where
+        K: Copy,
+        V: Copy,
+    {
+        self.entries
+            .iter()
+            .map(|(key, index)| (*key, self.values[*index]))
+    }
+
+    pub fn map_values<F>(&mut self, mut map: F)
+    where
+        K: Copy + Ord,
+        V: Copy + Eq + Hash,
+        F: FnMut(K, V) -> V,
+    {
+        *self = self
+            .iter()
+            .map(|(key, value)| (key, map(key, value)))
+            .collect();
+    }
+}
+
+impl<K, V> FromIterator<(K, V)> for FrozenValueMap<K, V>
+where
+    K: Ord,
+    V: Copy + Eq + Hash,
+{
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let mut source_entries = iter.into_iter().collect::<Vec<_>>();
+        source_entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        source_entries.dedup_by(|(left, _), (right, _)| left == right);
+
+        let (entries, values) = index_values(source_entries);
+
+        Self {
+            entries: FrozenMap(entries.into_boxed_slice()),
+            values: values.into(),
+        }
+    }
+}
+
+impl<K, V, S> From<std::collections::HashMap<K, V, S>> for FrozenValueMap<K, V>
+where
+    K: Ord,
+    V: Copy + Eq + Hash,
+{
+    fn from(map: std::collections::HashMap<K, V, S>) -> Self {
+        let (mut entries, values) = index_values(map);
+        entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+
+        Self {
+            entries: FrozenMap(entries.into_boxed_slice()),
+            values: values.into(),
+        }
+    }
+}
+
+impl<K, V> Default for FrozenValueMap<K, V> {
+    fn default() -> Self {
+        Self {
+            entries: FrozenMap::default(),
+            values: IndexVec::new().into(),
+        }
+    }
+}
+
 /// Compact immutable keys stored in ascending order.
 ///
 /// Analysis builds these sets with hash sets, but after construction they only need membership
@@ -139,5 +251,47 @@ impl<'a, K> IntoIterator for &'a FrozenSet<K> {
 impl<K> Default for FrozenSet<K> {
     fn default() -> Self {
         Self(Box::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FrozenMap, FrozenValueMap};
+
+    #[test]
+    fn frozen_value_map_deduplicates_values() {
+        let map = FrozenValueMap::from_iter([(3, [1; 4]), (1, [2; 4]), (2, [1; 4])]);
+
+        assert_eq!(map.values.len(), 2);
+        assert_eq!(map.get(&1), Some(&[2; 4]));
+        assert_eq!(map.get(&2), Some(&[1; 4]));
+        assert_eq!(
+            map.iter().collect::<Vec<_>>(),
+            vec![(1, [2; 4]), (2, [1; 4]), (3, [1; 4])]
+        );
+    }
+
+    #[test]
+    fn frozen_value_map_updates_and_rededuplicates_values() {
+        let mut map = FrozenValueMap::from_iter([(1, 10), (2, 20), (3, 30)]);
+
+        map.map_values(|_, _| 42);
+
+        assert_eq!(&map.values.raw, &[42]);
+        assert_eq!(
+            map.iter().collect::<Vec<_>>(),
+            vec![(1, 42), (2, 42), (3, 42)]
+        );
+    }
+
+    #[test]
+    fn frozen_value_map_uses_less_heap_for_repeated_large_values() {
+        let entries = [(1, [1; 8]), (2, [1; 8]), (3, [1; 8]), (4, [2; 8])];
+        let direct = FrozenMap::from_iter(entries);
+        let deduplicated = FrozenValueMap::from_iter(entries);
+
+        assert!(
+            ruff_memory_usage::heap_size(&deduplicated) < ruff_memory_usage::heap_size(&direct)
+        );
     }
 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -51,7 +51,7 @@ use rustc_hash::FxHashMap;
 use salsa;
 use salsa::plumbing::AsId;
 use std::borrow::Cow;
-pub(super) use ty_python_core::frozen::{FrozenMap, FrozenSet};
+pub(super) use ty_python_core::frozen::{FrozenMap, FrozenSet, FrozenValueMap};
 
 use crate::types::diagnostic::TypeCheckDiagnostics;
 use crate::types::function::{FunctionDecorators, FunctionType};
@@ -750,7 +750,7 @@ impl<'db> InferenceRegion<'db> {
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct ScopeInference<'db> {
     /// The types of every expression in this region.
-    expressions: FrozenMap<ExpressionNodeKey, Type<'db>>,
+    expressions: FrozenValueMap<ExpressionNodeKey, Type<'db>>,
 
     /// The extra data that is only present for few inference regions.
     extra: Option<Box<ScopeInferenceExtra<'db>>>,
@@ -787,7 +787,7 @@ impl<'db> ScopeInference<'db> {
                 cycle_recovery: Some(cycle_recovery),
                 ..ScopeInferenceExtra::default()
             })),
-            expressions: FrozenMap::default(),
+            expressions: FrozenValueMap::default(),
         }
     }
 
@@ -797,10 +797,9 @@ impl<'db> ScopeInference<'db> {
         previous_inference: &ScopeInference<'db>,
         cycle: &salsa::Cycle,
     ) -> ScopeInference<'db> {
-        for (expr, ty) in &mut self.expressions {
-            let previous_ty = previous_inference.expression_type(*expr);
-            *ty = ty.cycle_normalized(db, previous_ty, cycle);
-        }
+        self.expressions.map_values(|expr, ty| {
+            ty.cycle_normalized(db, previous_inference.expression_type(expr), cycle)
+        });
 
         self
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -23,7 +23,7 @@ use ty_python_core::statement::StatementInner;
 
 use super::{
     DeferredAndUndecorated, DefinitionInference, DefinitionInferenceExtra, DefinitionTypes,
-    ExpressionInference, ExpressionInferenceExtra, FrozenMap, FrozenSet,
+    ExpressionInference, ExpressionInferenceExtra, FrozenMap, FrozenSet, FrozenValueMap,
     FunctionDecoratorInference, InferenceRegion, OtherDefinitionInferenceExtra, ScopeInference,
     ScopeInferenceExtra, infer_deferred_types, infer_definition_types, infer_expression_types,
     infer_same_file_expression_type, infer_unpack_types,
@@ -586,8 +586,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn extend_scope(&mut self, inference: &ScopeInference<'db>) {
-        self.expressions
-            .extend(inference.expressions.iter().copied());
+        self.expressions.extend(inference.expressions.iter());
 
         if let Some(extra) = &inference.extra {
             self.context.extend(&extra.diagnostics);
@@ -10952,7 +10951,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         ScopeInference {
-            expressions: FrozenMap::from(expressions),
+            expressions: FrozenValueMap::from(expressions),
             extra,
         }
     }


### PR DESCRIPTION
## Summary

Scope inference retains a type for every expression in the scope. Many expressions share the same type, but the existing frozen map stores a complete `Type` value in every entry.

This adds a frozen map representation that stores each distinct value once and maps sorted keys to compact value indices. Scope inference uses the new representation when freezing its expression types, and cycle normalization rebuilds the table so normalized values are deduplicated again.
