### PR TITLE
[ty] Route reStructuredText parameter documentation through the `Formats` interface.

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -6,10 +6,11 @@
 //! There are no formal specifications for any of these formats, so the parsing
 //! logic needs to be tolerant of variations.
 
+mod formats;
 mod markdown;
 mod preformatted;
-mod rest;
 
+use formats::Formats;
 use indexmap::IndexMap;
 use regex::Regex;
 use ruff_python_trivia::{PythonWhitespace, leading_indentation};
@@ -79,7 +80,9 @@ impl Docstring {
         param_docs.extend(extract_numpy_style_params(&self.0));
 
         // reST/Sphinx-style docstrings
-        param_docs.extend(extract_rest_style_params(&self.0));
+        for parameter in Formats::parse(&self.0).parameter_documentation() {
+            param_docs.insert(parameter.name, parameter.description);
+        }
 
         param_docs
     }
@@ -403,17 +406,6 @@ fn extract_numpy_style_params(docstring: &str) -> IndexMap<String, String> {
     // Don't forget the last parameter
     if let Some(param_name) = current_param {
         param_docs.insert(param_name, current_doc.trim().to_string());
-    }
-
-    param_docs
-}
-
-/// Extract parameter documentation from reST/Sphinx-style docstrings.
-fn extract_rest_style_params(docstring: &str) -> IndexMap<String, String> {
-    let mut param_docs = IndexMap::new();
-
-    for parameter in rest::Docstring::parse(docstring).parameter_documentation() {
-        param_docs.insert(parameter.name.into_string(), parameter.description);
     }
 
     param_docs

--- a/crates/ty_ide/src/docstring/formats.rs
+++ b/crates/ty_ide/src/docstring/formats.rs
@@ -1,0 +1,31 @@
+pub(super) mod rst;
+
+/// Represents documentation for a single parameter parsed from a docstring.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ParameterDocumentation {
+    pub(super) name: String,
+    pub(super) description: String,
+}
+
+/// Encapsulates the set of docstring formats for which we support the following
+/// features:
+///
+/// 1. Extracting parameter documentation for signature help.
+/// 2. Rendering as Markdown on hover.
+pub(super) struct Formats {
+    rst: rst::Docstring,
+}
+
+impl Formats {
+    /// Parses all supported formats in the given docstring.
+    pub(super) fn parse(raw: &str) -> Self {
+        Self {
+            rst: rst::Docstring::parse(raw),
+        }
+    }
+
+    /// Returns docs for all parameters recognized in a parsed docstring.
+    pub(super) fn parameter_documentation(&self) -> Vec<ParameterDocumentation> {
+        self.rst.parameter_documentation()
+    }
+}

--- a/crates/ty_ide/src/docstring/formats/rst.rs
+++ b/crates/ty_ide/src/docstring/formats/rst.rs
@@ -5,7 +5,7 @@ use ruff_python_trivia::leading_indentation;
 use ruff_source_file::{Line as SourceLine, UniversalNewlineIterator, UniversalNewlines};
 use ruff_text_size::{TextRange, TextSize};
 
-use super::preformatted::PreformattedBlockScanner;
+use super::super::preformatted::PreformattedBlockScanner;
 
 /// Represents a parsed restructured text (reST) docstring.
 pub(super) struct Docstring {
@@ -20,7 +20,7 @@ impl Docstring {
     }
 
     /// Returns the parameter documentation that we were able to recognize in a docstring.
-    pub(super) fn parameter_documentation(&self) -> Vec<ParameterDocumentation> {
+    pub(super) fn parameter_documentation(&self) -> Vec<super::ParameterDocumentation> {
         let mut parameters = Vec::new();
 
         for field_list in &self.field_lists {
@@ -38,7 +38,7 @@ impl Docstring {
                     continue;
                 }
 
-                parameters.push(ParameterDocumentation {
+                parameters.push(super::ParameterDocumentation {
                     name: lookup_name.clone(),
                     description: description.clone(),
                 });
@@ -270,7 +270,7 @@ impl<'a> FieldBuilder<'a> {
                 ty,
             } => Field::Parameter {
                 display_name: display_name.to_compact_string(),
-                lookup_name: lookup_name.to_compact_string(),
+                lookup_name: lookup_name.to_string(),
                 ty: ty.map(|ty| ty.to_compact_string()),
                 description: body,
             },
@@ -559,7 +559,7 @@ impl<'a> FieldKind<'a> {
 enum Field {
     Parameter {
         display_name: CompactString,
-        lookup_name: CompactString,
+        lookup_name: String,
         ty: Option<CompactString>,
         description: String,
     },
@@ -593,12 +593,6 @@ enum Field {
         argument: CompactString,
         body: String,
     },
-}
-
-/// Parameter documentation extracted from a reST field list.
-pub(super) struct ParameterDocumentation {
-    pub(super) name: CompactString,
-    pub(super) description: String,
 }
 
 /// Container for the display name (shown to the user) and the lookup name


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
En route to https://github.com/astral-sh/ty/issues/3454, this is a small refactor that established the `Formats` interface as the source of truth for parameter documentation across all supported docstring formats. For now only the reStructuredText module conforms to that interface, but the Google and NumPy formats will be made to in subsequent changes.

## Test Plan

This is a pure refactor that relies on existing test coverage.

<!-- How was it tested? -->
