### PR TITLE
[ty] Run benchmarks for cached empty dunder calls

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1014,6 +1014,17 @@ struct GeneratorTypes<'db> {
     return_ty: Option<Type<'db>>,
 }
 
+/// The cached result of an argument-free dunder call.
+///
+/// `Bindings` isn't Salsa-updateable, so the tracked field is always replaced when the query
+/// re-executes instead of being compared with its previous value.
+#[salsa::tracked]
+struct EmptyDunderCallResult<'db> {
+    #[tracked]
+    #[no_eq]
+    result: Result<Bindings<'db>, CallDunderError<'db>>,
+}
+
 fn object_type_form(db: &dyn Db) -> Type<'_> {
     TypeFormType::from_type_expression(db, Type::object())
 }
@@ -5149,6 +5160,40 @@ impl<'db> Type<'db> {
     /// Note that `NO_INSTANCE_FALLBACK` is always added to the policy, since implicit calls to
     /// dunder methods never access instance members.
     fn try_call_dunder_with_policy(
+        self,
+        db: &'db dyn Db,
+        name: &str,
+        argument_types: &mut CallArguments<'_, 'db>,
+        tcx: TypeContext<'db>,
+        policy: MemberLookupPolicy,
+    ) -> Result<Bindings<'db>, CallDunderError<'db>> {
+        #[salsa::tracked]
+        fn try_call_empty_dunder_with_policy<'db>(
+            db: &'db dyn Db,
+            this: Type<'db>,
+            name: Name,
+            policy: MemberLookupPolicy,
+        ) -> EmptyDunderCallResult<'db> {
+            EmptyDunderCallResult::new(
+                db,
+                this.try_call_dunder_with_policy_impl(
+                    db,
+                    name.as_str(),
+                    &mut CallArguments::none(),
+                    TypeContext::default(),
+                    policy,
+                ),
+            )
+        }
+
+        if argument_types.len() == 0 && tcx == TypeContext::default() {
+            return try_call_empty_dunder_with_policy(db, self, name.into(), policy).result(db);
+        }
+
+        self.try_call_dunder_with_policy_impl(db, name, argument_types, tcx, policy)
+    }
+
+    fn try_call_dunder_with_policy_impl(
         self,
         db: &'db dyn Db,
         name: &str,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5167,6 +5167,8 @@ impl<'db> Type<'db> {
         tcx: TypeContext<'db>,
         policy: MemberLookupPolicy,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
+        // Salsa query keys must be owned.
+        #[allow(clippy::needless_pass_by_value)]
         #[salsa::tracked]
         fn try_call_empty_dunder_with_policy<'db>(
             db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -188,7 +188,7 @@ pub(crate) enum CallErrorKind {
     PossiblyNotCallable,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(super) enum CallDunderError<'db> {
     /// The dunder attribute exists but it can't be called with the given arguments.
     ///

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -325,7 +325,7 @@ fn dependency_dunder_call_change() -> anyhow::Result<()> {
     let mut db = setup_db();
 
     db.write_files([
-        ("/src/a.py", "from foo import C\nx = next(iter(C()))"),
+        ("/src/a.py", "from foo import C\nx = [*C()]"),
         (
             "/src/foo.py",
             "class C:\n    def __iter__(self) -> 'C': ...\n    def __next__(self) -> int: ...",
@@ -335,7 +335,7 @@ fn dependency_dunder_call_change() -> anyhow::Result<()> {
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
     let x_ty = global_symbol(&db, a, "x").place.expect_type();
 
-    assert_eq!(x_ty.display(&db).to_string(), "int");
+    assert_eq!(x_ty.display(&db).to_string(), "list[int]");
 
     db.write_file(
         "/src/foo.py",
@@ -345,7 +345,7 @@ fn dependency_dunder_call_change() -> anyhow::Result<()> {
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
     let x_ty = global_symbol(&db, a, "x").place.expect_type();
 
-    assert_eq!(x_ty.display(&db).to_string(), "str");
+    assert_eq!(x_ty.display(&db).to_string(), "list[str]");
 
     Ok(())
 }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -321,6 +321,36 @@ fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
 }
 
 #[test]
+fn dependency_dunder_call_change() -> anyhow::Result<()> {
+    let mut db = setup_db();
+
+    db.write_files([
+        ("/src/a.py", "from foo import C\nx = next(iter(C()))"),
+        (
+            "/src/foo.py",
+            "class C:\n    def __iter__(self) -> 'C': ...\n    def __next__(self) -> int: ...",
+        ),
+    ])?;
+
+    let a = system_path_to_file(&db, "/src/a.py").unwrap();
+    let x_ty = global_symbol(&db, a, "x").place.expect_type();
+
+    assert_eq!(x_ty.display(&db).to_string(), "int");
+
+    db.write_file(
+        "/src/foo.py",
+        "class C:\n    def __iter__(self) -> 'C': ...\n    def __next__(self) -> str: ...",
+    )?;
+
+    let a = system_path_to_file(&db, "/src/a.py").unwrap();
+    let x_ty = global_symbol(&db, a, "x").place.expect_type();
+
+    assert_eq!(x_ty.display(&db).to_string(), "str");
+
+    Ok(())
+}
+
+#[test]
 fn dependency_internal_symbol_change() -> anyhow::Result<()> {
     let mut db = setup_db();
 


### PR DESCRIPTION
## Summary

- cache no-argument dunder calls made with the default type context
- reuse the existing member lookup, argument binding, and type-checking path without duplicating iteration semantics
- add an incremental regression test for changes to a cached dunder method

## Motivation

Profiling Home Assistant shows that member lookup itself is a relatively small part of iteration cost. Most of the time is spent binding and type-checking repeated `__iter__`, `__next__`, `__await__`, and related calls. This draft measures caching that shared path instead of special-casing iterable types.

## Local results

- at least 120,000 eligible calls, with 6,438 query executions (about 94.6% reuse)
- CPU geometric mean: 3.45% faster across eight alternating pairs; candidate improved in 8/8 pairs
- Home Assistant diagnostics are byte-identical to the baseline
- memory-report lower bound: +5.40 MB of Salsa metadata and inline fields; nested `Bindings` heap allocations are not currently accounted for

This is an experimental benchmark draft, not a merge-ready proposal. Retained memory and cycle behavior are acceptance gates.

## Test plan

- `cargo nextest run -p ty_python_semantic` (559/559 passed)
- `cargo clippy -p ty_python_semantic --all-targets --all-features -- -D warnings`
- file-scoped `uvx prek`
- exact Home Assistant diagnostic comparison
