### PR TITLE
[ty] Run benchmarks for cached superclass member checks

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3272,6 +3272,24 @@ impl<'db> Type<'db> {
         policy: InstanceFallbackShadowsNonDataDescriptor,
         member_policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
+        let class_member = self.class_member_with_policy(db, name.into(), member_policy);
+        self.invoke_descriptor_protocol_with_class_member(
+            db,
+            receiver,
+            class_member,
+            fallback,
+            policy,
+        )
+    }
+
+    fn invoke_descriptor_protocol_with_class_member(
+        self,
+        db: &'db dyn Db,
+        receiver: Type<'db>,
+        class_member: PlaceAndQualifiers<'db>,
+        fallback: PlaceAndQualifiers<'db>,
+        policy: InstanceFallbackShadowsNonDataDescriptor,
+    ) -> PlaceAndQualifiers<'db> {
         let (
             PlaceAndQualifiers {
                 place: meta_attr,
@@ -3280,7 +3298,7 @@ impl<'db> Type<'db> {
             meta_attr_kind,
         ) = Self::try_call_dunder_get_on_attribute(
             db,
-            self.class_member_with_policy(db, name.into(), member_policy),
+            class_member,
             Some(receiver),
             self.to_meta_type(db),
         );
@@ -3398,6 +3416,26 @@ impl<'db> Type<'db> {
     #[must_use]
     pub(crate) fn member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         self.member_lookup_with_policy(db, name.into(), MemberLookupPolicy::default())
+    }
+
+    /// Resolve an instance member whose class-level definition is known to be definitely bound on
+    /// the first class in the MRO.
+    pub(crate) fn member_from_own_class_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        class_member: PlaceAndQualifiers<'db>,
+    ) -> PlaceAndQualifiers<'db> {
+        let fallback = self.instance_member(db, name);
+        let result = self.invoke_descriptor_protocol_with_class_member(
+            db,
+            self,
+            class_member,
+            fallback,
+            InstanceFallbackShadowsNonDataDescriptor::No,
+        );
+        self.fallback_to_getattr(db, &Name::new(name), result, MemberLookupPolicy::default())
+            .map_type(|ty| ty.bind_self_typevars(db, self))
     }
 
     /// Similar to [`Type::member`], but allows the caller to specify what policy should be used

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -58,6 +58,39 @@ const PROHIBITED_NAMEDTUPLE_ATTRS: &[&str] = &[
     "_source",
 ];
 
+#[salsa::tracked(
+    cycle_initial=|_, id, _, _| Place::bound(Type::divergent(id)).into(),
+    heap_size=ruff_memory_usage::heap_size
+)]
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "Salsa tracked query keys must be owned"
+)]
+fn superclass_instance_member<'db>(
+    db: &'db dyn Db,
+    superclass: ClassType<'db>,
+    name: Name,
+) -> PlaceAndQualifiers<'db> {
+    let instance = Type::instance(db, superclass);
+    let Some((literal, _)) = superclass.static_class_literal(db) else {
+        return instance.member(db, &name);
+    };
+    let own_class_member = superclass.own_class_member(db, None, &name);
+
+    if matches!(
+        own_class_member.inner.place,
+        Place::Defined(DefinedPlace {
+            definedness: crate::place::Definedness::AlwaysDefined,
+            ..
+        })
+    ) && enum_metadata(db, literal.into()).is_none()
+    {
+        instance.member_from_own_class_member(db, &name, own_class_member.inner)
+    } else {
+        instance.member(db, &name)
+    }
+}
+
 // TODO: Support dynamic class literals. If we allow dynamic classes to define attributes in their
 // namespace dictionary, we should also check whether those attributes are valid overrides of
 // attributes in their superclasses.
@@ -369,7 +402,7 @@ fn check_class_declaration<'db>(
             }
 
             let superclass_instance_member =
-                Type::instance(db, superclass).member(db, &member.name);
+                superclass_instance_member(db, superclass, member.name.clone());
             let Place::Defined(DefinedPlace {
                 ty: superclass_type,
                 ..


### PR DESCRIPTION
## Summary

- cache superclass instance-member resolution by class and member name during override checking
- reuse a definitely-bound own class member instead of repeating generic MRO lookup
- isolate this candidate from #25867 so CodSpeed can measure it independently

## Test plan

- `cargo nextest run -p ty_python_semantic`
- targeted Clippy with `-D warnings`
- file-scoped `uvx prek`
- byte-identical Home Assistant diagnostics