### PR TITLE
[ty] Reuse simple specialization mappings

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -580,6 +580,17 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         inferable: InferableTypeVars<'db>,
     ) -> Self {
         self.verify_builder(builder);
+        if self
+            .node
+            .simple_lower_bound_conjunction(db, builder)
+            .is_some_and(|constraints| {
+                constraints
+                    .iter()
+                    .all(|(typevar, _, _)| typevar.is_inferable(db, inferable))
+            })
+        {
+            return self;
+        }
         Self::from_node(
             builder,
             self.node.remove_noninferable(db, builder, inferable),
@@ -1824,6 +1835,41 @@ impl NodeId {
                     } else {
                         data.if_false.node()
                     };
+                }
+            }
+        }
+    }
+
+    /// Returns the concrete lower bounds in this BDD if it is a single positive conjunction.
+    fn simple_lower_bound_conjunction<'db>(
+        self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+    ) -> Option<Vec<(BoundTypeVarInstance<'db>, Type<'db>, usize)>> {
+        let mut constraints = Vec::new();
+        let mut node = self;
+
+        loop {
+            match node.node() {
+                Node::AlwaysTrue => return Some(constraints),
+                Node::AlwaysFalse => return None,
+                Node::Interior(_) => {
+                    let interior = builder.interior_node_data(node);
+                    if interior.if_uncertain != ALWAYS_FALSE || interior.if_false != ALWAYS_FALSE {
+                        return None;
+                    }
+
+                    let constraint = builder.constraint_data(interior.constraint);
+                    let lower = constraint.bounds.lower?;
+                    if constraint.bounds.upper.is_some()
+                        || lower.has_typevar(db)
+                        || lower.has_unspecialized_type_var(db)
+                    {
+                        return None;
+                    }
+
+                    constraints.push((constraint.typevar, lower, interior.source_order));
+                    node = interior.if_true;
                 }
             }
         }
@@ -3112,6 +3158,10 @@ impl<'db> PathBounds<'db> {
             Node::Interior(_) => {}
         }
 
+        if let Some(path_bounds) = Self::compute_simple_lower_bound_conjunction(db, builder, node) {
+            return path_bounds;
+        }
+
         // Sort the constraints in each path by their `source_order`s, to ensure that we construct
         // any unions or intersections in our type mappings in a stable order. Constraints might
         // come out of `PathAssignment`s with identical `source_order`s, but if they do, those
@@ -3167,6 +3217,34 @@ impl<'db> PathBounds<'db> {
         }
 
         PathBounds::Constrained(result.into_boxed_slice())
+    }
+
+    /// Accumulates a conjunction of concrete lower-bound constraints without constructing a
+    /// [`PathAssignments`] or its sequent map.
+    ///
+    /// There are no relationships to derive between these constraints: each lower bound contains
+    /// no typevars, and an unconstrained upper bound cannot make the path unsatisfiable. The normal
+    /// solution-selection logic still validates each accumulated bound against the typevar's
+    /// declared bound or constraints.
+    fn compute_simple_lower_bound_conjunction(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        node: NodeId,
+    ) -> Option<Self> {
+        let mut constraints = node.simple_lower_bound_conjunction(db, builder)?;
+        constraints.sort_by_key(|(_, _, source_order)| *source_order);
+
+        let mut mappings: FxHashMap<BoundTypeVarInstance<'db>, ConstraintBoundsBuilder<'db>> =
+            FxHashMap::default();
+        for (typevar, lower, _) in constraints {
+            mappings.entry(typevar).or_default().add_lower(db, lower);
+        }
+
+        let path = mappings
+            .drain()
+            .map(|(bound_typevar, bounds)| (bound_typevar, bounds.finish(db)))
+            .collect();
+        Some(PathBounds::Constrained(Box::new([path])))
     }
 
     pub(crate) fn solve(
@@ -6435,6 +6513,46 @@ mod tests {
     ) -> ConstraintSet<'db, 'c> {
         let ty = bound.to_instance(db);
         ConstraintSet::constrain_typevar(db, builder, bound_typevar, ty, ty)
+    }
+
+    #[test]
+    fn simple_lower_bound_conjunction_skips_sequent_analysis() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let int = KnownClass::Int.to_instance(&db);
+        let str = KnownClass::Str.to_instance(&db);
+        let set = ConstraintSet::constrain_typevar_lower_bound(&db, &builder, t, int).and(
+            &db,
+            &builder,
+            || ConstraintSet::constrain_typevar_lower_bound(&db, &builder, t, str),
+        );
+        let inferable =
+            InferableTypeVars::from_typevars(&db, std::iter::once(t.identity(&db)).collect());
+        let (single_sequents, pair_sequents) = {
+            let storage = builder.storage.borrow();
+            (
+                storage.single_sequent_cache.len(),
+                storage.pair_sequent_cache.len(),
+            )
+        };
+
+        let set = set.remove_noninferable(&db, &builder, inferable);
+        let solutions = set.solutions(&db, &builder);
+        assert!(matches!(&solutions, Solutions::Constrained(_)));
+        if let Solutions::Constrained(solutions) = solutions {
+            assert_eq!(solutions.len(), 1);
+            assert_eq!(solutions[0].len(), 1);
+            assert_eq!(solutions[0][0].bound_typevar, t);
+            assert_eq!(
+                solutions[0][0].solution,
+                UnionType::from_elements(&db, [int, str])
+            );
+        }
+
+        let storage = builder.storage.borrow();
+        assert_eq!(storage.single_sequent_cache.len(), single_sequents);
+        assert_eq!(storage.pair_sequent_cache.len(), pair_sequents);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -597,6 +597,29 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         )
     }
 
+    /// Returns whether this constraint set is a positive conjunction of concrete lower bounds for
+    /// inferable typevars.
+    ///
+    /// This classifies the final BDD shape only. A caller that wants to reuse data accumulated
+    /// while constructing the constraint set must separately prove that the data has matching
+    /// provenance.
+    pub(crate) fn is_simple_inferable_lower_bound_conjunction(
+        self,
+        db: &'db dyn Db,
+        builder: &'c ConstraintSetBuilder<'db>,
+        inferable: InferableTypeVars<'db>,
+    ) -> bool {
+        self.verify_builder(builder);
+        self.node
+            .simple_lower_bound_conjunction(db, builder)
+            .is_some_and(|constraints| {
+                !constraints.is_empty()
+                    && constraints
+                        .iter()
+                        .all(|(typevar, _, _)| typevar.is_inferable(db, inferable))
+            })
+    }
+
     /// Computes solutions for each BDD path, using a caller-provided hook to select solutions.
     ///
     /// The `choose` hook is called for each typevar on each BDD path with the typevar's explicit

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1837,6 +1837,43 @@ impl<'db> Type<'db> {
     }
 }
 
+/// Records whether the accumulated type map is known to mirror a simple pending constraint set.
+///
+/// This tracks provenance that cannot be recovered from the BDD alone. In particular, a bivariant
+/// mapping can update the type map without adding a constraint, so BDD shape is not sufficient to
+/// decide whether the map can be reused directly.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SimpleMappingState {
+    /// No type mapping has been added yet.
+    Empty,
+    /// Every mapping is a direct covariant mapping from an unbounded ordinary typevar to a
+    /// concrete type.
+    ConcreteCovariant,
+    /// Every mapping is a checked root-level `typing.Self` mapping to a concrete nominal type.
+    ConcreteSelf,
+    /// The accumulated map may no longer represent the same information as the pending constraint
+    /// set.
+    Ineligible,
+}
+
+impl SimpleMappingState {
+    /// Records another direct covariant mapping, invalidating a preceding `typing.Self` mapping.
+    fn add_covariant(self) -> Self {
+        match self {
+            Self::Empty | Self::ConcreteCovariant => Self::ConcreteCovariant,
+            Self::ConcreteSelf | Self::Ineligible => Self::Ineligible,
+        }
+    }
+
+    /// Records another checked `typing.Self` mapping, invalidating ordinary covariant mappings.
+    fn add_self(self) -> Self {
+        match self {
+            Self::Empty | Self::ConcreteSelf => Self::ConcreteSelf,
+            Self::ConcreteCovariant | Self::Ineligible => Self::Ineligible,
+        }
+    }
+}
+
 /// Performs type inference between parameter annotations and argument types, producing a
 /// specialization of a generic function.
 pub(crate) struct SpecializationBuilder<'db, 'c> {
@@ -1846,6 +1883,7 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
     pending: ConstraintSet<'db, 'c>,
     types: FxHashMap<BoundTypeVarIdentity<'db>, UnionAccumulator<'db>>,
     paramspec_seen: FxHashSet<BoundTypeVarIdentity<'db>>,
+    simple_mapping_state: SimpleMappingState,
 }
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
@@ -1861,6 +1899,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             pending: ConstraintSet::from_bool(constraints, true),
             types: FxHashMap::default(),
             paramspec_seen: FxHashSet::default(),
+            simple_mapping_state: SimpleMappingState::Empty,
         }
     }
 
@@ -1905,12 +1944,18 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             Option<ConstraintBounds<'db>>,
         ) -> Option<Type<'db>>,
     ) -> FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> {
+        if self.can_solve_simple_self_mapping(generic_context)
+            || self.can_solve_simple_covariant_mappings(generic_context)
+        {
+            return self.solve_hash_map_with(generic_context, choose, true);
+        }
+
         if generic_context
             .variables_inner(self.db)
             .values()
             .any(|typevar| typevar.is_paramspec(self.db))
         {
-            return self.solve_hash_map_with(generic_context, choose);
+            return self.solve_hash_map_with(generic_context, choose, false);
         }
 
         // TODO: This projection / solve can be expensive for large-union collection-literal type
@@ -1937,7 +1982,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 PathBounds::default_solve(self.db, self.constraints, typevar, bounds)
             }) {
                 Solutions::Unsatisfiable | Solutions::Unconstrained => {
-                    return self.solve_hash_map_with(generic_context, choose);
+                    return self.solve_hash_map_with(generic_context, choose, false);
                 }
                 Solutions::Constrained(solutions) => solutions,
             };
@@ -1981,10 +2026,62 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         {
             // Recursive specialization cannot reach a fixed point when a cycle grows through an
             // embedded generic type, such as `SupportsAdd[T, S]`.
-            self.solve_hash_map_with(generic_context, choose)
+            self.solve_hash_map_with(generic_context, choose, false)
         } else {
             types
         }
+    }
+
+    /// Returns whether the accumulated map can be used as the covariant solution directly.
+    ///
+    /// The provenance state proves that `types` and `pending` were built from the same direct
+    /// mappings; the constraint-set check independently verifies that the final BDD still has the
+    /// expected concrete lower-bound shape.
+    fn can_solve_simple_covariant_mappings(&self, generic_context: GenericContext<'db>) -> bool {
+        self.simple_mapping_state == SimpleMappingState::ConcreteCovariant
+            && self.pending.is_simple_inferable_lower_bound_conjunction(
+                self.db,
+                self.constraints,
+                self.inferable,
+            )
+            && self
+                .types
+                .keys()
+                .all(|identity| generic_context.contains(self.db, *identity))
+            && generic_context
+                .variables_inner(self.db)
+                .values()
+                .all(|typevar| {
+                    matches!(
+                        typevar.kind(self.db),
+                        TypeVarKind::Legacy | TypeVarKind::Pep695
+                    ) && typevar
+                        .typevar(self.db)
+                        .bound_or_constraints(self.db)
+                        .is_none()
+                })
+    }
+
+    /// Returns whether a checked root-level `typing.Self` mapping can be reused directly.
+    ///
+    /// This is limited to a single `Self` typevar and concrete nominal receiver mappings whose
+    /// declared bound was validated when the mapping was recorded.
+    fn can_solve_simple_self_mapping(&self, generic_context: GenericContext<'db>) -> bool {
+        self.simple_mapping_state == SimpleMappingState::ConcreteSelf
+            && self.pending.is_simple_inferable_lower_bound_conjunction(
+                self.db,
+                self.constraints,
+                self.inferable,
+            )
+            && self.types.len() == 1
+            && generic_context.variables_inner(self.db).len() == 1
+            && generic_context
+                .variables_inner(self.db)
+                .iter()
+                .next()
+                .is_some_and(|(identity, typevar)| {
+                    typevar.typevar(self.db).is_self(self.db) && self.types.contains_key(identity)
+                })
     }
 
     fn has_expanding_cycle(
@@ -2145,6 +2242,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             BoundTypeVarInstance<'db>,
             Option<ConstraintBounds<'db>>,
         ) -> Option<Type<'db>>,
+        covariant_only: bool,
     ) -> FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> {
         generic_context
             .variables_inner(self.db)
@@ -2155,8 +2253,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     .get_mut(identity)
                     .map(|accumulator| accumulator.get_or_build(self.db));
                 let chosen = match mapped_ty {
-                    Some(mapped_ty) => choose(*variable, Some(ConstraintBounds::exact(mapped_ty)))
-                        .unwrap_or(mapped_ty),
+                    Some(mapped_ty) => {
+                        let bounds = if covariant_only {
+                            ConstraintBounds::new(Some(mapped_ty), None)
+                        } else {
+                            ConstraintBounds::exact(mapped_ty)
+                        };
+                        choose(*variable, Some(bounds)).unwrap_or(mapped_ty)
+                    }
                     None => choose(*variable, None)?,
                 };
                 Some((*identity, chosen))
@@ -2233,6 +2337,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         ty: Type<'db>,
         variance: TypeVarVariance,
     ) {
+        self.simple_mapping_state = SimpleMappingState::Ineligible;
         self.insert_hash_map_type_mapping(bound_typevar, ty);
 
         let bounds = match variance {
@@ -2243,6 +2348,34 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         };
 
         self.intersect_pending_typevar_constraint(bound_typevar, bounds);
+    }
+
+    /// Records a direct covariant mapping whose concrete type requires no further inference.
+    fn add_simple_covariant_type_mapping(
+        &mut self,
+        bound_typevar: BoundTypeVarInstance<'db>,
+        ty: Type<'db>,
+    ) {
+        self.simple_mapping_state = self.simple_mapping_state.add_covariant();
+        self.insert_hash_map_type_mapping(bound_typevar, ty);
+        self.intersect_pending_typevar_constraint(
+            bound_typevar,
+            ConstraintBounds::new(Some(ty), None),
+        );
+    }
+
+    /// Records a concrete root-level `typing.Self` mapping after validating its declared bound.
+    fn add_simple_self_type_mapping(
+        &mut self,
+        bound_typevar: BoundTypeVarInstance<'db>,
+        ty: Type<'db>,
+    ) {
+        self.simple_mapping_state = self.simple_mapping_state.add_self();
+        self.insert_hash_map_type_mapping(bound_typevar, ty);
+        self.intersect_pending_typevar_constraint(
+            bound_typevar,
+            ConstraintBounds::new(Some(ty), None),
+        );
     }
 
     /// Finds all of the valid specializations of a constraint set, and adds their type mappings to
@@ -2257,6 +2390,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         &mut self,
         set: ConstraintSet<'db, 'c>,
     ) -> Result<(), ()> {
+        self.simple_mapping_state = SimpleMappingState::Ineligible;
         let set = set.remove_noninferable(self.db, self.constraints, self.inferable);
         let solutions = match set.solutions(self.db, self.constraints) {
             Solutions::Unsatisfiable => return Err(()),
@@ -2398,6 +2532,43 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         formal: Type<'db>,
         actual: Type<'db>,
     ) -> Result<(), SpecializationError<'db>> {
+        if let Type::TypeVar(bound_typevar) = formal
+            && bound_typevar.is_inferable(self.db, self.inferable)
+            && bound_typevar.typevar(self.db).is_self(self.db)
+            && matches!(actual, Type::NominalInstance(_))
+            && !actual.has_typevar(self.db)
+            && !actual.has_unspecialized_type_var(self.db)
+            && let Some(bound) = bound_typevar.typevar(self.db).upper_bound(self.db)
+            && actual
+                .when_assignable_to(self.db, bound, self.constraints, self.inferable)
+                .is_always_satisfied(self.db)
+        {
+            self.add_simple_self_type_mapping(bound_typevar, actual);
+            return Ok(());
+        }
+
+        if let Type::TypeVar(bound_typevar) = formal
+            && bound_typevar.is_inferable(self.db, self.inferable)
+            && matches!(
+                bound_typevar.kind(self.db),
+                TypeVarKind::Legacy | TypeVarKind::Pep695
+            )
+            && bound_typevar
+                .typevar(self.db)
+                .bound_or_constraints(self.db)
+                .is_none()
+            && !actual.has_typevar(self.db)
+            && !actual.has_unspecialized_type_var(self.db)
+        {
+            let actual = actual.filter_disjoint_elements(self.db, formal, self.inferable);
+            self.add_simple_covariant_type_mapping(bound_typevar, actual);
+            return Ok(());
+        }
+
+        if actual.has_typevar(self.db) {
+            self.simple_mapping_state = SimpleMappingState::Ineligible;
+        }
+
         self.infer_map_impl(
             formal,
             actual,
@@ -3012,5 +3183,42 @@ impl<'db> SpecializationError<'db> {
             Self::MismatchedBound { argument, .. } => *argument,
             Self::MismatchedConstraint { argument, .. } => *argument,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ruff_python_ast::name::Name;
+
+    use crate::db::tests::setup_db;
+
+    #[test]
+    fn bivariant_mapping_disables_simple_map_reuse() {
+        let db = setup_db();
+        let t =
+            BoundTypeVarInstance::synthetic(&db, Name::new_static("T"), TypeVarVariance::Invariant);
+        let u =
+            BoundTypeVarInstance::synthetic(&db, Name::new_static("U"), TypeVarVariance::Invariant);
+        let inferable = InferableTypeVars::from_typevars(
+            &db,
+            [t.identity(&db), u.identity(&db)].into_iter().collect(),
+        );
+        let constraints = ConstraintSetBuilder::new();
+        let mut builder = SpecializationBuilder::new(&db, &constraints, inferable);
+
+        builder.add_simple_covariant_type_mapping(t, KnownClass::Int.to_instance(&db));
+        assert_eq!(
+            builder.simple_mapping_state,
+            SimpleMappingState::ConcreteCovariant
+        );
+
+        builder.add_type_mapping(
+            u,
+            KnownClass::Str.to_instance(&db),
+            TypeVarVariance::Bivariant,
+        );
+        assert_eq!(builder.simple_mapping_state, SimpleMappingState::Ineligible);
     }
 }


### PR DESCRIPTION
## Summary

`SpecializationBuilder` maintains an accumulated type map alongside its pending constraint set. For direct covariant mappings from an unbounded type variable to a concrete type, solving the pending set reconstructs information that is already present in that map.

This recognizes direct root-level mappings for ordinary type variables and `typing.Self`, then reuses the accumulated map when the constraint solver confirms that the pending BDD is a simple concrete lower-bound conjunction. Explicit provenance tracking ensures that the fast path is disabled after bivariant, contravariant, invariant, nested-type-variable, or constraint-set-derived mappings, where the map and pending set may no longer represent the same information.

In the earlier benchmark run for this fast-path behavior, multithreaded Altair improved from 1.6 s to 1.0 s, single-threaded Altair improved from 5.6 s to 4.7 s, and Pydantic improved from 10.8 s to 9.2 s. This PR is stacked on #25879, which contains the underlying constraint-set conjunction optimization.
