### PR TITLE
[ty] Run benchmarks for skipping empty implicit attribute lookups

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -10,7 +10,7 @@ pub(super) use self::named_tuple::{
     DynamicNamedTupleAnchor, DynamicNamedTupleLiteral, NamedTupleField, NamedTupleSpec,
 };
 pub(crate) use self::static_literal::{
-    ExpandedClassBaseEntry, StaticClassLiteral, expanded_class_base_entries,
+    ExpandedClassBaseEntry, StaticClassLiteral, StaticClassShape, expanded_class_base_entries,
 };
 pub(super) use self::typed_dict::{DynamicTypedDictAnchor, DynamicTypedDictLiteral};
 use super::{

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -68,6 +68,12 @@ use ty_python_core::{
 ///
 /// This does not in itself represent a type, but can be transformed into a [`ClassType`] that
 /// does. (For generic classes, this requires specializing its generic context.)
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
+pub struct StaticClassShape {
+    pub(crate) has_explicit_metaclass: bool,
+    pub(crate) has_implicit_attributes: bool,
+}
+
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct StaticClassLiteral<'db> {
     /// Name of the class at definition
@@ -98,8 +104,7 @@ pub struct StaticClassLiteral<'db> {
     /// Whether this class has any explicit base classes.
     pub(crate) has_explicit_bases: bool,
 
-    /// Whether this class has an explicit `metaclass` keyword argument.
-    pub(crate) has_explicit_metaclass: bool,
+    pub(crate) shape: StaticClassShape,
 }
 
 // The Salsa heap is tracked separately.
@@ -107,6 +112,14 @@ impl get_size2::GetSize for StaticClassLiteral<'_> {}
 
 #[salsa::tracked]
 impl<'db> StaticClassLiteral<'db> {
+    pub(crate) fn has_explicit_metaclass(self, db: &'db dyn Db) -> bool {
+        self.shape(db).has_explicit_metaclass
+    }
+
+    fn has_implicit_attributes(self, db: &'db dyn Db) -> bool {
+        self.shape(db).has_implicit_attributes
+    }
+
     /// Return `true` if this class represents `known_class`
     pub(crate) fn is_known(self, db: &'db dyn Db, known_class: KnownClass) -> bool {
         self.known(db) == Some(known_class)
@@ -168,7 +181,7 @@ impl<'db> StaticClassLiteral<'db> {
             self.has_decorators(db),
             self.has_type_params(db),
             self.has_explicit_bases(db),
-            self.has_explicit_metaclass(db),
+            self.shape(db),
         )
     }
 
@@ -1198,7 +1211,7 @@ impl<'db> StaticClassLiteral<'db> {
                 return Member::definitely_declared(synthesized_member);
             }
             // The symbol was not found in the class scope. It might still be implicitly defined in `@classmethod`s.
-            return Self::implicit_attribute(db, body_scope, name, MethodDecorator::ClassMethod);
+            return self.implicit_attribute(db, name, MethodDecorator::ClassMethod);
         }
 
         // For dataclass-like classes, `KW_ONLY` sentinel fields are not real
@@ -2145,14 +2158,20 @@ impl<'db> StaticClassLiteral<'db> {
 
     /// Tries to find declarations/bindings of an attribute named `name` that are only
     /// "implicitly" defined (`self.x = …`, `cls.x = …`) in a method of the class that
-    /// corresponds to `class_body_scope`. The `target_method_decorator` parameter is
-    /// used to skip methods that do not have the expected decorator.
+    /// The `target_method_decorator` parameter is used to skip methods that do not have the
+    /// expected decorator.
     fn implicit_attribute(
+        self,
         db: &'db dyn Db,
-        class_body_scope: ScopeId<'db>,
         name: &str,
         target_method_decorator: MethodDecorator,
     ) -> Member<'db> {
+        if !self.has_implicit_attributes(db) {
+            return Member::unbound();
+        }
+
+        let class_body_scope = self.body_scope(db);
+
         // Collect names in a tracked query so unrelated edits can preserve dependent member
         // lookups, and avoid retaining query entries for names that no method can define.
         if implicit_attribute_names(db, class_body_scope)
@@ -2544,7 +2563,8 @@ impl<'db> StaticClassLiteral<'db> {
                     if qualifiers.contains(TypeQualifiers::INIT_VAR) {
                         // We ignore `InitVar` declarations on the class body, unless that attribute is overwritten
                         // by an implicit assignment in a method
-                        if Self::implicit_attribute(db, body_scope, name, MethodDecorator::None)
+                        if self
+                            .implicit_attribute(db, name, MethodDecorator::None)
                             .is_undefined()
                         {
                             return Member::unbound();
@@ -2569,8 +2589,7 @@ impl<'db> StaticClassLiteral<'db> {
                     if has_binding {
                         // The attribute is declared and bound in the class body.
 
-                        let implicit =
-                            Self::implicit_attribute(db, body_scope, name, MethodDecorator::None);
+                        let implicit = self.implicit_attribute(db, name, MethodDecorator::None);
                         if let Place::Defined(DefinedPlace {
                             ty: implicit_ty,
                             provenance: implicit_provenance,
@@ -2643,14 +2662,10 @@ impl<'db> StaticClassLiteral<'db> {
                                 ty: implicit_ty,
                                 provenance: implicit_provenance,
                                 ..
-                            }) = Self::implicit_attribute(
-                                db,
-                                body_scope,
-                                name,
-                                MethodDecorator::None,
-                            )
-                            .inner
-                            .place
+                            }) = self
+                                .implicit_attribute(db, name, MethodDecorator::None)
+                                .inner
+                                .place
                             {
                                 Member {
                                     inner: Place::Defined(DefinedPlace {
@@ -2682,14 +2697,14 @@ impl<'db> StaticClassLiteral<'db> {
                     // The attribute is not *declared* in the class body. It could still be declared/bound
                     // in a method.
 
-                    Self::implicit_attribute(db, body_scope, name, MethodDecorator::None)
+                    self.implicit_attribute(db, name, MethodDecorator::None)
                 }
             }
         } else {
             // This attribute is neither declared nor bound in the class body.
             // It could still be implicitly defined in a method.
 
-            Self::implicit_attribute(db, body_scope, name, MethodDecorator::None)
+            self.implicit_attribute(db, name, MethodDecorator::None)
         }
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -1,4 +1,5 @@
 use crate::place::Place;
+use crate::types::class::StaticClassShape;
 use crate::types::{
     CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
     SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
@@ -15,7 +16,7 @@ use crate::types::{
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, helpers::any_over_expr};
 use ty_module_resolver::{KnownModule, file_to_module};
-use ty_python_core::{definition::Definition, scope::NodeWithScopeRef};
+use ty_python_core::{attribute_scopes, definition::Definition, scope::NodeWithScopeRef};
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     pub(super) fn infer_class_body(&mut self, class: &ast::StmtClassDef) {
@@ -132,6 +133,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .arguments
             .as_deref()
             .is_some_and(|arguments| arguments.find_keyword("metaclass").is_some());
+        let has_implicit_attributes = attribute_scopes(db, body_scope).any(|function_scope_id| {
+            self.index
+                .place_table(function_scope_id)
+                .members()
+                .any(|member| member.as_instance_attribute().is_some())
+        });
         let infer_original_class_ty = |deprecated,
                                        type_check_only,
                                        dataclass_params,
@@ -158,7 +165,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     !class_node.decorator_list.is_empty(),
                     class_node.type_params.is_some(),
                     has_explicit_bases,
-                    has_explicit_metaclass,
+                    StaticClassShape {
+                        has_explicit_metaclass,
+                        has_implicit_attributes,
+                    },
                 )),
             }
         };

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -478,6 +478,65 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn dependency_added_implicit_instance_attribute() -> anyhow::Result<()> {
+    let mut db = setup_db();
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class C:
+            def f(self):
+                pass
+        "#,
+    )?;
+    db.write_dedented(
+        "/src/main.py",
+        r#"
+        from mod import C
+        x = C().attr
+        "#,
+    )?;
+
+    let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
+    assert!(
+        global_symbol(&db, file_main, "x")
+            .place
+            .expect_type()
+            .is_unknown()
+    );
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class C:
+            def f(self):
+                self.attr = 1
+        "#,
+    )?;
+
+    let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+    assert_eq!(attr_ty.display(&db).to_string(), "int");
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class C:
+            def f(self):
+                pass
+        "#,
+    )?;
+
+    assert!(
+        global_symbol(&db, file_main, "x")
+            .place
+            .expect_type()
+            .is_unknown()
+    );
+
+    Ok(())
+}
+
 /// This test verifies that changing a class's declaration in a non-meaningful way (e.g. by adding a comment)
 /// doesn't trigger type inference for expressions that depend on the class's members.
 #[test]


### PR DESCRIPTION
## Summary

- record whether a class defines any implicit `self.x` or `cls.x` attributes
- return immediately from implicit-attribute lookup for classes with none
- preserve the existing precise lookup path for classes that may define implicit attributes
- add an incremental test covering addition and removal of an implicit attribute

## Motivation

Home Assistant performs roughly 1.1 million implicit-attribute probes for classes where the candidate-name set is known to be empty. This draft measures avoiding those repeated scans as a broad member-lookup optimization.

## Local results

- Home Assistant diagnostics are byte-identical to the baseline
- CPU geometric mean: 0.50% faster across eight alternating pairs; candidate improved in 6/8 pairs
- wall-clock geometric mean: 1.21% slower and noisy

The local signal is marginal. This is an experimental benchmark draft so CodSpeed can determine whether the optimization is consistently useful across projects.

## Test plan

- `cargo nextest run -p ty_python_semantic` (558/558 passed before the final focused regression was added)
- focused `dependency_added_implicit_instance_attribute` regression
- `cargo check -p ty_python_semantic`
- `cargo clippy -p ty_python_semantic --lib -- -D warnings`
- file-scoped `uvx prek`
- exact Home Assistant diagnostic comparison
