### PR TITLE
[ty] Run benchmarks for allocation-free empty parameter lists

### DIFF
--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -927,13 +927,15 @@ impl<'db> Signature<'db> {
         db: &'db dyn Db,
         self_type: impl FnOnce() -> Option<Type<'db>>,
     ) {
-        if let Some(first_parameter) = self.parameters.data.value.first()
-            && first_parameter.is_positional()
-            && first_parameter.annotated_type.is_unknown()
-            && first_parameter.inferred_annotation
+        let needs_annotation = self.parameters.as_slice().first().is_some_and(|parameter| {
+            parameter.is_positional()
+                && parameter.annotated_type.is_unknown()
+                && parameter.inferred_annotation
+        });
+        if needs_annotation
             && let Some(self_type) = self_type()
-            && let Some(first_parameter) =
-                Arc::make_mut(&mut self.parameters.data).value.first_mut()
+            && let Some(data) = self.parameters.data.as_mut()
+            && let Some(first_parameter) = Arc::make_mut(data).value.first_mut()
         {
             first_parameter.annotated_type = self_type;
 
@@ -3196,16 +3198,19 @@ struct ParametersData<'db> {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
 pub(crate) struct Parameters<'db> {
-    data: Arc<ParametersData<'db>>,
+    /// `None` represents the common standard empty parameter list without allocating.
+    data: Option<Arc<ParametersData<'db>>>,
 }
 
 impl<'db> Parameters<'db> {
     fn from_parts(value: impl Into<Box<[Parameter<'db>]>>, kind: ParametersKind<'db>) -> Self {
-        Self {
-            data: Arc::new(ParametersData {
-                value: value.into(),
-                kind,
-            }),
+        let value = value.into();
+        if value.is_empty() && kind == ParametersKind::Standard {
+            Self::empty()
+        } else {
+            Self {
+                data: Some(Arc::new(ParametersData { value, kind })),
+            }
         }
     }
 
@@ -3341,34 +3346,36 @@ impl<'db> Parameters<'db> {
 
     /// Create an empty parameter list.
     pub(crate) fn empty() -> Self {
-        Self::from_parts(Box::default(), ParametersKind::Standard)
+        Self { data: None }
     }
 
     pub(crate) fn as_slice(&self) -> &[Parameter<'db>] {
-        &self.data.value
+        self.data.as_deref().map_or(&[], |data| &data.value)
     }
 
     pub(crate) fn kind(&self) -> ParametersKind<'db> {
-        self.data.kind
+        self.data
+            .as_deref()
+            .map_or(ParametersKind::Standard, |data| data.kind)
     }
 
     /// Returns `true` if the parameters represent a gradual form using `...` as the only parameter
     /// or a `Concatenate` form with `...` as the last argument.
     pub(crate) fn is_gradual(&self) -> bool {
         matches!(
-            self.data.kind,
+            self.kind(),
             ParametersKind::Gradual | ParametersKind::Concatenate(ConcatenateTail::Gradual)
         )
     }
 
     pub(crate) fn is_top(&self) -> bool {
-        matches!(self.data.kind, ParametersKind::Top)
+        matches!(self.kind(), ParametersKind::Top)
     }
 
     /// Returns `true` if the parameters are a standard parameter list (not gradual, top,
     /// `ParamSpec`, or `Concatenate`).
     pub(crate) fn is_standard(&self) -> bool {
-        matches!(self.data.kind, ParametersKind::Standard)
+        matches!(self.kind(), ParametersKind::Standard)
     }
 
     /// Returns the bound `ParamSpec` type variable if the parameter list is exactly `P`.
@@ -3377,7 +3384,7 @@ impl<'db> Parameters<'db> {
     ///
     /// [`as_paramspec_with_prefix`]: Self::as_paramspec_with_prefix
     pub(crate) fn as_paramspec(&self) -> Option<BoundTypeVarInstance<'db>> {
-        match self.data.kind {
+        match self.kind() {
             ParametersKind::ParamSpec(bound_typevar) => Some(bound_typevar),
             _ => None,
         }
@@ -3392,12 +3399,11 @@ impl<'db> Parameters<'db> {
     pub(crate) fn as_paramspec_with_prefix<'a>(
         &'a self,
     ) -> Option<(&'a [Parameter<'db>], BoundTypeVarInstance<'db>)> {
-        match self.data.kind {
+        match self.kind() {
             ParametersKind::ParamSpec(typevar) => Some((&[], typevar)),
-            ParametersKind::Concatenate(ConcatenateTail::ParamSpec(typevar)) => Some((
-                &self.data.value[..self.data.value.len().saturating_sub(2)],
-                typevar,
-            )),
+            ParametersKind::Concatenate(ConcatenateTail::ParamSpec(typevar)) => {
+                Some((&self.as_slice()[..self.len().saturating_sub(2)], typevar))
+            }
             _ => None,
         }
     }
@@ -3647,7 +3653,7 @@ impl<'db> Parameters<'db> {
     ) -> Self {
         if let TypeMapping::Materialize(materialization_kind) = type_mapping
             && matches!(
-                self.data.kind,
+                self.kind(),
                 ParametersKind::Gradual | ParametersKind::Concatenate(ConcatenateTail::Gradual)
             )
         {
@@ -3667,20 +3673,18 @@ impl<'db> Parameters<'db> {
         let type_mapping = type_mapping.flip();
 
         let value: Box<[_]> = self
-            .data
-            .value
             .iter()
             .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
             .collect();
 
-        Self::from_parts(value, self.data.kind)
+        Self::from_parts(value, self.kind())
     }
     pub(crate) fn len(&self) -> usize {
-        self.data.value.len()
+        self.as_slice().len()
     }
 
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, Parameter<'db>> {
-        self.data.value.iter()
+        self.as_slice().iter()
     }
 
     /// Iterate initial positional parameters, not including variadic parameter, if any.
@@ -3694,7 +3698,7 @@ impl<'db> Parameters<'db> {
 
     /// Return parameter at given index, or `None` if index is out-of-range.
     pub(crate) fn get(&self, index: usize) -> Option<&Parameter<'db>> {
-        self.data.value.get(index)
+        self.as_slice().get(index)
     }
 
     /// Return positional parameter at given index, or `None` if `index` is out of range.
@@ -3792,9 +3796,9 @@ impl<'db> Parameters<'db> {
         };
 
         let mut expanded = Vec::with_capacity(self.len());
-        expanded.extend_from_slice(&self.data.value[..variadic_index]);
+        expanded.extend_from_slice(&self.as_slice()[..variadic_index]);
         expanded.extend_from_slice(mapped_signature.parameters().as_slice());
-        expanded.extend_from_slice(&self.data.value[variadic_index + 2..]);
+        expanded.extend_from_slice(&self.as_slice()[variadic_index + 2..]);
         Parameters::new(db, expanded)
     }
 }
@@ -3804,7 +3808,7 @@ impl<'db, 'a> IntoIterator for &'a Parameters<'db> {
     type IntoIter = std::slice::Iter<'a, Parameter<'db>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.data.value.iter()
+        self.iter()
     }
 }
 
@@ -3812,7 +3816,7 @@ impl<'db> std::ops::Index<usize> for Parameters<'db> {
     type Output = Parameter<'db>;
 
     fn index(&self, index: usize) -> &Self::Output {
-        &self.data.value[index]
+        &self.as_slice()[index]
     }
 }
 


### PR DESCRIPTION
## Summary

- represent standard empty parameter lists without allocating an `Arc` payload
- preserve the existing representation for non-empty and non-standard parameter lists
- isolate this candidate from #25867 so CodSpeed can measure it independently

## Test plan

- `cargo nextest run -p ty_python_semantic`
- targeted Clippy with `-D warnings`
- file-scoped `uvx prek`
- byte-identical Home Assistant diagnostics