### PR TITLE
[ty] Run benchmarks for context-independent call argument reuse

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_form.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_form.md
@@ -427,6 +427,25 @@ reveal_type(foo(str))  # revealed: str
 foo(float)  # error: [no-matching-overload]
 ```
 
+Recursive aliases in overload parameter contexts should not cause contextual inference to recurse
+indefinitely.
+
+```py
+from typing import overload
+from typing_extensions import TypeForm
+
+type RecursiveForm = RecursiveForm | TypeForm[int]
+
+@overload
+def consume(value: RecursiveForm, discriminator: int) -> None: ...
+@overload
+def consume(value: RecursiveForm, discriminator: str) -> None: ...
+def consume(value: RecursiveForm, discriminator: int | str) -> None: ...
+
+value: object = object()
+consume(value, 1)
+```
+
 ## Narrowing to runtime classes
 
 A `TypeForm[T]` value may or may not be a runtime class object. An `isinstance(..., type)` check can

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -96,14 +96,13 @@ use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
 use crate::types::{
     BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType,
-    CycleDetector, DynamicType, InferenceFlags, InternedConstraintSet, InternedType,
-    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, KnownUnion,
-    LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters,
-    SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType,
-    TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind,
-    TypeVarVariance, TypedDictType, UnionAccumulator, UnionBuilder, UnionType, any_over_type,
-    binding_type, infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment,
-    todo_type,
+    DynamicType, InferenceFlags, InternedConstraintSet, InternedType, IntersectionBuilder,
+    IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueTypeKind,
+    MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters, SentinelInstance, Signature,
+    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
+    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType,
+    UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
+    infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
@@ -5625,28 +5624,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         fn contains_type_form<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-            struct ContainsTypeForm;
-            type ContainsTypeFormVisitor<'db> = CycleDetector<ContainsTypeForm, Type<'db>, bool>;
-
-            fn imp<'db>(
-                db: &'db dyn Db,
-                ty: Type<'db>,
-                visitor: &ContainsTypeFormVisitor<'db>,
-            ) -> bool {
-                match ty {
-                    Type::TypeForm(_) => true,
-                    Type::TypeAlias(alias) => {
-                        visitor.visit(ty, || imp(db, alias.value_type(db), visitor))
-                    }
-                    Type::Union(union) => union
-                        .elements(db)
-                        .iter()
-                        .any(|element| imp(db, *element, visitor)),
-                    _ => false,
-                }
+            match ty.resolve_type_alias(db) {
+                Type::TypeForm(_) => true,
+                Type::Union(union) => union
+                    .elements(db)
+                    .iter()
+                    .any(|element| matches!(element.resolve_type_alias(db), Type::TypeForm(_))),
+                _ => false,
             }
-
-            imp(db, ty, &ContainsTypeFormVisitor::default())
         }
 
         fn can_reuse_default_argument_type<'db>(
@@ -5655,18 +5640,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             default_ty: Type<'db>,
             parameter_contexts: &[ArgumentTypeContext<'db>],
         ) -> bool {
-            if !matches!(ast_argument, ast::Expr::Name(_) | ast::Expr::Attribute(_)) {
-                return false;
-            }
-
-            if matches!(
-                default_ty.resolve_type_alias(db),
-                Type::ClassLiteral(_)
-                    | Type::LiteralValue(_)
-                    | Type::SubclassOf(_)
-                    | Type::TypeForm(_)
-            ) {
-                return false;
+            match ast_argument {
+                ast::Expr::Name(_) | ast::Expr::Attribute(_) => {
+                    if matches!(
+                        default_ty.resolve_type_alias(db),
+                        Type::ClassLiteral(_) | Type::SubclassOf(_) | Type::TypeForm(_)
+                    ) {
+                        return false;
+                    }
+                }
+                ast::Expr::StringLiteral(_)
+                | ast::Expr::BytesLiteral(_)
+                | ast::Expr::NumberLiteral(_)
+                | ast::Expr::BooleanLiteral(_)
+                | ast::Expr::NoneLiteral(_)
+                | ast::Expr::EllipsisLiteral(_)
+                | ast::Expr::FString(_)
+                | ast::Expr::TString(_)
+                | ast::Expr::UnaryOp(_)
+                | ast::Expr::Compare(_)
+                | ast::Expr::Subscript(_)
+                | ast::Expr::Slice(_)
+                | ast::Expr::Named(_) => {}
+                _ => return false,
             }
 
             parameter_contexts.iter().all(|parameter_context| {
@@ -5806,11 +5802,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     default_ty,
                     &parameter_contexts,
                 ) {
+                    if matches!(ast_argument, ast::Expr::StringLiteral(_))
+                        && let Some(expected) = parameter_contexts
+                            .iter()
+                            .filter_map(|context| context.type_context().annotation)
+                            .filter(|expected| {
+                                self.has_string_literal_completion_candidates(*expected)
+                            })
+                            .reduce(|left, right| UnionType::from_two_elements(db, left, right))
+                    {
+                        self.store_expected_type(ast_argument, expected);
+                    }
+
                     for parameter_context in parameter_contexts {
+                        let inferred_ty = self.apply_literal_type_context(
+                            default_ty,
+                            parameter_context.type_context(),
+                        );
                         parameter_context.insert_inferred_type(
                             arguments_types,
                             argument_index,
-                            default_ty,
+                            inferred_ty,
                         );
                     }
                     continue;
@@ -6061,6 +6073,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_value_expression_impl(expression, tcx)
     }
 
+    fn apply_literal_type_context(&self, ty: Type<'db>, tcx: TypeContext<'db>) -> Type<'db> {
+        let db = self.db();
+        if let Type::LiteralValue(literal) = ty
+            && let Some(tcx) = tcx.annotation
+            && let literal_tcx @ (Type::Union(_) | Type::LiteralValue(_)) = tcx
+                .resolve_type_alias(db)
+                .filter_union(db, |ty| ty.as_literal_value().is_some())
+            && ty.is_assignable_to(db, literal_tcx)
+        {
+            Type::LiteralValue(literal.to_unpromotable())
+        } else {
+            ty
+        }
+    }
+
     /// Infer an expression without implicitly treating this root as a `TypeForm`.
     ///
     /// Child expressions still use their normal contextual inference, so the
@@ -6132,15 +6159,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         // Avoid promoting explicitly annotated literal values.
-        if let Type::LiteralValue(literal) = ty
-            && let Some(tcx) = tcx.annotation
-            && let literal_tcx @ (Type::Union(_) | Type::LiteralValue(_)) = tcx
-                .resolve_type_alias(self.db())
-                .filter_union(self.db(), |ty| ty.as_literal_value().is_some())
-            && ty.is_assignable_to(self.db(), literal_tcx)
-        {
-            ty = Type::LiteralValue(literal.to_unpromotable());
-        }
+        ty = self.apply_literal_type_context(ty, tcx);
 
         if let Some(tcx) = tcx.annotation
             && let Some(collection_def) = self.index.unconstrained_collection_binding(expression)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -37,7 +37,7 @@ use crate::place::{
 };
 use crate::reachability::ReachabilityConstraintsExtension;
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
-use crate::types::call::bind::MatchingOverloadIndex;
+use crate::types::call::bind::{ArgumentTypeContext, MatchingOverloadIndex};
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
@@ -96,13 +96,14 @@ use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
 use crate::types::{
     BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType,
-    DynamicType, InferenceFlags, InternedConstraintSet, InternedType, IntersectionBuilder,
-    IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueTypeKind,
-    MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters, SentinelInstance, Signature,
-    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
-    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType,
-    UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
-    infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
+    CycleDetector, DynamicType, InferenceFlags, InternedConstraintSet, InternedType,
+    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, KnownUnion,
+    LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters,
+    SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType,
+    TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind,
+    TypeVarVariance, TypedDictType, UnionAccumulator, UnionBuilder, UnionType, any_over_type,
+    binding_type, infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment,
+    todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
@@ -5599,7 +5600,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         call_expression_tcx: TypeContext<'db>,
     ) {
         fn add_overloads_from_binding<'a, 'db>(
-            overloads_with_binding: &mut Vec<(&'a Binding<'db>, &'a CallableBinding<'db>)>,
+            overloads_with_binding: &mut SmallVec<
+                [(&'a Binding<'db>, &'a CallableBinding<'db>); 1],
+            >,
             binding: &'a CallableBinding<'db>,
         ) {
             match binding.matching_overload_index() {
@@ -5621,47 +5624,115 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
+        fn contains_type_form<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+            struct ContainsTypeForm;
+            type ContainsTypeFormVisitor<'db> = CycleDetector<ContainsTypeForm, Type<'db>, bool>;
+
+            fn imp<'db>(
+                db: &'db dyn Db,
+                ty: Type<'db>,
+                visitor: &ContainsTypeFormVisitor<'db>,
+            ) -> bool {
+                match ty {
+                    Type::TypeForm(_) => true,
+                    Type::TypeAlias(alias) => {
+                        visitor.visit(ty, || imp(db, alias.value_type(db), visitor))
+                    }
+                    Type::Union(union) => union
+                        .elements(db)
+                        .iter()
+                        .any(|element| imp(db, *element, visitor)),
+                    _ => false,
+                }
+            }
+
+            imp(db, ty, &ContainsTypeFormVisitor::default())
+        }
+
+        fn can_reuse_default_argument_type<'db>(
+            db: &'db dyn Db,
+            ast_argument: &ast::Expr,
+            default_ty: Type<'db>,
+            parameter_contexts: &[ArgumentTypeContext<'db>],
+        ) -> bool {
+            if !matches!(ast_argument, ast::Expr::Name(_) | ast::Expr::Attribute(_)) {
+                return false;
+            }
+
+            if matches!(
+                default_ty.resolve_type_alias(db),
+                Type::ClassLiteral(_)
+                    | Type::LiteralValue(_)
+                    | Type::SubclassOf(_)
+                    | Type::TypeForm(_)
+            ) {
+                return false;
+            }
+
+            parameter_contexts.iter().all(|parameter_context| {
+                parameter_context
+                    .type_context()
+                    .annotation
+                    .is_none_or(|annotation| !contains_type_form(db, annotation))
+            })
+        }
+
         let db = self.db();
         let constraints = ConstraintSetBuilder::new();
 
-        let mut overloads_with_binding: Vec<(&Binding<'db>, &CallableBinding<'db>)> = Vec::new();
+        let mut overloads_with_binding: SmallVec<[(&Binding<'db>, &CallableBinding<'db>); 1]> =
+            SmallVec::new();
 
         bindings.visit_type_context_callables(&mut |binding| {
             add_overloads_from_binding(&mut overloads_with_binding, binding);
         });
 
-        // A keyword argument matched to `**P.kwargs` can appear before the keyword argument that
-        // binds `P`, e.g. `wrapper(TagSet=[...], func=put_object)`. Seed those binder argument
-        // types first so the normal ParamSpec context path below is not source-order dependent.
-        for (argument_index, ast_argument) in ast_arguments.clone().enumerate() {
-            if ast_argument.is_variadic() {
-                continue;
-            }
-            let ast_argument = ast_argument.value();
-
-            let mut inferred_declared_types = FxHashSet::default();
-            for declared_type in overloads_with_binding
-                .iter()
-                .filter_map(|(overload, binding)| {
-                    overload.paramspec_binder_parameter_type(db, binding, argument_index)
-                })
-            {
-                if !inferred_declared_types.insert(declared_type) {
+        if overloads_with_binding.iter().any(|(overload, _)| {
+            overload
+                .signature
+                .parameters()
+                .as_paramspec_with_prefix()
+                .is_some()
+        }) {
+            // A keyword argument matched to `**P.kwargs` can appear before the keyword argument that
+            // binds `P`, e.g. `wrapper(TagSet=[...], func=put_object)`. Seed those binder argument
+            // types first so the normal ParamSpec context path below is not source-order dependent.
+            for (argument_index, ast_argument) in ast_arguments.clone().enumerate() {
+                if ast_argument.is_variadic() {
                     continue;
                 }
+                let ast_argument = ast_argument.value();
 
-                let mut speculative_builder = self.speculate();
-                let inferred_ty = infer_argument_ty(
-                    &mut speculative_builder,
-                    (
-                        argument_index,
-                        ast_argument,
-                        TypeContext::new(Some(declared_type)),
-                    ),
-                );
-                arguments_types.insert_type(argument_index, declared_type, inferred_ty);
+                let mut inferred_declared_types = FxHashSet::default();
+                for declared_type in
+                    overloads_with_binding
+                        .iter()
+                        .filter_map(|(overload, binding)| {
+                            overload.paramspec_binder_parameter_type(db, binding, argument_index)
+                        })
+                {
+                    if !inferred_declared_types.insert(declared_type) {
+                        continue;
+                    }
+
+                    let mut speculative_builder = self.speculate();
+                    let inferred_ty = infer_argument_ty(
+                        &mut speculative_builder,
+                        (
+                            argument_index,
+                            ast_argument,
+                            TypeContext::new(Some(declared_type)),
+                        ),
+                    );
+                    arguments_types.insert_type(argument_index, declared_type, inferred_ty);
+                }
             }
         }
+
+        let single_overload_with_binding = match overloads_with_binding.as_slice() {
+            [(overload, binding)] => Some((*overload, *binding)),
+            _ => None,
+        };
 
         for (argument_index, ast_argument) in ast_arguments.enumerate() {
             // Splatted arguments are inferred before parameter matching to
@@ -5687,7 +5758,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // If there is only a single binding and overload, we can infer the argument directly with
             // the unique parameter type annotation.
-            if let Ok((overload, binding)) = overloads_with_binding.iter().exactly_one() {
+            if let Some((overload, binding)) = single_overload_with_binding {
                 let parameter_context = parameter_tcx(overload, binding);
 
                 if let Some(parameter_context) = parameter_context {
@@ -5717,10 +5788,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             } else {
                 // Infer the type of each argument once with each distinct parameter type as type context.
-                let parameter_contexts: Vec<_> = overloads_with_binding
-                    .iter()
-                    .filter_map(|(overload, binding)| parameter_tcx(overload, binding))
-                    .collect();
+                let parameter_contexts: SmallVec<[ArgumentTypeContext<'db>; 4]> =
+                    overloads_with_binding
+                        .iter()
+                        .filter_map(|(overload, binding)| parameter_tcx(overload, binding))
+                        .collect();
 
                 // We perform inference once without any type context, emitting any diagnostics that are unrelated
                 // to bidirectional type inference.
@@ -5728,55 +5800,98 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     infer_argument_ty(self, (argument_index, ast_argument, TypeContext::default()));
                 arguments_types.insert_type(argument_index, TypeContext::default(), default_ty);
 
-                let mut inferred_by_cache_key = FxHashMap::default();
+                if can_reuse_default_argument_type(
+                    db,
+                    ast_argument,
+                    default_ty,
+                    &parameter_contexts,
+                ) {
+                    for parameter_context in parameter_contexts {
+                        parameter_context.insert_inferred_type(
+                            arguments_types,
+                            argument_index,
+                            default_ty,
+                        );
+                    }
+                    continue;
+                }
 
-                // Cache expressions inferred across speculative inference attempts.
-                //
-                // This is important to avoid exponential blowup for deeply nested generic calls,
-                // as inner expressions are repeatedly inferred with the same type context.
-                let teardown = self.setup_expression_cache();
+                let [parameter_context] = parameter_contexts.as_slice() else {
+                    if parameter_contexts.is_empty() {
+                        continue;
+                    }
 
-                for parameter_context in parameter_contexts {
-                    let inference_cache_key = parameter_context.inference_cache_key();
-                    if let Some(inferred_ty) =
-                        inferred_by_cache_key.get(&inference_cache_key).copied()
-                    {
-                        // Even when the inference cache key is identical, this overload may later
-                        // look up the inferred type through a different original `ParamSpec`
-                        // annotation, so insert through its own context.
+                    let mut inferred_by_cache_key = FxHashMap::default();
+
+                    // Cache expressions inferred across speculative inference attempts.
+                    //
+                    // This is important to avoid exponential blowup for deeply nested generic calls,
+                    // as inner expressions are repeatedly inferred with the same type context.
+                    let teardown = self.setup_expression_cache();
+
+                    for parameter_context in parameter_contexts {
+                        let inference_cache_key = parameter_context.inference_cache_key();
+                        if let Some(inferred_ty) =
+                            inferred_by_cache_key.get(&inference_cache_key).copied()
+                        {
+                            // Even when the inference cache key is identical, this overload may later
+                            // look up the inferred type through a different original `ParamSpec`
+                            // annotation, so insert through its own context.
+                            parameter_context.insert_inferred_type(
+                                arguments_types,
+                                argument_index,
+                                inferred_ty,
+                            );
+                            continue;
+                        }
+
+                        // We use a speculative builder to silence any diagnostics emitted during multi-inference, as the
+                        // type context is only used as a hint to infer a more assignable argument type, and should not lead
+                        // to diagnostics for non-matching overloads.
+                        let mut speculative_builder = self.speculate();
+                        let inferred_ty = infer_argument_ty(
+                            &mut speculative_builder,
+                            (
+                                argument_index,
+                                ast_argument,
+                                parameter_context.type_context(),
+                            ),
+                        );
+
+                        inferred_by_cache_key.insert(inference_cache_key, inferred_ty);
+                        self.union_expected_types(&speculative_builder.expected_types);
                         parameter_context.insert_inferred_type(
                             arguments_types,
                             argument_index,
                             inferred_ty,
                         );
-                        continue;
                     }
 
-                    // We use a speculative builder to silence any diagnostics emitted during multi-inference, as the
-                    // type context is only used as a hint to infer a more assignable argument type, and should not lead
-                    // to diagnostics for non-matching overloads.
-                    let mut speculative_builder = self.speculate();
-                    let inferred_ty = infer_argument_ty(
-                        &mut speculative_builder,
-                        (
-                            argument_index,
-                            ast_argument,
-                            parameter_context.type_context(),
-                        ),
-                    );
+                    if teardown {
+                        self.teardown_expression_cache();
+                    }
 
-                    inferred_by_cache_key.insert(inference_cache_key, inferred_ty);
-                    self.union_expected_types(&speculative_builder.expected_types);
-                    parameter_context.insert_inferred_type(
-                        arguments_types,
+                    continue;
+                };
+
+                // Avoid allocating a per-argument inference cache when only one context is
+                // available. There are no repeated speculative inferences to deduplicate.
+                let mut speculative_builder = self.speculate();
+                let inferred_ty = infer_argument_ty(
+                    &mut speculative_builder,
+                    (
                         argument_index,
-                        inferred_ty,
-                    );
-                }
+                        ast_argument,
+                        parameter_context.type_context(),
+                    ),
+                );
 
-                if teardown {
-                    self.teardown_expression_cache();
-                }
+                self.union_expected_types(&speculative_builder.expected_types);
+                parameter_context.insert_inferred_type(
+                    arguments_types,
+                    argument_index,
+                    inferred_ty,
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary

- reduce repeated contextual inference across overload candidates
- reuse context-independent argument types when an expression's inferred type does not depend on the expected type
- isolate this change from #25867 so CodSpeed can measure it independently

## Test plan

- `cargo nextest run -p ty_python_semantic`
- `cargo clippy -p ty_python_semantic --all-targets --all-features -- -D warnings`
- file-scoped `uvx prek`