### PR TITLE
[playground] Use proportional font for subdiagnostics

### DIFF
--- a/playground/ruff/src/Editor/Diagnostics.tsx
+++ b/playground/ruff/src/Editor/Diagnostics.tsx
@@ -92,7 +92,7 @@ function Items({
               </span>
             </button>
             {diagnostic.subDiagnostics.length > 0 ? (
-              <ul className="pl-3 text-[0.9375rem] text-gray-500 whitespace-pre-wrap">
+              <ul className="pl-3 text-sm text-gray-500 whitespace-pre-wrap">
                 {diagnostic.subDiagnostics.map((subDiagnostic, index) => (
                   <li key={index}>
                     <SubDiagnosticItem

--- a/playground/ruff/src/Editor/Diagnostics.tsx
+++ b/playground/ruff/src/Editor/Diagnostics.tsx
@@ -92,7 +92,7 @@ function Items({
               </span>
             </button>
             {diagnostic.subDiagnostics.length > 0 ? (
-              <ul className="pl-3 font-mono text-gray-500 whitespace-pre-wrap">
+              <ul className="pl-3 text-[0.9375rem] text-gray-500 whitespace-pre-wrap">
                 {diagnostic.subDiagnostics.map((subDiagnostic, index) => (
                   <li key={index}>
                     <SubDiagnosticItem

--- a/playground/ty/src/Editor/Diagnostics.tsx
+++ b/playground/ty/src/Editor/Diagnostics.tsx
@@ -120,7 +120,7 @@ function Items({
               </button>
             )}
             {diagnostic.subDiagnostics.length > 0 ? (
-              <ul className="pl-3 font-mono text-gray-500 whitespace-pre-wrap">
+              <ul className="pl-3 text-[0.9375rem] text-gray-500 whitespace-pre-wrap">
                 {diagnostic.subDiagnostics.map((subDiagnostic, index) => (
                   <li key={index}>
                     <SubDiagnosticItem

--- a/playground/ty/src/Editor/Diagnostics.tsx
+++ b/playground/ty/src/Editor/Diagnostics.tsx
@@ -120,7 +120,7 @@ function Items({
               </button>
             )}
             {diagnostic.subDiagnostics.length > 0 ? (
-              <ul className="pl-3 text-[0.9375rem] text-gray-500 whitespace-pre-wrap">
+              <ul className="pl-3 text-sm text-gray-500 whitespace-pre-wrap">
                 {diagnostic.subDiagnostics.map((subDiagnostic, index) => (
                   <li key={index}>
                     <SubDiagnosticItem


### PR DESCRIPTION
## Summary

Don't use a mono space font for sub-diagnostics. They're not just code. Use a slightly smaller font also.

## Test Plan

<img width="1734" height="1680" alt="ty-playground-subdiagnostics" src="https://github.com/user-attachments/assets/f890d0c4-86ea-4c46-8bb0-797931b74aea" />

<img width="1734" height="1680" alt="ruff-playground-subdiagnostics" src="https://github.com/user-attachments/assets/95513b54-927b-4af9-ab84-54d74c237b0d" />

