### PR TITLE
[ty] Render Markdown for reStructuredText fields in docstrings on hover

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -84,6 +84,36 @@ impl Docstring {
     }
 }
 
+/// Text extracted from within a larger docstring.
+///
+/// Unlike a complete docstring, a fragment has already had its surrounding indentation removed.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DocstringFragment(String);
+
+impl DocstringFragment {
+    pub fn new(raw: &str) -> Self {
+        Self(documentation_fragment_trim(raw))
+    }
+
+    pub fn render(&self, kind: MarkupKind) -> String {
+        match kind {
+            MarkupKind::PlainText => self.0.clone(),
+            MarkupKind::Markdown => self.render_markdown(),
+        }
+    }
+}
+
+/// Normalizes an extracted docstring fragment without removing meaningful relative indentation.
+fn documentation_fragment_trim(docs: &str) -> String {
+    let expanded = docs.trim_end().replace('\t', "        ");
+    let mut output = String::with_capacity(expanded.len());
+    for line in expanded.universal_newlines() {
+        output.push_str(line.as_str().trim_whitespace_end());
+        output.push('\n');
+    }
+    output
+}
+
 /// Normalizes tabs and trims a docstring as specified in PEP-0257
 ///
 /// See: <https://peps.python.org/pep-0257/#handling-docstring-indentation>
@@ -1575,7 +1605,8 @@ mod tests {
 
         assert_snapshot!(docstring.render_markdown(), @"
         ## Parameters
-        **value**: First line.
+        **value**<HB>
+        First line.
 
         Second line.
         ");
@@ -1627,15 +1658,19 @@ mod tests {
         This is a function description.
 
         ## Parameters
-        **param1** `str`: The first parameter description
+        **param1**: `str`<HB>
+        The first parameter description
 
-        **param2** `int`: The second parameter description<HB>
+        **param2**: `int`<HB>
+        The second parameter description<HB>
         This is a continuation of param2 description.
 
-        **param3**: A parameter without type annotation
+        **param3**<HB>
+        A parameter without type annotation
 
         ## Returns
-        `str`: The return value description
+        `str`<HB>
+        The return value description
         ");
     }
 
@@ -1707,9 +1742,11 @@ mod tests {
         &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): Google-style duplicate parameter
 
         ## Parameters
-        **param2** `int`: reST-style parameter
+        **param2**: `int`<HB>
+        reST-style parameter
 
-        **param3**: Another reST-style parameter
+        **param3**<HB>
+        Another reST-style parameter
 
         Parameters<HB>
         ----------<HB>

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -1564,6 +1564,23 @@ mod tests {
         ");
     }
 
+    /// PEP 257 trimming removes indentation from a docstring's first physical
+    /// line. If a field starts there, continuation indentation is ambiguous, so
+    /// leave the normalized text unchanged rather than guessing. Starting the
+    /// field after the opening newline or a summary makes the intent unambiguous.
+    #[test]
+    fn rest_markdown_does_not_special_case_first_line_field_continuation() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(":param value: First line.\n    Second line.".to_owned());
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Parameters
+        **value**: First line.
+
+        Second line.
+        ");
+    }
+
     #[test]
     fn test_rest_style_parameter_documentation() {
         let _snap = bind_docstring_snapshot_filters();
@@ -1607,14 +1624,18 @@ mod tests {
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        :param str param1: The first parameter description<HB>
-        :param int param2: The second parameter description<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
-        :param param3: A parameter without type annotation<HB>
-        :returns: The return value description<HB>
-        :rtype: str
+        This is a function description.
+
+        ## Parameters
+        **param1** `str`: The first parameter description
+
+        **param2** `int`: The second parameter description<HB>
+        This is a continuation of param2 description.
+
+        **param3**: A parameter without type annotation
+
+        ## Returns
+        `str`: The return value description
         ");
     }
 
@@ -1683,11 +1704,13 @@ mod tests {
         <HB>
         Args:<HB>
         &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): Google-style duplicate parameter<HB>
-        <HB>
-        :param int param2: reST-style parameter<HB>
-        :param param3: Another reST-style parameter<HB>
-        <HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): Google-style duplicate parameter
+
+        ## Parameters
+        **param2** `int`: reST-style parameter
+
+        **param3**: Another reST-style parameter
+
         Parameters<HB>
         ----------<HB>
         param3 : str<HB>

--- a/crates/ty_ide/src/docstring/document.rs
+++ b/crates/ty_ide/src/docstring/document.rs
@@ -5,5 +5,5 @@ pub(super) mod rst;
 
 /// Returns docs for all parameters recognized in the given docstring.
 pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
-    rst::Docstring::parse(raw).parameter_documentation()
+    rst::parameter_documentation(raw)
 }

--- a/crates/ty_ide/src/docstring/document/rst.rs
+++ b/crates/ty_ide/src/docstring/document/rst.rs
@@ -4,31 +4,40 @@ use compact_str::{CompactString, ToCompactString};
 use indexmap::IndexMap;
 use ruff_python_trivia::leading_indentation;
 use ruff_source_file::{Line as SourceLine, UniversalNewlineIterator, UniversalNewlines};
-use ruff_text_size::{TextRange, TextSize};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use super::preformatted::PreformattedBlockScanner;
 
 /// Parses all reST field lists in a docstring.
-pub(in crate::docstring) fn field_lists(raw: &str) -> Vec<FieldList> {
+fn field_lists(raw: &str) -> Vec<FieldList> {
     FieldList::parse_all(raw)
+}
+
+/// Returns top-level field lists that begin at a reST block boundary.
+///
+/// `source` must have already undergone PEP-257 trimming and universal newline
+/// normalization (typically via `docstring::documentation_trim`).
+pub(in crate::docstring) fn top_level_field_lists(
+    source: &str,
+) -> impl Iterator<Item = FieldList> + '_ {
+    field_lists(source).into_iter().filter(|field_list| {
+        field_list.indent == TextSize::default()
+            && starts_at_block_boundary(source, field_list.range.start())
+    })
 }
 
 /// Returns the parameter documentation recognized in a reST docstring.
 pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
     let mut parameters = IndexMap::new();
+    let source = crate::docstring::documentation_trim(raw);
 
-    for field_list in field_lists(raw) {
+    for field_list in top_level_field_lists(&source) {
         for field in field_list.fields {
-            let (Field::Parameter {
+            let Field::Parameter {
                 lookup_name,
                 description,
                 ..
-            }
-            | Field::Keyword {
-                lookup_name,
-                description,
-                ..
-            }) = field
+            } = field
             else {
                 continue;
             };
@@ -42,6 +51,15 @@ pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
     }
 
     parameters
+}
+
+fn starts_at_block_boundary(source: &str, start: TextSize) -> bool {
+    source.get(..start.to_usize()).is_some_and(|prefix| {
+        prefix
+            .lines()
+            .next_back()
+            .is_none_or(|line| line.trim().is_empty())
+    })
 }
 
 /// Cursor over docstring lines and their line numbers.
@@ -102,14 +120,6 @@ pub(in crate::docstring) struct FieldList {
 }
 
 impl FieldList {
-    pub(in crate::docstring) fn range(&self) -> TextRange {
-        self.range
-    }
-
-    pub(in crate::docstring) fn indent(&self) -> TextSize {
-        self.indent
-    }
-
     pub(in crate::docstring) fn fields(&self) -> &[Field] {
         &self.fields
     }
@@ -250,6 +260,12 @@ impl FieldList {
     }
 }
 
+impl Ranged for FieldList {
+    fn range(&self) -> TextRange {
+        self.range
+    }
+}
+
 /// Constructs new instances of the model for a reST field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct FieldBuilder<'a> {
@@ -283,21 +299,7 @@ impl<'a> FieldBuilder<'a> {
                 ty: ty.map(|ty| ty.to_compact_string()),
                 description: body,
             },
-            FieldKind::Keyword {
-                display_name,
-                lookup_name,
-                ty,
-            } => Field::Keyword {
-                display_name: display_name.to_compact_string(),
-                lookup_name: lookup_name.to_string(),
-                ty: ty.map(|ty| ty.to_compact_string()),
-                description: body,
-            },
             FieldKind::ParameterType { lookup_name } => Field::ParameterType {
-                lookup_name: lookup_name.to_compact_string(),
-                ty: body,
-            },
-            FieldKind::KeywordType { lookup_name } => Field::KeywordType {
                 lookup_name: lookup_name.to_compact_string(),
                 ty: body,
             },
@@ -490,15 +492,7 @@ enum FieldKind<'a> {
         lookup_name: &'a str,
         ty: Option<&'a str>,
     },
-    Keyword {
-        display_name: &'a str,
-        lookup_name: &'a str,
-        ty: Option<&'a str>,
-    },
     ParameterType {
-        lookup_name: &'a str,
-    },
-    KeywordType {
         lookup_name: &'a str,
     },
     Attribute {
@@ -530,28 +524,18 @@ impl<'a> FieldKind<'a> {
 
     /// Categorizes a supported field, returning `None` only for an unknown field name.
     fn parse_supported(name: &'a str, argument: &'a str) -> Option<Self> {
-        let kind = match name {
-            "param" | "parameter" | "arg" | "argument" => Self::parse_parameter_argument(argument)
+        let normalized_name = name.to_ascii_lowercase();
+        let kind = match normalized_name.as_str() {
+            "param" | "parameter" | "arg" | "argument" | "key" | "keyword" | "kwarg"
+            | "kwparam" => Self::parse_parameter_argument(argument)
                 .map(|(ty, name)| Self::Parameter {
                     display_name: name.display,
                     lookup_name: name.lookup,
                     ty,
                 })
                 .unwrap_or(Self::Unknown { name, argument }),
-            "key" | "keyword" | "kwarg" | "kwparam" => Self::parse_parameter_argument(argument)
-                .map(|(ty, name)| Self::Keyword {
-                    display_name: name.display,
-                    lookup_name: name.lookup,
-                    ty,
-                })
-                .unwrap_or(Self::Unknown { name, argument }),
-            "type" | "paramtype" => Self::parse_parameter_name(argument)
+            "type" | "paramtype" | "kwtype" => Self::parse_parameter_name(argument)
                 .map(|name| Self::ParameterType {
-                    lookup_name: name.lookup,
-                })
-                .unwrap_or(Self::Unknown { name, argument }),
-            "kwtype" => Self::parse_parameter_name(argument)
-                .map(|name| Self::KeywordType {
                     lookup_name: name.lookup,
                 })
                 .unwrap_or(Self::Unknown { name, argument }),
@@ -641,17 +625,7 @@ pub(in crate::docstring) enum Field {
         ty: Option<CompactString>,
         description: String,
     },
-    Keyword {
-        display_name: CompactString,
-        lookup_name: String,
-        ty: Option<CompactString>,
-        description: String,
-    },
     ParameterType {
-        lookup_name: CompactString,
-        ty: String,
-    },
-    KeywordType {
         lookup_name: CompactString,
         ty: String,
     },
@@ -702,7 +676,10 @@ mod tests {
 
     use insta::{assert_debug_snapshot, assert_snapshot};
 
-    use super::{Field, FieldList, Lines, field_lists};
+    use super::{
+        Field, FieldList, Lines, field_lists,
+        parameter_documentation as extract_parameter_documentation,
+    };
 
     #[test]
     fn parameter_documentation_extracts_rest_parameters() {
@@ -723,6 +700,42 @@ mod tests {
           This is a continuation of param2 description.
         kwargs: Extra keyword arguments.
         ");
+    }
+
+    #[test]
+    fn parameter_documentation_ignores_fields_in_block_quotes() {
+        let parameters = extract_parameter_documentation(
+            "\
+Summary.
+
+    :param example: Quoted example.
+
+:param real: Real parameter.",
+        );
+
+        assert!(!parameters.contains_key("example"));
+        assert_eq!(
+            parameters.get("real").map(String::as_str),
+            Some("Real parameter.")
+        );
+    }
+
+    #[test]
+    fn parameter_documentation_ignores_fields_continuing_paragraphs() {
+        let parameters = extract_parameter_documentation(
+            "\
+Summary.
+:param example: Paragraph text.
+Continuation.
+
+:param real: Real parameter.",
+        );
+
+        assert!(!parameters.contains_key("example"));
+        assert_eq!(
+            parameters.get("real").map(String::as_str),
+            Some("Real parameter.")
+        );
     }
 
     #[test]
@@ -1088,10 +1101,7 @@ Section::
 
         let param_docs = parameter_documentation(docstring);
 
-        assert_snapshot!(param_docs, @r"
-        value: Value parameter.
-        next: Next parameter.
-        ");
+        assert_snapshot!(param_docs, @"next: Next parameter.");
     }
 
     #[test]

--- a/crates/ty_ide/src/docstring/document/rst.rs
+++ b/crates/ty_ide/src/docstring/document/rst.rs
@@ -8,43 +8,35 @@ use ruff_text_size::{TextRange, TextSize};
 
 use super::preformatted::PreformattedBlockScanner;
 
-/// Represents a parsed restructured text (reST) docstring.
-pub(super) struct Docstring {
-    field_lists: Vec<FieldList>,
+/// Parses all reST field lists in a docstring.
+pub(in crate::docstring) fn field_lists(raw: &str) -> Vec<FieldList> {
+    FieldList::parse_all(raw)
 }
 
-impl Docstring {
-    /// Constructs a parsed representation from a raw docstring.
-    pub(super) fn parse(raw: &str) -> Self {
-        let field_lists = FieldList::parse_all(raw);
-        Self { field_lists }
-    }
+/// Returns the parameter documentation recognized in a reST docstring.
+pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
+    let mut parameters = IndexMap::new();
 
-    /// Returns the parameter documentation that we were able to recognize in a docstring.
-    pub(super) fn parameter_documentation(&self) -> IndexMap<String, String> {
-        let mut parameters = IndexMap::new();
+    for field_list in field_lists(raw) {
+        for field in field_list.fields {
+            let Field::Parameter {
+                lookup_name,
+                description,
+                ..
+            } = field
+            else {
+                continue;
+            };
 
-        for field_list in &self.field_lists {
-            for field in &field_list.fields {
-                let Field::Parameter {
-                    lookup_name,
-                    description,
-                    ..
-                } = field
-                else {
-                    continue;
-                };
-
-                if description.is_empty() {
-                    continue;
-                }
-
-                parameters.insert(lookup_name.clone(), description.clone());
+            if description.is_empty() {
+                continue;
             }
-        }
 
-        parameters
+            parameters.insert(lookup_name, description);
+        }
     }
+
+    parameters
 }
 
 /// Cursor over docstring lines and their line numbers.
@@ -96,7 +88,7 @@ impl<'a> DocstringLine<'a> {
 ///
 /// <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#field-lists>
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct FieldList {
+pub(in crate::docstring) struct FieldList {
     start_line: usize,
     end_line: usize,
     range: TextRange,
@@ -554,7 +546,7 @@ impl<'a> FieldKind<'a> {
 
 /// Represents the reST fields captured by the parser.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum Field {
+pub(in crate::docstring) enum Field {
     Parameter {
         display_name: CompactString,
         lookup_name: String,
@@ -610,7 +602,7 @@ mod tests {
 
     use insta::{assert_debug_snapshot, assert_snapshot};
 
-    use super::{Docstring, FieldList, Lines};
+    use super::{Field, FieldList, Lines, field_lists};
 
     #[test]
     fn parameter_documentation_extracts_rest_parameters() {
@@ -658,14 +650,14 @@ mod tests {
 
     #[test]
     fn parser_supports_complex_inline_parameter_types() {
-        let parsed = Docstring::parse(
+        let parsed = field_lists(
             "\
 :param list[str] items: Item descriptions.
 :param dict[str, list[int | None]] mapping: Mapping description.
 :param Callable[[int, str], bool] callback: Callback description.",
         );
 
-        assert_debug_snapshot!(&parsed.field_lists[0].fields, @r#"
+        assert_debug_snapshot!(&parsed[0].fields, @r#"
         [
             Parameter {
                 display_name: "items",
@@ -728,16 +720,15 @@ mod tests {
 :raises ValueError: Error description.
 :meta private:
 :unknown with argument: Unknown description.";
-        let parsed = Docstring::parse(docstring);
+        let parsed = field_lists(docstring);
 
-        assert_eq!(parsed.field_lists[0].start_line, 0);
-        assert_eq!(parsed.field_lists[0].end_line, 9);
+        assert_eq!(parsed[0].start_line, 0);
+        assert_eq!(parsed[0].end_line, 9);
         assert_eq!(
-            &docstring[parsed.field_lists[0].range.start().to_usize()
-                ..parsed.field_lists[0].range.end().to_usize()],
+            &docstring[parsed[0].range.start().to_usize()..parsed[0].range.end().to_usize()],
             docstring
         );
-        assert_debug_snapshot!(&parsed.field_lists[0].fields, @r#"
+        assert_debug_snapshot!(&parsed[0].fields, @r#"
         [
             Parameter {
                 display_name: "*args",
@@ -803,19 +794,27 @@ Intervening prose.
 
 Trailing prose.
 ";
-        let parsed = Docstring::parse(docstring);
+        let parsed = field_lists(docstring);
 
-        assert_eq!(parsed.field_lists.len(), 2);
+        assert_eq!(parsed.len(), 2);
 
-        let first = &parsed.field_lists[0];
+        let first = &parsed[0];
         assert_eq!(first.start_line, 2);
         assert_eq!(first.end_line, 3);
 
-        let second = &parsed.field_lists[1];
+        let second = &parsed[1];
         assert_eq!(second.start_line, 6);
         assert_eq!(second.end_line, 10);
+        let second_description = second.fields.iter().find_map(|field| match field {
+            Field::Parameter { description, .. } => Some(description),
+            _ => None,
+        });
+        assert_eq!(
+            second_description.map(String::as_str),
+            Some("Second parameter.\nContinued::\n\n    literal block")
+        );
 
-        assert_snapshot!(field_list_ranges(docstring, &parsed.field_lists), @r"
+        assert_snapshot!(field_list_ranges(docstring, &parsed), @r"
         | Intro paragraph.
         |
         | :param first: First parameter.
@@ -1005,7 +1004,7 @@ Section::
     }
 
     fn parameter_documentation(docstring: &str) -> String {
-        let parameters = Docstring::parse(docstring).parameter_documentation();
+        let parameters = super::parameter_documentation(docstring);
         let mut rendered = String::new();
 
         for (name, description) in parameters {

--- a/crates/ty_ide/src/docstring/document/rst.rs
+++ b/crates/ty_ide/src/docstring/document/rst.rs
@@ -19,11 +19,16 @@ pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
 
     for field_list in field_lists(raw) {
         for field in field_list.fields {
-            let Field::Parameter {
+            let (Field::Parameter {
                 lookup_name,
                 description,
                 ..
-            } = field
+            }
+            | Field::Keyword {
+                lookup_name,
+                description,
+                ..
+            }) = field
             else {
                 continue;
             };
@@ -97,6 +102,18 @@ pub(in crate::docstring) struct FieldList {
 }
 
 impl FieldList {
+    pub(in crate::docstring) fn range(&self) -> TextRange {
+        self.range
+    }
+
+    pub(in crate::docstring) fn indent(&self) -> TextSize {
+        self.indent
+    }
+
+    pub(in crate::docstring) fn fields(&self) -> &[Field] {
+        &self.fields
+    }
+
     /// Parse all the field lists in the given lines of a docstring.
     fn parse_all(raw: &str) -> Vec<Self> {
         let mut field_lists = Vec::new();
@@ -126,7 +143,7 @@ impl FieldList {
         let line = lines.peek()?;
         let start_line = line.index;
         let range_start = line.range.start();
-        let header = FieldHeader::parse(line.text)?;
+        let header = FieldHeader::parse_list_member(line.text)?;
         lines.next();
 
         let field_list_indent = header.indent;
@@ -143,10 +160,14 @@ impl FieldList {
                     break;
                 }
 
-                current.lines.push(line.text);
-                lines.next();
-                end_line = line.index + 1;
-                range_end = line.range.end();
+                while let Some(blank_line) = lines.peek()
+                    && blank_line.text.trim().is_empty()
+                {
+                    current.lines.push(blank_line.text);
+                    lines.next();
+                    end_line = blank_line.index + 1;
+                    range_end = blank_line.range.end();
+                }
                 continue;
             }
 
@@ -232,7 +253,6 @@ impl FieldList {
 /// Constructs new instances of the model for a reST field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct FieldBuilder<'a> {
-    indent: TextSize,
     kind: FieldKind<'a>,
     body: &'a str,
     lines: Vec<&'a str>,
@@ -242,7 +262,6 @@ impl<'a> FieldBuilder<'a> {
     /// Initializes a builder object for a new field instance.
     fn new(header: FieldHeader<'a>) -> Self {
         Self {
-            indent: header.indent,
             kind: header.kind,
             body: header.body,
             lines: vec![header.raw],
@@ -264,7 +283,21 @@ impl<'a> FieldBuilder<'a> {
                 ty: ty.map(|ty| ty.to_compact_string()),
                 description: body,
             },
+            FieldKind::Keyword {
+                display_name,
+                lookup_name,
+                ty,
+            } => Field::Keyword {
+                display_name: display_name.to_compact_string(),
+                lookup_name: lookup_name.to_string(),
+                ty: ty.map(|ty| ty.to_compact_string()),
+                description: body,
+            },
             FieldKind::ParameterType { lookup_name } => Field::ParameterType {
+                lookup_name: lookup_name.to_compact_string(),
+                ty: body,
+            },
+            FieldKind::KeywordType { lookup_name } => Field::KeywordType {
                 lookup_name: lookup_name.to_compact_string(),
                 ty: body,
             },
@@ -286,7 +319,7 @@ impl<'a> FieldBuilder<'a> {
                 exception: exception.map(|exception| exception.to_compact_string()),
                 description: body,
             },
-            FieldKind::Metadata => Field::Metadata,
+            FieldKind::Metadata => Field::Metadata { body },
             FieldKind::Unknown { name, argument } => Field::Unknown {
                 name: name.to_compact_string(),
                 argument: argument.to_compact_string(),
@@ -352,11 +385,16 @@ struct FieldHeader<'a> {
 }
 
 impl<'a> FieldHeader<'a> {
+    /// Parses either a valid field header or a malformed header for a supported field.
+    fn parse_list_member(line: &'a str) -> Option<Self> {
+        Self::parse(line).or_else(|| Self::parse_malformed_supported_field(line))
+    }
+
     /// Finds the start of a reST field (if any) on the given line and at the
     /// given indentation level.
     fn at_indent(line: &'a str, indent: TextSize) -> Option<Self> {
         (Self::indentation(line) == indent)
-            .then(|| Self::parse(line))
+            .then(|| Self::parse_list_member(line))
             .flatten()
     }
 
@@ -388,6 +426,10 @@ impl<'a> FieldHeader<'a> {
         let trimmed = line.trim_start();
         let after_opening_colon = trimmed.strip_prefix(':')?;
         let (name_and_argument, body) = after_opening_colon.split_once(':')?;
+        // Escaped colons belong to the field name, not the field marker.
+        if name_and_argument.ends_with('\\') {
+            return None;
+        }
         if body
             .chars()
             .next()
@@ -396,16 +438,7 @@ impl<'a> FieldHeader<'a> {
             return None;
         }
 
-        let name_and_argument = name_and_argument.trim();
-        if name_and_argument.is_empty() {
-            return None;
-        }
-
-        let name_end = name_and_argument
-            .find(char::is_whitespace)
-            .unwrap_or(name_and_argument.len());
-        let name = &name_and_argument[..name_end];
-        let argument = name_and_argument[name_end..].trim();
+        let (name, argument) = Self::split_name_and_argument(name_and_argument)?;
 
         Some(Self {
             indent: Self::indentation(line),
@@ -413,6 +446,34 @@ impl<'a> FieldHeader<'a> {
             body: body.trim_start(),
             raw: line,
         })
+    }
+
+    /// Recognizes malformed syntax for a supported field so it remains part of
+    /// the surrounding field list and prevents partial structured rendering.
+    fn parse_malformed_supported_field(line: &'a str) -> Option<Self> {
+        let after_opening_colon = line.trim_start().strip_prefix(':')?;
+        let name_and_argument = after_opening_colon
+            .split_once(':')
+            .map_or(after_opening_colon, |(header, _)| header);
+        let (name, argument) = Self::split_name_and_argument(name_and_argument)?;
+        FieldKind::parse_supported(name, argument)?;
+
+        Some(Self {
+            indent: Self::indentation(line),
+            kind: FieldKind::Unknown { name, argument },
+            body: "",
+            raw: line,
+        })
+    }
+
+    fn split_name_and_argument(value: &'a str) -> Option<(&'a str, &'a str)> {
+        let value = value.trim();
+        if value.is_empty() {
+            return None;
+        }
+
+        let name_end = value.find(char::is_whitespace).unwrap_or(value.len());
+        Some((&value[..name_end], value[name_end..].trim()))
     }
 
     /// Returns the leading indentation of the given source line.
@@ -429,7 +490,15 @@ enum FieldKind<'a> {
         lookup_name: &'a str,
         ty: Option<&'a str>,
     },
+    Keyword {
+        display_name: &'a str,
+        lookup_name: &'a str,
+        ty: Option<&'a str>,
+    },
     ParameterType {
+        lookup_name: &'a str,
+    },
+    KeywordType {
         lookup_name: &'a str,
     },
     Attribute {
@@ -456,10 +525,21 @@ enum FieldKind<'a> {
 impl<'a> FieldKind<'a> {
     /// Categorizes a parsed field as a supported field or an unknown field.
     fn parse(name: &'a str, argument: &'a str) -> Self {
-        match name {
-            "param" | "parameter" | "arg" | "argument" | "key" | "keyword" | "kwarg"
-            | "kwparam" => Self::parse_parameter_argument(argument)
+        Self::parse_supported(name, argument).unwrap_or(Self::Unknown { name, argument })
+    }
+
+    /// Categorizes a supported field, returning `None` only for an unknown field name.
+    fn parse_supported(name: &'a str, argument: &'a str) -> Option<Self> {
+        let kind = match name {
+            "param" | "parameter" | "arg" | "argument" => Self::parse_parameter_argument(argument)
                 .map(|(ty, name)| Self::Parameter {
+                    display_name: name.display,
+                    lookup_name: name.lookup,
+                    ty,
+                })
+                .unwrap_or(Self::Unknown { name, argument }),
+            "key" | "keyword" | "kwarg" | "kwparam" => Self::parse_parameter_argument(argument)
+                .map(|(ty, name)| Self::Keyword {
                     display_name: name.display,
                     lookup_name: name.lookup,
                     ty,
@@ -467,6 +547,11 @@ impl<'a> FieldKind<'a> {
                 .unwrap_or(Self::Unknown { name, argument }),
             "type" | "paramtype" => Self::parse_parameter_name(argument)
                 .map(|name| Self::ParameterType {
+                    lookup_name: name.lookup,
+                })
+                .unwrap_or(Self::Unknown { name, argument }),
+            "kwtype" => Self::parse_parameter_name(argument)
+                .map(|name| Self::KeywordType {
                     lookup_name: name.lookup,
                 })
                 .unwrap_or(Self::Unknown { name, argument }),
@@ -484,16 +569,19 @@ impl<'a> FieldKind<'a> {
             "return" | "returns" => Self::Returns {
                 name: Self::parse_parameter_name(argument).map(|name| name.lookup),
             },
-            "rtype" => Self::ReturnType,
+            "rtype" if argument.is_empty() => Self::ReturnType,
+            "rtype" => Self::Unknown { name, argument },
             "raises" | "raise" | "except" | "exception" => {
                 let exception = argument.trim();
                 Self::Raises {
                     exception: (!exception.is_empty()).then_some(exception),
                 }
             }
-            "meta" => Self::Metadata,
-            _ => Self::Unknown { name, argument },
-        }
+            "meta" if !argument.is_empty() => Self::Metadata,
+            "meta" => Self::Unknown { name, argument },
+            _ => return None,
+        };
+        Some(kind)
     }
 
     /// Parses a parameter name and an optional parameter type from a raw field argument.
@@ -553,7 +641,17 @@ pub(in crate::docstring) enum Field {
         ty: Option<CompactString>,
         description: String,
     },
+    Keyword {
+        display_name: CompactString,
+        lookup_name: String,
+        ty: Option<CompactString>,
+        description: String,
+    },
     ParameterType {
+        lookup_name: CompactString,
+        ty: String,
+    },
+    KeywordType {
         lookup_name: CompactString,
         ty: String,
     },
@@ -577,7 +675,9 @@ pub(in crate::docstring) enum Field {
         exception: Option<CompactString>,
         description: String,
     },
-    Metadata,
+    Metadata {
+        body: String,
+    },
     Unknown {
         name: CompactString,
         argument: CompactString,
@@ -768,7 +868,9 @@ mod tests {
                 ),
                 description: "Error description.",
             },
-            Metadata,
+            Metadata {
+                body: "",
+            },
             Unknown {
                 name: "unknown",
                 argument: "with argument",
@@ -836,8 +938,7 @@ Trailing prose.
 
     #[test]
     fn parser_recovers_from_partial_and_malformed_fields() {
-        let param_docs = parameter_documentation(
-            "\
+        let docstring = "\
 :param first: Parsed before malformed input.
 :param missing-space:This is malformed because body text must be separated by whitespace.
 :param:
@@ -845,8 +946,10 @@ Trailing prose.
 :param empty:
 :param list[str] second: Parsed after malformed and partial fields.
 :param
-:param third: Parsed after an incomplete field marker.",
-        );
+:param third: Parsed after an incomplete field marker.";
+
+        assert_eq!(field_lists(docstring).len(), 1);
+        let param_docs = parameter_documentation(docstring);
 
         assert_snapshot!(param_docs, @r"
         first: Parsed before malformed input.
@@ -862,12 +965,14 @@ Trailing prose.
 :param value:
   First paragraph.
 
+
   Second paragraph.
 :param other: Other parameter.",
         );
 
         assert_snapshot!(param_docs, @r"
         value: First paragraph.
+
 
           Second paragraph.
         other: Other parameter.

--- a/crates/ty_ide/src/docstring/markdown.rs
+++ b/crates/ty_ide/src/docstring/markdown.rs
@@ -7,6 +7,6 @@ mod structured;
 /// normalization (typically via `docstring::documentation_trim`).
 pub(super) fn render(source: &str) -> String {
     let mut output = String::new();
-    structured::render_into(&mut output, source, Vec::new());
+    structured::render_into(&mut output, source);
     output
 }

--- a/crates/ty_ide/src/docstring/markdown.rs
+++ b/crates/ty_ide/src/docstring/markdown.rs
@@ -1,6 +1,8 @@
 mod general;
 mod structured;
 
+use super::DocstringFragment;
+
 /// Render Markdown for a source docstring.
 ///
 /// `source` must have already undergone PEP-257 trimming and universal newline
@@ -9,4 +11,12 @@ pub(super) fn render(source: &str) -> String {
     let mut output = String::new();
     structured::render_into(&mut output, source);
     output
+}
+
+impl DocstringFragment {
+    pub(super) fn render_markdown(&self) -> String {
+        let mut output = String::new();
+        general::render_fragment_into(&mut output, &self.0);
+        output
+    }
 }

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -208,7 +208,7 @@ impl SectionItem {
 
         if let Some(ty) = self.ty.as_deref() {
             if has_label {
-                output.push(' ');
+                output.push_str(": ");
                 render_type_code_span_into(output, ty);
             } else {
                 render_type_code_span_into(output, ty);
@@ -224,14 +224,14 @@ impl SectionItem {
             match block_start {
                 Some(0) => {
                     if has_label {
-                        output.push_str(":\n\n");
+                        output.push_str("\n\n");
                     }
                     output.push_str(&description);
                 }
                 Some(block_start) => {
                     let before_block = description[..block_start].trim_end();
                     if has_label {
-                        output.push_str(": ");
+                        output.push_str("  \n");
                         output.push_str(before_block);
                     } else {
                         output.push_str(before_block);
@@ -241,7 +241,7 @@ impl SectionItem {
                 }
                 None => {
                     if has_label {
-                        output.push_str(": ");
+                        output.push_str("  \n");
                         output.push_str(&description);
                     } else {
                         output.push_str(&description);
@@ -517,25 +517,32 @@ mod tests {
 
         assert_snapshot!(render_markdown(&section), @r"
         ## Parameters
-        **value** `str`: The value.
+        **value**: `str`  
+        The value.
 
         ## Keyword Arguments
-        **limit** `int`: Maximum result count.
+        **limit**: `int`  
+        Maximum result count.
 
         ## Other Parameters
-        **kw\_only** `str`: Less common option.
+        **kw\_only**: `str`  
+        Less common option.
 
         ## Attributes
-        **cache** `dict[str, object]`: Cached data.
+        **cache**: `dict[str, object]`  
+        Cached data.
 
         ## Returns
-        `bool`: Whether validation passed.
+        `bool`  
+        Whether validation passed.
 
         ## Yields
-        **item** `Iterator[int]`: Generated values.
+        **item**: `Iterator[int]`  
+        Generated values.
 
         ## Raises
-        `ValueError`: Invalid value.
+        `ValueError`  
+        Invalid value.
         ");
     }
 
@@ -587,11 +594,14 @@ mod tests {
 
         assert_snapshot!(render_markdown(&section), @r"
         ## Parameters
-        **\*args**: Escaped name.
+        **\*args**  
+        Escaped name.
 
-        **\_\_value\_\_**: Escaped name.
+        **\_\_value\_\_**  
+        Escaped name.
 
-        **&lt;value&gt; &amp; \[docs\](target) \| \~deleted\~**: Escaped name.
+        **&lt;value&gt; &amp; \[docs\](target) \| \~deleted\~**  
+        Escaped name.
         ");
     }
 
@@ -621,17 +631,18 @@ mod tests {
 
         assert_snapshot!(render_markdown(&section), @"
         ## Parameters
-        **paragraphs**: First paragraph.
+        **paragraphs**<HB>
+        First paragraph.
 
         Second paragraph.
 
-        **indented**:
+        **indented**
 
             code<HB>
         <HB>
         trailing
 
-        **nested**:
+        **nested**
 
         - parent<HB>
           - child
@@ -650,7 +661,8 @@ mod tests {
 
         assert_snapshot!(render_markdown(&section), @"
         ## Parameters
-        **ordered**: Introduction.<HB>
+        **ordered**<HB>
+        Introduction.<HB>
         2. Continuation.
         ");
     }
@@ -671,7 +683,7 @@ mod tests {
 
         assert_snapshot!(rendered, @"
         ## Parameters
-        **value**:
+        **value**
 
         1. First option.
 
@@ -685,7 +697,8 @@ mod tests {
 
         assert_snapshot!(rendered, @"
         ## Parameters
-        **value**: Value.
+        **value**  
+        Value.
 
         After.
         ");
@@ -697,7 +710,7 @@ mod tests {
 
         assert_snapshot!(rendered, @"
         ## Parameters
-        **value**:
+        **value**
 
         ```````````python
         >>> value
@@ -714,7 +727,7 @@ mod tests {
 
         assert_snapshot!(rendered, @"
         ## Parameters
-        **value**:
+        **value**
 
         ```python
         value = 1
@@ -784,10 +797,12 @@ mod tests {
 
         assert_snapshot!(rendered, @"
         ## Parameters
-        **value**: The value.
+        **value**  
+        The value.
 
         ## Returns
-        `bool`: The result.
+        `bool`  
+        The result.
         ");
     }
 

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -7,11 +7,18 @@ use strum_macros::EnumIter;
 use super::general;
 use crate::docstring::document::preformatted::MarkdownFence;
 
-/// Renders a docstring from non-overlapping structured sections and general source fragments.
+mod rst;
+
+/// Renders a docstring as Markdown.
 ///
 /// `source` must have already undergone PEP-257 trimming and universal newline
 /// normalization (typically via `docstring::documentation_trim`).
-pub(super) fn render_into(output: &mut String, source: &str, sections: Vec<Section>) {
+pub(super) fn render_into(output: &mut String, source: &str) {
+    render_sections_into(output, source, rst::structured_sections(source));
+}
+
+/// Renders a docstring from non-overlapping structured sections and general source fragments.
+fn render_sections_into(output: &mut String, source: &str, sections: Vec<Section>) {
     if sections.is_empty() {
         general::render_into(output, source);
         return;
@@ -38,12 +45,15 @@ pub(super) fn render_into(output: &mut String, source: &str, sections: Vec<Secti
                     raw
                 };
 
-                if follows_section && !raw.is_empty() {
+                if follows_section && !raw.is_empty() && !output.is_empty() {
                     ensure_blank_line(output);
                 }
                 general::render_into(output, raw);
             }
             Segment::Structured(section) => {
+                if section.is_empty() {
+                    continue;
+                }
                 if !output.is_empty() {
                     ensure_blank_line(output);
                 }
@@ -111,26 +121,25 @@ fn ensure_blank_line(output: &mut String) {
 /// field list, then this structured renderer places it back into the
 /// surrounding source text.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct Section {
-    /// Byte range occupied by this section in the source passed to
-    /// `structured::render_into`.
+struct Section {
+    /// Byte range occupied by this section in the normalized docstring source.
     range: TextRange,
     /// The list of semantically-meaningful items to render to Markdown.
     items: Vec<SectionItem>,
 }
 
 impl Section {
-    /// Creates a section block from the items parsed out of one source section.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used by follow-up structured docstring parsers")
-    )]
+    /// Creates a structured replacement from the items parsed out of one source section.
     fn new(range: TextRange, items: Vec<SectionItem>) -> Option<Self> {
-        if range.is_empty() || items.is_empty() || items.iter().any(SectionItem::is_empty) {
+        if range.is_empty() || items.iter().any(SectionItem::is_empty) {
             return None;
         }
 
         Some(Self { range, items })
+    }
+
+    fn is_empty(&self) -> bool {
+        self.items.is_empty()
     }
 
     /// Renders the section as Markdown into the given buffer.
@@ -166,10 +175,6 @@ struct SectionItem {
 
 impl SectionItem {
     /// Creates a section item from parser-prepared name, type, and description parts.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used by follow-up structured docstring parsers")
-    )]
     fn new(
         kind: SectionKind,
         display_name: Option<&str>,
@@ -461,7 +466,7 @@ mod tests {
     use insta::{Settings, assert_snapshot};
     use ruff_text_size::{TextRange, TextSize};
 
-    use super::{Section, SectionItem, SectionKind, render_into};
+    use super::{Section, SectionItem, SectionKind, render_sections_into};
 
     #[test]
     fn sections_render_in_canonical_order() {
@@ -868,7 +873,7 @@ mod tests {
 
     fn render_sections(raw: &str, sections: Vec<Section>) -> String {
         let mut output = String::new();
-        render_into(&mut output, raw, sections);
+        render_sections_into(&mut output, raw, sections);
         output
     }
 

--- a/crates/ty_ide/src/docstring/markdown/structured/rst.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured/rst.rs
@@ -1,0 +1,823 @@
+use ruff_text_size::TextSize;
+use rustc_hash::FxHashMap;
+
+use crate::docstring::document::rst;
+
+use super::{Section, SectionItem, SectionKind};
+
+/// Returns the portions of the docstring that describe canonical docstring data
+/// (e.g., parameters, return value, etc.).
+pub(super) fn structured_sections(source: &str) -> Vec<Section> {
+    let mut sections = Vec::new();
+
+    for field_list in rst::field_lists(source) {
+        if field_list.indent() != TextSize::default()
+            || !starts_at_block_boundary(source, field_list.range().start())
+        {
+            continue;
+        }
+
+        let Some(section) = RenderPlan::from_fields(field_list.fields())
+            .and_then(|plan| Section::new(field_list.range(), plan.items()))
+        else {
+            continue;
+        };
+
+        sections.push(section);
+    }
+
+    sections
+}
+
+fn starts_at_block_boundary(source: &str, start: TextSize) -> bool {
+    source.get(..start.to_usize()).is_some_and(|prefix| {
+        prefix
+            .lines()
+            .next_back()
+            .is_none_or(|line| line.trim().is_empty())
+    })
+}
+
+/// Validates a reST field list and stores cross-field metadata needed while rendering.
+struct RenderPlan<'a> {
+    fields: &'a [rst::Field],
+    parameter_types: SupplementalTypeFields<'a>,
+    keyword_types: SupplementalTypeFields<'a>,
+    attribute_types: SupplementalTypeFields<'a>,
+    return_type: Option<&'a str>,
+    has_returns: bool,
+}
+
+impl<'a> RenderPlan<'a> {
+    /// Validates `fields` and builds a plan for structured rendering.
+    ///
+    /// This factory conservatively returns `None` when we aren't certain that
+    /// we can interpret the field list correctly. This indicates to the caller
+    /// that the field list should be left raw rather than replaced with
+    /// Markdown.
+    fn from_fields(fields: &'a [rst::Field]) -> Option<Self> {
+        let mut has_returns = false;
+        let mut parameter_types = SupplementalTypeFields::default();
+        let mut keyword_types = SupplementalTypeFields::default();
+        let mut attribute_types = SupplementalTypeFields::default();
+        let mut return_type = None;
+
+        for field in fields {
+            match field {
+                rst::Field::Parameter {
+                    lookup_name, ty, ..
+                } => {
+                    parameter_types.record_value_field(lookup_name.as_str(), ty.is_some());
+                }
+                rst::Field::Keyword {
+                    lookup_name, ty, ..
+                } => {
+                    keyword_types.record_value_field(lookup_name.as_str(), ty.is_some());
+                }
+                rst::Field::Attribute { name, ty, .. } => {
+                    attribute_types.record_value_field(name.as_str(), ty.is_some());
+                }
+                rst::Field::Returns { .. } => {
+                    has_returns = true;
+                }
+                rst::Field::Raises { .. } => {}
+                rst::Field::ParameterType { .. }
+                | rst::Field::KeywordType { .. }
+                | rst::Field::AttributeType { .. } => {}
+                rst::Field::ReturnType { ty } => {
+                    let ty = ty.as_str();
+                    if ty.is_empty() || return_type.replace(ty).is_some() {
+                        return None;
+                    }
+                }
+                rst::Field::Metadata { body } if body.is_empty() => {
+                    // Sphinx metadata fields are not user-facing hover sections.
+                }
+                rst::Field::Metadata { .. } => return None,
+                rst::Field::Unknown { .. } => {
+                    // Unknown or unsupported fields may have section semantics we
+                    // do not understand, so leave the full field list unstructured.
+                    return None;
+                }
+            }
+        }
+
+        for field in fields {
+            match field {
+                rst::Field::ParameterType { lookup_name, ty } => {
+                    let name = lookup_name.as_str();
+                    let destination = match (
+                        parameter_types.accepts_separate_type(name),
+                        keyword_types.accepts_separate_type(name),
+                    ) {
+                        (true, false) => &mut parameter_types,
+                        (false, true) => &mut keyword_types,
+                        _ => return None,
+                    };
+                    destination.record_type_field(name, ty.as_str())?;
+                }
+                rst::Field::KeywordType { lookup_name, ty } => {
+                    keyword_types.record_type_field(lookup_name.as_str(), ty.as_str())?;
+                }
+                rst::Field::AttributeType { name, ty } => {
+                    attribute_types.record_type_field(name.as_str(), ty.as_str())?;
+                }
+                _ => {}
+            }
+        }
+
+        Some(Self {
+            fields,
+            parameter_types,
+            keyword_types,
+            attribute_types,
+            return_type,
+            has_returns,
+        })
+    }
+
+    fn items(&self) -> Vec<SectionItem> {
+        let mut items = Vec::new();
+
+        for field in self.fields {
+            match field {
+                rst::Field::Parameter {
+                    display_name,
+                    lookup_name,
+                    ty,
+                    description,
+                } => items.push(SectionItem::new(
+                    SectionKind::Parameters,
+                    Some(display_name.as_str()),
+                    self.parameter_types
+                        .type_for_value_field(lookup_name.as_str(), ty.as_deref()),
+                    description.as_str(),
+                )),
+                rst::Field::Keyword {
+                    display_name,
+                    lookup_name,
+                    ty,
+                    description,
+                } => items.push(SectionItem::new(
+                    SectionKind::KeywordArguments,
+                    Some(display_name.as_str()),
+                    self.keyword_types
+                        .type_for_value_field(lookup_name.as_str(), ty.as_deref()),
+                    description.as_str(),
+                )),
+                rst::Field::Attribute {
+                    name,
+                    ty,
+                    description,
+                } => items.push(SectionItem::new(
+                    SectionKind::Attributes,
+                    Some(name.as_str()),
+                    self.attribute_types
+                        .type_for_value_field(name.as_str(), ty.as_deref()),
+                    description.as_str(),
+                )),
+                rst::Field::Returns { name, description } => items.push(SectionItem::new(
+                    SectionKind::Returns,
+                    name.as_deref(),
+                    self.return_type,
+                    description.as_str(),
+                )),
+                rst::Field::Raises {
+                    exception,
+                    description,
+                } => items.push(SectionItem::new(
+                    SectionKind::Raises,
+                    exception.as_deref(),
+                    None,
+                    description.as_str(),
+                )),
+                rst::Field::ReturnType { .. } if !self.has_returns => {
+                    if let Some(return_type) = self.return_type {
+                        items.push(SectionItem::new(
+                            SectionKind::Returns,
+                            None,
+                            Some(return_type),
+                            "",
+                        ));
+                    }
+                }
+                rst::Field::ParameterType { .. }
+                | rst::Field::KeywordType { .. }
+                | rst::Field::AttributeType { .. }
+                | rst::Field::ReturnType { .. }
+                | rst::Field::Metadata { .. }
+                | rst::Field::Unknown { .. } => {}
+            }
+        }
+
+        items
+    }
+}
+
+/// Tracks `:type name:` fields that supplement matching value fields.
+///
+/// A separate type field is usable only when the corresponding value field
+/// exists and did not already include an inline type.
+#[derive(Default)]
+struct SupplementalTypeFields<'a> {
+    types: FxHashMap<&'a str, &'a str>,
+    value_fields_accepting_type: FxHashMap<&'a str, bool>,
+}
+
+impl<'a> SupplementalTypeFields<'a> {
+    /// Returns the type to render for a value field.
+    ///
+    /// reST allows types inline on the value field:
+    ///
+    /// ```python
+    /// """
+    /// :param str value: The value.
+    /// """
+    /// ```
+    ///
+    /// It also allows types in separate supplemental fields:
+    ///
+    /// ```python
+    /// """
+    /// :param value: The value.
+    /// :type value: str
+    /// """
+    /// ```
+    ///
+    /// Inline types win; supplemental types are only used for matching fields
+    /// without inline types.
+    fn type_for_value_field(&self, name: &str, inline_ty: Option<&'a str>) -> Option<&'a str> {
+        inline_ty.or_else(|| self.types.get(name).copied())
+    }
+
+    fn record_value_field(&mut self, name: &'a str, has_inline_type: bool) {
+        self.value_fields_accepting_type
+            .entry(name)
+            .and_modify(|accepts_separate_type| *accepts_separate_type &= !has_inline_type)
+            .or_insert(!has_inline_type);
+    }
+
+    fn record_type_field(&mut self, name: &'a str, ty: &'a str) -> Option<()> {
+        (!ty.is_empty()
+            && self.accepts_separate_type(name)
+            && self.types.insert(name, ty).is_none())
+        .then_some(())
+    }
+
+    fn accepts_separate_type(&self, name: &str) -> bool {
+        self.value_fields_accepting_type
+            .get(name)
+            .is_some_and(|accepts_separate_type| *accepts_separate_type)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::{Settings, assert_snapshot};
+
+    use super::super::render_into;
+
+    #[test]
+    fn render_parameters_with_inline_and_supplemental_types() {
+        let docstring = "\
+Summary.
+
+:param str value: The value.
+:param other: Another value.
+:type other: int
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        Summary.
+
+        ## Parameters
+        **value** `str`: The value.
+
+        **other** `int`: Another value.
+        ");
+    }
+
+    #[test]
+    fn render_returns_with_supplemental_type() {
+        let docstring = "\
+Summary.
+
+:returns: Whether validation passed.
+:rtype: bool
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        Summary.
+
+        ## Returns
+        `bool`: Whether validation passed.
+        ");
+    }
+
+    #[test]
+    fn preserve_field_description_rst_directives() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+:param value: The first sentence wraps
+    before the directive.
+
+    .. versionchanged:: 2.0
+       Directive text keeps its own wrapping.
+
+    The final sentence wraps
+    after the directive.
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        ## Parameters
+        **value**: The first sentence wraps<HB>
+        before the directive.
+
+        **Changed in version 2.0:**<HB>
+           Directive text keeps its own wrapping.<HB>
+        <HB>
+        The final sentence wraps<HB>
+        after the directive.
+        ");
+    }
+
+    #[test]
+    fn preserve_duplicate_parameters() {
+        let docstring = "\
+:param value: Stale description.
+:param value: Corrected description.
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        ## Parameters
+        **value**: Stale description.
+
+        **value**: Corrected description.
+        ");
+    }
+
+    #[test]
+    fn render_parameter_and_standalone_return_type() {
+        let docstring = "\
+Summary.
+
+:param value: The value.
+:rtype: str
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        Summary.
+
+        ## Parameters
+        **value**: The value.
+
+        ## Returns
+        `str`
+        ");
+    }
+
+    #[test]
+    fn render_standalone_return_type() {
+        let docstring = "\
+Summary.
+
+:rtype: str
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        Summary.
+
+        ## Returns
+        `str`
+        ");
+    }
+
+    #[test]
+    fn preserve_inline_roles_in_prose() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+This is a function description.
+:class:`Foo` instances can be passed here.
+
+:param value: The value.
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        This is a function description.<HB>
+        :class:`Foo` instances can be passed here.
+
+        ## Parameters
+        **value**: The value.
+        ");
+    }
+
+    #[test]
+    fn ignore_metadata_fields() {
+        let docstring = "\
+:meta private:
+
+Leading prose.
+
+:param value: The value.
+:meta private:
+:returns: The result.
+:meta hide-value:
+
+Trailing prose.
+
+:meta private:
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        Leading prose.
+
+        ## Parameters
+        **value**: The value.
+
+        ## Returns
+        The result.
+
+        Trailing prose.
+        ");
+    }
+
+    #[test]
+    fn render_parameter_aliases_and_variadics() {
+        let docstring = "\
+:param param: The parameter description.
+:type param: int
+:kwparam retries: Retry attempts.
+:paramtype retries: int
+:keyword timeout: Timeout in seconds.
+:kwtype timeout: float
+:param *args: Extra positional arguments.
+:type args: tuple[str, ...]
+:param **kwargs: Extra keyword arguments.
+:type **kwargs: dict[str, object]
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @r"
+        ## Parameters
+        **param** `int`: The parameter description.
+
+        **\*args** `tuple[str, ...]`: Extra positional arguments.
+
+        **\*\*kwargs** `dict[str, object]`: Extra keyword arguments.
+
+        ## Keyword Arguments
+        **retries** `int`: Retry attempts.
+
+        **timeout** `float`: Timeout in seconds.
+        ");
+    }
+
+    #[test]
+    fn render_attribute_aliases() {
+        let docstring = "\
+:var cache: Cached data.
+:vartype cache: dict[str,
+    object]
+:ivar state: Instance state.
+:var str title: Display title.
+:cvar VERSION: Package version.
+:vartype VERSION: str
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        ## Attributes
+        **cache** `dict[str, object]`: Cached data.
+
+        **state**: Instance state.
+
+        **title** `str`: Display title.
+
+        **VERSION** `str`: Package version.
+        ");
+    }
+
+    #[test]
+    fn render_named_returns_and_exceptions() {
+        let docstring = "\
+:returns baz: The return value description
+:rtype: dict[str,
+    int]
+:raises ValueError: If the value is invalid.
+:exception RuntimeError: If the system is unavailable.";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        ## Returns
+        **baz** `dict[str, int]`: The return value description
+
+        ## Raises
+        `ValueError`: If the value is invalid.
+
+        `RuntimeError`: If the system is unavailable.
+        ");
+    }
+
+    #[test]
+    fn unstructured_field_lists_stay_raw() {
+        for docstring in [
+            // Recognized fields that would lose information or render no
+            // visible item if converted structurally.
+            // `:type orphan:` has no matching value field, so rendering the
+            // field list structurally would drop the type information.
+            "\
+:param first: First parameter.
+:type orphan: str
+",
+            // Malformed or body-bearing metadata may contain user-visible text,
+            // so preserve the full field list rather than dropping it.
+            "\
+:param value: The value.
+:meta: Preserve this field list.
+",
+            "\
+:param value: The value.
+:meta private: Preserve this field list.
+",
+            // Unsupported or ambiguous field lists.
+            // `:unknown field:` is not a supported Sphinx-style field.
+            "\
+Summary.
+
+:param value: The value.
+:unknown field: Preserve this field list.
+",
+            // A malformed supported field must keep the surrounding contiguous
+            // field list from being partially converted.
+            "\
+:param first: First parameter.
+:param second:Missing whitespace before the body.
+:param third: Third parameter.
+",
+            // Empty `:returns:` and `:raises:` fields would render as empty
+            // section items.
+            "\
+Summary.
+
+:returns:
+:raises:
+",
+            // `:type value:` cannot supplement a parameter that already has
+            // an inline type.
+            "\
+Summary.
+
+:param str value: The value.
+:type value: int
+",
+            // Duplicate `:type value:` fields make the supplemental type
+            // ambiguous.
+            "\
+Summary.
+
+:param value: The value.
+:type value: str
+:type value: int
+",
+            // The empty `:returns:` field would render as an empty section item.
+            "\
+Summary.
+
+:param value: The value.
+:returns:
+",
+            // Empty supplemental type fields would otherwise be dropped from
+            // an otherwise renderable field list.
+            "\
+:param value: The value.
+:type value:
+",
+            "\
+:var value: The value.
+:vartype value:
+",
+            "\
+:param value: The value.
+:rtype:
+",
+            // `:rtype:` does not accept an argument, which the structured
+            // representation would otherwise drop.
+            "\
+:param value: The value.
+:rtype result: int
+",
+            // A field list requires a preceding block boundary. Without one,
+            // field-like lines remain part of the surrounding paragraph.
+            "\
+Summary.
+:param value: This is paragraph text.
+Continuation.
+",
+            "\
+Summary.
+:meta private:
+Continuation.
+",
+            // Escaped colons belong to the field name. Leave the field list raw
+            // rather than interpreting one as the end of the field header.
+            r#"\
+:param first: First parameter.
+:param Literal["a\: b"] value: The value.
+:param last: Last parameter.
+"#,
+        ] {
+            let rendered = render_docstring(docstring);
+            assert_eq!(rendered, render_general(docstring));
+        }
+    }
+
+    #[test]
+    fn preserve_preformatted_field_lists() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Markdown input:
+
+```text
+:param sample: This is sample input
+```
+
+Doctest output:
+
+>>> print(\"field list\")
+:param sample: This is sample output
+
+Literal block::
+
+    :param sample: This is sample input
+
+:param quoted: Example::
+
+:param sample: This is sample input
+:returns: This is still sample input
+
+:param second: Options:
+
+    - First option.
+        - Nested detail.
+    - Second option.
+:param third:
+    1. Validate the input.
+    2. Return the result.
+:param done: Whether work is done.";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @r#"
+        Markdown input:<HB>
+        <HB>
+        ```text
+        :param sample: This is sample input
+        ```<HB>
+        <HB>
+        Doctest output:<HB>
+        <HB>
+        ```````````python
+        >>> print("field list")
+        :param sample: This is sample output
+        ```````````<HB>
+        Literal block:  <HB>
+        ```````````python
+            :param sample: This is sample input
+        ```````````
+
+        ## Parameters
+        **quoted**: Example:
+
+        **sample**: This is sample input
+
+        **second**: Options:
+
+        - First option.<HB>
+            - Nested detail.<HB>
+        - Second option.
+
+        **third**:
+
+        1. Validate the input.<HB>
+        2. Return the result.
+
+        **done**: Whether work is done.
+
+        ## Returns
+        This is still sample input
+        "#);
+    }
+
+    #[test]
+    fn render_field_like_quoted_literal_blocks() {
+        let docstring = "\
+Summary.
+
+:param quoted: Example::
+
+:param sample: This is sample input.
+:returns: This is still sample input.
+
+:param real: Real parameter.
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        Summary.
+
+        ## Parameters
+        **quoted**: Example:
+
+        **sample**: This is sample input.
+
+        **real**: Real parameter.
+
+        ## Returns
+        This is still sample input.
+        ");
+    }
+
+    #[test]
+    fn render_non_field_like_quoted_literal_blocks() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+:param quoted: Example::
+
+!param sample: This is sample input.
+!returns: This is still sample input.
+
+:param real: Real parameter.";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @"
+        ## Parameters
+        **quoted**: Example:
+
+        !param sample: This is sample input.<HB>
+        !returns: This is still sample input.
+
+        ## Parameters
+        **real**: Real parameter.
+        ");
+    }
+
+    #[test]
+    fn field_lists_in_block_quotes_remain_raw() {
+        let docstring = "\
+Summary.
+
+    :param value: The value.
+    :returns: Another value.
+";
+        let rendered = render_docstring(docstring);
+
+        assert_eq!(rendered, render_general(docstring));
+    }
+
+    #[test]
+    fn literal_backticks_do_not_swallow_the_following_field() {
+        let rendered = render_docstring(
+            "\
+:param first: Example::
+
+    ```
+:param second: Visible parameter.",
+        );
+
+        assert_snapshot!(rendered, @"
+        ## Parameters
+        **first**: Example:
+
+        ```````````python
+        ```
+        ```````````
+
+        **second**: Visible parameter.
+        ");
+    }
+
+    fn render_docstring(raw: &str) -> String {
+        let mut output = String::new();
+        render_into(&mut output, raw);
+        output
+    }
+
+    fn render_general(raw: &str) -> String {
+        let mut output = String::new();
+        crate::docstring::markdown::general::render_into(&mut output, raw);
+        output
+    }
+
+    fn bind_markdown_snapshot_filters() -> impl Drop {
+        let mut settings = Settings::clone_current();
+        settings.add_filter("  \n", "<HB>\n");
+        settings.bind_to_scope()
+    }
+}

--- a/crates/ty_ide/src/docstring/markdown/structured/rst.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured/rst.rs
@@ -1,4 +1,4 @@
-use ruff_text_size::TextSize;
+use ruff_text_size::Ranged;
 use rustc_hash::FxHashMap;
 
 use crate::docstring::document::rst;
@@ -10,15 +10,9 @@ use super::{Section, SectionItem, SectionKind};
 pub(super) fn structured_sections(source: &str) -> Vec<Section> {
     let mut sections = Vec::new();
 
-    for field_list in rst::field_lists(source) {
-        if field_list.indent() != TextSize::default()
-            || !starts_at_block_boundary(source, field_list.range().start())
-        {
-            continue;
-        }
-
+    for field_list in rst::top_level_field_lists(source) {
         let Some(section) = RenderPlan::from_fields(field_list.fields())
-            .and_then(|plan| Section::new(field_list.range(), plan.items()))
+            .and_then(|plan| Section::new(field_list.range(), plan.to_items()))
         else {
             continue;
         };
@@ -29,20 +23,10 @@ pub(super) fn structured_sections(source: &str) -> Vec<Section> {
     sections
 }
 
-fn starts_at_block_boundary(source: &str, start: TextSize) -> bool {
-    source.get(..start.to_usize()).is_some_and(|prefix| {
-        prefix
-            .lines()
-            .next_back()
-            .is_none_or(|line| line.trim().is_empty())
-    })
-}
-
 /// Validates a reST field list and stores cross-field metadata needed while rendering.
 struct RenderPlan<'a> {
     fields: &'a [rst::Field],
     parameter_types: SupplementalTypeFields<'a>,
-    keyword_types: SupplementalTypeFields<'a>,
     attribute_types: SupplementalTypeFields<'a>,
     return_type: Option<&'a str>,
     has_returns: bool,
@@ -58,7 +42,6 @@ impl<'a> RenderPlan<'a> {
     fn from_fields(fields: &'a [rst::Field]) -> Option<Self> {
         let mut has_returns = false;
         let mut parameter_types = SupplementalTypeFields::default();
-        let mut keyword_types = SupplementalTypeFields::default();
         let mut attribute_types = SupplementalTypeFields::default();
         let mut return_type = None;
 
@@ -69,20 +52,14 @@ impl<'a> RenderPlan<'a> {
                 } => {
                     parameter_types.record_value_field(lookup_name.as_str(), ty.is_some());
                 }
-                rst::Field::Keyword {
-                    lookup_name, ty, ..
-                } => {
-                    keyword_types.record_value_field(lookup_name.as_str(), ty.is_some());
-                }
                 rst::Field::Attribute { name, ty, .. } => {
                     attribute_types.record_value_field(name.as_str(), ty.is_some());
                 }
                 rst::Field::Returns { .. } => {
                     has_returns = true;
                 }
-                rst::Field::Raises { .. } => {}
-                rst::Field::ParameterType { .. }
-                | rst::Field::KeywordType { .. }
+                rst::Field::Raises { .. }
+                | rst::Field::ParameterType { .. }
                 | rst::Field::AttributeType { .. } => {}
                 rst::Field::ReturnType { ty } => {
                     let ty = ty.as_str();
@@ -102,22 +79,13 @@ impl<'a> RenderPlan<'a> {
             }
         }
 
+        // Resolve supplemental types in a second pass so their matching value fields are known
+        // even when the type fields appear first.
         for field in fields {
             match field {
                 rst::Field::ParameterType { lookup_name, ty } => {
                     let name = lookup_name.as_str();
-                    let destination = match (
-                        parameter_types.accepts_separate_type(name),
-                        keyword_types.accepts_separate_type(name),
-                    ) {
-                        (true, false) => &mut parameter_types,
-                        (false, true) => &mut keyword_types,
-                        _ => return None,
-                    };
-                    destination.record_type_field(name, ty.as_str())?;
-                }
-                rst::Field::KeywordType { lookup_name, ty } => {
-                    keyword_types.record_type_field(lookup_name.as_str(), ty.as_str())?;
+                    parameter_types.record_type_field(name, ty.as_str())?;
                 }
                 rst::Field::AttributeType { name, ty } => {
                     attribute_types.record_type_field(name.as_str(), ty.as_str())?;
@@ -129,14 +97,13 @@ impl<'a> RenderPlan<'a> {
         Some(Self {
             fields,
             parameter_types,
-            keyword_types,
             attribute_types,
             return_type,
             has_returns,
         })
     }
 
-    fn items(&self) -> Vec<SectionItem> {
+    fn to_items(&self) -> Vec<SectionItem> {
         let mut items = Vec::new();
 
         for field in self.fields {
@@ -150,18 +117,6 @@ impl<'a> RenderPlan<'a> {
                     SectionKind::Parameters,
                     Some(display_name.as_str()),
                     self.parameter_types
-                        .type_for_value_field(lookup_name.as_str(), ty.as_deref()),
-                    description.as_str(),
-                )),
-                rst::Field::Keyword {
-                    display_name,
-                    lookup_name,
-                    ty,
-                    description,
-                } => items.push(SectionItem::new(
-                    SectionKind::KeywordArguments,
-                    Some(display_name.as_str()),
-                    self.keyword_types
                         .type_for_value_field(lookup_name.as_str(), ty.as_deref()),
                     description.as_str(),
                 )),
@@ -202,11 +157,17 @@ impl<'a> RenderPlan<'a> {
                     }
                 }
                 rst::Field::ParameterType { .. }
-                | rst::Field::KeywordType { .. }
                 | rst::Field::AttributeType { .. }
-                | rst::Field::ReturnType { .. }
-                | rst::Field::Metadata { .. }
-                | rst::Field::Unknown { .. } => {}
+                | rst::Field::ReturnType { .. } => {
+                    // Supplemental types render with their value fields.
+                }
+                rst::Field::Metadata { .. } => {
+                    // Metadata is omitted because it isn't user-facing.
+                }
+                rst::Field::Unknown { .. } => {
+                    // Required for exhaustiveness. `RenderPlan::from_fields` rejects this
+                    // variant before constructing `Self`.
+                }
             }
         }
 
@@ -292,9 +253,11 @@ Summary.
         Summary.
 
         ## Parameters
-        **value** `str`: The value.
+        **value**: `str`  
+        The value.
 
-        **other** `int`: Another value.
+        **other**: `int`  
+        Another value.
         ");
     }
 
@@ -312,7 +275,8 @@ Summary.
         Summary.
 
         ## Returns
-        `bool`: Whether validation passed.
+        `bool`  
+        Whether validation passed.
         ");
     }
 
@@ -333,7 +297,8 @@ Summary.
 
         assert_snapshot!(rendered, @"
         ## Parameters
-        **value**: The first sentence wraps<HB>
+        **value**<HB>
+        The first sentence wraps<HB>
         before the directive.
 
         **Changed in version 2.0:**<HB>
@@ -354,9 +319,11 @@ Summary.
 
         assert_snapshot!(rendered, @"
         ## Parameters
-        **value**: Stale description.
+        **value**  
+        Stale description.
 
-        **value**: Corrected description.
+        **value**  
+        Corrected description.
         ");
     }
 
@@ -374,7 +341,8 @@ Summary.
         Summary.
 
         ## Parameters
-        **value**: The value.
+        **value**  
+        The value.
 
         ## Returns
         `str`
@@ -414,7 +382,8 @@ This is a function description.
         :class:`Foo` instances can be passed here.
 
         ## Parameters
-        **value**: The value.
+        **value**<HB>
+        The value.
         ");
     }
 
@@ -440,7 +409,8 @@ Trailing prose.
         Leading prose.
 
         ## Parameters
-        **value**: The value.
+        **value**  
+        The value.
 
         ## Returns
         The result.
@@ -467,17 +437,42 @@ Trailing prose.
 
         assert_snapshot!(rendered, @r"
         ## Parameters
-        **param** `int`: The parameter description.
+        **param**: `int`  
+        The parameter description.
 
-        **\*args** `tuple[str, ...]`: Extra positional arguments.
+        **retries**: `int`  
+        Retry attempts.
 
-        **\*\*kwargs** `dict[str, object]`: Extra keyword arguments.
+        **timeout**: `float`  
+        Timeout in seconds.
 
-        ## Keyword Arguments
-        **retries** `int`: Retry attempts.
+        **\*args**: `tuple[str, ...]`  
+        Extra positional arguments.
 
-        **timeout** `float`: Timeout in seconds.
+        **\*\*kwargs**: `dict[str, object]`  
+        Extra keyword arguments.
         ");
+    }
+
+    #[test]
+    fn render_field_names_case_insensitively() {
+        let docstring = "\
+:Param value: The value.
+:TYPE value: str
+:KeY option: The option.
+:TyPe option: int
+:KwPaRaM retries: Retry attempts.
+:KwTyPe retries: int
+:VaR state: Current state.
+:VaRtYpE state: bool
+:ReTuRnS: Whether validation passed.
+:RTyPe: bool
+:RaIsEs ValueError: If validation fails.
+:MeTa private:
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered);
     }
 
     #[test]
@@ -495,13 +490,17 @@ Trailing prose.
 
         assert_snapshot!(rendered, @"
         ## Attributes
-        **cache** `dict[str, object]`: Cached data.
+        **cache**: `dict[str, object]`  
+        Cached data.
 
-        **state**: Instance state.
+        **state**  
+        Instance state.
 
-        **title** `str`: Display title.
+        **title**: `str`  
+        Display title.
 
-        **VERSION** `str`: Package version.
+        **VERSION**: `str`  
+        Package version.
         ");
     }
 
@@ -517,12 +516,15 @@ Trailing prose.
 
         assert_snapshot!(rendered, @"
         ## Returns
-        **baz** `dict[str, int]`: The return value description
+        **baz**: `dict[str, int]`  
+        The return value description
 
         ## Raises
-        `ValueError`: If the value is invalid.
+        `ValueError`  
+        If the value is invalid.
 
-        `RuntimeError`: If the system is unavailable.
+        `RuntimeError`  
+        If the system is unavailable.
         ");
     }
 
@@ -693,22 +695,26 @@ Literal block::
         ```````````
 
         ## Parameters
-        **quoted**: Example:
+        **quoted**<HB>
+        Example:
 
-        **sample**: This is sample input
+        **sample**<HB>
+        This is sample input
 
-        **second**: Options:
+        **second**<HB>
+        Options:
 
         - First option.<HB>
             - Nested detail.<HB>
         - Second option.
 
-        **third**:
+        **third**
 
         1. Validate the input.<HB>
         2. Return the result.
 
-        **done**: Whether work is done.
+        **done**<HB>
+        Whether work is done.
 
         ## Returns
         This is still sample input
@@ -733,11 +739,14 @@ Summary.
         Summary.
 
         ## Parameters
-        **quoted**: Example:
+        **quoted**  
+        Example:
 
-        **sample**: This is sample input.
+        **sample**  
+        This is sample input.
 
-        **real**: Real parameter.
+        **real**  
+        Real parameter.
 
         ## Returns
         This is still sample input.
@@ -758,13 +767,15 @@ Summary.
 
         assert_snapshot!(rendered, @"
         ## Parameters
-        **quoted**: Example:
+        **quoted**<HB>
+        Example:
 
         !param sample: This is sample input.<HB>
         !returns: This is still sample input.
 
         ## Parameters
-        **real**: Real parameter.
+        **real**<HB>
+        Real parameter.
         ");
     }
 
@@ -793,13 +804,15 @@ Summary.
 
         assert_snapshot!(rendered, @"
         ## Parameters
-        **first**: Example:
+        **first**  
+        Example:
 
         ```````````python
         ```
         ```````````
 
-        **second**: Visible parameter.
+        **second**  
+        Visible parameter.
         ");
     }
 

--- a/crates/ty_ide/src/docstring/markdown/structured/snapshots/ty_ide__docstring__markdown__structured__rst__tests__render_field_names_case_insensitively.snap
+++ b/crates/ty_ide/src/docstring/markdown/structured/snapshots/ty_ide__docstring__markdown__structured__rst__tests__render_field_names_case_insensitively.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ty_ide/src/docstring/markdown/structured/rst.rs
+expression: rendered
+---
+## Parameters
+**value**: `str`  
+The value.
+
+**option**: `int`  
+The option.
+
+**retries**: `int`  
+Retry attempts.
+
+## Attributes
+**state**: `bool`  
+Current state.
+
+## Returns
+`bool`  
+Whether validation passed.
+
+## Raises
+`ValueError`  
+If validation fails.

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -565,6 +565,55 @@ mod tests {
     }
 
     #[test]
+    fn hover_function_rest_docstring() {
+        let test = hover_test(
+            r#"
+        def documented(value):
+            '''Return a value.
+
+            :param str value: The input value.
+            :rtype: str
+            '''
+            return value
+
+        docu<CURSOR>mented("x")
+        "#,
+        );
+
+        assert_snapshot!(test.hover(), @r#"
+        def documented(value) -> Unknown
+        ---------------------------------------------
+        Return a value.
+
+        :param str value: The input value.
+        :rtype: str
+
+        ---------------------------------------------
+        ```python
+        def documented(value) -> Unknown
+        ```
+        ---
+        Return a value.
+
+        ## Parameters
+        **value** `str`: The input value.
+
+        ## Returns
+        `str`
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:10:1
+           |
+        10 | documented("x")
+           | ^^^^-^^^^^
+           | |   |
+           | |   Cursor offset
+           | source
+           |
+        "#);
+    }
+
+    #[test]
     fn hover_class() {
         let test = hover_test(
             r#"

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -1,4 +1,4 @@
-use crate::docstring::Docstring;
+use crate::docstring::{Docstring, DocstringFragment};
 use crate::goto::{Definitions, GotoTarget, docstring_for_call_definition, find_goto_target};
 use crate::{Db, MarkupKind, RangedValue};
 use ruff_db::files::{File, FileRange};
@@ -186,7 +186,7 @@ fn keyword_argument_hover_contents<'db>(
         .and_then(|definition| docstring_for_call_definition(db, definition))
         .and_then(|docstring| documentation_for_parameter(&docstring, &parameter.name))
     {
-        contents.push(HoverContent::Docstring(documentation));
+        contents.push(HoverContent::DocstringFragment(documentation));
     }
 
     Some(contents)
@@ -202,7 +202,7 @@ fn parameter_hover_label(label: &str, is_keyword_variadic: bool) -> String {
     format!("({kind}) {label}")
 }
 
-fn documentation_for_parameter(docstring: &Docstring, name: &str) -> Option<Docstring> {
+fn documentation_for_parameter(docstring: &Docstring, name: &str) -> Option<DocstringFragment> {
     let parameter_documentation = docstring.parameter_documentation();
     parameter_documentation
         .get(name)
@@ -210,8 +210,7 @@ fn documentation_for_parameter(docstring: &Docstring, name: &str) -> Option<Docs
             name.strip_prefix("**")
                 .and_then(|name| parameter_documentation.get(name))
         })
-        .cloned()
-        .map(Docstring::new)
+        .map(|documentation| DocstringFragment::new(documentation))
 }
 
 pub struct Hover<'db> {
@@ -297,6 +296,7 @@ pub enum HoverContent<'db> {
         ty: Type<'db>,
     },
     Docstring(Docstring),
+    DocstringFragment(DocstringFragment),
 }
 
 impl<'db> HoverContent<'db> {
@@ -388,6 +388,7 @@ impl fmt::Display for DisplayHoverContent<'_, '_> {
                     .fmt(f)
             }
             HoverContent::Docstring(docstring) => docstring.render(self.kind).fmt(f),
+            HoverContent::DocstringFragment(fragment) => fragment.render(self.kind).fmt(f),
         }
     }
 }
@@ -596,7 +597,8 @@ mod tests {
         Return a value.
 
         ## Parameters
-        **value** `str`: The input value.
+        **value**: `str`<HB>
+        The input value.
 
         ## Returns
         `str`
@@ -2204,6 +2206,48 @@ mod tests {
            |      ^-
            |      ||
            |      |Cursor offset
+           |      source
+           |
+        ");
+    }
+
+    #[test]
+    fn hover_keyword_parameter_preserves_rest_field_like_continuation() {
+        let test = hover_test(
+            r#"
+            def test(value: int):
+                """my cool test
+
+                :param value:
+                    :param fake: - Parent option.
+                        - Child option.
+                """
+                return 0
+
+            test(value<CURSOR>=123)
+            "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        (parameter) value: int
+        ---------------------------------------------
+        :param fake: - Parent option.
+            - Child option.
+
+        ---------------------------------------------
+        ```python
+        (parameter) value: int
+        ```
+        ---
+        :param fake: - Parent option.<HB>
+            - Child option.
+        ---------------------------------------------
+        info[hover]: Hovered content is
+          --> main.py:11:6
+           |
+        11 | test(value=123)
+           |      ^^^^^- Cursor offset
+           |      |
            |      source
            |
         ");


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This introduces Markdown rendering for reStructuredText (reST) field lists in docstrings. Here's what it looks like in two different editors:

|   | Before | After |
| :--- | :--- | :--- |
| **VS Code** | <img width="1308" height="586" alt="CleanShot 2026-06-17 at 00 02 54@2x" src="https://github.com/user-attachments/assets/0ba19662-8f34-4dc3-8955-f0d241ad53eb" />  | <img width="1502" height="558" alt="CleanShot 2026-06-17 at 23 44 19@2x" src="https://github.com/user-attachments/assets/1b8254af-b6ff-417f-9b66-0bc49ccbf4bb" /> |
| **Zed** | <img width="1432" height="864" alt="CleanShot 2026-06-17 at 00 02 19@2x" src="https://github.com/user-attachments/assets/20d409ca-5f03-4a7f-ba20-bf80b370147b" /> | <img width="1550" height="834" alt="CleanShot 2026-06-17 at 23 45 47@2x" src="https://github.com/user-attachments/assets/048e3339-c424-41c7-9506-f23a24d1f571" /> |

The implementation includes the following judgement calls that I think are acceptable, but that we may want to revisit based on user feedback:

- Our policy for handling malformed, unsupported, or ambiguous fields is to leave a section raw (i.e. source content, not Markdown) if even a single field in a field list cannot be confidently rendered (though other well-formed sections in the same docstring are still rendered as Markdown).  I hope this policy is easy to explain, to identify and correct in practice, and to maintain.
- We only render Markdown headings for a fixed subset of reST fields that are commonly used in docstrings. That list can be expanded in the future.
- Types are rendered with inline code spans, and so do not receive syntax highlighting. This makes the resulting rendered docstring more compact vertically at the cost of additional visual cues.
- Physical line breaks in field descriptions are preserved as Markdown hard breaks rather than being reflowed. This leads to some awkward line breaks in the rendered docstring, but it saves a lot of complexity in trying to identify which line breaks are actually collapsible.

**I expect that it will be marginally easier to review this diff commit-by-commit rather than wholesale.**

Closes https://github.com/astral-sh/ty/issues/3454.

## Test Plan

Please see included tests.

<!-- How was it tested? -->
