### PR TITLE
[ty] Preserve class-object intersections during receiver binding

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -474,6 +474,32 @@ def _(cls: Intersection[type[A], type[B], Not[Meta]]):
     reveal_type(cls.make())  # revealed: A & B
 ```
 
+### Deferred class-object projection arms
+
+```py
+from typing import Protocol, Self
+from ty_extensions import Intersection
+
+class A:
+    @classmethod
+    def make(cls) -> Self:
+        return cls()
+
+class B: ...
+
+class HasClassMarker(Protocol):
+    marker: int
+
+def structural_arm(cls: Intersection[type[A], type[B], HasClassMarker]):
+    # TODO: This should reveal `A & B`. The protocol constrains the class object itself and should
+    # not prevent the nominal class-object arms from being projected onto instances.
+    reveal_type(cls.make())  # revealed: A
+
+def typevar_arm[U](cls: Intersection[type[A], type[U]]):
+    # TODO: This should reveal `A & U@typevar_arm` once class-object TypeVar arms are projected.
+    reveal_type(cls.make())  # revealed: A
+```
+
 ### Calling `super()` in overridden methods with `Self` return type
 
 This is a regression test for <https://github.com/astral-sh/ty/issues/2122>.

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -431,8 +431,8 @@ reveal_type(GenericCircle.baz(1))  # revealed: GenericShape[Literal[1]]
 ### Class-object intersection
 
 ```py
-from typing import Self
-from ty_extensions import Intersection
+from typing import Any, Self
+from ty_extensions import Intersection, Unknown
 
 class A:
     @classmethod
@@ -448,6 +448,15 @@ class B: ...
 def _(cls: Intersection[type[A], type[B]]):
     reveal_type(cls.make())  # revealed: A & B
     reveal_type(cls.self_type())  # revealed: type[A] & type[B]
+
+def _(cls: Intersection[type[A], Any]):
+    reveal_type(cls.make())  # revealed: A & Any
+
+def _(cls: Intersection[type[A], type[Any]]):
+    reveal_type(cls.make())  # revealed: A & Any
+
+def _(cls: Intersection[type[A], type[Unknown]]):
+    reveal_type(cls.make())  # revealed: A & Unknown
 ```
 
 ### Calling `super()` in overridden methods with `Self` return type

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -428,6 +428,28 @@ reveal_type(GenericCircle[int].bar())  # revealed: GenericCircle[int]
 reveal_type(GenericCircle.baz(1))  # revealed: GenericShape[Literal[1]]
 ```
 
+### Class-object intersection
+
+```py
+from typing import Self
+from ty_extensions import Intersection
+
+class A:
+    @classmethod
+    def make(cls) -> Self:
+        return cls()
+
+    @classmethod
+    def self_type(cls) -> type[Self]:
+        return cls
+
+class B: ...
+
+def _(cls: Intersection[type[A], type[B]]):
+    reveal_type(cls.make())  # revealed: A & B
+    reveal_type(cls.self_type())  # revealed: type[A] & type[B]
+```
+
 ### Calling `super()` in overridden methods with `Self` return type
 
 This is a regression test for <https://github.com/astral-sh/ty/issues/2122>.

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -432,7 +432,7 @@ reveal_type(GenericCircle.baz(1))  # revealed: GenericShape[Literal[1]]
 
 ```py
 from typing import Any, Self
-from ty_extensions import Intersection, Unknown
+from ty_extensions import Intersection, Not, Unknown
 
 class A:
     @classmethod
@@ -457,6 +457,21 @@ def _(cls: Intersection[type[A], type[Any]]):
 
 def _(cls: Intersection[type[A], type[Unknown]]):
     reveal_type(cls.make())  # revealed: A & Unknown
+
+def _(cls: Intersection[type[A], Not[type[B]]]):
+    reveal_type(cls.make())  # revealed: A & ~B
+
+# Exact-class and metaclass exclusions constrain the class object itself, so they are skipped while
+# the other class-object arms are projected onto instances.
+def _(cls: Intersection[type[A], Any]):
+    if cls is not A:
+        reveal_type(cls.make())  # revealed: A & Any
+
+class Meta(type): ...
+
+def _(cls: Intersection[type[A], type[B], Not[Meta]]):
+    reveal_type(cls)  # revealed: type[A] & type[B] & ~Meta
+    reveal_type(cls.make())  # revealed: A & B
 ```
 
 ### Calling `super()` in overridden methods with `Self` return type

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1906,6 +1906,27 @@ def _(a_and_b: Intersection[A, B]):
     reveal_type(a_and_b.desc)  # revealed: A & B
 ```
 
+### Descriptor owner binding uses the full class-object intersection
+
+```py
+from typing import TypeVar
+from ty_extensions import Intersection
+
+T = TypeVar("T")
+
+class Descriptor:
+    def __get__(self, instance: object, owner: T, /) -> T:
+        return owner
+
+class A:
+    desc = Descriptor()
+
+class B: ...
+
+def _(a_and_b: Intersection[type[A], type[B]]):
+    reveal_type(a_and_b.desc)  # revealed: type[A] & type[B]
+```
+
 ### Negation types
 
 Make sure that attributes accessible on `object` are also accessible on a negation type like `~P`,

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -190,6 +190,129 @@ reveal_type(Box[int]().specialized)  # revealed: bound method Box[int].specializ
 reveal_type(Box[str]().specialized)  # revealed: Overload[(x: str) -> str, (x: int) -> int]
 ```
 
+## Class-object intersection receivers
+
+Binding a classmethod to a class-object intersection filters overloads whose explicit `cls`
+annotation cannot accept that receiver. The bound method type is filtered correctly, but the call
+diagnostic still includes rejected overloads.
+
+### Multiple matching receivers
+
+```py
+from __future__ import annotations
+
+from typing import overload
+from ty_extensions import Intersection
+
+class Base:
+    @overload
+    @classmethod
+    def choose(cls: type[C], value: str) -> str: ...
+    @overload
+    @classmethod
+    def choose(cls: type[A], value: int) -> int: ...
+    @overload
+    @classmethod
+    def choose(cls: type[A], value: bytes) -> bytes: ...
+    @classmethod
+    def choose(cls: type[Base], value: object) -> object:
+        return value
+
+class A(Base): ...
+class B: ...
+class C(Base): ...
+
+def _(cls: Intersection[type[A], type[B]]):
+    reveal_type(cls.choose)  # revealed: Overload[(value: int) -> int, (value: bytes) -> bytes]
+    # TODO: The diagnostic should list only the two `type[A]` overloads and point to the `int`
+    # overload as the first candidate.
+    cls.choose(1.0)  # snapshot: no-matching-overload
+```
+
+```snapshot
+error[no-matching-overload]: No overload of bound method `Base.choose` matches arguments
+  --> src/mdtest_snippet.py:28:5
+   |
+28 |     cls.choose(1.0)  # snapshot: no-matching-overload
+   |     ^^^^^^^^^^^^^^^
+   |
+info: First overload defined here
+ --> src/mdtest_snippet.py:7:5
+  |
+7 | /     @overload
+8 | |     @classmethod
+9 | |     def choose(cls: type[C], value: str) -> str: ...
+  | |____________________________________________________^ First overload defined here
+  |
+info: Possible overloads for bound method `choose`:
+info:   (cls: type[C], value: str) -> str
+info:   (cls: type[A], value: int) -> int
+info:   (cls: type[A], value: bytes) -> bytes
+info: Overload implementation defined here
+  --> src/mdtest_snippet.py:17:9
+   |
+17 |     def choose(cls: type[Base], value: object) -> object:
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+```
+
+### One matching receiver
+
+```py
+from __future__ import annotations
+
+from typing import overload
+from ty_extensions import Intersection
+
+class Base:
+    @overload
+    @classmethod
+    def choose(cls: type[A], value: int) -> int: ...
+    @overload
+    @classmethod
+    def choose(cls: type[C], value: str) -> str: ...
+    @classmethod
+    def choose(cls: type[Base], value: object) -> object:
+        return value
+
+class A(Base): ...
+class B: ...
+class C(Base): ...
+
+def _(cls: Intersection[type[A], type[B]]):
+    # revealed: bound method (type[A] & type[B]).choose(value: int) -> int
+    reveal_type(cls.choose)
+    # TODO: The diagnostic should list only the surviving `type[A]` overload.
+    result = cls.choose(1.0)  # snapshot: no-matching-overload
+    reveal_type(result)  # revealed: Unknown
+```
+
+```snapshot
+error[no-matching-overload]: No overload of bound method `Base.choose` matches arguments
+  --> src/mdtest_snippet.py:25:14
+   |
+25 |     result = cls.choose(1.0)  # snapshot: no-matching-overload
+   |              ^^^^^^^^^^^^^^^
+   |
+info: First overload defined here
+ --> src/mdtest_snippet.py:7:5
+  |
+7 | /     @overload
+8 | |     @classmethod
+9 | |     def choose(cls: type[A], value: int) -> int: ...
+  | |____________________________________________________^ First overload defined here
+  |
+info: Possible overloads for bound method `choose`:
+info:   (cls: type[A], value: int) -> int
+info:   (cls: type[C], value: str) -> str
+info: Overload implementation defined here
+  --> src/mdtest_snippet.py:14:9
+   |
+14 |     def choose(cls: type[Base], value: object) -> object:
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+```
+
 ## Nominal receiver mismatches
 
 `BaseForAny[Any]` has a dynamic type argument, but it is not necessarily an instance of its subclass

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -327,6 +327,15 @@ def f1[T](x: type[T]) -> type[T]:
 reveal_type(f1(int))  # revealed: type[int]
 reveal_type(f1(object))  # revealed: type
 
+class A: ...
+class B: ...
+
+def _(x: type[object]) -> None:
+    if issubclass(x, A):
+        reveal_type(f1(x))  # revealed: type[A]
+        if issubclass(x, B):
+            reveal_type(f1(x))  # revealed: type[A] & type[B]
+
 def f2[T](x: T) -> type[T]:
     return type(x)
 

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -319,7 +319,8 @@ def _[T](x: X[type[T]]):
 ## Generic Type Inference
 
 ```py
-from typing import Callable
+from typing import Any, Callable
+from ty_extensions import Intersection, Unknown
 
 def f1[T](x: type[T]) -> type[T]:
     return x
@@ -335,6 +336,15 @@ def _(x: type[object]) -> None:
         reveal_type(f1(x))  # revealed: type[A]
         if issubclass(x, B):
             reveal_type(f1(x))  # revealed: type[A] & type[B]
+
+def _(cls: Intersection[type[A], Any]):
+    reveal_type(f1(cls))  # revealed: type[A] & type[Any]
+
+def _(cls: Intersection[type[A], type[Any]]):
+    reveal_type(f1(cls))  # revealed: type[A] & type[Any]
+
+def _(cls: Intersection[type[A], type[Unknown]]):
+    reveal_type(f1(cls))  # revealed: type[A] & type[Unknown]
 
 def f2[T](x: T) -> type[T]:
     return type(x)

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -350,6 +350,11 @@ def _(cls: type[A]):
     if not issubclass(cls, B):
         reveal_type(f1(cls))  # revealed: type[A] & ~type[B]
 
+def typevar_arm[U](cls: Intersection[type[A], type[U]]):
+    # TODO: This should reveal `type[A] & type[U@typevar_arm]` once class-object TypeVar arms are
+    # projected as a single inference constraint.
+    reveal_type(f1(cls))  # revealed: type[A | U@typevar_arm]
+
 def f2[T](x: T) -> type[T]:
     return type(x)
 

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -346,6 +346,10 @@ def _(cls: Intersection[type[A], type[Any]]):
 def _(cls: Intersection[type[A], type[Unknown]]):
     reveal_type(f1(cls))  # revealed: type[A] & type[Unknown]
 
+def _(cls: type[A]):
+    if not issubclass(cls, B):
+        reveal_type(f1(cls))  # revealed: type[A] & ~type[B]
+
 def f2[T](x: T) -> type[T]:
     return type(x)
 
@@ -362,6 +366,10 @@ reveal_type(f2(foo))  # revealed: <class 'FunctionType'>
 
 def _(x: Callable[[int], int]):
     reveal_type(f2(x))  # revealed: type
+
+def _(x: A):
+    if not isinstance(x, B):
+        reveal_type(f2(x))  # revealed: type[A] & ~type[B]
 
 class Meta(type): ...
 class Base(metaclass=Meta): ...

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3940,8 +3940,12 @@ impl<'db> Type<'db> {
 
                     let class_attr_plain = this.class_object_member(db, name_str, policy);
 
-                    let self_instance = this
-                        .to_instance(db)
+                    let receiver_instance = match receiver {
+                        Type::Intersection(intersection) => intersection.to_instance(db),
+                        _ => receiver.to_instance(db),
+                    };
+                    let self_instance = receiver_instance
+                        .or_else(|| this.to_instance(db))
                         .expect("`to_instance` always returns `Some` for `ClassLiteral`, `GenericAlias`, and `SubclassOf`");
                     let class_attr_plain =
                         class_attr_plain.map_type(|ty| ty.bind_self_typevars(db, self_instance));
@@ -5560,7 +5564,11 @@ impl<'db> Type<'db> {
             // mapped through `to_instance`.
             Type::TypeVar(bound_typevar) => Some(Type::TypeVar(bound_typevar.to_instance(db)?)),
             Type::TypeAlias(alias) => alias.value_type(db).to_instance(db),
-            Type::Intersection(_) => Some(todo_type!("Type::Intersection.to_instance")),
+            Type::Intersection(intersection) => Some(
+                intersection
+                    .to_instance(db)
+                    .unwrap_or_else(|| todo_type!("Type::Intersection.to_instance")),
+            ),
             // An instance of class `C` may itself have instances if `C` is a subclass of `type`.
             Type::NominalInstance(instance)
                 if KnownClass::Type

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3916,6 +3916,8 @@ impl<'db> Type<'db> {
                 }
 
                 Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
+                    let receiver = receiver.unwrap_or(this);
+
                     let enum_class = match this {
                         Type::ClassLiteral(literal) => Some(literal),
                         Type::SubclassOf(subclass_of) => subclass_of
@@ -3939,17 +3941,22 @@ impl<'db> Type<'db> {
                     let class_attr_plain = this.class_object_member(db, name_str, policy);
 
                     let self_instance = this
-                    .to_instance(db)
-                    .expect("`to_instance` always returns `Some` for `ClassLiteral`, `GenericAlias`, and `SubclassOf`");
+                        .to_instance(db)
+                        .expect("`to_instance` always returns `Some` for `ClassLiteral`, `GenericAlias`, and `SubclassOf`");
                     let class_attr_plain =
                         class_attr_plain.map_type(|ty| ty.bind_self_typevars(db, self_instance));
 
-                    let class_attr_fallback =
-                        Type::try_call_dunder_get_on_attribute(db, class_attr_plain, None, this).0;
+                    let class_attr_fallback = Type::try_call_dunder_get_on_attribute(
+                        db,
+                        class_attr_plain,
+                        None,
+                        receiver,
+                    )
+                    .0;
 
                     let result = this.invoke_descriptor_protocol(
                         db,
-                        this,
+                        receiver,
                         name_str,
                         class_attr_fallback,
                         InstanceFallbackShadowsNonDataDescriptor::Yes,

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2742,7 +2742,22 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     self.infer_map_impl(positive, actual, polarity, seen)?;
                 }
             }
-            (_, Type::Intersection(actual_intersection)) => {
+            (formal, Type::Intersection(actual_intersection)) => {
+                if let Type::SubclassOf(formal_subclass) = formal
+                    && let Some(formal_typevar) = formal_subclass.into_type_var()
+                    && let Some(actual_instance) = actual_intersection.to_instance(self.db)
+                {
+                    // `type[A] & type[B]` is the class-object form of `A & B`. Preserve that
+                    // conjunction as one inference constraint instead of inferring from each
+                    // positive element separately, which would produce `A | B`.
+                    return self.infer_map_impl(
+                        Type::TypeVar(formal_typevar),
+                        actual_instance,
+                        polarity,
+                        seen,
+                    );
+                }
+
                 // Try to infer type mappings by checking against each intersection element. This
                 // is the dual of the `union_formal` arm above, and it handles cases like:
                 //

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -806,10 +806,11 @@ impl<'db> IntersectionType<'db> {
     /// Convert a class-object intersection such as `type[A] & type[B]` to `A & B`.
     ///
     /// This is deliberately conservative: every positive element must map to a nominal or gradual
-    /// instance, and intersections with negative elements are left unsupported. Structural
+    /// instance. Negative subclass constraints that map to nominal instances are retained; other
+    /// negative elements constrain the class object itself and are omitted. Structural positive
     /// elements do not have a lossless instance-space projection.
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        if self.positive(db).is_empty() || !self.negative(db).is_empty() {
+        if self.positive(db).is_empty() {
             return None;
         }
 
@@ -830,6 +831,18 @@ impl<'db> IntersectionType<'db> {
             }
             builder = builder.add_positive(instance);
         }
+
+        for element in self.negative(db) {
+            let Type::SubclassOf(subclass_of) = element else {
+                continue;
+            };
+            let instance = subclass_of.to_instance(db);
+            if !matches!(instance, Type::NominalInstance(_)) {
+                continue;
+            }
+            builder = builder.add_negative(instance);
+        }
+
         Some(builder.build())
     }
 
@@ -840,7 +853,7 @@ impl<'db> IntersectionType<'db> {
     /// Unsupported elements retain the existing intersection meta-type fallback instead of being
     /// discarded.
     pub(crate) fn to_meta_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        if self.positive(db).is_empty() || !self.negative(db).is_empty() {
+        if self.positive(db).is_empty() {
             return None;
         }
 
@@ -851,6 +864,14 @@ impl<'db> IntersectionType<'db> {
             }
             builder = builder.add_positive(element.to_meta_type(db));
         }
+
+        for element in self.negative(db) {
+            if !matches!(element, Type::NominalInstance(_)) {
+                return None;
+            }
+            builder = builder.add_negative(element.to_meta_type(db));
+        }
+
         Some(builder.build())
     }
 

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -803,6 +803,54 @@ impl<'db> IntersectionType<'db> {
         }
     }
 
+    /// Convert a pure class-object intersection such as `type[A] & type[B]` to `A & B`.
+    ///
+    /// This is deliberately conservative: every positive element must map to a nominal instance,
+    /// and intersections with negative elements are left unsupported. Structural and gradual
+    /// elements do not have a lossless instance-space projection.
+    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        if self.positive(db).is_empty() || !self.negative(db).is_empty() {
+            return None;
+        }
+
+        let mut builder = IntersectionBuilder::new(db);
+        for element in self.positive(db) {
+            if !matches!(
+                element,
+                Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_)
+            ) {
+                return None;
+            }
+            let instance = element.to_instance(db)?;
+            if !matches!(instance, Type::NominalInstance(_)) {
+                return None;
+            }
+            builder = builder.add_positive(instance);
+        }
+        Some(builder.build())
+    }
+
+    /// Convert a pure nominal instance intersection such as `A & B` to
+    /// `type[A] & type[B]`.
+    ///
+    /// This is the corresponding instance-to-class-object projection for [`Self::to_instance`].
+    /// Unsupported elements retain the existing intersection meta-type fallback instead of being
+    /// discarded.
+    pub(crate) fn to_meta_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        if self.positive(db).is_empty() || !self.negative(db).is_empty() {
+            return None;
+        }
+
+        let mut builder = IntersectionBuilder::new(db);
+        for element in self.positive(db) {
+            if !matches!(element, Type::NominalInstance(_)) {
+                return None;
+            }
+            builder = builder.add_positive(element.to_meta_type(db));
+        }
+        Some(builder.build())
+    }
+
     /// Map a type transformation over all positive elements of the intersection. Leave the
     /// negative elements unchanged.
     pub(crate) fn map_positive(

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -803,10 +803,10 @@ impl<'db> IntersectionType<'db> {
         }
     }
 
-    /// Convert a pure class-object intersection such as `type[A] & type[B]` to `A & B`.
+    /// Convert a class-object intersection such as `type[A] & type[B]` to `A & B`.
     ///
-    /// This is deliberately conservative: every positive element must map to a nominal instance,
-    /// and intersections with negative elements are left unsupported. Structural and gradual
+    /// This is deliberately conservative: every positive element must map to a nominal or gradual
+    /// instance, and intersections with negative elements are left unsupported. Structural
     /// elements do not have a lossless instance-space projection.
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
         if self.positive(db).is_empty() || !self.negative(db).is_empty() {
@@ -817,12 +817,15 @@ impl<'db> IntersectionType<'db> {
         for element in self.positive(db) {
             if !matches!(
                 element,
-                Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_)
+                Type::ClassLiteral(_)
+                    | Type::GenericAlias(_)
+                    | Type::SubclassOf(_)
+                    | Type::Dynamic(_)
             ) {
                 return None;
             }
             let instance = element.to_instance(db)?;
-            if !matches!(instance, Type::NominalInstance(_)) {
+            if !matches!(instance, Type::NominalInstance(_) | Type::Dynamic(_)) {
                 return None;
             }
             builder = builder.add_positive(instance);
@@ -830,7 +833,7 @@ impl<'db> IntersectionType<'db> {
         Some(builder.build())
     }
 
-    /// Convert a pure nominal instance intersection such as `A & B` to
+    /// Convert a nominal or gradual instance intersection such as `A & B` to
     /// `type[A] & type[B]`.
     ///
     /// This is the corresponding instance-to-class-object projection for [`Self::to_instance`].
@@ -843,7 +846,7 @@ impl<'db> IntersectionType<'db> {
 
         let mut builder = IntersectionBuilder::new(db);
         for element in self.positive(db) {
-            if !matches!(element, Type::NominalInstance(_)) {
+            if !matches!(element, Type::NominalInstance(_) | Type::Dynamic(_)) {
                 return None;
             }
             builder = builder.add_positive(element.to_meta_type(db));

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -160,7 +160,13 @@ impl<'db> SubclassOfType<'db> {
             },
             SubclassOfInner::TypeVar(typevar) => {
                 let mapped = typevar.apply_type_mapping_impl(db, type_mapping, visitor);
-                mapped.to_meta_type(db)
+                if let Type::Intersection(intersection) = mapped
+                    && let Some(meta_type) = intersection.to_meta_type(db)
+                {
+                    meta_type
+                } else {
+                    mapped.to_meta_type(db)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Previously, when we accessed a descriptor or classmethod through a class-object intersection, member lookup found the attribute on an individual positive element. We then bound the descriptor owner and `Self` using that element alone, discarding the rest of the receiver. The same decomposition during `type[T]` inference turned `type[A] & type[B]` into `type[A | B]`.

```py
from typing import Self
from ty_extensions import Intersection

class A:
    @classmethod
    def make(cls) -> Self:
        return cls()

class B: ...

def f(cls: Intersection[type[A], type[B]]):
    reveal_type(cls.make())  # before: A; after: A & B
```

This change keeps the full class-object intersection through descriptor binding and projects it into instance space only where the relationship is well-defined. Nominal and gradual positive arms are preserved, `~type[B]` becomes `~B`, and exact-class or metaclass exclusions are omitted because they constrain the class object rather than its instances. The inverse projection preserves the intersection for `type[Self]` and generic `type[T]` results.

This is a narrower replacement for #25704. It does not implement #24761's general intersection meta-type behavior: arbitrary `type(x)` and `x.__class__` operations on intersections retain the existing TODO. The related inverse `A & B` to `type[A] & type[B]` projection is applied only while substituting a receiver-bound intersection into `type[Self]` or generic `type[T]`. The remaining TODO mdtests are limited to receiver-specific structural or TypeVar arms and receiver-filtered overload diagnostics.

Closes https://github.com/astral-sh/ty/issues/3719.
