### PR TITLE
[ty] Narrow tuple expression match subjects

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -22,8 +22,8 @@ use smallvec::SmallVec;
 use ty_module_resolver::{ModuleName, resolve_module};
 
 use crate::HasTrackedScope;
-use crate::ast_ids::AstIdsBuilder;
 use crate::ast_ids::node_key::ExpressionNodeKey;
+use crate::ast_ids::{AstIdsBuilder, ScopedUseId};
 use crate::ast_node_ref::AstNodeRef;
 use crate::definition::{
     AnnotatedAssignmentDefinitionNodeRef, AssignmentDefinitionNodeRef,
@@ -2005,6 +2005,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         &mut self,
         subject: Expression<'db>,
         pattern: &ast::Pattern,
+        tuple_subject_targets: &[(ScopedSymbolId, ScopedUseId)],
         guard: Option<&ast::Expr>,
         previous_pattern: Option<PatternPredicate<'db>>,
         is_catchall: bool,
@@ -2051,7 +2052,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let predicate_id = if is_catchall {
             ScopedPredicateId::ALWAYS_TRUE
         } else {
-            self.record_narrowing_constraint(predicate)
+            let predicate_id = self.record_narrowing_constraint(predicate);
+            if !tuple_subject_targets.is_empty() {
+                self.current_use_def_map_mut()
+                    .record_narrowing_constraint_for_bindings_at_uses(
+                        predicate_id,
+                        tuple_subject_targets,
+                    );
+            }
+            predicate_id
         };
         (predicate, predicate_id, pattern_predicate)
     }
@@ -3380,6 +3389,33 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     return;
                 }
 
+                // A match subject is evaluated once. Retain the bindings read by each name so
+                // that case predicates constrain those values rather than later rebindings.
+                let tuple_subject_targets = if let ast::Expr::Tuple(tuple) = subject.as_ref() {
+                    let places = self.current_place_table();
+                    let ast_ids = self.current_ast_ids();
+                    let mut targets = SmallVec::<[(ScopedSymbolId, ScopedUseId); 2]>::new();
+                    for element in &tuple.elts {
+                        let Some(target) = element
+                            .as_name_expr()
+                            .and_then(|name| places.symbol_id(name.id.as_str()))
+                            .zip(ast_ids.try_use_id(element))
+                        else {
+                            targets.clear();
+                            break;
+                        };
+                        if targets
+                            .iter()
+                            .all(|(existing_symbol, _)| *existing_symbol != target.0)
+                        {
+                            targets.push(target);
+                        }
+                    }
+                    targets
+                } else {
+                    SmallVec::new()
+                };
+
                 let mut no_case_matched = self.flow_snapshot();
 
                 let has_catchall = cases
@@ -3402,6 +3438,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         .add_pattern_narrowing_constraint(
                             subject_expr,
                             &case.pattern,
+                            &tuple_subject_targets,
                             case.guard.as_deref(),
                             previous_pattern,
                             is_catchall,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2053,13 +2053,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ScopedPredicateId::ALWAYS_TRUE
         } else {
             let predicate_id = self.record_narrowing_constraint(predicate);
-            if !sequence_subject_targets.is_empty() {
-                self.current_use_def_map_mut()
-                    .record_narrowing_constraint_for_bindings_at_uses(
-                        predicate_id,
-                        sequence_subject_targets,
-                    );
-            }
+            self.current_use_def_map_mut()
+                .record_narrowing_constraint_for_bindings_at_uses(
+                    predicate_id,
+                    sequence_subject_targets,
+                );
             predicate_id
         };
         (predicate, predicate_id, pattern_predicate)

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -42,7 +42,7 @@ use crate::place::{PlaceExpr, PlaceTableBuilder, PossiblyNarrowedPlacesBuilder, 
 use crate::predicate::{
     CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
     PredicateNode, PredicateOrLiteral, ScopedPredicateId, SequencePatternPredicateKind,
-    StarImportPlaceholderPredicate,
+    StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
 };
 use crate::program::Program;
 use crate::re_exports::exported_names;
@@ -1811,7 +1811,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         PossiblyNarrowedPlacesBuilder::new(self.db, place_table)
                             .pattern(pattern, module)
                     }
-                    PredicateNode::IsNonTerminalCall(_)
+                    PredicateNode::SubjectElementPattern(_)
+                    | PredicateNode::IsNonTerminalCall(_)
                     | PredicateNode::StarImportPlaceholder(_) => {
                         // These predicates don't narrow any places
                         PossiblyNarrowedPlaces::default()
@@ -2005,7 +2006,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         &mut self,
         subject: Expression<'db>,
         pattern: &ast::Pattern,
-        sequence_subject_targets: &[(ScopedPlaceId, ScopedUseId)],
+        sequence_subject_targets: &[(ScopedPlaceId, ScopedUseId, ExpressionNodeKey)],
         guard: Option<&ast::Expr>,
         previous_pattern: Option<PatternPredicate<'db>>,
         is_catchall: bool,
@@ -2051,13 +2052,28 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // predicates are still created normally for proper control flow tracking.
         let predicate_id = if is_catchall {
             ScopedPredicateId::ALWAYS_TRUE
+        } else if sequence_subject_targets.is_empty() {
+            self.record_narrowing_constraint(predicate)
         } else {
-            let predicate_id = self.record_narrowing_constraint(predicate);
-            self.current_use_def_map_mut()
-                .record_narrowing_constraint_for_bindings_at_uses(
-                    predicate_id,
-                    sequence_subject_targets,
-                );
+            let predicate_id = self.add_predicate(predicate);
+            for &(place, use_id, target) in sequence_subject_targets {
+                let subject_element_id =
+                    self.add_predicate(PredicateOrLiteral::Predicate(Predicate {
+                        node: PredicateNode::SubjectElementPattern(
+                            SubjectElementPatternPredicate {
+                                pattern: pattern_predicate,
+                                target,
+                            },
+                        ),
+                        is_positive: true,
+                    }));
+                self.current_use_def_map_mut()
+                    .record_narrowing_constraint_for_bindings_at_use(
+                        subject_element_id,
+                        place,
+                        use_id,
+                    );
+            }
             predicate_id
         };
         (predicate, predicate_id, pattern_predicate)
@@ -3392,7 +3408,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let places = self.current_place_table();
                 let ast_ids = self.current_ast_ids();
                 let mut sequence_subject_targets =
-                    SmallVec::<[(ScopedPlaceId, ScopedUseId); 2]>::new();
+                    SmallVec::<[(ScopedPlaceId, ScopedUseId, ExpressionNodeKey); 2]>::new();
                 let mut subject_elements: Vec<&ast::Expr> = match subject.as_ref() {
                     ast::Expr::List(list) => list.elts.iter().collect(),
                     ast::Expr::Tuple(tuple) => tuple.elts.iter().collect(),
@@ -3409,12 +3425,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             else {
                                 continue;
                             };
-                            if sequence_subject_targets
-                                .iter()
-                                .all(|(existing_place, _)| *existing_place != target.0)
-                            {
-                                sequence_subject_targets.push(target);
-                            }
+                            sequence_subject_targets.push((
+                                target.0,
+                                target.1,
+                                ExpressionNodeKey::from(element),
+                            ));
                         }
                     }
                 }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2005,7 +2005,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         &mut self,
         subject: Expression<'db>,
         pattern: &ast::Pattern,
-        tuple_subject_targets: &[(ScopedSymbolId, ScopedUseId)],
+        sequence_subject_targets: &[(ScopedPlaceId, ScopedUseId)],
         guard: Option<&ast::Expr>,
         previous_pattern: Option<PatternPredicate<'db>>,
         is_catchall: bool,
@@ -2053,11 +2053,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ScopedPredicateId::ALWAYS_TRUE
         } else {
             let predicate_id = self.record_narrowing_constraint(predicate);
-            if !tuple_subject_targets.is_empty() {
+            if !sequence_subject_targets.is_empty() {
                 self.current_use_def_map_mut()
                     .record_narrowing_constraint_for_bindings_at_uses(
                         predicate_id,
-                        tuple_subject_targets,
+                        sequence_subject_targets,
                     );
             }
             predicate_id
@@ -3389,32 +3389,37 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     return;
                 }
 
-                // A match subject is evaluated once. Retain the bindings read by each name so
+                // A match subject is evaluated once. Retain the bindings read by each place so
                 // that case predicates constrain those values rather than later rebindings.
-                let tuple_subject_targets = if let ast::Expr::Tuple(tuple) = subject.as_ref() {
-                    let places = self.current_place_table();
-                    let ast_ids = self.current_ast_ids();
-                    let mut targets = SmallVec::<[(ScopedSymbolId, ScopedUseId); 2]>::new();
-                    for element in &tuple.elts {
-                        let Some(target) = element
-                            .as_name_expr()
-                            .and_then(|name| places.symbol_id(name.id.as_str()))
-                            .zip(ast_ids.try_use_id(element))
-                        else {
-                            targets.clear();
-                            break;
-                        };
-                        if targets
-                            .iter()
-                            .all(|(existing_symbol, _)| *existing_symbol != target.0)
-                        {
-                            targets.push(target);
+                let places = self.current_place_table();
+                let ast_ids = self.current_ast_ids();
+                let mut sequence_subject_targets =
+                    SmallVec::<[(ScopedPlaceId, ScopedUseId); 2]>::new();
+                let mut subject_elements: Vec<&ast::Expr> = match subject.as_ref() {
+                    ast::Expr::List(list) => list.elts.iter().collect(),
+                    ast::Expr::Tuple(tuple) => tuple.elts.iter().collect(),
+                    _ => Vec::new(),
+                };
+                while let Some(element) = subject_elements.pop() {
+                    match element {
+                        ast::Expr::List(list) => subject_elements.extend(&list.elts),
+                        ast::Expr::Tuple(tuple) => subject_elements.extend(&tuple.elts),
+                        _ => {
+                            let Some(target) = PlaceExpr::try_from_expr(element)
+                                .and_then(|place| places.place_id((&place).into()))
+                                .zip(ast_ids.try_use_id(element))
+                            else {
+                                continue;
+                            };
+                            if sequence_subject_targets
+                                .iter()
+                                .all(|(existing_place, _)| *existing_place != target.0)
+                            {
+                                sequence_subject_targets.push(target);
+                            }
                         }
                     }
-                    targets
-                } else {
-                    SmallVec::new()
-                };
+                }
 
                 let mut no_case_matched = self.flow_snapshot();
 
@@ -3438,7 +3443,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         .add_pattern_narrowing_constraint(
                             subject_expr,
                             &case.pattern,
-                            &tuple_subject_targets,
+                            &sequence_subject_targets,
                             case.guard.as_deref(),
                             previous_pattern,
                             is_catchall,

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -11,6 +11,7 @@ use ruff_db::files::File;
 use ruff_index::{FrozenIndexVec, Idx, IndexVec};
 use ruff_python_ast::{Singleton, name::Name};
 
+use crate::ast_ids::ExpressionNodeKey;
 use crate::db::Db;
 use crate::expression::Expression;
 use crate::global_scope;
@@ -130,7 +131,18 @@ pub enum PredicateNode<'db> {
     /// positives.
     IsNonTerminalCall(CallableAndCallExpr<'db>),
     Pattern(PatternPredicate<'db>),
+    SubjectElementPattern(SubjectElementPatternPredicate<'db>),
     StarImportPlaceholder(StarImportPlaceholderPredicate<'db>),
+}
+
+/// A pattern predicate applied to one expression in a sequence-display subject.
+///
+/// The full pattern determines the predicate's truth value, while `target` selects the subject
+/// occurrence whose aligned pattern constraint should be applied to a binding.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+pub struct SubjectElementPatternPredicate<'db> {
+    pub pattern: PatternPredicate<'db>,
+    pub target: ExpressionNodeKey,
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, salsa::Update, get_size2::GetSize)]

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1394,14 +1394,14 @@ impl<'db> UseDefMapBuilder<'db> {
             return;
         }
 
-        let constraint = self.reachability_constraints.add_atom(predicate);
+        let constraint = self.narrowing_constraints.add_atom(predicate);
         for &(place, use_id) in targets {
             let state = match place {
                 ScopedPlaceId::Symbol(symbol) => &mut self.symbol_states[symbol],
                 ScopedPlaceId::Member(member) => &mut self.member_states[member],
             };
             state.record_narrowing_constraint_for_bindings_at_use(
-                &mut self.reachability_constraints,
+                &mut self.narrowing_constraints,
                 constraint,
                 &self.bindings_by_use[use_id],
             );

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1387,7 +1387,8 @@ impl<'db> UseDefMapBuilder<'db> {
         predicate: ScopedPredicateId,
         targets: &[(ScopedPlaceId, ScopedUseId)],
     ) {
-        if predicate == ScopedPredicateId::ALWAYS_TRUE
+        if targets.is_empty()
+            || predicate == ScopedPredicateId::ALWAYS_TRUE
             || predicate == ScopedPredicateId::ALWAYS_FALSE
         {
             return;

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1380,6 +1380,29 @@ impl<'db> UseDefMapBuilder<'db> {
         self.record_narrowing_constraint_node_for_places(atom, places);
     }
 
+    /// Records a narrowing constraint on the current live bindings that were read by the
+    /// corresponding earlier uses.
+    pub(super) fn record_narrowing_constraint_for_bindings_at_uses(
+        &mut self,
+        predicate: ScopedPredicateId,
+        targets: &[(ScopedSymbolId, ScopedUseId)],
+    ) {
+        if predicate == ScopedPredicateId::ALWAYS_TRUE
+            || predicate == ScopedPredicateId::ALWAYS_FALSE
+        {
+            return;
+        }
+
+        let constraint = self.reachability_constraints.add_atom(predicate);
+        for &(symbol, use_id) in targets {
+            self.symbol_states[symbol].record_narrowing_constraint_for_bindings_at_use(
+                &mut self.reachability_constraints,
+                constraint,
+                &self.bindings_by_use[use_id],
+            );
+        }
+    }
+
     /// Records a negated narrowing constraint for only the specified places.
     ///
     /// The positive and negative constraints use the same predicate ID. This lets `P or not P`

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1385,7 +1385,7 @@ impl<'db> UseDefMapBuilder<'db> {
     pub(super) fn record_narrowing_constraint_for_bindings_at_uses(
         &mut self,
         predicate: ScopedPredicateId,
-        targets: &[(ScopedSymbolId, ScopedUseId)],
+        targets: &[(ScopedPlaceId, ScopedUseId)],
     ) {
         if predicate == ScopedPredicateId::ALWAYS_TRUE
             || predicate == ScopedPredicateId::ALWAYS_FALSE
@@ -1394,8 +1394,12 @@ impl<'db> UseDefMapBuilder<'db> {
         }
 
         let constraint = self.reachability_constraints.add_atom(predicate);
-        for &(symbol, use_id) in targets {
-            self.symbol_states[symbol].record_narrowing_constraint_for_bindings_at_use(
+        for &(place, use_id) in targets {
+            let state = match place {
+                ScopedPlaceId::Symbol(symbol) => &mut self.symbol_states[symbol],
+                ScopedPlaceId::Member(member) => &mut self.member_states[member],
+            };
+            state.record_narrowing_constraint_for_bindings_at_use(
                 &mut self.reachability_constraints,
                 constraint,
                 &self.bindings_by_use[use_id],

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1382,30 +1382,28 @@ impl<'db> UseDefMapBuilder<'db> {
 
     /// Records a narrowing constraint on the current live bindings that were read by the
     /// corresponding earlier uses.
-    pub(super) fn record_narrowing_constraint_for_bindings_at_uses(
+    pub(super) fn record_narrowing_constraint_for_bindings_at_use(
         &mut self,
         predicate: ScopedPredicateId,
-        targets: &[(ScopedPlaceId, ScopedUseId)],
+        place: ScopedPlaceId,
+        use_id: ScopedUseId,
     ) {
-        if targets.is_empty()
-            || predicate == ScopedPredicateId::ALWAYS_TRUE
+        if predicate == ScopedPredicateId::ALWAYS_TRUE
             || predicate == ScopedPredicateId::ALWAYS_FALSE
         {
             return;
         }
 
         let constraint = self.narrowing_constraints.add_atom(predicate);
-        for &(place, use_id) in targets {
-            let state = match place {
-                ScopedPlaceId::Symbol(symbol) => &mut self.symbol_states[symbol],
-                ScopedPlaceId::Member(member) => &mut self.member_states[member],
-            };
-            state.record_narrowing_constraint_for_bindings_at_use(
-                &mut self.narrowing_constraints,
-                constraint,
-                &self.bindings_by_use[use_id],
-            );
-        }
+        let state = match place {
+            ScopedPlaceId::Symbol(symbol) => &mut self.symbol_states[symbol],
+            ScopedPlaceId::Member(member) => &mut self.member_states[member],
+        };
+        state.record_narrowing_constraint_for_bindings_at_use(
+            &mut self.narrowing_constraints,
+            constraint,
+            &self.bindings_by_use[use_id],
+        );
     }
 
     /// Records a negated narrowing constraint for only the specified places.

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -520,7 +520,7 @@ impl PlaceState {
     /// Add the given constraint to live bindings that were also present at an earlier use.
     pub(super) fn record_narrowing_constraint_for_bindings_at_use(
         &mut self,
-        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
         constraint: ScopedNarrowingConstraint,
         bindings_at_use: &Bindings,
     ) {
@@ -529,7 +529,7 @@ impl PlaceState {
                 .iter()
                 .any(|binding_at_use| binding_at_use.binding() == binding.binding())
             {
-                binding.narrowing_constraint = reachability_constraints
+                binding.narrowing_constraint = narrowing_constraints
                     .add_and_constraint(binding.narrowing_constraint, constraint);
             }
         }

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -517,6 +517,24 @@ impl PlaceState {
             .record_narrowing_constraint(narrowing_constraints, constraint);
     }
 
+    /// Add the given constraint to live bindings that were also present at an earlier use.
+    pub(super) fn record_narrowing_constraint_for_bindings_at_use(
+        &mut self,
+        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+        constraint: ScopedNarrowingConstraint,
+        bindings_at_use: &Bindings,
+    ) {
+        for binding in &mut self.bindings.live_bindings {
+            if bindings_at_use
+                .iter()
+                .any(|binding_at_use| binding_at_use.binding() == binding.binding())
+            {
+                binding.narrowing_constraint = reachability_constraints
+                    .add_and_constraint(binding.narrowing_constraint, constraint);
+            }
+        }
+    }
+
     /// Add given reachability constraint to all live bindings.
     pub(super) fn record_reachability_constraint(
         &mut self,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -311,6 +311,48 @@ def match_tuple_expression_subject(a: TupleSubjectA, b: TupleSubjectB) -> None:
     reveal_type(a)  # revealed: TupleSubjectA
     reveal_type(b)  # revealed: TupleSubjectB
 
+def match_list_expression_subject(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match [a, b]:
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+            reveal_type(b)  # revealed: TupleSubjectB1
+
+class SequenceSubjectContainer:
+    a: TupleSubjectA
+
+def match_nested_sequence_expression_subject(
+    container: SequenceSubjectContainer,
+    values: list[TupleSubjectB],
+) -> None:
+    match [[container.a], values[0], object()]:
+        case [[TupleSubjectA1()], TupleSubjectB1(), _]:
+            reveal_type(container.a)  # revealed: TupleSubjectA1
+            reveal_type(values[0])  # revealed: TupleSubjectB1
+
+def match_nested_sequence_or_impossible_alternative(
+    a: TupleSubjectA,
+    x: object,
+    y: object,
+) -> None:
+    match [a, [x, y]]:
+        case [TupleSubjectA1(), [_]] | [TupleSubjectA2(), [_, _]]:
+            reveal_type(a)  # revealed: TupleSubjectA2
+
+def match_mapping_expression_subject(value: object) -> None:
+    match [{"value": value}]:
+        case [{"value": int()}]:
+            # TODO: Project mapping-pattern constraints through dictionary displays.
+            reveal_type(value)  # revealed: object
+
+def match_starred_list_expression_subject(
+    a: TupleSubjectA,
+    values: list[object],
+) -> None:
+    match [a, *values]:
+        case [TupleSubjectA1()]:
+            # The starred display has variable runtime length, so it is not projected yet.
+            reveal_type(a)  # revealed: TupleSubjectA
+
 def match_tuple_expression_later_case(a: TupleSubjectA, b: TupleSubjectB) -> None:
     match a, b:
         case [TupleSubjectA2(), TupleSubjectB2()]:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -176,7 +176,6 @@ def test_match_refutable(x: dict[Any, Any] | int) -> None:
 
 ```py
 from collections.abc import Sequence
-from typing import final
 from typing_extensions import assert_never
 
 def test_match_star(x: Sequence[int] | int) -> None:
@@ -292,161 +291,6 @@ def test_match_exact_tuple_sequence(subj: tuple[int | str, int | str]) -> None:
             # intersection above.
             reveal_type(subj[1])  # revealed: int | str
 
-class TupleSubjectA: ...
-class TupleSubjectA1(TupleSubjectA): ...
-class TupleSubjectA2(TupleSubjectA): ...
-class TupleSubjectB: ...
-class TupleSubjectB1(TupleSubjectB): ...
-class TupleSubjectB2(TupleSubjectB): ...
-class ReboundTupleSubject: ...
-
-@final
-class ReboundTupleSubject1(ReboundTupleSubject): ...
-
-@final
-class ReboundTupleSubject2(ReboundTupleSubject): ...
-
-def match_tuple_expression_subject(a: TupleSubjectA, b: TupleSubjectB) -> None:
-    match a, b:
-        case [TupleSubjectA1(), TupleSubjectB1()]:
-            reveal_type(a)  # revealed: TupleSubjectA1
-            reveal_type(b)  # revealed: TupleSubjectB1
-        case _:
-            # Failing the first pattern does not tell us which element failed to match.
-            reveal_type(a)  # revealed: TupleSubjectA
-            reveal_type(b)  # revealed: TupleSubjectB
-
-    reveal_type(a)  # revealed: TupleSubjectA
-    reveal_type(b)  # revealed: TupleSubjectB
-
-def match_list_expression_subject(a: TupleSubjectA, b: TupleSubjectB) -> None:
-    match [a, b]:
-        case [TupleSubjectA1(), TupleSubjectB1()]:
-            reveal_type(a)  # revealed: TupleSubjectA1
-            reveal_type(b)  # revealed: TupleSubjectB1
-
-def match_tuple_expression_rebound_subject(a: ReboundTupleSubject) -> None:
-    match a, (a := ReboundTupleSubject2()), a:
-        case [ReboundTupleSubject1(), ReboundTupleSubject2(), ReboundTupleSubject2()]:
-            reveal_type(a)  # revealed: ReboundTupleSubject2
-            1 + "x"  # error: [unsupported-operator]
-
-class SequenceSubjectContainer:
-    a: TupleSubjectA
-
-def match_nested_sequence_expression_subject(
-    container: SequenceSubjectContainer,
-    values: list[TupleSubjectB],
-) -> None:
-    match [[container.a], values[0], object()]:
-        case [[TupleSubjectA1()], TupleSubjectB1(), _]:
-            reveal_type(container.a)  # revealed: TupleSubjectA1
-            reveal_type(values[0])  # revealed: TupleSubjectB1
-
-def match_nested_sequence_or_impossible_alternative(
-    a: TupleSubjectA,
-    x: object,
-    y: object,
-) -> None:
-    match [a, [x, y]]:
-        case [TupleSubjectA1(), [_]] | [TupleSubjectA2(), [_, _]]:
-            reveal_type(a)  # revealed: TupleSubjectA2
-
-def match_mapping_expression_subject(value: object) -> None:
-    match [{"value": value}]:
-        case [{"value": int()}]:
-            # TODO: Propagate mapping-pattern constraints through dictionary displays.
-            reveal_type(value)  # revealed: object
-
-def match_starred_list_expression_subject(
-    a: TupleSubjectA,
-    values: list[object],
-) -> None:
-    match [a, *values]:
-        case [TupleSubjectA1()]:
-            # The starred display has variable runtime length, so its constraints are not
-            # propagated yet.
-            reveal_type(a)  # revealed: TupleSubjectA
-
-def match_tuple_expression_later_case(a: TupleSubjectA, b: TupleSubjectB) -> None:
-    match a, b:
-        case [TupleSubjectA2(), TupleSubjectB2()]:
-            pass
-        case [TupleSubjectA1(), TupleSubjectB1()]:
-            reveal_type(a)  # revealed: TupleSubjectA1
-            reveal_type(b)  # revealed: TupleSubjectB1
-
-def match_tuple_expression_or_pattern(a: TupleSubjectA, b: TupleSubjectB) -> None:
-    match a, b:
-        case [TupleSubjectA1(), TupleSubjectB1()] | [*_]:
-            # The second alternative does not constrain either tuple element.
-            reveal_type(a)  # revealed: TupleSubjectA
-            reveal_type(b)  # revealed: TupleSubjectB
-
-def match_tuple_expression_constrained_or_pattern(
-    a: TupleSubjectA,
-    b: TupleSubjectB,
-) -> None:
-    match a, b:
-        case [TupleSubjectA1(), TupleSubjectB1()] | [TupleSubjectA2(), TupleSubjectB2()]:
-            reveal_type(a)  # revealed: TupleSubjectA1 | TupleSubjectA2
-            reveal_type(b)  # revealed: TupleSubjectB1 | TupleSubjectB2
-
-def match_tuple_expression_or_impossible_alternative(
-    a: TupleSubjectA,
-    b: TupleSubjectB,
-) -> None:
-    match a, b:
-        case [TupleSubjectA1()] | [TupleSubjectA2(), TupleSubjectB1()]:
-            reveal_type(a)  # revealed: TupleSubjectA2
-            reveal_type(b)  # revealed: TupleSubjectB1
-
-def match_repeated_tuple_expression_subject(a: TupleSubjectA) -> None:
-    match a, a:
-        case [TupleSubjectA1(), TupleSubjectA()]:
-            reveal_type(a)  # revealed: TupleSubjectA1
-
-def match_tuple_expression_starred_pattern(
-    a: TupleSubjectA,
-    middle: object,
-    b: TupleSubjectB,
-) -> None:
-    match a, middle, b:
-        case [TupleSubjectA1(), *_, TupleSubjectB1()]:
-            reveal_type(a)  # revealed: TupleSubjectA1
-            reveal_type(middle)  # revealed: object
-            reveal_type(b)  # revealed: TupleSubjectB1
-
-def match_tuple_expression_multiple_bindings(flag: bool, b: TupleSubjectB) -> None:
-    if flag:
-        a: TupleSubjectA = TupleSubjectA1()
-    else:
-        a = TupleSubjectA2()
-
-    match a, b:
-        case [TupleSubjectA1(), TupleSubjectB1()]:
-            reveal_type(a)  # revealed: TupleSubjectA1
-            reveal_type(b)  # revealed: TupleSubjectB1
-
-def match_tuple_expression_subject_capture(a: TupleSubjectA, b: TupleSubjectB) -> None:
-    match a, b:
-        case [TupleSubjectA1(), a]:
-            # The pattern binding has replaced the subject-time binding of `a`.
-            reveal_type(a)  # revealed: @Todo(`match` pattern definition types)
-
-def match_tuple_expression_guard_rebinding(
-    a: TupleSubjectA,
-    b: TupleSubjectB,
-    flag: bool,
-) -> None:
-    match a, b:
-        case [TupleSubjectA1(), TupleSubjectB1()] if (a := TupleSubjectA2()) and flag:
-            pass
-        case [TupleSubjectA1(), TupleSubjectB1()]:
-            # The pattern only constrains the subject-time binding, not the guard assignment.
-            reveal_type(a)  # revealed: TupleSubjectA1 | TupleSubjectA2
-            reveal_type(b)  # revealed: TupleSubjectB1
-
 def test_match_exact_tuple_sequence_is_exhaustive(value: int | tuple[int, int]) -> int:
     match value:
         case int(value):
@@ -497,6 +341,194 @@ def test_match_value_sequence(value: object) -> None:
             # Value patterns use equality, so matching `1` does not prove that
             # the element is an `int`.
             reveal_type(value[0])  # revealed: object
+```
+
+## Sequence display subjects
+
+A tuple or list display has no place of its own to narrow. A successful sequence pattern instead
+narrows the corresponding narrowable elements. If a multi-element pattern fails, we do not know
+which element failed to match.
+
+```py
+class TupleSubjectA: ...
+class TupleSubjectA1(TupleSubjectA): ...
+class TupleSubjectB: ...
+class TupleSubjectB1(TupleSubjectB): ...
+
+def match_tuple_expression_subject(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+            reveal_type(b)  # revealed: TupleSubjectB1
+        case _:
+            reveal_type(a)  # revealed: TupleSubjectA
+            reveal_type(b)  # revealed: TupleSubjectB
+
+    reveal_type(a)  # revealed: TupleSubjectA
+    reveal_type(b)  # revealed: TupleSubjectB
+
+def match_list_expression_subject(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match [a, b]:
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+            reveal_type(b)  # revealed: TupleSubjectB1
+```
+
+## Nested sequence display subjects
+
+Element narrowing recurses through nested tuple and list displays. Attributes and subscripts are
+narrowed when they occupy a fixed position. Dictionary displays and starred subject elements do not
+yet have a fixed element-to-pattern correspondence.
+
+```py
+class TupleSubjectA: ...
+class TupleSubjectA1(TupleSubjectA): ...
+class TupleSubjectB: ...
+class TupleSubjectB1(TupleSubjectB): ...
+
+class SequenceSubjectContainer:
+    a: TupleSubjectA
+
+def match_nested_sequence_expression_subject(
+    container: SequenceSubjectContainer,
+    values: list[TupleSubjectB],
+) -> None:
+    match [[container.a], values[0], object()]:
+        case [[TupleSubjectA1()], TupleSubjectB1(), _]:
+            reveal_type(container.a)  # revealed: TupleSubjectA1
+            reveal_type(values[0])  # revealed: TupleSubjectB1
+
+def match_mapping_expression_subject(value: object) -> None:
+    match [{"value": value}]:
+        case [{"value": int()}]:
+            reveal_type(value)  # revealed: object
+
+def match_starred_list_expression_subject(
+    a: TupleSubjectA,
+    values: list[object],
+) -> None:
+    match [a, *values]:
+        case [TupleSubjectA1()]:
+            reveal_type(a)  # revealed: TupleSubjectA
+```
+
+## Sequence pattern forms for display subjects
+
+Element narrowing respects later cases, OR patterns, impossible alternatives, repeated subject
+expressions, and starred sequence patterns.
+
+```py
+class TupleSubjectA: ...
+class TupleSubjectA1(TupleSubjectA): ...
+class TupleSubjectA2(TupleSubjectA): ...
+class TupleSubjectB: ...
+class TupleSubjectB1(TupleSubjectB): ...
+class TupleSubjectB2(TupleSubjectB): ...
+
+def match_tuple_expression_later_case(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match a, b:
+        case [TupleSubjectA2(), TupleSubjectB2()]:
+            pass
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+            reveal_type(b)  # revealed: TupleSubjectB1
+
+def match_tuple_expression_or_pattern(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()] | [*_]:
+            # The second alternative does not constrain either tuple element.
+            reveal_type(a)  # revealed: TupleSubjectA
+            reveal_type(b)  # revealed: TupleSubjectB
+
+def match_tuple_expression_constrained_or_pattern(
+    a: TupleSubjectA,
+    b: TupleSubjectB,
+) -> None:
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()] | [TupleSubjectA2(), TupleSubjectB2()]:
+            reveal_type(a)  # revealed: TupleSubjectA1 | TupleSubjectA2
+            reveal_type(b)  # revealed: TupleSubjectB1 | TupleSubjectB2
+
+def match_tuple_expression_or_impossible_alternative(
+    a: TupleSubjectA,
+    b: TupleSubjectB,
+) -> None:
+    match a, b:
+        case [TupleSubjectA1()] | [TupleSubjectA2(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA2
+            reveal_type(b)  # revealed: TupleSubjectB1
+
+def match_repeated_tuple_expression_subject(a: TupleSubjectA) -> None:
+    match a, a:
+        case [TupleSubjectA1(), TupleSubjectA()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+
+def match_tuple_expression_starred_pattern(
+    a: TupleSubjectA,
+    middle: object,
+    b: TupleSubjectB,
+) -> None:
+    match a, middle, b:
+        case [TupleSubjectA1(), *_, TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+            reveal_type(middle)  # revealed: object
+            reveal_type(b)  # revealed: TupleSubjectB1
+```
+
+## Subject-time bindings in display subjects
+
+Each element constraint applies to the binding read while that subject element was evaluated. It
+does not constrain a binding introduced by a later subject element, pattern capture, or guard.
+
+```py
+from typing import final
+
+class TupleSubjectA: ...
+class TupleSubjectA1(TupleSubjectA): ...
+class TupleSubjectA2(TupleSubjectA): ...
+class TupleSubjectB: ...
+class TupleSubjectB1(TupleSubjectB): ...
+class ReboundTupleSubject: ...
+
+@final
+class ReboundTupleSubject1(ReboundTupleSubject): ...
+
+@final
+class ReboundTupleSubject2(ReboundTupleSubject): ...
+
+def match_tuple_expression_rebound_subject(a: ReboundTupleSubject) -> None:
+    match a, (a := ReboundTupleSubject2()), a:
+        case [ReboundTupleSubject1(), ReboundTupleSubject2(), ReboundTupleSubject2()]:
+            reveal_type(a)  # revealed: ReboundTupleSubject2
+            1 + "x"  # error: [unsupported-operator]
+
+def match_tuple_expression_multiple_bindings(flag: bool, b: TupleSubjectB) -> None:
+    if flag:
+        a: TupleSubjectA = TupleSubjectA1()
+    else:
+        a = TupleSubjectA2()
+
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+            reveal_type(b)  # revealed: TupleSubjectB1
+
+def match_tuple_expression_subject_capture(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match a, b:
+        case [TupleSubjectA1(), a]:
+            reveal_type(a)  # revealed: @Todo(`match` pattern definition types)
+
+def match_tuple_expression_guard_rebinding(
+    a: TupleSubjectA,
+    b: TupleSubjectB,
+    flag: bool,
+) -> None:
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()] if (a := TupleSubjectA2()) and flag:
+            pass
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1 | TupleSubjectA2
+            reveal_type(b)  # revealed: TupleSubjectB1
 ```
 
 ## Value patterns

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -340,6 +340,17 @@ def match_repeated_tuple_expression_subject(a: TupleSubjectA) -> None:
         case [TupleSubjectA1(), TupleSubjectA()]:
             reveal_type(a)  # revealed: TupleSubjectA1
 
+def match_tuple_expression_starred_pattern(
+    a: TupleSubjectA,
+    middle: object,
+    b: TupleSubjectB,
+) -> None:
+    match a, middle, b:
+        case [TupleSubjectA1(), *_, TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+            reveal_type(middle)  # revealed: object
+            reveal_type(b)  # revealed: TupleSubjectB1
+
 def match_tuple_expression_multiple_bindings(flag: bool, b: TupleSubjectB) -> None:
     if flag:
         a: TupleSubjectA = TupleSubjectA1()

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -291,6 +291,85 @@ def test_match_exact_tuple_sequence(subj: tuple[int | str, int | str]) -> None:
             # intersection above.
             reveal_type(subj[1])  # revealed: int | str
 
+class TupleSubjectA: ...
+class TupleSubjectA1(TupleSubjectA): ...
+class TupleSubjectA2(TupleSubjectA): ...
+class TupleSubjectB: ...
+class TupleSubjectB1(TupleSubjectB): ...
+class TupleSubjectB2(TupleSubjectB): ...
+
+def match_tuple_expression_subject(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+            reveal_type(b)  # revealed: TupleSubjectB1
+        case _:
+            # Failing the first pattern does not tell us which element failed to match.
+            reveal_type(a)  # revealed: TupleSubjectA
+            reveal_type(b)  # revealed: TupleSubjectB
+
+    reveal_type(a)  # revealed: TupleSubjectA
+    reveal_type(b)  # revealed: TupleSubjectB
+
+def match_tuple_expression_later_case(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match a, b:
+        case [TupleSubjectA2(), TupleSubjectB2()]:
+            pass
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+            reveal_type(b)  # revealed: TupleSubjectB1
+
+def match_tuple_expression_or_pattern(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()] | [*_]:
+            # The second alternative does not constrain either tuple element.
+            reveal_type(a)  # revealed: TupleSubjectA
+            reveal_type(b)  # revealed: TupleSubjectB
+
+def match_tuple_expression_constrained_or_pattern(
+    a: TupleSubjectA,
+    b: TupleSubjectB,
+) -> None:
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()] | [TupleSubjectA2(), TupleSubjectB2()]:
+            reveal_type(a)  # revealed: TupleSubjectA1 | TupleSubjectA2
+            reveal_type(b)  # revealed: TupleSubjectB1 | TupleSubjectB2
+
+def match_repeated_tuple_expression_subject(a: TupleSubjectA) -> None:
+    match a, a:
+        case [TupleSubjectA1(), TupleSubjectA()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+
+def match_tuple_expression_multiple_bindings(flag: bool, b: TupleSubjectB) -> None:
+    if flag:
+        a: TupleSubjectA = TupleSubjectA1()
+    else:
+        a = TupleSubjectA2()
+
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA1
+            reveal_type(b)  # revealed: TupleSubjectB1
+
+def match_tuple_expression_subject_capture(a: TupleSubjectA, b: TupleSubjectB) -> None:
+    match a, b:
+        case [TupleSubjectA1(), a]:
+            # The pattern binding has replaced the subject-time binding of `a`.
+            reveal_type(a)  # revealed: @Todo(`match` pattern definition types)
+
+def match_tuple_expression_guard_rebinding(
+    a: TupleSubjectA,
+    b: TupleSubjectB,
+    flag: bool,
+) -> None:
+    match a, b:
+        case [TupleSubjectA1(), TupleSubjectB1()] if (a := TupleSubjectA2()) and flag:
+            pass
+        case [TupleSubjectA1(), TupleSubjectB1()]:
+            # Projection only constrains the subject-time binding, not the guard assignment.
+            reveal_type(a)  # revealed: TupleSubjectA1 | TupleSubjectA2
+            reveal_type(b)  # revealed: TupleSubjectB1
+
 def test_match_exact_tuple_sequence_is_exhaustive(value: int | tuple[int, int]) -> int:
     match value:
         case int(value):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -176,6 +176,7 @@ def test_match_refutable(x: dict[Any, Any] | int) -> None:
 
 ```py
 from collections.abc import Sequence
+from typing import final
 from typing_extensions import assert_never
 
 def test_match_star(x: Sequence[int] | int) -> None:
@@ -297,6 +298,13 @@ class TupleSubjectA2(TupleSubjectA): ...
 class TupleSubjectB: ...
 class TupleSubjectB1(TupleSubjectB): ...
 class TupleSubjectB2(TupleSubjectB): ...
+class ReboundTupleSubject: ...
+
+@final
+class ReboundTupleSubject1(ReboundTupleSubject): ...
+
+@final
+class ReboundTupleSubject2(ReboundTupleSubject): ...
 
 def match_tuple_expression_subject(a: TupleSubjectA, b: TupleSubjectB) -> None:
     match a, b:
@@ -316,6 +324,12 @@ def match_list_expression_subject(a: TupleSubjectA, b: TupleSubjectB) -> None:
         case [TupleSubjectA1(), TupleSubjectB1()]:
             reveal_type(a)  # revealed: TupleSubjectA1
             reveal_type(b)  # revealed: TupleSubjectB1
+
+def match_tuple_expression_rebound_subject(a: ReboundTupleSubject) -> None:
+    match a, (a := ReboundTupleSubject2()), a:
+        case [ReboundTupleSubject1(), ReboundTupleSubject2(), ReboundTupleSubject2()]:
+            reveal_type(a)  # revealed: ReboundTupleSubject2
+            1 + "x"  # error: [unsupported-operator]
 
 class SequenceSubjectContainer:
     a: TupleSubjectA
@@ -341,7 +355,7 @@ def match_nested_sequence_or_impossible_alternative(
 def match_mapping_expression_subject(value: object) -> None:
     match [{"value": value}]:
         case [{"value": int()}]:
-            # TODO: Project mapping-pattern constraints through dictionary displays.
+            # TODO: Propagate mapping-pattern constraints through dictionary displays.
             reveal_type(value)  # revealed: object
 
 def match_starred_list_expression_subject(
@@ -350,7 +364,8 @@ def match_starred_list_expression_subject(
 ) -> None:
     match [a, *values]:
         case [TupleSubjectA1()]:
-            # The starred display has variable runtime length, so it is not projected yet.
+            # The starred display has variable runtime length, so its constraints are not
+            # propagated yet.
             reveal_type(a)  # revealed: TupleSubjectA
 
 def match_tuple_expression_later_case(a: TupleSubjectA, b: TupleSubjectB) -> None:
@@ -428,7 +443,7 @@ def match_tuple_expression_guard_rebinding(
         case [TupleSubjectA1(), TupleSubjectB1()] if (a := TupleSubjectA2()) and flag:
             pass
         case [TupleSubjectA1(), TupleSubjectB1()]:
-            # Projection only constrains the subject-time binding, not the guard assignment.
+            # The pattern only constrains the subject-time binding, not the guard assignment.
             reveal_type(a)  # revealed: TupleSubjectA1 | TupleSubjectA2
             reveal_type(b)  # revealed: TupleSubjectB1
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -335,6 +335,15 @@ def match_tuple_expression_constrained_or_pattern(
             reveal_type(a)  # revealed: TupleSubjectA1 | TupleSubjectA2
             reveal_type(b)  # revealed: TupleSubjectB1 | TupleSubjectB2
 
+def match_tuple_expression_or_impossible_alternative(
+    a: TupleSubjectA,
+    b: TupleSubjectB,
+) -> None:
+    match a, b:
+        case [TupleSubjectA1()] | [TupleSubjectA2(), TupleSubjectB1()]:
+            reveal_type(a)  # revealed: TupleSubjectA2
+            reveal_type(b)  # revealed: TupleSubjectB1
+
 def match_repeated_tuple_expression_subject(a: TupleSubjectA) -> None:
     match a, a:
         case [TupleSubjectA1(), TupleSubjectA()]:

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1162,6 +1162,9 @@ fn analyze_single(db: &dyn Db, predicate: &Predicate) -> Truthiness {
             .negate_if(!predicate.is_positive)
         }
         PredicateNode::Pattern(inner) => analyze_pattern_predicate(db, inner),
+        PredicateNode::SubjectElementPattern(subject_element) => {
+            analyze_pattern_predicate(db, subject_element.pattern)
+        }
         PredicateNode::StarImportPlaceholder(star_import) => {
             let place_table = place_table(db, star_import.scope(db));
             let symbol = place_table.symbol(star_import.symbol_id(db));
@@ -1314,6 +1317,9 @@ impl<'db> ReachabilityEvaluationCache<'db> {
                 callable.scope(db)
             }
             PredicateNode::Pattern(pattern) => pattern.scope(db),
+            PredicateNode::SubjectElementPattern(subject_element) => {
+                subject_element.pattern.scope(db)
+            }
             PredicateNode::StarImportPlaceholder(star_import) => star_import.scope(db),
         };
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2174,6 +2174,38 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         kind: &SequencePatternPredicateKind<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
+        let subject_node = subject.node_ref(self.db).node(self.module);
+
+        // A tuple expression has no place that can be narrowed as a whole. For example:
+        //
+        //     match (a, b):
+        //         case (A(), B()):
+        //
+        // Project the element constraints onto the subject-time bindings of `a` and `b`.
+        if let ast::Expr::Tuple(tuple) = subject_node {
+            if !is_positive
+                || !kind.is_exact_length()
+                || tuple.elts.len() != kind.patterns.len()
+                || !tuple.elts.iter().all(ast::Expr::is_name_expr)
+            {
+                return None;
+            }
+
+            let mut constraints = NarrowingConstraints::default();
+            for (element, pattern) in tuple.elts.iter().zip(&kind.patterns) {
+                let element = PlaceExpr::try_from_expr(element)?;
+                insert_narrowing_constraint(
+                    &mut constraints,
+                    self.expect_place(&element),
+                    NarrowingConstraint::intersection(self.necessary_match_pattern_type(pattern)),
+                );
+            }
+
+            return (!constraints.is_empty()).then_some(constraints);
+        }
+
+        let subject = PlaceExpr::try_from_expr(subject_node)?;
+
         let constraint = if is_positive {
             NarrowingConstraint::intersection(self.necessary_sequence_pattern_type(kind))
         } else {
@@ -2184,7 +2216,6 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             NarrowingConstraint::intersection(sequence_type.negate(self.db))
         };
 
-        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
         let place = self.expect_place(&subject);
 
         Some(NarrowingConstraints::from_iter([(place, constraint)]))
@@ -2266,22 +2297,17 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         predicates: &Vec<PatternPredicateKind<'db>>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        // DeMorgan's law---if the overall `or` is negated, we need to `and` the negated sub-constraints.
         let merge_constraints = if is_positive {
-            merge_constraints_or
+            Self::merge_optional_constraints_or
         } else {
-            merge_constraints_and
+            Self::merge_optional_constraints_and
         };
 
         predicates
             .iter()
-            .filter_map(|predicate| {
-                self.evaluate_pattern_predicate_kind(predicate, subject, is_positive)
-            })
-            .reduce(|mut constraints, constraints_| {
-                merge_constraints(&mut constraints, constraints_);
-                constraints
-            })
+            .map(|predicate| self.evaluate_pattern_predicate_kind(predicate, subject, is_positive))
+            .reduce(merge_constraints)
+            .flatten()
     }
 
     fn evaluate_bool_op(

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2197,54 +2197,14 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> PatternNarrowingResult<'db> {
         let subject_node = subject.node_ref(self.db).node(self.module);
 
-        // A tuple expression has no place that can be narrowed as a whole. For example:
+        // A tuple or list expression has no place that can be narrowed as a whole. For example:
         //
         //     match (a, b):
         //         case (A(), B()):
         //
         // Project the element constraints onto the subject-time bindings of `a` and `b`.
-        if let ast::Expr::Tuple(tuple) = subject_node {
-            if !tuple.elts.iter().all(ast::Expr::is_name_expr) {
-                return PatternNarrowingResult::Possible(None);
-            }
-
-            let (prefix_patterns, suffix_patterns) =
-                if let Some((prefix, suffix)) = kind.split_around_star() {
-                    if tuple.elts.len() < prefix.len() + suffix.len() {
-                        return PatternNarrowingResult::Impossible;
-                    }
-                    (prefix, suffix)
-                } else {
-                    if tuple.elts.len() != kind.patterns.len() {
-                        return PatternNarrowingResult::Impossible;
-                    }
-                    (kind.patterns.as_ref(), &[][..])
-                };
-
-            if !is_positive {
-                return PatternNarrowingResult::Possible(None);
-            }
-
-            let mut constraints = NarrowingConstraints::default();
-            let element_patterns = tuple
-                .elts
-                .iter()
-                .zip(prefix_patterns)
-                .chain(tuple.elts.iter().rev().zip(suffix_patterns.iter().rev()));
-            for (element, pattern) in element_patterns {
-                let Some(element) = PlaceExpr::try_from_expr(element) else {
-                    return PatternNarrowingResult::Possible(None);
-                };
-                insert_narrowing_constraint(
-                    &mut constraints,
-                    self.expect_place(&element),
-                    NarrowingConstraint::intersection(self.necessary_match_pattern_type(pattern)),
-                );
-            }
-
-            return PatternNarrowingResult::Possible(
-                (!constraints.is_empty()).then_some(constraints),
-            );
+        if let Some(elements) = Self::sequence_expression_elements(subject_node) {
+            return self.evaluate_projected_match_pattern_sequence(elements, kind, is_positive);
         }
 
         let Some(subject) = PlaceExpr::try_from_expr(subject_node) else {
@@ -2265,6 +2225,102 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
         PatternNarrowingResult::Possible(Some(NarrowingConstraints::from_iter([(
             place, constraint,
+        )])))
+    }
+
+    fn sequence_expression_elements(expression: &ast::Expr) -> Option<&[ast::Expr]> {
+        match expression {
+            ast::Expr::List(list) => Some(&list.elts),
+            ast::Expr::Tuple(tuple) => Some(&tuple.elts),
+            _ => None,
+        }
+    }
+
+    fn evaluate_projected_match_pattern_sequence(
+        &mut self,
+        elements: &[ast::Expr],
+        kind: &SequencePatternPredicateKind<'db>,
+        is_positive: bool,
+    ) -> PatternNarrowingResult<'db> {
+        // A starred display has variable runtime length, so its elements cannot be aligned with
+        // the pattern without separately modeling the value consumed by the star.
+        if elements.iter().any(ast::Expr::is_starred_expr) {
+            return PatternNarrowingResult::Possible(None);
+        }
+
+        let (prefix_patterns, suffix_patterns) =
+            if let Some((prefix, suffix)) = kind.split_around_star() {
+                if elements.len() < prefix.len() + suffix.len() {
+                    return PatternNarrowingResult::Impossible;
+                }
+                (prefix, suffix)
+            } else {
+                if elements.len() != kind.patterns.len() {
+                    return PatternNarrowingResult::Impossible;
+                }
+                (kind.patterns.as_ref(), &[][..])
+            };
+
+        if !is_positive {
+            return PatternNarrowingResult::Possible(None);
+        }
+
+        let element_patterns = elements
+            .iter()
+            .zip(prefix_patterns)
+            .chain(elements.iter().rev().zip(suffix_patterns.iter().rev()));
+        let mut constraints = None;
+        for (element, pattern) in element_patterns {
+            let element_constraints = self.evaluate_projected_match_pattern(element, pattern);
+            match element_constraints {
+                PatternNarrowingResult::Impossible => return PatternNarrowingResult::Impossible,
+                PatternNarrowingResult::Possible(element_constraints) => {
+                    constraints =
+                        Self::merge_optional_constraints_and(constraints, element_constraints);
+                }
+            }
+        }
+
+        PatternNarrowingResult::Possible(constraints)
+    }
+
+    fn evaluate_projected_match_pattern(
+        &mut self,
+        subject: &ast::Expr,
+        pattern: &PatternPredicateKind<'db>,
+    ) -> PatternNarrowingResult<'db> {
+        if let Some(elements) = Self::sequence_expression_elements(subject) {
+            return match pattern {
+                PatternPredicateKind::Sequence(kind) => {
+                    self.evaluate_projected_match_pattern_sequence(elements, kind, true)
+                }
+                PatternPredicateKind::As(Some(pattern), _) => {
+                    self.evaluate_projected_match_pattern(subject, pattern)
+                }
+                PatternPredicateKind::Or(patterns) => {
+                    let mut alternatives = patterns.iter().filter_map(|pattern| {
+                        match self.evaluate_projected_match_pattern(subject, pattern) {
+                            PatternNarrowingResult::Impossible => None,
+                            PatternNarrowingResult::Possible(constraints) => Some(constraints),
+                        }
+                    });
+                    let Some(first) = alternatives.next() else {
+                        return PatternNarrowingResult::Impossible;
+                    };
+                    PatternNarrowingResult::Possible(
+                        alternatives.fold(first, Self::merge_optional_constraints_or),
+                    )
+                }
+                _ => PatternNarrowingResult::Possible(None),
+            };
+        }
+
+        let Some(subject) = PlaceExpr::try_from_expr(subject) else {
+            return PatternNarrowingResult::Possible(None);
+        };
+        PatternNarrowingResult::Possible(Some(NarrowingConstraints::from_iter([(
+            self.expect_place(&subject),
+            NarrowingConstraint::intersection(self.necessary_match_pattern_type(pattern)),
         )])))
     }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -20,10 +20,10 @@ use ty_python_core::expression::Expression;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
 use ty_python_core::predicate::{
     CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
-    PredicateNode, SequencePatternPredicateKind,
+    PredicateNode, SequencePatternPredicateKind, SubjectElementPatternPredicate,
 };
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{NarrowingEvaluator, place_table, semantic_index};
+use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
 
 use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast::name::Name;
@@ -186,6 +186,15 @@ pub(crate) fn infer_narrowing_constraints<'db>(
                 .and_then(|constraints| constraints.get(&place).cloned());
             (positive, negative)
         }
+        PredicateNode::SubjectElementPattern(subject_element) => {
+            let positive = all_narrowing_constraints_for_subject_element_pattern(
+                db,
+                subject_element.pattern,
+                subject_element.target,
+            )
+            .and_then(|constraints| constraints.get(&place).cloned());
+            (positive, None)
+        }
         PredicateNode::IsNonTerminalCall(_) | PredicateNode::StarImportPlaceholder(_) => {
             (None, None)
         }
@@ -231,6 +240,22 @@ fn all_negative_narrowing_constraints_for_pattern<'db>(
 ) -> Option<NarrowingConstraints<'db>> {
     let module = parsed_module(db, pattern.file(db)).load(db);
     NarrowingConstraintsBuilder::new(db, &module, PredicateNode::Pattern(pattern), false).finish()
+}
+
+#[salsa::tracked(returns(as_ref), heap_size=ruff_memory_usage::heap_size)]
+fn all_narrowing_constraints_for_subject_element_pattern<'db>(
+    db: &'db dyn Db,
+    pattern: PatternPredicate<'db>,
+    target: ExpressionNodeKey,
+) -> Option<NarrowingConstraints<'db>> {
+    let module = parsed_module(db, pattern.file(db)).load(db);
+    NarrowingConstraintsBuilder::new(
+        db,
+        &module,
+        PredicateNode::SubjectElementPattern(SubjectElementPatternPredicate { pattern, target }),
+        true,
+    )
+    .finish()
 }
 
 /// Functions that can be used to narrow the type of a first argument using a "classinfo" second argument.
@@ -806,6 +831,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PredicateNode::Pattern(pattern) => {
                 self.evaluate_pattern_predicate(pattern, self.is_positive)
             }
+            PredicateNode::SubjectElementPattern(subject_element) => {
+                self.evaluate_subject_element_pattern(subject_element)
+            }
             PredicateNode::IsNonTerminalCall(_) => return None,
             PredicateNode::StarImportPlaceholder(_) => return None,
         };
@@ -980,6 +1008,20 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         .into_constraints()
     }
 
+    fn evaluate_subject_element_pattern(
+        &mut self,
+        subject_element: SubjectElementPatternPredicate<'db>,
+    ) -> Option<NarrowingConstraints<'db>> {
+        let pattern = subject_element.pattern;
+        let subject = pattern.subject(self.db).node_ref(self.db).node(self.module);
+        self.evaluate_match_pattern_for_subject_element(
+            subject,
+            pattern.kind(self.db),
+            Some(subject_element.target),
+        )
+        .into_constraints()
+    }
+
     fn places(&self) -> &'db PlaceTable {
         place_table(self.db, self.scope())
     }
@@ -988,6 +1030,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         match self.predicate {
             PredicateNode::Expression(expression) => expression.scope(self.db),
             PredicateNode::Pattern(pattern) => pattern.scope(self.db),
+            PredicateNode::SubjectElementPattern(subject_element) => {
+                subject_element.pattern.scope(self.db)
+            }
             PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. }) => {
                 callable.scope(self.db)
             }
@@ -2220,9 +2265,14 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         //     match (a, b):
         //         case (A(), B()):
         //
-        // Project the element constraints onto the narrowable elements of the subject expression.
+        // Apply the element constraints to the narrowable elements of the subject expression.
         if let Some(elements) = Self::sequence_expression_elements(subject_node) {
-            return self.evaluate_projected_match_pattern_sequence(elements, kind, is_positive);
+            return self.evaluate_match_pattern_sequence_for_subject_element(
+                elements,
+                kind,
+                is_positive,
+                None,
+            );
         }
 
         let Some(subject) = PlaceExpr::try_from_expr(subject_node) else {
@@ -2254,11 +2304,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
-    fn evaluate_projected_match_pattern_sequence(
+    fn evaluate_match_pattern_sequence_for_subject_element(
         &mut self,
         elements: &[ast::Expr],
         kind: &SequencePatternPredicateKind<'db>,
         is_positive: bool,
+        target: Option<ExpressionNodeKey>,
     ) -> PatternNarrowingResult<'db> {
         // A starred display has variable runtime length, so its elements cannot be aligned with
         // the pattern without separately modeling the value consumed by the star.
@@ -2289,7 +2340,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             .chain(elements.iter().rev().zip(suffix_patterns.iter().rev()));
         let mut constraints = None;
         for (element, pattern) in element_patterns {
-            match self.evaluate_projected_match_pattern(element, pattern) {
+            match self.evaluate_match_pattern_for_subject_element(element, pattern, target) {
                 PatternNarrowingResult::Impossible => return PatternNarrowingResult::Impossible,
                 PatternNarrowingResult::Possible(element_constraints) => {
                     constraints =
@@ -2301,32 +2352,40 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         PatternNarrowingResult::Possible(constraints)
     }
 
-    fn evaluate_projected_match_pattern(
+    fn evaluate_match_pattern_for_subject_element(
         &mut self,
         subject: &ast::Expr,
         pattern: &PatternPredicateKind<'db>,
+        target: Option<ExpressionNodeKey>,
     ) -> PatternNarrowingResult<'db> {
         if let Some(elements) = Self::sequence_expression_elements(subject) {
             return match pattern {
-                PatternPredicateKind::Sequence(kind) => {
-                    self.evaluate_projected_match_pattern_sequence(elements, kind, true)
-                }
+                PatternPredicateKind::Sequence(kind) => self
+                    .evaluate_match_pattern_sequence_for_subject_element(
+                        elements, kind, true, target,
+                    ),
                 PatternPredicateKind::As(Some(pattern), _) => {
-                    self.evaluate_projected_match_pattern(subject, pattern)
+                    self.evaluate_match_pattern_for_subject_element(subject, pattern, target)
                 }
                 PatternPredicateKind::Or(patterns) => PatternNarrowingResult::merge_alternatives(
-                    patterns
-                        .iter()
-                        .map(|pattern| self.evaluate_projected_match_pattern(subject, pattern)),
+                    patterns.iter().map(|pattern| {
+                        self.evaluate_match_pattern_for_subject_element(subject, pattern, target)
+                    }),
                     Self::merge_optional_constraints_or,
                 ),
                 _ => PatternNarrowingResult::Possible(None),
             };
         }
 
-        let Some(subject) = PlaceExpr::try_from_expr(subject) else {
+        let subject_expr = subject;
+        let Some(subject) = PlaceExpr::try_from_expr(subject_expr) else {
             return PatternNarrowingResult::Possible(None);
         };
+        if let Some(target) = target
+            && ExpressionNodeKey::from(subject_expr) != target
+        {
+            return PatternNarrowingResult::Possible(None);
+        }
         PatternNarrowingResult::Possible(Some(NarrowingConstraints::from_iter([(
             self.expect_place(&subject),
             NarrowingConstraint::intersection(self.necessary_match_pattern_type(pattern)),

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -583,6 +583,24 @@ impl<'db> From<Type<'db>> for NarrowingConstraint<'db> {
 
 type NarrowingConstraints<'db> = FxHashMap<ScopedPlaceId, NarrowingConstraint<'db>>;
 
+/// The narrowing constraints contributed by a match pattern.
+///
+/// An impossible alternative is omitted from an OR pattern, while a possible alternative with no
+/// constraints prevents the OR pattern from narrowing.
+enum PatternNarrowingResult<'db> {
+    Impossible,
+    Possible(Option<NarrowingConstraints<'db>>),
+}
+
+impl<'db> PatternNarrowingResult<'db> {
+    fn into_constraints(self) -> Option<NarrowingConstraints<'db>> {
+        match self {
+            Self::Impossible | Self::Possible(None) => None,
+            Self::Possible(Some(constraints)) => Some(constraints),
+        }
+    }
+}
+
 #[derive(Default, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 struct ExpressionNarrowingConstraints<'db> {
     positive: Option<NarrowingConstraints<'db>>,
@@ -902,30 +920,32 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         pattern_predicate_kind: &PatternPredicateKind<'db>,
         subject: Expression<'db>,
         is_positive: bool,
-    ) -> Option<NarrowingConstraints<'db>> {
+    ) -> PatternNarrowingResult<'db> {
         match pattern_predicate_kind {
-            PatternPredicateKind::Singleton(singleton) => {
-                self.evaluate_match_pattern_singleton(subject, *singleton, is_positive)
-            }
-            PatternPredicateKind::Class(cls, kind) => {
-                self.evaluate_match_pattern_class(subject, *cls, *kind, is_positive)
-            }
-            PatternPredicateKind::Mapping(kind) => {
-                self.evaluate_match_pattern_mapping(subject, *kind, is_positive)
-            }
+            PatternPredicateKind::Singleton(singleton) => PatternNarrowingResult::Possible(
+                self.evaluate_match_pattern_singleton(subject, *singleton, is_positive),
+            ),
+            PatternPredicateKind::Class(cls, kind) => PatternNarrowingResult::Possible(
+                self.evaluate_match_pattern_class(subject, *cls, *kind, is_positive),
+            ),
+            PatternPredicateKind::Mapping(kind) => PatternNarrowingResult::Possible(
+                self.evaluate_match_pattern_mapping(subject, *kind, is_positive),
+            ),
             PatternPredicateKind::Sequence(kind) => {
                 self.evaluate_match_pattern_sequence(subject, kind, is_positive)
             }
-            PatternPredicateKind::Value(expr) => {
-                self.evaluate_match_pattern_value(subject, *expr, is_positive)
-            }
+            PatternPredicateKind::Value(expr) => PatternNarrowingResult::Possible(
+                self.evaluate_match_pattern_value(subject, *expr, is_positive),
+            ),
             PatternPredicateKind::Or(predicates) => {
                 self.evaluate_match_pattern_or(subject, predicates, is_positive)
             }
-            PatternPredicateKind::As(pattern, _) => pattern
-                .as_deref()
-                .and_then(|p| self.evaluate_pattern_predicate_kind(p, subject, is_positive)),
-            PatternPredicateKind::MatchStar => None,
+            PatternPredicateKind::As(Some(pattern), _) => {
+                self.evaluate_pattern_predicate_kind(pattern, subject, is_positive)
+            }
+            PatternPredicateKind::As(None, _) | PatternPredicateKind::MatchStar => {
+                PatternNarrowingResult::Possible(None)
+            }
         }
     }
 
@@ -939,6 +959,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             pattern.subject(self.db),
             is_positive,
         )
+        .into_constraints()
     }
 
     fn places(&self) -> &'db PlaceTable {
@@ -2173,7 +2194,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         subject: Expression<'db>,
         kind: &SequencePatternPredicateKind<'db>,
         is_positive: bool,
-    ) -> Option<NarrowingConstraints<'db>> {
+    ) -> PatternNarrowingResult<'db> {
         let subject_node = subject.node_ref(self.db).node(self.module);
 
         // A tuple expression has no place that can be narrowed as a whole. For example:
@@ -2183,22 +2204,26 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         //
         // Project the element constraints onto the subject-time bindings of `a` and `b`.
         if let ast::Expr::Tuple(tuple) = subject_node {
-            if !is_positive || !tuple.elts.iter().all(ast::Expr::is_name_expr) {
-                return None;
+            if !tuple.elts.iter().all(ast::Expr::is_name_expr) {
+                return PatternNarrowingResult::Possible(None);
             }
 
             let (prefix_patterns, suffix_patterns) =
                 if let Some((prefix, suffix)) = kind.split_around_star() {
                     if tuple.elts.len() < prefix.len() + suffix.len() {
-                        return None;
+                        return PatternNarrowingResult::Impossible;
                     }
                     (prefix, suffix)
                 } else {
                     if tuple.elts.len() != kind.patterns.len() {
-                        return None;
+                        return PatternNarrowingResult::Impossible;
                     }
                     (kind.patterns.as_ref(), &[][..])
                 };
+
+            if !is_positive {
+                return PatternNarrowingResult::Possible(None);
+            }
 
             let mut constraints = NarrowingConstraints::default();
             let element_patterns = tuple
@@ -2207,7 +2232,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 .zip(prefix_patterns)
                 .chain(tuple.elts.iter().rev().zip(suffix_patterns.iter().rev()));
             for (element, pattern) in element_patterns {
-                let element = PlaceExpr::try_from_expr(element)?;
+                let Some(element) = PlaceExpr::try_from_expr(element) else {
+                    return PatternNarrowingResult::Possible(None);
+                };
                 insert_narrowing_constraint(
                     &mut constraints,
                     self.expect_place(&element),
@@ -2215,24 +2242,30 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 );
             }
 
-            return (!constraints.is_empty()).then_some(constraints);
+            return PatternNarrowingResult::Possible(
+                (!constraints.is_empty()).then_some(constraints),
+            );
         }
 
-        let subject = PlaceExpr::try_from_expr(subject_node)?;
+        let Some(subject) = PlaceExpr::try_from_expr(subject_node) else {
+            return PatternNarrowingResult::Possible(None);
+        };
 
         let constraint = if is_positive {
             NarrowingConstraint::intersection(self.necessary_sequence_pattern_type(kind))
         } else {
             let sequence_type = definite_sequence_pattern_type(self.db, kind);
             if sequence_type.is_never() {
-                return None;
+                return PatternNarrowingResult::Possible(None);
             }
             NarrowingConstraint::intersection(sequence_type.negate(self.db))
         };
 
         let place = self.expect_place(&subject);
 
-        Some(NarrowingConstraints::from_iter([(place, constraint)]))
+        PatternNarrowingResult::Possible(Some(NarrowingConstraints::from_iter([(
+            place, constraint,
+        )])))
     }
 
     fn evaluate_match_pattern_value(
@@ -2310,18 +2343,24 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         subject: Expression<'db>,
         predicates: &Vec<PatternPredicateKind<'db>>,
         is_positive: bool,
-    ) -> Option<NarrowingConstraints<'db>> {
+    ) -> PatternNarrowingResult<'db> {
         let merge_constraints = if is_positive {
             Self::merge_optional_constraints_or
         } else {
             Self::merge_optional_constraints_and
         };
 
-        predicates
-            .iter()
-            .map(|predicate| self.evaluate_pattern_predicate_kind(predicate, subject, is_positive))
-            .reduce(merge_constraints)
-            .flatten()
+        let mut alternatives = predicates.iter().filter_map(|predicate| {
+            match self.evaluate_pattern_predicate_kind(predicate, subject, is_positive) {
+                PatternNarrowingResult::Impossible => None,
+                PatternNarrowingResult::Possible(constraints) => Some(constraints),
+            }
+        });
+        let Some(first) = alternatives.next() else {
+            return PatternNarrowingResult::Impossible;
+        };
+
+        PatternNarrowingResult::Possible(alternatives.fold(first, merge_constraints))
     }
 
     fn evaluate_bool_op(

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2183,16 +2183,30 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         //
         // Project the element constraints onto the subject-time bindings of `a` and `b`.
         if let ast::Expr::Tuple(tuple) = subject_node {
-            if !is_positive
-                || !kind.is_exact_length()
-                || tuple.elts.len() != kind.patterns.len()
-                || !tuple.elts.iter().all(ast::Expr::is_name_expr)
-            {
+            if !is_positive || !tuple.elts.iter().all(ast::Expr::is_name_expr) {
                 return None;
             }
 
+            let (prefix_patterns, suffix_patterns) =
+                if let Some((prefix, suffix)) = kind.split_around_star() {
+                    if tuple.elts.len() < prefix.len() + suffix.len() {
+                        return None;
+                    }
+                    (prefix, suffix)
+                } else {
+                    if tuple.elts.len() != kind.patterns.len() {
+                        return None;
+                    }
+                    (kind.patterns.as_ref(), &[][..])
+                };
+
             let mut constraints = NarrowingConstraints::default();
-            for (element, pattern) in tuple.elts.iter().zip(&kind.patterns) {
+            let element_patterns = tuple
+                .elts
+                .iter()
+                .zip(prefix_patterns)
+                .chain(tuple.elts.iter().rev().zip(suffix_patterns.iter().rev()));
+            for (element, pattern) in element_patterns {
                 let element = PlaceExpr::try_from_expr(element)?;
                 insert_narrowing_constraint(
                     &mut constraints,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -593,6 +593,24 @@ enum PatternNarrowingResult<'db> {
 }
 
 impl<'db> PatternNarrowingResult<'db> {
+    fn merge_alternatives(
+        alternatives: impl Iterator<Item = Self>,
+        merge_constraints: fn(
+            Option<NarrowingConstraints<'db>>,
+            Option<NarrowingConstraints<'db>>,
+        ) -> Option<NarrowingConstraints<'db>>,
+    ) -> Self {
+        let mut alternatives = alternatives.filter_map(|alternative| match alternative {
+            Self::Impossible => None,
+            Self::Possible(constraints) => Some(constraints),
+        });
+        let Some(first) = alternatives.next() else {
+            return Self::Impossible;
+        };
+
+        Self::Possible(alternatives.fold(first, merge_constraints))
+    }
+
     fn into_constraints(self) -> Option<NarrowingConstraints<'db>> {
         match self {
             Self::Impossible | Self::Possible(None) => None,
@@ -2202,7 +2220,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         //     match (a, b):
         //         case (A(), B()):
         //
-        // Project the element constraints onto the subject-time bindings of `a` and `b`.
+        // Project the element constraints onto the narrowable elements of the subject expression.
         if let Some(elements) = Self::sequence_expression_elements(subject_node) {
             return self.evaluate_projected_match_pattern_sequence(elements, kind, is_positive);
         }
@@ -2271,8 +2289,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             .chain(elements.iter().rev().zip(suffix_patterns.iter().rev()));
         let mut constraints = None;
         for (element, pattern) in element_patterns {
-            let element_constraints = self.evaluate_projected_match_pattern(element, pattern);
-            match element_constraints {
+            match self.evaluate_projected_match_pattern(element, pattern) {
                 PatternNarrowingResult::Impossible => return PatternNarrowingResult::Impossible,
                 PatternNarrowingResult::Possible(element_constraints) => {
                     constraints =
@@ -2297,20 +2314,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 PatternPredicateKind::As(Some(pattern), _) => {
                     self.evaluate_projected_match_pattern(subject, pattern)
                 }
-                PatternPredicateKind::Or(patterns) => {
-                    let mut alternatives = patterns.iter().filter_map(|pattern| {
-                        match self.evaluate_projected_match_pattern(subject, pattern) {
-                            PatternNarrowingResult::Impossible => None,
-                            PatternNarrowingResult::Possible(constraints) => Some(constraints),
-                        }
-                    });
-                    let Some(first) = alternatives.next() else {
-                        return PatternNarrowingResult::Impossible;
-                    };
-                    PatternNarrowingResult::Possible(
-                        alternatives.fold(first, Self::merge_optional_constraints_or),
-                    )
-                }
+                PatternPredicateKind::Or(patterns) => PatternNarrowingResult::merge_alternatives(
+                    patterns
+                        .iter()
+                        .map(|pattern| self.evaluate_projected_match_pattern(subject, pattern)),
+                    Self::merge_optional_constraints_or,
+                ),
                 _ => PatternNarrowingResult::Possible(None),
             };
         }
@@ -2406,17 +2415,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             Self::merge_optional_constraints_and
         };
 
-        let mut alternatives = predicates.iter().filter_map(|predicate| {
-            match self.evaluate_pattern_predicate_kind(predicate, subject, is_positive) {
-                PatternNarrowingResult::Impossible => None,
-                PatternNarrowingResult::Possible(constraints) => Some(constraints),
-            }
-        });
-        let Some(first) = alternatives.next() else {
-            return PatternNarrowingResult::Impossible;
-        };
-
-        PatternNarrowingResult::Possible(alternatives.fold(first, merge_constraints))
+        PatternNarrowingResult::merge_alternatives(
+            predicates.iter().map(|predicate| {
+                self.evaluate_pattern_predicate_kind(predicate, subject, is_positive)
+            }),
+            merge_constraints,
+        )
     }
 
     fn evaluate_bool_op(


### PR DESCRIPTION
## Summary

Prior to this change, we narrowed a sequence value used as a match subject, but not the places used to construct an inline tuple or list display:

```py
class A: ...
class A1(A): ...
class B: ...
class B1(B): ...

def f(a: A, b: B) -> None:
    match [a, b]:
        case [A1(), B1()]:
            reveal_type(a)  # revealed: A1
            reveal_type(b)  # revealed: B1
```

A match subject is evaluated once, so we retain the bindings read by its narrowable elements at subject evaluation. Successful sequence patterns recursively project their fixed prefix and suffix constraints through nested tuple and list displays onto names, attributes, and literal subscripts whose subject-time bindings are still live.

This supports later cases, starred patterns, repeated places, multiple reaching definitions, nested displays, and constrained `or` patterns without scanning cases for possible reassignments. Failed matches still do not project element constraints because they do not identify which element failed. Dictionary displays and starred subject displays remain conservative and are documented with TODO tests.

When combining `or` patterns, we distinguish impossible alternatives from possible alternatives that do not constrain the subject. Impossible alternatives are omitted, while unconstrained alternatives correctly prevent the overall pattern from narrowing.

Closes https://github.com/astral-sh/ty/issues/3743.
