### PR TITLE
[ty] Support enum literals as tagged-union discriminants

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/complex_target.md
@@ -365,6 +365,33 @@ def _(x: tuple[Literal["a"], A] | tuple[Literal["b"], B]):
         reveal_type(x)  # revealed: tuple[Literal["a"], A]
 ```
 
+Enum literals are supported as tuple tags, including `IntEnum` literals:
+
+```py
+from enum import Enum, IntEnum
+from typing import Literal
+
+class Tag(Enum):
+    A = 1
+    B = 2
+
+def _(x: tuple[Literal[Tag.A], int] | tuple[Literal[Tag.B], str]):
+    if x[0] == Tag.A:
+        reveal_type(x)  # revealed: tuple[Literal[Tag.A], int]
+    else:
+        reveal_type(x)  # revealed: tuple[Literal[Tag.B], str]
+
+class IntTag(IntEnum):
+    A = 1
+    B = 2
+
+def _(x: tuple[Literal[IntTag.A], int] | tuple[Literal[IntTag.B], str]):
+    if x[0] == IntTag.A:
+        reveal_type(x)  # revealed: tuple[Literal[IntTag.A], int]
+    else:
+        reveal_type(x)  # revealed: tuple[Literal[IntTag.B], str]
+```
+
 Narrowing is restricted to `Literal` tag elements. If any tuple has a non-literal type at the
 discriminating index, we can't safely narrow with equality:
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -804,6 +804,29 @@ def _(x: A | B):
         reveal_type(x)  # revealed: A
 ```
 
+Enum literals are also supported as attribute tags:
+
+```py
+from enum import Enum
+from typing import Literal
+
+class Tag(Enum):
+    A = 1
+    B = 2
+
+class A:
+    tag: Literal[Tag.A]
+
+class B:
+    tag: Literal[Tag.B]
+
+def _(x: A | B):
+    if x.tag == Tag.A:
+        reveal_type(x)  # revealed: A
+    else:
+        reveal_type(x)  # revealed: B
+```
+
 Non-literal tag arms are preserved during positive narrowing:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -4745,6 +4745,60 @@ def _(u: Foo | Bar):
         reveal_type(u)  # revealed: Bar
 ```
 
+Enum literals are also supported as tags:
+
+```py
+from enum import Enum
+
+class Tag(Enum):
+    A = 1
+    B = 2
+    C = 3
+
+class WithEnumTagA(TypedDict):
+    tag: Literal[Tag.A]
+
+class WithEnumTagB(TypedDict):
+    tag: Literal[Tag.B]
+
+class WithEnumTagC(TypedDict):
+    tag: Literal[Tag.C]
+
+def _(u: WithEnumTagA | WithEnumTagB | WithEnumTagC):
+    if u["tag"] == Tag.A:
+        reveal_type(u)  # revealed: WithEnumTagA
+    elif u["tag"] == Tag.B:
+        reveal_type(u)  # revealed: WithEnumTagB
+    else:
+        reveal_type(u)  # revealed: WithEnumTagC
+```
+
+Explicit enum aliases resolve to their canonical member:
+
+```py
+class AliasTag(Enum):
+    A = 1
+    ALSO_A = A
+    B = 2
+
+class WithAliasTagA(TypedDict):
+    tag: Literal[AliasTag.A]
+    a: int
+
+class WithAliasTagAlsoA(TypedDict):
+    tag: Literal[AliasTag.ALSO_A]
+    also_a: int
+
+class WithAliasTagB(TypedDict):
+    tag: Literal[AliasTag.B]
+
+def _(u: WithAliasTagA | WithAliasTagAlsoA | WithAliasTagB):
+    if u["tag"] == AliasTag.A:
+        reveal_type(u)  # revealed: WithAliasTagA | WithAliasTagAlsoA
+    else:
+        reveal_type(u)  # revealed: WithAliasTagB
+```
+
 We can descend into intersections to discover `TypedDict` types that need narrowing:
 
 ```py
@@ -5058,6 +5112,35 @@ def match_statements(u: Foo | Bar | Baz | Bing):
             reveal_type(u)  # revealed: Baz
         case _:
             reveal_type(u)  # revealed: Bing
+```
+
+Enum literal tags are also supported in match statements:
+
+```py
+from enum import Enum
+
+class Tag(Enum):
+    A = 1
+    B = 2
+    C = 3
+
+class WithEnumTagA(TypedDict):
+    tag: Literal[Tag.A]
+
+class WithEnumTagB(TypedDict):
+    tag: Literal[Tag.B]
+
+class WithEnumTagC(TypedDict):
+    tag: Literal[Tag.C]
+
+def match_enum_tags(u: WithEnumTagA | WithEnumTagB | WithEnumTagC):
+    match u["tag"]:
+        case Tag.A:
+            reveal_type(u)  # revealed: WithEnumTagA
+        case Tag.B:
+            reveal_type(u)  # revealed: WithEnumTagB
+        case _:
+            reveal_type(u)  # revealed: WithEnumTagC
 ```
 
 We can also narrow a single `TypedDict` type to `Never`:

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2766,12 +2766,11 @@ fn key_membership_contains_protocol<'db>(db: &'db dyn Db, key: &str) -> Type<'db
 fn is_supported_tag_literal(ty: Type) -> bool {
     matches!(
         ty.as_literal_value_kind(),
-        // TODO: We'd like to support `EnumLiteral` also, but we have to be careful with types like
-        // `IntEnum` and `StrEnum` that have custom `__eq__` methods.
         Some(
             LiteralValueTypeKind::String(_)
                 | LiteralValueTypeKind::Bytes(_)
                 | LiteralValueTypeKind::Int(_)
+                | LiteralValueTypeKind::Enum(_)
         )
     )
 }


### PR DESCRIPTION
## Summary

This is stacked on #25788, which provides the underlying equality narrowing behavior.

Prior to this change, tagged-union narrowing accepted string, bytes, and integer literals as discriminants, but excluded enum literals. This adds enum literals to the same narrowing path:

```python
from enum import Enum
from typing import Literal, TypedDict, reveal_type

class Tag(Enum):
    A = 1
    B = 2

class A(TypedDict):
    tag: Literal[Tag.A]
    value: int

class B(TypedDict):
    tag: Literal[Tag.B]
    value: str

def handle(item: A | B) -> None:
    if item["tag"] == Tag.A:
        reveal_type(item)  # A
```

Closes https://github.com/astral-sh/ty/issues/2192.
