### PR TITLE
[ty] Narrow tuple expression match subjects

### DIFF
--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -796,6 +796,16 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
             places.insert(place);
         }
 
+        // This is a conservative upper bound. Semantic evaluation decides whether the pattern can
+        // actually project constraints onto these names.
+        if let ast::Expr::Tuple(tuple) = subject_node
+            && tuple.elts.iter().all(ast::Expr::is_name_expr)
+        {
+            for element in &tuple.elts {
+                places.extend(self.simple_expr(element));
+            }
+        }
+
         places.extend(self.pattern_aliases_kind(kind));
         places
     }

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -583,6 +583,42 @@ def test_match_exact_tuple_sequence(subj: tuple[int | str, int | str]) -> None:
             # intersection above.
             reveal_type(subj[1])  # revealed: int | str
 
+class TupleSubjectA: ...
+class TupleSubjectA1(TupleSubjectA): ...
+class TupleSubjectB: ...
+class TupleSubjectB1(TupleSubjectB): ...
+
+def match_tuple_expression_subject(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+            reveal_type(b)  # revealed: TupleSubjectB1
+        case _:
+            # Failing the first pattern does not tell us which element failed to match.
+            reveal_type(a)  # revealed: TupleSubjectA
+            reveal_type(b)  # revealed: TupleSubjectB
+
+def match_tuple_expression_or_pattern(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()] | [*_]:
+            # The second alternative does not constrain either tuple element.
+            reveal_type(a)  # revealed: TupleSubjectA
+            reveal_type(b)  # revealed: TupleSubjectB
+
+def match_repeated_tuple_expression_subject(a: TupleSubjectA) -> None:
+    match a, a:
+        case [TupleSubjectA1(), TupleSubjectA()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+
+def match_tuple_expression_subject_rebinding(
+    x: TupleSubjectA | TupleSubjectB,
+    b: TupleSubjectB,
+) -> None:
+    match x, (x := b):
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            # The second subject expression rebinds `x` after the tuple stores its first value.
+            reveal_type(x)  # revealed: TupleSubjectB
+
 def test_match_exact_tuple_sequence_is_exhaustive(value: int | tuple[int, int]) -> int:
     match value:
         case int(value):
@@ -971,6 +1007,11 @@ def _(x: A | B | C):
             reveal_type(x)  # revealed: A
         case _:
             reveal_type(x)  # revealed: (B & ~A) | (C & ~A)
+
+def unconstrained_or_alternative(x: A | B, flag: bool) -> None:
+    match x:
+        case A() | _ if flag:
+            reveal_type(x)  # revealed: A | B
 ```
 
 ## Or patterns with guard

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1102,9 +1102,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
     /// Return the type a subject can have after successfully matching `pattern`.
     ///
-    /// This is used for `as` bindings and nested captures. Unlike ordinary subject narrowing, it
-    /// must retain arms that can match through custom equality and preserve the original identity
-    /// of generic subjects where possible.
+    /// This is used for `as` bindings, nested captures, and tuple-subject projections. Unlike
+    /// ordinary subject narrowing, it must retain arms that can match through custom equality and
+    /// preserve the original identity of generic subjects where possible.
     fn match_pattern_subject_type(
         &mut self,
         pattern: &PatternPredicateKind<'db>,
@@ -1238,7 +1238,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
-    /// Infer each sequence capture from subject arms that can satisfy the complete pattern.
+    /// Infer each sequence element type from subject arms that can satisfy the complete pattern.
     ///
     /// Filtering the whole arm before combining element types preserves correlations such as the
     /// first element of `tuple[Literal[1], int] | tuple[Literal[2], str]`.
@@ -2634,20 +2634,53 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         kind: &SequencePatternPredicateKind<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        let constraint = if is_positive {
-            NarrowingConstraint::intersection(self.necessary_sequence_pattern_type(kind))
-        } else {
-            let sequence_type = definite_sequence_pattern_type(self.db, kind);
-            if sequence_type.is_never() {
-                return None;
-            }
-            NarrowingConstraint::intersection(sequence_type.negate(self.db))
+        let subject_node = subject.node_ref(self.db).node(self.module);
+        if let Some(subject_place) = PlaceExpr::try_from_expr(subject_node) {
+            let constraint_ty = if is_positive {
+                self.necessary_sequence_pattern_type(kind)
+            } else {
+                let sequence_type = definite_sequence_pattern_type(self.db, kind);
+                if sequence_type.is_never() {
+                    return None;
+                }
+                sequence_type.negate(self.db)
+            };
+            return Some(NarrowingConstraints::from_iter([(
+                self.expect_place(&subject_place),
+                NarrowingConstraint::intersection(constraint_ty),
+            )]));
+        }
+
+        // A failed sequence pattern does not tell us which element failed. Only project a
+        // successful exact match when every tuple-subject element is a simple name; evaluating
+        // more complex expressions could rebind or mutate an earlier place.
+        let ast::Expr::Tuple(tuple) = subject_node else {
+            return None;
         };
+        if !is_positive
+            || kind.split_around_star().is_some()
+            || tuple.elts.len() != kind.patterns.len()
+            || !tuple.elts.iter().all(ast::Expr::is_name_expr)
+        {
+            return None;
+        }
 
-        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
-        let place = self.expect_place(&subject);
+        let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
+        let element_types = self.match_sequence_pattern_element_types(kind, subject_ty);
+        let mut constraints = NarrowingConstraints::default();
 
-        Some(NarrowingConstraints::from_iter([(place, constraint)]))
+        for ((element, pattern), element_ty) in
+            tuple.elts.iter().zip(&kind.patterns).zip(element_types)
+        {
+            let element = PlaceExpr::try_from_expr(element)?;
+            let matched_ty = self.match_pattern_subject_type(pattern, element_ty);
+            insert_narrowing_constraint(
+                &mut constraints,
+                self.expect_place(&element),
+                NarrowingConstraint::intersection(matched_ty),
+            );
+        }
+        (!constraints.is_empty()).then_some(constraints)
     }
 
     fn evaluate_match_pattern_value(
@@ -2726,22 +2759,19 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         predicates: &Vec<PatternPredicateKind<'db>>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        // DeMorgan's law---if the overall `or` is negated, we need to `and` the negated sub-constraints.
-        let merge_constraints = if is_positive {
-            merge_constraints_or
-        } else {
-            merge_constraints_and
+        // An unconstrained positive alternative cancels narrowing; negated alternatives combine.
+        let merge_constraints = |left, right| {
+            if is_positive {
+                Self::merge_optional_constraints_or(left, right)
+            } else {
+                Self::merge_optional_constraints_and(left, right)
+            }
         };
-
         predicates
             .iter()
-            .filter_map(|predicate| {
-                self.evaluate_pattern_predicate_kind(predicate, subject, is_positive)
-            })
-            .reduce(|mut constraints, constraints_| {
-                merge_constraints(&mut constraints, constraints_);
-                constraints
-            })
+            .map(|predicate| self.evaluate_pattern_predicate_kind(predicate, subject, is_positive))
+            .reduce(merge_constraints)
+            .flatten()
     }
 
     fn evaluate_bool_op(


### PR DESCRIPTION
## Summary

This is stacked on #25637, which provides the complete-pattern element inference reused here.

Prior to this change, we narrowed a tuple value used as a match subject, but not the names used to construct a tuple expression:

```py
class A: ...
class A1(A): ...
class B: ...
class B1(B): ...

def f(a: A, b: B) -> None:
    match a, b:
        case [A1(), B1()]:
            reveal_type(a)  # revealed: A1
            reveal_type(b)  # revealed: B1
```

This projects a successful exact sequence match back onto each simple-name tuple element. We retain whole-pattern filtering from #25637 and intersect constraints for repeated names. We do not project failed matches because they do not identify which element failed, and we exclude more complex subject expressions because they can rebind or mutate an earlier place before the case body.

We also preserve unconstrained `or` alternatives when combining pattern constraints, so one constrained alternative cannot narrow the overall match.

Closes https://github.com/astral-sh/ty/issues/3743.
