### PR TITLE
[`pydoclint`] Don't flag DOC201 for a bare `return` in a generator

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -214,3 +214,16 @@ class Spam:
     def __new__(cls) -> 'Spam':
         """New!!"""
         return cls()
+
+
+# OK - bare `return` in a generator returns `None`; the loose `-> object`
+# annotation doesn't describe the generator's return value
+def my_generator(val: object) -> object:
+    """Minimal generator.
+
+    Yields:
+        val
+    """
+    if val is not None:
+        yield val
+    return

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_numpy.py
@@ -234,3 +234,19 @@ def generator_function_4():
 def not_a_generator() -> Iterator[int]:
     """"No returns documented here, oh no"""
     return (x for x in range(42))
+
+
+# This is okay -- a bare `return` in a generator returns `None`, and the loose
+# `-> object` annotation doesn't describe the generator's return value
+def generator_function_5(val: object) -> object:
+    """Generate some values"""
+    if val is not None:
+        yield val
+    return
+
+
+# DOC201 -- a non-None return, despite the loose `-> object` annotation
+def generator_function_6(val: object) -> object:
+    """Generate some values"""
+    yield val
+    return 42

--- a/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
+++ b/crates/ruff_linter/src/rules/pydoclint/rules/check_docstring.rs
@@ -1276,7 +1276,25 @@ pub(crate) fn check_docstring(
             let extra_property_decorators = checker.settings().pydocstyle.property_decorators();
             if !definition.is_property(extra_property_decorators, semantic) {
                 if !body_entries.returns.is_empty() {
+                    let has_non_none_return = body_entries
+                        .returns
+                        .iter()
+                        .any(|entry| !entry.is_none_return());
+                    let is_generator = !body_entries.yields.is_empty();
                     match function_def.returns.as_deref() {
+                        // For a generator function whose return annotation isn't a recognized
+                        // generator/iterator type (e.g. `-> object`), the annotation doesn't
+                        // describe the generator's *return* value, so defer to the body and only
+                        // flag a non-`None` return statement.
+                        Some(returns)
+                            if is_generator
+                                && generator_annotation_arguments(returns, semantic).is_none() =>
+                        {
+                            if has_non_none_return {
+                                checker
+                                    .report_diagnostic(DocstringMissingReturns, docstring.range());
+                            }
+                        }
                         Some(returns)
                             // Ignore it if it's annotated as returning `None`
                             // or it's a generator function annotated as returning `None`,
@@ -1291,11 +1309,7 @@ pub(crate) fn check_docstring(
                                 checker
                                     .report_diagnostic(DocstringMissingReturns, docstring.range());
                             }
-                        None if body_entries
-                            .returns
-                            .iter()
-                            .any(|entry| !entry.is_none_return()) =>
-                        {
+                        None if has_non_none_return => {
                             checker.report_diagnostic(DocstringMissingReturns, docstring.range());
                         }
                         _ => {}

--- a/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-returns_DOC201_numpy.py.snap
+++ b/crates/ruff_linter/src/rules/pydoclint/snapshots/ruff_linter__rules__pydoclint__tests__docstring-missing-returns_DOC201_numpy.py.snap
@@ -146,3 +146,15 @@ DOC201 `return` is not documented in docstring
 236 |     return (x for x in range(42))
     |
 help: Add a "Returns" section to the docstring
+
+DOC201 `return` is not documented in docstring
+   --> DOC201_numpy.py:250:5
+    |
+248 | # DOC201 -- a non-None return, despite the loose `-> object` annotation
+249 | def generator_function_6(val: object) -> object:
+250 |     """Generate some values"""
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+251 |     yield val
+252 |     return 42
+    |
+help: Add a "Returns" section to the docstring


### PR DESCRIPTION
## Summary

Fixes #21336.

While poking at the DOC rules I ran into the same catch-22 the issue describes. Take a generator like this:

```python
def my_generator(val: object) -> object:
    """
    Minimal generator.

    Yields:
        val
    """
    if val is not None:
        yield val
    return
```

`DOC201` complains that the `return` isn't documented and tells you to add a `Returns` section. So you add one... and now `DOC202` tells you to remove it again. There's no docstring that makes both rules happy, which is pretty frustrating in practice.

The function only ever returns `None` (the `return` is bare), and the rule even documents that it isn't enforced "for functions that only return None" — so it shouldn't be firing here at all.

## What was going on

DOC201 decides what to do based on the return annotation. It already knows to stay quiet for `-> None` and for the generator/iterator types it recognizes (`Iterator[...]`, `Generator[..., ..., None]`, etc.). But a loose annotation like `-> object` doesn't match any of those, so the rule assumed there was a real value being returned and flagged it.

The thing is, `-> object` on a generator tells us nothing about the generator's *return* value — the real type is `Generator[...]`. So leaning on that annotation is the wrong move.

## The fix

When the function is a generator and its annotation isn't one of the recognized generator/iterator types, fall back to looking at the body and only flag if there's an actual non-`None` `return`. This reuses the existing `generator_annotation_arguments` helper rather than adding new analysis.

Cases that *should* still fire are untouched:

- `-> str | None` returning only `None` (not a generator) — still flagged.
- `-> Generator[str, None, int | None]` with a bare `return` — still flagged, because that annotation really does say the return type can be `int`.
- a generator with a real `return 42`, even under a loose `-> object` — still flagged.

## Test Plan

Added fixtures for both the false-positive case and the "still fires" counter-case in the numpy fixture, plus the exact snippet from the issue (Google style) in the google fixture, and updated the snapshot. `cargo test -p ruff_linter pydoclint`, clippy, and `prek` all pass.

This is a preview rule, so the change only applies under `--preview`.