### PR TITLE
Prioritize human-readable names in CLI output

### DIFF
--- a/crates/ruff/src/printer.rs
+++ b/crates/ruff/src/printer.rs
@@ -14,7 +14,7 @@ use ruff_linter::fs::relativize_path;
 use ruff_linter::logging::LogLevel;
 use ruff_linter::message::{EmitterContext, render_diagnostics};
 use ruff_linter::notify_user;
-use ruff_linter::preview::is_warning_severity_enabled;
+use ruff_linter::preview::{is_human_readable_names_enabled, is_warning_severity_enabled};
 use ruff_linter::settings::flags::{self};
 use ruff_linter::settings::types::{OutputFormat, PreviewMode, UnsafeFixes};
 
@@ -223,7 +223,7 @@ impl Printer {
                 if self.flags.intersects(Flags::SHOW_FIX_SUMMARY) {
                     if !diagnostics.fixed.is_empty() {
                         writeln!(writer)?;
-                        print_fix_summary(writer, &diagnostics.fixed)?;
+                        print_fix_summary(writer, &diagnostics.fixed, preview)?;
                         writeln!(writer)?;
                     }
                 }
@@ -252,7 +252,7 @@ impl Printer {
             if self.flags.intersects(Flags::SHOW_FIX_SUMMARY) {
                 if !diagnostics.fixed.is_empty() {
                     writeln!(writer)?;
-                    print_fix_summary(writer, &diagnostics.fixed)?;
+                    print_fix_summary(writer, &diagnostics.fixed, preview)?;
                     writeln!(writer)?;
                 }
             }
@@ -447,7 +447,7 @@ fn show_fix_status(fix_mode: flags::FixMode, fixables: Option<&FixableStatistics
     (!fix_mode.is_apply()) && fixables.is_some_and(FixableStatistics::any_applicable_fixes)
 }
 
-fn print_fix_summary(writer: &mut dyn Write, fixed: &FixMap) -> Result<()> {
+fn print_fix_summary(writer: &mut dyn Write, fixed: &FixMap, preview: PreviewMode) -> Result<()> {
     let total = fixed
         .values()
         .map(|table| table.counts().sum::<usize>())
@@ -477,11 +477,19 @@ fn print_fix_summary(writer: &mut dyn Write, fixed: &FixMap) -> Result<()> {
             ":".cyan()
         )?;
         for (code, name, count) in table.iter().sorted_by_key(|(.., count)| Reverse(*count)) {
-            writeln!(
-                writer,
-                "    {count:>num_digits$} × {code} ({name})",
-                code = code.to_string().red().bold(),
-            )?;
+            if is_human_readable_names_enabled(preview) {
+                writeln!(
+                    writer,
+                    "    {count:>num_digits$} × {name} ({code})",
+                    name = name.to_string().red().bold(),
+                )?;
+            } else {
+                writeln!(
+                    writer,
+                    "    {count:>num_digits$} × {code} ({name})",
+                    code = code.to_string().red().bold(),
+                )?;
+            }
         }
     }
     Ok(())

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -3704,6 +3704,37 @@ fn output_format_show_fixes(output_format: &str) -> Result<()> {
 }
 
 #[test]
+fn show_fixes_preview() -> Result<()> {
+    let fixture = CliTest::with_file("input.py", "import os  # F401")?;
+
+    assert_cmd_snapshot!(
+        fixture.check_command().args([
+            "--select",
+            "F401",
+            "--fix",
+            "--show-fixes",
+            "--preview",
+            "input.py",
+        ]),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    Fixed 1 error:
+    - input.py:
+        1 × unused-import (F401)
+
+    Found 1 error (1 fixed, 0 remaining).
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn up045_nested_optional_flatten_all() {
     let contents = "\
 from typing import Optional

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -369,6 +369,6 @@ pub(crate) const fn is_pep604_future_annotations_fix_enabled(settings: &LinterSe
 }
 
 // https://github.com/astral-sh/ruff/pull/25614
-pub(crate) const fn is_human_readable_names_enabled(preview: PreviewMode) -> bool {
+pub const fn is_human_readable_names_enabled(preview: PreviewMode) -> bool {
     preview.is_enabled()
 }


### PR DESCRIPTION
Summary
--

This PR swaps the rule name and code in our `--show-fixes` output, which previously looked like
this:

<img width="324" height="107" alt="image" src="https://github.com/user-attachments/assets/32dff652-421c-4e7a-adbd-ac87cc740965" />

and now looks like this in preview:

<img width="314" height="103" alt="image" src="https://github.com/user-attachments/assets/d7d942d6-d5a5-4622-b9a2-a271eb5b0663" />


The actual code change is just for this one flag, but I also examined the other CLI flags (besides
diagnostic output formats, which I'll update separately) and think that nothing else needs to be
updated. The other two main candidates were `--statistics` and `--show-settings`, but these already
show both codes and names prominently. `--show-settings` even prioritizes them over codes:

```console
❯ ruff check --no-cache --ignore-noqa --statistics
1       F401    [*] unused-import
Found 1 error.
[*] 1 fixable with the `--fix` option.

❯ ruff check --no-cache --show-settings
...
linter.rules.enabled = [
        multiple-imports-on-one-line (E401),
        module-import-not-at-top-of-file (E402),
	...
]
...
```

Test Plan
--

New CLI test and the screenshots above
