### PR TITLE
[ty] Improve non-callable __await__ diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_await.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_await.md
@@ -69,8 +69,7 @@ async def main() -> None:
 
 ## Non-callable `__await__`
 
-This diagnostic doesn't point to the attribute definition, but complains about it being possibly not
-awaitable.
+This diagnostic points to the non-callable attribute definition.
 
 ```py
 class NonCallableAwait:

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Non-callable_`__awai…_(d78580fb6720e4ea).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid_await.md_-_Invalid_await_diagno…_-_Non-callable_`__awai…_(d78580fb6720e4ea).snap
@@ -24,16 +24,15 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/diagnostics/invalid_awai
 
 ```
 error[invalid-await]: `NonCallableAwait` is not awaitable
-   --> src/mdtest_snippet.py:5:11
-    |
-  5 |     await NonCallableAwait()  # error: [invalid-await]
-    |           ^^^^^^^^^^^^^^^^^^
-    |
-   ::: stdlib/builtins.pyi:349:7
-    |
-349 | class int:
-    |       --- attribute defined here
-    |
+ --> src/mdtest_snippet.py:2:5
+  |
+2 |     __await__ = 42
+  |     --------- attribute defined here
+3 |
+4 | async def main() -> None:
+5 |     await NonCallableAwait()  # error: [invalid-await]
+  |           ^^^^^^^^^^^^^^^^^^
+  |
 info: `__await__` is not callable
 
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -15,6 +15,7 @@ use context::InferContext;
 use ruff_db::Instant;
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span};
 use ruff_db::files::File;
+use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
@@ -52,7 +53,7 @@ pub(crate) use self::subclass_of::{SubclassOfInner, SubclassOfType};
 pub use crate::diagnostic::add_inferred_python_version_hint_to_diagnostic;
 use crate::place::{
     DefinedPlace, Definedness, Place, PlaceAndQualifiers, TypeOrigin, builtins_module_scope,
-    imported_symbol, known_module_symbol,
+    imported_symbol, known_module_symbol, place_from_bindings,
 };
 use crate::suppression::check_suppressions;
 use crate::types::bound_super::BoundSuperType;
@@ -108,7 +109,7 @@ pub use special_form::SpecialFormType;
 use ty_python_core::definition::Definition;
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{Truthiness, place_table, semantic_index};
+use ty_python_core::{Truthiness, place_table, semantic_index, use_def_map};
 
 mod bool;
 mod bound_super;
@@ -7910,7 +7911,7 @@ impl<'db> AwaitError<'db> {
             }
             Self::Call(CallDunderError::CallError(
                 kind @ (CallErrorKind::NotCallable | CallErrorKind::PossiblyNotCallable),
-                bindings,
+                _,
             )) => {
                 let possibly = if matches!(kind, CallErrorKind::PossiblyNotCallable) {
                     " possibly"
@@ -7918,12 +7919,15 @@ impl<'db> AwaitError<'db> {
                     ""
                 };
                 diag.info(format_args!("`__await__` is{possibly} not callable"));
-                if let Some(definition) = bindings.callable_type().definition(db)
-                    && let Some(definition_range) = definition.focus_range(db)
+                if let Some(definition) =
+                    first_member_definition(db, context_expression_type, "__await__")
                 {
+                    let definition_module = parsed_module(db, definition.file(db));
                     diag.annotate(
-                        Annotation::secondary(definition_range.into())
-                            .message("attribute defined here"),
+                        Annotation::secondary(Span::from(
+                            definition.focus_range(db, &definition_module.load(db)),
+                        ))
+                        .message("attribute defined here"),
                     );
                 }
             }
@@ -7971,6 +7975,25 @@ impl<'db> AwaitError<'db> {
             }
         }
     }
+}
+
+fn first_member_definition<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    member_name: &str,
+) -> Option<Definition<'db>> {
+    ty.nominal_class(db)?.iter_mro(db).find_map(|base| {
+        let class = base.into_class()?.class_literal(db).as_static()?;
+        let scope = class.body_scope(db);
+        let symbol = place_table(db, scope).symbol_id(member_name)?;
+        let bindings = use_def_map(db, scope).end_of_scope_bindings(ScopedPlaceId::Symbol(symbol));
+        let place_with_definition = place_from_bindings(db, bindings);
+        if place_with_definition.place.is_undefined() {
+            None
+        } else {
+            place_with_definition.first_definition
+        }
+    })
 }
 
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]


### PR DESCRIPTION
Summary
- Fix invalid-await diagnostics for classes whose `__await__` attribute exists but is not callable.
- The secondary annotation now points at the actual `__await__` attribute definition instead of the class of the attribute's value.

Reproduction
- Given:

```py
class NotAwaitable:
    __await__ = 1

async def _(na: NotAwaitable):
    await na
```

- Before this change, the diagnostic pointed at `stdlib/builtins.pyi`'s `int` definition as "attribute defined here".
- With this change, it points at `__await__ = 1`.

Root cause
- The non-callable `__await__` diagnostic used `bindings.callable_type().definition(db)`.
- For an assignment like `__await__ = 1`, that describes the value type (`int`) rather than the member binding that introduced `__await__` on the class.

Changes
- Add a small helper to find the first reachable definition of a member through the nominal class MRO.
- Use that helper for the non-callable / possibly non-callable `__await__` diagnostic annotation.
- Update the invalid-await mdtest description and snapshot.

Tests
- `cargo fmt --check`
- `cargo test -p ty_python_semantic --test mdtest -- diagnostics/invalid_await.md`

Screenshots/Logs
- The updated mdtest snapshot now shows the secondary annotation on `__await__ = 42` instead of `stdlib/builtins.pyi: class int`.

Fixes astral-sh/ty#3250.
