### PR TITLE
[ty] Run benchmarks for inline call-argument inference caches

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5728,7 +5728,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     infer_argument_ty(self, (argument_index, ast_argument, TypeContext::default()));
                 arguments_types.insert_type(argument_index, TypeContext::default(), default_ty);
 
-                let mut inferred_by_cache_key = FxHashMap::default();
+                // Most overloaded calls have only a handful of parameter contexts, so avoid both
+                // allocating and hashing for this short-lived cache.
+                let mut inferred_by_cache_key: SmallVec<[(Type<'db>, Type<'db>); 4]> =
+                    SmallVec::new();
 
                 // Cache expressions inferred across speculative inference attempts.
                 //
@@ -5739,7 +5742,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 for parameter_context in parameter_contexts {
                     let inference_cache_key = parameter_context.inference_cache_key();
                     if let Some(inferred_ty) =
-                        inferred_by_cache_key.get(&inference_cache_key).copied()
+                        inferred_by_cache_key
+                            .iter()
+                            .find_map(|(cache_key, inferred_ty)| {
+                                (*cache_key == inference_cache_key).then_some(*inferred_ty)
+                            })
                     {
                         // Even when the inference cache key is identical, this overload may later
                         // look up the inferred type through a different original `ParamSpec`
@@ -5765,7 +5772,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ),
                     );
 
-                    inferred_by_cache_key.insert(inference_cache_key, inferred_ty);
+                    inferred_by_cache_key.push((inference_cache_key, inferred_ty));
                     self.union_expected_types(&speculative_builder.expected_types);
                     parameter_context.insert_inferred_type(
                         arguments_types,


### PR DESCRIPTION
## Summary

- replace the short-lived hash map used to deduplicate contextual argument inference with an inline small vector
- avoid allocation and hashing for the common small-overload case
- isolate this candidate from #25867 so CodSpeed can measure it independently

## Test plan

- `cargo nextest run -p ty_python_semantic`
- targeted Clippy with `-D warnings`
- file-scoped `uvx prek`
- byte-identical Home Assistant diagnostics