### PR TITLE
Clarify manual-list-copy iterable wording

### DIFF
--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
@@ -7,12 +7,12 @@ use crate::Violation;
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for `for` loops that can be replaced by a making a copy of a list.
+/// Checks for `for` loops that append each item from an iterable to a list
+/// without modification.
 ///
 /// ## Why is this bad?
-/// When creating a copy of an existing list using a for-loop, prefer
-/// `list` or `list.copy` instead. Making a direct copy is more readable and
-/// more performant.
+/// When creating a list from an iterable using a for-loop, prefer `list`
+/// instead. Building the list directly is more readable and more performant.
 ///
 /// Using the below as an example, the `list`-based copy is ~2x faster on
 /// Python 3.11.
@@ -41,7 +41,7 @@ pub(crate) struct ManualListCopy;
 impl Violation for ManualListCopy {
     #[derive_message_formats]
     fn message(&self) -> String {
-        "Use `list` or `list.copy` to create a copy of a list".to_string()
+        "Use `list` to create a list from an iterable".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF402_PERF402.py.snap
+++ b/crates/ruff_linter/src/rules/perflint/snapshots/ruff_linter__rules__perflint__tests__PERF402_PERF402.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/perflint/mod.rs
 ---
-PERF402 Use `list` or `list.copy` to create a copy of a list
+PERF402 Use `list` to create a list from an iterable
  --> PERF402.py:5:9
   |
 3 |     result = []


### PR DESCRIPTION
## Summary

- Clarify the `manual-list-copy` (`PERF402`) rule docs so they describe building a list from an iterable, not only copying an existing list.
- Update the diagnostic message to avoid suggesting `list.copy()` when the source may be any iterable.
- Refresh the PERF402 snapshot for the updated message.

## Reproduction

The current rule page and diagnostic describe PERF402 as creating a copy of a list and suggest `list.copy()`. The rule only verifies that the destination is a list; the source expression being iterated can be any iterable, so the wording is too narrow.

## Root cause

The rule documentation and message were framed around copying an existing list, while the implementation flags loops that append each item from an iterable to a list without modification.

## Changes

- Reword the generated rule documentation in `manual_list_copy.rs` to describe appending items from an iterable to a list.
- Change the diagnostic message to recommend `list` for creating a list from an iterable.
- Update the PERF402 snapshot.

## Tests

- `cargo dev generate-docs`
- `INSTA_UPDATE=always INSTA_FORCE_PASS=1 cargo test -p ruff_linter rules::perflint::tests::rules --no-fail-fast`
- `cargo test -p ruff_linter rules::perflint::tests::rules --no-fail-fast`
- `cargo fmt --check`
- `git diff --check`
- Not run: `uvx prek run --files ...` (`uvx`/`prek` are not installed in this environment)

## Screenshots/Logs

- Not applicable; docs and diagnostic message wording only.

## AI Policy

- This PR follows the repository AI policy.

Fixes #21593.