### PR TITLE
Clarify UP029 Python 2 compatibility imports

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -10,11 +10,14 @@ use crate::rules::pyupgrade::rules::is_import_required_by_isort;
 use crate::{AlwaysFixableViolation, Fix};
 
 /// ## What it does
-/// Checks for unnecessary imports of builtins.
+/// Checks for imports from Python 2 compatibility modules that are
+/// unnecessary on Python 3.
 ///
 /// ## Why is this bad?
-/// Builtins are always available. Importing them is unnecessary and should be
-/// removed to avoid confusion.
+/// The `builtins`, `io`, and `six.moves` modules expose Python 3-compatible
+/// builtins for code that supports both Python 2 and Python 3. When running
+/// on Python 3 only, importing these names is unnecessary; they can be used
+/// directly instead.
 ///
 /// ## Example
 /// ```python
@@ -51,15 +54,15 @@ impl AlwaysFixableViolation for UnnecessaryBuiltinImport {
         let UnnecessaryBuiltinImport { names } = self;
         if names.len() == 1 {
             let import = &names[0];
-            format!("Unnecessary builtin import: `{import}`")
+            format!("Unnecessary Python 2 compatibility import: `{import}`")
         } else {
             let imports = names.iter().map(|name| format!("`{name}`")).join(", ");
-            format!("Unnecessary builtin imports: {imports}")
+            format!("Unnecessary Python 2 compatibility imports: {imports}")
         }
     }
 
     fn fix_title(&self) -> String {
-        "Remove unnecessary builtin import".to_string()
+        "Remove unnecessary Python 2 compatibility import".to_string()
     }
 }
 

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP029_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP029_0.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP029 [*] Unnecessary builtin import: `*`
+UP029 [*] Unnecessary Python 2 compatibility import: `*`
  --> UP029_0.py:1:1
   |
 1 | from builtins import *
@@ -9,14 +9,14 @@ UP029 [*] Unnecessary builtin import: `*`
 2 | from builtins import ascii, bytes, compile
 3 | from builtins import str as _str
   |
-help: Remove unnecessary builtin import
+help: Remove unnecessary Python 2 compatibility import
   - from builtins import *
 1 | from builtins import ascii, bytes, compile
 2 | from builtins import str as _str
 3 | from six.moves import filter, zip, zip_longest
 note: This is an unsafe fix and may change runtime behavior
 
-UP029 [*] Unnecessary builtin imports: `ascii`, `bytes`
+UP029 [*] Unnecessary Python 2 compatibility imports: `ascii`, `bytes`
  --> UP029_0.py:2:1
   |
 1 | from builtins import *
@@ -25,7 +25,7 @@ UP029 [*] Unnecessary builtin imports: `ascii`, `bytes`
 3 | from builtins import str as _str
 4 | from six.moves import filter, zip, zip_longest
   |
-help: Remove unnecessary builtin import
+help: Remove unnecessary Python 2 compatibility import
 1 | from builtins import *
   - from builtins import ascii, bytes, compile
 2 + from builtins import compile
@@ -34,7 +34,7 @@ help: Remove unnecessary builtin import
 5 | from io import open
 note: This is an unsafe fix and may change runtime behavior
 
-UP029 [*] Unnecessary builtin imports: `filter`, `zip`
+UP029 [*] Unnecessary Python 2 compatibility imports: `filter`, `zip`
  --> UP029_0.py:4:1
   |
 2 | from builtins import ascii, bytes, compile
@@ -44,7 +44,7 @@ UP029 [*] Unnecessary builtin imports: `filter`, `zip`
 5 | from io import open
 6 | import io
   |
-help: Remove unnecessary builtin import
+help: Remove unnecessary Python 2 compatibility import
 1 | from builtins import *
 2 | from builtins import ascii, bytes, compile
 3 | from builtins import str as _str
@@ -55,7 +55,7 @@ help: Remove unnecessary builtin import
 7 | import six
 note: This is an unsafe fix and may change runtime behavior
 
-UP029 [*] Unnecessary builtin import: `open`
+UP029 [*] Unnecessary Python 2 compatibility import: `open`
  --> UP029_0.py:5:1
   |
 3 | from builtins import str as _str
@@ -65,7 +65,7 @@ UP029 [*] Unnecessary builtin import: `open`
 6 | import io
 7 | import six
   |
-help: Remove unnecessary builtin import
+help: Remove unnecessary Python 2 compatibility import
 2 | from builtins import ascii, bytes, compile
 3 | from builtins import str as _str
 4 | from six.moves import filter, zip, zip_longest

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP029_1.py_skip_required_imports.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP029_1.py_skip_required_imports.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP029 [*] Unnecessary builtin import: `int`
+UP029 [*] Unnecessary Python 2 compatibility import: `int`
  --> UP029_1.py:1:1
   |
 1 | from builtins import str, int
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-help: Remove unnecessary builtin import
+help: Remove unnecessary Python 2 compatibility import
   - from builtins import str, int
 1 + from builtins import str
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP029_3.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP029_3.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/pyupgrade/mod.rs
 ---
-UP029 [*] Unnecessary builtin import: `pow`
+UP029 [*] Unnecessary Python 2 compatibility import: `pow`
   --> UP029_3.py:19:5
    |
 17 | def star_import():
@@ -11,7 +11,7 @@ UP029 [*] Unnecessary builtin import: `pow`
 20 |
 21 |     pow(1, 1, 1)
    |
-help: Remove unnecessary builtin import
+help: Remove unnecessary Python 2 compatibility import
 16 |
 17 | def star_import():
 18 |     from math import *
@@ -21,7 +21,7 @@ help: Remove unnecessary builtin import
 21 |
 note: This is an unsafe fix and may change runtime behavior
 
-UP029 [*] Unnecessary builtin import: `str`
+UP029 [*] Unnecessary Python 2 compatibility import: `str`
   --> UP029_3.py:25:5
    |
 24 |   def unsafe_fix():
@@ -32,7 +32,7 @@ UP029 [*] Unnecessary builtin import: `str`
 28 |
 29 |       str(1)
    |
-help: Remove unnecessary builtin import
+help: Remove unnecessary Python 2 compatibility import
 22 |
 23 |
 24 | def unsafe_fix():


### PR DESCRIPTION
## Summary

- Clarify `unnecessary-builtin-import` (`UP029`) as targeting Python 2 compatibility imports that are redundant on Python 3.
- Update the diagnostic and fix title to avoid implying that the rule checks every import from `builtins`.
- Refresh the UP029 snapshots.

## Reproduction

The current UP029 documentation says the rule checks unnecessary imports of builtins. That wording is broader than the implementation: the rule targets selected imports from Python 2 compatibility modules such as `builtins`, `io`, `six`, and `six.moves`, while intentionally not flagging every import from `builtins` such as `from builtins import tuple`.

## Root cause

The docs and diagnostic message were framed around builtins generally, while the implementation and pyupgrade origin are about removing Python 2/3 compatibility imports that are unnecessary for Python 3-only code.

## Changes

- Reword the generated rule documentation in `unnecessary_builtin_import.rs`.
- Change the diagnostic message and fix title to mention Python 2 compatibility imports.
- Update the UP029 snapshots, including the `required-imports` interaction snapshot.

## Tests

- `cargo fmt --check`
- `cargo dev generate-docs`
- `INSTA_UPDATE=always INSTA_FORCE_PASS=1 cargo test -p ruff_linter rules::pyupgrade::tests::rules --no-fail-fast`
- `INSTA_UPDATE=always INSTA_FORCE_PASS=1 cargo test -p ruff_linter rules::pyupgrade::tests::i002_up029_conflict --no-fail-fast`
- `cargo test -p ruff_linter rules::pyupgrade::tests::rules --no-fail-fast`
- `cargo test -p ruff_linter rules::pyupgrade::tests::i002_up029_conflict --no-fail-fast`
- `git diff --check`
- Not run: `uvx prek run --files ...` (`uvx`/`prek` are not installed in this environment)

## Screenshots/Logs

- Not applicable; documentation and diagnostic wording only.

## AI Policy

- This PR follows the repository AI policy.

Fixes #21148.