### PR TITLE
Handle escaped f-string format specs in RUF027

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_0.py
@@ -111,6 +111,7 @@ def hash_in_format_spec_test():
     n = 255
     print("Hex: {n:#x}")   # RUF027: `#` is in format spec, not a comment
     print("Oct: {n:#o}")   # RUF027: same
+    print("Dec: {n:\x64}")  # RUF027: escape sequences are valid in format specs
 
 # Test case for `#` in nested interpolation inside format spec (e.g., `{1:{x #}}`)
 # The `#` is a comment inside a nested interpolation — should NOT trigger RUF027 on Python < 3.12

--- a/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/missing_fstring_syntax.rs
@@ -259,8 +259,7 @@ fn should_be_fstring(
                 has_name = true;
             }
             if let Some(spec) = &element.format_spec {
-                let spec = &fstring_expr[spec.range()];
-                if FormatSpec::parse(spec).is_err() {
+                if !is_valid_format_spec(spec, &fstring_expr) {
                     return false;
                 }
             }
@@ -271,6 +270,23 @@ fn should_be_fstring(
     }
 
     true
+}
+
+fn is_valid_format_spec(spec: &ast::InterpolatedStringFormatSpec, fstring_expr: &str) -> bool {
+    let mut decoded_spec = String::new();
+
+    for element in &spec.elements {
+        match element {
+            ast::InterpolatedStringElement::Literal(literal) => {
+                decoded_spec.push_str(&literal.value);
+            }
+            ast::InterpolatedStringElement::Interpolation(_) => {
+                return FormatSpec::parse(&fstring_expr[spec.range()]).is_ok();
+            }
+        }
+    }
+
+    FormatSpec::parse(&decoded_spec).is_ok()
 }
 
 // fast check to disqualify any string literal without brackets

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF027_RUF027_0.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF027_RUF027_0.py.snap
@@ -393,6 +393,7 @@ RUF027 [*] Possible f-string without an `f` prefix
 112 |     print("Hex: {n:#x}")   # RUF027: `#` is in format spec, not a comment
     |           ^^^^^^^^^^^^^
 113 |     print("Oct: {n:#o}")   # RUF027: same
+114 |     print("Dec: {n:\x64}")  # RUF027: escape sequences are valid in format specs
     |
 help: Add `f` prefix
 109 | # `#` in a format spec is NOT a comment — should trigger RUF027 even on Python < 3.12
@@ -401,8 +402,8 @@ help: Add `f` prefix
     -     print("Hex: {n:#x}")   # RUF027: `#` is in format spec, not a comment
 112 +     print(f"Hex: {n:#x}")   # RUF027: `#` is in format spec, not a comment
 113 |     print("Oct: {n:#o}")   # RUF027: same
-114 |
-115 | # Test case for `#` in nested interpolation inside format spec (e.g., `{1:{x #}}`)
+114 |     print("Dec: {n:\x64}")  # RUF027: escape sequences are valid in format specs
+115 |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF027 [*] Possible f-string without an `f` prefix
@@ -412,8 +413,7 @@ RUF027 [*] Possible f-string without an `f` prefix
 112 |     print("Hex: {n:#x}")   # RUF027: `#` is in format spec, not a comment
 113 |     print("Oct: {n:#o}")   # RUF027: same
     |           ^^^^^^^^^^^^^
-114 |
-115 | # Test case for `#` in nested interpolation inside format spec (e.g., `{1:{x #}}`)
+114 |     print("Dec: {n:\x64}")  # RUF027: escape sequences are valid in format specs
     |
 help: Add `f` prefix
 110 | def hash_in_format_spec_test():
@@ -421,7 +421,28 @@ help: Add `f` prefix
 112 |     print("Hex: {n:#x}")   # RUF027: `#` is in format spec, not a comment
     -     print("Oct: {n:#o}")   # RUF027: same
 113 +     print(f"Oct: {n:#o}")   # RUF027: same
-114 |
-115 | # Test case for `#` in nested interpolation inside format spec (e.g., `{1:{x #}}`)
-116 | # The `#` is a comment inside a nested interpolation — should NOT trigger RUF027 on Python < 3.12
+114 |     print("Dec: {n:\x64}")  # RUF027: escape sequences are valid in format specs
+115 |
+116 | # Test case for `#` in nested interpolation inside format spec (e.g., `{1:{x #}}`)
+note: This is an unsafe fix and may change runtime behavior
+
+RUF027 [*] Possible f-string without an `f` prefix
+   --> RUF027_0.py:114:11
+    |
+112 |     print("Hex: {n:#x}")   # RUF027: `#` is in format spec, not a comment
+113 |     print("Oct: {n:#o}")   # RUF027: same
+114 |     print("Dec: {n:\x64}")  # RUF027: escape sequences are valid in format specs
+    |           ^^^^^^^^^^^^^^^
+115 |
+116 | # Test case for `#` in nested interpolation inside format spec (e.g., `{1:{x #}}`)
+    |
+help: Add `f` prefix
+111 |     n = 255
+112 |     print("Hex: {n:#x}")   # RUF027: `#` is in format spec, not a comment
+113 |     print("Oct: {n:#o}")   # RUF027: same
+    -     print("Dec: {n:\x64}")  # RUF027: escape sequences are valid in format specs
+114 +     print(f"Dec: {n:\x64}")  # RUF027: escape sequences are valid in format specs
+115 |
+116 | # Test case for `#` in nested interpolation inside format spec (e.g., `{1:{x #}}`)
+117 | # The `#` is a comment inside a nested interpolation — should NOT trigger RUF027 on Python < 3.12
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Fixes #23360.

RUF027 currently validates f-string format specs by slicing the raw source that was reparsed with an inserted `f` prefix. That rejects valid specs like `{n:\x64}` because the raw slice still contains the escape sequence, even though the parser stores the decoded literal value for the format spec.

This uses decoded format-spec literal elements when there are no nested interpolations, while keeping the existing raw-source fallback for dynamic specs.

## Test

- `cargo test -p ruff_linter rules::ruff::tests::rules::rule_missingfstringsyntax_path_new_ruf027_0_py_expects -- --exact`
- `cargo test -p ruff_linter rules::ruff::tests::missing_fstring_syntax_backslash_py311 -- --exact`
- `cargo fmt --all --check`
- `git diff --check`

## Risk

Low. The change is limited to RUF027 validation, and nested interpolation format specs keep the existing source-slice behavior.