### PR TITLE
Document Ruff argfile support

### DIFF
--- a/docs/linter.md
+++ b/docs/linter.md
@@ -19,6 +19,19 @@ $ ruff check --watch          # Lint files in the current directory and re-lint 
 $ ruff check path/to/code/    # Lint files in `path/to/code`.
 ```
 
+For long argument lists, Ruff supports argument files. Prefix a file path with `@`
+to expand additional command-line arguments from that file, with one argument per line:
+
+```console
+$ ruff check @paths.txt
+```
+
+```text title="paths.txt"
+src/package
+tests/test_package.py
+path with spaces/example.py
+```
+
 For the full list of supported options, run `ruff check --help`.
 
 ## Rule selection


### PR DESCRIPTION
## Summary

- Document Ruff's existing `@argfile` support for long command-line argument lists.
- Add a `paths.txt` example showing one argument per line, including a path with spaces.

## Reproduction

Users with very large path lists, or paths that are awkward to pass directly through a shell, can use Ruff's existing argfile support:

```console
$ ruff check @paths.txt
```

However, this was only discoverable from code, tests, or maintainer comments, not from the linter documentation.

## Root cause

Ruff expands CLI arguments via `argfile::expand_args_from` with the `@` prefix, and the integration tests cover this behavior, but `docs/linter.md` did not mention it.

## Changes

- Add an argfile example near the `ruff check` usage examples.
- Clarify that each line in the argfile is treated as one command-line argument.

## Tests

- `git diff --check`
- `cargo fmt --check`
- `cargo run --bin ruff -- check --isolated --no-cache "@$tmpdir/paths.txt"` with an argfile containing a path with spaces (`All checks passed!`)
- Not run: `uvx prek run --files docs/linter.md` (`uvx` is not installed in this environment)

## Screenshots/Logs

- Not applicable; documentation-only change.

## AI Policy

- This PR follows the repository AI policy.

Fixes #21894.