### PR TITLE
[ty] Solve simple specializations from pending constraints

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -580,6 +580,17 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         inferable: InferableTypeVars<'db>,
     ) -> Self {
         self.verify_builder(builder);
+        if self
+            .node
+            .simple_lower_bound_conjunction(db, builder)
+            .is_some_and(|constraints| {
+                constraints
+                    .iter()
+                    .all(|(typevar, _, _)| typevar.is_inferable(db, inferable))
+            })
+        {
+            return self;
+        }
         Self::from_node(
             builder,
             self.node.remove_noninferable(db, builder, inferable),
@@ -1824,6 +1835,41 @@ impl NodeId {
                     } else {
                         data.if_false.node()
                     };
+                }
+            }
+        }
+    }
+
+    /// Returns the concrete lower bounds in this BDD if it is a single positive conjunction.
+    fn simple_lower_bound_conjunction<'db>(
+        self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+    ) -> Option<Vec<(BoundTypeVarInstance<'db>, Type<'db>, usize)>> {
+        let mut constraints = Vec::new();
+        let mut node = self;
+
+        loop {
+            match node.node() {
+                Node::AlwaysTrue => return Some(constraints),
+                Node::AlwaysFalse => return None,
+                Node::Interior(_) => {
+                    let interior = builder.interior_node_data(node);
+                    if interior.if_uncertain != ALWAYS_FALSE || interior.if_false != ALWAYS_FALSE {
+                        return None;
+                    }
+
+                    let constraint = builder.constraint_data(interior.constraint);
+                    let lower = constraint.bounds.lower?;
+                    if constraint.bounds.upper.is_some()
+                        || lower.has_typevar(db)
+                        || lower.has_unspecialized_type_var(db)
+                    {
+                        return None;
+                    }
+
+                    constraints.push((constraint.typevar, lower, interior.source_order));
+                    node = interior.if_true;
                 }
             }
         }
@@ -3112,6 +3158,10 @@ impl<'db> PathBounds<'db> {
             Node::Interior(_) => {}
         }
 
+        if let Some(path_bounds) = Self::compute_simple_lower_bound_conjunction(db, builder, node) {
+            return path_bounds;
+        }
+
         // Sort the constraints in each path by their `source_order`s, to ensure that we construct
         // any unions or intersections in our type mappings in a stable order. Constraints might
         // come out of `PathAssignment`s with identical `source_order`s, but if they do, those
@@ -3167,6 +3217,34 @@ impl<'db> PathBounds<'db> {
         }
 
         PathBounds::Constrained(result.into_boxed_slice())
+    }
+
+    /// Accumulates a conjunction of concrete lower-bound constraints without constructing a
+    /// [`PathAssignments`] or its sequent map.
+    ///
+    /// There are no relationships to derive between these constraints: each lower bound contains
+    /// no typevars, and an unconstrained upper bound cannot make the path unsatisfiable. The normal
+    /// solution-selection logic still validates each accumulated bound against the typevar's
+    /// declared bound or constraints.
+    fn compute_simple_lower_bound_conjunction(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        node: NodeId,
+    ) -> Option<Self> {
+        let mut constraints = node.simple_lower_bound_conjunction(db, builder)?;
+        constraints.sort_by_key(|(_, _, source_order)| *source_order);
+
+        let mut mappings: FxHashMap<BoundTypeVarInstance<'db>, ConstraintBoundsBuilder<'db>> =
+            FxHashMap::default();
+        for (typevar, lower, _) in constraints {
+            mappings.entry(typevar).or_default().add_lower(db, lower);
+        }
+
+        let path = mappings
+            .drain()
+            .map(|(bound_typevar, bounds)| (bound_typevar, bounds.finish(db)))
+            .collect();
+        Some(PathBounds::Constrained(Box::new([path])))
     }
 
     pub(crate) fn solve(
@@ -6435,6 +6513,46 @@ mod tests {
     ) -> ConstraintSet<'db, 'c> {
         let ty = bound.to_instance(db);
         ConstraintSet::constrain_typevar(db, builder, bound_typevar, ty, ty)
+    }
+
+    #[test]
+    fn simple_lower_bound_conjunction_skips_sequent_analysis() {
+        let db = setup_db();
+        let t = create_typevar(&db, "T");
+        let builder = ConstraintSetBuilder::new();
+        let int = KnownClass::Int.to_instance(&db);
+        let str = KnownClass::Str.to_instance(&db);
+        let set = ConstraintSet::constrain_typevar_lower_bound(&db, &builder, t, int).and(
+            &db,
+            &builder,
+            || ConstraintSet::constrain_typevar_lower_bound(&db, &builder, t, str),
+        );
+        let inferable =
+            InferableTypeVars::from_typevars(&db, std::iter::once(t.identity(&db)).collect());
+        let (single_sequents, pair_sequents) = {
+            let storage = builder.storage.borrow();
+            (
+                storage.single_sequent_cache.len(),
+                storage.pair_sequent_cache.len(),
+            )
+        };
+
+        let set = set.remove_noninferable(&db, &builder, inferable);
+        let solutions = set.solutions(&db, &builder);
+        assert!(matches!(&solutions, Solutions::Constrained(_)));
+        if let Solutions::Constrained(solutions) = solutions {
+            assert_eq!(solutions.len(), 1);
+            assert_eq!(solutions[0].len(), 1);
+            assert_eq!(solutions[0][0].bound_typevar, t);
+            assert_eq!(
+                solutions[0][0].solution,
+                UnionType::from_elements(&db, [int, str])
+            );
+        }
+
+        let storage = builder.storage.borrow();
+        assert_eq!(storage.single_sequent_cache.len(), single_sequents);
+        assert_eq!(storage.pair_sequent_cache.len(), pair_sequents);
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -630,6 +630,52 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         self.node.solutions_with(db, builder, choose)
     }
 
+    /// Solves this constraint set directly if it is a positive conjunction of concrete lower
+    /// bounds for inferable typevars.
+    ///
+    /// Unlike [`Self::solutions_with`], this avoids constructing [`PathBounds`] and [`Solutions`]
+    /// wrappers for the single path. It returns `None` when the constraint set does not have the
+    /// required shape.
+    pub(crate) fn try_solve_simple_lower_bound_conjunction_with(
+        self,
+        db: &'db dyn Db,
+        builder: &'c ConstraintSetBuilder<'db>,
+        inferable: InferableTypeVars<'db>,
+        mut choose: impl FnMut(
+            BoundTypeVarInstance<'db>,
+            TypeVarVariance,
+            ConstraintBounds<'db>,
+        ) -> Result<Option<Type<'db>>, ()>,
+    ) -> Option<Result<Vec<TypeVarSolution<'db>>, ()>> {
+        self.verify_builder(builder);
+        let mappings = PathBounds::compute_simple_lower_bound_mappings(db, builder, self.node)?;
+        if mappings.is_empty()
+            || mappings
+                .keys()
+                .any(|typevar| !typevar.is_inferable(db, inferable))
+        {
+            return None;
+        }
+
+        let mut solutions = Vec::with_capacity(mappings.len());
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "each typevar solution is independent of iteration order"
+        )]
+        for (bound_typevar, bounds) in mappings {
+            let bounds = bounds.finish(db);
+            match choose(bound_typevar, bounds.variance(), bounds) {
+                Ok(Some(solution)) => solutions.push(TypeVarSolution {
+                    bound_typevar,
+                    solution,
+                }),
+                Ok(None) => {}
+                Err(()) => return Some(Err(())),
+            }
+        }
+        Some(Ok(solutions))
+    }
+
     pub(crate) fn display(self, db: &'db dyn Db) -> impl Display {
         self.node
             .simplify_for_display(db, self.builder)
@@ -3231,6 +3277,19 @@ impl<'db> PathBounds<'db> {
         builder: &ConstraintSetBuilder<'db>,
         node: NodeId,
     ) -> Option<Self> {
+        let mut mappings = Self::compute_simple_lower_bound_mappings(db, builder, node)?;
+        let path = mappings
+            .drain()
+            .map(|(bound_typevar, bounds)| (bound_typevar, bounds.finish(db)))
+            .collect();
+        Some(PathBounds::Constrained(Box::new([path])))
+    }
+
+    fn compute_simple_lower_bound_mappings(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        node: NodeId,
+    ) -> Option<FxHashMap<BoundTypeVarInstance<'db>, ConstraintBoundsBuilder<'db>>> {
         let mut constraints = node.simple_lower_bound_conjunction(db, builder)?;
         constraints.sort_by_key(|(_, _, source_order)| *source_order);
 
@@ -3239,12 +3298,7 @@ impl<'db> PathBounds<'db> {
         for (typevar, lower, _) in constraints {
             mappings.entry(typevar).or_default().add_lower(db, lower);
         }
-
-        let path = mappings
-            .drain()
-            .map(|(bound_typevar, bounds)| (bound_typevar, bounds.finish(db)))
-            .collect();
-        Some(PathBounds::Constrained(Box::new([path])))
+        Some(mappings)
     }
 
     pub(crate) fn solve(
@@ -6538,6 +6592,44 @@ mod tests {
         };
 
         let set = set.remove_noninferable(&db, &builder, inferable);
+        assert!(
+            set.try_solve_simple_lower_bound_conjunction_with(
+                &db,
+                &builder,
+                InferableTypeVars::None,
+                |typevar, _variance, bounds| {
+                    PathBounds::default_solve(&db, &builder, typevar, bounds)
+                },
+            )
+            .is_none()
+        );
+        assert!(matches!(
+            set.try_solve_simple_lower_bound_conjunction_with(
+                &db,
+                &builder,
+                inferable,
+                |_typevar, _variance, _bounds| Err(())
+            ),
+            Some(Err(()))
+        ));
+        let direct_solutions = set
+            .try_solve_simple_lower_bound_conjunction_with(
+                &db,
+                &builder,
+                inferable,
+                |typevar, _variance, bounds| {
+                    PathBounds::default_solve(&db, &builder, typevar, bounds)
+                },
+            )
+            .expect("simple conjunction")
+            .expect("satisfiable conjunction");
+        assert_eq!(direct_solutions.len(), 1);
+        assert_eq!(direct_solutions[0].bound_typevar, t);
+        assert_eq!(
+            direct_solutions[0].solution,
+            UnionType::from_elements(&db, [int, str])
+        );
+
         let solutions = set.solutions(&db, &builder);
         assert!(matches!(&solutions, Solutions::Constrained(_)));
         if let Solutions::Constrained(solutions) = solutions {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -12,7 +12,7 @@ use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::{
     ConstraintBounds, ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
-    PathBounds, Solutions,
+    PathBounds, Solutions, TypeVarSolution,
 };
 use crate::types::infer::original_class_type;
 use crate::types::relation::{
@@ -1846,6 +1846,8 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
     pending: ConstraintSet<'db, 'c>,
     types: FxHashMap<BoundTypeVarIdentity<'db>, UnionAccumulator<'db>>,
     paramspec_seen: FxHashSet<BoundTypeVarIdentity<'db>>,
+    // The legacy map contains inferred types that `pending` does not represent exactly.
+    has_legacy_only_mappings: bool,
 }
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
@@ -1861,6 +1863,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             pending: ConstraintSet::from_bool(constraints, true),
             types: FxHashMap::default(),
             paramspec_seen: FxHashSet::default(),
+            has_legacy_only_mappings: false,
         }
     }
 
@@ -1913,6 +1916,32 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             return self.solve_hash_map_with(generic_context, choose);
         }
 
+        if !self.has_legacy_only_mappings
+            && let Some(result) = self.pending.try_solve_simple_lower_bound_conjunction_with(
+                self.db,
+                self.constraints,
+                self.inferable,
+                |typevar, _variance, bounds| {
+                    if let Some(ty) = choose(typevar, Some(bounds)) {
+                        return Ok(Some(ty));
+                    }
+
+                    PathBounds::default_solve(self.db, self.constraints, typevar, bounds)
+                },
+            )
+        {
+            return match result {
+                Ok(solutions) => {
+                    let mut types = FxHashMap::default();
+                    for solution in solutions {
+                        self.insert_solution(&mut types, &solution);
+                    }
+                    types
+                }
+                Err(()) => self.solve_hash_map_with(generic_context, choose),
+            };
+        }
+
         // TODO: This projection / solve can be expensive for large-union collection-literal type
         // contexts. During the pending-constraint-set migration, pydantic and hydra-zen regressed
         // on empty dict literals with a context equivalent to
@@ -1945,14 +1974,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let mut types = FxHashMap::default();
         for solution in solutions {
             for binding in solution {
-                let identity = binding.bound_typevar.identity(self.db);
-                types
-                    .entry(identity)
-                    .and_modify(|existing| {
-                        *existing =
-                            UnionType::from_two_elements(self.db, *existing, binding.solution);
-                    })
-                    .or_insert(binding.solution);
+                self.insert_solution(&mut types, &binding);
             }
         }
 
@@ -1985,6 +2007,20 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         } else {
             types
         }
+    }
+
+    fn insert_solution(
+        &self,
+        types: &mut FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>>,
+        binding: &TypeVarSolution<'db>,
+    ) {
+        let identity = binding.bound_typevar.identity(self.db);
+        types
+            .entry(identity)
+            .and_modify(|existing| {
+                *existing = UnionType::from_two_elements(self.db, *existing, binding.solution);
+            })
+            .or_insert(binding.solution);
     }
 
     fn has_expanding_cycle(
@@ -2239,7 +2275,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             TypeVarVariance::Covariant => ConstraintBounds::new(Some(ty), None),
             TypeVarVariance::Contravariant => ConstraintBounds::new(None, Some(ty)),
             TypeVarVariance::Invariant => ConstraintBounds::exact(ty),
-            TypeVarVariance::Bivariant => return,
+            TypeVarVariance::Bivariant => {
+                self.has_legacy_only_mappings = true;
+                return;
+            }
         };
 
         self.intersect_pending_typevar_constraint(bound_typevar, bounds);
@@ -2257,6 +2296,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         &mut self,
         set: ConstraintSet<'db, 'c>,
     ) -> Result<(), ()> {
+        self.has_legacy_only_mappings = true;
         let set = set.remove_noninferable(self.db, self.constraints, self.inferable);
         let solutions = match set.solutions(self.db, self.constraints) {
             Solutions::Unsatisfiable => return Err(()),
@@ -2398,6 +2438,39 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         formal: Type<'db>,
         actual: Type<'db>,
     ) -> Result<(), SpecializationError<'db>> {
+        if let Type::TypeVar(bound_typevar) = formal
+            && bound_typevar.is_inferable(self.db, self.inferable)
+            && bound_typevar.typevar(self.db).is_self(self.db)
+            && matches!(actual, Type::NominalInstance(_))
+            && !actual.has_typevar(self.db)
+            && !actual.has_unspecialized_type_var(self.db)
+            && let Some(bound) = bound_typevar.typevar(self.db).upper_bound(self.db)
+            && actual
+                .when_assignable_to(self.db, bound, self.constraints, self.inferable)
+                .is_always_satisfied(self.db)
+        {
+            self.add_type_mapping(bound_typevar, actual, TypeVarVariance::Covariant);
+            return Ok(());
+        }
+
+        if let Type::TypeVar(bound_typevar) = formal
+            && bound_typevar.is_inferable(self.db, self.inferable)
+            && matches!(
+                bound_typevar.kind(self.db),
+                TypeVarKind::Legacy | TypeVarKind::Pep695
+            )
+            && bound_typevar
+                .typevar(self.db)
+                .bound_or_constraints(self.db)
+                .is_none()
+            && !actual.has_typevar(self.db)
+            && !actual.has_unspecialized_type_var(self.db)
+        {
+            let actual = actual.filter_disjoint_elements(self.db, formal, self.inferable);
+            self.add_type_mapping(bound_typevar, actual, TypeVarVariance::Covariant);
+            return Ok(());
+        }
+
         self.infer_map_impl(
             formal,
             actual,
@@ -3012,5 +3085,56 @@ impl<'db> SpecializationError<'db> {
             Self::MismatchedBound { argument, .. } => *argument,
             Self::MismatchedConstraint { argument, .. } => *argument,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ruff_python_ast::name::Name;
+
+    use crate::db::tests::setup_db;
+
+    #[test]
+    fn legacy_only_mappings_disable_pending_only_solution() {
+        let db = setup_db();
+        let t =
+            BoundTypeVarInstance::synthetic(&db, Name::new_static("T"), TypeVarVariance::Invariant);
+        let u =
+            BoundTypeVarInstance::synthetic(&db, Name::new_static("U"), TypeVarVariance::Invariant);
+        let inferable = InferableTypeVars::from_typevars(
+            &db,
+            [t.identity(&db), u.identity(&db)].into_iter().collect(),
+        );
+        let constraints = ConstraintSetBuilder::new();
+        let mut builder = SpecializationBuilder::new(&db, &constraints, inferable);
+
+        builder.add_type_mapping(
+            t,
+            KnownClass::Int.to_instance(&db),
+            TypeVarVariance::Covariant,
+        );
+        assert!(!builder.has_legacy_only_mappings);
+
+        builder.add_type_mapping(
+            u,
+            KnownClass::Str.to_instance(&db),
+            TypeVarVariance::Bivariant,
+        );
+        assert!(builder.has_legacy_only_mappings);
+
+        let constraints = ConstraintSetBuilder::new();
+        let mut builder = SpecializationBuilder::new(&db, &constraints, inferable);
+        let set = ConstraintSet::constrain_typevar_lower_bound(
+            &db,
+            &constraints,
+            t,
+            KnownClass::Int.to_instance(&db),
+        );
+        builder
+            .add_type_mappings_from_constraint_set(set)
+            .expect("satisfiable constraint set");
+        assert!(builder.has_legacy_only_mappings);
     }
 }


### PR DESCRIPTION
## Summary

This is an alternative to #25886 that keeps the specialization fast path in the pending constraint solver instead of reusing `SpecializationBuilder`'s legacy type map.

Building on #25879, `ConstraintSet` can solve a positive conjunction of concrete lower bounds directly, while still applying the normal solution-selection logic for declared bounds and constraints. `SpecializationBuilder` uses that result without constructing the general path and solution wrappers.

The fast path declines when inference still contains information represented only by the legacy solver, including bivariant mappings and mappings accumulated from separately solved constraint sets. Those cases continue through the existing fallback. This keeps the optimization compatible with removing the old solver.
