### PR TITLE
[ty] Infer TypeVarTuple specializations with the legacy solver

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
@@ -17,12 +17,14 @@ def append_int(*args: *Ts) -> tuple[*Ts, int]:
 
     return (*args, 1)
 
-# TODO: revealed: tuple[Literal[True], Literal["a"], int]
-reveal_type(append_int(True, "a"))  # revealed: tuple[*tuple[Literal[True, "a"], ...], int]
+reveal_type(append_int(True, "a"))  # revealed: tuple[Literal[True], Literal["a"], int]
+reveal_type(append_int())  # revealed: tuple[int]
 
 def first_arg_int(*args: *tuple[int, *tuple[str, ...]]): ...
 
 first_arg_int(42, "42", "42")  # fine
-first_arg_int("not an int", "42", "42")  # TODO: should error
-first_arg_int(56, "42", 56)  # TODO: should error
+# error: [invalid-argument-type] "Argument to function `first_arg_int` is incorrect: Expected `tuple[int, *tuple[str, ...]]`, found `tuple[Literal["not an int"], Literal["42"], Literal["42"]]`"
+first_arg_int("not an int", "42", "42")
+# error: [invalid-argument-type] "Argument to function `first_arg_int` is incorrect: Expected `tuple[int, *tuple[str, ...]]`, found `tuple[Literal[56], Literal["42"], Literal[56]]`"
+first_arg_int(56, "42", 56)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -45,8 +45,8 @@ def ex3(msg: str):
 def first_arg_int(*args: Unpack[tuple[int, Unpack[tuple[str, ...]]]]): ...
 
 first_arg_int(42, "42", "42")  # fine
-first_arg_int("not an int", "42", "42")  # TODO: should error
-first_arg_int(56, "42", 56)  # TODO: should error
+first_arg_int("not an int", "42", "42")  # error: [invalid-argument-type]
+first_arg_int(56, "42", 56)  # error: [invalid-argument-type]
 ```
 
 ## Allowed `Unpack` contexts

--- a/crates/ty_python_semantic/resources/mdtest/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/async.md
@@ -42,11 +42,8 @@ def blocking_function() -> int:
 async def main():
     loop = asyncio.get_event_loop()
     with concurrent.futures.ThreadPoolExecutor() as pool:
-        # TODO: No `invalid-argument-type` diagnostic should be emitted here.
-        # error: [invalid-argument-type] "Argument to bound method `AbstractEventLoop.run_in_executor` is incorrect: Expected `(*tuple[Unknown, ...]) -> Unknown`, found `def blocking_function() -> int`"
         result = await loop.run_in_executor(pool, blocking_function)
-        # TODO: revealed: int
-        reveal_type(result)  # revealed: Unknown
+        reveal_type(result)  # revealed: int
 ```
 
 ### `asyncio.Task`

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -245,75 +245,54 @@ U = TypeVar("U")
 class Simple(Generic[*Ts]):
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[()]
-reveal_type(Simple[()]().attr)  # revealed: tuple[tuple[()], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Simple[int, str]().attr)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[tuple[int, str], ...]
+reveal_type(Simple[()]().attr)  # revealed: tuple[()]
+reveal_type(Simple[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[int, str]
 
-# TODO: revealed: tuple[Unknown]
 # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[tuple[Unknown], ...]
-# TODO: revealed: tuple[Unknown, ...]
+reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[Unknown]
 # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ```py
 class Prefix(Generic[T, *Ts]):
     attr: tuple[T, *Ts]
 
-# TODO: revealed: tuple[int]
-reveal_type(Prefix[int]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...]]
-# TODO: revealed: tuple[int, bool]
-reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...]]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
+reveal_type(Prefix[int]().attr)  # revealed: tuple[int]
+reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, bool]
+reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, bool, str]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...]]
-reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...]]
+reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...]]
 ```
 
 ```py
 class Suffix(Generic[*Ts, T]):
     attr: tuple[*Ts, T]
 
-# TODO: revealed: tuple[int]
-reveal_type(Suffix[int]().attr)  # revealed: tuple[*tuple[tuple[()], ...], int]
-# TODO: revealed: tuple[int, str]
-reveal_type(Suffix[int, str]().attr)  # revealed: tuple[*tuple[tuple[int], ...], str]
-# TODO: revealed: tuple[int, str, bool]
-reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
-# TODO: revealed: tuple[int, str, bool]
-reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
+reveal_type(Suffix[int]().attr)  # revealed: tuple[int]
+reveal_type(Suffix[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[int, str, bool]
+reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[int, str, bool]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[*tuple[Unknown, ...], Unknown]
-reveal_type(Suffix().attr)  # revealed: tuple[*tuple[tuple[Unknown, ...], ...], Unknown]
+reveal_type(Suffix().attr)  # revealed: tuple[*tuple[Unknown, ...], Unknown]
 ```
 
 ```py
 class Between(Generic[T, *Ts, U]):
     attr: tuple[T, *Ts, U]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(Between[int, str]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
-# TODO: revealed: tuple[int, bool, bytes, str]
-reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
+reveal_type(Between[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, bool, bytes, str]
+reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, bool, str]
 
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 # error: [invalid-type-arguments] "No type argument provided for required type variable `U` of class `Between`"
-reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Inferred specialization from construction
@@ -334,21 +313,15 @@ class Variadic(Generic[*Ts]):
     def __init__(self, *shape: *Ts) -> None:
         self.shape = shape
 
-# TODO: revealed: Positional[()]
-reveal_type(Positional(()))  # revealed: Positional[*tuple[Unknown, ...]]
-# TODO: revealed: Positional[int, str]
-reveal_type(Positional((1, "a")))  # revealed: Positional[int | str]
+reveal_type(Positional(()))  # revealed: Positional[()]
+reveal_type(Positional((1, "a")))  # revealed: Positional[int, str]
 
-# TODO: revealed: Variadic[()]
-reveal_type(Variadic())  # revealed: Variadic[*tuple[Unknown, ...]]
-# TODO: revealed: Variadic[int, str]
-reveal_type(Variadic(1, "a"))  # revealed: Variadic[int | str]
+reveal_type(Variadic())  # revealed: Variadic[()]
+reveal_type(Variadic(1, "a"))  # revealed: Variadic[int, str]
 
 def _(i: int, s: str) -> None:
-    # TODO: revealed: Positional[int, str]
-    reveal_type(Positional((i, s)))  # revealed: Positional[int | str]
-    # TODO: revealed: Variadic[int, str]
-    reveal_type(Variadic(i, s))  # revealed: Variadic[int | str]
+    reveal_type(Positional((i, s)))  # revealed: Positional[int, str]
+    reveal_type(Variadic(i, s))  # revealed: Variadic[int, str]
 ```
 
 ### Unspecified type arguments
@@ -368,8 +341,7 @@ class Unspecified(Generic[*Ts]):
 
 unspecified = Unspecified()
 reveal_type(unspecified)  # revealed: Unspecified[*tuple[Unknown, ...]]
-# TODO: revealed: tuple[Unknown, ...]
-reveal_type(unspecified.attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(unspecified.attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ### Default type arguments
@@ -393,10 +365,8 @@ InvalidDefault = TypeVarTuple("InvalidDefault", default=tuple[int, str])
 class WithDefault(Generic[*Ts]):
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithDefault().attr)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[bool, bytes]
-reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[tuple[bool, bytes], ...]
+reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
+reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
 ```
 
 ### Backported default type arguments
@@ -417,8 +387,7 @@ Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
 class WithBackportedDefault(Generic[*Ts]):
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithBackportedDefault().attr)  # revealed: tuple[tuple[int, str], ...]
+reveal_type(WithBackportedDefault().attr)  # revealed: tuple[int, str]
 ```
 
 ## Type Aliases
@@ -450,26 +419,16 @@ def _(
     # error: [invalid-type-arguments] "No type argument provided for required type variable `U`"
     a10: Between[int],
 ):
-    # TODO: revealed: tuple[()]
-    reveal_type(a1)  # revealed: tuple[tuple[()], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a2)  # revealed: tuple[tuple[int, str], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a3)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
-    # TODO: revealed: tuple[int, bool, str]
-    reveal_type(a4)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
-    # TODO: revealed: tuple[int, bool, bytes, str]
-    reveal_type(a5)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a6)  # revealed: tuple[bool, *tuple[tuple[()], ...]]
-    # TODO: revealed: tuple[bool, int, str]
-    reveal_type(a7)  # revealed: tuple[bool, *tuple[tuple[int, str], ...]]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a8)  # revealed: tuple[*tuple[tuple[()], ...], bool]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a9)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
-    # TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+    reveal_type(a1)  # revealed: tuple[()]
+    reveal_type(a2)  # revealed: tuple[int, str]
+    reveal_type(a3)  # revealed: tuple[int, str]
+    reveal_type(a4)  # revealed: tuple[int, bool, str]
+    reveal_type(a5)  # revealed: tuple[int, bool, bytes, str]
+    reveal_type(a6)  # revealed: tuple[bool]
+    reveal_type(a7)  # revealed: tuple[bool, int, str]
+    reveal_type(a8)  # revealed: tuple[bool]
+    reveal_type(a9)  # revealed: tuple[int, str, bool]
+    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Unpacked tuple type arguments
@@ -482,10 +441,8 @@ Ts = TypeVarTuple("Ts")
 Alias = tuple[int, *Ts]
 
 def _(a1: Alias[*tuple[str, bool]], a2: Alias[*tuple[str, ...]]) -> None:
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a1)  # revealed: tuple[int, *tuple[tuple[str, bool], ...]]
-    # TODO: revealed: tuple[int, *tuple[str, ...]]
-    reveal_type(a2)  # revealed: tuple[int, *tuple[tuple[str, ...], ...]]
+    reveal_type(a1)  # revealed: tuple[int, str, bool]
+    reveal_type(a2)  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
 ### Unspecified alias type arguments
@@ -500,10 +457,8 @@ Ts = TypeVarTuple("Ts")
 Alias = tuple[bytes, *Ts]
 
 def _(a1: Alias, a2: Alias[*tuple[Any, ...]]) -> None:
-    # TODO: revealed: tuple[bytes, *tuple[Unknown, ...]]
-    reveal_type(a1)  # revealed: tuple[bytes, *tuple[tuple[Unknown, ...], ...]]
-    # TODO: revealed: tuple[bytes, *tuple[Any, ...]]
-    reveal_type(a2)  # revealed: tuple[bytes, *tuple[tuple[Any, ...], ...]]
+    reveal_type(a1)  # revealed: tuple[bytes, *tuple[Unknown, ...]]
+    reveal_type(a2)  # revealed: tuple[bytes, *tuple[Any, ...]]
 ```
 
 ### Splitting arbitrary-length tuples
@@ -523,14 +478,10 @@ def _(
     s1: Second[*tuple[int, ...]],
     s2: Second[str, *tuple[int, ...]],
 ):
-    # TODO: revealed: tuple[*tuple[int, ...], int]
-    reveal_type(f1)  # revealed: tuple[*tuple[tuple[int, ...], ...], int]
-    # TODO: revealed: tuple[*tuple[int, ...], str]
-    reveal_type(f2)  # revealed: tuple[*tuple[tuple[int, ...], ...], str]
-    # TODO: revealed: tuple[int, *tuple[int, ...]]
-    reveal_type(s1)  # revealed: tuple[int, *tuple[tuple[int, ...], ...]]
-    # TODO: revealed: tuple[str, *tuple[int, ...]]
-    reveal_type(s2)  # revealed: tuple[str, *tuple[tuple[int, ...], ...]]
+    reveal_type(f1)  # revealed: tuple[*tuple[int, ...], int]
+    reveal_type(f2)  # revealed: tuple[*tuple[int, ...], str]
+    reveal_type(s1)  # revealed: tuple[int, *tuple[int, ...]]
+    reveal_type(s2)  # revealed: tuple[str, *tuple[int, ...]]
 ```
 
 ### Variadic substitutions
@@ -546,8 +497,6 @@ First = tuple[bytes, *Ts]
 Second = First[int, *Ts]
 
 def f(a1: First[str, bool], a2: Second[str, bool]) -> None:
-    # TODO: revealed: tuple[bytes, str, bool]
-    reveal_type(a1)  # revealed: tuple[bytes, *tuple[tuple[str, bool], ...]]
-    # TODO: revealed: tuple[bytes, int, str, bool]
-    reveal_type(a2)  # revealed: tuple[bytes, *tuple[tuple[int, *tuple[tuple[str, bool], ...]], ...]]
+    reveal_type(a1)  # revealed: tuple[bytes, str, bool]
+    reveal_type(a2)  # revealed: tuple[bytes, int, str, bool]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
@@ -21,12 +21,9 @@ Ts = TypeVarTuple("Ts")
 class Array(Generic[Unpack[Ts]]):
     value: tuple[Unpack[Ts]]
 
-# TODO: revealed: tuple[()]
-reveal_type(Array[()]().value)  # revealed: tuple[tuple[()], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Array[int, str]().value)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Array[Unpack[tuple[int, str]]]().value)  # revealed: tuple[tuple[int, str], ...]
+reveal_type(Array[()]().value)  # revealed: tuple[()]
+reveal_type(Array[int, str]().value)  # revealed: tuple[int, str]
+reveal_type(Array[Unpack[tuple[int, str]]]().value)  # revealed: tuple[int, str]
 ```
 
 ## Variadic parameter inference
@@ -43,10 +40,8 @@ def collect(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
     reveal_type(args)  # revealed: tuple[*Ts@collect]
     raise NotImplementedError
 
-# TODO: revealed: tuple[()]
-reveal_type(collect())  # revealed: tuple[tuple[Unknown, ...], ...]
-# TODO: revealed: tuple[Literal[1], Literal["a"]]
-reveal_type(collect(1, "a"))  # revealed: tuple[Literal[1, "a"], ...]
+reveal_type(collect())  # revealed: tuple[()]
+reveal_type(collect(1, "a"))  # revealed: tuple[Literal[1], Literal["a"]]
 ```
 
 ## Callable parameters
@@ -69,13 +64,9 @@ def invoke(
 def format_value(value: int, label: str, /) -> str:
     return f"{label}: {value}"
 
-# TODO: revealed: str
-# error: [invalid-argument-type]
-reveal_type(invoke(format_value, 1, "value"))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> str`, found `def format_value(value: int, label: str, /) -> str`"
-# TODO: revealed: str
-# error: [invalid-argument-type]
-reveal_type(invoke(format_value, 1))  # revealed: Unknown
+reveal_type(invoke(format_value, 1, "value"))  # revealed: str
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> str`, found `def format_value(value: int, label: str, /) -> str`"
+reveal_type(invoke(format_value, 1))  # revealed: str
 ```
 
 ## Type aliases
@@ -93,10 +84,8 @@ def f(
     fixed: Alias[str, bool],
     unbounded: Alias[Unpack[tuple[str, ...]]],
 ) -> None:
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(fixed)  # revealed: tuple[int, *tuple[tuple[str, bool], ...]]
-    # TODO: revealed: tuple[int, *tuple[str, ...]]
-    reveal_type(unbounded)  # revealed: tuple[int, *tuple[tuple[str, ...], ...]]
+    reveal_type(fixed)  # revealed: tuple[int, str, bool]
+    reveal_type(unbounded)  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
 ## Concrete and nested tuple unpacking
@@ -112,7 +101,7 @@ def accept(
 
 accept(True, "phase", "status", b"ok")
 accept(True, b"ok")
-# TODO: error: [invalid-argument-type] "Argument to function `accept` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
+# error: [invalid-argument-type] "Argument to function `accept` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
 accept(True, 1, b"bad")
 ```
 
@@ -133,10 +122,8 @@ Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
 class WithDefault(Generic[Unpack[Ts]]):
     value: tuple[Unpack[Ts]]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithDefault().value)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[bool, bytes]
-reveal_type(WithDefault[bool, bytes]().value)  # revealed: tuple[tuple[bool, bytes], ...]
+reveal_type(WithDefault().value)  # revealed: tuple[int, str]
+reveal_type(WithDefault[bool, bytes]().value)  # revealed: tuple[bool, bytes]
 ```
 
 ## Validation

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -567,7 +567,7 @@ reveal_type(only_variadic)  # revealed: (...) -> None
 @decorator
 def unpack_variadic(*args: *tuple[int, *tuple[str, ...]], **kwargs: int) -> None: ...
 
-reveal_type(unpack_variadic)  # revealed: (...) -> None
+reveal_type(unpack_variadic)  # revealed: (*args: str, **kwargs: int) -> None
 ```
 
 ## `Concatenate` with `ParamSpec` in generic function calls

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -564,8 +564,6 @@ def only_variadic(*args: str, **kwargs: int) -> None: ...
 
 reveal_type(only_variadic)  # revealed: (...) -> None
 
-# TODO: This should accept the callable and reveal `(*args: str, **kwargs: int) -> None`.
-# error: [invalid-argument-type]
 @decorator
 def unpack_variadic(*args: *tuple[int, *tuple[str, ...]], **kwargs: int) -> None: ...
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -49,75 +49,54 @@ invariant_in: InvariantArray[int] = InvariantArray[object]()  # error: [invalid-
 class Simple[*Ts]:
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[()]
-reveal_type(Simple[()]().attr)  # revealed: tuple[tuple[()], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Simple[int, str]().attr)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[tuple[int, str], ...]
+reveal_type(Simple[()]().attr)  # revealed: tuple[()]
+reveal_type(Simple[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[int, str]
 
-# TODO: revealed: tuple[Unknown]
 # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[tuple[Unknown], ...]
-# TODO: revealed: tuple[Unknown, ...]
+reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[Unknown]
 # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ```py
 class Prefix[T, *Ts]:
     attr: tuple[T, *Ts]
 
-# TODO: revealed: tuple[int]
-reveal_type(Prefix[int]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...]]
-# TODO: revealed: tuple[int, bool]
-reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...]]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
+reveal_type(Prefix[int]().attr)  # revealed: tuple[int]
+reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, bool]
+reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, bool, str]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...]]
-reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...]]
+reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...]]
 ```
 
 ```py
 class Suffix[*Ts, T]:
     attr: tuple[*Ts, T]
 
-# TODO: revealed: tuple[int]
-reveal_type(Suffix[int]().attr)  # revealed: tuple[*tuple[tuple[()], ...], int]
-# TODO: revealed: tuple[int, str]
-reveal_type(Suffix[int, str]().attr)  # revealed: tuple[*tuple[tuple[int], ...], str]
-# TODO: revealed: tuple[int, str, bool]
-reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
-# TODO: revealed: tuple[int, str, bool]
-reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
+reveal_type(Suffix[int]().attr)  # revealed: tuple[int]
+reveal_type(Suffix[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[int, str, bool]
+reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[int, str, bool]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[*tuple[Unknown, ...], Unknown]
-reveal_type(Suffix().attr)  # revealed: tuple[*tuple[tuple[Unknown, ...], ...], Unknown]
+reveal_type(Suffix().attr)  # revealed: tuple[*tuple[Unknown, ...], Unknown]
 ```
 
 ```py
 class Between[T, *Ts, U]:
     attr: tuple[T, *Ts, U]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(Between[int, str]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
-# TODO: revealed: tuple[int, bool, bytes, str]
-reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
+reveal_type(Between[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, bool, bytes, str]
+reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, bool, str]
 
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 # error: [invalid-type-arguments] "No type argument provided for required type variable `U` of class `Between`"
-reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Inferred specialization from construction
@@ -134,21 +113,15 @@ class Variadic[*Ts]:
     def __init__(self, *shape: *Ts) -> None:
         self.shape = shape
 
-# TODO: revealed: Positional[()]
-reveal_type(Positional(()))  # revealed: Positional[*tuple[Unknown, ...]]
-# TODO: revealed: Positional[int, str]
-reveal_type(Positional((1, "a")))  # revealed: Positional[int | str]
+reveal_type(Positional(()))  # revealed: Positional[()]
+reveal_type(Positional((1, "a")))  # revealed: Positional[int, str]
 
-# TODO: revealed: Variadic[()]
-reveal_type(Variadic())  # revealed: Variadic[*tuple[Unknown, ...]]
-# TODO: revealed: Variadic[int, str]
-reveal_type(Variadic(1, "a"))  # revealed: Variadic[int | str]
+reveal_type(Variadic())  # revealed: Variadic[()]
+reveal_type(Variadic(1, "a"))  # revealed: Variadic[int, str]
 
 def _(i: int, s: str) -> None:
-    # TODO: revealed: Positional[int, str]
-    reveal_type(Positional((i, s)))  # revealed: Positional[int | str]
-    # TODO: revealed: Variadic[int, str]
-    reveal_type(Variadic(i, s))  # revealed: Variadic[int | str]
+    reveal_type(Positional((i, s)))  # revealed: Positional[int, str]
+    reveal_type(Variadic(i, s))  # revealed: Variadic[int, str]
 ```
 
 ### Unspecified type arguments
@@ -163,8 +136,7 @@ class Unspecified[*Ts]:
 
 unspecified = Unspecified()
 reveal_type(unspecified)  # revealed: Unspecified[*tuple[Unknown, ...]]
-# TODO: revealed: tuple[Unknown, ...]
-reveal_type(unspecified.attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(unspecified.attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ### Default type arguments
@@ -181,10 +153,8 @@ python-version = "3.13"
 class WithDefault[*Ts = *tuple[int, str]]:
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithDefault().attr)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[bool, bytes]
-reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[tuple[bool, bytes], ...]
+reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
+reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
 ```
 
 ### Assignment checks
@@ -233,16 +203,11 @@ def with_both[T, *Ts, U](x: tuple[T, *Ts, U]) -> tuple[*Ts]:
     raise NotImplementedError
 
 def f(i: int, s: str, b: bool) -> None:
-    # TODO: revealed: tuple[()]
-    reveal_type(simple(()))  # revealed: tuple[tuple[Unknown, ...], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(simple((i, s)))  # revealed: tuple[int | str, ...]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(with_prefix(i, (s, b)))  # revealed: tuple[int, *tuple[str | bool, ...]]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(with_suffix((i, s), b))  # revealed: tuple[*tuple[int | str, ...], bool]
-    # TODO: revealed: tuple[str]
-    reveal_type(with_both((i, s, b)))  # revealed: tuple[str, ...]
+    reveal_type(simple(()))  # revealed: tuple[()]
+    reveal_type(simple((i, s)))  # revealed: tuple[int, str]
+    reveal_type(with_prefix(i, (s, b)))  # revealed: tuple[int, str, bool]
+    reveal_type(with_suffix((i, s), b))  # revealed: tuple[int, str, bool]
+    reveal_type(with_both((i, s, b)))  # revealed: tuple[str]
 ```
 
 ### Starred variadic parameters
@@ -262,17 +227,12 @@ def kw_only[T, *Ts](*args: *Ts, kw: T) -> tuple[*Ts, T]:
     raise NotImplementedError
 
 def f(i: int, s: str, b: bool) -> None:
-    # TODO: revealed: tuple[()]
-    reveal_type(simple())  # revealed: tuple[tuple[Unknown, ...], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(simple(i, s))  # revealed: tuple[int | str, ...]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(with_prefix(i, s, b))  # revealed: tuple[int, *tuple[str | bool, ...]]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(kw_only(i, s, kw=b))  # revealed: tuple[*tuple[int | str, ...], bool]
-    # TODO: revealed: tuple[int, str, bool, Unknown]
+    reveal_type(simple())  # revealed: tuple[()]
+    reveal_type(simple(i, s))  # revealed: tuple[int, str]
+    reveal_type(with_prefix(i, s, b))  # revealed: tuple[int, str, bool]
+    reveal_type(kw_only(i, s, kw=b))  # revealed: tuple[int, str, bool]
     # error: [missing-argument] "No argument provided for required parameter `kw` of function `kw_only`"
-    reveal_type(kw_only(i, s, b))  # revealed: tuple[*tuple[int | str, ...], Unknown]
+    reveal_type(kw_only(i, s, b))  # revealed: tuple[int, str, bool, Unknown]
 ```
 
 ### Callable parameters
@@ -304,25 +264,15 @@ def variadic2(*args: int) -> tuple[str, ...]:
 def keyword_only(*, x: int) -> tuple[int]:
     raise NotImplementedError
 
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(simple(positional_only))  # revealed: tuple[tuple[Unknown, ...], ...]
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(simple(standard))  # revealed: tuple[tuple[Unknown, ...], ...]
-# TODO: revealed: tuple[int, *tuple[str, ...]]
-# error: [invalid-argument-type]
-reveal_type(simple(positional_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(simple(positional_only))  # revealed: tuple[int, str]
+reveal_type(simple(standard))  # revealed: tuple[int, str]
+reveal_type(simple(positional_variadic))  # revealed: tuple[int, *tuple[str, ...]]
 reveal_type(simple(variadic1))  # revealed: tuple[int, ...]
 
-# TODO: error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: int) -> tuple[int, ...]`, found `def variadic2(*args: int) -> tuple[str, ...]`"
-# TODO: revealed: tuple[int, ...]
-# error: [invalid-argument-type]
-reveal_type(simple(variadic2))  # revealed: tuple[tuple[Unknown, ...], ...]
-# TODO: error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: Unknown) -> tuple[Unknown, ...]`, found `def keyword_only(*, x: int) -> tuple[int]`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(simple(keyword_only))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: int) -> tuple[int, ...]`, found `def variadic2(*args: int) -> tuple[str, ...]`"
+reveal_type(simple(variadic2))  # revealed: tuple[int, ...]
+# error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: Unknown) -> tuple[Unknown, ...]`, found `def keyword_only(*, x: int) -> tuple[int]`"
+reveal_type(simple(keyword_only))  # revealed: tuple[Unknown, ...]
 ```
 
 This usage pattern is similar to how `ParamSpec` can be used to accept a callable and its arguments
@@ -332,42 +282,24 @@ except that in the case of `TypeVarTuple` all parameters are positional-only.
 def invoke[*Ts, R](callback: Callable[[*Ts], R], *args: *Ts) -> R:
     raise NotImplementedError
 
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_only, 1, "a"))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_only))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_only, 1))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(int, Literal[2] | str, /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_only, 1, 2))  # revealed: Unknown
+reveal_type(invoke(positional_only, 1, "a"))  # revealed: tuple[int, str]
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+reveal_type(invoke(positional_only))  # revealed: tuple[int, str]
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+reveal_type(invoke(positional_only, 1))  # revealed: tuple[int, str]
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(int, Literal[2] | str, /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+reveal_type(invoke(positional_only, 1, 2))  # revealed: tuple[int, str]
 
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(invoke(standard, 1, "a"))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def standard(x: int, y: str) -> tuple[int, str]`"
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
+reveal_type(invoke(standard, 1, "a"))  # revealed: tuple[int, str]
 # error: [unknown-argument] "Argument `x` does not match any known parameter of function `invoke`"
 # error: [unknown-argument] "Argument `y` does not match any known parameter of function `invoke`"
-reveal_type(invoke(standard, x=1, y="a"))  # revealed: Unknown
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def standard(x: int, y: str) -> tuple[int, str]`"
+reveal_type(invoke(standard, x=1, y="a"))  # revealed: tuple[int, str]
 
-# TODO: revealed: tuple[int, *tuple[str, ...]]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_variadic, 1, "a", "b"))  # revealed: Unknown
-# TODO: revealed: tuple[int, *tuple[str, ...]]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_variadic, 1))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, *tuple[str, ...]]`, found `def positional_variadic(x: int, *args: str) -> tuple[int, *tuple[str, ...]]`"
-# TODO: revealed: tuple[int, *tuple[str, ...]]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_variadic))  # revealed: Unknown
+reveal_type(invoke(positional_variadic, 1, "a", "b"))  # revealed: tuple[int, *tuple[str, ...]]
+reveal_type(invoke(positional_variadic, 1))  # revealed: tuple[int, *tuple[str, ...]]
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, *tuple[str, ...]]`, found `def positional_variadic(x: int, *args: str) -> tuple[int, *tuple[str, ...]]`"
+reveal_type(invoke(positional_variadic))  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
 ### Callable inference with fixed positional parameters
@@ -384,13 +316,9 @@ def infer_with_suffix[*Ts](callback: Callable[[int, *Ts, bytes], None]) -> tuple
 def fixed_suffix(prefix: int, middle: str, suffix: bytes, /) -> None: ...
 def unpacked_suffix(*args: *tuple[int, *tuple[str, ...], bytes]) -> None: ...
 
-# TODO: revealed: tuple[str]
-# error: [invalid-argument-type]
-reveal_type(infer_with_suffix(fixed_suffix))  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(infer_with_suffix(fixed_suffix))  # revealed: tuple[str]
 # TODO: Should reveal `tuple[str, ...]`.
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_with_suffix(unpacked_suffix))  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(infer_with_suffix(unpacked_suffix))  # revealed: tuple[Unknown, ...]
 ```
 
 ### Callable inference with additional keyword parameters
@@ -408,15 +336,11 @@ def optional_keyword_only(x: int, y: str, *, debug: bool = False) -> None: ...
 def extra_keywords(x: int, y: str, **kwargs: object) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def optional_keyword_only(x: int, y: str, *, debug: bool = False) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_positional(optional_keyword_only))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def optional_keyword_only(x: int, y: str, *, debug: bool = False) -> None`"
+reveal_type(infer_positional(optional_keyword_only))  # revealed: tuple[Unknown, ...]
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def extra_keywords(x: int, y: str, **kwargs: object) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_positional(extra_keywords))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def extra_keywords(x: int, y: str, **kwargs: object) -> None`"
+reveal_type(infer_positional(extra_keywords))  # revealed: tuple[Unknown, ...]
 ```
 
 ### Callable protocol inference with keyword-only parameters
@@ -439,25 +363,17 @@ def positional_or_keyword(x: int, y: str, flag: bool) -> None: ...
 def keyword_catch_all(x: int, y: str, **kwargs: object) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def explicit_keyword_only(x: int, y: str, *, flag: bool) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_only(explicit_keyword_only))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def explicit_keyword_only(x: int, y: str, *, flag: bool) -> None`"
+reveal_type(infer_keyword_only(explicit_keyword_only))  # revealed: tuple[Unknown, ...]
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_only_with_keyword(x: int, y: str, /, *, flag: bool) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_only(positional_only_with_keyword))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_only_with_keyword(x: int, y: str, /, *, flag: bool) -> None`"
+reveal_type(infer_keyword_only(positional_only_with_keyword))  # revealed: tuple[Unknown, ...]
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_or_keyword(x: int, y: str, flag: bool) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_only(positional_or_keyword))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_or_keyword(x: int, y: str, flag: bool) -> None`"
+reveal_type(infer_keyword_only(positional_or_keyword))  # revealed: tuple[Unknown, ...]
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_only(keyword_catch_all))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
+reveal_type(infer_keyword_only(keyword_catch_all))  # revealed: tuple[Unknown, ...]
 
 class OptionalKeywordCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, flag: bool = False) -> None: ...
@@ -468,10 +384,8 @@ def infer_optional_keyword[*Ts](callback: OptionalKeywordCallback[*Ts]) -> tuple
 def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_optional_keyword` is incorrect: Expected `OptionalKeywordCallback[*tuple[Unknown, ...]]`, found `def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_optional_keyword(optional_keyword_callback))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_optional_keyword` is incorrect: Expected `OptionalKeywordCallback[*tuple[Unknown, ...]]`, found `def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None`"
+reveal_type(infer_optional_keyword(optional_keyword_callback))  # revealed: tuple[Unknown, ...]
 
 class PrefixedKeywordCallback[*Ts](Protocol):
     def __call__(self, prefix: bytes, *args: *Ts, flag: bool) -> None: ...
@@ -483,15 +397,11 @@ def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None: ...
 def prefixed_variadic(prefix: bytes, *args: str, flag: bool) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_prefixed` is incorrect: Expected `PrefixedKeywordCallback[*tuple[Unknown, ...]]`, found `def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_prefixed(prefixed))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_prefixed` is incorrect: Expected `PrefixedKeywordCallback[*tuple[Unknown, ...]]`, found `def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None`"
+reveal_type(infer_prefixed(prefixed))  # revealed: tuple[Unknown, ...]
 
 # An open-ended positional parameter can be inferred in an otherwise mixed signature.
-# TODO: revealed: tuple[str, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_prefixed(prefixed_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(infer_prefixed(prefixed_variadic))  # revealed: tuple[str, ...]
 ```
 
 ### Callable protocol inference with variadic keyword parameters
@@ -511,10 +421,8 @@ def infer_keyword_variadic[*Ts](callback: KeywordVariadicCallback[*Ts]) -> tuple
 def keyword_variadic(x: int, y: str, **kwargs: int) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_variadic` is incorrect: Expected `KeywordVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_variadic(x: int, y: str, **kwargs: int) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_variadic(keyword_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_variadic` is incorrect: Expected `KeywordVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_variadic(x: int, y: str, **kwargs: int) -> None`"
+reveal_type(infer_keyword_variadic(keyword_variadic))  # revealed: tuple[Unknown, ...]
 
 class KeywordOnlyAndVariadicCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, flag: bool, **kwargs: int) -> None: ...
@@ -527,10 +435,8 @@ def infer_keyword_only_and_variadic[*Ts](
 def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only_and_variadic` is incorrect: Expected `KeywordOnlyAndVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_only_and_variadic(keyword_only_and_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_only_and_variadic` is incorrect: Expected `KeywordOnlyAndVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None`"
+reveal_type(infer_keyword_only_and_variadic(keyword_only_and_variadic))  # revealed: tuple[Unknown, ...]
 
 class MultipleKeywordCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, first: int, second: str) -> None: ...
@@ -541,10 +447,8 @@ def infer_multiple_keywords[*Ts](callback: MultipleKeywordCallback[*Ts]) -> tupl
 def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_multiple_keywords` is incorrect: Expected `MultipleKeywordCallback[*tuple[Unknown, ...]]`, found `def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_multiple_keywords(multiple_keyword_catch_all))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_multiple_keywords` is incorrect: Expected `MultipleKeywordCallback[*tuple[Unknown, ...]]`, found `def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
+reveal_type(infer_multiple_keywords(multiple_keyword_catch_all))  # revealed: tuple[Unknown, ...]
 ```
 
 ### Length-sensitive inference
@@ -557,11 +461,9 @@ def foo[*Ts](arg1: tuple[*Ts], arg2: tuple[*Ts]) -> tuple[*Ts]:
     raise NotImplementedError
 
 def f(i: int, s: str, b: bool) -> None:
-    # TODO: revealed: tuple[int, str | int]
-    reveal_type(foo((i, s), (b, i)))  # revealed: tuple[int | str, ...]
-    # TODO: error: [invalid-argument-type] "Argument to function `foo` is incorrect: Expected `tuple[int]`, found `tuple[str, bool]`"
-    # TODO: revealed: tuple[int]
-    reveal_type(foo((i,), (s, b)))  # revealed: tuple[int | str, ...]
+    reveal_type(foo((i, s), (b, i)))  # revealed: tuple[int, str | int]
+    # error: [invalid-argument-type] "Argument to function `foo` is incorrect: Expected `tuple[int]`, found `tuple[str, bool]`"
+    reveal_type(foo((i,), (s, b)))  # revealed: tuple[int]
 ```
 
 ## Type concatenation
@@ -590,27 +492,19 @@ def del_letter_c[*Ts](x: Array[*Ts, C]) -> Array[*Ts]:
 def generic[T, *Ts](x: T, y: Array[*Ts]) -> Array[T, *Ts]:
     raise NotImplementedError
 
-# TODO: revealed: Array[A, B, D, C]
-reveal_type(add_letters(Array[B, D]()))  # revealed: Array[*tuple[A, *tuple[B | D, ...], C]]
-# TODO: revealed: Array[A, B, C]
-reveal_type(add_letter_a(Array[B, C]()))  # revealed: Array[*tuple[A, *tuple[B | C, ...]]]
+reveal_type(add_letters(Array[B, D]()))  # revealed: Array[A, B, D, C]
+reveal_type(add_letter_a(Array[B, C]()))  # revealed: Array[A, B, C]
 
-# TODO: revealed: Array[B]
-reveal_type(del_letter_a(Array[A, B]()))  # revealed: Array[*tuple[B, ...]]
+reveal_type(del_letter_a(Array[A, B]()))  # revealed: Array[B]
 # TODO: error: [invalid-argument-type]
-# TODO: revealed: Array[C]
-reveal_type(del_letter_a(Array[B, C]()))  # revealed: Array[*tuple[C, ...]]
+reveal_type(del_letter_a(Array[B, C]()))  # revealed: Array[C]
 
-# TODO: revealed: Array[A, B]
-reveal_type(del_letter_c(Array[A, B, C]()))  # revealed: Array[*tuple[A | B, ...]]
+reveal_type(del_letter_c(Array[A, B, C]()))  # revealed: Array[A, B]
 # TODO: error: [invalid-argument-type]
-# TODO: revealed: Array[A]
-reveal_type(del_letter_c(Array[A, B]()))  # revealed: Array[*tuple[A, ...]]
+reveal_type(del_letter_c(Array[A, B]()))  # revealed: Array[A]
 
-# TODO: revealed: Array[A, B, D]
-reveal_type(generic(A(), Array[B, D]()))  # revealed: Array[*tuple[A, *tuple[tuple[Unknown, ...], ...]]]
-# TODO: revealed: Array[A]
-reveal_type(generic(A(), Array[()]()))  # revealed: Array[*tuple[A, *tuple[tuple[Unknown, ...], ...]]]
+reveal_type(generic(A(), Array[B, D]()))  # revealed: Array[A, B, D]
+reveal_type(generic(A(), Array[()]()))  # revealed: Array[A]
 ```
 
 ## Unpacking Unbounded Tuple Types
@@ -651,17 +545,14 @@ def f(
     mixed: tuple[int, *tuple[str, ...], bytes],
 ) -> None:
     # TODO: Should reveal `tuple[int, *tuple[str, ...]]`.
-    # TODO: error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...]]`"
-    # TODO: revealed: tuple[int, ...]
-    reveal_type(preserve(prefix))  # revealed: tuple[int | str, ...]
+    # error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...]]`"
+    reveal_type(preserve(prefix))  # revealed: tuple[int, ...]
     # TODO: Should reveal `tuple[*tuple[str, ...], bytes]`.
-    # TODO: error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[str, ...]`, found `tuple[*tuple[str, ...], bytes]`"
-    # TODO: revealed: tuple[str, ...]
-    reveal_type(preserve(suffix))  # revealed: tuple[str | bytes, ...]
+    # error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[str, ...]`, found `tuple[*tuple[str, ...], bytes]`"
+    reveal_type(preserve(suffix))  # revealed: tuple[str, ...]
     # TODO: Should reveal `tuple[int, *tuple[str, ...], bytes]`.
-    # TODO: error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...], bytes]`"
-    # TODO: revealed: tuple[int, ...]
-    reveal_type(preserve(mixed))  # revealed: tuple[int | str | bytes, ...]
+    # error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...], bytes]`"
+    reveal_type(preserve(mixed))  # revealed: tuple[int, ...]
 ```
 
 A tuple containing an unpacked tuple can precisely describe heterogeneous positional arguments,
@@ -674,11 +565,10 @@ def remove_bytes[*Prefix](*args: *tuple[*Prefix, bytes]) -> tuple[*Prefix]:
 
 accept_str_in_between(True, "phase", "status", b"ok")
 accept_str_in_between(True, b"ok")
-# TODO: error: [invalid-argument-type] "Argument to function `accept_str_in_between` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
+# error: [invalid-argument-type] "Argument to function `accept_str_in_between` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
 accept_str_in_between(True, 1, b"bad")
 
-# TODO: revealed: tuple[Literal[1], Literal["record"]]
-reveal_type(remove_bytes(1, "record", b"sum"))  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(remove_bytes(1, "record", b"sum"))  # revealed: tuple[Literal[1], Literal["record"]]
 ```
 
 ## Type Aliases
@@ -704,26 +594,16 @@ def _(
     # error: [invalid-type-arguments] "No type argument provided for required type variable `U`"
     a10: Between[int],
 ):
-    # TODO: revealed: tuple[()]
-    reveal_type(a1)  # revealed: tuple[tuple[()], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a2)  # revealed: tuple[tuple[int, str], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a3)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
-    # TODO: revealed: tuple[int, bool, str]
-    reveal_type(a4)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
-    # TODO: revealed: tuple[int, bool, bytes, str]
-    reveal_type(a5)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a6)  # revealed: tuple[bool, *tuple[tuple[()], ...]]
-    # TODO: revealed: tuple[bool, int, str]
-    reveal_type(a7)  # revealed: tuple[bool, *tuple[tuple[int, str], ...]]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a8)  # revealed: tuple[*tuple[tuple[()], ...], bool]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a9)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
-    # TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+    reveal_type(a1)  # revealed: tuple[()]
+    reveal_type(a2)  # revealed: tuple[int, str]
+    reveal_type(a3)  # revealed: tuple[int, str]
+    reveal_type(a4)  # revealed: tuple[int, bool, str]
+    reveal_type(a5)  # revealed: tuple[int, bool, bytes, str]
+    reveal_type(a6)  # revealed: tuple[bool]
+    reveal_type(a7)  # revealed: tuple[bool, int, str]
+    reveal_type(a8)  # revealed: tuple[bool]
+    reveal_type(a9)  # revealed: tuple[int, str, bool]
+    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Unpacked tuple type arguments
@@ -732,10 +612,8 @@ def _(
 type Alias[*Ts] = tuple[int, *Ts]
 
 def _(a1: Alias[*tuple[str, bool]], a2: Alias[*tuple[str, ...]]) -> None:
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a1)  # revealed: tuple[int, *tuple[tuple[str, bool], ...]]
-    # TODO: revealed: tuple[int, *tuple[str, ...]]
-    reveal_type(a2)  # revealed: tuple[int, *tuple[tuple[str, ...], ...]]
+    reveal_type(a1)  # revealed: tuple[int, str, bool]
+    reveal_type(a2)  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
 ### Unspecified alias type arguments
@@ -749,10 +627,8 @@ from typing import Any
 type Headered[*Fields] = tuple[bytes, *Fields]
 
 def _(a1: Headered, a2: Headered[*tuple[Any, ...]]) -> None:
-    # TODO: revealed: tuple[bytes, *tuple[Unknown, ...]]
-    reveal_type(a1)  # revealed: tuple[bytes, *tuple[tuple[Unknown, ...], ...]]
-    # TODO: revealed: tuple[bytes, *tuple[Any, ...]]
-    reveal_type(a2)  # revealed: tuple[bytes, *tuple[tuple[Any, ...], ...]]
+    reveal_type(a1)  # revealed: tuple[bytes, *tuple[Unknown, ...]]
+    reveal_type(a2)  # revealed: tuple[bytes, *tuple[Any, ...]]
 ```
 
 ### Splitting arbitrary-length tuples

--- a/crates/ty_python_semantic/resources/mdtest/regression/typevartuple_exception_handler.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/typevartuple_exception_handler.md
@@ -1,0 +1,36 @@
+# `TypeVarTuple` in exception handlers
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+Semantic analysis should not panic when syntax recovery exposes a PEP 695 `TypeVarTuple` as an
+exception handler type on an older Python version.
+
+```py
+# error: [invalid-syntax]
+def regular[*Ts]() -> None:
+    try:
+        pass
+    # error: [invalid-exception-caught] "Invalid object caught in an exception handler: Object has type `TypeVarTuple`"
+    except Ts:
+        pass
+
+# error: [invalid-syntax]
+def tuple_handler[*Ts]() -> None:
+    try:
+        pass
+    # error: [invalid-exception-caught]
+    except (Ts,):
+        pass
+
+# error: [invalid-syntax]
+def starred[*Us]() -> None:
+    try:
+        pass
+    # error: 11 [invalid-syntax] "Cannot use `except*` on Python 3.10 (syntax was added in Python 3.11)"
+    # error: [invalid-exception-caught] "Invalid object caught in an exception handler: Object has type `TypeVarTuple`"
+    except* Us:
+        pass
+```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1476,6 +1476,42 @@ def g3(obj: Foo[tuple[A]]):
     f3(obj)
 ```
 
+### Assignability of generic types parameterized by typevar tuples
+
+For a class parameterized by a typevar tuple, the whole unpacked tuple participates in the generic
+class's variance.
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+```py
+from typing import Any, Generic, TypeVarTuple
+from ty_extensions import static_assert, is_assignable_to
+
+Ts = TypeVarTuple("Ts")
+
+class Array(Generic[*Ts]):
+    values: tuple[*Ts]
+
+    def gradual(self) -> "Array[*tuple[Any, ...]]":
+        return self
+
+static_assert(is_assignable_to(Array[int, str], Array[int, str]))
+static_assert(not is_assignable_to(Array[str, int], Array[int, str]))
+static_assert(not is_assignable_to(Array[int], Array[int, str]))
+
+OutTs = TypeVarTuple("OutTs", covariant=True)
+
+class CovariantArray(Generic[*OutTs]):
+    def get(self) -> tuple[*OutTs]:
+        raise NotImplementedError
+
+static_assert(is_assignable_to(CovariantArray[int, str], CovariantArray[object, object]))
+static_assert(not is_assignable_to(CovariantArray[object, object], CovariantArray[int, str]))
+```
+
 ## Generic aliases
 
 ```py

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -54,7 +54,7 @@ use crate::types::signatures::{
     CallableSignature, Parameter, ParameterKind, Parameters, ParametersKind, PartialApplication,
     PartialSignatureApplication,
 };
-use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
+use crate::types::tuple::{TupleLength, TupleSpec, TupleSpecBuilder, TupleType};
 use crate::types::typed_dict::{TypedDictOpenness, extract_unpacked_typed_dict_from_value_type};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarNonceGenerator};
 use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
@@ -5059,11 +5059,86 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         specialization_errors: &mut Vec<BindingError<'db>>,
     ) -> bool {
         let parameters = self.signature.parameters();
+        let starred_typevartuple_declared_type = |parameter: &Parameter<'db>| {
+            if !parameter.has_starred_annotation() {
+                return None;
+            }
+            if let Type::TypeVar(typevar) = parameter.annotated_type()
+                && typevar.is_typevartuple(self.db)
+            {
+                return Some(Type::tuple(TupleType::new(
+                    self.db,
+                    &TupleSpecBuilder::with_capacity(0)
+                        .concat_variadic_typevar(self.db, typevar)
+                        .build(),
+                )));
+            }
+            let tuple = parameter
+                .annotated_type()
+                .exact_tuple_instance_spec(self.db)?;
+            let TupleSpec::Variable(variable) = tuple.as_ref() else {
+                return None;
+            };
+            if matches!(
+                variable.variable(),
+                Type::TypeVar(typevar) if typevar.is_typevartuple(self.db)
+            ) {
+                Some(parameter.annotated_type())
+            } else {
+                None
+            }
+        };
+
+        let starred_typevartuple_declared_types = parameters
+            .iter()
+            .map(starred_typevartuple_declared_type)
+            .collect::<Vec<_>>();
+        let mut starred_typevartuple_arguments = starred_typevartuple_declared_types
+            .iter()
+            .map(|declared_type| declared_type.map(|_| Vec::new()))
+            .collect::<Vec<_>>();
+        if starred_typevartuple_arguments.iter().any(Option::is_some) {
+            for (argument_index, _, _, argument_types) in self.enumerate_argument_types() {
+                for matched_parameter in self.argument_matches[argument_index].iter() {
+                    let parameter_index = matched_parameter.index;
+                    if let Some(typevartuple_arguments) =
+                        &mut starred_typevartuple_arguments[parameter_index]
+                    {
+                        typevartuple_arguments
+                            .push(argument_types.get_default().unwrap_or(Type::unknown()));
+                    }
+                }
+            }
+        }
+
+        for (declared_type, argument_types) in starred_typevartuple_declared_types
+            .iter()
+            .zip(&starred_typevartuple_arguments)
+        {
+            let Some((declared_type, argument_types)) =
+                declared_type.as_ref().zip(argument_types.as_ref())
+            else {
+                continue;
+            };
+            let argument_type = Type::heterogeneous_tuple(self.db, argument_types.iter().copied());
+            let specialization_result = builder.infer(*declared_type, argument_type);
+
+            if let Err(error) = specialization_result {
+                specialization_errors.push(BindingError::SpecializationError {
+                    error,
+                    argument_index: None,
+                });
+            }
+        }
+
         for (argument_index, adjusted_argument_index, _, argument_types) in
             self.enumerate_argument_types()
         {
             for matched_parameter in self.argument_matches[argument_index].iter() {
                 let parameter_index = matched_parameter.index;
+                if starred_typevartuple_arguments[parameter_index].is_some() {
+                    continue;
+                }
                 if self.is_gradual_variadic_parameter(parameter_index) {
                     continue;
                 }
@@ -5231,6 +5306,67 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let is_paramspec_component_parameter = |parameter_index: usize| {
             paramspec_component_start.is_some_and(|start| parameter_index >= start)
         };
+
+        for (parameter_index, parameter) in self.signature.parameters().iter().enumerate() {
+            if !parameter.is_variadic()
+                || !parameter.has_starred_annotation()
+                || parameter
+                    .annotated_type()
+                    .exact_tuple_instance_spec(self.db)
+                    .is_none()
+            {
+                continue;
+            }
+
+            let mut positional_types = Vec::new();
+            let mut diagnostic_argument_index = None;
+            let mut has_unpacked_argument = false;
+            for (argument_index, adjusted_argument_index, argument, argument_types) in
+                self.enumerate_argument_types()
+            {
+                if !self.argument_matches[argument_index]
+                    .iter()
+                    .any(|matched_parameter| matched_parameter.index == parameter_index)
+                {
+                    continue;
+                }
+                if matches!(argument, Argument::Variadic) {
+                    has_unpacked_argument = true;
+                    break;
+                }
+                if !matches!(argument, Argument::Positional | Argument::Synthetic) {
+                    continue;
+                }
+                positional_types
+                    .push(argument_types.get_for_declared_type(parameter.annotated_type()));
+                diagnostic_argument_index = diagnostic_argument_index.or(adjusted_argument_index);
+            }
+            if has_unpacked_argument {
+                continue;
+            }
+
+            let provided_ty = Type::heterogeneous_tuple(self.db, positional_types);
+            let expected_ty = self.specialization.map_or_else(
+                || parameter.annotated_type(),
+                |specialization| {
+                    parameter
+                        .annotated_type()
+                        .apply_specialization(self.db, specialization)
+                },
+            );
+            if provided_ty
+                .when_assignable_to(self.db, expected_ty, constraints, self.inferable_typevars)
+                .is_never_satisfied(self.db)
+            {
+                self.errors.push(BindingError::InvalidArgumentType {
+                    parameter: ParameterContext::new(parameter, parameter_index, false),
+                    argument_index: diagnostic_argument_index,
+                    expected_ty,
+                    provided_ty,
+                    provenance: InvalidArgumentTypeProvenance::Argument,
+                });
+            }
+        }
 
         for (argument_index, adjusted_argument_index, argument, argument_types) in
             self.enumerate_argument_types()

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 
 use crate::types::callable::walk_callable_type;
 use crate::types::class::ClassType;
@@ -18,8 +19,10 @@ use crate::types::infer::original_class_type;
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
-use crate::types::signatures::{CallableSignature, Parameters, SignatureRelationVisitor};
-use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
+use crate::types::signatures::{
+    CallableSignature, Parameter, Parameters, Signature, SignatureRelationVisitor,
+};
+use crate::types::tuple::{TupleSpec, TupleSpecBuilder, TupleType, walk_tuple_type};
 use crate::types::type_alias::{walk_manual_pep_695_type_alias, walk_pep_695_type_alias};
 use crate::types::typevar::{
     BoundTypeVarIdentity, TypeVarIdentity, TypeVarInstance, walk_type_var_bounds,
@@ -1925,10 +1928,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             Option<ConstraintBounds<'db>>,
         ) -> Option<Type<'db>>,
     ) -> FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> {
+        // TODO: Move `ParamSpec` and `TypeVarTuple` handling to the new constraint solver.
         if generic_context
             .variables_inner(self.db)
             .values()
-            .any(|typevar| typevar.is_paramspec(self.db))
+            .any(|typevar| typevar.is_paramspec(self.db) || typevar.is_typevartuple(self.db))
         {
             return self.solve_hash_map_with(generic_context, choose);
         }
@@ -2192,17 +2196,42 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let identity = bound_typevar.identity(self.db);
         match self.types.entry(identity) {
             Entry::Occupied(mut entry) => {
-                // TODO: The spec says that when a ParamSpec is used multiple times in a signature,
-                // the type checker can solve it to a common behavioral supertype. We don't
-                // implement that yet so in case there are multiple ParamSpecs, use the
-                // specialization from the first occurrence.
-                // https://github.com/astral-sh/ty/issues/1778
-                // https://github.com/astral-sh/ruff/pull/21445#discussion_r2591510145
-                if bound_typevar.is_paramspec(self.db) {
-                    return;
+                match bound_typevar.kind(self.db) {
+                    TypeVarKind::ParamSpec | TypeVarKind::Pep695ParamSpec => {
+                        // TODO: The spec says that when a ParamSpec is used multiple times in a signature,
+                        // the type checker can solve it to a common behavioral supertype. We don't
+                        // implement that yet so in case there are multiple ParamSpecs, use the
+                        // specialization from the first occurrence.
+                        // https://github.com/astral-sh/ty/issues/1778
+                        // https://github.com/astral-sh/ruff/pull/21445#discussion_r2591510145
+                    }
+                    TypeVarKind::TypeVarTuple | TypeVarKind::Pep695TypeVarTuple => {
+                        // Repeated uses of a `TypeVarTuple` must have the same length, but the typing
+                        // spec leaves the exact inference behavior unspecified. Merge equal-length
+                        // candidates element-wise using unions.
+                        // https://typing.python.org/en/latest/spec/generics.html#type-variable-tuple-equality
+                        let accumulator = entry.get_mut();
+                        let existing = accumulator.get_or_build(self.db);
+                        let Some(existing_tuple) = existing.exact_tuple_instance_spec(self.db)
+                        else {
+                            return;
+                        };
+                        let Some(new_tuple) = ty.exact_tuple_instance_spec(self.db) else {
+                            return;
+                        };
+                        if existing_tuple.len() != new_tuple.len() {
+                            return;
+                        }
+                        let unioned = TupleSpecBuilder::from(existing_tuple.as_ref())
+                            .union(self.db, &new_tuple)
+                            .build();
+                        *accumulator =
+                            UnionAccumulator::new(Type::tuple(TupleType::new(self.db, &unioned)));
+                    }
+                    _ => {
+                        entry.get_mut().add(self.db, ty);
+                    }
                 }
-
-                entry.get_mut().add(self.db, ty);
             }
             Entry::Vacant(entry) => {
                 entry.insert(UnionAccumulator::new(ty));
@@ -2367,6 +2396,79 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             .then_some(mapping_when)
     }
 
+    fn infer_typevartuple_from_callable_parameters(
+        &mut self,
+        formal_signature: &Signature<'db>,
+        variadic_index: usize,
+        typevartuple: BoundTypeVarInstance<'db>,
+        actual_signature: &Signature<'db>,
+    ) {
+        let formal_parameters = formal_signature.parameters().as_slice();
+        let suffix_len = formal_parameters.len() - variadic_index - 1;
+        if !formal_parameters[..variadic_index]
+            .iter()
+            .chain(&formal_parameters[variadic_index + 1..])
+            .all(Parameter::is_positional)
+        {
+            return;
+        }
+
+        let actual_parameters = actual_signature.parameters().as_slice();
+        if !actual_parameters
+            .iter()
+            .all(|parameter| parameter.is_positional() || parameter.is_variadic())
+        {
+            return;
+        }
+
+        let tuple = if let Some(actual_variadic_index) =
+            actual_parameters.iter().position(Parameter::is_variadic)
+        {
+            // An actual variadic parameter can only satisfy the open-ended portion of the formal
+            // callable. It cannot provide a fixed suffix because callers are not required to pass
+            // any arguments to it.
+            if suffix_len > 0
+                || actual_variadic_index < variadic_index
+                || actual_variadic_index + 1 != actual_parameters.len()
+            {
+                return;
+            }
+
+            Type::tuple(TupleType::new(
+                self.db,
+                &TupleSpecBuilder::Variable {
+                    prefix: actual_parameters[variadic_index..actual_variadic_index]
+                        .iter()
+                        .map(Parameter::annotated_type)
+                        .collect(),
+                    variable: actual_parameters[actual_variadic_index].annotated_type(),
+                    suffix: vec![],
+                }
+                .build(),
+            ))
+        } else {
+            if actual_parameters.len() < variadic_index + suffix_len {
+                return;
+            }
+
+            let middle_end = actual_parameters.len() - suffix_len;
+            Type::heterogeneous_tuple(
+                self.db,
+                actual_parameters[variadic_index..middle_end]
+                    .iter()
+                    .map(Parameter::annotated_type),
+            )
+        };
+        self.add_type_mapping(typevartuple, tuple, TypeVarVariance::Contravariant);
+
+        let _ = self.infer_map_impl(
+            formal_signature.return_ty,
+            actual_signature.return_ty,
+            TypeVarVariance::Covariant,
+            &mut FxHashSet::default(),
+        );
+    }
+
     /// Infer type mappings by comparing formal callable signatures against actual callables.
     fn infer_from_callable_signature(
         &mut self,
@@ -2374,6 +2476,33 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         actual_callables: &CallableTypes<'db>,
     ) -> Result<(), ()> {
         let formal_is_single_paramspec = formal_signature.is_single_paramspec().is_some();
+
+        let typevartuple_formal_overloads: SmallVec<[_; 1]> = if formal_is_single_paramspec {
+            SmallVec::new()
+        } else {
+            formal_signature
+                .iter()
+                .filter_map(|formal_overload| {
+                    formal_overload
+                        .parameters()
+                        .as_slice()
+                        .iter()
+                        .find_position(|parameter| {
+                            parameter.is_variadic() && parameter.has_starred_annotation()
+                        })
+                        .and_then(|(index, parameter)| {
+                            let Type::TypeVar(typevartuple) = parameter.annotated_type() else {
+                                return None;
+                            };
+                            typevartuple.is_typevartuple(self.db).then_some((
+                                formal_overload,
+                                index,
+                                typevartuple,
+                            ))
+                        })
+                })
+                .collect()
+        };
 
         for actual_callable in actual_callables.as_slice() {
             if formal_is_single_paramspec {
@@ -2393,6 +2522,17 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     .overloads
                     .iter()
                     .filter_map(|actual_signature| {
+                        for (formal_overload, variadic_index, typevartuple) in
+                            &typevartuple_formal_overloads
+                        {
+                            self.infer_typevartuple_from_callable_parameters(
+                                formal_overload,
+                                *variadic_index,
+                                *typevartuple,
+                                actual_signature,
+                            );
+                        }
+
                         let when = actual_signature.when_constraint_set_assignable_to_signatures(
                             db,
                             formal_signature,
@@ -2845,6 +2985,46 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     formal.tuple_instance_spec(self.db),
                     actual_nominal.tuple_spec(self.db),
                 ) {
+                    if let TupleSpec::Variable(formal_variable) = formal_tuple.as_ref()
+                        && let Type::TypeVar(typevartuple) = formal_variable.variable()
+                        && typevartuple.is_typevartuple(self.db)
+                        && let TupleSpec::Fixed(actual_fixed) = actual_tuple.as_ref()
+                    {
+                        let prefix_len = formal_variable.prefix_elements().len();
+                        let suffix_len = formal_variable.suffix_elements().len();
+                        let actual_len = actual_fixed.len();
+                        let Some(middle_end) = actual_len.checked_sub(suffix_len) else {
+                            return Ok(());
+                        };
+                        if middle_end < prefix_len {
+                            return Ok(());
+                        }
+
+                        let actual_elements = actual_fixed.elements_slice();
+                        let variance = TypeVarVariance::Covariant.compose(polarity);
+                        for (formal_element, actual_element) in formal_variable
+                            .prefix_elements()
+                            .iter()
+                            .zip(&actual_elements[..prefix_len])
+                        {
+                            self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
+                        }
+                        for (formal_element, actual_element) in formal_variable
+                            .suffix_elements()
+                            .iter()
+                            .zip(&actual_elements[middle_end..])
+                        {
+                            self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
+                        }
+
+                        let packed = Type::heterogeneous_tuple(
+                            self.db,
+                            actual_elements[prefix_len..middle_end].iter().copied(),
+                        );
+                        self.add_type_mapping(typevartuple, packed, variance);
+                        return Ok(());
+                    }
+
                     let Some(most_precise_length) =
                         formal_tuple.len().most_precise(actual_tuple.len())
                     else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1998,6 +1998,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.exception_handler_symbol_ty_from_valid_ty(node_ty, type_base_exception)
         {
             symbol_ty
+        } else if is_typevartuple_type_or_instance(self.db(), node_ty) {
+            if let Some(node) = node {
+                report_invalid_exception_caught(&self.context, node, node_ty);
+            }
+            Type::unknown()
         } else if node_ty.is_assignable_to(
             self.db(),
             UnionType::from_two_elements(
@@ -2035,6 +2040,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ty: Type<'db>,
         type_base_exception: Type<'db>,
     ) -> Option<Type<'db>> {
+        if is_typevartuple_type_or_instance(self.db(), ty) {
+            return None;
+        }
+
         if let Some(tuple_spec) = ty.tuple_instance_spec(self.db()) {
             // `except (ValueError, TypeError) as e:`
             UnionType::try_from_elements(
@@ -11536,6 +11545,14 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
                         .zip(safe_mutable_class.generic_origin(db))
                         .is_some_and(|(l, r)| l == r)
             })
+    }
+}
+
+fn is_typevartuple_type_or_instance<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty {
+        Type::TypeVar(typevar) => typevar.is_typevartuple(db),
+        Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => typevar.is_typevartuple(db),
+        _ => false,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -15,6 +15,7 @@ use crate::types::enums::is_single_member_enum;
 use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
+use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -1354,6 +1355,32 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     .when_some_and(db, self.constraints, |(target_i, source_i)| {
                         self.check_type_pair(db, source_i, Type::TypeVar(target_i))
                     })
+            }
+
+            // A TypeVarTuple specialization is represented by one tuple value. Keep inferable
+            // TypeVarTuples bare for constraint solving, but compare fixed symbolic values using
+            // the same tuple relation as concrete specializations.
+            (Type::TypeVar(bound_typevar), target)
+                if !bound_typevar.is_inferable(db, self.inferable)
+                    && bound_typevar.is_typevartuple(db)
+                    && target.exact_tuple_instance_spec(db).is_some() =>
+            {
+                self.check_type_pair(
+                    db,
+                    Type::tuple(Some(TupleType::unpacked_typevartuple(db, bound_typevar))),
+                    target,
+                )
+            }
+            (source, Type::TypeVar(bound_typevar))
+                if !bound_typevar.is_inferable(db, self.inferable)
+                    && bound_typevar.is_typevartuple(db)
+                    && source.exact_tuple_instance_spec(db).is_some() =>
+            {
+                self.check_type_pair(
+                    db,
+                    source,
+                    Type::tuple(Some(TupleType::unpacked_typevartuple(db, bound_typevar))),
+                )
             }
 
             // A gradual `ParamSpec` value (`...`) is assignability-consistent with any concrete

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -30,6 +30,7 @@ use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
 use crate::types::relation::{
     HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker, TypeVarEvaluation,
 };
+use crate::types::tuple::Tuple;
 use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation;
 use crate::types::typevar::{BoundTypeVarIdentity, max_typevar_freshness_matching_generic_context};
 use crate::types::{
@@ -3673,7 +3674,7 @@ impl<'db> Parameters<'db> {
             .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
             .collect();
 
-        Self::from_parts(value, self.data.kind)
+        Self::from_parts(value, self.data.kind).expand_starred_variadic_annotations(db)
     }
     pub(crate) fn len(&self) -> usize {
         self.data.value.len()
@@ -3740,6 +3741,65 @@ impl<'db> Parameters<'db> {
         self.iter()
             .enumerate()
             .rfind(|(_, parameter)| parameter.is_keyword_variadic())
+    }
+
+    /// Expands an unpacked `*args` annotation into its logical callable parameters.
+    fn expand_starred_variadic_annotations(self, db: &'db dyn Db) -> Self {
+        if !self
+            .data
+            .value
+            .iter()
+            .any(|parameter| parameter.is_variadic() && parameter.has_starred_annotation())
+        {
+            return self;
+        }
+
+        let mut expanded = false;
+        let mut parameters = Vec::with_capacity(self.data.value.len());
+        for parameter in &self.data.value {
+            if parameter.is_variadic()
+                && parameter.has_starred_annotation()
+                && let Some(tuple) = parameter.annotated_type().exact_tuple_instance_spec(db)
+            {
+                expanded = true;
+                match tuple.as_ref() {
+                    Tuple::Fixed(tuple) => {
+                        parameters.extend(
+                            tuple
+                                .iter_all_elements()
+                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
+                        );
+                    }
+                    Tuple::Variable(variable) => {
+                        parameters.extend(
+                            variable
+                                .iter_prefix_elements()
+                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
+                        );
+                        let name = parameter
+                            .name()
+                            .cloned()
+                            .unwrap_or_else(|| Name::new_static("args"));
+                        parameters.push(
+                            Parameter::variadic(name).with_annotated_type(variable.variable()),
+                        );
+                        parameters.extend(
+                            variable
+                                .iter_suffix_elements()
+                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
+                        );
+                    }
+                }
+            } else {
+                parameters.push(parameter.clone());
+            }
+        }
+
+        if expanded {
+            Self::new(db, parameters)
+        } else {
+            self
+        }
     }
 
     /// Expands adjacent `P.args`/`P.kwargs` placeholders into their mapped parameters.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2267,12 +2267,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // self: callable without ParamSpec
                 // other: `Concatenate[<prefix_params>, P]`
                 (None, Some((target_prefix_params, target_bound_typevar))) => {
+                    let source_parameters = source
+                        .parameters
+                        .clone()
+                        .expand_starred_variadic_annotations(db);
                     // Loop over self parameters and target_prefix_params in a similar manner to the
                     // above loop
                     let mut parameters = ParametersZip {
                         current_source: None,
                         current_target: None,
-                        source_iter: source.parameters.iter(),
+                        source_iter: source_parameters.iter(),
                         target_iter: target_prefix_params.iter(),
                     };
 

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -199,6 +199,18 @@ impl<'db> TupleType<'db> {
         }
     }
 
+    /// Packs a `TypeVarTuple` into the tuple value used for generic specialization relations.
+    pub(crate) fn unpacked_typevartuple(
+        db: &'db dyn Db,
+        typevar: BoundTypeVarInstance<'db>,
+    ) -> Self {
+        debug_assert!(typevar.is_typevartuple(db));
+        TupleType::new_internal(
+            db,
+            VariableLengthTuple::mixed([], Type::TypeVar(typevar), []),
+        )
+    }
+
     // N.B. If this method is not Salsa-tracked, we take 10 minutes to check
     // `static-frame` as part of the ecosystem analysis. This is because it's called
     // from `NominalInstanceType::class()`, which is a very hot method.
@@ -1130,16 +1142,33 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> TupleSpec<'db> {
-        Self::mixed(
-            self.prefix_elements()
-                .iter()
-                .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
-            self.variable()
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-            self.suffix_elements()
-                .iter()
-                .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
-        )
+        let prefix = self
+            .prefix_elements()
+            .iter()
+            .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+        let variable = self.variable();
+        let mapped_variable = variable.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+        let suffix = self
+            .suffix_elements()
+            .iter()
+            .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+
+        if let Type::TypeVar(typevar) = variable
+            && typevar.is_typevartuple(db)
+            && let Some(mapped_tuple) = mapped_variable.exact_tuple_instance_spec(db)
+        {
+            let mut builder = TupleSpecBuilder::with_capacity(self.elements.len());
+            for element in prefix {
+                builder.push(element);
+            }
+            builder = builder.concat(db, &mapped_tuple);
+            for element in suffix {
+                builder.push(element);
+            }
+            return builder.build();
+        }
+
+        Self::mixed(prefix, mapped_variable, suffix)
     }
 
     fn find_legacy_typevars_impl(

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -543,8 +543,7 @@ if __name__ == "__main__":
     )
     # https://stackoverflow.com/a/58840987/3549270
     for signal in [SIGINT, SIGTERM]:
-        # TODO: Remove once starred variadic annotations are expanded for callable matching.
-        loop.add_signal_handler(signal, main_task.cancel)  # ty: ignore[invalid-argument-type]
+        loop.add_signal_handler(signal, main_task.cancel)
     try:
         loop.run_until_complete(main_task)
     finally:


### PR DESCRIPTION
## Summary

- infer concrete `TypeVarTuple` specializations in generic calls, tuple relations, and callable signatures
- preserve variadic tuple shape when expanding unpacked annotations, including the prefixed `ParamSpec` interoperability case
- avoid exception-handler recovery panics when malformed or version-gated syntax exposes a `TypeVarTuple`

This is stacked on #25240 and should be reviewed after the type-form foundation. The completed stack preserves the exact final source tree of the original combined branch.

## Why

The type-form layer can represent `TypeVarTuple` and `Unpack`, but the legacy constraint solver previously treated variadic inference like an ordinary scalar mapping. That left generic and callable specializations imprecise and exposed two adjacent recovery and `ParamSpec` edge cases.

## Validation

- focused PEP 695 TypeVarTuple, legacy TypeVarTuple, legacy Unpack, and exception-handler regression mdtests
- `cargo nextest run -p ty_python_semantic`: 562 passed, 34 skipped
- `uvx prek run --files ...` over all 15 files changed from the base
- no changed or pending snapshots
- final tree verified byte-for-byte against the preserved original combined branch
