### PR TITLE
[ty] Fast path exact list and dict iteration

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -133,6 +133,27 @@ for x in (1, "a", b"foo"):
 reveal_type(x)
 ```
 
+## Exact builtin containers and subclass overrides
+
+```py
+from typing import Any, Iterator
+
+def builtins(values: list[int], mapping: dict[str, int]):
+    for value in values:
+        reveal_type(value)  # revealed: int
+
+    for key in mapping:
+        reveal_type(key)  # revealed: str
+
+class CustomList(list[Any]):
+    def __iter__(self) -> Iterator[str]:
+        return iter([""])
+
+def subclass(values: CustomList):
+    for value in values:
+        reveal_type(value)  # revealed: str
+```
+
 ## With non-callable iterator
 
 ```py

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -2,7 +2,7 @@ use crate::{
     Db,
     types::{
         AwaitError, Bindings, CallArguments, CallDunderError, KnownClass, LintDiagnosticGuard,
-        LintDiagnosticGuardBuilder, LiteralValueTypeKind, Type, TypeContext,
+        LintDiagnosticGuardBuilder, LiteralValueTypeKind, MaterializationKind, Type, TypeContext,
         TypeVarBoundOrConstraints, UnionType,
         call::CallErrorKind,
         context::InferContext,
@@ -105,7 +105,38 @@ impl<'db> Type<'db> {
             const MAX_TUPLE_LENGTH: usize = 128;
 
             match ty {
-                Type::NominalInstance(nominal) => nominal.tuple_spec(db),
+                Type::NominalInstance(nominal) => match nominal.known_class(db) {
+                    // Iteration over these exact builtin classes cannot be customized. Subclasses
+                    // have no `KnownClass`, so they continue through the dunder lookup below.
+                    Some(KnownClass::List | KnownClass::Dict) => {
+                        let element_type = nominal.class(db).into_generic_alias().map_or(
+                            Type::unknown(),
+                            |alias| {
+                                let specialization = alias.specialization(db);
+                                let element_type = specialization
+                                    .types(db)
+                                    .first()
+                                    .copied()
+                                    .unwrap_or(Type::unknown());
+                                if element_type.has_dynamic(db) {
+                                    match specialization.materialization_kind(db) {
+                                        Some(MaterializationKind::Top) => {
+                                            element_type.top_materialization(db)
+                                        }
+                                        Some(MaterializationKind::Bottom) => {
+                                            element_type.bottom_materialization(db)
+                                        }
+                                        None => element_type,
+                                    }
+                                } else {
+                                    element_type
+                                }
+                            },
+                        );
+                        Some(Cow::Owned(TupleSpec::homogeneous(element_type)))
+                    }
+                    _ => nominal.tuple_spec(db),
+                },
                 Type::NewTypeInstance(newtype) => non_async_special_case(db, newtype.concrete_base_type(db)),
                 Type::GenericAlias(alias) if alias.origin(db).is_tuple(db) => {
                     Some(Cow::Owned(TupleSpec::homogeneous(todo_type!(


### PR DESCRIPTION
## Summary

Iteration over exact built-in `list` and `dict` instances cannot be customized, but we currently resolve their yielded types through the general `__iter__` protocol lookup. This adds a direct path that reads the element type from a `list` specialization and the key type from a `dict` specialization, avoiding member lookup and signature binding for these common cases. Dynamic type arguments retain the specialization's top or bottom materialization.

The fast path is limited to exact built-in instances. Subclasses continue through normal method lookup, so an overridden `__iter__` still determines the yielded type.
