### PR TITLE
[ty] Report redefined legacy TypeVars

### DIFF
--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1026,6 +1026,7 @@ impl<'map, 'db> Iterator for BindingWithConstraintsIterator<'map, 'db> {
             .next()
             .map(|live_binding| BindingWithConstraints {
                 binding: self.all_definitions[live_binding.binding()],
+                binding_order: live_binding.binding(),
                 narrowing_constraint: NarrowingEvaluator {
                     constraint: live_binding.narrowing_constraint(),
                     predicates,
@@ -1040,6 +1041,8 @@ impl std::iter::FusedIterator for BindingWithConstraintsIterator<'_, '_> {}
 
 pub struct BindingWithConstraints<'map, 'db> {
     pub binding: DefinitionState<'db>,
+    /// Stable binding order within the containing scope.
+    pub binding_order: ScopedDefinitionId,
     pub narrowing_constraint: NarrowingEvaluator<'map, 'db>,
     pub reachability_constraint: ScopedReachabilityConstraintId,
 }

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typevars.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typevars.md
@@ -49,6 +49,17 @@ from typing import TypeVar
 T = TypeVar("Q")
 ```
 
+## Must not be redefined
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T")
+
+# error: [invalid-legacy-type-variable]
+T = TypeVar("T")
+```
+
 ## No variadic arguments
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -106,13 +106,184 @@ class Outer(Generic[Q]):
 
 > Type variables must not be redefined.
 
+#### Sequential definitions
+
 ```py
 from typing import TypeVar
 
 T = TypeVar("T")
 
-# TODO: error
+# error: [invalid-legacy-type-variable] "Cannot redefine `T` as a type variable"
 T = TypeVar("T")
+
+S = object()
+
+# error: [invalid-legacy-type-variable] "Cannot redefine `S` as a type variable"
+S = TypeVar("S")
+
+DeclaredT: object
+
+# error: [invalid-legacy-type-variable] "Cannot redefine `DeclaredT` as a type variable"
+DeclaredT = TypeVar("DeclaredT")
+```
+
+#### Control flow
+
+A previous definition counts if it is reachable from the beginning of the scope, even if it is in a
+mutually exclusive branch. Statically unreachable definitions do not count.
+
+```py
+from typing import TypeVar
+
+def flag() -> bool:
+    return True
+
+if flag():
+    ConditionalT = TypeVar("ConditionalT")
+
+# error: [invalid-legacy-type-variable]
+ConditionalT = TypeVar("ConditionalT")
+
+if flag():
+    BranchT = TypeVar("BranchT")
+else:
+    # error: [invalid-legacy-type-variable]
+    BranchT = TypeVar("BranchT")
+
+# error: [invalid-legacy-type-variable]
+BranchT = TypeVar("BranchT")
+
+if False:
+    UnreachableT = TypeVar("UnreachableT")
+
+UnreachableT = TypeVar("UnreachableT")
+```
+
+Definitions in version-dependent fallback branches are also mutually exclusive:
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+```py
+import sys
+from typing import TypeVar
+
+class Reader: ...
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    Self = TypeVar("Self", bound=Reader)
+```
+
+#### Star imports
+
+Only names actually exported by a star import count as previous definitions.
+
+`excluded.py`:
+
+```py
+from typing import TypeVar
+
+__all__ = ["X"]
+
+X = 1
+ExcludedT = TypeVar("ExcludedT")
+```
+
+`included.py`:
+
+```py
+from typing import TypeVar
+
+__all__ = ["IncludedT"]
+
+IncludedT = TypeVar("IncludedT")
+```
+
+`main.py`:
+
+```py
+from typing import TypeVar
+
+from excluded import *
+from included import *
+
+ExcludedT = TypeVar("ExcludedT")
+
+# error: [invalid-assignment]
+# error: [invalid-legacy-type-variable]
+IncludedT = TypeVar("IncludedT")
+```
+
+#### Nested scopes
+
+```py
+from typing import TypeVar
+
+ScopedT = TypeVar("ScopedT")
+
+class C:
+    ScopedT = TypeVar("ScopedT")
+
+    # error: [invalid-legacy-type-variable]
+    ScopedT = TypeVar("ScopedT")
+
+GlobalT = TypeVar("GlobalT")
+
+def redefine_global() -> None:
+    global GlobalT
+    # error: [invalid-legacy-type-variable]
+    GlobalT = TypeVar("GlobalT")
+
+def define_global_before_module_binding() -> None:
+    global LaterGlobalT
+    LaterGlobalT = TypeVar("LaterGlobalT")
+
+LaterGlobalT = object()
+
+DeepGlobalT = object()
+
+def middle() -> None:
+    def redefine_deep_global() -> None:
+        global DeepGlobalT
+        # error: [invalid-legacy-type-variable]
+        DeepGlobalT = TypeVar("DeepGlobalT")
+
+def later_middle() -> None:
+    def define_deep_global_before_module_binding() -> None:
+        global LaterDeepGlobalT
+        LaterDeepGlobalT = TypeVar("LaterDeepGlobalT")
+
+LaterDeepGlobalT = object()
+
+def outer() -> None:
+    NonlocalT = TypeVar("NonlocalT")
+
+    def redefine_nonlocal() -> None:
+        nonlocal NonlocalT
+        # error: [invalid-legacy-type-variable]
+        NonlocalT = TypeVar("NonlocalT")
+
+def define_nonlocal_before_binding() -> None:
+    def inner() -> None:
+        nonlocal LaterNonlocalT
+        LaterNonlocalT = TypeVar("LaterNonlocalT")
+
+    LaterNonlocalT = object()
+
+def chained_nonlocal() -> None:
+    ChainedNonlocalT = object()
+
+    def middle() -> None:
+        nonlocal ChainedNonlocalT
+
+        def inner() -> None:
+            nonlocal ChainedNonlocalT
+            # error: [invalid-legacy-type-variable]
+            ChainedNonlocalT = TypeVar("ChainedNonlocalT")
 ```
 
 ### No variadic arguments

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Must_not_be_redefine…_(b1be57970f924722).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/legacy_typevars.md_-_Legacy_typevar_creat…_-_Must_not_be_redefine…_(b1be57970f924722).snap
@@ -1,0 +1,38 @@
+---
+source: crates/mdtest/src/lib.rs
+expression: snapshot
+---
+
+---
+mdtest name: legacy_typevars.md - Legacy typevar creation diagnostics - Must not be redefined
+mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/legacy_typevars.md
+---
+
+# Python source files
+
+## mdtest_snippet.py
+
+```
+1 | from typing import TypeVar
+2 | 
+3 | T = TypeVar("T")
+4 | 
+5 | # error: [invalid-legacy-type-variable]
+6 | T = TypeVar("T")
+```
+
+# Diagnostics
+
+```
+error[invalid-legacy-type-variable]: Cannot redefine `T` as a type variable
+ --> src/mdtest_snippet.py:3:1
+  |
+3 | T = TypeVar("T")
+  | - Previously defined here
+4 |
+5 | # error: [invalid-legacy-type-variable]
+6 | T = TypeVar("T")
+  | ^
+  |
+
+```

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1484,7 +1484,7 @@ fn place_from_bindings_impl<'db>(
         Some(BindingWithConstraints {
             binding,
             reachability_constraint,
-            narrowing_constraint: _,
+            ..
         }) if binding.is_undefined_or(is_non_exported) => Some(*reachability_constraint),
         _ => None,
     };
@@ -1515,6 +1515,7 @@ fn place_from_bindings_impl<'db>(
              binding,
              narrowing_constraint,
              reachability_constraint,
+             ..
          }| {
             let binding = match binding {
                 DefinitionState::Defined(binding)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1207,78 +1207,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let place_table = self.index.place_table(file_scope_id);
         let use_def = self.index.use_def_map(file_scope_id);
 
-        let global_use_def_map = self.index.use_def_map(FileScopeId::global());
         let place_id = binding.place(self.db());
         let place = place_table.place(place_id);
 
-        let (declarations, is_local) = if let Some(symbol) = place.as_symbol() {
-            let symbol_id = place_id.expect_symbol();
-            let skip_non_global_scopes = self.skip_non_global_scopes(file_scope_id, symbol_id);
-
-            if skip_non_global_scopes {
-                match self
-                    .index
-                    .place_table(FileScopeId::global())
-                    .symbol_id(symbol.name())
-                {
-                    Some(id) => (
-                        global_use_def_map.end_of_scope_symbol_declarations(id),
-                        false,
-                    ),
-                    // This variable shows up in `global` declarations but doesn't have an explicit
-                    // binding in the global scope.
-                    None => (use_def.declarations_at_binding(binding), true),
-                }
-            } else if self
-                .index
-                .symbol_is_nonlocal_in_scope(symbol_id, file_scope_id)
-            {
-                // If we run out of ancestor scopes without finding a definition, we'll fall back to
-                // the local scope. This will also be a syntax error in `infer_nonlocal_statement` (no
-                // binding for `nonlocal` found), but ignore that here.
-                let mut declarations = use_def.declarations_at_binding(binding);
-                let mut is_local = true;
-                // Walk up parent scopes looking for the enclosing scope that has definition of this
-                // name. `ancestor_scopes` includes the current scope, so skip that one.
-                for (enclosing_scope_file_id, enclosing_scope) in
-                    self.index.ancestor_scopes(file_scope_id).skip(1)
-                {
-                    // Ignore class scopes and the global scope.
-                    if !enclosing_scope.kind().is_function_like() {
-                        continue;
-                    }
-                    let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-                    let Some(enclosing_symbol_id) = enclosing_place_table.symbol_id(symbol.name())
-                    else {
-                        // This ancestor scope doesn't have a binding. Keep going.
-                        continue;
-                    };
-
-                    let enclosing_symbol = enclosing_place_table.symbol(enclosing_symbol_id);
-                    if enclosing_symbol.is_global() {
-                        // The variable is `global` in this ancestor scope. This breaks the `nonlocal`
-                        // chain, and it's a syntax error in `infer_nonlocal_statement`. Ignore that
-                        // here and just bail out of this loop.
-                        break;
-                    }
-                    if !enclosing_symbol.is_local() {
-                        // The variable is either explicitly `nonlocal` or just a free read in this
-                        // ancestor scope. Keep going.
-                        continue;
-                    }
-                    // We found the closest definition. Note that (as in `infer_place_load`) this does
-                    // *not* need to be a binding. It could be just a declaration, e.g. `x: int`.
-                    declarations = self
-                        .index
-                        .use_def_map(enclosing_scope_file_id)
-                        .end_of_scope_symbol_declarations(enclosing_symbol_id);
-                    is_local = false;
-                    break;
-                }
-                (declarations, is_local)
-            } else {
-                (use_def.declarations_at_binding(binding), true)
-            }
+        let (declarations, is_local) = if let Some(symbol) = place_id.as_symbol()
+            && let Some((owner_scope, owner_symbol)) =
+                self.forwarded_assignment_owner(file_scope_id, symbol)
+        {
+            (
+                self.index
+                    .use_def_map(owner_scope)
+                    .end_of_scope_symbol_declarations(owner_symbol),
+                false,
+            )
         } else {
             (use_def.declarations_at_binding(binding), true)
         };
@@ -1367,6 +1308,83 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } else {
             None
         }
+    }
+
+    /// Returns the owner of an assignment redirected by `global` or `nonlocal`.
+    ///
+    /// `global` assignments target the module symbol, while `nonlocal` assignments target the
+    /// closest owning function-like scope. Local assignments and forwarding declarations whose
+    /// owner cannot be resolved return `None`.
+    ///
+    /// ```python
+    /// x = 0
+    ///
+    /// def outer():
+    ///     y = 0
+    ///
+    ///     def inner():
+    ///         global x
+    ///         nonlocal y
+    ///         x = 1  # owned by the module scope
+    ///         y = 1  # owned by `outer`
+    /// ```
+    fn forwarded_assignment_owner(
+        &self,
+        scope: FileScopeId,
+        symbol: ScopedSymbolId,
+    ) -> Option<(FileScopeId, ScopedSymbolId)> {
+        let scoped_symbol = self.index.place_table(scope).symbol(symbol);
+
+        if scope.is_global() || scoped_symbol.is_local() {
+            return None;
+        }
+
+        if scoped_symbol.is_global() {
+            let global_scope = FileScopeId::global();
+            // If this variable appears in a `global` declaration but has no explicit binding in
+            // the global scope, return `None` so the caller can fall back to the local scope.
+            return self
+                .index
+                .place_table(global_scope)
+                .symbol_id(scoped_symbol.name())
+                .map(|symbol| (global_scope, symbol));
+        }
+
+        debug_assert!(scoped_symbol.is_nonlocal());
+
+        // Walk up parent scopes looking for the enclosing scope that defines this name.
+        // `ancestor_scopes` includes the current scope, so skip that one.
+        for (enclosing_scope, enclosing) in self.index.ancestor_scopes(scope).skip(1) {
+            // Ignore class scopes and the global scope.
+            if !enclosing.kind().is_function_like() {
+                continue;
+            }
+            let place_table = self.index.place_table(enclosing_scope);
+            let Some(enclosing_symbol) = place_table.symbol_id(scoped_symbol.name()) else {
+                // This ancestor scope doesn't have a binding. Keep going.
+                continue;
+            };
+            let symbol = place_table.symbol(enclosing_symbol);
+            if symbol.is_global() {
+                // The variable is `global` in this ancestor scope. This breaks the `nonlocal`
+                // chain, and it's a syntax error in `infer_nonlocal_statement`. Ignore that here
+                // and bail out of this loop.
+                break;
+            }
+            if !symbol.is_local() {
+                // The variable is either explicitly `nonlocal` or just a free read in this
+                // ancestor scope. Keep going.
+                continue;
+            }
+
+            // We found the closest definition. Note that (as in `infer_place_load`) this does not
+            // need to be a binding. It could be just a declaration, e.g. `x: int`.
+            return Some((enclosing_scope, enclosing_symbol));
+        }
+
+        // If no ancestor owns the name, return `None` so the caller can fall back to the local
+        // scope. This will also be reported as a syntax error in `infer_nonlocal_statement`.
+        None
     }
 
     /// Returns `true` if `symbol_id` should be looked up in the global scope, skipping intervening

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -1,5 +1,6 @@
 use crate::{
     Program,
+    reachability::is_reachable,
     types::{
         BindingContext, KnownClass, KnownInstanceType, LintDiagnosticGuard, Truthiness, Type,
         TypeContext, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance,
@@ -27,7 +28,10 @@ use ruff_db::{
 };
 use ruff_python_ast::{self as ast, PythonVersion};
 use ruff_text_size::{Ranged, TextRange};
-use ty_python_core::{definition::Definition, scope::NodeWithScopeKind};
+use ty_python_core::{
+    definition::{Definition, DefinitionKind},
+    scope::NodeWithScopeKind,
+};
 
 impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     pub(super) fn infer_typevar_definition(
@@ -1137,6 +1141,82 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 target_name,
                 Some(name_param),
                 name_param_ty,
+            );
+        }
+
+        let previous_definition_in = |scope, place, before| {
+            let use_def = self.index.use_def_map(scope);
+            use_def
+                .reachable_bindings(place)
+                .map(|binding| {
+                    (
+                        binding.binding_order,
+                        binding.binding,
+                        binding.reachability_constraint,
+                    )
+                })
+                .chain(use_def.reachable_declarations(place).map(|declaration| {
+                    (
+                        declaration.declaration_order,
+                        declaration.declaration,
+                        declaration.reachability_constraint,
+                    )
+                }))
+                .filter(|(order, _, _)| *order < before)
+                .filter(|(_, _, reachability)| is_reachable(db, use_def, *reachability))
+                .filter_map(|(order, definition, _)| {
+                    definition
+                        .definition()
+                        .map(|definition| (order, definition))
+                })
+                .filter(|(_, definition)| definition.kind(db).is_user_visible())
+                .max_by_key(|(order, _)| *order)
+                .map(|(_, definition)| definition)
+        };
+
+        let scope = definition.file_scope(db);
+        let place = definition.place(db);
+        let use_def = self.index.use_def_map(scope);
+        let definition_order = use_def.reachable_bindings(place).find_map(|binding| {
+            (binding.binding.definition() == Some(definition)).then_some(binding.binding_order)
+        });
+        debug_assert!(definition_order.is_some());
+
+        let previous_definition = definition_order
+            .and_then(|before| previous_definition_in(scope, place, before))
+            .or_else(|| {
+                self.forwarded_assignment_owner(scope, place.expect_symbol())
+                    .and_then(|(owner_scope, owner_place)| {
+                        let owner_use_def = self.index.use_def_map(owner_scope);
+                        let before = owner_use_def
+                            .reachable_bindings(owner_place.into())
+                            .find_map(|binding| {
+                                let definition = binding.binding.definition()?;
+                                let DefinitionKind::NestedBindings(nested) = definition.kind(db)
+                                else {
+                                    return None;
+                                };
+                                nested
+                                    .nested_declarations
+                                    .iter()
+                                    .any(|declaration| declaration.file_scope_id == scope)
+                                    .then_some(binding.binding_order)
+                            })?;
+                        previous_definition_in(owner_scope, owner_place.into(), before)
+                    })
+            });
+        if let Some(previous_definition) = previous_definition
+            && let Some(builder) = self
+                .context
+                .report_lint(&INVALID_LEGACY_TYPE_VARIABLE, target)
+        {
+            let mut diagnostic = builder.into_diagnostic(format_args!(
+                "Cannot redefine `{target_name}` as a type variable"
+            ));
+            diagnostic.annotate(
+                self.context
+                    .secondary(previous_definition.focus_range(db, self.module()))
+                    .message("Previously defined here"),
             );
         }
 


### PR DESCRIPTION
## Summary

The `invalid-legacy-type-variable` rule already validates the assignment shape and declared name, but it did not report when a name had already been defined in the same scope:

```python
from typing import TypeVar

T = TypeVar("T")
T = TypeVar("T")  # error: invalid-legacy-type-variable
```

The diagnostic points back to the preceding definition and considers earlier bindings and declarations that are reachable from the beginning of the owning scope.

The implementation reuses the existing per-place use-def snapshot and reachability predicates, so it only inspects definitions of the target name rather than scanning every definition in the scope.

Closes https://github.com/astral-sh/ty/issues/3732.
