### PR TITLE
[ty] Reference child inference types from scope results

### DIFF
--- a/crates/ty_python_core/src/frozen.rs
+++ b/crates/ty_python_core/src/frozen.rs
@@ -21,6 +21,11 @@ impl<K, V> FrozenMap<K, V> {
     pub fn values(&self) -> impl DoubleEndedIterator<Item = &V> + ExactSizeIterator {
         self.0.iter().map(|(_, value)| value)
     }
+
+    /// Returns the entry at `index` in key order.
+    pub fn get_index(&self, index: usize) -> Option<&(K, V)> {
+        self.0.get(index)
+    }
 }
 
 impl<K: Ord, V> FromIterator<(K, V)> for FrozenMap<K, V> {

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -675,7 +675,7 @@ impl HasType for ast::ExprRef<'_> {
         let file_scope = index.try_expression_scope_id(&model.expr_ref_in_ast(*self))?;
         let scope = file_scope.to_scope_id(model.db, model.file);
 
-        infer_complete_scope_types(model.db, scope).try_expression_type(*self)
+        infer_complete_scope_types(model.db, scope).try_expression_type(model.db, *self)
     }
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -244,7 +244,7 @@ fn definition_expression_type<'db>(
         }
     } else {
         // expression is in a type-params sub-scope
-        infer_complete_scope_types(db, scope).expression_type(expression)
+        infer_complete_scope_types(db, scope).expression_type(db, expression)
     }
 }
 
@@ -271,7 +271,7 @@ fn definition_expression_annotation<'db>(
     } else {
         let inference = infer_complete_scope_types(db, scope);
         TypeAndQualifiers::new(
-            inference.expression_type(expression),
+            inference.expression_type(db, expression),
             TypeOrigin::Declared,
             inference.qualifiers(expression),
         )

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -750,10 +750,428 @@ impl<'db> InferenceRegion<'db> {
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct ScopeInference<'db> {
     /// The types of every expression in this region.
-    expressions: FrozenMap<ExpressionNodeKey, Type<'db>>,
+    expressions: ScopeExpressionTypes<'db>,
 
     /// The extra data that is only present for few inference regions.
     extra: Option<Box<ScopeInferenceExtra<'db>>>,
+}
+
+// A segmented scope entry uses one bit for local types, three for the source kind, five for the
+// source-entry width, and the remaining 23 for the packed source and source-entry indices.
+const LOCAL_SCOPE_EXPRESSION: u32 = 1 << 31;
+const SCOPE_EXPRESSION_SOURCE_KIND_SHIFT: u32 = 28;
+const SCOPE_EXPRESSION_SOURCE_KIND_MASK: u32 = 0b111 << SCOPE_EXPRESSION_SOURCE_KIND_SHIFT;
+const SCOPE_EXPRESSION_SOURCE_ENTRY_BITS_SHIFT: u32 = 23;
+const SCOPE_EXPRESSION_SOURCE_ENTRY_BITS_MASK: u32 =
+    0b1_1111 << SCOPE_EXPRESSION_SOURCE_ENTRY_BITS_SHIFT;
+const SCOPE_EXPRESSION_SOURCE_LOCATION_MASK: u32 =
+    (1 << SCOPE_EXPRESSION_SOURCE_ENTRY_BITS_SHIFT) - 1;
+
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+enum ScopeExpressionTypes<'db> {
+    Flat(FrozenMap<ExpressionNodeKey, Type<'db>>),
+    Segmented(Box<SegmentedScopeExpressionTypes<'db>>),
+}
+
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+struct SegmentedScopeExpressionTypes<'db> {
+    // Entries are sorted by key. Source-entry indices address the corresponding child inference
+    // result in the same key order, and each raw Salsa ID must be reconstructed using its packed
+    // concrete kind. Resolving a source intentionally invokes its query so Salsa records the
+    // dependency of the caller that reads the type.
+    entries: Box<[ScopeExpressionEntry]>,
+    local_types: Box<[Type<'db>]>,
+    sources: Box<[ScopeExpressionSourceId]>,
+}
+
+impl<'db> SegmentedScopeExpressionTypes<'db> {
+    fn source_location(entry: ScopeExpressionEntry) -> (usize, usize, ScopeExpressionSourceKind) {
+        let source_entry_bits = ((entry.location & SCOPE_EXPRESSION_SOURCE_ENTRY_BITS_MASK)
+            >> SCOPE_EXPRESSION_SOURCE_ENTRY_BITS_SHIFT) as u8;
+        let entry_mask = if source_entry_bits == 0 {
+            0
+        } else {
+            (1 << source_entry_bits) - 1
+        };
+        let source_location = entry.location & SCOPE_EXPRESSION_SOURCE_LOCATION_MASK;
+        let source = source_location >> source_entry_bits;
+        let source_entry = source_location & entry_mask;
+        let source_kind = ScopeExpressionSourceKind::from_location(entry.location)
+            .expect("segmented scope entry has a valid source kind");
+        (source as usize, source_entry as usize, source_kind)
+    }
+
+    fn source_entry_type(
+        db: &'db dyn Db,
+        entry: ScopeExpressionEntry,
+        source_entry: usize,
+        source: ScopeExpressionSourceInference<'db>,
+    ) -> Type<'db> {
+        let (source_key, ty) = source
+            .get_index(db, source_entry)
+            .expect("segmented scope entry references a valid source entry");
+        assert_eq!(
+            source_key, entry.key,
+            "segmented scope entry references the matching source expression"
+        );
+        ty
+    }
+
+    fn entry_type(&self, db: &'db dyn Db, entry: ScopeExpressionEntry) -> Type<'db> {
+        if entry.location & LOCAL_SCOPE_EXPRESSION != 0 {
+            self.local_types
+                .get((entry.location & !LOCAL_SCOPE_EXPRESSION) as usize)
+                .copied()
+                .expect("segmented scope entry references a valid local type")
+        } else {
+            let (source, source_entry, source_kind) = Self::source_location(entry);
+            let source = self
+                .sources
+                .get(source)
+                .expect("segmented scope entry references a valid source")
+                .resolve(db, source_kind);
+            Self::source_entry_type(db, entry, source_entry, source)
+        }
+    }
+
+    fn entry_type_cached(
+        &self,
+        db: &'db dyn Db,
+        entry: ScopeExpressionEntry,
+        sources: &mut [Option<ScopeExpressionSourceInference<'db>>],
+    ) -> Type<'db> {
+        if entry.location & LOCAL_SCOPE_EXPRESSION != 0 {
+            self.local_types
+                .get((entry.location & !LOCAL_SCOPE_EXPRESSION) as usize)
+                .copied()
+                .expect("segmented scope entry references a valid local type")
+        } else {
+            let (source, source_entry, source_kind) = Self::source_location(entry);
+            let cached = sources
+                .get_mut(source)
+                .expect("segmented scope entry references a valid source");
+            let source = if let Some(source) = *cached {
+                source
+            } else {
+                let source = self
+                    .sources
+                    .get(source)
+                    .expect("segmented scope entry references a valid source")
+                    .resolve(db, source_kind);
+                *cached = Some(source);
+                source
+            };
+            Self::source_entry_type(db, entry, source_entry, source)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+struct ScopeExpressionEntry {
+    key: ExpressionNodeKey,
+    location: u32,
+}
+
+enum ScopeExpressionSource<'db> {
+    Definition(Definition<'db>),
+    Expression(InferExpression<'db>),
+    Statement(StatementInner<'db>),
+    Scope(InferScope<'db>),
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[repr(u8)]
+enum ScopeExpressionSourceKind {
+    Definition,
+    Expression,
+    ExpressionWithContext,
+    Statement,
+    Scope,
+    ScopeWithContext,
+}
+
+impl ScopeExpressionSourceKind {
+    fn from_location(location: u32) -> Option<Self> {
+        match (location & SCOPE_EXPRESSION_SOURCE_KIND_MASK) >> SCOPE_EXPRESSION_SOURCE_KIND_SHIFT {
+            0 => Some(Self::Definition),
+            1 => Some(Self::Expression),
+            2 => Some(Self::ExpressionWithContext),
+            3 => Some(Self::Statement),
+            4 => Some(Self::Scope),
+            5 => Some(Self::ScopeWithContext),
+            _ => None,
+        }
+    }
+
+    fn location_bits(self) -> u32 {
+        (self as u32) << SCOPE_EXPRESSION_SOURCE_KIND_SHIFT
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, salsa::Update)]
+struct ScopeExpressionSourceId(salsa::Id);
+
+impl get_size2::GetSize for ScopeExpressionSourceId {}
+
+impl ScopeExpressionSourceId {
+    // The kind is stored separately because Salsa IDs are only meaningful together with their
+    // concrete tracked type. Reconstructing a supertype from an untagged ID can select the wrong
+    // query when two variants use the same underlying ID representation.
+    fn new(source: &ScopeExpressionSource<'_>) -> (Self, ScopeExpressionSourceKind) {
+        let (id, kind) = match source {
+            ScopeExpressionSource::Definition(definition) => {
+                (definition.as_id(), ScopeExpressionSourceKind::Definition)
+            }
+            ScopeExpressionSource::Expression(InferExpression::Bare(expression)) => {
+                (expression.as_id(), ScopeExpressionSourceKind::Expression)
+            }
+            ScopeExpressionSource::Expression(InferExpression::WithContext(expression)) => (
+                expression.as_id(),
+                ScopeExpressionSourceKind::ExpressionWithContext,
+            ),
+            ScopeExpressionSource::Statement(statement) => {
+                (statement.as_id(), ScopeExpressionSourceKind::Statement)
+            }
+            ScopeExpressionSource::Scope(InferScope::Bare(scope)) => {
+                (scope.as_id(), ScopeExpressionSourceKind::Scope)
+            }
+            ScopeExpressionSource::Scope(InferScope::WithContext(scope)) => {
+                (scope.as_id(), ScopeExpressionSourceKind::ScopeWithContext)
+            }
+        };
+        (Self(id), kind)
+    }
+
+    fn resolve<'db>(
+        self,
+        db: &'db dyn Db,
+        kind: ScopeExpressionSourceKind,
+    ) -> ScopeExpressionSourceInference<'db> {
+        match kind {
+            ScopeExpressionSourceKind::Definition => {
+                ScopeExpressionSourceInference::Definition(infer_definition_types(
+                    db,
+                    <Definition<'db> as salsa::plumbing::FromId>::from_id(self.0),
+                ))
+            }
+            ScopeExpressionSourceKind::Expression => {
+                ScopeExpressionSourceInference::Expression(infer_expression_types_impl(
+                    db,
+                    InferExpression::Bare(<Expression<'db> as salsa::plumbing::FromId>::from_id(
+                        self.0,
+                    )),
+                ))
+            }
+            ScopeExpressionSourceKind::ExpressionWithContext => {
+                ScopeExpressionSourceInference::Expression(infer_expression_types_impl(
+                    db,
+                    InferExpression::WithContext(
+                        <ExpressionWithContext<'db> as salsa::plumbing::FromId>::from_id(self.0),
+                    ),
+                ))
+            }
+            ScopeExpressionSourceKind::Statement => {
+                ScopeExpressionSourceInference::Statement(infer_statement_types_impl(
+                    db,
+                    <StatementInner<'db> as salsa::plumbing::FromId>::from_id(self.0),
+                ))
+            }
+            ScopeExpressionSourceKind::Scope => {
+                ScopeExpressionSourceInference::Scope(infer_scope_types_impl(
+                    db,
+                    InferScope::Bare(<ScopeId<'db> as salsa::plumbing::FromId>::from_id(self.0)),
+                ))
+            }
+            ScopeExpressionSourceKind::ScopeWithContext => {
+                ScopeExpressionSourceInference::Scope(infer_scope_types_impl(
+                    db,
+                    InferScope::WithContext(
+                        <ScopeWithContext<'db> as salsa::plumbing::FromId>::from_id(self.0),
+                    ),
+                ))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ScopeExpressionSourceInference<'db> {
+    Definition(&'db DefinitionInference<'db>),
+    Expression(&'db ExpressionInference<'db>),
+    Statement(&'db StatementInferenceInner<'db>),
+    Scope(&'db ScopeInference<'db>),
+}
+
+impl<'db> ScopeExpressionSourceInference<'db> {
+    fn get_index(self, db: &'db dyn Db, index: usize) -> Option<(ExpressionNodeKey, Type<'db>)> {
+        match self {
+            Self::Definition(inference) => inference.expressions.get_index(index).copied(),
+            Self::Expression(inference) => inference.expressions.get_index(index).copied(),
+            Self::Statement(inference) => inference.expressions.get_index(index).copied(),
+            Self::Scope(inference) => inference.expressions.get_index(db, index),
+        }
+    }
+}
+
+impl<'db> ScopeExpressionTypes<'db> {
+    fn flat(expressions: FrozenMap<ExpressionNodeKey, Type<'db>>) -> Self {
+        Self::Flat(expressions)
+    }
+
+    fn try_expression_type(&self, db: &'db dyn Db, key: ExpressionNodeKey) -> Option<Type<'db>> {
+        match self {
+            Self::Flat(expressions) => expressions.get(&key).copied(),
+            Self::Segmented(expressions) => {
+                let entry = expressions
+                    .entries
+                    .binary_search_by_key(&key, |entry| entry.key)
+                    .ok()
+                    .map(|index| expressions.entries[index])?;
+                Some(expressions.entry_type(db, entry))
+            }
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Flat(expressions) => expressions.iter().len(),
+            Self::Segmented(expressions) => expressions.entries.len(),
+        }
+    }
+
+    fn get_index(&self, db: &'db dyn Db, index: usize) -> Option<(ExpressionNodeKey, Type<'db>)> {
+        match self {
+            Self::Flat(expressions) => expressions.get_index(index).copied(),
+            Self::Segmented(expressions) => {
+                let entry = *expressions.entries.get(index)?;
+                Some((entry.key, expressions.entry_type(db, entry)))
+            }
+        }
+    }
+
+    fn for_each(
+        &self,
+        db: &'db dyn Db,
+        mut visit: impl FnMut(usize, ExpressionNodeKey, Type<'db>),
+    ) {
+        match self {
+            Self::Flat(expressions) => {
+                for (index, &(key, ty)) in expressions.iter().enumerate() {
+                    visit(index, key, ty);
+                }
+            }
+            Self::Segmented(expressions) => {
+                let mut sources = vec![None; expressions.sources.len()];
+                for (index, &entry) in expressions.entries.iter().enumerate() {
+                    let ty = expressions.entry_type_cached(db, entry, &mut sources);
+                    visit(index, entry.key, ty);
+                }
+            }
+        }
+    }
+
+    fn materialize(&self, db: &'db dyn Db) -> FrozenMap<ExpressionNodeKey, Type<'db>> {
+        let mut entries = Vec::with_capacity(self.len());
+        self.for_each(db, |_, key, ty| entries.push((key, ty)));
+        entries.into_iter().collect()
+    }
+
+    fn from_scope_builder(
+        expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
+        origins: &FxHashMap<ExpressionNodeKey, (u32, u32)>,
+        sources: Vec<ScopeExpressionSource<'db>>,
+    ) -> Self {
+        let flat_bytes = expressions.len() * std::mem::size_of::<(ExpressionNodeKey, Type<'db>)>();
+        let minimum_segmented_bytes = expressions.len()
+            * std::mem::size_of::<ScopeExpressionEntry>()
+            + expressions.len().saturating_sub(origins.len()) * std::mem::size_of::<Type<'db>>()
+            + std::mem::size_of::<SegmentedScopeExpressionTypes<'db>>();
+        if minimum_segmented_bytes >= flat_bytes {
+            return Self::flat(FrozenMap::from(expressions));
+        }
+
+        debug_assert!(
+            origins
+                .keys()
+                .all(|expression| expressions.contains_key(expression)),
+            "scope expression origins only contain retained expressions"
+        );
+        let local_count = expressions
+            .len()
+            .checked_sub(origins.len())
+            .expect("scope expression origins only contain retained expressions");
+        let mut used_sources = vec![false; sources.len()];
+        let mut max_source_entry = 0;
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "source use and maximum entry are independent of iteration order"
+        )]
+        for &(source, source_entry) in origins.values() {
+            *used_sources
+                .get_mut(source as usize)
+                .expect("scope expression origin references a known source") = true;
+            max_source_entry = max_source_entry.max(source_entry);
+        }
+
+        let retained_source_count = used_sources.iter().filter(|&&used| used).count();
+        let source_entry_bits = u8::try_from(u32::BITS - max_source_entry.leading_zeros())
+            .expect("u32 bit width fits u8");
+        let source_bits = retained_source_count
+            .checked_sub(1)
+            .and_then(|max_source| u32::try_from(max_source).ok())
+            .map_or(0, |max_source| u32::BITS - max_source.leading_zeros());
+        let segmented_bytes = expressions.len() * std::mem::size_of::<ScopeExpressionEntry>()
+            + local_count * std::mem::size_of::<Type<'db>>()
+            + retained_source_count * std::mem::size_of::<ScopeExpressionSourceId>()
+            + std::mem::size_of::<SegmentedScopeExpressionTypes<'db>>();
+
+        if local_count > LOCAL_SCOPE_EXPRESSION as usize
+            || u32::from(source_entry_bits) + source_bits > SCOPE_EXPRESSION_SOURCE_ENTRY_BITS_SHIFT
+            || segmented_bytes >= flat_bytes
+        {
+            return Self::flat(FrozenMap::from(expressions));
+        }
+
+        let mut source_remap = vec![None; sources.len()];
+        let mut retained_sources = Vec::with_capacity(retained_source_count);
+        for (old_source, (source, used)) in sources.into_iter().zip(used_sources).enumerate() {
+            if used {
+                let new_source = u32::try_from(retained_sources.len())
+                    .expect("scope expression source count fits u32");
+                let (source, kind) = ScopeExpressionSourceId::new(&source);
+                source_remap[old_source] = Some((new_source, kind));
+                retained_sources.push(source);
+            }
+        }
+
+        let mut entries = expressions.into_iter().collect::<Vec<_>>();
+        entries.sort_unstable_by_key(|(key, _)| *key);
+        let mut segmented_entries = Vec::with_capacity(entries.len());
+        let mut local_types = Vec::with_capacity(local_count);
+        for (key, ty) in entries {
+            let location = if let Some(&(source, source_entry)) = origins.get(&key) {
+                let (source, kind) =
+                    source_remap[source as usize].expect("used source is retained");
+                (source << source_entry_bits)
+                    | source_entry
+                    | kind.location_bits()
+                    | (u32::from(source_entry_bits) << SCOPE_EXPRESSION_SOURCE_ENTRY_BITS_SHIFT)
+            } else {
+                let local =
+                    u32::try_from(local_types.len()).expect("scope expression count fits u32");
+                debug_assert!(local < LOCAL_SCOPE_EXPRESSION);
+                local_types.push(ty);
+                LOCAL_SCOPE_EXPRESSION | local
+            };
+            segmented_entries.push(ScopeExpressionEntry { key, location });
+        }
+
+        Self::Segmented(Box::new(SegmentedScopeExpressionTypes {
+            entries: segmented_entries.into_boxed_slice(),
+            local_types: local_types.into_boxed_slice(),
+            sources: retained_sources.into_boxed_slice(),
+        }))
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::Update, Default)]
@@ -787,7 +1205,7 @@ impl<'db> ScopeInference<'db> {
                 cycle_recovery: Some(cycle_recovery),
                 ..ScopeInferenceExtra::default()
             })),
-            expressions: FrozenMap::default(),
+            expressions: ScopeExpressionTypes::flat(FrozenMap::default()),
         }
     }
 
@@ -797,10 +1215,20 @@ impl<'db> ScopeInference<'db> {
         previous_inference: &ScopeInference<'db>,
         cycle: &salsa::Cycle,
     ) -> ScopeInference<'db> {
-        for (expr, ty) in &mut self.expressions {
-            let previous_ty = previous_inference.expression_type(*expr);
+        if let ScopeExpressionTypes::Flat(expressions) = &mut self.expressions {
+            for (expr, ty) in expressions {
+                let previous_ty = previous_inference.expression_type(db, *expr);
+                *ty = ty.cycle_normalized(db, previous_ty, cycle);
+            }
+            return self;
+        }
+
+        let mut expressions = self.expressions.materialize(db);
+        for (expr, ty) in &mut expressions {
+            let previous_ty = previous_inference.expression_type(db, *expr);
             *ty = ty.cycle_normalized(db, previous_ty, cycle);
         }
+        self.expressions = ScopeExpressionTypes::flat(expressions);
 
         self
     }
@@ -809,18 +1237,22 @@ impl<'db> ScopeInference<'db> {
         self.extra.as_deref().map(|extra| &extra.diagnostics)
     }
 
-    pub(crate) fn expression_type(&self, expression: impl Into<ExpressionNodeKey>) -> Type<'db> {
-        self.try_expression_type(expression)
+    pub(crate) fn expression_type(
+        &self,
+        db: &'db dyn Db,
+        expression: impl Into<ExpressionNodeKey>,
+    ) -> Type<'db> {
+        self.try_expression_type(db, expression)
             .unwrap_or_else(Type::unknown)
     }
 
     pub(crate) fn try_expression_type(
         &self,
+        db: &'db dyn Db,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
         self.expressions
-            .get(&expression.into())
-            .copied()
+            .try_expression_type(db, expression.into())
             .or_else(|| self.fallback_type())
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -23,9 +23,10 @@ use ty_python_core::statement::StatementInner;
 
 use super::{
     DefinitionInference, DefinitionInferenceExtra, DefinitionTypes, ExpressionInference,
-    ExpressionInferenceExtra, FrozenMap, FrozenSet, FunctionDecoratorInference, InferenceRegion,
-    ScopeInference, ScopeInferenceExtra, infer_deferred_types, infer_definition_types,
-    infer_expression_types, infer_same_file_expression_type, infer_unpack_types,
+    ExpressionInferenceExtra, FrozenMap, FrozenSet, FunctionDecoratorInference, InferExpression,
+    InferScope, InferenceRegion, ScopeExpressionSource, ScopeExpressionTypes, ScopeInference,
+    ScopeInferenceExtra, infer_deferred_types, infer_definition_types, infer_expression_types_impl,
+    infer_same_file_expression_type, infer_scope_types_impl, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -101,7 +102,7 @@ use crate::types::{
     Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers,
     TypeContext, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance,
     TypedDictType, UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
-    infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
+    infer_complete_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
@@ -236,6 +237,11 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// The types of every expression in this region.
     expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
 
+    /// Child-query expression entries merged into a scope, used to retain source references
+    /// instead of copying their types into the finished scope result.
+    scope_expression_sources: Vec<ScopeExpressionSource<'db>>,
+    scope_expression_origins: FxHashMap<ExpressionNodeKey, (u32, u32)>,
+
     /// An expression cache shared across builders during multi-inference.
     expression_cache: Option<Rc<RefCell<ExpressionCache<'db>>>>,
 
@@ -368,6 +374,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             called_functions: FxIndexSet::default(),
             deferred_state: DeferredExpressionState::None,
             expressions: FxHashMap::default(),
+            scope_expression_sources: Vec::new(),
+            scope_expression_origins: FxHashMap::default(),
             expression_cache: None,
             qualifiers: FxHashMap::default(),
             type_expression_flags: FxHashMap::default(),
@@ -421,12 +429,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
-    fn extend_definition(&mut self, inference: &DefinitionInference<'db>) {
+    fn extend_definition(
+        &mut self,
+        source: Option<Definition<'db>>,
+        inference: &DefinitionInference<'db>,
+    ) {
         #[cfg(debug_assertions)]
         assert_eq!(self.scope, inference.scope);
 
-        self.expressions
-            .extend(inference.expressions.iter().copied());
+        if let Some(source) = source {
+            self.extend_expression_source(
+                ScopeExpressionSource::Definition(source),
+                inference.expressions.iter().copied(),
+            );
+        } else {
+            for (key, ty) in inference.expressions.iter().copied() {
+                self.insert_expression_type(key, ty);
+            }
+        }
         self.declarations.extend(inference.declarations());
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
@@ -460,18 +480,30 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
-    fn extend_statement(&mut self, inference: &StatementInference<'db>) {
-        let inference = match inference {
-            StatementInference::Other(inference) => inference,
-            StatementInference::Expression(inference) => return self.extend_expression(inference),
-            StatementInference::Definition(inference) => return self.extend_definition(inference),
+    fn extend_statement(&mut self, statement: Statement<'db>, inference: &StatementInference<'db>) {
+        let (statement, inference) = match (statement, inference) {
+            (Statement::Other(statement), StatementInference::Other(inference)) => {
+                (statement, inference)
+            }
+            (Statement::Expression(expression), StatementInference::Expression(inference)) => {
+                return self.extend_expression(
+                    InferExpression::new(self.db(), expression, TypeContext::default()),
+                    inference,
+                );
+            }
+            (Statement::Definition(definition), StatementInference::Definition(inference)) => {
+                return self.extend_definition(Some(definition), inference);
+            }
+            _ => unreachable!("statement inference kind matches its input"),
         };
 
         #[cfg(debug_assertions)]
         assert_eq!(self.scope, inference.scope);
 
-        self.expressions
-            .extend(inference.expressions.iter().copied());
+        self.extend_expression_source(
+            ScopeExpressionSource::Statement(statement),
+            inference.expressions.iter().copied(),
+        );
         self.declarations.extend(inference.declarations());
 
         if !matches!(self.region, InferenceRegion::Scope(..)) {
@@ -496,16 +528,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
-    fn extend_expression(&mut self, inference: &ExpressionInference<'db>) {
+    fn extend_expression(
+        &mut self,
+        input: InferExpression<'db>,
+        inference: &ExpressionInference<'db>,
+    ) {
         #[cfg(debug_assertions)]
         assert_eq!(self.scope, inference.scope);
 
-        self.extend_expression_unchecked(inference);
+        self.extend_expression_unchecked(input, inference);
     }
 
-    fn extend_expression_unchecked(&mut self, inference: &ExpressionInference<'db>) {
-        self.expressions
-            .extend(inference.expressions.iter().copied());
+    fn extend_expression_unchecked(
+        &mut self,
+        input: InferExpression<'db>,
+        inference: &ExpressionInference<'db>,
+    ) {
+        self.extend_expression_source(
+            ScopeExpressionSource::Expression(input),
+            inference.expressions.iter().copied(),
+        );
 
         if let Some(extra) = &inference.extra {
             self.context.extend(&extra.diagnostics);
@@ -534,9 +576,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
-    fn extend_scope(&mut self, inference: &ScopeInference<'db>) {
-        self.expressions
-            .extend(inference.expressions.iter().copied());
+    fn extend_scope(&mut self, input: InferScope<'db>, inference: &ScopeInference<'db>) {
+        let db = self.db();
+        if matches!(self.region, InferenceRegion::Scope(..)) {
+            let expression_count = inference.expressions.len();
+            if expression_count > 0 {
+                self.expressions.reserve(expression_count);
+                self.scope_expression_origins.reserve(expression_count);
+                let source_id = u32::try_from(self.scope_expression_sources.len())
+                    .expect("scope expression source count fits u32");
+                self.scope_expression_sources
+                    .push(ScopeExpressionSource::Scope(input));
+                inference.expressions.for_each(db, |source_entry, key, ty| {
+                    self.expressions.insert(key, ty);
+                    self.scope_expression_origins.insert(
+                        key,
+                        (
+                            source_id,
+                            u32::try_from(source_entry).expect("source expression count fits u32"),
+                        ),
+                    );
+                });
+            }
+        } else {
+            inference.expressions.for_each(db, |_, key, ty| {
+                self.insert_expression_type(key, ty);
+            });
+        }
 
         if let Some(extra) = &inference.extra {
             self.context.extend(&extra.diagnostics);
@@ -559,6 +625,49 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .or_insert(constraints.clone());
             }
         }
+    }
+
+    fn extend_expression_source(
+        &mut self,
+        source: ScopeExpressionSource<'db>,
+        expressions: impl ExactSizeIterator<Item = (ExpressionNodeKey, Type<'db>)>,
+    ) {
+        if matches!(self.region, InferenceRegion::Scope(..)) {
+            let expression_count = expressions.len();
+            if expression_count == 0 {
+                return;
+            }
+            self.expressions.reserve(expression_count);
+            self.scope_expression_origins.reserve(expression_count);
+            let source_id = u32::try_from(self.scope_expression_sources.len())
+                .expect("scope expression source count fits u32");
+            self.scope_expression_sources.push(source);
+            for (source_entry, (key, ty)) in expressions.enumerate() {
+                self.expressions.insert(key, ty);
+                self.scope_expression_origins.insert(
+                    key,
+                    (
+                        source_id,
+                        u32::try_from(source_entry).expect("source expression count fits u32"),
+                    ),
+                );
+            }
+        } else {
+            for (key, ty) in expressions {
+                self.insert_expression_type(key, ty);
+            }
+        }
+    }
+
+    fn insert_expression_type(
+        &mut self,
+        key: ExpressionNodeKey,
+        ty: Type<'db>,
+    ) -> Option<Type<'db>> {
+        if matches!(self.region, InferenceRegion::Scope(..)) {
+            self.scope_expression_origins.remove(&key);
+        }
+        self.expressions.insert(key, ty)
     }
 
     fn file(&self) -> File {
@@ -754,7 +863,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Get the type of an expression from any scope in the same file.
     ///
     /// If the expression is in the current scope, and we are inferring the entire scope, just look
-    /// up the expression in our own results, otherwise call [`infer_scope_types()`] for the scope
+    /// up the expression in our own results, otherwise call [`super::infer_scope_types()`] for the
+    /// scope
     /// of the expression.
     ///
     /// ## Panics
@@ -770,7 +880,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             InferenceRegion::Scope(scope, _) if scope == expr_scope => {
                 self.expression_type(expression)
             }
-            _ => infer_complete_scope_types(self.db(), expr_scope).expression_type(expression),
+            _ => infer_complete_scope_types(self.db(), expr_scope)
+                .expression_type(self.db(), expression),
         }
     }
 
@@ -855,7 +966,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Infer deferred types for all definitions.
         let deferred_definitions: Vec<_> = std::mem::take(&mut self.deferred).into_iter().collect();
         for definition in &deferred_definitions {
-            self.extend_definition(infer_deferred_types(self.db(), *definition));
+            self.extend_definition(None, infer_deferred_types(self.db(), *definition));
         }
 
         assert!(
@@ -1573,8 +1684,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ));
             }
             // Replace with `Divergent`.
-            self.expressions
-                .insert(type_alias.value.as_ref().into(), expanded);
+            self.insert_expression_type(type_alias.value.as_ref().into(), expanded);
         }
     }
 
@@ -1730,7 +1840,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn infer_definition(&mut self, node: impl Into<DefinitionNodeKey> + std::fmt::Debug + Copy) {
         let definition = self.index.expect_single_definition(node);
         let result = infer_definition_types(self.db(), definition);
-        self.extend_definition(result);
+        self.extend_definition(Some(definition), result);
     }
 
     fn infer_type_alias_definition(
@@ -4392,7 +4502,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             } else {
                 annotated.inner_type()
             };
-            self.expressions.insert((&**target).into(), target_ty);
+            self.insert_expression_type((&**target).into(), target_ty);
         }
     }
 
@@ -4667,7 +4777,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // retained as the alias binding.
                 match inferred_ty {
                     Type::SpecialForm(SpecialFormType::TypingSelf) => {
-                        self.expressions.insert(value.into(), Type::unknown());
+                        self.insert_expression_type(value.into(), Type::unknown());
                         Type::unknown()
                     }
                     Type::KnownInstance(KnownInstanceType::LiteralStringAlias(ty))
@@ -5814,7 +5924,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_standalone_statement_impl(&mut self, standalone_statement: Statement<'db>) {
         let types = infer_statement_types(self.db(), standalone_statement);
-        self.extend_statement(&types);
+        self.extend_statement(standalone_statement, &types);
     }
 
     fn infer_optional_expression(
@@ -5875,8 +5985,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         standalone_expression: Expression<'db>,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        let types = infer_expression_types(self.db(), standalone_expression, tcx);
-        self.extend_expression(types);
+        let input = InferExpression::new(self.db(), standalone_expression, tcx);
+        let types = infer_expression_types_impl(self.db(), input);
+        self.extend_expression(input, types);
 
         // Instead of calling `self.expression_type(expr)` after extending here, we get
         // the result from `types` directly because we might be in cycle recovery where
@@ -6162,7 +6273,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     #[track_caller]
     fn store_expression_type(&mut self, expression: &ast::Expr, ty: Type<'db>) {
-        let previous = self.expressions.insert(expression.into(), ty);
+        let previous = self.insert_expression_type(expression.into(), ty);
         assert_eq!(previous, None);
     }
 
@@ -7281,8 +7392,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         };
         let scope = scope_id.to_scope_id(self.db(), self.file());
-        let inference = infer_scope_types(self.db(), scope, yield_tcx);
-        self.extend_scope(inference);
+        let input = InferScope::new(self.db(), scope, yield_tcx);
+        let inference = infer_scope_types_impl(self.db(), input);
+        self.extend_scope(input, inference);
         let yield_type = self.comprehension_element_type(elt, inference);
 
         if evaluation_mode.is_async() {
@@ -7301,7 +7413,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         element: &ast::Expr,
         inference: &ScopeInference<'db>,
     ) -> Type<'db> {
-        let element_type = inference.expression_type(element);
+        let element_type = inference.expression_type(self.db(), element);
         if element.is_starred_expr() {
             element_type
                 .iterate(self.db())
@@ -7322,7 +7434,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         tcx: TypeContext<'db>,
     ) -> Option<Type<'db>> {
         let mut infer_element_ty =
-            |_builder: &mut Self, (_, elt, _)| inference.expression_type(elt);
+            |builder: &mut Self, (_, elt, _)| inference.expression_type(builder.db(), elt);
 
         self.infer_collection_literal(
             collection_class,
@@ -7354,8 +7466,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         };
         let scope = scope_id.to_scope_id(self.db(), self.file());
-        let inference = infer_scope_types(self.db(), scope, tcx);
-        self.extend_scope(inference);
+        let input = InferScope::new(self.db(), scope, tcx);
+        let inference = infer_scope_types_impl(self.db(), input);
+        self.extend_scope(input, inference);
 
         self.infer_comprehension_specialization(
             KnownClass::List,
@@ -7388,8 +7501,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         };
         let scope = scope_id.to_scope_id(self.db(), self.file());
-        let inference = infer_scope_types(self.db(), scope, tcx);
-        self.extend_scope(inference);
+        let input = InferScope::new(self.db(), scope, tcx);
+        let inference = infer_scope_types_impl(self.db(), input);
+        self.extend_scope(input, inference);
 
         self.infer_comprehension_specialization(
             KnownClass::Set,
@@ -7423,8 +7537,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         };
         let scope = scope_id.to_scope_id(self.db(), self.file());
-        let inference = infer_scope_types(self.db(), scope, tcx);
-        self.extend_scope(inference);
+        let input = InferScope::new(self.db(), scope, tcx);
+        let inference = infer_scope_types_impl(self.db(), input);
+        self.extend_scope(input, inference);
 
         self.infer_comprehension_specialization(
             KnownClass::Dict,
@@ -7601,7 +7716,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let mut infer_iterable_type = || {
             let expression = self.index.expression(iterable);
-            let result = infer_expression_types(self.db(), expression, TypeContext::default());
+            let input = InferExpression::new(self.db(), expression, TypeContext::default());
+            let result = infer_expression_types_impl(self.db(), input);
 
             // Two things are different if it's the first comprehension:
             // (1) We must lookup the `ScopedExpressionId` of the iterable expression in the outer scope,
@@ -7612,7 +7728,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if comprehension.is_first() && target.is_name_expr() {
                 result.expression_type(iterable)
             } else {
-                self.extend_expression_unchecked(result);
+                self.extend_expression_unchecked(input, result);
                 result.expression_type(iterable)
             }
         };
@@ -7642,7 +7758,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        self.expressions.insert(target.into(), target_type);
+        self.insert_expression_type(target.into(), target_type);
         self.add_binding(target.into(), definition)
             .insert(self, target_type);
     }
@@ -7652,7 +7768,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if named.target.is_name_expr() {
             let definition = self.index.expect_single_definition(named);
             let result = infer_definition_types(self.db(), definition);
-            self.extend_definition(result);
+            self.extend_definition(Some(definition), result);
             result.binding_type(definition)
         } else {
             // For syntactically invalid targets, we still need to run type inference:
@@ -7846,10 +7962,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             TypeContext::new(None)
         };
 
-        let inference = infer_scope_types(self.db(), scope, return_tcx);
-        self.extend_scope(inference);
+        let input = InferScope::new(self.db(), scope, return_tcx);
+        let inference = infer_scope_types_impl(self.db(), input);
+        self.extend_scope(input, inference);
 
-        let return_ty = inference.expression_type(lambda_expression.body.as_ref());
+        let return_ty = inference.expression_type(self.db(), lambda_expression.body.as_ref());
         Type::Callable(CallableType::new(
             self.db(),
             CallableSignature::single(Signature::new(parameters, return_ty)),
@@ -10355,6 +10472,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            scope_expression_sources: _,
+            scope_expression_origins: _,
             typevar_binding_context: _,
             deferred_state: _,
             called_functions: _,
@@ -10436,6 +10555,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            scope_expression_sources: _,
+            scope_expression_origins: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10530,6 +10651,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             bindings,
             called_functions,
             expression_cache: _,
+            scope_expression_sources: _,
+            scope_expression_origins: _,
             declarations: _,
             deferred: _,
             scope: _,
@@ -10584,6 +10707,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            scope_expression_sources: _,
+            scope_expression_origins: _,
             dataclass_field_specifiers: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -10661,6 +10786,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             type_expression_flags,
             mut collection_use_constraints,
             expressions,
+            scope_expression_sources,
+            scope_expression_origins,
             scope,
             cycle_recovery,
             qualifiers,
@@ -10709,7 +10836,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         ScopeInference {
-            expressions: FrozenMap::from(expressions),
+            expressions: ScopeExpressionTypes::from_scope_builder(
+                expressions,
+                &scope_expression_origins,
+                scope_expression_sources,
+            ),
             extra,
         }
     }
@@ -10739,6 +10870,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             context: _,
             collection_use_constraints: _,
             expressions: _,
+            scope_expression_sources: _,
+            scope_expression_origins: _,
             string_annotations: _,
             expected_types: _,
             scope: _,
@@ -10795,6 +10928,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             expression_cache: _,
+            scope_expression_sources: _,
+            scope_expression_origins: _,
             typevar_binding_context: _,
             deferred_state: _,
             called_functions: _,
@@ -10816,7 +10951,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             "speculative `TypeInferenceBuilder` should only be used for expression inference"
         );
 
-        self.expressions.extend(expressions.iter());
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "speculative expression results are independent entries"
+        )]
+        for (key, ty) in expressions {
+            self.insert_expression_type(key, ty);
+        }
         self.context.extend(&diagnostics);
         self.extend_cycle_recovery(cycle_recovery);
         self.string_annotations

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -554,7 +554,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .as_deref()
                         .map(|annotation| {
                             TypeContext::new(Some(
-                                type_params_inference.expression_type(annotation),
+                                type_params_inference.expression_type(db, annotation),
                             ))
                         })
                         .unwrap_or_else(TypeContext::default);

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -243,7 +243,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         self.check_deprecated(alias, ty.inner);
                     }
                 }
-                self.extend_definition(inferred);
+                self.extend_definition(Some(*definition), inferred);
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -294,6 +294,128 @@ fn first_public_binding<'db>(db: &'db TestDb, file: File, name: &str) -> Definit
         .expect("no binding found")
 }
 
+#[salsa::tracked]
+fn tracked_scope_expression_type<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    expression: ExpressionNodeKey,
+) -> Type<'db> {
+    infer_complete_scope_types(db, scope).expression_type(db, expression)
+}
+
+#[test]
+fn segmented_scope_expression_dependency() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_file(
+        "/src/a.py",
+        "x = y = (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)\n",
+    )?;
+
+    let file = system_path_to_file(&db, "/src/a.py").unwrap();
+    let (expression, scope_id, location, sources) = {
+        let module = parsed_module(&db, file).load(&db);
+        let assignment = module.syntax().body[0].as_assign_stmt().unwrap();
+        let tuple = assignment.value.as_tuple_expr().unwrap();
+        let expression = ExpressionNodeKey::from(&tuple.elts[0]);
+        let scope = global_scope(&db, file);
+
+        let inference = infer_complete_scope_types(&db, scope);
+        let ScopeExpressionTypes::Segmented(expressions) = &inference.expressions else {
+            panic!("expected segmented scope expression storage");
+        };
+        let entry = expressions
+            .entries
+            .binary_search_by_key(&expression, |entry| entry.key)
+            .map(|index| expressions.entries[index])
+            .expect("expression is present in scope inference");
+        assert_eq!(
+            entry.location & LOCAL_SCOPE_EXPRESSION,
+            0,
+            "expression should refer to its source inference"
+        );
+        assert_eq!(
+            tracked_scope_expression_type(&db, scope, expression)
+                .display(&db)
+                .to_string(),
+            "Literal[1]"
+        );
+        (
+            expression,
+            scope.as_id(),
+            entry.location,
+            expressions.sources.to_vec(),
+        )
+    };
+
+    db.write_file(
+        "/src/a.py",
+        r#"x = y = ("x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x")
+"#,
+    )?;
+
+    let scope = global_scope(&db, file);
+    assert_eq!(scope.as_id(), scope_id);
+    let inference = infer_complete_scope_types(&db, scope);
+    let ScopeExpressionTypes::Segmented(expressions) = &inference.expressions else {
+        panic!("expected segmented scope expression storage");
+    };
+    let entry = expressions
+        .entries
+        .binary_search_by_key(&expression, |entry| entry.key)
+        .map(|index| expressions.entries[index])
+        .expect("expression is present in scope inference");
+    assert_eq!(entry.location, location);
+    assert_eq!(&*expressions.sources, &*sources);
+    assert_eq!(
+        tracked_scope_expression_type(&db, scope, expression)
+            .display(&db)
+            .to_string(),
+        r#"Literal["x"]"#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn segmented_scope_copies_deferred_expressions_locally() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_file(
+        "/src/a.py",
+        "from __future__ import annotations\n\
+         a = b = (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)\n\
+         def f(x: int) -> str: ...\n",
+    )?;
+
+    let file = system_path_to_file(&db, "/src/a.py").unwrap();
+    let module = parsed_module(&db, file).load(&db);
+    let function = module.syntax().body[2].as_function_def_stmt().unwrap();
+    let annotation = function.returns.as_deref().unwrap();
+    let expression = ExpressionNodeKey::from(annotation);
+    let scope = global_scope(&db, file);
+    let inference = infer_complete_scope_types(&db, scope);
+    let ScopeExpressionTypes::Segmented(expressions) = &inference.expressions else {
+        panic!("expected segmented scope expression storage");
+    };
+    let entry = expressions
+        .entries
+        .binary_search_by_key(&expression, |entry| entry.key)
+        .map(|index| expressions.entries[index])
+        .expect("annotation is present in scope inference");
+    assert_ne!(
+        entry.location & LOCAL_SCOPE_EXPRESSION,
+        0,
+        "deferred expression should retain its type locally"
+    );
+
+    let definition = semantic_index(&db, file).expect_single_definition(function);
+    assert_eq!(
+        inference.expression_type(&db, annotation),
+        infer_deferred_types(&db, definition).expression_type(annotation)
+    );
+
+    Ok(())
+}
+
 #[test]
 fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
     let mut db = setup_db();

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -74,7 +74,7 @@ fn function_signature_expression_type<'db>(
         infer_deferred_types(db, definition).expression_type(expression)
     } else {
         // expression is in the PEP-695 type params sub-scope
-        infer_complete_scope_types(db, scope).expression_type(expression)
+        infer_complete_scope_types(db, scope).expression_type(db, expression)
     }
 }
 


### PR DESCRIPTION
## Summary

Scope inference currently copies every child inference expression type into its own retained result, keeping the same `Type` in both the child query and the completed scope result.

This stores compact references to child-query entries when that representation is smaller than the existing flat map. Reading a referenced type resolves the original query so Salsa records the dependency, while locally produced and deferred expression types remain stored directly. Small scopes continue to use the flat representation.

On a representative large project, this reduced retained memory by about 1.6%. Paired local timings were neutral. The change includes incremental coverage for source-backed types and regression coverage for deferred annotations in segmented scopes.
