### PR TITLE
[ty] Fast path collection literals with exact type contexts

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -16,7 +16,7 @@ python-version = "3.12"
 ## Propagating target type annotation
 
 ```py
-from typing import AsyncGenerator, AsyncIterable, Generator, Iterable, Literal
+from typing import Any, AsyncGenerator, AsyncIterable, Generator, Iterable, Literal
 
 def list1[T](x: T) -> list[T]:
     return [x]
@@ -86,6 +86,37 @@ reveal_type(x)  # revealed: list[int]
 
 x: list[list[int]] = [[1], [2], *([3], [4])]
 reveal_type(x)  # revealed: list[list[int]]
+
+type IntDict = dict[str, int]
+
+unique: set[int] = {1, 2, 3}
+reveal_type(unique)  # revealed: set[int]
+
+mapping: dict[str, int] = {"a": 1, **{"b": 2}}
+reveal_type(mapping)  # revealed: dict[str, int]
+
+def dynamic_mapping() -> Any: ...
+
+dynamic_unpack: dict[str, int] = reveal_type({**dynamic_mapping()})  # revealed: dict[str | Any, int | Any]
+
+alias_mapping: IntDict = {"a": 1}
+reveal_type(alias_mapping)  # revealed: dict[str, int]
+
+optional_mapping: dict[str, int] | None = {"a": 1}
+reveal_type(optional_mapping)  # revealed: dict[str, int]
+
+either: list[int] | list[str] = [1]
+reveal_type(either)  # revealed: list[int]
+
+# A protocol context is not an exact nominal collection context and must use the general path.
+iterable: Iterable[int] = [1]
+reveal_type(iterable)  # revealed: list[int]
+
+bad_list: list[str] = [1]  # error: [invalid-assignment]
+bad_dict: dict[str, int] = {"a": "bad"}  # error: [invalid-assignment]
+
+# error: [invalid-argument-type] "Argument expression after ** must be a mapping type"
+bad_unpack: dict[str, int] = {**42}
 
 x: list[list[int | str]] = [[1], [2]] * 3
 reveal_type(x)  # revealed: list[list[int | str]]

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -115,6 +115,8 @@ reveal_type(iterable)  # revealed: list[int]
 bad_list: list[str] = [1]  # error: [invalid-assignment]
 bad_dict: dict[str, int] = {"a": "bad"}  # error: [invalid-assignment]
 
+bad_nested_list: list[list[list[str]]] = [[[1]]]  # error: [invalid-assignment]
+
 # error: [invalid-argument-type] "Argument expression after ** must be a mapping type"
 bad_unpack: dict[str, int] = {**42}
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7062,6 +7062,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .iter()
                 .any(|elts| matches!(elts.as_slice(), [None, Some(_)]));
 
+        let mut pre_inferred_elt_tys = None;
+
         // Avoid projecting and solving a constraint set when contextual inference has already
         // provided the complete specialization and every literal element is compatible with it.
         if !has_dict_unpack
@@ -7086,12 +7088,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         {
             // The slow path below adds the contextual specialization as an invariant mapping,
             // then discards every element constraint that is already assignable to its context.
-            // Probe that case speculatively so that a failed probe can fall back without changing
-            // diagnostics or inferred expression types.
-            let mut speculative_builder = self.speculate();
+            // Infer the elements once here and retain their types so that a failed fast-path check
+            // does not recursively re-infer nested collection literals on the slow path.
+            let mut inferred_elts = Vec::with_capacity(elts.len());
             let mut compatible = true;
 
-            'elements: for elts in elts {
+            for elts in elts {
+                let mut inferred_elt_tys = [None; N];
                 for (i, elt, elt_tcx) in itertools::izip!(0.., elts, specialization.iter().copied())
                 {
                     let Some(elt) = elt else { continue };
@@ -7100,21 +7103,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     } else {
                         elt_tcx
                     };
-                    let inferred_elt_ty = infer_elt_expression(
-                        &mut speculative_builder,
-                        (i, elt, TypeContext::new(Some(elt_tcx))),
-                    );
+                    let inferred_elt_ty =
+                        infer_elt_expression(self, (i, elt, TypeContext::new(Some(elt_tcx))));
+                    inferred_elt_tys[i] = Some(inferred_elt_ty);
 
                     if !inferred_elt_ty.is_assignable_to(self.db(), elt_tcx) {
                         compatible = false;
-                        break 'elements;
                     }
                 }
+                inferred_elts.push(inferred_elt_tys);
             }
 
             if compatible {
-                self.extend(speculative_builder);
-
                 let class_type = collection_alias.origin(self.db()).apply_specialization(
                     self.db(),
                     |generic_context| {
@@ -7124,6 +7124,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 );
                 return Type::from(class_type).to_instance(self.db());
             }
+
+            pre_inferred_elt_tys = Some(inferred_elts);
         }
 
         // Create a set of constraints to infer a precise type for `T`.
@@ -7216,7 +7218,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        for elts in elts {
+        for (elts_index, elts) in elts.iter().enumerate() {
             // An unpacking expression for a dictionary.
             if let &[None, Some(value_expr)] = elts.as_slice() {
                 let unpack_ty = infer_elt_expression(self, (1, value_expr, tcx));
@@ -7285,8 +7287,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }
                     });
 
-                let inferred_elt_ty =
-                    infer_elt_expression(self, (i, elt, TypeContext::new(elt_tcx)));
+                let inferred_elt_ty = pre_inferred_elt_tys
+                    .as_ref()
+                    .and_then(|inferred_elts| inferred_elts[elts_index][i])
+                    .unwrap_or_else(|| {
+                        infer_elt_expression(self, (i, elt, TypeContext::new(elt_tcx)))
+                    });
 
                 // Simplify the inference based on a non-covariant declared type.
                 if let Some(elt_tcx) =

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6948,7 +6948,40 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mut elt_tcx_variance: FxHashMap<BoundTypeVarIdentity<'_>, TypeVarVariance> =
                 FxHashMap::default();
 
-            if let Some(tcx) = tcx.annotation
+            if let Some(tcx) = tcx.annotation.map(|tcx| tcx.resolve_type_alias(self.db()))
+                && matches!(tcx, Type::NominalInstance(_))
+                && let Some(specialization) = tcx.known_specialization(self.db(), collection_class)
+                && specialization.generic_context(self.db()) == generic_context
+                && generic_context.variables(self.db()).all(|typevar| {
+                    !typevar.is_paramspec(self.db())
+                        && typevar
+                            .typevar(self.db())
+                            .bound_or_constraints(self.db())
+                            .is_none()
+                })
+            {
+                // For an instance of the collection class itself, the identity specialization
+                // maps directly to the contextual specialization. Avoid constructing and solving
+                // a general assignability constraint set for this common case.
+                for (typevar, inferred_ty) in generic_context
+                    .variables(self.db())
+                    .zip(specialization.types(self.db()))
+                {
+                    let inferred_ty = inferred_ty
+                        .filter_union(self.db(), |ty| {
+                            !ty.as_typevar()
+                                .is_some_and(|tv| tv.is_inferable(self.db(), inferable))
+                        })
+                        .filter_union(self.db(), |ty| !ty.has_unspecialized_type_var(self.db()));
+                    if inferred_ty.has_unspecialized_type_var(self.db()) {
+                        continue;
+                    }
+
+                    let identity = typevar.identity(self.db());
+                    elt_tcx_constraints.insert(identity, UnionAccumulator::new(inferred_ty));
+                    elt_tcx_variance.insert(identity, typevar.variance(self.db()));
+                }
+            } else if let Some(tcx) = tcx.annotation
                 && tcx.class_specialization(self.db()).is_some()
             {
                 let db = self.db();
@@ -7021,9 +7054,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (elt_tcx_constraints, elt_tcx_variance)
         };
 
+        // Dictionary unpacking always contributes constraints on the inferred key and value types,
+        // even when the unpacked mapping is assignable to the context. Keep it on the general path
+        // so gradual types such as `Any` are preserved.
+        let has_dict_unpack = collection_class == KnownClass::Dict
+            && elts
+                .iter()
+                .any(|elts| matches!(elts.as_slice(), [None, Some(_)]));
+
         // Avoid projecting and solving a constraint set when contextual inference has already
-        // provided the complete specialization for an empty collection literal.
-        if elts.is_empty()
+        // provided the complete specialization and every literal element is compatible with it.
+        if !has_dict_unpack
             && tcx.annotation.is_some()
             && let Some(specialization) = generic_context
                 .variables(self.db())
@@ -7043,14 +7084,46 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
                 .collect::<Option<Vec<_>>>()
         {
-            let class_type = collection_alias.origin(self.db()).apply_specialization(
-                self.db(),
-                |generic_context| {
-                    generic_context
-                        .specialize_recursive(self.db(), specialization.into_iter().map(Some))
-                },
-            );
-            return Type::from(class_type).to_instance(self.db());
+            // The slow path below adds the contextual specialization as an invariant mapping,
+            // then discards every element constraint that is already assignable to its context.
+            // Probe that case speculatively so that a failed probe can fall back without changing
+            // diagnostics or inferred expression types.
+            let mut speculative_builder = self.speculate();
+            let mut compatible = true;
+
+            'elements: for elts in elts {
+                for (i, elt, elt_tcx) in itertools::izip!(0.., elts, specialization.iter().copied())
+                {
+                    let Some(elt) = elt else { continue };
+                    let elt_tcx = if elt.is_starred_expr() && collection_class != KnownClass::Dict {
+                        Type::homogeneous_tuple(self.db(), elt_tcx)
+                    } else {
+                        elt_tcx
+                    };
+                    let inferred_elt_ty = infer_elt_expression(
+                        &mut speculative_builder,
+                        (i, elt, TypeContext::new(Some(elt_tcx))),
+                    );
+
+                    if !inferred_elt_ty.is_assignable_to(self.db(), elt_tcx) {
+                        compatible = false;
+                        break 'elements;
+                    }
+                }
+            }
+
+            if compatible {
+                self.extend(speculative_builder);
+
+                let class_type = collection_alias.origin(self.db()).apply_specialization(
+                    self.db(),
+                    |generic_context| {
+                        generic_context
+                            .specialize_recursive(self.db(), specialization.into_iter().map(Some))
+                    },
+                );
+                return Type::from(class_type).to_instance(self.db());
+            }
         }
 
         // Create a set of constraints to infer a precise type for `T`.


### PR DESCRIPTION
## Summary

When a collection literal has an exact `list`, `set`, or `dict` type context, that context can already determine the collection specialization. We currently recover those element types by constructing and solving a general assignability constraint set, which is expensive when a contextual type argument is a large union such as Pydantic's `CoreSchema`.

For example:

```python
choices: dict[Hashable, CoreSchema] = {}
```

Here, the annotation gives the literal an exact `dict` context with known key and value types. An abstract context such as `Mapping[Hashable, CoreSchema]` is not an exact nominal collection context and continues through the general inference path.

This adds a direct path that maps the collection's identity specialization to the contextual specialization and checks the literal elements against those contextual types speculatively. If every element is compatible, we reuse the contextual specialization without projecting and solving a constraint set.

Partially specialized, bounded, constrained, union, protocol, and dictionary-unpacking contexts continue through the general solver. Failed speculative checks also fall back, preserving diagnostics and the existing inferred types.

## Performance

In the existing CodSpeed comparison, this improved `ty_micro[pydantic_core_schema_dict]` by 36.9%, the Pydantic wall-time benchmark by 11.4%, `ty_micro[recursive_typed_dict_union_contextual_inference]` by 8.8%, and `static_frame` by 3.1%.
