### PR TITLE
simplify Ruff Rule macro

### DIFF
--- a/crates/ruff/src/commands/rule.rs
+++ b/crates/ruff/src/commands/rule.rs
@@ -4,7 +4,6 @@ use std::io::{self, BufWriter, Write};
 use anyhow::Result;
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
-use strum::IntoEnumIterator;
 
 use ruff_linter::FixAvailability;
 use ruff_linter::codes::RuleGroup;

--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -9,7 +9,6 @@ use anyhow::Result;
 use itertools::Itertools;
 use regex::{Captures, Regex};
 use ruff_linter::codes::RuleGroup;
-use strum::IntoEnumIterator;
 
 use ruff_linter::FixAvailability;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -25,7 +25,7 @@ const SYMBOL_STYLE: &str = "style='width: 1em; display: inline-block;'";
 /// Style for the container wrapping the fixability and status icons.
 const SYMBOLS_CONTAINER: &str = "style='display: flex; gap: 0.5rem; justify-content: end;'";
 
-fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>, linter: &Linter) {
+fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>, linter: Linter) {
     table_out.push_str("| Code { scope='col' } | Name { scope='col' } | Message { scope='col' } | Fix/Status { scope='col' .sr-only } |");
     table_out.push('\n');
     table_out.push_str("| ---- | ---- | ------- | -: |");
@@ -189,7 +189,7 @@ pub(crate) fn generate() -> String {
         }
 
         let rules_by_upstream_category = linter
-            .all_rules()
+            .rules()
             .map(|rule| (rule.upstream_category(&linter), rule))
             .into_group_map();
 
@@ -222,10 +222,10 @@ pub(crate) fn generate() -> String {
                 }
                 table_out.push('\n');
                 table_out.push('\n');
-                generate_table(&mut table_out, rules.clone(), &linter);
+                generate_table(&mut table_out, rules.clone(), linter);
             }
         } else {
-            generate_table(&mut table_out, linter.all_rules(), &linter);
+            generate_table(&mut table_out, linter.rules(), linter);
         }
     }
 

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -6,9 +6,8 @@ use std::fmt::Formatter;
 
 use ruff_db::diagnostic::SecondaryCode;
 use serde::Serialize;
-use strum_macros::EnumIter;
 
-use crate::registry::Linter;
+use crate::registry::{Linter, RuleNamespace};
 use crate::rule_selector::is_single_rule_selector;
 use crate::rules;
 
@@ -87,6 +86,25 @@ pub enum RuleGroup {
     Deprecated { since: &'static str },
     /// The rule was removed in the provided Ruff version, and errors will be displayed on use.
     Removed { since: &'static str },
+}
+
+#[derive(Debug)]
+pub struct RuleMetadata {
+    pub rule: Rule,
+    pub linter: Linter,
+    pub code: &'static str,
+    pub message_formats: fn() -> &'static [&'static str],
+    pub fix_availability: crate::FixAvailability,
+    pub explanation: Option<&'static str>,
+    pub group: RuleGroup,
+    pub file: &'static str,
+    pub line: u32,
+}
+
+impl RuleMetadata {
+    pub fn message_formats(&self) -> &'static [&'static str] {
+        (self.message_formats)()
+    }
 }
 
 #[ruff_macros::map_codes]
@@ -1219,6 +1237,78 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
 
         _ => return None,
     })
+}
+
+impl Rule {
+    /// Iterate over all rules.
+    pub fn iter() -> RuleIter {
+        RuleIter(RULE_METADATA.iter())
+    }
+
+    /// Returns the format strings used to report violations of this rule.
+    pub fn message_formats(&self) -> &'static [&'static str] {
+        self.metadata().message_formats()
+    }
+
+    /// Returns the documentation for this rule.
+    pub fn explanation(&self) -> Option<&'static str> {
+        self.metadata().explanation
+    }
+
+    /// Returns the fix status of this rule.
+    pub fn fixable(&self) -> crate::FixAvailability {
+        self.metadata().fix_availability
+    }
+
+    pub fn group(&self) -> RuleGroup {
+        self.metadata().group
+    }
+
+    pub fn file(&self) -> &'static str {
+        self.metadata().file
+    }
+
+    pub fn line(&self) -> u32 {
+        self.metadata().line
+    }
+
+    pub fn noqa_code(&self) -> NoqaCode {
+        let metadata = self.metadata();
+        NoqaCode(metadata.linter.common_prefix(), metadata.code)
+    }
+
+    pub fn is_preview(&self) -> bool {
+        matches!(self.group(), RuleGroup::Preview { .. })
+    }
+
+    pub fn is_deprecated(&self) -> bool {
+        matches!(self.group(), RuleGroup::Deprecated { .. })
+    }
+
+    pub fn is_removed(&self) -> bool {
+        matches!(self.group(), RuleGroup::Removed { .. })
+    }
+}
+
+impl Linter {
+    /// All rules for this linter, regardless of rule group filters like preview and deprecated.
+    pub fn rules(self: &Linter) -> impl Iterator<Item = Rule> {
+        let linter = *self;
+
+        RULE_METADATA
+            .iter()
+            .filter_map(move |metadata| (metadata.linter == linter).then_some(metadata.rule))
+    }
+}
+
+impl RuleCodePrefix {
+    pub(crate) fn rules(&self) -> impl Iterator<Item = Rule> {
+        let short_code = self.short_code();
+
+        self.linter()
+            .rules()
+            .filter(move |rule| rule.metadata().code.starts_with(short_code))
+    }
 }
 
 impl std::fmt::Display for Rule {

--- a/crates/ruff_linter/src/message/sarif.rs
+++ b/crates/ruff_linter/src/message/sarif.rs
@@ -124,7 +124,7 @@ impl<'a> From<(&'a SecondaryCode, SarifLevel)> for SarifRule<'a> {
         // avoids calling Linter::parse_code twice.
         let (linter, suffix) = Linter::parse_code(code).unwrap();
         let rule = linter
-            .all_rules()
+            .rules()
             .find(|rule| rule.noqa_code().suffix() == suffix)
             .expect("Expected a valid noqa code corresponding to a rule");
         Self {

--- a/crates/ruff_linter/src/registry.rs
+++ b/crates/ruff_linter/src/registry.rs
@@ -20,7 +20,7 @@ impl Rule {
     pub fn from_code(code: &str) -> Result<Self, FromCodeError> {
         let (linter, code) = Linter::parse_code(code).ok_or(FromCodeError::Unknown)?;
         linter
-            .all_rules()
+            .rules()
             .find(|rule| rule.noqa_code().suffix() == code)
             .ok_or(FromCodeError::Unknown)
     }
@@ -32,7 +32,7 @@ pub enum FromCodeError {
     Unknown,
 }
 
-#[derive(EnumIter, Debug, PartialEq, Eq, Clone, Hash, RuleNamespace)]
+#[derive(EnumIter, Debug, PartialEq, Eq, Copy, Clone, Hash, RuleNamespace)]
 pub enum Linter {
     /// [Airflow](https://pypi.org/project/apache-airflow/)
     #[prefix = "AIR"]
@@ -386,7 +386,6 @@ pub mod clap_completion {
         PossibleValue, PossibleValuesParser, TypedValueParser, ValueParserFactory,
     };
     use clap::error::ContextKind;
-    use strum::IntoEnumIterator;
 
     use crate::registry::Rule;
 

--- a/crates/ruff_linter/src/registry/rule_set.rs
+++ b/crates/ruff_linter/src/registry/rule_set.rs
@@ -388,8 +388,6 @@ impl FusedIterator for RuleSetIterator {}
 
 #[cfg(test)]
 mod tests {
-    use strum::IntoEnumIterator;
-
     use crate::registry::{Rule, RuleSet};
 
     /// Tests that the set can contain all rules

--- a/crates/ruff_linter/src/rule_redirects.rs
+++ b/crates/ruff_linter/src/rule_redirects.rs
@@ -142,7 +142,6 @@ static REDIRECTS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(
 mod tests {
     use crate::codes::{Rule, RuleGroup};
     use crate::rule_redirects::REDIRECTS;
-    use strum::IntoEnumIterator;
 
     /// Tests for rule codes that overlap with a redirect.
     #[test]

--- a/crates/ruff_linter/src/rule_selector.rs
+++ b/crates/ruff_linter/src/rule_selector.rs
@@ -2,10 +2,8 @@ use std::str::FromStr;
 
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Serialize};
-use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
-use crate::codes::RuleIter;
 use crate::codes::{RuleCodePrefix, RuleGroup};
 use crate::registry::{Linter, Rule, RuleNamespace};
 use crate::rule_redirects::get_redirect;
@@ -190,24 +188,30 @@ impl Visitor<'_> for SelectorVisitor {
 impl RuleSelector {
     /// Return all matching rules, regardless of rule group filters like preview and deprecated.
     pub fn all_rules(&self) -> impl Iterator<Item = Rule> + '_ {
-        match self {
-            RuleSelector::All => RuleSelectorIter::All(Rule::iter()),
+        Rule::iter().filter(|rule| {
+            let metadata = rule.metadata();
 
-            RuleSelector::C => RuleSelectorIter::Chain(
-                Linter::Flake8Comprehensions
-                    .rules()
-                    .chain(Linter::McCabe.rules()),
-            ),
-            RuleSelector::T => RuleSelectorIter::Chain(
-                Linter::Flake8Debugger
-                    .rules()
-                    .chain(Linter::Flake8Print.rules()),
-            ),
-            RuleSelector::Linter(linter) => RuleSelectorIter::Vec(linter.rules()),
-            RuleSelector::Prefix { prefix, .. } | RuleSelector::Rule { prefix, .. } => {
-                RuleSelectorIter::Vec(prefix.clone().rules())
+            match self {
+                RuleSelector::All => true,
+                RuleSelector::C => {
+                    matches!(
+                        metadata.linter,
+                        Linter::Flake8Comprehensions | Linter::McCabe
+                    )
+                }
+                RuleSelector::T => {
+                    matches!(
+                        metadata.linter,
+                        Linter::Flake8Debugger | Linter::Flake8Print
+                    )
+                }
+                RuleSelector::Linter(linter) => metadata.linter == *linter,
+                RuleSelector::Prefix { prefix, .. } | RuleSelector::Rule { prefix, .. } => {
+                    metadata.linter == *prefix.linter()
+                        && metadata.code.starts_with(prefix.short_code())
+                }
             }
-        }
+        })
     }
 
     /// Returns rules matching the selector, taking into account rule groups like preview and deprecated.
@@ -234,24 +238,6 @@ impl RuleSelector {
     /// Returns true if this selector is exact i.e. selects a single rule by code
     pub fn is_exact(&self) -> bool {
         matches!(self, Self::Rule { .. })
-    }
-}
-
-pub enum RuleSelectorIter {
-    All(RuleIter),
-    Chain(std::iter::Chain<std::vec::IntoIter<Rule>, std::vec::IntoIter<Rule>>),
-    Vec(std::vec::IntoIter<Rule>),
-}
-
-impl Iterator for RuleSelectorIter {
-    type Item = Rule;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            RuleSelectorIter::All(iter) => iter.next(),
-            RuleSelectorIter::Chain(iter) => iter.next(),
-            RuleSelectorIter::Vec(iter) => iter.next(),
-        }
     }
 }
 

--- a/crates/ruff_linter/src/violation.rs
+++ b/crates/ruff_linter/src/violation.rs
@@ -29,21 +29,47 @@ impl Display for FixAvailability {
 }
 
 pub trait ViolationMetadata {
+    /// The rule for this violation.
+    const RULE: Rule;
+
+    /// An explanation of what this violation catches, why it's bad, and what users should do
+    /// instead.
+    const EXPLANATION: Option<&'static str>;
+
+    /// The rule group for this violation.
+    const GROUP: RuleGroup;
+
+    /// The file where the violation is declared.
+    const FILE: &'static str;
+
+    /// The 1-based line where the violation is declared.
+    const LINE: u32;
+
     /// Returns the rule for this violation
-    fn rule() -> Rule;
+    fn rule() -> Rule {
+        Self::RULE
+    }
 
     /// Returns an explanation of what this violation catches,
     /// why it's bad, and what users should do instead.
-    fn explain() -> Option<&'static str>;
+    fn explain() -> Option<&'static str> {
+        Self::EXPLANATION
+    }
 
     /// Returns the rule group for this violation.
-    fn group() -> RuleGroup;
+    fn group() -> RuleGroup {
+        Self::GROUP
+    }
 
     /// Returns the file where the violation is declared.
-    fn file() -> &'static str;
+    fn file() -> &'static str {
+        Self::FILE
+    }
 
     /// Returns the 1-based line where the violation is declared.
-    fn line() -> u32;
+    fn line() -> u32 {
+        Self::LINE
+    }
 }
 
 pub trait Violation: ViolationMetadata + Sized {

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -8,10 +8,7 @@ use syn::{
     parenthesized, parse::Parse, spanned::Spanned,
 };
 
-use crate::{
-    kebab_case::kebab_case,
-    rule_code_prefix::{get_prefix_ident, intersection_all},
-};
+use crate::kebab_case::kebab_case;
 
 /// A rule entry in the big match statement such a
 /// `(Pycodestyle, "E112") => (RuleGroup::Preview, rules::pycodestyle::rules::logical_lines::NoIndentedBlock),`
@@ -75,7 +72,6 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
     }
 
     let linter_idents: Vec<_> = linter_to_rules.keys().collect();
-
     let all_rules = linter_to_rules.values().flat_map(BTreeMap::values);
     let mut output = register_rules(all_rules);
 
@@ -136,51 +132,6 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
         });
     }
 
-    let mut all_codes = Vec::new();
-
-    for (linter, rules) in &linter_to_rules {
-        let rules_by_prefix = rules_by_prefix(rules);
-
-        for (prefix, rules) in &rules_by_prefix {
-            let prefix_ident = get_prefix_ident(prefix);
-            let attrs = intersection_all(rules.iter().map(|(.., attrs)| attrs.as_slice()));
-            let attrs = if attrs.is_empty() {
-                quote!()
-            } else {
-                quote!(#(#attrs)*)
-            };
-            all_codes.push(quote! {
-                #attrs Self::#linter(#linter::#prefix_ident)
-            });
-        }
-
-        let mut prefix_into_iter_match_arms = quote!();
-
-        for (prefix, rules) in rules_by_prefix {
-            let rule_paths = rules.iter().map(|(path, .., attrs)| {
-                let rule_name = path.segments.last().unwrap();
-                quote!(#(#attrs)* Rule::#rule_name)
-            });
-            let prefix_ident = get_prefix_ident(&prefix);
-            let attrs = intersection_all(rules.iter().map(|(.., attrs)| attrs.as_slice()));
-            let attrs = if attrs.is_empty() {
-                quote!()
-            } else {
-                quote!(#(#attrs)*)
-            };
-            prefix_into_iter_match_arms.extend(quote! {
-                #attrs #linter::#prefix_ident => vec![#(#rule_paths,)*].into_iter(),
-            });
-        }
-
-        output.extend(quote! {
-            impl #linter {
-                pub(crate) fn rules(&self) -> ::std::vec::IntoIter<Rule> {
-                    match self { #prefix_into_iter_match_arms }
-                }
-            }
-        });
-    }
     output.extend(quote! {
         impl RuleCodePrefix {
             pub(crate) fn parse(linter: &Linter, code: &str) -> Result<Self, crate::registry::FromCodeError> {
@@ -191,46 +142,15 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
                 })
             }
 
-            pub(crate) fn rules(&self) -> ::std::vec::IntoIter<Rule> {
-                match self {
-                    #(RuleCodePrefix::#linter_idents(prefix) => prefix.clone().rules(),)*
-                }
-            }
         }
     });
 
     let rule_to_code = generate_rule_to_code(&linter_to_rules);
     output.extend(rule_to_code);
 
-    output.extend(generate_iter_impl(&linter_to_rules, &linter_idents));
+    output.extend(generate_rule_code_prefix_iter_impl(&linter_idents));
 
     Ok(output)
-}
-
-/// Group the rules by their common prefixes.
-fn rules_by_prefix(
-    rules: &BTreeMap<String, Rule>,
-) -> BTreeMap<String, Vec<(Path, Vec<Attribute>)>> {
-    // TODO(charlie): Why do we do this here _and_ in `rule_code_prefix::expand`?
-    let mut rules_by_prefix = BTreeMap::new();
-
-    for code in rules.keys() {
-        for i in 1..=code.len() {
-            let prefix = code[..i].to_string();
-            let rules: Vec<_> = rules
-                .iter()
-                .filter_map(|(code, rule)| {
-                    if code.starts_with(&prefix) {
-                        Some((rule.path.clone(), rule.attrs.clone()))
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            rules_by_prefix.insert(prefix, rules);
-        }
-    }
-    rules_by_prefix
 }
 
 /// Map from rule to codes that can be used to select it.
@@ -240,21 +160,13 @@ fn rules_by_prefix(
 /// done to support it, so the logic exists here.
 fn generate_rule_to_code(linter_to_rules: &BTreeMap<Ident, BTreeMap<String, Rule>>) -> TokenStream {
     let mut rule_to_codes: HashMap<&Path, Vec<&Rule>> = HashMap::new();
-    let mut linter_code_for_rule_match_arms = quote!();
 
-    for (linter, map) in linter_to_rules {
-        for (code, rule) in map {
-            let Rule {
-                path, attrs, name, ..
-            } = rule;
+    for map in linter_to_rules.values() {
+        for rule in map.values() {
+            let Rule { path, .. } = rule;
             rule_to_codes.entry(path).or_default().push(rule);
-            linter_code_for_rule_match_arms.extend(quote! {
-                #(#attrs)* (Self::#linter, Rule::#name) => Some(#code),
-            });
         }
     }
-
-    let mut rule_noqa_code_match_arms = quote!();
 
     // Keep the proc-macro output stable so unchanged code can be reused incrementally.
     for (rule, codes) in rule_to_codes
@@ -279,55 +191,16 @@ See also https://github.com/astral-sh/ruff/issues/2186.
 ",
             rule_name.ident
         );
-
-        let Rule {
-            linter,
-            code,
-            attrs,
-            ..
-        } = codes
-            .iter()
-            .sorted_by_key(|data| data.linter == "Pylint")
-            .next()
-            .unwrap();
-
-        rule_noqa_code_match_arms.extend(quote! {
-            #(#attrs)* Rule::#rule_name => NoqaCode(crate::registry::Linter::#linter.common_prefix(), #code),
-        });
     }
 
     let rule_to_code = quote! {
-        impl Rule {
-            pub fn noqa_code(&self) -> NoqaCode {
-                use crate::registry::RuleNamespace;
-
-                match self {
-                    #rule_noqa_code_match_arms
-                }
-            }
-
-            pub fn is_preview(&self) -> bool {
-                matches!(self.group(), RuleGroup::Preview { .. })
-            }
-
-            pub(crate) fn is_stable(&self) -> bool {
-                matches!(self.group(), RuleGroup::Stable { .. })
-            }
-
-            pub fn is_deprecated(&self) -> bool {
-                matches!(self.group(), RuleGroup::Deprecated { .. })
-            }
-
-            pub fn is_removed(&self) -> bool {
-                matches!(self.group(), RuleGroup::Removed { .. })
-            }
-        }
-
         impl Linter {
             pub fn code_for_rule(&self, rule: Rule) -> Option<&'static str> {
-                match (self, rule) {
-                    #linter_code_for_rule_match_arms
-                    _ => None,
+                let metadata = rule.metadata();
+                if metadata.linter == *self {
+                    Some(metadata.code)
+                } else {
+                    None
                 }
             }
         }
@@ -335,46 +208,9 @@ See also https://github.com/astral-sh/ruff/issues/2186.
     rule_to_code
 }
 
-/// Implement `impl IntoIterator for &Linter` and `RuleCodePrefix::iter()`
-fn generate_iter_impl(
-    linter_to_rules: &BTreeMap<Ident, BTreeMap<String, Rule>>,
-    linter_idents: &[&Ident],
-) -> TokenStream {
-    let mut linter_rules_match_arms = quote!();
-    let mut linter_all_rules_match_arms = quote!();
-    for (linter, map) in linter_to_rules {
-        let rule_paths = map.values().map(|Rule { attrs, path, .. }| {
-            let rule_name = path.segments.last().unwrap();
-            quote!(#(#attrs)* Rule::#rule_name)
-        });
-        linter_rules_match_arms.extend(quote! {
-            Linter::#linter => vec![#(#rule_paths,)*].into_iter(),
-        });
-        let rule_paths = map.values().map(|Rule { attrs, path, .. }| {
-            let rule_name = path.segments.last().unwrap();
-            quote!(#(#attrs)* Rule::#rule_name)
-        });
-        linter_all_rules_match_arms.extend(quote! {
-            Linter::#linter => vec![#(#rule_paths,)*].into_iter(),
-        });
-    }
-
+/// Implement `RuleCodePrefix::iter()`
+fn generate_rule_code_prefix_iter_impl(linter_idents: &[&Ident]) -> TokenStream {
     quote! {
-        impl Linter {
-            /// Rules not in the preview.
-            pub(crate) fn rules(self: &Linter) -> ::std::vec::IntoIter<Rule> {
-                match self {
-                    #linter_rules_match_arms
-                }
-            }
-            /// All rules, including those in the preview.
-            pub fn all_rules(self: &Linter) -> ::std::vec::IntoIter<Rule> {
-                match self {
-                    #linter_all_rules_match_arms
-                }
-            }
-        }
-
         impl RuleCodePrefix {
             pub(crate) fn iter() -> impl Iterator<Item = RuleCodePrefix> {
                 use strum::IntoEnumIterator;
@@ -391,16 +227,15 @@ fn generate_iter_impl(
 /// Generate the `Rule` enum
 fn register_rules<'a>(input: impl Iterator<Item = &'a Rule>) -> TokenStream {
     let mut rule_variants = quote!();
-    let mut rule_message_formats_match_arms = quote!();
-    let mut rule_fixable_match_arms = quote!();
-    let mut rule_explanation_match_arms = quote!();
-    let mut rule_group_match_arms = quote!();
-    let mut rule_file_match_arms = quote!();
-    let mut rule_line_match_arms = quote!();
     let mut rule_parse_match_arms = quote!();
+    let mut rule_metadata = quote!();
 
     for Rule {
-        name, attrs, path, ..
+        name,
+        linter,
+        code,
+        attrs,
+        path,
     } in input
     {
         let kebab_name = kebab_case(name);
@@ -408,31 +243,25 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a Rule>) -> TokenStream {
             #(#attrs)*
             #name,
         });
-        // Apply the `attrs` to each arm, like `[cfg(feature = "foo")]`.
-        rule_message_formats_match_arms.extend(
-            quote! {#(#attrs)* Self::#name => <#path as crate::Violation>::message_formats(),},
-        );
-        rule_fixable_match_arms.extend(
-            quote! {#(#attrs)* Self::#name => <#path as crate::Violation>::FIX_AVAILABILITY,},
-        );
-        rule_explanation_match_arms.extend(quote! {#(#attrs)* Self::#name => #path::explain(),});
-        rule_group_match_arms.extend(
-            quote! {#(#attrs)* Self::#name => <#path as crate::ViolationMetadata>::group(),},
-        );
-        rule_file_match_arms.extend(
-            quote! {#(#attrs)* Self::#name => <#path as crate::ViolationMetadata>::file(),},
-        );
-        rule_line_match_arms.extend(
-            quote! {#(#attrs)* Self::#name => <#path as crate::ViolationMetadata>::line(),},
-        );
         rule_parse_match_arms.extend(quote! {#(#attrs)* #kebab_name => Ok(Self::#name),});
+        rule_metadata.extend(quote! {
+            #(#attrs)*
+            RuleMetadata {
+                rule: Rule::#name,
+                linter: Linter::#linter,
+                code: #code,
+                message_formats: <#path as crate::Violation>::message_formats,
+                fix_availability: <#path as crate::Violation>::FIX_AVAILABILITY,
+                explanation: <#path as crate::ViolationMetadata>::EXPLANATION,
+                group: <#path as crate::ViolationMetadata>::GROUP,
+                file: <#path as crate::ViolationMetadata>::FILE,
+                line: <#path as crate::ViolationMetadata>::LINE,
+            },
+        });
     }
 
     quote! {
-        use crate::Violation;
-
         #[derive(
-            EnumIter,
             Debug,
             PartialEq,
             Eq,
@@ -445,33 +274,30 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a Rule>) -> TokenStream {
         #[strum(serialize_all = "kebab-case")]
         pub enum Rule { #rule_variants }
 
+        pub static RULE_METADATA: &[RuleMetadata] = &[
+            #rule_metadata
+        ];
+
+        pub struct RuleIter(::std::slice::Iter<'static, RuleMetadata>);
+
+        impl Iterator for RuleIter {
+            type Item = Rule;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                self.0.next().map(|metadata| metadata.rule)
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                self.0.size_hint()
+            }
+        }
+
+        impl ExactSizeIterator for RuleIter {}
+
         impl Rule {
-            /// Returns the format strings used to report violations of this rule.
-            pub fn message_formats(&self) -> &'static [&'static str] {
-                match self { #rule_message_formats_match_arms }
-            }
-
-            /// Returns the documentation for this rule.
-            pub fn explanation(&self) -> Option<&'static str> {
-                use crate::ViolationMetadata;
-                match self { #rule_explanation_match_arms }
-            }
-
-            /// Returns the fix status of this rule.
-            pub const fn fixable(&self) -> crate::FixAvailability {
-                match self { #rule_fixable_match_arms }
-            }
-
-            pub fn group(&self) -> crate::codes::RuleGroup {
-                match self { #rule_group_match_arms }
-            }
-
-            pub fn file(&self) -> &'static str {
-                match self { #rule_file_match_arms }
-            }
-
-            pub fn line(&self) -> u32 {
-                match self { #rule_line_match_arms }
+            /// Returns the metadata for this rule.
+            pub fn metadata(&self) -> &'static RuleMetadata {
+                &RULE_METADATA[*self as usize]
             }
 
             /// Try to parse a kebab-case rule name into a `Rule`.

--- a/crates/ruff_macros/src/violation_metadata.rs
+++ b/crates/ruff_macros/src/violation_metadata.rs
@@ -23,25 +23,15 @@ pub(crate) fn violation_metadata(input: DeriveInput) -> syn::Result<TokenStream>
         #[automatically_derived]
         #[expect(deprecated)]
         impl #impl_generics crate::ViolationMetadata for #name #ty_generics #where_clause {
-            fn rule() -> crate::registry::Rule {
-                crate::registry::Rule::#name
-            }
+            const RULE: crate::registry::Rule = crate::registry::Rule::#name;
 
-            fn explain() -> Option<&'static str> {
-                Some(#docs)
-            }
+            const EXPLANATION: Option<&'static str> = Some(#docs);
 
-            fn group() -> crate::codes::RuleGroup {
-                crate::codes::#group
-            }
+            const GROUP: crate::codes::RuleGroup = crate::codes::#group;
 
-            fn file() -> &'static str {
-                file!()
-            }
+            const FILE: &'static str = file!();
 
-            fn line() -> u32 {
-                line!()
-            }
+            const LINE: u32 = line!();
         }
     })
 }


### PR DESCRIPTION
## Summary

Simplify the Ruff rule macro by generating a static metadata table and moving metadata-backed Rule methods into handwritten impls.

## Test Plan

<!-- How was it tested? -->