### PR TITLE
[flake8-pyi] Clarify PYI051 is opinionated

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
@@ -23,6 +23,12 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// `Literal[1] | int` is equivalent to `int`, as `str` and `int` are the
 /// supertypes of `"A"` and `1` respectively.
 ///
+/// This is an opinionated stylistic rule. In some codebases, redundant
+/// `Literal` members are used intentionally to document common expected
+/// values or to improve editor completions while still allowing arbitrary
+/// values of the builtin supertype. In those cases, consider disabling this
+/// rule or using a `noqa` directive for the affected annotation.
+///
 /// ## Example
 /// ```pyi
 /// from typing import Literal


### PR DESCRIPTION
## Summary

- Clarify that `PYI051` is an opinionated stylistic rule.
- Document why some projects may intentionally keep redundant `Literal` members in a union with a builtin supertype.
- Suggest disabling the rule or using `noqa` when the redundant literal is intentionally used for documentation or editor completions.

## Reproduction

`PYI051` currently documents `Literal["A"] | str` as redundant because it is equivalent to `str` for type checking. However, issue #23134 points out that projects can use this pattern intentionally to communicate common expected values or improve editor completions while still allowing arbitrary strings.

## Root cause

The existing docs described the type-theoretic redundancy but did not mention the rule's opinionated nature or the intentional editor/documentation use case discussed by maintainers in #23134.

## Changes

- Add a short note to the `redundant-literal-union` rule documentation source explaining that the rule is opinionated.
- Mention when disabling the rule or adding a targeted `noqa` can be appropriate.
- Leave rule behavior unchanged.

## Tests

- `cargo fmt --check`
- `cargo dev generate-docs`
- `cargo test -p ruff_linter rules::flake8_pyi::tests::rules --no-fail-fast`
- `git diff --check`

## Screenshots/Logs

- Not applicable; documentation-only change.

## AI Policy

- I have followed the repository AI policy.

Fixes #23134.
