### PR TITLE
[ty] Run benchmarks for the cleaned Home Assistant performance stack

### DIFF
--- a/crates/ty_module_resolver/src/path.rs
+++ b/crates/ty_module_resolver/src/path.rs
@@ -169,27 +169,14 @@ impl ModulePath {
 
     /// Get the `py.typed` info for this package (not considering parent packages)
     pub(super) fn py_typed(&self, resolver: &ResolverContext) -> PyTyped {
-        let Some(py_typed_contents) = self.to_system_path().and_then(|path| {
+        let Some(py_typed_file) = self.to_system_path().and_then(|path| {
             let py_typed_path = path.join("py.typed");
-            let py_typed_file = system_path_to_file(resolver.db, py_typed_path).ok()?;
-            // If we fail to read it let's say that's like it doesn't exist
-            // (right now the difference between Untyped and Full is academic)
-            py_typed_file.read_to_string(resolver.db).ok()
+            system_path_to_file(resolver.db, py_typed_path).ok()
         }) else {
             return PyTyped::Untyped;
         };
-        // The python typing spec says to look for "partial\n" but in the wild we've seen:
-        //
-        // * PARTIAL\n
-        // * partial\\n (as in they typed "\n")
-        // * partial/n
-        //
-        // since the py.typed file never really grew any other contents, let's be permissive
-        if py_typed_contents.to_ascii_lowercase().contains("partial") {
-            PyTyped::Partial
-        } else {
-            PyTyped::Full
-        }
+
+        py_typed_file_status(resolver.db, py_typed_file)
     }
 
     pub(super) fn to_system_path(&self) -> Option<SystemPathBuf> {
@@ -328,6 +315,28 @@ impl ModulePath {
 
     pub(crate) fn into_search_path(self) -> SearchPath {
         self.search_path
+    }
+}
+
+#[salsa::tracked]
+fn py_typed_file_status(db: &dyn Db, py_typed_file: File) -> PyTyped {
+    // If we fail to read it let's say that's like it doesn't exist
+    // (right now the difference between Untyped and Full is academic)
+    let Ok(py_typed_contents) = py_typed_file.read_to_string(db) else {
+        return PyTyped::Untyped;
+    };
+
+    // The python typing spec says to look for "partial\n" but in the wild we've seen:
+    //
+    // * PARTIAL\n
+    // * partial\\n (as in they typed "\n")
+    // * partial/n
+    //
+    // since the py.typed file never really grew any other contents, let's be permissive
+    if py_typed_contents.to_ascii_lowercase().contains("partial") {
+        PyTyped::Partial
+    } else {
+        PyTyped::Full
     }
 }
 
@@ -837,6 +846,7 @@ impl std::fmt::Display for SystemOrVendoredPathRef<'_> {
 #[cfg(test)]
 mod tests {
     use ruff_db::Db;
+    use ruff_db::system::DbWithWritableSystem as _;
     use ruff_python_ast::PythonVersion;
 
     use crate::db::tests::TestDb;
@@ -858,6 +868,27 @@ mod tests {
         fn join(&self, component: &str) -> ModulePath {
             self.to_module_path().join(component)
         }
+    }
+
+    #[test]
+    fn py_typed_cache_invalidates_when_file_changes() {
+        let TestCase { mut db, src, .. } = TestCaseBuilder::new()
+            .with_src_files(&[("package/py.typed", "")])
+            .build();
+        let package = SearchPath::first_party(db.system(), src.clone())
+            .unwrap()
+            .join("package");
+
+        let resolver =
+            ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::StubsAllowed);
+        assert_eq!(package.py_typed(&resolver), PyTyped::Full);
+
+        db.write_file(src.join("package/py.typed"), "partial\n")
+            .unwrap();
+
+        let resolver =
+            ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::StubsAllowed);
+        assert_eq!(package.py_typed(&resolver), PyTyped::Partial);
     }
 
     #[test]

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -317,13 +317,18 @@ fn file_to_module_impl<'db, 'a>(
     path: SystemOrVendoredPathRef<'a>,
     mut search_paths: impl Iterator<Item = &'a SearchPath>,
 ) -> Option<Module<'db>> {
-    let module_name = search_paths.find_map(|candidate: &SearchPath| {
-        let relative_path = match path {
+    let (module_path, module_name) = search_paths.find_map(|candidate: &SearchPath| {
+        let module_path = match path {
             SystemOrVendoredPathRef::System(path) => candidate.relativize_system_path(path),
             SystemOrVendoredPathRef::Vendored(path) => candidate.relativize_vendored_path(path),
         }?;
-        relative_path.to_module_name()
+        let module_name = module_path.to_module_name()?;
+        Some((module_path, module_name))
     })?;
+
+    if let Some(module) = file_to_module_from_parent(db, file, path, &module_path, &module_name) {
+        return Some(module);
+    }
 
     // Resolve the module name to see if Python would resolve the name to the same path.
     // If it doesn't, then that means that multiple modules have the same name in different
@@ -354,6 +359,86 @@ fn file_to_module_impl<'db, 'a>(
     // The module name of `src/foo.py` is `foo`, but the module loaded by Python is `src/foo/__init__.py`.
     // That means we need to ignore `src/foo.py` even though it resolves to the same module name.
     None
+}
+
+/// Resolve a first-party file from its already-resolved parent package.
+///
+/// Once a regular parent package has been resolved to a specific search path, resolving one of
+/// its children cannot switch to a different search path. Resolving the parent through its own
+/// cached query means each package in a large tree is validated once instead of re-resolving every
+/// child module name from the root.
+fn file_to_module_from_parent<'db>(
+    db: &'db dyn Db,
+    file: File,
+    path: SystemOrVendoredPathRef<'_>,
+    module_path: &ModulePath,
+    module_name: &ModuleName,
+) -> Option<Module<'db>> {
+    let SystemOrVendoredPathRef::System(path) = path else {
+        return None;
+    };
+    let search_path = module_path.search_path();
+    if !search_path.is_first_party() {
+        return None;
+    }
+
+    let is_package = matches!(path.file_name(), Some("__init__.py" | "__init__.pyi"));
+    let parent_name = module_name.parent()?;
+
+    let mut parent_path = module_path.clone();
+    parent_path.pop();
+    if is_package {
+        parent_path.pop();
+    }
+    parent_path.push("__init__");
+
+    let context = ResolverContext::new(db, db.python_version(), ModuleResolveMode::StubsAllowed);
+    let parent_init = resolve_file_module_without_case_check(&parent_path, &context)?;
+    let mut parent_package_path = parent_path.clone();
+    parent_package_path.pop();
+    if is_legacy_namespace_package(&parent_package_path, &context, parent_init) {
+        return None;
+    }
+    let parent = resolve_module(db, parent_init, &parent_name)?;
+    if parent.kind(db) != ModuleKind::Package
+        || parent.name(db) != &parent_name
+        || parent.search_path(db) != Some(search_path)
+        || parent.file(db) != Some(parent_init)
+    {
+        return None;
+    }
+
+    // A regular package has priority over a same-named file module.
+    if !is_package {
+        let mut package_path = module_path.clone();
+        package_path.pop();
+        package_path.push(module_name.last_component());
+        package_path.push("__init__");
+        if resolve_file_module(&package_path, &context).is_some() {
+            return None;
+        }
+    }
+
+    // `system_path_to_file` follows the host filesystem's casing rules. Import resolution does
+    // not, so preserve the case-sensitive check performed by `resolve_file_module`.
+    let system = db.system();
+    if !system.case_sensitivity().is_case_sensitive()
+        && !system.path_exists_case_sensitive(path, search_path.as_system_path()?)
+    {
+        return None;
+    }
+
+    Some(Module::file_module(
+        db,
+        module_name.clone(),
+        if is_package {
+            ModuleKind::Package
+        } else {
+            ModuleKind::Module
+        },
+        search_path.clone(),
+        file,
+    ))
 }
 
 pub fn search_paths(db: &dyn Db, resolve_mode: ModuleResolveMode) -> SearchPathIterator<'_> {
@@ -1061,11 +1146,61 @@ struct ModuleNameIngredient<'db> {
     pub(super) mode: ModuleResolveMode,
 }
 
+/// The first two components of a module name, cached independently from the full name.
+///
+/// Large projects often have thousands of modules under the same second-level package. Caching
+/// exactly this prefix captures that reuse without creating a Salsa query for every intermediate
+/// package in the module tree.
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+struct ModuleNamePrefixIngredient<'db> {
+    #[returns(ref)]
+    name: ModuleName,
+    mode: ModuleResolveMode,
+    is_non_shadowable: bool,
+}
+
+#[salsa::tracked(returns(ref))]
+fn resolve_two_component_prefix<'db>(
+    db: &'db dyn Db,
+    prefix: ModuleNamePrefixIngredient<'db>,
+) -> ResolvedNames {
+    let name = prefix.name(db);
+    let mode = prefix.mode(db);
+    let search_paths = search_paths(db, mode);
+    let candidates = initial_resolution_candidates(search_paths, prefix.is_non_shadowable(db));
+    resolve_name_components(db, name.components(), mode, candidates, true).unwrap_or_default()
+}
+
 /// Given a module name and a list of search paths in which to lookup modules,
 /// attempt to resolve the module name
 fn resolve_name(db: &dyn Db, name: &ModuleName, mode: ModuleResolveMode) -> Option<ResolvedNames> {
-    let search_paths = search_paths(db, mode);
-    resolve_name_impl(db, name, mode, search_paths)
+    let mut components = name.components();
+    let first = components.next().expect("module names are non-empty");
+    let Some(second) = components.next() else {
+        return resolve_name_impl(db, name, mode, search_paths(db, mode));
+    };
+    let Some(third) = components.next() else {
+        return resolve_name_impl(db, name, mode, search_paths(db, mode));
+    };
+
+    let python_version = db.python_version();
+    let is_non_shadowable = mode.is_non_shadowable(python_version.minor, name.as_str());
+    let prefix_name = ModuleName::from_components([first, second])
+        .expect("components came from a valid module name");
+    let prefix = ModuleNamePrefixIngredient::new(db, prefix_name, mode, is_non_shadowable);
+    let candidates = resolve_two_component_prefix(db, prefix).clone();
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    resolve_name_components(
+        db,
+        std::iter::once(third).chain(components),
+        mode,
+        candidates,
+        false,
+    )
 }
 
 /// Like `resolve_name` but for cases where it failed to resolve the module
@@ -1082,7 +1217,7 @@ fn desperately_resolve_name(
     resolve_name_impl(db, name, mode, search_paths.iter().flatten())
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum ResolvedModule {
     NamespacePackage,
     LegacyNamespacePackage(File),
@@ -1090,7 +1225,7 @@ enum ResolvedModule {
     Module(File),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 struct ModuleResolutionCandidate {
     path: ModulePath,
     module: ResolvedModule,
@@ -1193,11 +1328,17 @@ fn resolve_name_impl<'a>(
     search_paths: impl Iterator<Item = &'a SearchPath>,
 ) -> Option<ResolvedNames> {
     let python_version = db.python_version();
-    let context = ResolverContext::new(db, python_version, mode);
     let is_non_shadowable = mode.is_non_shadowable(python_version.minor, name.as_str());
-    let mut stub_name = None;
+    let candidates = initial_resolution_candidates(search_paths, is_non_shadowable);
 
-    let mut cur_candidates = search_paths
+    resolve_name_components(db, name.components(), mode, candidates, true)
+}
+
+fn initial_resolution_candidates<'a>(
+    search_paths: impl Iterator<Item = &'a SearchPath>,
+    is_non_shadowable: bool,
+) -> ResolvedNames {
+    search_paths
         .filter_map(|search_path| {
             // When a builtin module is imported, standard module resolution is bypassed:
             // the module name always resolves to the stdlib module,
@@ -1215,15 +1356,25 @@ fn resolve_name_impl<'a>(
                 is_stub_package: false,
             })
         })
-        .collect::<Vec<_>>();
+        .collect()
+}
+
+fn resolve_name_components<'a>(
+    db: &dyn Db,
+    components: impl Iterator<Item = &'a str>,
+    mode: ModuleResolveMode,
+    mut cur_candidates: ResolvedNames,
+    mut is_root: bool,
+) -> Option<ResolvedNames> {
+    let context = ResolverContext::new(db, db.python_version(), mode);
+    let mut stub_name = None;
     let mut next_candidates = vec![];
 
     // FIXME?: because we have to search every candidate on each step of this loop,
     // in theory we can search them all in parallel. However we need to join the parallelism
     // at the end of each iteration, and after the first iteration in 99% of cases we will have
     // reduced down to a single candidate, so maybe meh?
-    let mut is_root = true;
-    for component in name.components() {
+    for component in components {
         // Search for the next component in every search-path
         for mut candidate in cur_candidates.drain(..) {
             // On the first iteration, look for `mypackage-stubs` as well
@@ -1447,17 +1598,7 @@ pub(super) fn resolve_file_module(
     module: &ModulePath,
     resolver_state: &ResolverContext,
 ) -> Option<File> {
-    // Stubs have precedence over source files
-    let stub_file = if resolver_state.mode.stubs_allowed() {
-        module.with_pyi_extension().to_file(resolver_state)
-    } else {
-        None
-    };
-    let file = stub_file.or_else(|| {
-        module
-            .with_py_extension()
-            .and_then(|path| path.to_file(resolver_state))
-    })?;
+    let file = resolve_file_module_without_case_check(module, resolver_state)?;
 
     // For system files, test if the path has the correct casing.
     // We can skip this step for vendored files or virtual files because
@@ -1473,6 +1614,23 @@ pub(super) fn resolve_file_module(
     }
 
     Some(file)
+}
+
+fn resolve_file_module_without_case_check(
+    module: &ModulePath,
+    resolver_state: &ResolverContext,
+) -> Option<File> {
+    // Stubs have precedence over source files
+    let stub_file = if resolver_state.mode.stubs_allowed() {
+        module.with_pyi_extension().to_file(resolver_state)
+    } else {
+        None
+    };
+    stub_file.or_else(|| {
+        module
+            .with_py_extension()
+            .and_then(|path| path.to_file(resolver_state))
+    })
 }
 
 /// Determines whether a package is a legacy namespace package.
@@ -1519,9 +1677,14 @@ fn is_legacy_namespace_package(
     //
     // The downside is if you write slightly different syntax we will fail to detect the idiom,
     // but hey, this is better than nothing!
-    let parsed = ruff_db::parsed::parsed_module(context.db, init);
+    is_legacy_namespace_package_file(context.db, init)
+}
+
+#[salsa::tracked]
+fn is_legacy_namespace_package_file(db: &dyn Db, init: File) -> bool {
+    let parsed = ruff_db::parsed::parsed_module(db, init);
     let mut visitor = LegacyNamespacePackageVisitor::default();
-    visitor.visit_body(parsed.load(context.db).suite());
+    visitor.visit_body(parsed.load(db).suite());
 
     visitor.is_legacy_namespace_package
 }
@@ -2233,6 +2396,89 @@ mod tests {
             path_to_module(&db, &FilePath::from(src.join("foo.py")))
         );
         assert!(foo_real != foo);
+    }
+
+    #[test]
+    fn nested_stub_over_module_source() {
+        const SRC: &[FileSpec] = &[
+            ("foo/__init__.py", ""),
+            ("foo/bar.py", ""),
+            ("foo/bar.pyi", ""),
+        ];
+
+        let TestCase { db, src, .. } = TestCaseBuilder::new().with_src_files(SRC).build();
+        let name = ModuleName::new_static("foo.bar").unwrap();
+        let stub = resolve_module_confident(&db, &name).unwrap();
+        let implementation = resolve_real_module_confident(&db, &name).unwrap();
+
+        assert_eq!(
+            Some(stub),
+            path_to_module(&db, &FilePath::from(src.join("foo/bar.pyi")))
+        );
+        assert_eq!(
+            Some(implementation),
+            path_to_module(&db, &FilePath::from(src.join("foo/bar.py")))
+        );
+    }
+
+    #[test]
+    fn stub_package_controls_runtime_submodule_visibility() {
+        const SRC: &[FileSpec] = &[("foo/__init__.py", ""), ("foo/bar.py", "")];
+        const STUBS: &[FileSpec] = &[("foo-stubs/__init__.pyi", ""), ("foo-stubs/py.typed", "")];
+
+        let TestCase {
+            mut db,
+            src,
+            site_packages,
+            ..
+        } = TestCaseBuilder::new()
+            .with_src_files(SRC)
+            .with_site_packages_files(STUBS)
+            .build();
+        let bar_path = src.join("foo/bar.py");
+        let bar_name = ModuleName::new_static("foo.bar").unwrap();
+
+        assert_eq!(None, resolve_module_confident(&db, &bar_name));
+        let runtime_bar = path_to_module(&db, &FilePath::from(bar_path.clone()))
+            .expect("desperate resolution should still identify the runtime file");
+        assert_eq!(runtime_bar.file(&db).unwrap().path(&db), &bar_path);
+
+        db.write_file(site_packages.join("foo-stubs/py.typed"), "partial\n")
+            .unwrap();
+        let bar = resolve_module_confident(&db, &bar_name)
+            .expect("partial stub package should fall back to runtime submodule");
+        assert_eq!(Some(bar), path_to_module(&db, &FilePath::from(bar_path)));
+    }
+
+    #[test]
+    fn file_to_module_in_second_legacy_namespace_root() {
+        const LEGACY_INIT: &str =
+            "__path__ = __import__('pkgutil').extend_path(__path__, __name__)";
+
+        let first = SystemPathBuf::from("/first");
+        let second = SystemPathBuf::from("/second");
+        let second_child = second.join("foo/child.py");
+        let mut db = TestDb::new();
+        db.write_files([
+            (first.join("foo/__init__.py"), LEGACY_INIT),
+            (second.join("foo/__init__.py"), LEGACY_INIT),
+            (second_child.clone(), ""),
+        ])
+        .unwrap();
+        db.set_search_paths(
+            SearchPathSettings {
+                src_roots: vec![first, second.clone()],
+                ..SearchPathSettings::empty()
+            }
+            .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
+            .unwrap(),
+        );
+
+        let child = path_to_module(&db, &FilePath::from(second_child)).unwrap();
+        assert_eq!(
+            child.search_path(&db),
+            Some(&SearchPath::first_party(db.system(), second).unwrap())
+        );
     }
 
     #[test]

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -16,7 +16,7 @@ python-version = "3.12"
 ## Propagating target type annotation
 
 ```py
-from typing import AsyncGenerator, AsyncIterable, Generator, Iterable, Literal
+from typing import Any, AsyncGenerator, AsyncIterable, Generator, Iterable, Literal
 
 def list1[T](x: T) -> list[T]:
     return [x]
@@ -86,6 +86,37 @@ reveal_type(x)  # revealed: list[int]
 
 x: list[list[int]] = [[1], [2], *([3], [4])]
 reveal_type(x)  # revealed: list[list[int]]
+
+type IntDict = dict[str, int]
+
+unique: set[int] = {1, 2, 3}
+reveal_type(unique)  # revealed: set[int]
+
+mapping: dict[str, int] = {"a": 1, **{"b": 2}}
+reveal_type(mapping)  # revealed: dict[str, int]
+
+def dynamic_mapping() -> Any: ...
+
+dynamic_unpack: dict[str, int] = reveal_type({**dynamic_mapping()})  # revealed: dict[str | Any, int | Any]
+
+alias_mapping: IntDict = {"a": 1}
+reveal_type(alias_mapping)  # revealed: dict[str, int]
+
+optional_mapping: dict[str, int] | None = {"a": 1}
+reveal_type(optional_mapping)  # revealed: dict[str, int]
+
+either: list[int] | list[str] = [1]
+reveal_type(either)  # revealed: list[int]
+
+# A protocol context is not an exact nominal collection context and must use the general path.
+iterable: Iterable[int] = [1]
+reveal_type(iterable)  # revealed: list[int]
+
+bad_list: list[str] = [1]  # error: [invalid-assignment]
+bad_dict: dict[str, int] = {"a": "bad"}  # error: [invalid-assignment]
+
+# error: [invalid-argument-type] "Argument expression after ** must be a mapping type"
+bad_unpack: dict[str, int] = {**42}
 
 x: list[list[int | str]] = [[1], [2]] * 3
 reveal_type(x)  # revealed: list[list[int | str]]

--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -133,6 +133,27 @@ for x in (1, "a", b"foo"):
 reveal_type(x)
 ```
 
+## Exact builtin containers and subclass overrides
+
+```py
+from typing import Any, Iterator
+
+def builtins(values: list[int], mapping: dict[str, int]):
+    for value in values:
+        reveal_type(value)  # revealed: int
+
+    for key in mapping:
+        reveal_type(key)  # revealed: str
+
+class CustomList(list[Any]):
+    def __iter__(self) -> Iterator[str]:
+        return iter([""])
+
+def subclass(values: CustomList):
+    for value in values:
+        reveal_type(value)  # revealed: str
+```
+
 ## With non-callable iterator
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_form.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_form.md
@@ -427,6 +427,25 @@ reveal_type(foo(str))  # revealed: str
 foo(float)  # error: [no-matching-overload]
 ```
 
+Recursive aliases in overload parameter contexts should not cause contextual inference to recurse
+indefinitely.
+
+```py
+from typing import overload
+from typing_extensions import TypeForm
+
+type RecursiveForm = RecursiveForm | TypeForm[int]
+
+@overload
+def consume(value: RecursiveForm, discriminator: int) -> None: ...
+@overload
+def consume(value: RecursiveForm, discriminator: str) -> None: ...
+def consume(value: RecursiveForm, discriminator: int | str) -> None: ...
+
+value: object = object()
+consume(value, 1)
+```
+
 ## Narrowing to runtime classes
 
 A `TypeForm[T]` value may or may not be a runtime class object. An `isinstance(..., type)` check can

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3306,6 +3306,24 @@ impl<'db> Type<'db> {
         policy: InstanceFallbackShadowsNonDataDescriptor,
         member_policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
+        let class_member = self.class_member_with_policy(db, name.into(), member_policy);
+        self.invoke_descriptor_protocol_with_class_member(
+            db,
+            receiver,
+            class_member,
+            fallback,
+            policy,
+        )
+    }
+
+    fn invoke_descriptor_protocol_with_class_member(
+        self,
+        db: &'db dyn Db,
+        receiver: Type<'db>,
+        class_member: PlaceAndQualifiers<'db>,
+        fallback: PlaceAndQualifiers<'db>,
+        policy: InstanceFallbackShadowsNonDataDescriptor,
+    ) -> PlaceAndQualifiers<'db> {
         let (
             PlaceAndQualifiers {
                 place: meta_attr,
@@ -3314,7 +3332,7 @@ impl<'db> Type<'db> {
             meta_attr_kind,
         ) = Self::try_call_dunder_get_on_attribute(
             db,
-            self.class_member_with_policy(db, name.into(), member_policy),
+            class_member,
             Some(receiver),
             self.to_meta_type(db),
         );
@@ -3432,6 +3450,26 @@ impl<'db> Type<'db> {
     #[must_use]
     pub(crate) fn member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
         self.member_lookup_with_policy(db, name.into(), MemberLookupPolicy::default())
+    }
+
+    /// Resolve an instance member whose class-level definition is known to be definitely bound on
+    /// the first class in the MRO.
+    pub(crate) fn member_from_own_class_member(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        class_member: PlaceAndQualifiers<'db>,
+    ) -> PlaceAndQualifiers<'db> {
+        let fallback = self.instance_member(db, name);
+        let result = self.invoke_descriptor_protocol_with_class_member(
+            db,
+            self,
+            class_member,
+            fallback,
+            InstanceFallbackShadowsNonDataDescriptor::No,
+        );
+        self.fallback_to_getattr(db, &Name::new(name), result, MemberLookupPolicy::default())
+            .map_type(|ty| ty.bind_self_typevars(db, self))
     }
 
     /// Similar to [`Type::member`], but allows the caller to specify what policy should be used

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -245,12 +245,14 @@ impl<'db> GenericAlias<'db> {
             .map(|specialization| specialization.types(db))
             .unwrap_or(&[]);
 
-        Self::new(
-            db,
-            self.origin(db),
-            self.specialization(db)
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-        )
+        let original_specialization = self.specialization(db);
+        let specialization =
+            original_specialization.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+        if specialization == original_specialization {
+            self
+        } else {
+            Self::new(db, self.origin(db), specialization)
+        }
     }
 
     pub(super) fn find_legacy_typevars_impl(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1112,6 +1112,35 @@ pub(super) fn walk_specialization<'db, V: TypeVisitor<'db> + ?Sized>(
 }
 
 impl<'db> Specialization<'db> {
+    /// Maps the specialization's types without allocating if every type is unchanged.
+    fn map_types(
+        self,
+        db: &'db dyn Db,
+        mut map: impl FnMut(usize, BoundTypeVarInstance<'db>, Type<'db>) -> Type<'db>,
+    ) -> Cow<'db, [Type<'db>]> {
+        let types = self.types(db);
+        let mut mapped_types: Option<Vec<Type<'db>>> = None;
+
+        for (index, (typevar, ty)) in self
+            .generic_context(db)
+            .variables(db)
+            .zip(types.iter().copied())
+            .enumerate()
+        {
+            let mapped_ty = map(index, typevar, ty);
+            if let Some(mapped_types) = &mut mapped_types {
+                mapped_types.push(mapped_ty);
+            } else if mapped_ty != ty {
+                let mut changed_types = Vec::with_capacity(types.len());
+                changed_types.extend_from_slice(&types[..index]);
+                changed_types.push(mapped_ty);
+                mapped_types = Some(changed_types);
+            }
+        }
+
+        mapped_types.map_or(Cow::Borrowed(types), Cow::Owned)
+    }
+
     /// Restricts this specialization to only include the typevars in a generic context. If the
     /// specialization does not include all of those typevars, returns `None`.
     pub(crate) fn restrict(
@@ -1217,32 +1246,31 @@ impl<'db> Specialization<'db> {
             return self.materialize_impl(db, *materialization_kind, visitor);
         }
 
-        let types: Box<[_]> = self
-            .types(db)
-            .iter()
-            .zip(self.generic_context(db).variables(db))
-            .enumerate()
-            .map(|(i, (ty, typevar))| {
-                let tcx = TypeContext::new(tcx.get(i).copied());
-                if typevar.variance(db).is_covariant() {
-                    ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
-                } else {
-                    ty.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor)
-                }
-            })
-            .collect();
+        let types = self.map_types(db, |i, typevar, ty| {
+            let tcx = TypeContext::new(tcx.get(i).copied());
+            if typevar.variance(db).is_covariant() {
+                ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+            } else {
+                ty.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor)
+            }
+        });
 
-        let tuple_inner = self.tuple_inner(db).and_then(|tuple| {
+        let original_tuple_inner = self.tuple_inner(db);
+        let tuple_inner = original_tuple_inner.and_then(|tuple| {
             tuple.apply_type_mapping_impl(db, type_mapping, TypeContext::default(), visitor)
         });
 
-        Specialization::new(
-            db,
-            self.generic_context(db),
-            types,
-            self.materialization_kind(db),
-            tuple_inner,
-        )
+        if matches!(types, Cow::Borrowed(_)) && tuple_inner == original_tuple_inner {
+            self
+        } else {
+            Specialization::new(
+                db,
+                self.generic_context(db),
+                types,
+                self.materialization_kind(db),
+                tuple_inner,
+            )
+        }
     }
 
     /// Applies an optional specialization to this specialization.

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1849,6 +1849,9 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
     // Whether `pending` only contains direct covariant mappings from unbounded ordinary typevars
     // to types that contain no typevars.
     simple_covariant_mappings_only: bool,
+    // Whether `pending` contains a checked root-level mapping from `typing.Self` to a concrete
+    // nominal receiver type.
+    simple_self_mapping: bool,
 }
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
@@ -1865,6 +1868,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             types: FxHashMap::default(),
             paramspec_seen: FxHashSet::default(),
             simple_covariant_mappings_only: true,
+            simple_self_mapping: false,
         }
     }
 
@@ -1909,6 +1913,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             Option<ConstraintBounds<'db>>,
         ) -> Option<Type<'db>>,
     ) -> FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> {
+        if self.can_solve_simple_self_mapping(generic_context) {
+            return self.solve_hash_map_with(generic_context, choose, true);
+        }
+
         if self.can_solve_simple_covariant_mappings(generic_context) {
             return self.solve_hash_map_with(generic_context, choose, true);
         }
@@ -2013,6 +2021,20 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         .typevar(self.db)
                         .bound_or_constraints(self.db)
                         .is_none()
+                })
+    }
+
+    fn can_solve_simple_self_mapping(&self, generic_context: GenericContext<'db>) -> bool {
+        self.simple_self_mapping
+            && self.simple_covariant_mappings_only
+            && self.types.len() == 1
+            && generic_context.variables_inner(self.db).len() == 1
+            && generic_context
+                .variables_inner(self.db)
+                .iter()
+                .next()
+                .is_some_and(|(identity, typevar)| {
+                    typevar.typevar(self.db).is_self(self.db) && self.types.contains_key(identity)
                 })
     }
 
@@ -2448,6 +2470,22 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         formal: Type<'db>,
         actual: Type<'db>,
     ) -> Result<(), SpecializationError<'db>> {
+        if let Type::TypeVar(bound_typevar) = formal
+            && bound_typevar.is_inferable(self.db, self.inferable)
+            && bound_typevar.typevar(self.db).is_self(self.db)
+            && matches!(actual, Type::NominalInstance(_))
+            && !actual.has_typevar(self.db)
+            && !actual.has_unspecialized_type_var(self.db)
+            && let Some(bound) = bound_typevar.typevar(self.db).upper_bound(self.db)
+            && actual
+                .when_assignable_to(self.db, bound, self.constraints, self.inferable)
+                .is_always_satisfied(self.db)
+        {
+            self.simple_self_mapping = true;
+            self.add_simple_covariant_type_mapping(bound_typevar, actual);
+            return Ok(());
+        }
+
         if let Type::TypeVar(bound_typevar) = formal
             && bound_typevar.is_inferable(self.db, self.inferable)
             && matches!(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1846,6 +1846,9 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
     pending: ConstraintSet<'db, 'c>,
     types: FxHashMap<BoundTypeVarIdentity<'db>, UnionAccumulator<'db>>,
     paramspec_seen: FxHashSet<BoundTypeVarIdentity<'db>>,
+    // Whether `pending` only contains direct covariant mappings from unbounded ordinary typevars
+    // to types that contain no typevars.
+    simple_covariant_mappings_only: bool,
 }
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
@@ -1861,6 +1864,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             pending: ConstraintSet::from_bool(constraints, true),
             types: FxHashMap::default(),
             paramspec_seen: FxHashSet::default(),
+            simple_covariant_mappings_only: true,
         }
     }
 
@@ -1905,12 +1909,16 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             Option<ConstraintBounds<'db>>,
         ) -> Option<Type<'db>>,
     ) -> FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> {
+        if self.can_solve_simple_covariant_mappings(generic_context) {
+            return self.solve_hash_map_with(generic_context, choose, true);
+        }
+
         if generic_context
             .variables_inner(self.db)
             .values()
             .any(|typevar| typevar.is_paramspec(self.db))
         {
-            return self.solve_hash_map_with(generic_context, choose);
+            return self.solve_hash_map_with(generic_context, choose, false);
         }
 
         // TODO: This projection / solve can be expensive for large-union collection-literal type
@@ -1937,7 +1945,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 PathBounds::default_solve(self.db, self.constraints, typevar, bounds)
             }) {
                 Solutions::Unsatisfiable | Solutions::Unconstrained => {
-                    return self.solve_hash_map_with(generic_context, choose);
+                    return self.solve_hash_map_with(generic_context, choose, false);
                 }
                 Solutions::Constrained(solutions) => solutions,
             };
@@ -1981,10 +1989,31 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         {
             // Recursive specialization cannot reach a fixed point when a cycle grows through an
             // embedded generic type, such as `SupportsAdd[T, S]`.
-            self.solve_hash_map_with(generic_context, choose)
+            self.solve_hash_map_with(generic_context, choose, false)
         } else {
             types
         }
+    }
+
+    fn can_solve_simple_covariant_mappings(&self, generic_context: GenericContext<'db>) -> bool {
+        !self.types.is_empty()
+            && self.simple_covariant_mappings_only
+            && self
+                .types
+                .keys()
+                .all(|identity| generic_context.contains(self.db, *identity))
+            && generic_context
+                .variables_inner(self.db)
+                .values()
+                .all(|typevar| {
+                    matches!(
+                        typevar.kind(self.db),
+                        TypeVarKind::Legacy | TypeVarKind::Pep695
+                    ) && typevar
+                        .typevar(self.db)
+                        .bound_or_constraints(self.db)
+                        .is_none()
+                })
     }
 
     fn has_expanding_cycle(
@@ -2145,6 +2174,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             BoundTypeVarInstance<'db>,
             Option<ConstraintBounds<'db>>,
         ) -> Option<Type<'db>>,
+        covariant_only: bool,
     ) -> FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> {
         generic_context
             .variables_inner(self.db)
@@ -2155,8 +2185,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     .get_mut(identity)
                     .map(|accumulator| accumulator.get_or_build(self.db));
                 let chosen = match mapped_ty {
-                    Some(mapped_ty) => choose(*variable, Some(ConstraintBounds::exact(mapped_ty)))
-                        .unwrap_or(mapped_ty),
+                    Some(mapped_ty) => {
+                        let bounds = if covariant_only {
+                            ConstraintBounds::new(Some(mapped_ty), None)
+                        } else {
+                            ConstraintBounds::exact(mapped_ty)
+                        };
+                        choose(*variable, Some(bounds)).unwrap_or(mapped_ty)
+                    }
                     None => choose(*variable, None)?,
                 };
                 Some((*identity, chosen))
@@ -2233,6 +2269,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         ty: Type<'db>,
         variance: TypeVarVariance,
     ) {
+        self.simple_covariant_mappings_only = false;
         self.insert_hash_map_type_mapping(bound_typevar, ty);
 
         let bounds = match variance {
@@ -2243,6 +2280,18 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         };
 
         self.intersect_pending_typevar_constraint(bound_typevar, bounds);
+    }
+
+    fn add_simple_covariant_type_mapping(
+        &mut self,
+        bound_typevar: BoundTypeVarInstance<'db>,
+        ty: Type<'db>,
+    ) {
+        self.insert_hash_map_type_mapping(bound_typevar, ty);
+        self.intersect_pending_typevar_constraint(
+            bound_typevar,
+            ConstraintBounds::new(Some(ty), None),
+        );
     }
 
     /// Finds all of the valid specializations of a constraint set, and adds their type mappings to
@@ -2257,6 +2306,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         &mut self,
         set: ConstraintSet<'db, 'c>,
     ) -> Result<(), ()> {
+        self.simple_covariant_mappings_only = false;
         let set = set.remove_noninferable(self.db, self.constraints, self.inferable);
         let solutions = match set.solutions(self.db, self.constraints) {
             Solutions::Unsatisfiable => return Err(()),
@@ -2398,6 +2448,28 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         formal: Type<'db>,
         actual: Type<'db>,
     ) -> Result<(), SpecializationError<'db>> {
+        if let Type::TypeVar(bound_typevar) = formal
+            && bound_typevar.is_inferable(self.db, self.inferable)
+            && matches!(
+                bound_typevar.kind(self.db),
+                TypeVarKind::Legacy | TypeVarKind::Pep695
+            )
+            && bound_typevar
+                .typevar(self.db)
+                .bound_or_constraints(self.db)
+                .is_none()
+            && !actual.has_typevar(self.db)
+            && !actual.has_unspecialized_type_var(self.db)
+        {
+            let actual = actual.filter_disjoint_elements(self.db, formal, self.inferable);
+            self.add_simple_covariant_type_mapping(bound_typevar, actual);
+            return Ok(());
+        }
+
+        if actual.has_typevar(self.db) {
+            self.simple_covariant_mappings_only = false;
+        }
+
         self.infer_map_impl(
             formal,
             actual,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -38,7 +38,7 @@ use crate::place::{
 };
 use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_with_cache};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
-use crate::types::call::bind::MatchingOverloadIndex;
+use crate::types::call::bind::{ArgumentTypeContext, MatchingOverloadIndex};
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
@@ -97,13 +97,14 @@ use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
 use crate::types::{
     BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType,
-    DynamicType, InferenceFlags, InternedConstraintSet, InternedType, IntersectionBuilder,
-    IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueTypeKind,
-    MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters, SentinelInstance, Signature,
-    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
-    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType,
-    UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
-    infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
+    CycleDetector, DynamicType, InferenceFlags, InternedConstraintSet, InternedType,
+    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, KnownUnion,
+    LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters,
+    SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType,
+    TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind,
+    TypeVarVariance, TypedDictType, UnionAccumulator, UnionBuilder, UnionType, any_over_type,
+    binding_type, infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment,
+    todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
@@ -5623,7 +5624,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         call_expression_tcx: TypeContext<'db>,
     ) {
         fn add_overloads_from_binding<'a, 'db>(
-            overloads_with_binding: &mut Vec<(&'a Binding<'db>, &'a CallableBinding<'db>)>,
+            overloads_with_binding: &mut SmallVec<
+                [(&'a Binding<'db>, &'a CallableBinding<'db>); 1],
+            >,
             binding: &'a CallableBinding<'db>,
         ) {
             match binding.matching_overload_index() {
@@ -5645,47 +5648,115 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
+        fn contains_type_form<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+            struct ContainsTypeForm;
+            type ContainsTypeFormVisitor<'db> = CycleDetector<ContainsTypeForm, Type<'db>, bool>;
+
+            fn imp<'db>(
+                db: &'db dyn Db,
+                ty: Type<'db>,
+                visitor: &ContainsTypeFormVisitor<'db>,
+            ) -> bool {
+                match ty {
+                    Type::TypeForm(_) => true,
+                    Type::TypeAlias(alias) => {
+                        visitor.visit(ty, || imp(db, alias.value_type(db), visitor))
+                    }
+                    Type::Union(union) => union
+                        .elements(db)
+                        .iter()
+                        .any(|element| imp(db, *element, visitor)),
+                    _ => false,
+                }
+            }
+
+            imp(db, ty, &ContainsTypeFormVisitor::default())
+        }
+
+        fn can_reuse_default_argument_type<'db>(
+            db: &'db dyn Db,
+            ast_argument: &ast::Expr,
+            default_ty: Type<'db>,
+            parameter_contexts: &[ArgumentTypeContext<'db>],
+        ) -> bool {
+            if !matches!(ast_argument, ast::Expr::Name(_) | ast::Expr::Attribute(_)) {
+                return false;
+            }
+
+            if matches!(
+                default_ty.resolve_type_alias(db),
+                Type::ClassLiteral(_)
+                    | Type::LiteralValue(_)
+                    | Type::SubclassOf(_)
+                    | Type::TypeForm(_)
+            ) {
+                return false;
+            }
+
+            parameter_contexts.iter().all(|parameter_context| {
+                parameter_context
+                    .type_context()
+                    .annotation
+                    .is_none_or(|annotation| !contains_type_form(db, annotation))
+            })
+        }
+
         let db = self.db();
         let constraints = ConstraintSetBuilder::new();
 
-        let mut overloads_with_binding: Vec<(&Binding<'db>, &CallableBinding<'db>)> = Vec::new();
+        let mut overloads_with_binding: SmallVec<[(&Binding<'db>, &CallableBinding<'db>); 1]> =
+            SmallVec::new();
 
         bindings.visit_type_context_callables(&mut |binding| {
             add_overloads_from_binding(&mut overloads_with_binding, binding);
         });
 
-        // A keyword argument matched to `**P.kwargs` can appear before the keyword argument that
-        // binds `P`, e.g. `wrapper(TagSet=[...], func=put_object)`. Seed those binder argument
-        // types first so the normal ParamSpec context path below is not source-order dependent.
-        for (argument_index, ast_argument) in ast_arguments.clone().enumerate() {
-            if ast_argument.is_variadic() {
-                continue;
-            }
-            let ast_argument = ast_argument.value();
-
-            let mut inferred_declared_types = FxHashSet::default();
-            for declared_type in overloads_with_binding
-                .iter()
-                .filter_map(|(overload, binding)| {
-                    overload.paramspec_binder_parameter_type(db, binding, argument_index)
-                })
-            {
-                if !inferred_declared_types.insert(declared_type) {
+        if overloads_with_binding.iter().any(|(overload, _)| {
+            overload
+                .signature
+                .parameters()
+                .as_paramspec_with_prefix()
+                .is_some()
+        }) {
+            // A keyword argument matched to `**P.kwargs` can appear before the keyword argument that
+            // binds `P`, e.g. `wrapper(TagSet=[...], func=put_object)`. Seed those binder argument
+            // types first so the normal ParamSpec context path below is not source-order dependent.
+            for (argument_index, ast_argument) in ast_arguments.clone().enumerate() {
+                if ast_argument.is_variadic() {
                     continue;
                 }
+                let ast_argument = ast_argument.value();
 
-                let mut speculative_builder = self.speculate();
-                let inferred_ty = infer_argument_ty(
-                    &mut speculative_builder,
-                    (
-                        argument_index,
-                        ast_argument,
-                        TypeContext::new(Some(declared_type)),
-                    ),
-                );
-                arguments_types.insert_type(argument_index, declared_type, inferred_ty);
+                let mut inferred_declared_types = FxHashSet::default();
+                for declared_type in
+                    overloads_with_binding
+                        .iter()
+                        .filter_map(|(overload, binding)| {
+                            overload.paramspec_binder_parameter_type(db, binding, argument_index)
+                        })
+                {
+                    if !inferred_declared_types.insert(declared_type) {
+                        continue;
+                    }
+
+                    let mut speculative_builder = self.speculate();
+                    let inferred_ty = infer_argument_ty(
+                        &mut speculative_builder,
+                        (
+                            argument_index,
+                            ast_argument,
+                            TypeContext::new(Some(declared_type)),
+                        ),
+                    );
+                    arguments_types.insert_type(argument_index, declared_type, inferred_ty);
+                }
             }
         }
+
+        let single_overload_with_binding = match overloads_with_binding.as_slice() {
+            [(overload, binding)] => Some((*overload, *binding)),
+            _ => None,
+        };
 
         for (argument_index, ast_argument) in ast_arguments.enumerate() {
             // Splatted arguments are inferred before parameter matching to
@@ -5711,7 +5782,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // If there is only a single binding and overload, we can infer the argument directly with
             // the unique parameter type annotation.
-            if let Ok((overload, binding)) = overloads_with_binding.iter().exactly_one() {
+            if let Some((overload, binding)) = single_overload_with_binding {
                 let parameter_context = parameter_tcx(overload, binding);
 
                 if let Some(parameter_context) = parameter_context {
@@ -5741,10 +5812,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             } else {
                 // Infer the type of each argument once with each distinct parameter type as type context.
-                let parameter_contexts: Vec<_> = overloads_with_binding
-                    .iter()
-                    .filter_map(|(overload, binding)| parameter_tcx(overload, binding))
-                    .collect();
+                let parameter_contexts: SmallVec<[ArgumentTypeContext<'db>; 4]> =
+                    overloads_with_binding
+                        .iter()
+                        .filter_map(|(overload, binding)| parameter_tcx(overload, binding))
+                        .collect();
 
                 // We perform inference once without any type context, emitting any diagnostics that are unrelated
                 // to bidirectional type inference.
@@ -5752,55 +5824,98 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     infer_argument_ty(self, (argument_index, ast_argument, TypeContext::default()));
                 arguments_types.insert_type(argument_index, TypeContext::default(), default_ty);
 
-                let mut inferred_by_cache_key = FxHashMap::default();
+                if can_reuse_default_argument_type(
+                    db,
+                    ast_argument,
+                    default_ty,
+                    &parameter_contexts,
+                ) {
+                    for parameter_context in parameter_contexts {
+                        parameter_context.insert_inferred_type(
+                            arguments_types,
+                            argument_index,
+                            default_ty,
+                        );
+                    }
+                    continue;
+                }
 
-                // Cache expressions inferred across speculative inference attempts.
-                //
-                // This is important to avoid exponential blowup for deeply nested generic calls,
-                // as inner expressions are repeatedly inferred with the same type context.
-                let teardown = self.setup_expression_cache();
+                let [parameter_context] = parameter_contexts.as_slice() else {
+                    if parameter_contexts.is_empty() {
+                        continue;
+                    }
 
-                for parameter_context in parameter_contexts {
-                    let inference_cache_key = parameter_context.inference_cache_key();
-                    if let Some(inferred_ty) =
-                        inferred_by_cache_key.get(&inference_cache_key).copied()
-                    {
-                        // Even when the inference cache key is identical, this overload may later
-                        // look up the inferred type through a different original `ParamSpec`
-                        // annotation, so insert through its own context.
+                    let mut inferred_by_cache_key = FxHashMap::default();
+
+                    // Cache expressions inferred across speculative inference attempts.
+                    //
+                    // This is important to avoid exponential blowup for deeply nested generic calls,
+                    // as inner expressions are repeatedly inferred with the same type context.
+                    let teardown = self.setup_expression_cache();
+
+                    for parameter_context in parameter_contexts {
+                        let inference_cache_key = parameter_context.inference_cache_key();
+                        if let Some(inferred_ty) =
+                            inferred_by_cache_key.get(&inference_cache_key).copied()
+                        {
+                            // Even when the inference cache key is identical, this overload may later
+                            // look up the inferred type through a different original `ParamSpec`
+                            // annotation, so insert through its own context.
+                            parameter_context.insert_inferred_type(
+                                arguments_types,
+                                argument_index,
+                                inferred_ty,
+                            );
+                            continue;
+                        }
+
+                        // We use a speculative builder to silence any diagnostics emitted during multi-inference, as the
+                        // type context is only used as a hint to infer a more assignable argument type, and should not lead
+                        // to diagnostics for non-matching overloads.
+                        let mut speculative_builder = self.speculate();
+                        let inferred_ty = infer_argument_ty(
+                            &mut speculative_builder,
+                            (
+                                argument_index,
+                                ast_argument,
+                                parameter_context.type_context(),
+                            ),
+                        );
+
+                        inferred_by_cache_key.insert(inference_cache_key, inferred_ty);
+                        self.union_expected_types(&speculative_builder.expected_types);
                         parameter_context.insert_inferred_type(
                             arguments_types,
                             argument_index,
                             inferred_ty,
                         );
-                        continue;
                     }
 
-                    // We use a speculative builder to silence any diagnostics emitted during multi-inference, as the
-                    // type context is only used as a hint to infer a more assignable argument type, and should not lead
-                    // to diagnostics for non-matching overloads.
-                    let mut speculative_builder = self.speculate();
-                    let inferred_ty = infer_argument_ty(
-                        &mut speculative_builder,
-                        (
-                            argument_index,
-                            ast_argument,
-                            parameter_context.type_context(),
-                        ),
-                    );
+                    if teardown {
+                        self.teardown_expression_cache();
+                    }
 
-                    inferred_by_cache_key.insert(inference_cache_key, inferred_ty);
-                    self.union_expected_types(&speculative_builder.expected_types);
-                    parameter_context.insert_inferred_type(
-                        arguments_types,
+                    continue;
+                };
+
+                // Avoid allocating a per-argument inference cache when only one context is
+                // available. There are no repeated speculative inferences to deduplicate.
+                let mut speculative_builder = self.speculate();
+                let inferred_ty = infer_argument_ty(
+                    &mut speculative_builder,
+                    (
                         argument_index,
-                        inferred_ty,
-                    );
-                }
+                        ast_argument,
+                        parameter_context.type_context(),
+                    ),
+                );
 
-                if teardown {
-                    self.teardown_expression_cache();
-                }
+                self.union_expected_types(&speculative_builder.expected_types);
+                parameter_context.insert_inferred_type(
+                    arguments_types,
+                    argument_index,
+                    inferred_ty,
+                );
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7028,7 +7028,41 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mut elt_tcx_variance: FxHashMap<BoundTypeVarIdentity<'_>, TypeVarVariance> =
                 FxHashMap::default();
 
-            if let Some(tcx) = tcx.annotation
+            if collection_class != KnownClass::Dict
+                && let Some(tcx) = tcx.annotation.map(|tcx| tcx.resolve_type_alias(self.db()))
+                && matches!(tcx, Type::NominalInstance(_))
+                && let Some(specialization) = tcx.known_specialization(self.db(), collection_class)
+                && specialization.generic_context(self.db()) == generic_context
+                && generic_context.variables(self.db()).all(|typevar| {
+                    !typevar.is_paramspec(self.db())
+                        && typevar
+                            .typevar(self.db())
+                            .bound_or_constraints(self.db())
+                            .is_none()
+                })
+            {
+                // For an instance of the collection class itself, the identity specialization
+                // maps directly to the contextual specialization. Avoid constructing and solving
+                // a general assignability constraint set for this common case.
+                for (typevar, inferred_ty) in generic_context
+                    .variables(self.db())
+                    .zip(specialization.types(self.db()))
+                {
+                    let inferred_ty = inferred_ty
+                        .filter_union(self.db(), |ty| {
+                            !ty.as_typevar()
+                                .is_some_and(|tv| tv.is_inferable(self.db(), inferable))
+                        })
+                        .filter_union(self.db(), |ty| !ty.has_unspecialized_type_var(self.db()));
+                    if inferred_ty.has_unspecialized_type_var(self.db()) {
+                        continue;
+                    }
+
+                    let identity = typevar.identity(self.db());
+                    elt_tcx_constraints.insert(identity, UnionAccumulator::new(inferred_ty));
+                    elt_tcx_variance.insert(identity, typevar.variance(self.db()));
+                }
+            } else if let Some(tcx) = tcx.annotation
                 && tcx.class_specialization(self.db()).is_some()
             {
                 let db = self.db();
@@ -7101,9 +7135,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (elt_tcx_constraints, elt_tcx_variance)
         };
 
+        // Dictionary unpacking always contributes constraints on the inferred key and value types,
+        // even when the unpacked mapping is assignable to the context. Keep it on the general path
+        // so gradual types such as `Any` are preserved.
+        let has_dict_unpack = collection_class == KnownClass::Dict
+            && elts
+                .iter()
+                .any(|elts| matches!(elts.as_slice(), [None, Some(_)]));
+
         // Avoid projecting and solving a constraint set when contextual inference has already
-        // provided the complete specialization for an empty collection literal.
-        if elts.is_empty()
+        // provided the complete specialization and every literal element is compatible with it.
+        if !has_dict_unpack
             && tcx.annotation.is_some()
             && let Some(specialization) = generic_context
                 .variables(self.db())
@@ -7123,14 +7165,53 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
                 .collect::<Option<Vec<_>>>()
         {
-            let class_type = collection_alias.origin(self.db()).apply_specialization(
-                self.db(),
-                |generic_context| {
-                    generic_context
-                        .specialize_recursive(self.db(), specialization.into_iter().map(Some))
-                },
-            );
-            return Type::from(class_type).to_instance(self.db());
+            // For non-empty dictionaries, the slow path preserves the entry-derived ordering of
+            // union members in the inferred value type. That ordering is observable in
+            // diagnostics, so keep those literals on the general path rather than returning the
+            // contextual specialization directly.
+            let preserves_inferred_union_order =
+                elts.is_empty() || collection_class != KnownClass::Dict;
+
+            // The slow path below adds the contextual specialization as an invariant mapping,
+            // then discards every element constraint that is already assignable to its context.
+            // Probe that case speculatively so that a failed probe can fall back without changing
+            // diagnostics or inferred expression types.
+            let mut speculative_builder = self.speculate();
+            let mut compatible = true;
+
+            'elements: for elts in elts {
+                for (i, elt, elt_tcx) in itertools::izip!(0.., elts, specialization.iter().copied())
+                {
+                    let Some(elt) = elt else { continue };
+                    let elt_tcx = if elt.is_starred_expr() && collection_class != KnownClass::Dict {
+                        Type::homogeneous_tuple(self.db(), elt_tcx)
+                    } else {
+                        elt_tcx
+                    };
+                    let inferred_elt_ty = infer_elt_expression(
+                        &mut speculative_builder,
+                        (i, elt, TypeContext::new(Some(elt_tcx))),
+                    );
+
+                    if !inferred_elt_ty.is_assignable_to(self.db(), elt_tcx) {
+                        compatible = false;
+                        break 'elements;
+                    }
+                }
+            }
+
+            if compatible && preserves_inferred_union_order {
+                self.extend(speculative_builder);
+
+                let class_type = collection_alias.origin(self.db()).apply_specialization(
+                    self.db(),
+                    |generic_context| {
+                        generic_context
+                            .specialize_recursive(self.db(), specialization.into_iter().map(Some))
+                    },
+                );
+                return Type::from(class_type).to_instance(self.db());
+            }
         }
 
         // Create a set of constraints to infer a precise type for `T`.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -97,14 +97,13 @@ use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
 use crate::types::{
     BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType,
-    CycleDetector, DynamicType, InferenceFlags, InternedConstraintSet, InternedType,
-    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, KnownUnion,
-    LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters,
-    SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType,
-    TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind,
-    TypeVarVariance, TypedDictType, UnionAccumulator, UnionBuilder, UnionType, any_over_type,
-    binding_type, infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment,
-    todo_type,
+    DynamicType, InferenceFlags, InternedConstraintSet, InternedType, IntersectionBuilder,
+    IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueTypeKind,
+    MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters, SentinelInstance, Signature,
+    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
+    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType,
+    UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
+    infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
@@ -5649,28 +5648,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         fn contains_type_form<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-            struct ContainsTypeForm;
-            type ContainsTypeFormVisitor<'db> = CycleDetector<ContainsTypeForm, Type<'db>, bool>;
-
-            fn imp<'db>(
-                db: &'db dyn Db,
-                ty: Type<'db>,
-                visitor: &ContainsTypeFormVisitor<'db>,
-            ) -> bool {
-                match ty {
-                    Type::TypeForm(_) => true,
-                    Type::TypeAlias(alias) => {
-                        visitor.visit(ty, || imp(db, alias.value_type(db), visitor))
-                    }
-                    Type::Union(union) => union
-                        .elements(db)
-                        .iter()
-                        .any(|element| imp(db, *element, visitor)),
-                    _ => false,
-                }
+            match ty.resolve_type_alias(db) {
+                Type::TypeForm(_) => true,
+                Type::Union(union) => union
+                    .elements(db)
+                    .iter()
+                    .any(|element| matches!(element.resolve_type_alias(db), Type::TypeForm(_))),
+                _ => false,
             }
-
-            imp(db, ty, &ContainsTypeFormVisitor::default())
         }
 
         fn can_reuse_default_argument_type<'db>(
@@ -5679,18 +5664,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             default_ty: Type<'db>,
             parameter_contexts: &[ArgumentTypeContext<'db>],
         ) -> bool {
-            if !matches!(ast_argument, ast::Expr::Name(_) | ast::Expr::Attribute(_)) {
-                return false;
-            }
-
-            if matches!(
-                default_ty.resolve_type_alias(db),
-                Type::ClassLiteral(_)
-                    | Type::LiteralValue(_)
-                    | Type::SubclassOf(_)
-                    | Type::TypeForm(_)
-            ) {
-                return false;
+            match ast_argument {
+                ast::Expr::Name(_) | ast::Expr::Attribute(_) => {
+                    if matches!(
+                        default_ty.resolve_type_alias(db),
+                        Type::ClassLiteral(_) | Type::SubclassOf(_) | Type::TypeForm(_)
+                    ) {
+                        return false;
+                    }
+                }
+                ast::Expr::StringLiteral(_)
+                | ast::Expr::BytesLiteral(_)
+                | ast::Expr::NumberLiteral(_)
+                | ast::Expr::BooleanLiteral(_)
+                | ast::Expr::NoneLiteral(_)
+                | ast::Expr::EllipsisLiteral(_)
+                | ast::Expr::FString(_)
+                | ast::Expr::TString(_)
+                | ast::Expr::UnaryOp(_)
+                | ast::Expr::Compare(_)
+                | ast::Expr::Subscript(_)
+                | ast::Expr::Slice(_)
+                | ast::Expr::Named(_) => {}
+                _ => return false,
             }
 
             parameter_contexts.iter().all(|parameter_context| {
@@ -5830,11 +5826,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     default_ty,
                     &parameter_contexts,
                 ) {
+                    if matches!(ast_argument, ast::Expr::StringLiteral(_))
+                        && let Some(expected) = parameter_contexts
+                            .iter()
+                            .filter_map(|context| context.type_context().annotation)
+                            .filter(|expected| {
+                                self.has_string_literal_completion_candidates(*expected)
+                            })
+                            .reduce(|left, right| UnionType::from_two_elements(db, left, right))
+                    {
+                        self.store_expected_type(ast_argument, expected);
+                    }
+
                     for parameter_context in parameter_contexts {
+                        let inferred_ty = self.apply_literal_type_context(
+                            default_ty,
+                            parameter_context.type_context(),
+                        );
                         parameter_context.insert_inferred_type(
                             arguments_types,
                             argument_index,
-                            default_ty,
+                            inferred_ty,
                         );
                     }
                     continue;
@@ -6085,6 +6097,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_value_expression_impl(expression, tcx)
     }
 
+    fn apply_literal_type_context(&self, ty: Type<'db>, tcx: TypeContext<'db>) -> Type<'db> {
+        let db = self.db();
+        if let Type::LiteralValue(literal) = ty
+            && let Some(tcx) = tcx.annotation
+            && let literal_tcx @ (Type::Union(_) | Type::LiteralValue(_)) = tcx
+                .resolve_type_alias(db)
+                .filter_union(db, |ty| ty.as_literal_value().is_some())
+            && ty.is_assignable_to(db, literal_tcx)
+        {
+            Type::LiteralValue(literal.to_unpromotable())
+        } else {
+            ty
+        }
+    }
+
     /// Infer an expression without implicitly treating this root as a `TypeForm`.
     ///
     /// Child expressions still use their normal contextual inference, so the
@@ -6156,15 +6183,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         // Avoid promoting explicitly annotated literal values.
-        if let Type::LiteralValue(literal) = ty
-            && let Some(tcx) = tcx.annotation
-            && let literal_tcx @ (Type::Union(_) | Type::LiteralValue(_)) = tcx
-                .resolve_type_alias(self.db())
-                .filter_union(self.db(), |ty| ty.as_literal_value().is_some())
-            && ty.is_assignable_to(self.db(), literal_tcx)
-        {
-            ty = Type::LiteralValue(literal.to_unpromotable());
-        }
+        ty = self.apply_literal_type_context(ty, tcx);
 
         if let Some(tcx) = tcx.annotation
             && let Some(collection_def) = self.index.unconstrained_collection_binding(expression)

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -2,7 +2,7 @@ use crate::{
     Db,
     types::{
         AwaitError, Bindings, CallArguments, CallDunderError, KnownClass, LintDiagnosticGuard,
-        LintDiagnosticGuardBuilder, LiteralValueTypeKind, Type, TypeContext,
+        LintDiagnosticGuardBuilder, LiteralValueTypeKind, MaterializationKind, Type, TypeContext,
         TypeVarBoundOrConstraints, UnionType,
         call::CallErrorKind,
         context::InferContext,
@@ -105,7 +105,38 @@ impl<'db> Type<'db> {
             const MAX_TUPLE_LENGTH: usize = 128;
 
             match ty {
-                Type::NominalInstance(nominal) => nominal.tuple_spec(db),
+                Type::NominalInstance(nominal) => match nominal.known_class(db) {
+                    // Iteration over these exact builtin classes cannot be customized. Subclasses
+                    // have no `KnownClass`, so they continue through the dunder lookup below.
+                    Some(KnownClass::List | KnownClass::Dict) => {
+                        let element_type = nominal.class(db).into_generic_alias().map_or(
+                            Type::unknown(),
+                            |alias| {
+                                let specialization = alias.specialization(db);
+                                let element_type = specialization
+                                    .types(db)
+                                    .first()
+                                    .copied()
+                                    .unwrap_or(Type::unknown());
+                                if element_type.has_dynamic(db) {
+                                    match specialization.materialization_kind(db) {
+                                        Some(MaterializationKind::Top) => {
+                                            element_type.top_materialization(db)
+                                        }
+                                        Some(MaterializationKind::Bottom) => {
+                                            element_type.bottom_materialization(db)
+                                        }
+                                        None => element_type,
+                                    }
+                                } else {
+                                    element_type
+                                }
+                            },
+                        );
+                        Some(Cow::Owned(TupleSpec::homogeneous(element_type)))
+                    }
+                    _ => nominal.tuple_spec(db),
+                },
                 Type::NewTypeInstance(newtype) => non_async_special_case(db, newtype.concrete_base_type(db)),
                 Type::GenericAlias(alias) if alias.origin(db).is_tuple(db) => {
                     Some(Cow::Owned(TupleSpec::homogeneous(todo_type!(

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -58,6 +58,39 @@ const PROHIBITED_NAMEDTUPLE_ATTRS: &[&str] = &[
     "_source",
 ];
 
+#[salsa::tracked(
+    cycle_initial=|_, id, _, _| Place::bound(Type::divergent(id)).into(),
+    heap_size=ruff_memory_usage::heap_size
+)]
+#[allow(
+    clippy::needless_pass_by_value,
+    reason = "Salsa tracked query keys must be owned"
+)]
+fn superclass_instance_member<'db>(
+    db: &'db dyn Db,
+    superclass: ClassType<'db>,
+    name: Name,
+) -> PlaceAndQualifiers<'db> {
+    let instance = Type::instance(db, superclass);
+    let Some((literal, _)) = superclass.static_class_literal(db) else {
+        return instance.member(db, &name);
+    };
+    let own_class_member = superclass.own_class_member(db, None, &name);
+
+    if matches!(
+        own_class_member.inner.place,
+        Place::Defined(DefinedPlace {
+            definedness: crate::place::Definedness::AlwaysDefined,
+            ..
+        })
+    ) && enum_metadata(db, literal.into()).is_none()
+    {
+        instance.member_from_own_class_member(db, &name, own_class_member.inner)
+    } else {
+        instance.member(db, &name)
+    }
+}
+
 // TODO: Support dynamic class literals. If we allow dynamic classes to define attributes in their
 // namespace dictionary, we should also check whether those attributes are valid overrides of
 // attributes in their superclasses.
@@ -369,7 +402,7 @@ fn check_class_declaration<'db>(
             }
 
             let superclass_instance_member =
-                Type::instance(db, superclass).member(db, &member.name);
+                superclass_instance_member(db, superclass, member.name.clone());
             let Place::Defined(DefinedPlace {
                 ty: superclass_type,
                 ..


### PR DESCRIPTION
## Summary

This draft verifies the cleaned performance stack against the current-main Home Assistant baseline in #25894.

The stack retains the independently supported inference, specialization, iteration, module-resolution, and override-member optimizations. It excludes:

- the empty benchmark-trigger commit
- the marginal unconstrained-collection experiment
- the inline cache and shared parameter-list candidates that did not improve CodSpeed
- the dictionary collection fast path that changed current-main diagnostic text

The remaining collection optimization is limited to list and set contexts, preserving byte-identical Home Assistant diagnostics.

## Benchmark target

- current-main baseline: #25894
- required improvement: at least 10%
- exact diagnostic output must match the baseline byte-for-byte

## Test plan

- `cargo nextest run -p ty_python_semantic -p ty_module_resolver` (701/701)
- targeted Clippy with `-D warnings`
- file-scoped `uvx prek`
- profiling build
- byte-identical Home Assistant diagnostics