### PR TITLE
[ty] Use peer context for collection literals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -571,13 +571,23 @@ the other operand can provide type context for the literal:
 ```py
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Literal, reveal_type
+from typing import Literal, TypedDict, reveal_type
 
 type Key = Literal["foo", "bar"]
+
+class Payload(TypedDict):
+    required: int
 
 def from_or(values: list[str] | None) -> None:
     for value in reveal_type(values or []):  # revealed: list[str]
         reveal_type(value)  # revealed: str
+
+def from_and(values: list[str]) -> None:
+    reveal_type(values and [])  # revealed: list[str]
+
+def chained_or(first: list[int], second: list[str]) -> None:
+    for value in first or second or []:
+        reveal_type(value)  # revealed: int | str
 
 def from_conditional(values: set[str], allowed: set[str] | None) -> None:
     filtered = reveal_type(
@@ -600,6 +610,11 @@ def widened_non_empty_fallback(values: list[int] | None) -> None:
 
 def incompatible_collection_kind(values: set[str] | None) -> None:
     reveal_type(values or [1])  # revealed: (set[str] & ~AlwaysFalsy) | list[int]
+
+def typed_dict_peer_is_only_a_hint(value: Payload | None, flag: bool) -> None:
+    value or {}
+    {} if flag else value
+    value or {"other": 1}
 
 def stored_literal_is_not_fresh(values: dict[Key, int] | None) -> None:
     fallback = {"foo": 0}

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -604,6 +604,19 @@ def collection_literal_first(values: list[str], flag: bool) -> None:
 def non_empty_dict_fallback(values: dict[Key, int] | None) -> None:
     reveal_type(values or {"foo": 0})  # revealed: dict[Literal["foo", "bar"], int]
 
+def non_empty_set_fallback(values: set[Key] | None) -> None:
+    reveal_type(values or {"foo"})  # revealed: set[Literal["foo", "bar"]]
+
+def preserve_generic[T](value: T) -> T:
+    return value
+
+def preserve_partially_specialized[T](value: list[T | int]) -> list[T | int]:
+    return value
+
+def generic_type_context(values: list[int | str] | None) -> None:
+    reveal_type(preserve_generic(values or []))  # revealed: list[int | str]
+    reveal_type(preserve_partially_specialized(values or []))  # revealed: list[Unknown | int]
+
 def widened_non_empty_fallback(values: list[int] | None) -> None:
     result = values or ["x"]
     reveal_type(result)  # revealed: (list[int] & ~AlwaysFalsy) | list[int | str]

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -563,6 +563,71 @@ def _(flag: bool):
     reveal_type(x2)  # revealed: list[int | None]
 ```
 
+## Peer type context for collection literals
+
+When a boolean or conditional expression combines a fresh collection literal with another operand,
+the other operand can provide type context for the literal:
+
+```py
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal, reveal_type
+
+type Key = Literal["foo", "bar"]
+
+def from_or(values: list[str] | None) -> None:
+    for value in reveal_type(values or []):  # revealed: list[str]
+        reveal_type(value)  # revealed: str
+
+def from_conditional(values: set[str], allowed: set[str] | None) -> None:
+    filtered = reveal_type(
+        sorted(value for value in values if value not in allowed)  # revealed: list[str]
+        if allowed is not None
+        else []
+    )
+    for value in filtered:
+        reveal_type(value)  # revealed: str
+
+def collection_literal_first(values: list[str], flag: bool) -> None:
+    reveal_type([] if flag else values)  # revealed: list[str]
+
+def non_empty_dict_fallback(values: dict[Key, int] | None) -> None:
+    reveal_type(values or {"foo": 0})  # revealed: dict[Literal["foo", "bar"], int]
+
+def widened_non_empty_fallback(values: list[int] | None) -> None:
+    result = values or ["x"]
+    reveal_type(result)  # revealed: (list[int] & ~AlwaysFalsy) | list[int | str]
+
+def incompatible_collection_kind(values: set[str] | None) -> None:
+    reveal_type(values or [1])  # revealed: (set[str] & ~AlwaysFalsy) | list[int]
+
+def stored_literal_is_not_fresh(values: dict[Key, int] | None) -> None:
+    fallback = {"foo": 0}
+    reveal_type(fallback)  # revealed: dict[str, int]
+    result = values or fallback
+    reveal_type(result)  # revealed: (dict[Key, int] & ~AlwaysFalsy) | dict[str, int]
+
+@dataclass
+class SortParams[F]:
+    field: F
+    direction: Literal["asc", "desc"] = "desc"
+
+def build_sort_spec[T](
+    sort_params: SortParams[T] | None,
+) -> dict[T, Literal[1, -1]] | None:
+    if not sort_params:
+        return None
+    return {sort_params.field: 1}
+
+type Path = Literal["name", "age", "created"]
+
+def use_sort(value: Mapping[Path, Literal[1, -1]]) -> None: ...
+
+params: SortParams[Path] | None = None
+sort = build_sort_spec(params) or {"name": -1}
+use_sort(sort)
+```
+
 ## Lambda expressions
 
 If a lambda expression is annotated as a `Callable` type, the body of the lambda is inferred with

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -103,6 +103,10 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         self.diagnostics.get_mut().extend(other);
     }
 
+    pub(crate) fn has_diagnostics(&self) -> bool {
+        !self.diagnostics.borrow().is_empty()
+    }
+
     pub(super) fn is_lint_enabled(&self, lint: &'static LintMetadata) -> bool {
         LintDiagnosticGuardBuilder::severity_and_source(self, LintId::of(lint)).is_some()
     }

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -103,7 +103,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         self.diagnostics.get_mut().extend(other);
     }
 
-    pub(crate) fn has_diagnostics(&self) -> bool {
+    pub(super) fn has_diagnostics(&self) -> bool {
         !self.diagnostics.borrow().is_empty()
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7338,8 +7338,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = if_expression;
 
         let test_ty = self.infer_maybe_standalone_expression(test, TypeContext::default());
-        let body_ty = self.infer_expression(body, tcx);
-        let orelse_ty = self.infer_expression(orelse, tcx);
+        let (body_ty, orelse_ty) =
+            if allows_collection_literal_peer_context(tcx) && is_collection_literal(body) {
+                // Infer the peer branch first so the body can use its type as context.
+                let orelse_ty = self.infer_expression(orelse, tcx);
+                let body_tcx = collection_literal_peer_context(body, tcx, Some(orelse_ty));
+                let body_ty = self.infer_expression(body, body_tcx);
+                (body_ty, orelse_ty)
+            } else {
+                let body_ty = self.infer_expression(body, tcx);
+                let orelse_tcx = collection_literal_peer_context(orelse, tcx, Some(body_ty));
+                let orelse_ty = self.infer_expression(orelse, orelse_tcx);
+                (body_ty, orelse_ty)
+            };
 
         match test_ty.try_bool(self.db()).unwrap_or_else(|err| {
             err.report_diagnostic(&self.context, &**test);
@@ -9686,14 +9697,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             op,
             values,
         } = bool_op;
+        let track_peer_types = allows_collection_literal_peer_context(tcx);
         self.infer_chained_boolean_types(
             *op,
+            track_peer_types,
             values.iter().enumerate(),
-            |builder, (index, value)| {
+            |builder, (index, value), peer_ty| {
+                let value_tcx = collection_literal_peer_context(value, tcx, peer_ty);
                 let ty = if index == values.len() - 1 {
-                    builder.infer_expression(value, tcx)
+                    builder.infer_expression(value, value_tcx)
                 } else {
-                    builder.infer_maybe_standalone_expression(value, tcx)
+                    builder.infer_maybe_standalone_expression(value, value_tcx)
                 };
 
                 (ty, value.range())
@@ -9705,24 +9719,37 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// of operations and calling the `infer_ty` for each to infer their types.
     /// The iterator is consumed even if the boolean evaluation can be short-circuited,
     /// in order to ensure the invariant that all expressions are evaluated when inferring types.
+    ///
+    /// `infer_ty` receives the unguarded union of previous operand types that may contribute to the
+    /// result. This can be used as a type context without losing generic specialization information
+    /// to the truthiness guards applied to the final result type.
     fn infer_chained_boolean_types<Iterator, Item, F>(
         &mut self,
         op: ast::BoolOp,
+        track_peer_types: bool,
         operations: Iterator,
         infer_ty: F,
     ) -> Type<'db>
     where
         Iterator: IntoIterator<Item = Item>,
-        F: Fn(&mut Self, Item) -> (Type<'db>, TextRange),
+        F: Fn(&mut Self, Item, Option<Type<'db>>) -> (Type<'db>, TextRange),
     {
         let mut done = false;
+        let mut peer_types: Option<UnionAccumulator<'db>> = None;
         let db = self.db();
 
         let elements = operations
             .into_iter()
             .with_position()
             .map(|(position, item)| {
-                let (ty, range) = infer_ty(self, item);
+                let peer_ty = if done || !track_peer_types {
+                    None
+                } else {
+                    peer_types
+                        .as_mut()
+                        .map(|peer_types| peer_types.get_or_build(db))
+                };
+                let (ty, range) = infer_ty(self, item, peer_ty);
 
                 let is_last = matches!(
                     position,
@@ -9751,13 +9778,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             ty
                         }
 
-                        (Truthiness::Ambiguous, _) => IntersectionBuilder::new(db)
-                            .add_positive(ty)
-                            .add_negative(match op {
-                                ast::BoolOp::And => Type::AlwaysTruthy,
-                                ast::BoolOp::Or => Type::AlwaysFalsy,
-                            })
-                            .build(),
+                        (Truthiness::Ambiguous, _) => {
+                            if track_peer_types {
+                                match &mut peer_types {
+                                    Some(peer_types) => peer_types.add(db, ty),
+                                    None => peer_types = Some(UnionAccumulator::new(ty)),
+                                }
+                            }
+                            IntersectionBuilder::new(db)
+                                .add_positive(ty)
+                                .add_negative(match op {
+                                    ast::BoolOp::And => Type::AlwaysTruthy,
+                                    ast::BoolOp::Or => Type::AlwaysFalsy,
+                                })
+                                .build()
+                        }
                     }
                 }
             });
@@ -9785,11 +9820,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // is shared with the one in `infer_binary_type_comparison`.
         self.infer_chained_boolean_types(
             ast::BoolOp::And,
+            false,
             std::iter::once(&**left)
                 .chain(comparators)
                 .tuple_windows::<(_, _)>()
                 .zip(ops),
-            |builder, ((left, right), op)| {
+            |builder, ((left, right), op), _peer_ty| {
                 let left_ty = builder.expression_type(left);
                 let right_ty = builder.infer_expression(right, TypeContext::default());
 
@@ -10420,6 +10456,47 @@ impl Drop for MultiInferenceGuard<'_, '_, '_> {
 /// An expression representing the function argument at the given index, along with its type
 /// context.
 type ArgExpr<'db, 'ast> = (usize, &'ast ast::Expr, TypeContext<'db>);
+
+fn is_collection_literal(expression: &ast::Expr) -> bool {
+    matches!(
+        expression,
+        ast::Expr::List(_) | ast::Expr::Set(_) | ast::Expr::Dict(_)
+    )
+}
+
+fn collection_literal_peer_context<'db>(
+    expression: &ast::Expr,
+    tcx: TypeContext<'db>,
+    peer_ty: Option<Type<'db>>,
+) -> TypeContext<'db> {
+    if allows_collection_literal_peer_context(tcx)
+        && is_collection_literal(expression)
+        && let Some(peer_ty) = peer_ty
+    {
+        TypeContext::new(Some(peer_ty))
+    } else {
+        tcx
+    }
+}
+
+/// Returns `true` if `tcx` cannot provide useful type context for a collection literal.
+///
+/// During generic call argument inference, type variables that cannot yet be specialized are
+/// replaced by `UnspecializedTypeVar`. This marker intentionally carries neither type-variable
+/// identity nor a concrete expected type, and collection literal inference ignores it rather than
+/// using it as a constraint.
+///
+/// A bare generic parameter, such as the parameter to `reveal_type`, therefore provides an exact
+/// `UnspecializedTypeVar` context that should not prevent a peer expression from providing context
+/// instead.
+///
+/// This deliberately matches only the bare marker: a partially specialized context such as
+/// `list[UnspecializedTypeVar | int]` still carries useful collection structure and concrete type
+/// information.
+fn allows_collection_literal_peer_context(tcx: TypeContext<'_>) -> bool {
+    tcx.annotation
+        .is_none_or(|annotation| annotation == Type::Dynamic(DynamicType::UnspecializedTypeVar))
+}
 
 /// An iterator over arguments to a functional call.
 #[derive(Clone)]

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5695,6 +5695,52 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    fn infer_expression_with_collection_literal_peer_context(
+        &mut self,
+        expression: &ast::Expr,
+        tcx: TypeContext<'db>,
+        peer_ty: Option<Type<'db>>,
+    ) -> Type<'db> {
+        self.infer_with_collection_literal_peer_context(expression, tcx, peer_ty, |builder, tcx| {
+            builder.infer_expression(expression, tcx)
+        })
+    }
+
+    fn infer_maybe_standalone_expression_with_collection_literal_peer_context(
+        &mut self,
+        expression: &ast::Expr,
+        tcx: TypeContext<'db>,
+        peer_ty: Option<Type<'db>>,
+    ) -> Type<'db> {
+        self.infer_with_collection_literal_peer_context(expression, tcx, peer_ty, |builder, tcx| {
+            builder.infer_maybe_standalone_expression(expression, tcx)
+        })
+    }
+
+    fn infer_with_collection_literal_peer_context(
+        &mut self,
+        expression: &ast::Expr,
+        tcx: TypeContext<'db>,
+        peer_ty: Option<Type<'db>>,
+        mut infer_expression: impl FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
+    ) -> Type<'db> {
+        let Some(peer_tcx) = collection_literal_peer_context(expression, tcx, peer_ty) else {
+            return infer_expression(self, tcx);
+        };
+
+        let mut speculative_builder = self.speculate();
+        let ty = infer_expression(&mut speculative_builder, peer_tcx);
+
+        // Peer context is only an inference hint. If it introduces diagnostics, discard it and
+        // infer normally so that only diagnostics intrinsic to the expression are reported.
+        if speculative_builder.context.has_diagnostics() {
+            infer_expression(self, tcx)
+        } else {
+            self.extend(speculative_builder);
+            ty
+        }
+    }
+
     #[track_caller]
     fn infer_standalone_expression(
         &mut self,
@@ -7342,13 +7388,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if allows_collection_literal_peer_context(tcx) && is_collection_literal(body) {
                 // Infer the peer branch first so the body can use its type as context.
                 let orelse_ty = self.infer_expression(orelse, tcx);
-                let body_tcx = collection_literal_peer_context(body, tcx, Some(orelse_ty));
-                let body_ty = self.infer_expression(body, body_tcx);
+                let body_ty = self.infer_expression_with_collection_literal_peer_context(
+                    body,
+                    tcx,
+                    Some(orelse_ty),
+                );
                 (body_ty, orelse_ty)
             } else {
                 let body_ty = self.infer_expression(body, tcx);
-                let orelse_tcx = collection_literal_peer_context(orelse, tcx, Some(body_ty));
-                let orelse_ty = self.infer_expression(orelse, orelse_tcx);
+                let orelse_ty = self.infer_expression_with_collection_literal_peer_context(
+                    orelse,
+                    tcx,
+                    Some(body_ty),
+                );
                 (body_ty, orelse_ty)
             };
 
@@ -9697,17 +9749,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             op,
             values,
         } = bool_op;
-        let track_peer_types = allows_collection_literal_peer_context(tcx);
+        // The first operand has no peers. If no later operand is a collection literal,
+        // accumulating prior types cannot affect inference.
+        let track_peer_types = allows_collection_literal_peer_context(tcx)
+            && values.iter().skip(1).any(is_collection_literal);
         self.infer_chained_boolean_types(
             *op,
             track_peer_types,
             values.iter().enumerate(),
+            |(_, value)| is_collection_literal(value),
             |builder, (index, value), peer_ty| {
-                let value_tcx = collection_literal_peer_context(value, tcx, peer_ty);
                 let ty = if index == values.len() - 1 {
-                    builder.infer_expression(value, value_tcx)
+                    builder
+                        .infer_expression_with_collection_literal_peer_context(value, tcx, peer_ty)
                 } else {
-                    builder.infer_maybe_standalone_expression(value, value_tcx)
+                    builder.infer_maybe_standalone_expression_with_collection_literal_peer_context(
+                        value, tcx, peer_ty,
+                    )
                 };
 
                 (ty, value.range())
@@ -9722,17 +9780,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ///
     /// `infer_ty` receives the unguarded union of previous operand types that may contribute to the
     /// result. This can be used as a type context without losing generic specialization information
-    /// to the truthiness guards applied to the final result type.
-    fn infer_chained_boolean_types<Iterator, Item, F>(
+    /// to the truthiness guards applied to the final result type. `needs_peer_type` determines
+    /// whether that union is materialized for each operand.
+    fn infer_chained_boolean_types<Iterator, Item, NeedsPeerType, InferType>(
         &mut self,
         op: ast::BoolOp,
         track_peer_types: bool,
         operations: Iterator,
-        infer_ty: F,
+        needs_peer_type: NeedsPeerType,
+        infer_ty: InferType,
     ) -> Type<'db>
     where
         Iterator: IntoIterator<Item = Item>,
-        F: Fn(&mut Self, Item, Option<Type<'db>>) -> (Type<'db>, TextRange),
+        NeedsPeerType: Fn(&Item) -> bool,
+        InferType: Fn(&mut Self, Item, Option<Type<'db>>) -> (Type<'db>, TextRange),
     {
         let mut done = false;
         let mut peer_types: Option<UnionAccumulator<'db>> = None;
@@ -9742,7 +9803,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .into_iter()
             .with_position()
             .map(|(position, item)| {
-                let peer_ty = if done || !track_peer_types {
+                let peer_ty = if done || !track_peer_types || !needs_peer_type(&item) {
                     None
                 } else {
                     peer_types
@@ -9825,6 +9886,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .chain(comparators)
                 .tuple_windows::<(_, _)>()
                 .zip(ops),
+            |_| false,
             |builder, ((left, right), op), _peer_ty| {
                 let left_ty = builder.expression_type(left);
                 let right_ty = builder.infer_expression(right, TypeContext::default());
@@ -10345,7 +10407,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expression_cache: _,
             typevar_binding_context: _,
             deferred_state: _,
-            called_functions: _,
+            called_functions,
             index: _,
             region: _,
             return_types_and_ranges: _,
@@ -10372,6 +10434,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.expected_types.extend(expected_types.iter());
         self.type_expression_flags
             .extend(type_expression_flags.iter());
+        self.called_functions.extend(called_functions);
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
             self.bindings
@@ -10468,14 +10531,14 @@ fn collection_literal_peer_context<'db>(
     expression: &ast::Expr,
     tcx: TypeContext<'db>,
     peer_ty: Option<Type<'db>>,
-) -> TypeContext<'db> {
+) -> Option<TypeContext<'db>> {
     if allows_collection_literal_peer_context(tcx)
         && is_collection_literal(expression)
         && let Some(peer_ty) = peer_ty
     {
-        TypeContext::new(Some(peer_ty))
+        Some(TypeContext::new(Some(peer_ty)))
     } else {
-        tcx
+        None
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5724,7 +5724,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         peer_ty: Option<Type<'db>>,
         mut infer_expression: impl FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
     ) -> Type<'db> {
-        let Some(peer_tcx) = collection_literal_peer_context(expression, tcx, peer_ty) else {
+        let peer_tcx = if allows_collection_literal_peer_context(tcx)
+            && is_collection_literal(expression)
+            && let Some(peer_ty) = peer_ty
+        {
+            TypeContext::new(Some(peer_ty))
+        } else {
             return infer_expression(self, tcx);
         };
 
@@ -10525,21 +10530,6 @@ fn is_collection_literal(expression: &ast::Expr) -> bool {
         expression,
         ast::Expr::List(_) | ast::Expr::Set(_) | ast::Expr::Dict(_)
     )
-}
-
-fn collection_literal_peer_context<'db>(
-    expression: &ast::Expr,
-    tcx: TypeContext<'db>,
-    peer_ty: Option<Type<'db>>,
-) -> Option<TypeContext<'db>> {
-    if allows_collection_literal_peer_context(tcx)
-        && is_collection_literal(expression)
-        && let Some(peer_ty) = peer_ty
-    {
-        Some(TypeContext::new(Some(peer_ty)))
-    } else {
-        None
-    }
 }
 
 /// Returns `true` if `tcx` cannot provide useful type context for a collection literal.


### PR DESCRIPTION
## Summary

Use the type of peer operands as context when inferring fresh list, set, and dict literals in boolean and conditional expressions. This prevents empty literals from introducing `Unknown` and preserves literal key types in fallback expressions such as `values or []` and `build_sort_spec(params) or {"name": -1}`.

Peer context is applied speculatively and discarded if it introduces diagnostics, so it remains an inference hint rather than a new constraint. The implementation also preserves generic specialization by accumulating unguarded peer types before truthiness refinement, while retaining existing structured generic context when it is already useful.

Fixes https://github.com/astral-sh/ty/issues/3574.
Fixes https://github.com/astral-sh/ty/issues/3693.

## Test Plan

Added/updated mdtests.

Ecosystem report is all good news. The new Apprise diagnostic is just a result of us not narrowing the place `result["fullpath"]` to truthy based on a check of `result.get("fullpath")`. This is orthogonal, just exposed by our better inference for `result` in the first place.
