### PR TITLE
[ty] Finish TypeVarTuple support

### DIFF
--- a/crates/mdtest/src/matcher.rs
+++ b/crates/mdtest/src/matcher.rs
@@ -260,31 +260,13 @@ impl UnmatchedWithColumn for &Diagnostic {
 
 /// Discard `@Todo`-type metadata from expected types, which is not available
 /// when running in release mode.
-///
-/// Some `@Todo` variants (like `@Todo(StarredExpression)` and `@Todo(typing.Unpack)`)
-/// are hardcoded enum variants that always display their message, so we preserve those.
 fn discard_todo_metadata(ty: &str) -> Cow<'_, str> {
     #[cfg(not(debug_assertions))]
     {
-        /// `@Todo` variants that are hardcoded and always display their message,
-        /// even in release mode.
-        const PRESERVED_TODO_VARIANTS: &[&str] = &[
-            "@Todo(StarredExpression)",
-            "@Todo(typing.Unpack)",
-            "@Todo(TypeVarTuple)",
-        ];
-
         static TODO_METADATA_REGEX: LazyLock<regex::Regex> =
             LazyLock::new(|| regex::Regex::new(r"@Todo\([^)]*\)").unwrap());
 
-        TODO_METADATA_REGEX.replace_all(ty, |caps: &regex::Captures| {
-            let matched = caps.get(0).unwrap().as_str();
-            if PRESERVED_TODO_VARIANTS.contains(&matched) {
-                matched.to_string()
-            } else {
-                "@Todo".to_string()
-            }
-        })
+        TODO_METADATA_REGEX.replace_all(ty, "@Todo")
     }
 
     #[cfg(debug_assertions)]

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1478,7 +1478,7 @@ fn anyio(criterion: &mut Criterion) {
             max_dep_date: "2025-06-17",
             python_version: SupportedPythonVersion::Py313,
         },
-        150,
+        170,
     );
 
     bench_project(&benchmark, criterion);

--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -231,7 +231,7 @@ static STATIC_FRAME: Benchmark = Benchmark::new(
         max_dep_date: "2025-08-09",
         python_version: SupportedPythonVersion::Py311,
     },
-    1810,
+    1970,
 );
 
 #[track_caller]

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -725,10 +725,20 @@ mod tests {
             "#,
         );
 
-        // TODO: Goto type definition currently doesn't work for type var tuples
-        // because the inference doesn't support them yet.
-        // This snapshot should show a single target pointing to `T`
-        assert_snapshot!(test.goto_type_definition(), @"No type definitions found");
+        assert_snapshot!(test.goto_type_definition(), @r"
+        info[goto-type definition]: Go to type definition
+         --> main.py:2:31
+          |
+        2 | type Alias[*Ts = ()] = tuple[*Ts]
+          |                               ^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:2:13
+          |
+        2 | type Alias[*Ts = ()] = tuple[*Ts]
+          |             --
+          |
+        ");
     }
 
     #[test]
@@ -1490,7 +1500,20 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No type definitions found");
+        assert_snapshot!(test.goto_type_definition(), @r"
+        info[goto-type definition]: Go to type definition
+         --> main.py:2:38
+          |
+        2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
+          |                                      ^^ Clicking here
+          |
+        info: Found 1 type definition
+         --> main.py:2:14
+          |
+        2 | type Alias3[*AB = ()] = tuple[tuple[*AB], tuple[*AB]]
+          |              --
+          |
+        ");
     }
 
     #[test]

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -4034,10 +4034,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        @Todo
+        AB@Alias3 (covariant)
         ---------------------------------------------
         ```python
-        @Todo
+        AB@Alias3 (covariant)
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -4196,10 +4196,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        @Todo
+        Ts@Alias (covariant)
         ---------------------------------------------
         ```python
-        @Todo
+        Ts@Alias (covariant)
         ```
         ---------------------------------------------
         info[hover]: Hovered content is

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -4034,10 +4034,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        AB@Alias3 (covariant)
+        AB@Alias3 (invariant)
         ---------------------------------------------
         ```python
-        AB@Alias3 (covariant)
+        AB@Alias3 (invariant)
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -4196,10 +4196,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        Ts@Alias (covariant)
+        Ts@Alias (invariant)
         ---------------------------------------------
         ```python
-        Ts@Alias (covariant)
+        Ts@Alias (invariant)
         ```
         ---------------------------------------------
         info[hover]: Hovered content is

--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -435,9 +435,8 @@ from typing_extensions import Callable, TypeVarTuple
 
 Ts = TypeVarTuple("Ts")
 
-def _(c: Callable[[int, *Ts], int]):
-    # TODO: Should reveal the correct signature
-    reveal_type(c)  # revealed: (...) -> int
+def unpack_operator(c: Callable[[int, *Ts], int]):
+    reveal_type(c)  # revealed: (int, /, *Ts@unpack_operator) -> int
 ```
 
 And, using the legacy syntax using `Unpack`:
@@ -445,9 +444,8 @@ And, using the legacy syntax using `Unpack`:
 ```py
 from typing_extensions import Unpack
 
-def _(c: Callable[[int, Unpack[Ts]], int]):
-    # TODO: Should reveal the correct signature
-    reveal_type(c)  # revealed: (...) -> int
+def unpack_special_form(c: Callable[[int, Unpack[Ts]], int]):
+    reveal_type(c)  # revealed: (int, /, *Ts@unpack_special_form) -> int
 ```
 
 ## Member lookup

--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -448,6 +448,70 @@ def unpack_special_form(c: Callable[[int, Unpack[Ts]], int]):
     reveal_type(c)  # revealed: (int, /, *Ts@unpack_special_form) -> int
 ```
 
+Concrete tuple unpacks describe the corresponding positional parameter list, including tuples with
+an arbitrary-length middle portion.
+
+```py
+from typing import Any
+from typing_extensions import Callable, Unpack
+from ty_extensions import RegularCallableTypeOf, is_equivalent_to, static_assert
+
+def fixed(x: int, y: str, /) -> None: ...
+def fixed_star(*args: Unpack[tuple[int, str]]) -> None: ...
+
+fixed_from_parameters: Callable[[Unpack[tuple[int, str]]], None] = fixed
+fixed_from_starred: Callable[[int, str], None] = fixed_star
+
+def mixed_star(
+    *args: Unpack[tuple[int, Unpack[tuple[str, ...]], bytes]],
+) -> None: ...
+
+mixed_from_starred: Callable[
+    [Unpack[tuple[int, Unpack[tuple[str, ...]], bytes]]],
+    None,
+] = mixed_star
+mixed_without_middle: Callable[[int, bytes], None] = mixed_star
+mixed_with_middle: Callable[[int, str, str, bytes], None] = mixed_star
+
+def mixed_returns_str(
+    *args: Unpack[tuple[int, Unpack[tuple[str, ...]], bytes]],
+) -> str:
+    raise NotImplementedError
+
+invalid_return: Callable[
+    [Unpack[tuple[int, Unpack[tuple[str, ...]], bytes]]],
+    int,
+] = mixed_returns_str  # error: [invalid-assignment] "Object of type `def mixed_returns_str(*args: tuple[int, *tuple[str, ...], bytes]) -> str` is not assignable to `(*tuple[int, *tuple[str, ...], bytes]) -> int`"
+
+def call_mixed(
+    callback: Callable[[int, Unpack[tuple[str, ...]], bytes], None],
+) -> None:
+    callback(1, b"end")
+    callback(1, "one", "two", b"end")
+
+def call_mixed_splat(
+    callback: Callable[
+        [Unpack[tuple[int, Unpack[tuple[str, ...]], bytes]]],
+        None,
+    ],
+    arguments: tuple[int, Unpack[tuple[str, ...]], bytes],
+) -> None:
+    callback(*arguments)
+
+def gradual_starred(
+    *args: Unpack[tuple[Any, ...]],
+    **kwargs: Any,
+) -> None: ...
+def gradual_ordinary(*args: Any, **kwargs: Any) -> None: ...
+
+static_assert(
+    is_equivalent_to(
+        RegularCallableTypeOf[gradual_starred],
+        RegularCallableTypeOf[gradual_ordinary],
+    )
+)
+```
+
 ## Member lookup
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
@@ -13,12 +13,12 @@ from typing_extensions import TypeVarTuple
 Ts = TypeVarTuple("Ts")
 
 def append_int(*args: *Ts) -> tuple[*Ts, int]:
-    reveal_type(args)  # revealed: @Todo(PEP 646)
+    reveal_type(args)  # revealed: tuple[*Ts@append_int]
 
     return (*args, 1)
 
-# TODO should be tuple[Literal[True], Literal["a"], int]
-reveal_type(append_int(True, "a"))  # revealed: tuple[@Todo(TypeVarTuple), ...]
+# TODO: revealed: tuple[Literal[True], Literal["a"], int]
+reveal_type(append_int(True, "a"))  # revealed: tuple[*tuple[Literal[True, "a"], ...], int]
 
 def first_arg_int(*args: *tuple[int, *tuple[str, ...]]): ...
 

--- a/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/starred.md
@@ -17,12 +17,14 @@ def append_int(*args: *Ts) -> tuple[*Ts, int]:
 
     return (*args, 1)
 
-# TODO: revealed: tuple[Literal[True], Literal["a"], int]
-reveal_type(append_int(True, "a"))  # revealed: tuple[*tuple[Literal[True, "a"], ...], int]
+reveal_type(append_int(True, "a"))  # revealed: tuple[Literal[True], Literal["a"], int]
+reveal_type(append_int())  # revealed: tuple[int]
 
 def first_arg_int(*args: *tuple[int, *tuple[str, ...]]): ...
 
 first_arg_int(42, "42", "42")  # fine
-first_arg_int("not an int", "42", "42")  # TODO: should error
-first_arg_int(56, "42", 56)  # TODO: should error
+# error: [invalid-argument-type] "Argument to function `first_arg_int` is incorrect: Expected `tuple[int, *tuple[str, ...]]`, found `tuple[Literal["not an int"], Literal["42"], Literal["42"]]`"
+first_arg_int("not an int", "42", "42")
+# error: [invalid-argument-type] "Argument to function `first_arg_int` is incorrect: Expected `tuple[int, *tuple[str, ...]]`, found `tuple[Literal[56], Literal["42"], Literal[56]]`"
+first_arg_int(56, "42", 56)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -13,7 +13,7 @@ Ts = TypeVarTuple("Ts")
 R_co = TypeVar("R_co", covariant=True)
 
 def f(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
-    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
+    reveal_type(args)  # revealed: tuple[*Ts@f]
     return args
 
 def i(callback: Callable[Concatenate[int, P], R_co], *args: P.args, **kwargs: P.kwargs) -> R_co:
@@ -74,10 +74,10 @@ class Pair(Generic[T, U]): ...
 class Triple(Generic[T, U, Unpack[Us]]): ...
 
 def variadic_typevartuple(*args: Unpack[Ts]) -> None:
-    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
+    reveal_type(args)  # revealed: tuple[*Ts@variadic_typevartuple]
 
 def variadic_tuple(*args: Unpack[tuple[int, str]]) -> None:
-    reveal_type(args)  # revealed: tuple[@Todo(`Unpack[]` special form), ...]
+    reveal_type(args)  # revealed: tuple[int, str]
 
 def allowed(
     tuple_fixed: tuple[int, Unpack[tuple[str, bytes]]],
@@ -95,8 +95,8 @@ def allowed(
 ) -> None:
     reveal_type(tuple_fixed)  # revealed: tuple[int, str, bytes]
     reveal_type(tuple_variadic)  # revealed: tuple[int, *tuple[str, ...], bytes]
-    reveal_type(callable_typevartuple)  # revealed: (...) -> None
-    reveal_type(callable_tuple)  # revealed: (tuple[int, str], /) -> None
+    reveal_type(callable_typevartuple)  # revealed: (int, /, *Ts@allowed) -> None
+    reveal_type(callable_tuple)  # revealed: (*tuple[int, str]) -> None
     reveal_type(pair)  # revealed: Pair[int, str]
     reveal_type(quoted_pair_argument)  # revealed: Pair[int, str]
     reveal_type(quoted_tuple)  # revealed: tuple[int, str, bytes]

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -45,8 +45,8 @@ def ex3(msg: str):
 def first_arg_int(*args: Unpack[tuple[int, Unpack[tuple[str, ...]]]]): ...
 
 first_arg_int(42, "42", "42")  # fine
-first_arg_int("not an int", "42", "42")  # TODO: should error
-first_arg_int(56, "42", 56)  # TODO: should error
+first_arg_int("not an int", "42", "42")  # error: [invalid-argument-type]
+first_arg_int(56, "42", 56)  # error: [invalid-argument-type]
 ```
 
 ## Allowed `Unpack` contexts

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_forms.md
@@ -96,7 +96,7 @@ def allowed(
     reveal_type(tuple_fixed)  # revealed: tuple[int, str, bytes]
     reveal_type(tuple_variadic)  # revealed: tuple[int, *tuple[str, ...], bytes]
     reveal_type(callable_typevartuple)  # revealed: (int, /, *Ts@allowed) -> None
-    reveal_type(callable_tuple)  # revealed: (*tuple[int, str]) -> None
+    reveal_type(callable_tuple)  # revealed: (int, str, /) -> None
     reveal_type(pair)  # revealed: Pair[int, str]
     reveal_type(quoted_pair_argument)  # revealed: Pair[int, str]
     reveal_type(quoted_tuple)  # revealed: tuple[int, str, bytes]

--- a/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/unsupported_special_types.md
@@ -42,8 +42,7 @@ y: Bar[int, str, bytes]  # fine
 
 class Baz[*Ts]: ...
 
-# TODO: false positive
-z: Baz[int, str, bytes]  # error: [not-subscriptable]
+z: Baz[int, str, bytes]
 ```
 
 And we also provide some basic validation in some cases:

--- a/crates/ty_python_semantic/resources/mdtest/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/async.md
@@ -42,8 +42,11 @@ def blocking_function() -> int:
 async def main():
     loop = asyncio.get_event_loop()
     with concurrent.futures.ThreadPoolExecutor() as pool:
+        # TODO: No `invalid-argument-type` diagnostic should be emitted here.
+        # error: [invalid-argument-type] "Argument to bound method `AbstractEventLoop.run_in_executor` is incorrect: Expected `(*tuple[Unknown, ...]) -> Unknown`, found `def blocking_function() -> int`"
         result = await loop.run_in_executor(pool, blocking_function)
-        reveal_type(result)  # revealed: int
+        # TODO: revealed: int
+        reveal_type(result)  # revealed: Unknown
 ```
 
 ### `asyncio.Task`

--- a/crates/ty_python_semantic/resources/mdtest/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/async.md
@@ -42,11 +42,8 @@ def blocking_function() -> int:
 async def main():
     loop = asyncio.get_event_loop()
     with concurrent.futures.ThreadPoolExecutor() as pool:
-        # TODO: No `invalid-argument-type` diagnostic should be emitted here.
-        # error: [invalid-argument-type] "Argument to bound method `AbstractEventLoop.run_in_executor` is incorrect: Expected `(*tuple[Unknown, ...]) -> Unknown`, found `def blocking_function() -> int`"
         result = await loop.run_in_executor(pool, blocking_function)
-        # TODO: revealed: int
-        reveal_type(result)  # revealed: Unknown
+        reveal_type(result)  # revealed: int
 ```
 
 ### `asyncio.Task`

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -698,7 +698,7 @@ reveal_type(f5_paramspec)  # revealed: (x: int) -> int
 
 # error: [invalid-assignment]
 f6: Callable[[*tuple[int, ...]], None] = lambda x, y, z: None
-reveal_type(f6)  # revealed: (*tuple[int, ...]) -> None
+reveal_type(f6)  # revealed: (*args: int) -> None
 
 f7: Callable[[int, str], None] = lambda *args: None
 reveal_type(f7)  # revealed: (*args) -> None
@@ -708,11 +708,10 @@ reveal_type(f7)  # revealed: (*args) -> None
 f8: Callable[[int], None] = lambda *, x=1: None
 reveal_type(f8)  # revealed: (int, /) -> None
 
-# `Callable` annotations only describe positional parameters, so the keyword-only `x` is not
-# compatible with the positional suffix in the annotation.
-# error: [invalid-assignment]
+# The lambda accepts every positional call described by the mixed tuple. Its optional keyword-only
+# parameter does not restrict those calls.
 f9: Callable[[*tuple[int, ...], int], None] = lambda *args, x=1: None
-reveal_type(f9)  # revealed: (*tuple[int, ...], int) -> None
+reveal_type(f9)  # revealed: (*args, *, x=1) -> None
 
 f10: Callable[[str, int, str], tuple[str, int, str]] = lambda x, y, z: reveal_type((x, y, z))  # revealed: tuple[str, int, str]
 reveal_type(f10)  # revealed: (x: str, y: int, z: str) -> tuple[str, int, str]

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -696,10 +696,9 @@ def id_callable[**P, R](x: Callable[P, R]) -> Callable[P, R]:
 f5_paramspec: Callable[[int], int] = id_callable(lambda x: reveal_type(x))  # revealed: int
 reveal_type(f5_paramspec)  # revealed: (x: int) -> int
 
-# TODO: This should not error once we support `Unpack`.
 # error: [invalid-assignment]
 f6: Callable[[*tuple[int, ...]], None] = lambda x, y, z: None
-reveal_type(f6)  # revealed: (tuple[int, ...], /) -> None
+reveal_type(f6)  # revealed: (*tuple[int, ...]) -> None
 
 f7: Callable[[int, str], None] = lambda *args: None
 reveal_type(f7)  # revealed: (*args) -> None
@@ -709,9 +708,11 @@ reveal_type(f7)  # revealed: (*args) -> None
 f8: Callable[[int], None] = lambda *, x=1: None
 reveal_type(f8)  # revealed: (int, /) -> None
 
-# TODO: This should reveal `(*args: int, *, x=1) -> None` once we support `Unpack`.
+# `Callable` annotations only describe positional parameters, so the keyword-only `x` is not
+# compatible with the positional suffix in the annotation.
+# error: [invalid-assignment]
 f9: Callable[[*tuple[int, ...], int], None] = lambda *args, x=1: None
-reveal_type(f9)  # revealed: (*args, *, x=1) -> None
+reveal_type(f9)  # revealed: (*tuple[int, ...], int) -> None
 
 f10: Callable[[str, int, str], tuple[str, int, str]] = lambda x, y, z: reveal_type((x, y, z))  # revealed: tuple[str, int, str]
 reveal_type(f10)  # revealed: (x: str, y: int, z: str) -> tuple[str, int, str]

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -38,11 +38,14 @@ reveal_type(generic_context(SingleParamSpec))
 # revealed: ty_extensions.GenericContext[P@TypeVarAndParamSpec, T@TypeVarAndParamSpec]
 reveal_type(generic_context(TypeVarAndParamSpec))
 
-# TODO: support `TypeVarTuple` properly (these should not reveal `None`)
-reveal_type(generic_context(SingleTypeVarTuple))  # revealed: None
-reveal_type(generic_context(TypeVarAndTypeVarTuple))  # revealed: None
-reveal_type(generic_context(StarredSingleTypeVarTuple))  # revealed: None
-reveal_type(generic_context(StarredTypeVarAndTypeVarTuple))  # revealed: None
+# revealed: ty_extensions.GenericContext[Ts@SingleTypeVarTuple]
+reveal_type(generic_context(SingleTypeVarTuple))
+# revealed: ty_extensions.GenericContext[T@TypeVarAndTypeVarTuple, Ts@TypeVarAndTypeVarTuple]
+reveal_type(generic_context(TypeVarAndTypeVarTuple))
+# revealed: ty_extensions.GenericContext[Ts@StarredSingleTypeVarTuple]
+reveal_type(generic_context(StarredSingleTypeVarTuple))
+# revealed: ty_extensions.GenericContext[T@StarredTypeVarAndTypeVarTuple, Ts@StarredTypeVarAndTypeVarTuple]
+reveal_type(generic_context(StarredTypeVarAndTypeVarTuple))
 ```
 
 Inheriting from `Generic` multiple times yields a `duplicate-base` diagnostic, just like any other
@@ -60,11 +63,14 @@ You cannot use the same typevar more than once.
 class RepeatedTypevar(Generic[T, T]): ...
 ```
 
-You can only specialize `typing.Generic` with typevars (TODO: or param specs or typevar tuples).
+You can only specialize `typing.Generic` with typevars, param specs, or typevar tuples.
 
 ```py
 # error: [invalid-argument-type] "`<class 'int'>` is not a valid argument to `Generic`"
 class GenericOfType(Generic[int]): ...
+
+# error: [invalid-argument-type] "`<special-form 'typing.Unpack'>` is not a valid argument to `Generic`"
+class GenericOfInvalidUnpack(Generic[T, Unpack[int]]): ...
 ```
 
 You can also define a generic class by inheriting from some _other_ generic class, and specializing

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -1,0 +1,553 @@
+# Legacy `TypeVarTuple`
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+The tests in this file focus on how `TypeVarTuple`s are defined and specialized using the legacy
+notation. Shared uses of `TypeVarTuple`s are tested with PEP 695 syntax in
+`../pep695/typevartuple.md`; alternate `Unpack` spelling is tested in `unpack.md`.
+
+## Definition
+
+### Valid
+
+```py
+from typing import TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+reveal_type(type(Ts))  # revealed: <class 'TypeVarTuple'>
+reveal_type(Ts)  # revealed: TypeVarTuple
+reveal_type(Ts.__name__)  # revealed: Literal["Ts"]
+```
+
+The `TypeVarTuple` name can also be provided as a keyword argument:
+
+```py
+from typing import TypeVarTuple
+
+Ts = TypeVarTuple(name="Ts")
+reveal_type(Ts.__name__)  # revealed: Literal["Ts"]
+```
+
+### Must be directly assigned to a variable
+
+```py
+from typing import TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+# error: [invalid-legacy-type-variable]
+Ts1: TypeVarTuple = TypeVarTuple("Ts1")
+
+# error: [invalid-legacy-type-variable]
+tuple_with_typevartuple = ("foo", TypeVarTuple("Us"))
+reveal_type(tuple_with_typevartuple[1])  # revealed: TypeVarTuple
+```
+
+### `TypeVarTuple` parameter must match variable name
+
+```py
+from typing import Generic, TypeVarTuple
+
+Ts1 = TypeVarTuple("Ts1")
+
+# error: [mismatched-type-name]
+Ts2 = TypeVarTuple("Ts3")
+
+class Array(Generic[*Ts2]): ...
+```
+
+### Bounds and constraints
+
+The `bound` parameter was added to `typing.TypeVarTuple` in Python 3.15. On older Python versions,
+using it is invalid. Constraints are not supported in any Python version.
+
+#### Before Python 3.15
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from typing import TypeVarTuple
+
+# error: [invalid-legacy-type-variable] "The `bound` parameter of `typing.TypeVarTuple` was added in Python 3.15"
+Ts1 = TypeVarTuple("Ts1", bound=int)
+# error: [invalid-legacy-type-variable]
+Ts2 = TypeVarTuple("Ts2", int, str)
+```
+
+#### Python 3.15
+
+ty does not yet support the `bound` parameter when targeting Python 3.15.
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+```py
+from typing import TypeVarTuple
+
+# error: [invalid-legacy-type-variable] "The `bound` argument for `TypeVarTuple` is not supported"
+Ts = TypeVarTuple("Ts", bound=int)
+```
+
+#### `typing_extensions.TypeVarTuple`
+
+`typing_extensions.TypeVarTuple` exposes the `bound` parameter on older Python versions. ty
+recognizes the backport but does not yet support the parameter.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing_extensions import TypeVarTuple
+
+# error: [invalid-legacy-type-variable] "The `bound` argument for `TypeVarTuple` is not supported"
+Ts = TypeVarTuple("Ts", bound=int)
+```
+
+### Variance
+
+Legacy `TypeVarTuple` accepts `covariant` and `contravariant` arguments. A `TypeVarTuple` with no
+variance specified is invariant, and a `TypeVarTuple` with `infer_variance=True` uses variance
+inference. These parameters were added to `typing.TypeVarTuple` in Python 3.15.
+
+#### Before Python 3.15
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from typing import TypeVarTuple
+
+# error: [invalid-legacy-type-variable] "The `covariant` parameter of `typing.TypeVarTuple` was added in Python 3.15"
+Ts_Co = TypeVarTuple("Ts_Co", covariant=True)
+# error: [invalid-legacy-type-variable] "The `contravariant` parameter of `typing.TypeVarTuple` was added in Python 3.15"
+Ts_Contra = TypeVarTuple("Ts_Contra", contravariant=True)
+# error: [invalid-legacy-type-variable] "The `infer_variance` parameter of `typing.TypeVarTuple` was added in Python 3.15"
+Ts_Inferred = TypeVarTuple("Ts_Inferred", infer_variance=True)
+```
+
+#### Python 3.15
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+```py
+from typing import Generic, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+class InvariantArray(Generic[*Ts]):
+    values: tuple[*Ts]
+
+invariant_out: InvariantArray[object] = InvariantArray[int]()  # error: [invalid-assignment]
+invariant_in: InvariantArray[int] = InvariantArray[object]()  # error: [invalid-assignment]
+
+Ts_Co = TypeVarTuple("Ts_Co", covariant=True)
+
+class CovariantArray(Generic[*Ts_Co]):
+    def get(self) -> tuple[*Ts_Co]:
+        raise NotImplementedError
+
+covariant_ok: CovariantArray[object] = CovariantArray[int]()
+covariant_error: CovariantArray[int] = CovariantArray[object]()  # error: [invalid-assignment]
+
+Ts_Contra = TypeVarTuple("Ts_Contra", contravariant=True)
+
+class ContravariantArray(Generic[*Ts_Contra]):
+    def set(self, value: tuple[*Ts_Contra]) -> None:
+        raise NotImplementedError
+
+contravariant_ok: ContravariantArray[int] = ContravariantArray[object]()
+contravariant_error: ContravariantArray[object] = ContravariantArray[int]()  # error: [invalid-assignment]
+
+Ts_Inferred_Co = TypeVarTuple("Ts_Inferred_Co", infer_variance=True)
+
+class InferredCovariantArray(Generic[*Ts_Inferred_Co]):
+    def get(self) -> tuple[*Ts_Inferred_Co]:
+        raise NotImplementedError
+
+inferred_covariant_ok: InferredCovariantArray[object] = InferredCovariantArray[int]()
+inferred_covariant_error: InferredCovariantArray[int] = InferredCovariantArray[object]()  # error: [invalid-assignment]
+
+Ts_Inferred_Contra = TypeVarTuple("Ts_Inferred_Contra", infer_variance=True)
+
+class InferredContravariantArray(Generic[*Ts_Inferred_Contra]):
+    def set(self, value: tuple[*Ts_Inferred_Contra]) -> None:
+        raise NotImplementedError
+
+inferred_contravariant_ok: InferredContravariantArray[int] = InferredContravariantArray[object]()
+# error: [invalid-assignment]
+inferred_contravariant_error: InferredContravariantArray[object] = InferredContravariantArray[int]()
+```
+
+The variance arguments must have statically known boolean values, and `infer_variance=True` cannot
+be combined with an explicit variance.
+
+```py
+from typing import TypeVarTuple
+
+def cond() -> bool:
+    return True
+
+# error: [invalid-legacy-type-variable]
+Both = TypeVarTuple("Both", covariant=True, contravariant=True)
+# error: [invalid-legacy-type-variable]
+AmbiguousCovariant = TypeVarTuple("AmbiguousCovariant", covariant=cond())
+# error: [invalid-legacy-type-variable]
+AmbiguousContravariant = TypeVarTuple("AmbiguousContravariant", contravariant=cond())
+# error: [invalid-legacy-type-variable]
+AmbiguousInferVariance = TypeVarTuple("AmbiguousInferVariance", infer_variance=cond())
+# error: [invalid-legacy-type-variable]
+CovariantAndInferred = TypeVarTuple("CovariantAndInferred", covariant=True, infer_variance=True)
+```
+
+#### `typing_extensions.TypeVarTuple`
+
+`typing_extensions.TypeVarTuple` backports the variance parameters to older Python versions.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing_extensions import TypeVarTuple
+
+Ts_Co = TypeVarTuple("Ts_Co", covariant=True)
+Ts_Contra = TypeVarTuple("Ts_Contra", contravariant=True)
+Ts_Inferred = TypeVarTuple("Ts_Inferred", infer_variance=True)
+```
+
+## Generic Classes
+
+### Explicit specialization
+
+```py
+from typing import Generic, TypeVar, TypeVarTuple
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+U = TypeVar("U")
+
+class Simple(Generic[*Ts]):
+    attr: tuple[*Ts]
+
+# TODO: revealed: tuple[()]
+reveal_type(Simple[()]().attr)  # revealed: tuple[tuple[()], ...]
+# TODO: revealed: tuple[int, str]
+reveal_type(Simple[int, str]().attr)  # revealed: tuple[tuple[int, str], ...]
+# TODO: revealed: tuple[int, str]
+reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[tuple[int, str], ...]
+
+# TODO: revealed: tuple[Unknown]
+# error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[tuple[Unknown], ...]
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+```
+
+```py
+class Prefix(Generic[T, *Ts]):
+    attr: tuple[T, *Ts]
+
+# TODO: revealed: tuple[int]
+reveal_type(Prefix[int]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...]]
+# TODO: revealed: tuple[int, bool]
+reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...]]
+# TODO: revealed: tuple[int, bool, str]
+reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
+# TODO: revealed: tuple[int, bool, str]
+reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
+
+# TODO: Should this raise an error?
+# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...]]
+reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...]]
+```
+
+```py
+class Suffix(Generic[*Ts, T]):
+    attr: tuple[*Ts, T]
+
+# TODO: revealed: tuple[int]
+reveal_type(Suffix[int]().attr)  # revealed: tuple[*tuple[tuple[()], ...], int]
+# TODO: revealed: tuple[int, str]
+reveal_type(Suffix[int, str]().attr)  # revealed: tuple[*tuple[tuple[int], ...], str]
+# TODO: revealed: tuple[int, str, bool]
+reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
+# TODO: revealed: tuple[int, str, bool]
+reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
+
+# TODO: Should this raise an error?
+# TODO: revealed: tuple[*tuple[Unknown, ...], Unknown]
+reveal_type(Suffix().attr)  # revealed: tuple[*tuple[tuple[Unknown, ...], ...], Unknown]
+```
+
+```py
+class Between(Generic[T, *Ts, U]):
+    attr: tuple[T, *Ts, U]
+
+# TODO: revealed: tuple[int, str]
+reveal_type(Between[int, str]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
+# TODO: revealed: tuple[int, bool, str]
+reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
+# TODO: revealed: tuple[int, bool, bytes, str]
+reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
+# TODO: revealed: tuple[int, bool, str]
+reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
+
+# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+# error: [invalid-type-arguments] "No type argument provided for required type variable `U` of class `Between`"
+reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+```
+
+### Inferred specialization from construction
+
+Calling a generic class without explicit type arguments infers its specialization from the
+constructor arguments.
+
+```py
+from typing import Generic, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+class Positional(Generic[*Ts]):
+    def __init__(self, shape: tuple[*Ts]) -> None:
+        self.shape = shape
+
+class Variadic(Generic[*Ts]):
+    def __init__(self, *shape: *Ts) -> None:
+        self.shape = shape
+
+# TODO: revealed: Positional[()]
+reveal_type(Positional(()))  # revealed: Positional[*tuple[Unknown, ...]]
+# TODO: revealed: Positional[int, str]
+reveal_type(Positional((1, "a")))  # revealed: Positional[int | str]
+
+# TODO: revealed: Variadic[()]
+reveal_type(Variadic())  # revealed: Variadic[*tuple[Unknown, ...]]
+# TODO: revealed: Variadic[int, str]
+reveal_type(Variadic(1, "a"))  # revealed: Variadic[int | str]
+
+def _(i: int, s: str) -> None:
+    # TODO: revealed: Positional[int, str]
+    reveal_type(Positional((i, s)))  # revealed: Positional[int | str]
+    # TODO: revealed: Variadic[int, str]
+    reveal_type(Variadic(i, s))  # revealed: Variadic[int | str]
+```
+
+### Unspecified type arguments
+
+When a generic class parameterized by a type variable tuple is used without any type parameters and
+the `TypeVarTuple` has no default value, it behaves as if the type variable tuple was substituted
+with `tuple[Any, ...]`. ty represents the missing type information as `tuple[Unknown, ...]`,
+distinguishing it from an explicitly provided `tuple[Any, ...]`.
+
+```py
+from typing import Generic, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+class Unspecified(Generic[*Ts]):
+    attr: tuple[*Ts]
+
+unspecified = Unspecified()
+reveal_type(unspecified)  # revealed: Unspecified[*tuple[Unknown, ...]]
+# TODO: revealed: tuple[Unknown, ...]
+reveal_type(unspecified.attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+```
+
+### Default type arguments
+
+A defaulted type variable tuple supplies its unpacked tuple when the generic class is not explicitly
+specialized. Explicit type arguments override the default.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Generic, TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
+
+# error: [invalid-legacy-type-variable] "The default value for `TypeVarTuple` must be an unpacked tuple type or another TypeVarTuple"
+InvalidDefault = TypeVarTuple("InvalidDefault", default=tuple[int, str])
+
+class WithDefault(Generic[*Ts]):
+    attr: tuple[*Ts]
+
+# TODO: revealed: tuple[int, str]
+reveal_type(WithDefault().attr)  # revealed: tuple[tuple[int, str], ...]
+# TODO: revealed: tuple[bool, bytes]
+reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[tuple[bool, bytes], ...]
+```
+
+### Backported default type arguments
+
+`typing_extensions.TypeVarTuple` backports the `default` parameter to older Python versions.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from typing import Generic
+from typing_extensions import TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
+
+class WithBackportedDefault(Generic[*Ts]):
+    attr: tuple[*Ts]
+
+# TODO: revealed: tuple[int, str]
+reveal_type(WithBackportedDefault().attr)  # revealed: tuple[tuple[int, str], ...]
+```
+
+## Type Aliases
+
+### Legacy generic aliases
+
+```py
+from typing import TypeVar, TypeVarTuple
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+U = TypeVar("U")
+
+Simple = tuple[*Ts]
+Between = tuple[T, *Ts, U]
+Prefix = tuple[T, *Ts]
+Suffix = tuple[*Ts, U]
+
+def _(
+    a1: Simple[()],
+    a2: Simple[int, str],
+    a3: Between[int, str],
+    a4: Between[int, bool, str],
+    a5: Between[int, bool, bytes, str],
+    a6: Prefix[bool],
+    a7: Prefix[bool, int, str],
+    a8: Suffix[bool],
+    a9: Suffix[int, str, bool],
+    # error: [invalid-type-arguments] "No type argument provided for required type variable `U`"
+    a10: Between[int],
+):
+    # TODO: revealed: tuple[()]
+    reveal_type(a1)  # revealed: tuple[tuple[()], ...]
+    # TODO: revealed: tuple[int, str]
+    reveal_type(a2)  # revealed: tuple[tuple[int, str], ...]
+    # TODO: revealed: tuple[int, str]
+    reveal_type(a3)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
+    # TODO: revealed: tuple[int, bool, str]
+    reveal_type(a4)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
+    # TODO: revealed: tuple[int, bool, bytes, str]
+    reveal_type(a5)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
+    # TODO: revealed: tuple[bool]
+    reveal_type(a6)  # revealed: tuple[bool, *tuple[tuple[()], ...]]
+    # TODO: revealed: tuple[bool, int, str]
+    reveal_type(a7)  # revealed: tuple[bool, *tuple[tuple[int, str], ...]]
+    # TODO: revealed: tuple[bool]
+    reveal_type(a8)  # revealed: tuple[*tuple[tuple[()], ...], bool]
+    # TODO: revealed: tuple[int, str, bool]
+    reveal_type(a9)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
+    # TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+```
+
+### Unpacked tuple type arguments
+
+```py
+from typing import TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+Alias = tuple[int, *Ts]
+
+def _(a1: Alias[*tuple[str, bool]], a2: Alias[*tuple[str, ...]]) -> None:
+    # TODO: revealed: tuple[int, str, bool]
+    reveal_type(a1)  # revealed: tuple[int, *tuple[tuple[str, bool], ...]]
+    # TODO: revealed: tuple[int, *tuple[str, ...]]
+    reveal_type(a2)  # revealed: tuple[int, *tuple[tuple[str, ...], ...]]
+```
+
+### Unspecified alias type arguments
+
+A bare variadic alias substitutes an unknown-length tuple of `Any`.
+
+```py
+from typing import Any, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+Alias = tuple[bytes, *Ts]
+
+def _(a1: Alias, a2: Alias[*tuple[Any, ...]]) -> None:
+    # TODO: revealed: tuple[bytes, *tuple[Unknown, ...]]
+    reveal_type(a1)  # revealed: tuple[bytes, *tuple[tuple[Unknown, ...], ...]]
+    # TODO: revealed: tuple[bytes, *tuple[Any, ...]]
+    reveal_type(a2)  # revealed: tuple[bytes, *tuple[tuple[Any, ...], ...]]
+```
+
+### Splitting arbitrary-length tuples
+
+```py
+from typing import TypeVar, TypeVarTuple
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+
+First = tuple[*Ts, T]
+Second = tuple[T, *Ts]
+
+def _(
+    f1: First[*tuple[int, ...]],
+    f2: First[*tuple[int, ...], str],
+    s1: Second[*tuple[int, ...]],
+    s2: Second[str, *tuple[int, ...]],
+):
+    # TODO: revealed: tuple[*tuple[int, ...], int]
+    reveal_type(f1)  # revealed: tuple[*tuple[tuple[int, ...], ...], int]
+    # TODO: revealed: tuple[*tuple[int, ...], str]
+    reveal_type(f2)  # revealed: tuple[*tuple[tuple[int, ...], ...], str]
+    # TODO: revealed: tuple[int, *tuple[int, ...]]
+    reveal_type(s1)  # revealed: tuple[int, *tuple[tuple[int, ...], ...]]
+    # TODO: revealed: tuple[str, *tuple[int, ...]]
+    reveal_type(s2)  # revealed: tuple[str, *tuple[tuple[int, ...], ...]]
+```
+
+### Variadic substitutions
+
+Legacy aliases can forward a type variable tuple.
+
+```py
+from typing import TypeVar, TypeVarTuple
+
+Ts = TypeVarTuple("Ts")
+
+First = tuple[bytes, *Ts]
+Second = First[int, *Ts]
+
+def f(a1: First[str, bool], a2: Second[str, bool]) -> None:
+    # TODO: revealed: tuple[bytes, str, bool]
+    reveal_type(a1)  # revealed: tuple[bytes, *tuple[tuple[str, bool], ...]]
+    # TODO: revealed: tuple[bytes, int, str, bool]
+    reveal_type(a2)  # revealed: tuple[bytes, *tuple[tuple[int, *tuple[tuple[str, bool], ...]], ...]]
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -245,75 +245,54 @@ U = TypeVar("U")
 class Simple(Generic[*Ts]):
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[()]
-reveal_type(Simple[()]().attr)  # revealed: tuple[tuple[()], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Simple[int, str]().attr)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[tuple[int, str], ...]
+reveal_type(Simple[()]().attr)  # revealed: tuple[()]
+reveal_type(Simple[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[int, str]
 
-# TODO: revealed: tuple[Unknown]
 # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[tuple[Unknown], ...]
-# TODO: revealed: tuple[Unknown, ...]
+reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[Unknown]
 # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ```py
 class Prefix(Generic[T, *Ts]):
     attr: tuple[T, *Ts]
 
-# TODO: revealed: tuple[int]
-reveal_type(Prefix[int]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...]]
-# TODO: revealed: tuple[int, bool]
-reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...]]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
+reveal_type(Prefix[int]().attr)  # revealed: tuple[int]
+reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, bool]
+reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, bool, str]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...]]
-reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...]]
+reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...]]
 ```
 
 ```py
 class Suffix(Generic[*Ts, T]):
     attr: tuple[*Ts, T]
 
-# TODO: revealed: tuple[int]
-reveal_type(Suffix[int]().attr)  # revealed: tuple[*tuple[tuple[()], ...], int]
-# TODO: revealed: tuple[int, str]
-reveal_type(Suffix[int, str]().attr)  # revealed: tuple[*tuple[tuple[int], ...], str]
-# TODO: revealed: tuple[int, str, bool]
-reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
-# TODO: revealed: tuple[int, str, bool]
-reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
+reveal_type(Suffix[int]().attr)  # revealed: tuple[int]
+reveal_type(Suffix[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[int, str, bool]
+reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[int, str, bool]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[*tuple[Unknown, ...], Unknown]
-reveal_type(Suffix().attr)  # revealed: tuple[*tuple[tuple[Unknown, ...], ...], Unknown]
+reveal_type(Suffix().attr)  # revealed: tuple[*tuple[Unknown, ...], Unknown]
 ```
 
 ```py
 class Between(Generic[T, *Ts, U]):
     attr: tuple[T, *Ts, U]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(Between[int, str]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
-# TODO: revealed: tuple[int, bool, bytes, str]
-reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
+reveal_type(Between[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, bool, bytes, str]
+reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, bool, str]
 
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 # error: [invalid-type-arguments] "No type argument provided for required type variable `U` of class `Between`"
-reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Inferred specialization from construction
@@ -334,21 +313,15 @@ class Variadic(Generic[*Ts]):
     def __init__(self, *shape: *Ts) -> None:
         self.shape = shape
 
-# TODO: revealed: Positional[()]
-reveal_type(Positional(()))  # revealed: Positional[*tuple[Unknown, ...]]
-# TODO: revealed: Positional[int, str]
-reveal_type(Positional((1, "a")))  # revealed: Positional[int | str]
+reveal_type(Positional(()))  # revealed: Positional[()]
+reveal_type(Positional((1, "a")))  # revealed: Positional[int, str]
 
-# TODO: revealed: Variadic[()]
-reveal_type(Variadic())  # revealed: Variadic[*tuple[Unknown, ...]]
-# TODO: revealed: Variadic[int, str]
-reveal_type(Variadic(1, "a"))  # revealed: Variadic[int | str]
+reveal_type(Variadic())  # revealed: Variadic[()]
+reveal_type(Variadic(1, "a"))  # revealed: Variadic[int, str]
 
 def _(i: int, s: str) -> None:
-    # TODO: revealed: Positional[int, str]
-    reveal_type(Positional((i, s)))  # revealed: Positional[int | str]
-    # TODO: revealed: Variadic[int, str]
-    reveal_type(Variadic(i, s))  # revealed: Variadic[int | str]
+    reveal_type(Positional((i, s)))  # revealed: Positional[int, str]
+    reveal_type(Variadic(i, s))  # revealed: Variadic[int, str]
 ```
 
 ### Unspecified type arguments
@@ -368,8 +341,7 @@ class Unspecified(Generic[*Ts]):
 
 unspecified = Unspecified()
 reveal_type(unspecified)  # revealed: Unspecified[*tuple[Unknown, ...]]
-# TODO: revealed: tuple[Unknown, ...]
-reveal_type(unspecified.attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(unspecified.attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ### Default type arguments
@@ -393,10 +365,8 @@ InvalidDefault = TypeVarTuple("InvalidDefault", default=tuple[int, str])
 class WithDefault(Generic[*Ts]):
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithDefault().attr)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[bool, bytes]
-reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[tuple[bool, bytes], ...]
+reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
+reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
 ```
 
 ### Backported default type arguments
@@ -417,8 +387,7 @@ Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
 class WithBackportedDefault(Generic[*Ts]):
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithBackportedDefault().attr)  # revealed: tuple[tuple[int, str], ...]
+reveal_type(WithBackportedDefault().attr)  # revealed: tuple[int, str]
 ```
 
 ## Type Aliases
@@ -450,26 +419,16 @@ def _(
     # error: [invalid-type-arguments] "No type argument provided for required type variable `U`"
     a10: Between[int],
 ):
-    # TODO: revealed: tuple[()]
-    reveal_type(a1)  # revealed: tuple[tuple[()], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a2)  # revealed: tuple[tuple[int, str], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a3)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
-    # TODO: revealed: tuple[int, bool, str]
-    reveal_type(a4)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
-    # TODO: revealed: tuple[int, bool, bytes, str]
-    reveal_type(a5)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a6)  # revealed: tuple[bool, *tuple[tuple[()], ...]]
-    # TODO: revealed: tuple[bool, int, str]
-    reveal_type(a7)  # revealed: tuple[bool, *tuple[tuple[int, str], ...]]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a8)  # revealed: tuple[*tuple[tuple[()], ...], bool]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a9)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
-    # TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+    reveal_type(a1)  # revealed: tuple[()]
+    reveal_type(a2)  # revealed: tuple[int, str]
+    reveal_type(a3)  # revealed: tuple[int, str]
+    reveal_type(a4)  # revealed: tuple[int, bool, str]
+    reveal_type(a5)  # revealed: tuple[int, bool, bytes, str]
+    reveal_type(a6)  # revealed: tuple[bool]
+    reveal_type(a7)  # revealed: tuple[bool, int, str]
+    reveal_type(a8)  # revealed: tuple[bool]
+    reveal_type(a9)  # revealed: tuple[int, str, bool]
+    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Unpacked tuple type arguments
@@ -482,10 +441,8 @@ Ts = TypeVarTuple("Ts")
 Alias = tuple[int, *Ts]
 
 def _(a1: Alias[*tuple[str, bool]], a2: Alias[*tuple[str, ...]]) -> None:
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a1)  # revealed: tuple[int, *tuple[tuple[str, bool], ...]]
-    # TODO: revealed: tuple[int, *tuple[str, ...]]
-    reveal_type(a2)  # revealed: tuple[int, *tuple[tuple[str, ...], ...]]
+    reveal_type(a1)  # revealed: tuple[int, str, bool]
+    reveal_type(a2)  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
 ### Unspecified alias type arguments
@@ -500,10 +457,8 @@ Ts = TypeVarTuple("Ts")
 Alias = tuple[bytes, *Ts]
 
 def _(a1: Alias, a2: Alias[*tuple[Any, ...]]) -> None:
-    # TODO: revealed: tuple[bytes, *tuple[Unknown, ...]]
-    reveal_type(a1)  # revealed: tuple[bytes, *tuple[tuple[Unknown, ...], ...]]
-    # TODO: revealed: tuple[bytes, *tuple[Any, ...]]
-    reveal_type(a2)  # revealed: tuple[bytes, *tuple[tuple[Any, ...], ...]]
+    reveal_type(a1)  # revealed: tuple[bytes, *tuple[Unknown, ...]]
+    reveal_type(a2)  # revealed: tuple[bytes, *tuple[Any, ...]]
 ```
 
 ### Splitting arbitrary-length tuples
@@ -523,14 +478,10 @@ def _(
     s1: Second[*tuple[int, ...]],
     s2: Second[str, *tuple[int, ...]],
 ):
-    # TODO: revealed: tuple[*tuple[int, ...], int]
-    reveal_type(f1)  # revealed: tuple[*tuple[tuple[int, ...], ...], int]
-    # TODO: revealed: tuple[*tuple[int, ...], str]
-    reveal_type(f2)  # revealed: tuple[*tuple[tuple[int, ...], ...], str]
-    # TODO: revealed: tuple[int, *tuple[int, ...]]
-    reveal_type(s1)  # revealed: tuple[int, *tuple[tuple[int, ...], ...]]
-    # TODO: revealed: tuple[str, *tuple[int, ...]]
-    reveal_type(s2)  # revealed: tuple[str, *tuple[tuple[int, ...], ...]]
+    reveal_type(f1)  # revealed: tuple[*tuple[int, ...], int]
+    reveal_type(f2)  # revealed: tuple[*tuple[int, ...], str]
+    reveal_type(s1)  # revealed: tuple[int, *tuple[int, ...]]
+    reveal_type(s2)  # revealed: tuple[str, *tuple[int, ...]]
 ```
 
 ### Variadic substitutions
@@ -546,8 +497,6 @@ First = tuple[bytes, *Ts]
 Second = First[int, *Ts]
 
 def f(a1: First[str, bool], a2: Second[str, bool]) -> None:
-    # TODO: revealed: tuple[bytes, str, bool]
-    reveal_type(a1)  # revealed: tuple[bytes, *tuple[tuple[str, bool], ...]]
-    # TODO: revealed: tuple[bytes, int, str, bool]
-    reveal_type(a2)  # revealed: tuple[bytes, *tuple[tuple[int, *tuple[tuple[str, bool], ...]], ...]]
+    reveal_type(a1)  # revealed: tuple[bytes, str, bool]
+    reveal_type(a2)  # revealed: tuple[bytes, int, str, bool]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -359,6 +359,9 @@ from typing import Generic, TypeVar, TypeVarTuple, Unpack
 
 Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
 
+OtherTs = TypeVarTuple("OtherTs")
+CopiedTs = TypeVarTuple("CopiedTs", default=Unpack[OtherTs])
+
 # error: [invalid-legacy-type-variable] "The default value for `TypeVarTuple` must be an unpacked tuple type or another TypeVarTuple"
 InvalidDefault = TypeVarTuple("InvalidDefault", default=tuple[int, str])
 
@@ -392,6 +395,8 @@ from typing import Generic
 from typing_extensions import TypeVarTuple, Unpack
 
 Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
+reveal_type(Ts.__default__)  # revealed: tuple[int, str]
+reveal_type(Ts.has_default())  # revealed: bool
 
 class WithBackportedDefault(Generic[*Ts]):
     attr: tuple[*Ts]

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -355,7 +355,7 @@ python-version = "3.13"
 ```
 
 ```py
-from typing import Generic, TypeVarTuple, Unpack
+from typing import Generic, TypeVar, TypeVarTuple, Unpack
 
 Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
 
@@ -366,7 +366,16 @@ class WithDefault(Generic[*Ts]):
     attr: tuple[*Ts]
 
 reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
+reveal_type(WithDefault[()]().attr)  # revealed: tuple[()]
 reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
+
+T = TypeVar("T")
+
+class PrefixWithDefault(Generic[T, *Ts]):
+    attr: tuple[T, *Ts]
+
+reveal_type(PrefixWithDefault[bool]().attr)  # revealed: tuple[bool, int, str]
+reveal_type(PrefixWithDefault[bool, *tuple[()]]().attr)  # revealed: tuple[bool]
 ```
 
 ### Backported default type arguments
@@ -467,21 +476,39 @@ def _(a1: Alias, a2: Alias[*tuple[Any, ...]]) -> None:
 from typing import TypeVar, TypeVarTuple
 
 T = TypeVar("T")
+U = TypeVar("U")
 Ts = TypeVarTuple("Ts")
 
 First = tuple[*Ts, T]
 Second = tuple[T, *Ts]
+Middle = tuple[T, *Ts, U]
+PrefixTwo = tuple[T, U, *Ts]
+SuffixTwo = tuple[*Ts, T, U]
 
 def _(
     f1: First[*tuple[int, ...]],
     f2: First[*tuple[int, ...], str],
     s1: Second[*tuple[int, ...]],
     s2: Second[str, *tuple[int, ...]],
+    m1: Middle[*tuple[int, ...]],
+    m2: Middle[*tuple[int, ...], str],
+    m3: Middle[str, *tuple[int, ...]],
+    p1: PrefixTwo[*tuple[int, ...]],
+    p2: PrefixTwo[*tuple[int, ...], str],
+    s3: SuffixTwo[*tuple[int, ...]],
+    s4: SuffixTwo[*tuple[int, ...], str],
 ):
     reveal_type(f1)  # revealed: tuple[*tuple[int, ...], int]
     reveal_type(f2)  # revealed: tuple[*tuple[int, ...], str]
     reveal_type(s1)  # revealed: tuple[int, *tuple[int, ...]]
     reveal_type(s2)  # revealed: tuple[str, *tuple[int, ...]]
+    reveal_type(m1)  # revealed: tuple[int, *tuple[int, ...], int]
+    reveal_type(m2)  # revealed: tuple[int, *tuple[int, ...], str]
+    reveal_type(m3)  # revealed: tuple[str, *tuple[int, ...], int]
+    reveal_type(p1)  # revealed: tuple[int, int, *tuple[int, ...]]
+    reveal_type(p2)  # revealed: tuple[int, int, *tuple[int, ...], str]
+    reveal_type(s3)  # revealed: tuple[*tuple[int, ...], int, int]
+    reveal_type(s4)  # revealed: tuple[*tuple[int, ...], int, str]
 ```
 
 ### Variadic substitutions

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/typevartuple.md
@@ -96,23 +96,6 @@ from typing import TypeVarTuple
 Ts = TypeVarTuple("Ts", bound=int)
 ```
 
-#### `typing_extensions.TypeVarTuple`
-
-`typing_extensions.TypeVarTuple` exposes the `bound` parameter on older Python versions. ty
-recognizes the backport but does not yet support the parameter.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from typing_extensions import TypeVarTuple
-
-# error: [invalid-legacy-type-variable] "The `bound` argument for `TypeVarTuple` is not supported"
-Ts = TypeVarTuple("Ts", bound=int)
-```
-
 ### Variance
 
 Legacy `TypeVarTuple` accepts `covariant` and `contravariant` arguments. A `TypeVarTuple` with no
@@ -212,23 +195,6 @@ AmbiguousContravariant = TypeVarTuple("AmbiguousContravariant", contravariant=co
 AmbiguousInferVariance = TypeVarTuple("AmbiguousInferVariance", infer_variance=cond())
 # error: [invalid-legacy-type-variable]
 CovariantAndInferred = TypeVarTuple("CovariantAndInferred", covariant=True, infer_variance=True)
-```
-
-#### `typing_extensions.TypeVarTuple`
-
-`typing_extensions.TypeVarTuple` backports the variance parameters to older Python versions.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from typing_extensions import TypeVarTuple
-
-Ts_Co = TypeVarTuple("Ts_Co", covariant=True)
-Ts_Contra = TypeVarTuple("Ts_Contra", contravariant=True)
-Ts_Inferred = TypeVarTuple("Ts_Inferred", infer_variance=True)
 ```
 
 ## Generic Classes

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
@@ -1,0 +1,175 @@
+# Legacy `typing.Unpack`
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+`Unpack[Ts]` is the legacy spelling of `*Ts`. The shared semantics of type variable tuples are
+covered in `../pep695/typevartuple.md`; this file checks the distinct syntax paths used by `Unpack`.
+
+## Generic specialization
+
+`Unpack` can introduce a type variable tuple in a legacy generic declaration. An unpacked fixed
+tuple can also provide multiple type arguments when specializing the generic.
+
+```py
+from typing import Generic, TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts")
+
+class Array(Generic[Unpack[Ts]]):
+    value: tuple[Unpack[Ts]]
+
+# TODO: revealed: tuple[()]
+reveal_type(Array[()]().value)  # revealed: tuple[tuple[()], ...]
+# TODO: revealed: tuple[int, str]
+reveal_type(Array[int, str]().value)  # revealed: tuple[tuple[int, str], ...]
+# TODO: revealed: tuple[int, str]
+reveal_type(Array[Unpack[tuple[int, str]]]().value)  # revealed: tuple[tuple[int, str], ...]
+```
+
+## Variadic parameter inference
+
+An unpacked type variable tuple used for `*args` preserves the number and types of positional
+arguments.
+
+```py
+from typing import TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts")
+
+def collect(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
+    reveal_type(args)  # revealed: tuple[*Ts@collect]
+    raise NotImplementedError
+
+# TODO: revealed: tuple[()]
+reveal_type(collect())  # revealed: tuple[tuple[Unknown, ...], ...]
+# TODO: revealed: tuple[Literal[1], Literal["a"]]
+reveal_type(collect(1, "a"))  # revealed: tuple[Literal[1, "a"], ...]
+```
+
+## Callable parameters
+
+`Unpack` expands a type variable tuple into a callable's positional parameter list. The same tuple
+can describe the arguments forwarded to that callable.
+
+```py
+from typing import Callable, TypeVar, TypeVarTuple, Unpack
+
+R = TypeVar("R")
+Ts = TypeVarTuple("Ts")
+
+def invoke(
+    callback: Callable[[Unpack[Ts]], R],
+    *args: Unpack[Ts],
+) -> R:
+    raise NotImplementedError
+
+def format_value(value: int, label: str, /) -> str:
+    return f"{label}: {value}"
+
+# TODO: revealed: str
+# error: [invalid-argument-type]
+reveal_type(invoke(format_value, 1, "value"))  # revealed: Unknown
+# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> str`, found `def format_value(value: int, label: str, /) -> str`"
+# TODO: revealed: str
+# error: [invalid-argument-type]
+reveal_type(invoke(format_value, 1))  # revealed: Unknown
+```
+
+## Type aliases
+
+A legacy alias can use `Unpack[Ts]` and accept either individual types or an unpacked tuple type.
+
+```py
+from typing import TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts")
+
+Alias = tuple[int, Unpack[Ts]]
+
+def f(
+    fixed: Alias[str, bool],
+    unbounded: Alias[Unpack[tuple[str, ...]]],
+) -> None:
+    # TODO: revealed: tuple[int, str, bool]
+    reveal_type(fixed)  # revealed: tuple[int, *tuple[tuple[str, bool], ...]]
+    # TODO: revealed: tuple[int, *tuple[str, ...]]
+    reveal_type(unbounded)  # revealed: tuple[int, *tuple[tuple[str, ...], ...]]
+```
+
+## Concrete and nested tuple unpacking
+
+`Unpack` can expand a concrete tuple annotation for `*args`, including a nested unbounded tuple.
+
+```py
+from typing import Unpack
+
+def accept(
+    *args: Unpack[tuple[bool, Unpack[tuple[str, ...]], bytes]],
+) -> None: ...
+
+accept(True, "phase", "status", b"ok")
+accept(True, b"ok")
+# TODO: error: [invalid-argument-type] "Argument to function `accept` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
+accept(True, 1, b"bad")
+```
+
+## Defaults
+
+A type variable tuple default can use `Unpack`, and an explicit specialization overrides it.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import Generic, TypeVarTuple, Unpack
+
+Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
+
+class WithDefault(Generic[Unpack[Ts]]):
+    value: tuple[Unpack[Ts]]
+
+# TODO: revealed: tuple[int, str]
+reveal_type(WithDefault().value)  # revealed: tuple[tuple[int, str], ...]
+# TODO: revealed: tuple[bool, bytes]
+reveal_type(WithDefault[bool, bytes]().value)  # revealed: tuple[tuple[bool, bytes], ...]
+```
+
+## Validation
+
+`Unpack` requires a tuple operand, and a tuple specialization can contain only one variadic unpack.
+
+```py
+from typing import Generic, TypeVar, TypeVarTuple, Unpack
+
+U = TypeVar("U")
+Ts = TypeVarTuple("Ts")
+
+class Pair(Generic[Unpack[Ts], U]): ...
+
+def invalid(
+    # error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
+    non_tuple: Pair[Unpack[int], str],
+    # error: [invalid-type-form] "Multiple unpacked variadic tuples are not allowed in a `tuple` specialization"
+    multiple: tuple[Unpack[Ts], Unpack[tuple[str, ...]]],
+) -> None:
+    reveal_type(non_tuple)  # revealed: Pair[*tuple[Unknown, ...], str]
+
+# error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
+def invalid_vararg(*args: Unpack[int]) -> None:
+    reveal_type(args)  # revealed: tuple[Unknown, ...]
+
+# error: [invalid-type-form] "`Unpack` can only unpack a tuple type or `TypeVarTuple`"
+def invalid_stringified_vararg(*args: "Unpack[int]") -> None:
+    reveal_type(args)  # revealed: tuple[Unknown, ...]
+
+# error: [invalid-type-form] "`Unpack` cannot be nested"
+def nested(*args: Unpack[Unpack[tuple[int, ...]]]) -> None: ...
+
+# error: [invalid-type-form] "Bare TypeVarTuple `Ts` is not valid in this context in a parameter annotation"
+def nested_bare_typevartuple(*args: Unpack[tuple[Ts]]) -> None: ...
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
@@ -21,12 +21,9 @@ Ts = TypeVarTuple("Ts")
 class Array(Generic[Unpack[Ts]]):
     value: tuple[Unpack[Ts]]
 
-# TODO: revealed: tuple[()]
-reveal_type(Array[()]().value)  # revealed: tuple[tuple[()], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Array[int, str]().value)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Array[Unpack[tuple[int, str]]]().value)  # revealed: tuple[tuple[int, str], ...]
+reveal_type(Array[()]().value)  # revealed: tuple[()]
+reveal_type(Array[int, str]().value)  # revealed: tuple[int, str]
+reveal_type(Array[Unpack[tuple[int, str]]]().value)  # revealed: tuple[int, str]
 ```
 
 ## Variadic parameter inference
@@ -43,10 +40,8 @@ def collect(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
     reveal_type(args)  # revealed: tuple[*Ts@collect]
     raise NotImplementedError
 
-# TODO: revealed: tuple[()]
-reveal_type(collect())  # revealed: tuple[tuple[Unknown, ...], ...]
-# TODO: revealed: tuple[Literal[1], Literal["a"]]
-reveal_type(collect(1, "a"))  # revealed: tuple[Literal[1, "a"], ...]
+reveal_type(collect())  # revealed: tuple[()]
+reveal_type(collect(1, "a"))  # revealed: tuple[Literal[1], Literal["a"]]
 ```
 
 ## Callable parameters
@@ -69,13 +64,9 @@ def invoke(
 def format_value(value: int, label: str, /) -> str:
     return f"{label}: {value}"
 
-# TODO: revealed: str
-# error: [invalid-argument-type]
-reveal_type(invoke(format_value, 1, "value"))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> str`, found `def format_value(value: int, label: str, /) -> str`"
-# TODO: revealed: str
-# error: [invalid-argument-type]
-reveal_type(invoke(format_value, 1))  # revealed: Unknown
+reveal_type(invoke(format_value, 1, "value"))  # revealed: str
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> str`, found `def format_value(value: int, label: str, /) -> str`"
+reveal_type(invoke(format_value, 1))  # revealed: str
 ```
 
 ## Type aliases
@@ -93,10 +84,8 @@ def f(
     fixed: Alias[str, bool],
     unbounded: Alias[Unpack[tuple[str, ...]]],
 ) -> None:
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(fixed)  # revealed: tuple[int, *tuple[tuple[str, bool], ...]]
-    # TODO: revealed: tuple[int, *tuple[str, ...]]
-    reveal_type(unbounded)  # revealed: tuple[int, *tuple[tuple[str, ...], ...]]
+    reveal_type(fixed)  # revealed: tuple[int, str, bool]
+    reveal_type(unbounded)  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
 ## Concrete and nested tuple unpacking
@@ -112,7 +101,7 @@ def accept(
 
 accept(True, "phase", "status", b"ok")
 accept(True, b"ok")
-# TODO: error: [invalid-argument-type] "Argument to function `accept` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
+# error: [invalid-argument-type] "Argument to function `accept` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
 accept(True, 1, b"bad")
 ```
 
@@ -133,10 +122,8 @@ Ts = TypeVarTuple("Ts", default=Unpack[tuple[int, str]])
 class WithDefault(Generic[Unpack[Ts]]):
     value: tuple[Unpack[Ts]]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithDefault().value)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[bool, bytes]
-reveal_type(WithDefault[bool, bytes]().value)  # revealed: tuple[tuple[bool, bytes], ...]
+reveal_type(WithDefault().value)  # revealed: tuple[int, str]
+reveal_type(WithDefault[bool, bytes]().value)  # revealed: tuple[bool, bytes]
 ```
 
 ## Validation

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
@@ -74,6 +74,10 @@ def format_value(value: int, label: str, /) -> str:
 reveal_type(invoke(format_value, 1, "value"))  # revealed: str
 # error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> str`, found `def format_value(value: int, label: str, /) -> str`"
 reveal_type(invoke(format_value, 1))  # revealed: str
+
+def fixed(x: int, y: str, /) -> None: ...
+
+fixed_callback: Callable[[Unpack[tuple[int, str]]], None] = fixed
 ```
 
 ## Type aliases

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/unpack.md
@@ -42,6 +42,13 @@ def collect(*args: Unpack[Ts]) -> tuple[Unpack[Ts]]:
 
 reveal_type(collect())  # revealed: tuple[()]
 reveal_type(collect(1, "a"))  # revealed: tuple[Literal[1], Literal["a"]]
+
+def splatted(
+    fixed: tuple[int, str],
+    homogeneous: tuple[bytes, ...],
+) -> None:
+    reveal_type(collect(*fixed))  # revealed: tuple[int, str]
+    reveal_type(collect(*homogeneous))  # revealed: tuple[bytes, ...]
 ```
 
 ## Callable parameters

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -26,15 +26,13 @@ reveal_type(generic_context(SingleTypevar))
 # revealed: ty_extensions.GenericContext[T@MultipleTypevars, S@MultipleTypevars]
 reveal_type(generic_context(MultipleTypevars))
 
-# TODO: support `TypeVarTuple` properly
-# (these should include the `TypeVarTuple`s in their generic contexts)
 # revealed: ty_extensions.GenericContext[P@SingleParamSpec]
 reveal_type(generic_context(SingleParamSpec))
 # revealed: ty_extensions.GenericContext[T@TypeVarAndParamSpec, P@TypeVarAndParamSpec]
 reveal_type(generic_context(TypeVarAndParamSpec))
-# revealed: ty_extensions.GenericContext[]
+# revealed: ty_extensions.GenericContext[Ts@SingleTypeVarTuple]
 reveal_type(generic_context(SingleTypeVarTuple))
-# revealed: ty_extensions.GenericContext[T@TypeVarAndTypeVarTuple]
+# revealed: ty_extensions.GenericContext[T@TypeVarAndTypeVarTuple, Ts@TypeVarAndTypeVarTuple]
 reveal_type(generic_context(TypeVarAndTypeVarTuple))
 ```
 
@@ -709,18 +707,20 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 
 ```py
 # snapshot: invalid-type-variable-default
+# error: [invalid-type-form] "TypeVarTuple `Ts` cannot appear after TypeVarTuple `Us`"
+# error: [invalid-type-form] "Multiple unpacked variadic tuples are not allowed in a `tuple` specialization"
 type Alias4[*Us, *Ts = *tuple[int, str]] = tuple[*Us, *Ts]
 ```
 
 ```snapshot
 error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
- --> src/mdtest_snippet.py:8:13
-  |
-8 | type Alias4[*Us, *Ts = *tuple[int, str]] = tuple[*Us, *Ts]
-  |             ---  ^^^^^^^^^^^^^^^^^^^^^^ `Ts` has a default
-  |             |
-  |             `Us` is a TypeVarTuple
-  |
+  --> src/mdtest_snippet.py:10:13
+   |
+10 | type Alias4[*Us, *Ts = *tuple[int, str]] = tuple[*Us, *Ts]
+   |             ---  ^^^^^^^^^^^^^^^^^^^^^^ `Ts` has a default
+   |             |
+   |             `Us` is a TypeVarTuple
+   |
 info: See https://typing.python.org/en/latest/spec/generics.html#defaults-following-typevartuple
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -25,15 +25,13 @@ reveal_type(generic_context(SingleTypevar))
 # revealed: ty_extensions.GenericContext[T@MultipleTypevars, S@MultipleTypevars]
 reveal_type(generic_context(MultipleTypevars))
 
-# TODO: support `TypeVarTuple` properly
-# (these should include the `TypeVarTuple`s in their generic contexts)
 # revealed: ty_extensions.GenericContext[P@SingleParamSpec]
 reveal_type(generic_context(SingleParamSpec))
 # revealed: ty_extensions.GenericContext[T@TypeVarAndParamSpec, P@TypeVarAndParamSpec]
 reveal_type(generic_context(TypeVarAndParamSpec))
-# revealed: ty_extensions.GenericContext[]
+# revealed: ty_extensions.GenericContext[Ts@SingleTypeVarTuple]
 reveal_type(generic_context(SingleTypeVarTuple))
-# revealed: ty_extensions.GenericContext[T@TypeVarAndTypeVarTuple]
+# revealed: ty_extensions.GenericContext[T@TypeVarAndTypeVarTuple, Ts@TypeVarAndTypeVarTuple]
 reveal_type(generic_context(TypeVarAndTypeVarTuple))
 ```
 
@@ -978,6 +976,7 @@ class Quux[*Ts, T1 = int, **P = [int, str]]: ...
 class Corge[*Ts, T1 = int, T2 = str, **P = [int, str]]: ...
 
 # error: [invalid-type-variable-default]
+# error: [invalid-type-form] "TypeVarTuple `Ts` cannot appear after TypeVarTuple `Us`"
 class Grault[*Us, *Ts = *tuple[int, str]]: ...
 
 # These are fine:

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -567,7 +567,7 @@ reveal_type(only_variadic)  # revealed: (...) -> None
 @decorator
 def unpack_variadic(*args: *tuple[int, *tuple[str, ...]], **kwargs: int) -> None: ...
 
-reveal_type(unpack_variadic)  # revealed: (...) -> None
+reveal_type(unpack_variadic)  # revealed: (*args: str, **kwargs: int) -> None
 ```
 
 ## `Concatenate` with `ParamSpec` in generic function calls

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -564,8 +564,6 @@ def only_variadic(*args: str, **kwargs: int) -> None: ...
 
 reveal_type(only_variadic)  # revealed: (...) -> None
 
-# TODO: This should accept the callable and reveal `(*args: str, **kwargs: int) -> None`.
-# error: [invalid-argument-type]
 @decorator
 def unpack_variadic(*args: *tuple[int, *tuple[str, ...]], **kwargs: int) -> None: ...
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/concatenate.md
@@ -568,6 +568,23 @@ reveal_type(only_variadic)  # revealed: (...) -> None
 def unpack_variadic(*args: *tuple[int, *tuple[str, ...]], **kwargs: int) -> None: ...
 
 reveal_type(unpack_variadic)  # revealed: (*args: str, **kwargs: int) -> None
+
+def returning_decorator[**P, R](
+    func: Callable[Concatenate[int, P], R],
+) -> Callable[P, R]:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        return func(0, *args, **kwargs)
+    return wrapper
+
+@returning_decorator
+def mixed_unpack(
+    *args: *tuple[int, *tuple[str, ...], bytes],
+    **kwargs: int,
+) -> str:
+    return ""
+
+reveal_type(mixed_unpack(b"end"))  # revealed: str
+reveal_type(mixed_unpack("one", "two", b"end", key=1))  # revealed: str
 ```
 
 ## `Concatenate` with `ParamSpec` in generic function calls

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -49,75 +49,54 @@ invariant_in: InvariantArray[int] = InvariantArray[object]()  # error: [invalid-
 class Simple[*Ts]:
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[()]
-reveal_type(Simple[()]().attr)  # revealed: tuple[tuple[()], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Simple[int, str]().attr)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[int, str]
-reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[tuple[int, str], ...]
+reveal_type(Simple[()]().attr)  # revealed: tuple[()]
+reveal_type(Simple[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[int, str]
 
-# TODO: revealed: tuple[Unknown]
 # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[tuple[Unknown], ...]
-# TODO: revealed: tuple[Unknown, ...]
+reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[Unknown]
 # error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
-reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ```py
 class Prefix[T, *Ts]:
     attr: tuple[T, *Ts]
 
-# TODO: revealed: tuple[int]
-reveal_type(Prefix[int]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...]]
-# TODO: revealed: tuple[int, bool]
-reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...]]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
+reveal_type(Prefix[int]().attr)  # revealed: tuple[int]
+reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, bool]
+reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, bool, str]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...]]
-reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...]]
+reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...]]
 ```
 
 ```py
 class Suffix[*Ts, T]:
     attr: tuple[*Ts, T]
 
-# TODO: revealed: tuple[int]
-reveal_type(Suffix[int]().attr)  # revealed: tuple[*tuple[tuple[()], ...], int]
-# TODO: revealed: tuple[int, str]
-reveal_type(Suffix[int, str]().attr)  # revealed: tuple[*tuple[tuple[int], ...], str]
-# TODO: revealed: tuple[int, str, bool]
-reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
-# TODO: revealed: tuple[int, str, bool]
-reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
+reveal_type(Suffix[int]().attr)  # revealed: tuple[int]
+reveal_type(Suffix[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[int, str, bool]
+reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[int, str, bool]
 
 # TODO: Should this raise an error?
-# TODO: revealed: tuple[*tuple[Unknown, ...], Unknown]
-reveal_type(Suffix().attr)  # revealed: tuple[*tuple[tuple[Unknown, ...], ...], Unknown]
+reveal_type(Suffix().attr)  # revealed: tuple[*tuple[Unknown, ...], Unknown]
 ```
 
 ```py
 class Between[T, *Ts, U]:
     attr: tuple[T, *Ts, U]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(Between[int, str]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
-# TODO: revealed: tuple[int, bool, bytes, str]
-reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
-# TODO: revealed: tuple[int, bool, str]
-reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
+reveal_type(Between[int, str]().attr)  # revealed: tuple[int, str]
+reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, bool, str]
+reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, bool, bytes, str]
+reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, bool, str]
 
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
-# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 # error: [invalid-type-arguments] "No type argument provided for required type variable `U` of class `Between`"
-reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Inferred specialization from construction
@@ -134,21 +113,15 @@ class Variadic[*Ts]:
     def __init__(self, *shape: *Ts) -> None:
         self.shape = shape
 
-# TODO: revealed: Positional[()]
-reveal_type(Positional(()))  # revealed: Positional[*tuple[Unknown, ...]]
-# TODO: revealed: Positional[int, str]
-reveal_type(Positional((1, "a")))  # revealed: Positional[int | str]
+reveal_type(Positional(()))  # revealed: Positional[()]
+reveal_type(Positional((1, "a")))  # revealed: Positional[int, str]
 
-# TODO: revealed: Variadic[()]
-reveal_type(Variadic())  # revealed: Variadic[*tuple[Unknown, ...]]
-# TODO: revealed: Variadic[int, str]
-reveal_type(Variadic(1, "a"))  # revealed: Variadic[int | str]
+reveal_type(Variadic())  # revealed: Variadic[()]
+reveal_type(Variadic(1, "a"))  # revealed: Variadic[int, str]
 
 def _(i: int, s: str) -> None:
-    # TODO: revealed: Positional[int, str]
-    reveal_type(Positional((i, s)))  # revealed: Positional[int | str]
-    # TODO: revealed: Variadic[int, str]
-    reveal_type(Variadic(i, s))  # revealed: Variadic[int | str]
+    reveal_type(Positional((i, s)))  # revealed: Positional[int, str]
+    reveal_type(Variadic(i, s))  # revealed: Variadic[int, str]
 ```
 
 ### Unspecified type arguments
@@ -163,8 +136,7 @@ class Unspecified[*Ts]:
 
 unspecified = Unspecified()
 reveal_type(unspecified)  # revealed: Unspecified[*tuple[Unknown, ...]]
-# TODO: revealed: tuple[Unknown, ...]
-reveal_type(unspecified.attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(unspecified.attr)  # revealed: tuple[Unknown, ...]
 ```
 
 ### Default type arguments
@@ -181,10 +153,8 @@ python-version = "3.13"
 class WithDefault[*Ts = *tuple[int, str]]:
     attr: tuple[*Ts]
 
-# TODO: revealed: tuple[int, str]
-reveal_type(WithDefault().attr)  # revealed: tuple[tuple[int, str], ...]
-# TODO: revealed: tuple[bool, bytes]
-reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[tuple[bool, bytes], ...]
+reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
+reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
 ```
 
 ### Assignment checks
@@ -233,16 +203,11 @@ def with_both[T, *Ts, U](x: tuple[T, *Ts, U]) -> tuple[*Ts]:
     raise NotImplementedError
 
 def f(i: int, s: str, b: bool) -> None:
-    # TODO: revealed: tuple[()]
-    reveal_type(simple(()))  # revealed: tuple[tuple[Unknown, ...], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(simple((i, s)))  # revealed: tuple[int | str, ...]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(with_prefix(i, (s, b)))  # revealed: tuple[int, *tuple[str | bool, ...]]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(with_suffix((i, s), b))  # revealed: tuple[*tuple[int | str, ...], bool]
-    # TODO: revealed: tuple[str]
-    reveal_type(with_both((i, s, b)))  # revealed: tuple[str, ...]
+    reveal_type(simple(()))  # revealed: tuple[()]
+    reveal_type(simple((i, s)))  # revealed: tuple[int, str]
+    reveal_type(with_prefix(i, (s, b)))  # revealed: tuple[int, str, bool]
+    reveal_type(with_suffix((i, s), b))  # revealed: tuple[int, str, bool]
+    reveal_type(with_both((i, s, b)))  # revealed: tuple[str]
 ```
 
 ### Starred variadic parameters
@@ -262,17 +227,12 @@ def kw_only[T, *Ts](*args: *Ts, kw: T) -> tuple[*Ts, T]:
     raise NotImplementedError
 
 def f(i: int, s: str, b: bool) -> None:
-    # TODO: revealed: tuple[()]
-    reveal_type(simple())  # revealed: tuple[tuple[Unknown, ...], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(simple(i, s))  # revealed: tuple[int | str, ...]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(with_prefix(i, s, b))  # revealed: tuple[int, *tuple[str | bool, ...]]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(kw_only(i, s, kw=b))  # revealed: tuple[*tuple[int | str, ...], bool]
-    # TODO: revealed: tuple[int, str, bool, Unknown]
+    reveal_type(simple())  # revealed: tuple[()]
+    reveal_type(simple(i, s))  # revealed: tuple[int, str]
+    reveal_type(with_prefix(i, s, b))  # revealed: tuple[int, str, bool]
+    reveal_type(kw_only(i, s, kw=b))  # revealed: tuple[int, str, bool]
     # error: [missing-argument] "No argument provided for required parameter `kw` of function `kw_only`"
-    reveal_type(kw_only(i, s, b))  # revealed: tuple[*tuple[int | str, ...], Unknown]
+    reveal_type(kw_only(i, s, b))  # revealed: tuple[int, str, bool, Unknown]
 ```
 
 ### Callable parameters
@@ -304,25 +264,15 @@ def variadic2(*args: int) -> tuple[str, ...]:
 def keyword_only(*, x: int) -> tuple[int]:
     raise NotImplementedError
 
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(simple(positional_only))  # revealed: tuple[tuple[Unknown, ...], ...]
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(simple(standard))  # revealed: tuple[tuple[Unknown, ...], ...]
-# TODO: revealed: tuple[int, *tuple[str, ...]]
-# error: [invalid-argument-type]
-reveal_type(simple(positional_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(simple(positional_only))  # revealed: tuple[int, str]
+reveal_type(simple(standard))  # revealed: tuple[int, str]
+reveal_type(simple(positional_variadic))  # revealed: tuple[int, *tuple[str, ...]]
 reveal_type(simple(variadic1))  # revealed: tuple[int, ...]
 
-# TODO: error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: int) -> tuple[int, ...]`, found `def variadic2(*args: int) -> tuple[str, ...]`"
-# TODO: revealed: tuple[int, ...]
-# error: [invalid-argument-type]
-reveal_type(simple(variadic2))  # revealed: tuple[tuple[Unknown, ...], ...]
-# TODO: error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: Unknown) -> tuple[Unknown, ...]`, found `def keyword_only(*, x: int) -> tuple[int]`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(simple(keyword_only))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: int) -> tuple[int, ...]`, found `def variadic2(*args: int) -> tuple[str, ...]`"
+reveal_type(simple(variadic2))  # revealed: tuple[int, ...]
+# error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: Unknown) -> tuple[Unknown, ...]`, found `def keyword_only(*, x: int) -> tuple[int]`"
+reveal_type(simple(keyword_only))  # revealed: tuple[Unknown, ...]
 ```
 
 This usage pattern is similar to how `ParamSpec` can be used to accept a callable and its arguments
@@ -332,42 +282,24 @@ except that in the case of `TypeVarTuple` all parameters are positional-only.
 def invoke[*Ts, R](callback: Callable[[*Ts], R], *args: *Ts) -> R:
     raise NotImplementedError
 
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_only, 1, "a"))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_only))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_only, 1))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(int, Literal[2] | str, /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_only, 1, 2))  # revealed: Unknown
+reveal_type(invoke(positional_only, 1, "a"))  # revealed: tuple[int, str]
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+reveal_type(invoke(positional_only))  # revealed: tuple[int, str]
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+reveal_type(invoke(positional_only, 1))  # revealed: tuple[int, str]
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(int, Literal[2] | str, /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+reveal_type(invoke(positional_only, 1, 2))  # revealed: tuple[int, str]
 
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
-reveal_type(invoke(standard, 1, "a"))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def standard(x: int, y: str) -> tuple[int, str]`"
-# TODO: revealed: tuple[int, str]
-# error: [invalid-argument-type]
+reveal_type(invoke(standard, 1, "a"))  # revealed: tuple[int, str]
 # error: [unknown-argument] "Argument `x` does not match any known parameter of function `invoke`"
 # error: [unknown-argument] "Argument `y` does not match any known parameter of function `invoke`"
-reveal_type(invoke(standard, x=1, y="a"))  # revealed: Unknown
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def standard(x: int, y: str) -> tuple[int, str]`"
+reveal_type(invoke(standard, x=1, y="a"))  # revealed: tuple[int, str]
 
-# TODO: revealed: tuple[int, *tuple[str, ...]]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_variadic, 1, "a", "b"))  # revealed: Unknown
-# TODO: revealed: tuple[int, *tuple[str, ...]]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_variadic, 1))  # revealed: Unknown
-# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, *tuple[str, ...]]`, found `def positional_variadic(x: int, *args: str) -> tuple[int, *tuple[str, ...]]`"
-# TODO: revealed: tuple[int, *tuple[str, ...]]
-# error: [invalid-argument-type]
-reveal_type(invoke(positional_variadic))  # revealed: Unknown
+reveal_type(invoke(positional_variadic, 1, "a", "b"))  # revealed: tuple[int, *tuple[str, ...]]
+reveal_type(invoke(positional_variadic, 1))  # revealed: tuple[int, *tuple[str, ...]]
+# error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, *tuple[str, ...]]`, found `def positional_variadic(x: int, *args: str) -> tuple[int, *tuple[str, ...]]`"
+reveal_type(invoke(positional_variadic))  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
 ### Callable inference with fixed positional parameters
@@ -384,13 +316,9 @@ def infer_with_suffix[*Ts](callback: Callable[[int, *Ts, bytes], None]) -> tuple
 def fixed_suffix(prefix: int, middle: str, suffix: bytes, /) -> None: ...
 def unpacked_suffix(*args: *tuple[int, *tuple[str, ...], bytes]) -> None: ...
 
-# TODO: revealed: tuple[str]
-# error: [invalid-argument-type]
-reveal_type(infer_with_suffix(fixed_suffix))  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(infer_with_suffix(fixed_suffix))  # revealed: tuple[str]
 # TODO: Should reveal `tuple[str, ...]`.
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_with_suffix(unpacked_suffix))  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(infer_with_suffix(unpacked_suffix))  # revealed: tuple[Unknown, ...]
 ```
 
 ### Callable inference with additional keyword parameters
@@ -408,15 +336,11 @@ def optional_keyword_only(x: int, y: str, *, debug: bool = False) -> None: ...
 def extra_keywords(x: int, y: str, **kwargs: object) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def optional_keyword_only(x: int, y: str, *, debug: bool = False) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_positional(optional_keyword_only))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def optional_keyword_only(x: int, y: str, *, debug: bool = False) -> None`"
+reveal_type(infer_positional(optional_keyword_only))  # revealed: tuple[Unknown, ...]
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def extra_keywords(x: int, y: str, **kwargs: object) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_positional(extra_keywords))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def extra_keywords(x: int, y: str, **kwargs: object) -> None`"
+reveal_type(infer_positional(extra_keywords))  # revealed: tuple[Unknown, ...]
 ```
 
 ### Callable protocol inference with keyword-only parameters
@@ -439,25 +363,17 @@ def positional_or_keyword(x: int, y: str, flag: bool) -> None: ...
 def keyword_catch_all(x: int, y: str, **kwargs: object) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def explicit_keyword_only(x: int, y: str, *, flag: bool) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_only(explicit_keyword_only))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def explicit_keyword_only(x: int, y: str, *, flag: bool) -> None`"
+reveal_type(infer_keyword_only(explicit_keyword_only))  # revealed: tuple[Unknown, ...]
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_only_with_keyword(x: int, y: str, /, *, flag: bool) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_only(positional_only_with_keyword))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_only_with_keyword(x: int, y: str, /, *, flag: bool) -> None`"
+reveal_type(infer_keyword_only(positional_only_with_keyword))  # revealed: tuple[Unknown, ...]
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_or_keyword(x: int, y: str, flag: bool) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_only(positional_or_keyword))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_or_keyword(x: int, y: str, flag: bool) -> None`"
+reveal_type(infer_keyword_only(positional_or_keyword))  # revealed: tuple[Unknown, ...]
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_only(keyword_catch_all))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
+reveal_type(infer_keyword_only(keyword_catch_all))  # revealed: tuple[Unknown, ...]
 
 class OptionalKeywordCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, flag: bool = False) -> None: ...
@@ -468,10 +384,8 @@ def infer_optional_keyword[*Ts](callback: OptionalKeywordCallback[*Ts]) -> tuple
 def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_optional_keyword` is incorrect: Expected `OptionalKeywordCallback[*tuple[Unknown, ...]]`, found `def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_optional_keyword(optional_keyword_callback))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_optional_keyword` is incorrect: Expected `OptionalKeywordCallback[*tuple[Unknown, ...]]`, found `def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None`"
+reveal_type(infer_optional_keyword(optional_keyword_callback))  # revealed: tuple[Unknown, ...]
 
 class PrefixedKeywordCallback[*Ts](Protocol):
     def __call__(self, prefix: bytes, *args: *Ts, flag: bool) -> None: ...
@@ -483,15 +397,11 @@ def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None: ...
 def prefixed_variadic(prefix: bytes, *args: str, flag: bool) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_prefixed` is incorrect: Expected `PrefixedKeywordCallback[*tuple[Unknown, ...]]`, found `def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_prefixed(prefixed))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_prefixed` is incorrect: Expected `PrefixedKeywordCallback[*tuple[Unknown, ...]]`, found `def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None`"
+reveal_type(infer_prefixed(prefixed))  # revealed: tuple[Unknown, ...]
 
 # An open-ended positional parameter can be inferred in an otherwise mixed signature.
-# TODO: revealed: tuple[str, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_prefixed(prefixed_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(infer_prefixed(prefixed_variadic))  # revealed: tuple[str, ...]
 ```
 
 ### Callable protocol inference with variadic keyword parameters
@@ -511,10 +421,8 @@ def infer_keyword_variadic[*Ts](callback: KeywordVariadicCallback[*Ts]) -> tuple
 def keyword_variadic(x: int, y: str, **kwargs: int) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_variadic` is incorrect: Expected `KeywordVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_variadic(x: int, y: str, **kwargs: int) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_variadic(keyword_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_variadic` is incorrect: Expected `KeywordVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_variadic(x: int, y: str, **kwargs: int) -> None`"
+reveal_type(infer_keyword_variadic(keyword_variadic))  # revealed: tuple[Unknown, ...]
 
 class KeywordOnlyAndVariadicCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, flag: bool, **kwargs: int) -> None: ...
@@ -527,10 +435,8 @@ def infer_keyword_only_and_variadic[*Ts](
 def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only_and_variadic` is incorrect: Expected `KeywordOnlyAndVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_keyword_only_and_variadic(keyword_only_and_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_keyword_only_and_variadic` is incorrect: Expected `KeywordOnlyAndVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None`"
+reveal_type(infer_keyword_only_and_variadic(keyword_only_and_variadic))  # revealed: tuple[Unknown, ...]
 
 class MultipleKeywordCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, first: int, second: str) -> None: ...
@@ -541,10 +447,8 @@ def infer_multiple_keywords[*Ts](callback: MultipleKeywordCallback[*Ts]) -> tupl
 def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None: ...
 
 # TODO: Should reveal `tuple[int, str]`.
-# TODO: error: [invalid-argument-type] "Argument to function `infer_multiple_keywords` is incorrect: Expected `MultipleKeywordCallback[*tuple[Unknown, ...]]`, found `def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
-# TODO: revealed: tuple[Unknown, ...]
-# error: [invalid-argument-type]
-reveal_type(infer_multiple_keywords(multiple_keyword_catch_all))  # revealed: tuple[tuple[Unknown, ...], ...]
+# error: [invalid-argument-type] "Argument to function `infer_multiple_keywords` is incorrect: Expected `MultipleKeywordCallback[*tuple[Unknown, ...]]`, found `def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
+reveal_type(infer_multiple_keywords(multiple_keyword_catch_all))  # revealed: tuple[Unknown, ...]
 ```
 
 ### Length-sensitive inference
@@ -557,11 +461,9 @@ def foo[*Ts](arg1: tuple[*Ts], arg2: tuple[*Ts]) -> tuple[*Ts]:
     raise NotImplementedError
 
 def f(i: int, s: str, b: bool) -> None:
-    # TODO: revealed: tuple[int, str | int]
-    reveal_type(foo((i, s), (b, i)))  # revealed: tuple[int | str, ...]
-    # TODO: error: [invalid-argument-type] "Argument to function `foo` is incorrect: Expected `tuple[int]`, found `tuple[str, bool]`"
-    # TODO: revealed: tuple[int]
-    reveal_type(foo((i,), (s, b)))  # revealed: tuple[int | str, ...]
+    reveal_type(foo((i, s), (b, i)))  # revealed: tuple[int, str | int]
+    # error: [invalid-argument-type] "Argument to function `foo` is incorrect: Expected `tuple[int]`, found `tuple[str, bool]`"
+    reveal_type(foo((i,), (s, b)))  # revealed: tuple[int]
 ```
 
 ## Type concatenation
@@ -590,27 +492,19 @@ def del_letter_c[*Ts](x: Array[*Ts, C]) -> Array[*Ts]:
 def generic[T, *Ts](x: T, y: Array[*Ts]) -> Array[T, *Ts]:
     raise NotImplementedError
 
-# TODO: revealed: Array[A, B, D, C]
-reveal_type(add_letters(Array[B, D]()))  # revealed: Array[*tuple[A, *tuple[B | D, ...], C]]
-# TODO: revealed: Array[A, B, C]
-reveal_type(add_letter_a(Array[B, C]()))  # revealed: Array[*tuple[A, *tuple[B | C, ...]]]
+reveal_type(add_letters(Array[B, D]()))  # revealed: Array[A, B, D, C]
+reveal_type(add_letter_a(Array[B, C]()))  # revealed: Array[A, B, C]
 
-# TODO: revealed: Array[B]
-reveal_type(del_letter_a(Array[A, B]()))  # revealed: Array[*tuple[B, ...]]
+reveal_type(del_letter_a(Array[A, B]()))  # revealed: Array[B]
 # TODO: error: [invalid-argument-type]
-# TODO: revealed: Array[C]
-reveal_type(del_letter_a(Array[B, C]()))  # revealed: Array[*tuple[C, ...]]
+reveal_type(del_letter_a(Array[B, C]()))  # revealed: Array[C]
 
-# TODO: revealed: Array[A, B]
-reveal_type(del_letter_c(Array[A, B, C]()))  # revealed: Array[*tuple[A | B, ...]]
+reveal_type(del_letter_c(Array[A, B, C]()))  # revealed: Array[A, B]
 # TODO: error: [invalid-argument-type]
-# TODO: revealed: Array[A]
-reveal_type(del_letter_c(Array[A, B]()))  # revealed: Array[*tuple[A, ...]]
+reveal_type(del_letter_c(Array[A, B]()))  # revealed: Array[A]
 
-# TODO: revealed: Array[A, B, D]
-reveal_type(generic(A(), Array[B, D]()))  # revealed: Array[*tuple[A, *tuple[tuple[Unknown, ...], ...]]]
-# TODO: revealed: Array[A]
-reveal_type(generic(A(), Array[()]()))  # revealed: Array[*tuple[A, *tuple[tuple[Unknown, ...], ...]]]
+reveal_type(generic(A(), Array[B, D]()))  # revealed: Array[A, B, D]
+reveal_type(generic(A(), Array[()]()))  # revealed: Array[A]
 ```
 
 ## Unpacking Unbounded Tuple Types
@@ -651,17 +545,14 @@ def f(
     mixed: tuple[int, *tuple[str, ...], bytes],
 ) -> None:
     # TODO: Should reveal `tuple[int, *tuple[str, ...]]`.
-    # TODO: error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...]]`"
-    # TODO: revealed: tuple[int, ...]
-    reveal_type(preserve(prefix))  # revealed: tuple[int | str, ...]
+    # error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...]]`"
+    reveal_type(preserve(prefix))  # revealed: tuple[int, ...]
     # TODO: Should reveal `tuple[*tuple[str, ...], bytes]`.
-    # TODO: error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[str, ...]`, found `tuple[*tuple[str, ...], bytes]`"
-    # TODO: revealed: tuple[str, ...]
-    reveal_type(preserve(suffix))  # revealed: tuple[str | bytes, ...]
+    # error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[str, ...]`, found `tuple[*tuple[str, ...], bytes]`"
+    reveal_type(preserve(suffix))  # revealed: tuple[str, ...]
     # TODO: Should reveal `tuple[int, *tuple[str, ...], bytes]`.
-    # TODO: error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...], bytes]`"
-    # TODO: revealed: tuple[int, ...]
-    reveal_type(preserve(mixed))  # revealed: tuple[int | str | bytes, ...]
+    # error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...], bytes]`"
+    reveal_type(preserve(mixed))  # revealed: tuple[int, ...]
 ```
 
 A tuple containing an unpacked tuple can precisely describe heterogeneous positional arguments,
@@ -674,11 +565,10 @@ def remove_bytes[*Prefix](*args: *tuple[*Prefix, bytes]) -> tuple[*Prefix]:
 
 accept_str_in_between(True, "phase", "status", b"ok")
 accept_str_in_between(True, b"ok")
-# TODO: error: [invalid-argument-type] "Argument to function `accept_str_in_between` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
+# error: [invalid-argument-type] "Argument to function `accept_str_in_between` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
 accept_str_in_between(True, 1, b"bad")
 
-# TODO: revealed: tuple[Literal[1], Literal["record"]]
-reveal_type(remove_bytes(1, "record", b"sum"))  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(remove_bytes(1, "record", b"sum"))  # revealed: tuple[Literal[1], Literal["record"]]
 ```
 
 ## Type Aliases
@@ -704,26 +594,16 @@ def _(
     # error: [invalid-type-arguments] "No type argument provided for required type variable `U`"
     a10: Between[int],
 ):
-    # TODO: revealed: tuple[()]
-    reveal_type(a1)  # revealed: tuple[tuple[()], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a2)  # revealed: tuple[tuple[int, str], ...]
-    # TODO: revealed: tuple[int, str]
-    reveal_type(a3)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
-    # TODO: revealed: tuple[int, bool, str]
-    reveal_type(a4)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
-    # TODO: revealed: tuple[int, bool, bytes, str]
-    reveal_type(a5)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a6)  # revealed: tuple[bool, *tuple[tuple[()], ...]]
-    # TODO: revealed: tuple[bool, int, str]
-    reveal_type(a7)  # revealed: tuple[bool, *tuple[tuple[int, str], ...]]
-    # TODO: revealed: tuple[bool]
-    reveal_type(a8)  # revealed: tuple[*tuple[tuple[()], ...], bool]
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a9)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
-    # TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
-    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+    reveal_type(a1)  # revealed: tuple[()]
+    reveal_type(a2)  # revealed: tuple[int, str]
+    reveal_type(a3)  # revealed: tuple[int, str]
+    reveal_type(a4)  # revealed: tuple[int, bool, str]
+    reveal_type(a5)  # revealed: tuple[int, bool, bytes, str]
+    reveal_type(a6)  # revealed: tuple[bool]
+    reveal_type(a7)  # revealed: tuple[bool, int, str]
+    reveal_type(a8)  # revealed: tuple[bool]
+    reveal_type(a9)  # revealed: tuple[int, str, bool]
+    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
 ```
 
 ### Unpacked tuple type arguments
@@ -732,10 +612,8 @@ def _(
 type Alias[*Ts] = tuple[int, *Ts]
 
 def _(a1: Alias[*tuple[str, bool]], a2: Alias[*tuple[str, ...]]) -> None:
-    # TODO: revealed: tuple[int, str, bool]
-    reveal_type(a1)  # revealed: tuple[int, *tuple[tuple[str, bool], ...]]
-    # TODO: revealed: tuple[int, *tuple[str, ...]]
-    reveal_type(a2)  # revealed: tuple[int, *tuple[tuple[str, ...], ...]]
+    reveal_type(a1)  # revealed: tuple[int, str, bool]
+    reveal_type(a2)  # revealed: tuple[int, *tuple[str, ...]]
 ```
 
 ### Unspecified alias type arguments
@@ -749,10 +627,8 @@ from typing import Any
 type Headered[*Fields] = tuple[bytes, *Fields]
 
 def _(a1: Headered, a2: Headered[*tuple[Any, ...]]) -> None:
-    # TODO: revealed: tuple[bytes, *tuple[Unknown, ...]]
-    reveal_type(a1)  # revealed: tuple[bytes, *tuple[tuple[Unknown, ...], ...]]
-    # TODO: revealed: tuple[bytes, *tuple[Any, ...]]
-    reveal_type(a2)  # revealed: tuple[bytes, *tuple[tuple[Any, ...], ...]]
+    reveal_type(a1)  # revealed: tuple[bytes, *tuple[Unknown, ...]]
+    reveal_type(a2)  # revealed: tuple[bytes, *tuple[Any, ...]]
 ```
 
 ### Splitting arbitrary-length tuples

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -1,0 +1,858 @@
+# PEP 695 `TypeVarTuple`
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+## Definition
+
+A PEP 695 type variable tuple is introduced with a single starred type parameter.
+
+```py
+def foo[*Ts](*args: *Ts) -> None:
+    reveal_type(Ts)  # revealed: TypeVarTuple
+    reveal_type(args)  # revealed: tuple[*Ts@foo]
+```
+
+## Variance inference
+
+PEP 695 type variable tuples infer variance from how the class uses them.
+
+```py
+class CovariantArray[*Ts]:
+    def get(self) -> tuple[*Ts]:
+        raise NotImplementedError
+
+covariant_ok: CovariantArray[object] = CovariantArray[int]()
+covariant_error: CovariantArray[int] = CovariantArray[object]()  # error: [invalid-assignment]
+
+class ContravariantArray[*Ts]:
+    def set(self, value: tuple[*Ts]) -> None:
+        raise NotImplementedError
+
+contravariant_ok: ContravariantArray[int] = ContravariantArray[object]()
+contravariant_error: ContravariantArray[object] = ContravariantArray[int]()  # error: [invalid-assignment]
+
+class InvariantArray[*Ts]:
+    values: tuple[*Ts]
+
+invariant_out: InvariantArray[object] = InvariantArray[int]()  # error: [invalid-assignment]
+invariant_in: InvariantArray[int] = InvariantArray[object]()  # error: [invalid-assignment]
+```
+
+## Generic Classes
+
+### Explicit specialization
+
+```py
+class Simple[*Ts]:
+    attr: tuple[*Ts]
+
+# TODO: revealed: tuple[()]
+reveal_type(Simple[()]().attr)  # revealed: tuple[tuple[()], ...]
+# TODO: revealed: tuple[int, str]
+reveal_type(Simple[int, str]().attr)  # revealed: tuple[tuple[int, str], ...]
+# TODO: revealed: tuple[int, str]
+reveal_type(Simple[*tuple[int, str]]().attr)  # revealed: tuple[tuple[int, str], ...]
+
+# TODO: revealed: tuple[Unknown]
+# error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+reveal_type(Simple[[int, str]]().attr)  # revealed: tuple[tuple[Unknown], ...]
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-type-form] "List literals are not allowed in this context in a type expression"
+reveal_type(Simple[*[int, str]]().attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+```
+
+```py
+class Prefix[T, *Ts]:
+    attr: tuple[T, *Ts]
+
+# TODO: revealed: tuple[int]
+reveal_type(Prefix[int]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...]]
+# TODO: revealed: tuple[int, bool]
+reveal_type(Prefix[int, bool]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...]]
+# TODO: revealed: tuple[int, bool, str]
+reveal_type(Prefix[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
+# TODO: revealed: tuple[int, bool, str]
+reveal_type(Prefix[int, *tuple[bool, str]]().attr)  # revealed: tuple[int, *tuple[tuple[bool, str], ...]]
+
+# TODO: Should this raise an error?
+# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...]]
+reveal_type(Prefix().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...]]
+```
+
+```py
+class Suffix[*Ts, T]:
+    attr: tuple[*Ts, T]
+
+# TODO: revealed: tuple[int]
+reveal_type(Suffix[int]().attr)  # revealed: tuple[*tuple[tuple[()], ...], int]
+# TODO: revealed: tuple[int, str]
+reveal_type(Suffix[int, str]().attr)  # revealed: tuple[*tuple[tuple[int], ...], str]
+# TODO: revealed: tuple[int, str, bool]
+reveal_type(Suffix[int, str, bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
+# TODO: revealed: tuple[int, str, bool]
+reveal_type(Suffix[*tuple[int, str], bool]().attr)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
+
+# TODO: Should this raise an error?
+# TODO: revealed: tuple[*tuple[Unknown, ...], Unknown]
+reveal_type(Suffix().attr)  # revealed: tuple[*tuple[tuple[Unknown, ...], ...], Unknown]
+```
+
+```py
+class Between[T, *Ts, U]:
+    attr: tuple[T, *Ts, U]
+
+# TODO: revealed: tuple[int, str]
+reveal_type(Between[int, str]().attr)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
+# TODO: revealed: tuple[int, bool, str]
+reveal_type(Between[int, bool, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
+# TODO: revealed: tuple[int, bool, bytes, str]
+reveal_type(Between[int, bool, bytes, str]().attr)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
+# TODO: revealed: tuple[int, bool, str]
+reveal_type(Between[int, *tuple[bool], str]().attr)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
+
+# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+reveal_type(Between().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+# TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+# error: [invalid-type-arguments] "No type argument provided for required type variable `U` of class `Between`"
+reveal_type(Between[int]().attr)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+```
+
+### Inferred specialization from construction
+
+Calling a generic class without explicit type arguments infers its specialization from the
+constructor arguments.
+
+```py
+class Positional[*Ts]:
+    def __init__(self, shape: tuple[*Ts]) -> None:
+        self.shape = shape
+
+class Variadic[*Ts]:
+    def __init__(self, *shape: *Ts) -> None:
+        self.shape = shape
+
+# TODO: revealed: Positional[()]
+reveal_type(Positional(()))  # revealed: Positional[*tuple[Unknown, ...]]
+# TODO: revealed: Positional[int, str]
+reveal_type(Positional((1, "a")))  # revealed: Positional[int | str]
+
+# TODO: revealed: Variadic[()]
+reveal_type(Variadic())  # revealed: Variadic[*tuple[Unknown, ...]]
+# TODO: revealed: Variadic[int, str]
+reveal_type(Variadic(1, "a"))  # revealed: Variadic[int | str]
+
+def _(i: int, s: str) -> None:
+    # TODO: revealed: Positional[int, str]
+    reveal_type(Positional((i, s)))  # revealed: Positional[int | str]
+    # TODO: revealed: Variadic[int, str]
+    reveal_type(Variadic(i, s))  # revealed: Variadic[int | str]
+```
+
+### Unspecified type arguments
+
+An unsubscripted variadic generic behaves as if it used an unknown-length tuple of `Any` arguments.
+ty represents the missing type information as `Unknown`, distinguishing it from explicitly provided
+`Any`.
+
+```py
+class Unspecified[*Ts]:
+    attr: tuple[*Ts]
+
+unspecified = Unspecified()
+reveal_type(unspecified)  # revealed: Unspecified[*tuple[Unknown, ...]]
+# TODO: revealed: tuple[Unknown, ...]
+reveal_type(unspecified.attr)  # revealed: tuple[tuple[Unknown, ...], ...]
+```
+
+### Default type arguments
+
+A defaulted type variable tuple supplies its unpacked tuple when the generic class is not explicitly
+specialized. Explicit type arguments override the default.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+class WithDefault[*Ts = *tuple[int, str]]:
+    attr: tuple[*Ts]
+
+# TODO: revealed: tuple[int, str]
+reveal_type(WithDefault().attr)  # revealed: tuple[tuple[int, str], ...]
+# TODO: revealed: tuple[bool, bytes]
+reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[tuple[bool, bytes], ...]
+```
+
+### Assignment checks
+
+```py
+class Array[*Ts]:
+    values: tuple[*Ts]
+
+def takes_int_str(x: Array[int, str]) -> None: ...
+def takes_int_str_tuple(x: tuple[int, str]) -> None: ...
+def f(x: Array[int, str], y: Array[str, int], xs: tuple[int, str], ys: tuple[str, int]) -> None:
+    takes_int_str(x)
+    takes_int_str(y)  # error: [invalid-argument-type]
+    takes_int_str_tuple(xs)
+    takes_int_str_tuple(ys)  # error: [invalid-argument-type]
+```
+
+### Gradual specializations
+
+A type variable tuple remains assignable to an explicitly gradual specialization of its generic
+class.
+
+```py
+from typing import Any
+
+class Array[*Ts]:
+    def erase_shape(self) -> "Array[*tuple[Any, ...]]":
+        return self
+```
+
+## Functions
+
+### Tuple arguments and returns
+
+```py
+def simple[*Ts](x: tuple[*Ts]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def with_prefix[T, *Ts](x: T, y: tuple[*Ts]) -> tuple[T, *Ts]:
+    raise NotImplementedError
+
+def with_suffix[*Ts, U](x: tuple[*Ts], y: U) -> tuple[*Ts, U]:
+    raise NotImplementedError
+
+def with_both[T, *Ts, U](x: tuple[T, *Ts, U]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def f(i: int, s: str, b: bool) -> None:
+    # TODO: revealed: tuple[()]
+    reveal_type(simple(()))  # revealed: tuple[tuple[Unknown, ...], ...]
+    # TODO: revealed: tuple[int, str]
+    reveal_type(simple((i, s)))  # revealed: tuple[int | str, ...]
+    # TODO: revealed: tuple[int, str, bool]
+    reveal_type(with_prefix(i, (s, b)))  # revealed: tuple[int, *tuple[str | bool, ...]]
+    # TODO: revealed: tuple[int, str, bool]
+    reveal_type(with_suffix((i, s), b))  # revealed: tuple[*tuple[int | str, ...], bool]
+    # TODO: revealed: tuple[str]
+    reveal_type(with_both((i, s, b)))  # revealed: tuple[str, ...]
+```
+
+### Starred variadic parameters
+
+When a `TypeVarTuple` appears in `*args`, the argument tuple keeps the exact element types from the
+call site.
+
+```py
+def simple[*Ts](*args: *Ts) -> tuple[*Ts]:
+    reveal_type(args)  # revealed: tuple[*Ts@simple]
+    raise NotImplementedError
+
+def with_prefix[T, *Ts](prefix: T, *args: *Ts) -> tuple[T, *Ts]:
+    raise NotImplementedError
+
+def kw_only[T, *Ts](*args: *Ts, kw: T) -> tuple[*Ts, T]:
+    raise NotImplementedError
+
+def f(i: int, s: str, b: bool) -> None:
+    # TODO: revealed: tuple[()]
+    reveal_type(simple())  # revealed: tuple[tuple[Unknown, ...], ...]
+    # TODO: revealed: tuple[int, str]
+    reveal_type(simple(i, s))  # revealed: tuple[int | str, ...]
+    # TODO: revealed: tuple[int, str, bool]
+    reveal_type(with_prefix(i, s, b))  # revealed: tuple[int, *tuple[str | bool, ...]]
+    # TODO: revealed: tuple[int, str, bool]
+    reveal_type(kw_only(i, s, kw=b))  # revealed: tuple[*tuple[int | str, ...], bool]
+    # TODO: revealed: tuple[int, str, bool, Unknown]
+    # error: [missing-argument] "No argument provided for required parameter `kw` of function `kw_only`"
+    reveal_type(kw_only(i, s, b))  # revealed: tuple[*tuple[int | str, ...], Unknown]
+```
+
+### Callable parameters
+
+`Callable` accepts unpacked `TypeVarTuple`s in its positional parameter list.
+
+```py
+from typing import Any, Callable
+
+def simple[*Ts](callback: Callable[[*Ts], tuple[*Ts]]) -> tuple[*Ts]:
+    reveal_type(callback)  # revealed: (*Ts@simple) -> tuple[*Ts@simple]
+    raise NotImplementedError
+
+def positional_only(x: int, y: str, /) -> tuple[int, str]:
+    raise NotImplementedError
+
+def standard(x: int, y: str) -> tuple[int, str]:
+    raise NotImplementedError
+
+def positional_variadic(x: int, *args: str) -> tuple[int, *tuple[str, ...]]:
+    raise NotImplementedError
+
+def variadic1(*args: int) -> tuple[int, ...]:
+    raise NotImplementedError
+
+def variadic2(*args: int) -> tuple[str, ...]:
+    raise NotImplementedError
+
+def keyword_only(*, x: int) -> tuple[int]:
+    raise NotImplementedError
+
+# TODO: revealed: tuple[int, str]
+# error: [invalid-argument-type]
+reveal_type(simple(positional_only))  # revealed: tuple[tuple[Unknown, ...], ...]
+# TODO: revealed: tuple[int, str]
+# error: [invalid-argument-type]
+reveal_type(simple(standard))  # revealed: tuple[tuple[Unknown, ...], ...]
+# TODO: revealed: tuple[int, *tuple[str, ...]]
+# error: [invalid-argument-type]
+reveal_type(simple(positional_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+reveal_type(simple(variadic1))  # revealed: tuple[int, ...]
+
+# TODO: error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: int) -> tuple[int, ...]`, found `def variadic2(*args: int) -> tuple[str, ...]`"
+# TODO: revealed: tuple[int, ...]
+# error: [invalid-argument-type]
+reveal_type(simple(variadic2))  # revealed: tuple[tuple[Unknown, ...], ...]
+# TODO: error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: Unknown) -> tuple[Unknown, ...]`, found `def keyword_only(*, x: int) -> tuple[int]`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(simple(keyword_only))  # revealed: tuple[tuple[Unknown, ...], ...]
+```
+
+This usage pattern is similar to how `ParamSpec` can be used to accept a callable and its arguments
+except that in the case of `TypeVarTuple` all parameters are positional-only.
+
+```py
+def invoke[*Ts, R](callback: Callable[[*Ts], R], *args: *Ts) -> R:
+    raise NotImplementedError
+
+# TODO: revealed: tuple[int, str]
+# error: [invalid-argument-type]
+reveal_type(invoke(positional_only, 1, "a"))  # revealed: Unknown
+# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+# TODO: revealed: tuple[int, str]
+# error: [invalid-argument-type]
+reveal_type(invoke(positional_only))  # revealed: Unknown
+# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(Literal[1], /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+# TODO: revealed: tuple[int, str]
+# error: [invalid-argument-type]
+reveal_type(invoke(positional_only, 1))  # revealed: Unknown
+# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `(int, Literal[2] | str, /) -> tuple[int, str]`, found `def positional_only(x: int, y: str, /) -> tuple[int, str]`"
+# TODO: revealed: tuple[int, str]
+# error: [invalid-argument-type]
+reveal_type(invoke(positional_only, 1, 2))  # revealed: Unknown
+
+# TODO: revealed: tuple[int, str]
+# error: [invalid-argument-type]
+reveal_type(invoke(standard, 1, "a"))  # revealed: Unknown
+# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, str]`, found `def standard(x: int, y: str) -> tuple[int, str]`"
+# TODO: revealed: tuple[int, str]
+# error: [invalid-argument-type]
+# error: [unknown-argument] "Argument `x` does not match any known parameter of function `invoke`"
+# error: [unknown-argument] "Argument `y` does not match any known parameter of function `invoke`"
+reveal_type(invoke(standard, x=1, y="a"))  # revealed: Unknown
+
+# TODO: revealed: tuple[int, *tuple[str, ...]]
+# error: [invalid-argument-type]
+reveal_type(invoke(positional_variadic, 1, "a", "b"))  # revealed: Unknown
+# TODO: revealed: tuple[int, *tuple[str, ...]]
+# error: [invalid-argument-type]
+reveal_type(invoke(positional_variadic, 1))  # revealed: Unknown
+# TODO: error: [invalid-argument-type] "Argument to function `invoke` is incorrect: Expected `() -> tuple[int, *tuple[str, ...]]`, found `def positional_variadic(x: int, *args: str) -> tuple[int, *tuple[str, ...]]`"
+# TODO: revealed: tuple[int, *tuple[str, ...]]
+# error: [invalid-argument-type]
+reveal_type(invoke(positional_variadic))  # revealed: Unknown
+```
+
+### Callable inference with fixed positional parameters
+
+Fixed positional parameters surrounding an unpacked `TypeVarTuple` are excluded from the inferred
+tuple.
+
+```py
+from typing import Callable
+
+def infer_with_suffix[*Ts](callback: Callable[[int, *Ts, bytes], None]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def fixed_suffix(prefix: int, middle: str, suffix: bytes, /) -> None: ...
+def unpacked_suffix(*args: *tuple[int, *tuple[str, ...], bytes]) -> None: ...
+
+# TODO: revealed: tuple[str]
+# error: [invalid-argument-type]
+reveal_type(infer_with_suffix(fixed_suffix))  # revealed: tuple[tuple[Unknown, ...], ...]
+# TODO: Should reveal `tuple[str, ...]`.
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_with_suffix(unpacked_suffix))  # revealed: tuple[tuple[Unknown, ...], ...]
+```
+
+### Callable inference with additional keyword parameters
+
+Additional keyword-only or variadic keyword parameters do not contribute to a `TypeVarTuple`
+inferred from a `Callable`'s positional parameter list.
+
+```py
+from typing import Callable
+
+def infer_positional[*Ts](callback: Callable[[*Ts], None]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def optional_keyword_only(x: int, y: str, *, debug: bool = False) -> None: ...
+def extra_keywords(x: int, y: str, **kwargs: object) -> None: ...
+
+# TODO: Should reveal `tuple[int, str]`.
+# TODO: error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def optional_keyword_only(x: int, y: str, *, debug: bool = False) -> None`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_positional(optional_keyword_only))  # revealed: tuple[tuple[Unknown, ...], ...]
+# TODO: Should reveal `tuple[int, str]`.
+# TODO: error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def extra_keywords(x: int, y: str, **kwargs: object) -> None`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_positional(extra_keywords))  # revealed: tuple[tuple[Unknown, ...], ...]
+```
+
+### Callable protocol inference with keyword-only parameters
+
+A callable protocol can combine a `TypeVarTuple` with required or optional keyword-only parameters
+and a fixed positional prefix.
+
+```py
+from typing import Protocol
+
+class KeywordOnlyCallback[*Ts](Protocol):
+    def __call__(self, *args: *Ts, flag: bool) -> None: ...
+
+def infer_keyword_only[*Ts](callback: KeywordOnlyCallback[*Ts]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def explicit_keyword_only(x: int, y: str, *, flag: bool) -> None: ...
+def positional_only_with_keyword(x: int, y: str, /, *, flag: bool) -> None: ...
+def positional_or_keyword(x: int, y: str, flag: bool) -> None: ...
+def keyword_catch_all(x: int, y: str, **kwargs: object) -> None: ...
+
+# TODO: Should reveal `tuple[int, str]`.
+# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def explicit_keyword_only(x: int, y: str, *, flag: bool) -> None`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_keyword_only(explicit_keyword_only))  # revealed: tuple[tuple[Unknown, ...], ...]
+# TODO: Should reveal `tuple[int, str]`.
+# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_only_with_keyword(x: int, y: str, /, *, flag: bool) -> None`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_keyword_only(positional_only_with_keyword))  # revealed: tuple[tuple[Unknown, ...], ...]
+# TODO: Should reveal `tuple[int, str]`.
+# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_or_keyword(x: int, y: str, flag: bool) -> None`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_keyword_only(positional_or_keyword))  # revealed: tuple[tuple[Unknown, ...], ...]
+# TODO: Should reveal `tuple[int, str]`.
+# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_keyword_only(keyword_catch_all))  # revealed: tuple[tuple[Unknown, ...], ...]
+
+class OptionalKeywordCallback[*Ts](Protocol):
+    def __call__(self, *args: *Ts, flag: bool = False) -> None: ...
+
+def infer_optional_keyword[*Ts](callback: OptionalKeywordCallback[*Ts]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None: ...
+
+# TODO: Should reveal `tuple[int, str]`.
+# TODO: error: [invalid-argument-type] "Argument to function `infer_optional_keyword` is incorrect: Expected `OptionalKeywordCallback[*tuple[Unknown, ...]]`, found `def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_optional_keyword(optional_keyword_callback))  # revealed: tuple[tuple[Unknown, ...], ...]
+
+class PrefixedKeywordCallback[*Ts](Protocol):
+    def __call__(self, prefix: bytes, *args: *Ts, flag: bool) -> None: ...
+
+def infer_prefixed[*Ts](callback: PrefixedKeywordCallback[*Ts]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None: ...
+def prefixed_variadic(prefix: bytes, *args: str, flag: bool) -> None: ...
+
+# TODO: Should reveal `tuple[int, str]`.
+# TODO: error: [invalid-argument-type] "Argument to function `infer_prefixed` is incorrect: Expected `PrefixedKeywordCallback[*tuple[Unknown, ...]]`, found `def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_prefixed(prefixed))  # revealed: tuple[tuple[Unknown, ...], ...]
+
+# An open-ended positional parameter can be inferred in an otherwise mixed signature.
+# TODO: revealed: tuple[str, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_prefixed(prefixed_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+```
+
+### Callable protocol inference with variadic keyword parameters
+
+Variadic keyword parameters are matched separately from the positional parameters captured by a
+`TypeVarTuple`.
+
+```py
+from typing import Protocol
+
+class KeywordVariadicCallback[*Ts](Protocol):
+    def __call__(self, *args: *Ts, **kwargs: int) -> None: ...
+
+def infer_keyword_variadic[*Ts](callback: KeywordVariadicCallback[*Ts]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def keyword_variadic(x: int, y: str, **kwargs: int) -> None: ...
+
+# TODO: Should reveal `tuple[int, str]`.
+# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_variadic` is incorrect: Expected `KeywordVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_variadic(x: int, y: str, **kwargs: int) -> None`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_keyword_variadic(keyword_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+
+class KeywordOnlyAndVariadicCallback[*Ts](Protocol):
+    def __call__(self, *args: *Ts, flag: bool, **kwargs: int) -> None: ...
+
+def infer_keyword_only_and_variadic[*Ts](
+    callback: KeywordOnlyAndVariadicCallback[*Ts],
+) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None: ...
+
+# TODO: Should reveal `tuple[int, str]`.
+# TODO: error: [invalid-argument-type] "Argument to function `infer_keyword_only_and_variadic` is incorrect: Expected `KeywordOnlyAndVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_keyword_only_and_variadic(keyword_only_and_variadic))  # revealed: tuple[tuple[Unknown, ...], ...]
+
+class MultipleKeywordCallback[*Ts](Protocol):
+    def __call__(self, *args: *Ts, first: int, second: str) -> None: ...
+
+def infer_multiple_keywords[*Ts](callback: MultipleKeywordCallback[*Ts]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None: ...
+
+# TODO: Should reveal `tuple[int, str]`.
+# TODO: error: [invalid-argument-type] "Argument to function `infer_multiple_keywords` is incorrect: Expected `MultipleKeywordCallback[*tuple[Unknown, ...]]`, found `def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
+# TODO: revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type]
+reveal_type(infer_multiple_keywords(multiple_keyword_catch_all))  # revealed: tuple[tuple[Unknown, ...], ...]
+```
+
+### Length-sensitive inference
+
+If the same `TypeVarTuple` instance is used in multiple places in a signature or class, the exact
+inference behavior is not specified in the typing spec. However, all usages must match in length.
+
+```py
+def foo[*Ts](arg1: tuple[*Ts], arg2: tuple[*Ts]) -> tuple[*Ts]:
+    raise NotImplementedError
+
+def f(i: int, s: str, b: bool) -> None:
+    # TODO: revealed: tuple[int, str | int]
+    reveal_type(foo((i, s), (b, i)))  # revealed: tuple[int | str, ...]
+    # TODO: error: [invalid-argument-type] "Argument to function `foo` is incorrect: Expected `tuple[int]`, found `tuple[str, bool]`"
+    # TODO: revealed: tuple[int]
+    reveal_type(foo((i,), (s, b)))  # revealed: tuple[int | str, ...]
+```
+
+## Type concatenation
+
+A type variable tuple can be combined with fixed leading or trailing types.
+
+```py
+class Array[*Ts]: ...
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+
+def add_letter_a[*Ts](x: Array[*Ts]) -> Array[A, *Ts]:
+    raise NotImplementedError
+
+def del_letter_a[*Ts](x: Array[A, *Ts]) -> Array[*Ts]:
+    raise NotImplementedError
+
+def add_letters[*Ts](x: Array[*Ts]) -> Array[A, *Ts, C]:
+    raise NotImplementedError
+
+def del_letter_c[*Ts](x: Array[*Ts, C]) -> Array[*Ts]:
+    raise NotImplementedError
+
+def generic[T, *Ts](x: T, y: Array[*Ts]) -> Array[T, *Ts]:
+    raise NotImplementedError
+
+# TODO: revealed: Array[A, B, D, C]
+reveal_type(add_letters(Array[B, D]()))  # revealed: Array[*tuple[A, *tuple[B | D, ...], C]]
+# TODO: revealed: Array[A, B, C]
+reveal_type(add_letter_a(Array[B, C]()))  # revealed: Array[*tuple[A, *tuple[B | C, ...]]]
+
+# TODO: revealed: Array[B]
+reveal_type(del_letter_a(Array[A, B]()))  # revealed: Array[*tuple[B, ...]]
+# TODO: error: [invalid-argument-type]
+# TODO: revealed: Array[C]
+reveal_type(del_letter_a(Array[B, C]()))  # revealed: Array[*tuple[C, ...]]
+
+# TODO: revealed: Array[A, B]
+reveal_type(del_letter_c(Array[A, B, C]()))  # revealed: Array[*tuple[A | B, ...]]
+# TODO: error: [invalid-argument-type]
+# TODO: revealed: Array[A]
+reveal_type(del_letter_c(Array[A, B]()))  # revealed: Array[*tuple[A, ...]]
+
+# TODO: revealed: Array[A, B, D]
+reveal_type(generic(A(), Array[B, D]()))  # revealed: Array[*tuple[A, *tuple[tuple[Unknown, ...], ...]]]
+# TODO: revealed: Array[A]
+reveal_type(generic(A(), Array[()]()))  # revealed: Array[*tuple[A, *tuple[tuple[Unknown, ...], ...]]]
+```
+
+## Unpacking Unbounded Tuple Types
+
+An unpacked unbounded tuple can describe an unknown middle section while retaining fixed endpoints,
+and it can be passed into a function that solves a type variable tuple.
+
+```py
+from typing import Any
+
+def accept_any_in_between(x: tuple[bytes, *tuple[Any, ...], int]) -> None: ...
+def carry_items[*Items](x: tuple[bytes, *Items, int]) -> tuple[*Items]:
+    raise NotImplementedError
+
+def f(
+    empty: tuple[bytes, int],
+    multi: tuple[bytes, str, bool, int],
+    truncated: tuple[bytes],
+    dynamic: tuple[bytes, *tuple[Any, ...], int],
+) -> None:
+    accept_any_in_between(empty)
+    accept_any_in_between(multi)
+    # error: [invalid-argument-type] "Argument to function `accept_any_in_between` is incorrect: Expected `tuple[bytes, *tuple[Any, ...], int]`, found `tuple[bytes]`"
+    accept_any_in_between(truncated)
+    reveal_type(carry_items(dynamic))  # revealed: tuple[Any, ...]
+```
+
+When a mixed unbounded tuple is used to solve a `TypeVarTuple`, its fixed prefix and suffix remain
+part of the solution.
+
+```py
+def preserve[*Ts](value: tuple[*Ts]) -> tuple[*Ts]:
+    return value
+
+def f(
+    prefix: tuple[int, *tuple[str, ...]],
+    suffix: tuple[*tuple[str, ...], bytes],
+    mixed: tuple[int, *tuple[str, ...], bytes],
+) -> None:
+    # TODO: Should reveal `tuple[int, *tuple[str, ...]]`.
+    # TODO: error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...]]`"
+    # TODO: revealed: tuple[int, ...]
+    reveal_type(preserve(prefix))  # revealed: tuple[int | str, ...]
+    # TODO: Should reveal `tuple[*tuple[str, ...], bytes]`.
+    # TODO: error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[str, ...]`, found `tuple[*tuple[str, ...], bytes]`"
+    # TODO: revealed: tuple[str, ...]
+    reveal_type(preserve(suffix))  # revealed: tuple[str | bytes, ...]
+    # TODO: Should reveal `tuple[int, *tuple[str, ...], bytes]`.
+    # TODO: error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...], bytes]`"
+    # TODO: revealed: tuple[int, ...]
+    reveal_type(preserve(mixed))  # revealed: tuple[int | str | bytes, ...]
+```
+
+A tuple containing an unpacked tuple can precisely describe heterogeneous positional arguments,
+including a variable-length middle portion or a type-variable prefix.
+
+```py
+def accept_str_in_between(*args: *tuple[bool, *tuple[str, ...], bytes]) -> None: ...
+def remove_bytes[*Prefix](*args: *tuple[*Prefix, bytes]) -> tuple[*Prefix]:
+    raise NotImplementedError
+
+accept_str_in_between(True, "phase", "status", b"ok")
+accept_str_in_between(True, b"ok")
+# TODO: error: [invalid-argument-type] "Argument to function `accept_str_in_between` is incorrect: Expected `tuple[bool, *tuple[str, ...], bytes]`"
+accept_str_in_between(True, 1, b"bad")
+
+# TODO: revealed: tuple[Literal[1], Literal["record"]]
+reveal_type(remove_bytes(1, "record", b"sum"))  # revealed: tuple[tuple[Unknown, ...], ...]
+```
+
+## Type Aliases
+
+### Variadic aliases
+
+```py
+type Simple[*Ts] = tuple[*Ts]
+type Prefix[T, *Ts] = tuple[T, *Ts]
+type Suffix[*Ts, T] = tuple[*Ts, T]
+type Between[T, *Ts, U] = tuple[T, *Ts, U]
+
+def _(
+    a1: Simple[()],
+    a2: Simple[int, str],
+    a3: Between[int, str],
+    a4: Between[int, bool, str],
+    a5: Between[int, bool, bytes, str],
+    a6: Prefix[bool],
+    a7: Prefix[bool, int, str],
+    a8: Suffix[bool],
+    a9: Suffix[int, str, bool],
+    # error: [invalid-type-arguments] "No type argument provided for required type variable `U`"
+    a10: Between[int],
+):
+    # TODO: revealed: tuple[()]
+    reveal_type(a1)  # revealed: tuple[tuple[()], ...]
+    # TODO: revealed: tuple[int, str]
+    reveal_type(a2)  # revealed: tuple[tuple[int, str], ...]
+    # TODO: revealed: tuple[int, str]
+    reveal_type(a3)  # revealed: tuple[int, *tuple[tuple[()], ...], str]
+    # TODO: revealed: tuple[int, bool, str]
+    reveal_type(a4)  # revealed: tuple[int, *tuple[tuple[bool], ...], str]
+    # TODO: revealed: tuple[int, bool, bytes, str]
+    reveal_type(a5)  # revealed: tuple[int, *tuple[tuple[bool, bytes], ...], str]
+    # TODO: revealed: tuple[bool]
+    reveal_type(a6)  # revealed: tuple[bool, *tuple[tuple[()], ...]]
+    # TODO: revealed: tuple[bool, int, str]
+    reveal_type(a7)  # revealed: tuple[bool, *tuple[tuple[int, str], ...]]
+    # TODO: revealed: tuple[bool]
+    reveal_type(a8)  # revealed: tuple[*tuple[tuple[()], ...], bool]
+    # TODO: revealed: tuple[int, str, bool]
+    reveal_type(a9)  # revealed: tuple[*tuple[tuple[int, str], ...], bool]
+    # TODO: revealed: tuple[Unknown, *tuple[Unknown, ...], Unknown]
+    reveal_type(a10)  # revealed: tuple[Unknown, *tuple[tuple[Unknown, ...], ...], Unknown]
+```
+
+### Unpacked tuple type arguments
+
+```py
+type Alias[*Ts] = tuple[int, *Ts]
+
+def _(a1: Alias[*tuple[str, bool]], a2: Alias[*tuple[str, ...]]) -> None:
+    # TODO: revealed: tuple[int, str, bool]
+    reveal_type(a1)  # revealed: tuple[int, *tuple[tuple[str, bool], ...]]
+    # TODO: revealed: tuple[int, *tuple[str, ...]]
+    reveal_type(a2)  # revealed: tuple[int, *tuple[tuple[str, ...], ...]]
+```
+
+### Unspecified alias type arguments
+
+A bare variadic alias substitutes an unknown-length tuple of `Any`, just like a bare variadic
+generic class.
+
+```py
+from typing import Any
+
+type Headered[*Fields] = tuple[bytes, *Fields]
+
+def _(a1: Headered, a2: Headered[*tuple[Any, ...]]) -> None:
+    # TODO: revealed: tuple[bytes, *tuple[Unknown, ...]]
+    reveal_type(a1)  # revealed: tuple[bytes, *tuple[tuple[Unknown, ...], ...]]
+    # TODO: revealed: tuple[bytes, *tuple[Any, ...]]
+    reveal_type(a2)  # revealed: tuple[bytes, *tuple[tuple[Any, ...], ...]]
+```
+
+### Splitting arbitrary-length tuples
+
+```py
+type First[*Ts, T] = tuple[*Ts, T]
+type Second[T, *Ts] = tuple[T, *Ts]
+
+reveal_type(First[*tuple[int, ...]])  # revealed: <type alias 'First[*tuple[int, ...], int]'>
+reveal_type(First[*tuple[int, ...], str])  # revealed: <type alias 'First[*tuple[int, ...], str]'>
+reveal_type(Second[*tuple[int, ...]])  # revealed: <type alias 'Second[int, *tuple[int, ...]]'>
+reveal_type(Second[str, *tuple[int, ...]])  # revealed: <type alias 'Second[str, *tuple[int, ...]]'>
+```
+
+### Variadic substitutions
+
+A variadic alias can forward its remaining arguments to another variadic alias.
+
+```py
+type First[*Ts] = tuple[bytes, *Ts]
+type Second[*Ts] = First[int, *Ts]
+
+reveal_type(First[str, bool])  # revealed: <type alias 'First[str, bool]'>
+reveal_type(Second[str, bool])  # revealed: <type alias 'Second[str, bool]'>
+```
+
+## Accessing Individual Types
+
+Operations that need to rearrange individual members of a type variable tuple can expose overloads
+for each supported tuple length.
+
+```py
+from typing import Any, overload
+
+class Row[*Cells]:
+    def cells(self) -> tuple[*Cells]:
+        raise NotImplementedError
+
+    @overload
+    def rotate_left[A, B](self: "Row[A, B]") -> "Row[B, A]": ...
+    @overload
+    def rotate_left[A, B, C](self: "Row[A, B, C]") -> "Row[B, C, A]": ...
+    def rotate_left(self) -> "Row[*tuple[Any, ...]]":
+        raise NotImplementedError
+
+def f(pair: Row[int, str], triple: Row[int, str, bytes]) -> None:
+    reveal_type(pair.rotate_left())  # revealed: Row[str, int]
+    reveal_type(triple.rotate_left())  # revealed: Row[str, bytes, int]
+```
+
+## Invalid Forms
+
+### Multiple Type Variable Tuples not allowed
+
+Only one type variable tuple can appear in a type parameter list.
+
+```py
+# error: [invalid-type-form]
+class Array[*Ts1, *Ts2]: ...
+```
+
+### Must always be unpacked
+
+```py
+def invalid[*Ts](x: Ts) -> None: ...  # error: [invalid-type-form]
+def invalid_args[*Ts](*args: Ts) -> None: ...  # error: [invalid-type-form]
+
+class InvalidTupleElement[*Ts]:
+    # error: [invalid-type-form] "Bare TypeVarTuple `Ts` is not valid in this context in a type expression"
+    values: tuple[Ts]
+
+def valid[*Ts](x: tuple[*Ts]) -> tuple[*Ts]:
+    return x
+```
+
+### Invalid unpack operand
+
+Only tuple types and type variable tuples can be unpacked in a type expression.
+
+```py
+# error: [invalid-type-form] "`*` can only unpack a tuple type or `TypeVarTuple`"
+def invalid(*args: *int) -> None:
+    reveal_type(args)  # revealed: tuple[Unknown, ...]
+
+class Pair[*Ts, U]: ...
+
+def invalid_generic(
+    # error: [invalid-type-form] "`*` can only unpack a tuple type or `TypeVarTuple`"
+    value: Pair[*int, str],
+) -> None:
+    reveal_type(value)  # revealed: Pair[*tuple[Unknown, ...], str]
+```
+
+### Only one variadic unpack
+
+```py
+def f[*Ts](
+    ok1: tuple[int, *Ts],
+    ok2: tuple[int, *Ts, str],
+    bad1: tuple[*Ts, *tuple[str, ...]],  # error: [invalid-type-form]
+    bad2: tuple[*tuple[str, ...], *Ts],  # error: [invalid-type-form]
+) -> None: ...
+```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -15,24 +15,24 @@ def foo[*Ts](*args: *Ts) -> None:
     reveal_type(args)  # revealed: tuple[*Ts@foo]
 ```
 
-## Variance inference
+## Variance
 
-PEP 695 type variable tuples infer variance from how the class uses them.
+PEP 695 type variable tuples are always invariant, regardless of how the class uses them.
 
 ```py
-class CovariantArray[*Ts]:
+class ReturnOnlyArray[*Ts]:
     def get(self) -> tuple[*Ts]:
         raise NotImplementedError
 
-covariant_ok: CovariantArray[object] = CovariantArray[int]()
-covariant_error: CovariantArray[int] = CovariantArray[object]()  # error: [invalid-assignment]
+return_only_out: ReturnOnlyArray[object] = ReturnOnlyArray[int]()  # error: [invalid-assignment]
+return_only_in: ReturnOnlyArray[int] = ReturnOnlyArray[object]()  # error: [invalid-assignment]
 
-class ContravariantArray[*Ts]:
+class ParameterOnlyArray[*Ts]:
     def set(self, value: tuple[*Ts]) -> None:
         raise NotImplementedError
 
-contravariant_ok: ContravariantArray[int] = ContravariantArray[object]()
-contravariant_error: ContravariantArray[object] = ContravariantArray[int]()  # error: [invalid-assignment]
+parameter_only_out: ParameterOnlyArray[object] = ParameterOnlyArray[int]()  # error: [invalid-assignment]
+parameter_only_in: ParameterOnlyArray[int] = ParameterOnlyArray[object]()  # error: [invalid-assignment]
 
 class InvariantArray[*Ts]:
     values: tuple[*Ts]
@@ -606,11 +606,11 @@ reveal_type(add_letters(Array[B, D]()))  # revealed: Array[A, B, D, C]
 reveal_type(add_letter_a(Array[B, C]()))  # revealed: Array[A, B, C]
 
 reveal_type(del_letter_a(Array[A, B]()))  # revealed: Array[B]
-# TODO: error: [invalid-argument-type]
+# error: [invalid-argument-type] "Argument to function `del_letter_a` is incorrect: Expected `Array[A, C]`, found `Array[B, C]`"
 reveal_type(del_letter_a(Array[B, C]()))  # revealed: Array[C]
 
 reveal_type(del_letter_c(Array[A, B, C]()))  # revealed: Array[A, B]
-# TODO: error: [invalid-argument-type]
+# error: [invalid-argument-type] "Argument to function `del_letter_c` is incorrect: Expected `Array[A, C]`, found `Array[A, B]`"
 reveal_type(del_letter_c(Array[A, B]()))  # revealed: Array[A]
 
 reveal_type(generic(A(), Array[B, D]()))  # revealed: Array[A, B, D]

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -208,6 +208,13 @@ def f(i: int, s: str, b: bool) -> None:
     reveal_type(with_prefix(i, (s, b)))  # revealed: tuple[int, str, bool]
     reveal_type(with_suffix((i, s), b))  # revealed: tuple[int, str, bool]
     reveal_type(with_both((i, s, b)))  # revealed: tuple[str]
+
+def variable_tuples(
+    homogeneous: tuple[bytes, ...],
+    mixed: tuple[int, *tuple[str, ...], bytes],
+) -> None:
+    reveal_type(simple(homogeneous))  # revealed: tuple[bytes, ...]
+    simple(mixed)
 ```
 
 ### Starred variadic parameters
@@ -233,6 +240,15 @@ def f(i: int, s: str, b: bool) -> None:
     reveal_type(kw_only(i, s, kw=b))  # revealed: tuple[int, str, bool]
     # error: [missing-argument] "No argument provided for required parameter `kw` of function `kw_only`"
     reveal_type(kw_only(i, s, b))  # revealed: tuple[int, str, bool, Unknown]
+
+def splatted(
+    fixed: tuple[int, str],
+    homogeneous: tuple[bytes, ...],
+) -> None:
+    reveal_type(simple(*fixed))  # revealed: tuple[int, str]
+    reveal_type(simple(*homogeneous))  # revealed: tuple[bytes, ...]
+    reveal_type(with_prefix(*fixed))  # revealed: tuple[int, str]
+    with_prefix(*homogeneous)
 ```
 
 ### Callable parameters
@@ -264,15 +280,72 @@ def variadic2(*args: int) -> tuple[str, ...]:
 def keyword_only(*, x: int) -> tuple[int]:
     raise NotImplementedError
 
+class PositionalCallable:
+    def __call__(self, x: int, y: str, /) -> tuple[int, str]:
+        raise NotImplementedError
+
 reveal_type(simple(positional_only))  # revealed: tuple[int, str]
 reveal_type(simple(standard))  # revealed: tuple[int, str]
 reveal_type(simple(positional_variadic))  # revealed: tuple[int, *tuple[str, ...]]
 reveal_type(simple(variadic1))  # revealed: tuple[int, ...]
+reveal_type(simple(PositionalCallable()))  # revealed: tuple[int, str]
 
 # error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: int) -> tuple[int, ...]`, found `def variadic2(*args: int) -> tuple[str, ...]`"
 reveal_type(simple(variadic2))  # revealed: tuple[int, ...]
-# error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: Unknown) -> tuple[Unknown, ...]`, found `def keyword_only(*, x: int) -> tuple[int]`"
-reveal_type(simple(keyword_only))  # revealed: tuple[Unknown, ...]
+# error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `() -> tuple[()]`, found `def keyword_only(*, x: int) -> tuple[int]`"
+reveal_type(simple(keyword_only))  # revealed: tuple[()]
+```
+
+An overloaded callable is accepted if any overload is compatible. The order of the overloads does
+not affect whether the callable is accepted.
+
+```py
+from typing import Any, Callable, overload
+
+def accepts_integer_callback[*Ts](callback: Callable[[*Ts], int]) -> None:
+    pass
+
+@overload
+def overloaded(value: str, /) -> str: ...
+@overload
+def overloaded(value: int, scale: float, /) -> int: ...
+def overloaded(*args: Any) -> Any:
+    raise NotImplementedError
+
+@overload
+def overloaded_reversed(value: int, scale: float, /) -> int: ...
+@overload
+def overloaded_reversed(value: str, /) -> str: ...
+def overloaded_reversed(*args: Any) -> Any:
+    raise NotImplementedError
+
+accepts_integer_callback(overloaded)
+accepts_integer_callback(overloaded_reversed)
+
+def choose[*Ts](
+    callback: Callable[[*Ts], int],
+    arguments: tuple[*Ts],
+) -> tuple[*Ts]:
+    raise NotImplementedError
+
+@overload
+def integer_overloads(value: str, /) -> int: ...
+@overload
+def integer_overloads(value: int, scale: float, /) -> int: ...
+def integer_overloads(*args: Any) -> int:
+    raise NotImplementedError
+
+@overload
+def integer_overloads_reversed(value: int, scale: float, /) -> int: ...
+@overload
+def integer_overloads_reversed(value: str, /) -> int: ...
+def integer_overloads_reversed(*args: Any) -> int:
+    raise NotImplementedError
+
+choose(integer_overloads, (1, 1.0))
+choose(integer_overloads, ("x",))
+choose(integer_overloads_reversed, (1, 1.0))
+choose(integer_overloads_reversed, ("x",))
 ```
 
 This usage pattern is similar to how `ParamSpec` can be used to accept a callable and its arguments
@@ -335,12 +408,16 @@ def infer_positional[*Ts](callback: Callable[[*Ts], None]) -> tuple[*Ts]:
 def optional_keyword_only(x: int, y: str, *, debug: bool = False) -> None: ...
 def extra_keywords(x: int, y: str, **kwargs: object) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def optional_keyword_only(x: int, y: str, *, debug: bool = False) -> None`"
-reveal_type(infer_positional(optional_keyword_only))  # revealed: tuple[Unknown, ...]
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_positional` is incorrect: Expected `(*args: Unknown) -> None`, found `def extra_keywords(x: int, y: str, **kwargs: object) -> None`"
-reveal_type(infer_positional(extra_keywords))  # revealed: tuple[Unknown, ...]
+infer_positional(optional_keyword_only)
+infer_positional(extra_keywords)
+
+def infer_return[*Ts, R](callback: Callable[[*Ts], R]) -> R:
+    raise NotImplementedError
+
+def returns_str(x: int, *, debug: bool = False) -> str:
+    return ""
+
+reveal_type(infer_return(returns_str))  # revealed: str
 ```
 
 ### Callable protocol inference with keyword-only parameters
@@ -362,18 +439,29 @@ def positional_only_with_keyword(x: int, y: str, /, *, flag: bool) -> None: ...
 def positional_or_keyword(x: int, y: str, flag: bool) -> None: ...
 def keyword_catch_all(x: int, y: str, **kwargs: object) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def explicit_keyword_only(x: int, y: str, *, flag: bool) -> None`"
-reveal_type(infer_keyword_only(explicit_keyword_only))  # revealed: tuple[Unknown, ...]
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_only_with_keyword(x: int, y: str, /, *, flag: bool) -> None`"
-reveal_type(infer_keyword_only(positional_only_with_keyword))  # revealed: tuple[Unknown, ...]
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def positional_or_keyword(x: int, y: str, flag: bool) -> None`"
-reveal_type(infer_keyword_only(positional_or_keyword))  # revealed: tuple[Unknown, ...]
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_keyword_only` is incorrect: Expected `KeywordOnlyCallback[*tuple[Unknown, ...]]`, found `def keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
-reveal_type(infer_keyword_only(keyword_catch_all))  # revealed: tuple[Unknown, ...]
+class KeywordOnlyCallable:
+    def __call__(self, x: int, y: str, *, flag: bool) -> None: ...
+
+infer_keyword_only(explicit_keyword_only)
+infer_keyword_only(positional_only_with_keyword)
+infer_keyword_only(positional_or_keyword)
+infer_keyword_only(keyword_catch_all)
+infer_keyword_only(KeywordOnlyCallable())
+
+class ValuedCallback[T, *Ts](Protocol):
+    value: T
+
+    def __call__(self, *args: *Ts) -> None: ...
+
+def infer_value[T, *Ts](callback: ValuedCallback[T, *Ts]) -> T:
+    raise NotImplementedError
+
+class ValuedCallable:
+    value: int = 0
+
+    def __call__(self) -> None: ...
+
+reveal_type(infer_value(ValuedCallable()))  # revealed: int
 
 class OptionalKeywordCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, flag: bool = False) -> None: ...
@@ -383,9 +471,7 @@ def infer_optional_keyword[*Ts](callback: OptionalKeywordCallback[*Ts]) -> tuple
 
 def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_optional_keyword` is incorrect: Expected `OptionalKeywordCallback[*tuple[Unknown, ...]]`, found `def optional_keyword_callback(x: int, y: str, *, flag: bool = False) -> None`"
-reveal_type(infer_optional_keyword(optional_keyword_callback))  # revealed: tuple[Unknown, ...]
+infer_optional_keyword(optional_keyword_callback)
 
 class PrefixedKeywordCallback[*Ts](Protocol):
     def __call__(self, prefix: bytes, *args: *Ts, flag: bool) -> None: ...
@@ -396,9 +482,7 @@ def infer_prefixed[*Ts](callback: PrefixedKeywordCallback[*Ts]) -> tuple[*Ts]:
 def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None: ...
 def prefixed_variadic(prefix: bytes, *args: str, flag: bool) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_prefixed` is incorrect: Expected `PrefixedKeywordCallback[*tuple[Unknown, ...]]`, found `def prefixed(prefix: bytes, x: int, y: str, *, flag: bool) -> None`"
-reveal_type(infer_prefixed(prefixed))  # revealed: tuple[Unknown, ...]
+infer_prefixed(prefixed)
 
 # An open-ended positional parameter can be inferred in an otherwise mixed signature.
 reveal_type(infer_prefixed(prefixed_variadic))  # revealed: tuple[str, ...]
@@ -420,9 +504,7 @@ def infer_keyword_variadic[*Ts](callback: KeywordVariadicCallback[*Ts]) -> tuple
 
 def keyword_variadic(x: int, y: str, **kwargs: int) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_keyword_variadic` is incorrect: Expected `KeywordVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_variadic(x: int, y: str, **kwargs: int) -> None`"
-reveal_type(infer_keyword_variadic(keyword_variadic))  # revealed: tuple[Unknown, ...]
+infer_keyword_variadic(keyword_variadic)
 
 class KeywordOnlyAndVariadicCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, flag: bool, **kwargs: int) -> None: ...
@@ -434,9 +516,7 @@ def infer_keyword_only_and_variadic[*Ts](
 
 def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_keyword_only_and_variadic` is incorrect: Expected `KeywordOnlyAndVariadicCallback[*tuple[Unknown, ...]]`, found `def keyword_only_and_variadic(x: int, y: str, *, flag: bool, **kwargs: int) -> None`"
-reveal_type(infer_keyword_only_and_variadic(keyword_only_and_variadic))  # revealed: tuple[Unknown, ...]
+infer_keyword_only_and_variadic(keyword_only_and_variadic)
 
 class MultipleKeywordCallback[*Ts](Protocol):
     def __call__(self, *args: *Ts, first: int, second: str) -> None: ...
@@ -446,9 +526,7 @@ def infer_multiple_keywords[*Ts](callback: MultipleKeywordCallback[*Ts]) -> tupl
 
 def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None: ...
 
-# TODO: Should reveal `tuple[int, str]`.
-# error: [invalid-argument-type] "Argument to function `infer_multiple_keywords` is incorrect: Expected `MultipleKeywordCallback[*tuple[Unknown, ...]]`, found `def multiple_keyword_catch_all(x: int, y: str, **kwargs: object) -> None`"
-reveal_type(infer_multiple_keywords(multiple_keyword_catch_all))  # revealed: tuple[Unknown, ...]
+infer_multiple_keywords(multiple_keyword_catch_all)
 ```
 
 ### Length-sensitive inference
@@ -464,6 +542,10 @@ def f(i: int, s: str, b: bool) -> None:
     reveal_type(foo((i, s), (b, i)))  # revealed: tuple[int, str | int]
     # error: [invalid-argument-type] "Argument to function `foo` is incorrect: Expected `tuple[int]`, found `tuple[str, bool]`"
     reveal_type(foo((i,), (s, b)))  # revealed: tuple[int]
+
+def variable_and_fixed(variable: tuple[int, ...], fixed: tuple[int]) -> None:
+    foo(variable, fixed)
+    foo(fixed, variable)
 ```
 
 ## Type concatenation
@@ -544,15 +626,9 @@ def f(
     suffix: tuple[*tuple[str, ...], bytes],
     mixed: tuple[int, *tuple[str, ...], bytes],
 ) -> None:
-    # TODO: Should reveal `tuple[int, *tuple[str, ...]]`.
-    # error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...]]`"
-    reveal_type(preserve(prefix))  # revealed: tuple[int, ...]
-    # TODO: Should reveal `tuple[*tuple[str, ...], bytes]`.
-    # error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[str, ...]`, found `tuple[*tuple[str, ...], bytes]`"
-    reveal_type(preserve(suffix))  # revealed: tuple[str, ...]
-    # TODO: Should reveal `tuple[int, *tuple[str, ...], bytes]`.
-    # error: [invalid-argument-type] "Argument to function `preserve` is incorrect: Expected `tuple[int, ...]`, found `tuple[int, *tuple[str, ...], bytes]`"
-    reveal_type(preserve(mixed))  # revealed: tuple[int, ...]
+    reveal_type(preserve(prefix))  # revealed: tuple[int, *tuple[str, ...]]
+    reveal_type(preserve(suffix))  # revealed: tuple[*tuple[str, ...], bytes]
+    reveal_type(preserve(mixed))  # revealed: tuple[int, *tuple[str, ...], bytes]
 ```
 
 A tuple containing an unpacked tuple can precisely describe heterogeneous positional arguments,

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -280,6 +280,12 @@ def variadic2(*args: int) -> tuple[str, ...]:
 def keyword_only(*, x: int) -> tuple[int]:
     raise NotImplementedError
 
+def fixed_unpacked(*args: *tuple[int, str]) -> tuple[int, str]:
+    raise NotImplementedError
+
+def homogeneous_unpacked(*args: *tuple[bytes, ...]) -> tuple[bytes, ...]:
+    raise NotImplementedError
+
 class PositionalCallable:
     def __call__(self, x: int, y: str, /) -> tuple[int, str]:
         raise NotImplementedError
@@ -288,12 +294,22 @@ reveal_type(simple(positional_only))  # revealed: tuple[int, str]
 reveal_type(simple(standard))  # revealed: tuple[int, str]
 reveal_type(simple(positional_variadic))  # revealed: tuple[int, *tuple[str, ...]]
 reveal_type(simple(variadic1))  # revealed: tuple[int, ...]
+reveal_type(simple(fixed_unpacked))  # revealed: tuple[int, str]
+reveal_type(simple(homogeneous_unpacked))  # revealed: tuple[bytes, ...]
 reveal_type(simple(PositionalCallable()))  # revealed: tuple[int, str]
 
 # error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `(*args: int) -> tuple[int, ...]`, found `def variadic2(*args: int) -> tuple[str, ...]`"
 reveal_type(simple(variadic2))  # revealed: tuple[int, ...]
 # error: [invalid-argument-type] "Argument to function `simple` is incorrect: Expected `() -> tuple[()]`, found `def keyword_only(*, x: int) -> tuple[int]`"
 reveal_type(simple(keyword_only))  # revealed: tuple[()]
+
+class Holder[*Ts]:
+    callback: Callable[[*Ts], None]
+
+def use_holder(holder: Holder[*tuple[*tuple[str, ...], bytes]]) -> None:
+    reveal_type(holder.callback)  # revealed: (*tuple[*tuple[str, ...], bytes]) -> None
+    holder.callback(b"end")
+    holder.callback("one", "two", b"end")
 ```
 
 An overloaded callable is accepted if any overload is compatible. The order of the overloads does

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/typevartuple.md
@@ -154,7 +154,19 @@ class WithDefault[*Ts = *tuple[int, str]]:
     attr: tuple[*Ts]
 
 reveal_type(WithDefault().attr)  # revealed: tuple[int, str]
+reveal_type(WithDefault[()]().attr)  # revealed: tuple[()]
 reveal_type(WithDefault[bool, bytes]().attr)  # revealed: tuple[bool, bytes]
+
+class PrefixWithDefault[T, *Ts = *tuple[int, str]]:
+    attr: tuple[T, *Ts]
+
+reveal_type(PrefixWithDefault[bool]().attr)  # revealed: tuple[bool, int, str]
+reveal_type(PrefixWithDefault[bool, *tuple[()]]().attr)  # revealed: tuple[bool]
+
+class DependentDefault[T, *Ts = *tuple[T]]:
+    attr: tuple[T, *Ts]
+
+reveal_type(DependentDefault[bytes]().attr)  # revealed: tuple[bytes, bytes]
 ```
 
 ### Assignment checks
@@ -728,11 +740,21 @@ def _(a1: Headered, a2: Headered[*tuple[Any, ...]]) -> None:
 ```py
 type First[*Ts, T] = tuple[*Ts, T]
 type Second[T, *Ts] = tuple[T, *Ts]
+type Middle[T, *Ts, U] = tuple[T, *Ts, U]
+type PrefixTwo[T, U, *Ts] = tuple[T, U, *Ts]
+type SuffixTwo[*Ts, T, U] = tuple[*Ts, T, U]
 
 reveal_type(First[*tuple[int, ...]])  # revealed: <type alias 'First[*tuple[int, ...], int]'>
 reveal_type(First[*tuple[int, ...], str])  # revealed: <type alias 'First[*tuple[int, ...], str]'>
 reveal_type(Second[*tuple[int, ...]])  # revealed: <type alias 'Second[int, *tuple[int, ...]]'>
 reveal_type(Second[str, *tuple[int, ...]])  # revealed: <type alias 'Second[str, *tuple[int, ...]]'>
+reveal_type(Middle[*tuple[int, ...]])  # revealed: <type alias 'Middle[int, *tuple[int, ...], int]'>
+reveal_type(Middle[*tuple[int, ...], str])  # revealed: <type alias 'Middle[int, *tuple[int, ...], str]'>
+reveal_type(Middle[str, *tuple[int, ...]])  # revealed: <type alias 'Middle[str, *tuple[int, ...], int]'>
+reveal_type(PrefixTwo[*tuple[int, ...]])  # revealed: <type alias 'PrefixTwo[int, int, *tuple[int, ...]]'>
+reveal_type(PrefixTwo[*tuple[int, ...], str])  # revealed: <type alias 'PrefixTwo[int, int, *tuple[*tuple[int, ...], str]]'>
+reveal_type(SuffixTwo[*tuple[int, ...]])  # revealed: <type alias 'SuffixTwo[*tuple[int, ...], int, int]'>
+reveal_type(SuffixTwo[*tuple[int, ...], str])  # revealed: <type alias 'SuffixTwo[*tuple[int, ...], int, str]'>
 ```
 
 ### Variadic substitutions

--- a/crates/ty_python_semantic/resources/mdtest/regression/typevartuple_exception_handler.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/typevartuple_exception_handler.md
@@ -1,0 +1,36 @@
+# `TypeVarTuple` in exception handlers
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+Semantic analysis should not panic when syntax recovery exposes a PEP 695 `TypeVarTuple` as an
+exception handler type on an older Python version.
+
+```py
+# error: [invalid-syntax]
+def regular[*Ts]() -> None:
+    try:
+        pass
+    # error: [invalid-exception-caught] "Invalid object caught in an exception handler: Object has type `TypeVarTuple`"
+    except Ts:
+        pass
+
+# error: [invalid-syntax]
+def tuple_handler[*Ts]() -> None:
+    try:
+        pass
+    # error: [invalid-exception-caught]
+    except (Ts,):
+        pass
+
+# error: [invalid-syntax]
+def starred[*Us]() -> None:
+    try:
+        pass
+    # error: 11 [invalid-syntax] "Cannot use `except*` on Python 3.10 (syntax was added in Python 3.11)"
+    # error: [invalid-exception-caught] "Invalid object caught in an exception handler: Object has type `TypeVarTuple`"
+    except* Us:
+        pass
+```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Default_type_paramet…_(6bb09b09c131074).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/classes.md_-_Generic_classes___PEP…_-_Default_type_paramet…_(6bb09b09c131074).snap
@@ -36,11 +36,12 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.
 21 | class Corge[*Ts, T1 = int, T2 = str, **P = [int, str]]: ...
 22 | 
 23 | # error: [invalid-type-variable-default]
-24 | class Grault[*Us, *Ts = *tuple[int, str]]: ...
-25 | 
-26 | # These are fine:
-27 | class Ok1[T, *Ts]: ...
-28 | class Ok3[*Ts]: ...
+24 | # error: [invalid-type-form] "TypeVarTuple `Ts` cannot appear after TypeVarTuple `Us`"
+25 | class Grault[*Us, *Ts = *tuple[int, str]]: ...
+26 | 
+27 | # These are fine:
+28 | class Ok1[T, *Ts]: ...
+29 | class Ok3[*Ts]: ...
 ```
 
 # Diagnostics
@@ -128,10 +129,23 @@ info: See https://typing.python.org/en/latest/spec/generics.html#defaults-follow
 ```
 
 ```
-error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
-  --> src/mdtest_snippet.py:24:14
+error[invalid-type-form]: Only one TypeVarTuple parameter is allowed
+  --> src/mdtest_snippet.py:25:14
    |
-24 | class Grault[*Us, *Ts = *tuple[int, str]]: ...
+25 | class Grault[*Us, *Ts = *tuple[int, str]]: ...
+   |              ---  ^^^^^^^^^^^^^^^^^^^^^^ `Ts` is an additional TypeVarTuple
+   |              |
+   |              `Us` is the first TypeVarTuple
+   |
+info: See https://typing.python.org/en/latest/spec/generics.html#multiple-type-variable-tuples-not-allowed
+
+```
+
+```
+error[invalid-type-variable-default]: Type parameters with defaults cannot follow a TypeVarTuple parameter
+  --> src/mdtest_snippet.py:25:14
+   |
+25 | class Grault[*Us, *Ts = *tuple[int, str]]: ...
    |              ---  ^^^^^^^^^^^^^^^^^^^^^^ `Ts` has a default
    |              |
    |              `Us` is a TypeVarTuple

--- a/crates/ty_python_semantic/resources/mdtest/type_form.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_form.md
@@ -340,7 +340,10 @@ bad_literal_var: TypeForm = Literal[var]  # error: [invalid-type-form]
 bad_literal_f_string: TypeForm = Literal[f""]  # error: [invalid-type-form]
 bad_qualifier: TypeForm = ClassVar[int]  # error: [invalid-type-form]
 bad_final: TypeForm = Final[int]  # error: [invalid-type-form]
-bad_unpack: TypeForm = Unpack[Ts]  # error: [invalid-type-form]
+# error: [invalid-type-form] "`Unpack` is not allowed in type expressions"
+bad_unpack: TypeForm = Unpack[Ts]
+# error: [invalid-type-form] "`Unpack` is not allowed in type expressions"
+bad_concrete_unpack: TypeForm = Unpack[tuple[int, ...]]
 bad_optional: TypeForm = Optional  # error: [invalid-type-form]
 bad_quoted_operator: TypeForm = "int + str"  # error: [invalid-type-form]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -1476,6 +1476,42 @@ def g3(obj: Foo[tuple[A]]):
     f3(obj)
 ```
 
+### Assignability of generic types parameterized by typevar tuples
+
+For a class parameterized by a typevar tuple, the whole unpacked tuple participates in the generic
+class's variance.
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+```py
+from typing import Any, Generic, TypeVarTuple
+from ty_extensions import static_assert, is_assignable_to
+
+Ts = TypeVarTuple("Ts")
+
+class Array(Generic[*Ts]):
+    values: tuple[*Ts]
+
+    def gradual(self) -> "Array[*tuple[Any, ...]]":
+        return self
+
+static_assert(is_assignable_to(Array[int, str], Array[int, str]))
+static_assert(not is_assignable_to(Array[str, int], Array[int, str]))
+static_assert(not is_assignable_to(Array[int], Array[int, str]))
+
+OutTs = TypeVarTuple("OutTs", covariant=True)
+
+class CovariantArray(Generic[*OutTs]):
+    def get(self) -> tuple[*OutTs]:
+        raise NotImplementedError
+
+static_assert(is_assignable_to(CovariantArray[int, str], CovariantArray[object, object]))
+static_assert(not is_assignable_to(CovariantArray[object, object], CovariantArray[int, str]))
+```
+
 ## Generic aliases
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1213,10 +1213,7 @@ impl<'db> Type<'db> {
             | DynamicType::UnknownGeneric(_)
             | DynamicType::UnspecializedTypeVar
             | DynamicType::AmbiguousOverload => false,
-            DynamicType::Todo(_)
-            | DynamicType::TodoStarredExpression
-            | DynamicType::TodoUnpack
-            | DynamicType::TodoTypeVarTuple => true,
+            DynamicType::Todo(_) => true,
         })
     }
 
@@ -1956,11 +1953,8 @@ impl<'db> Type<'db> {
                 DynamicType::Unknown
                 | DynamicType::UnknownGeneric(_)
                 | DynamicType::UnspecializedTypeVar
-                | DynamicType::TodoUnpack
-                | DynamicType::TodoTypeVarTuple
                 | DynamicType::Todo(_)
                 | DynamicType::InvalidConcatenateUnknown
-                | DynamicType::TodoStarredExpression
                 | DynamicType::AmbiguousOverload => false,
             },
         }
@@ -5596,6 +5590,16 @@ impl<'db> Type<'db> {
                             fallback_type: Type::unknown(),
                         });
                     }
+                    if !inference_flags.contains(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT)
+                        && typevar.is_typevartuple(db)
+                    {
+                        return Err(InvalidTypeExpressionError {
+                            invalid_expressions: smallvec_inline![
+                                InvalidTypeExpression::InvalidBareTypeVarTuple(*typevar)
+                            ],
+                            fallback_type: Type::unknown(),
+                        });
+                    }
                     let index = semantic_index(db, scope_id.file(db));
                     Ok(bind_typevar(
                         db,
@@ -5728,7 +5732,9 @@ impl<'db> Type<'db> {
                 Some(KnownClass::TypeVar) => Ok(todo_type!(
                     "Support for `typing.TypeVar` instances in type expressions"
                 )),
-                Some(KnownClass::TypeVarTuple) => Ok(Type::Dynamic(DynamicType::TodoTypeVarTuple)),
+                Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple) => Ok(
+                    todo_type!("Support for `typing.TypeVarTuple` instances in type expressions"),
+                ),
                 _ => Err(InvalidTypeExpressionError {
                     invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
                         *self, scope_id
@@ -6314,6 +6320,14 @@ impl<'db> Type<'db> {
                 {
                     Some(*bound_typevar)
                 }
+                TypeVarKind::TypeVarTuple
+                    if binding_context.is_none_or(|binding_context| {
+                        bound_typevar.binding_context(db)
+                            == BindingContext::Definition(binding_context)
+                    }) =>
+                {
+                    Some(*bound_typevar)
+                }
                 TypeVarKind::ParamSpec => {
                     // For `ParamSpec`, we're only interested in `P` itself, not `P.args` or
                     // `P.kwargs`.
@@ -6750,9 +6764,6 @@ impl<'db> Type<'db> {
             Self::Divergent(_)
             | Self::Dynamic(
                 DynamicType::Todo(_)
-                | DynamicType::TodoUnpack
-                | DynamicType::TodoStarredExpression
-                | DynamicType::TodoTypeVarTuple
                 | DynamicType::InvalidConcatenateUnknown
                 | DynamicType::UnspecializedTypeVar,
             )
@@ -7414,12 +7425,6 @@ pub enum DynamicType<'db> {
     ///
     /// This variant should be created with the `todo_type!` macro.
     Todo(TodoType),
-    /// A special Todo-variant for `Unpack[Ts]`, so that we can treat it specially in `Generic[Unpack[Ts]]`
-    TodoUnpack,
-    /// A special Todo-variant for `*Ts`, so that we can treat it specially in `Generic[*Ts]`
-    TodoStarredExpression,
-    /// A special Todo-variant for `TypeVarTuple` instances encountered in type expressions
-    TodoTypeVarTuple,
 }
 
 impl DynamicType<'_> {
@@ -7428,7 +7433,7 @@ impl DynamicType<'_> {
     }
 
     pub(crate) fn is_todo(&self) -> bool {
-        matches!(self, Self::Todo(_) | Self::TodoUnpack)
+        matches!(self, Self::Todo(_))
     }
 }
 
@@ -7444,9 +7449,6 @@ impl std::fmt::Display for DynamicType<'_> {
             // `DynamicType::Todo`'s display should be explicit that is not a valid display of
             // any other type
             DynamicType::Todo(todo) => write!(f, "@Todo{todo}"),
-            DynamicType::TodoUnpack => f.write_str("@Todo(typing.Unpack)"),
-            DynamicType::TodoStarredExpression => f.write_str("@Todo(StarredExpression)"),
-            DynamicType::TodoTypeVarTuple => f.write_str("@Todo(TypeVarTuple)"),
         }
     }
 }
@@ -7650,6 +7652,7 @@ enum InvalidTypeExpression<'db> {
     /// Some types are always invalid in type expressions
     InvalidType(Type<'db>, ScopeId<'db>),
     InvalidBareParamSpec(TypeVarInstance<'db>),
+    InvalidBareTypeVarTuple(TypeVarInstance<'db>),
 }
 
 impl<'db> InvalidTypeExpression<'db> {
@@ -7771,6 +7774,11 @@ impl<'db> InvalidTypeExpression<'db> {
                         "Bare ParamSpec `{}` is not valid in this context in a {location}",
                         paramspec.name(self.db)
                     ),
+                    InvalidTypeExpression::InvalidBareTypeVarTuple(typevartuple) => write!(
+                        f,
+                        "Bare TypeVarTuple `{}` is not valid in this context in a {location}",
+                        typevartuple.name(self.db)
+                    ),
                     InvalidTypeExpression::Concatenate => write!(
                         f,
                         "`typing.Concatenate` is not allowed in this context in a {location}",
@@ -7849,6 +7857,8 @@ impl<'db> InvalidTypeExpression<'db> {
             diagnostic.info(" - as the default type for another ParamSpec");
             diagnostic.info(" - as part of a type parameter list when defining a generic class");
             diagnostic.info(" - or as part of an argument list when specializing a generic class");
+        } else if matches!(self, InvalidTypeExpression::InvalidBareTypeVarTuple(_)) {
+            diagnostic.info("A TypeVarTuple must be unpacked with `*` or `Unpack[]`.");
         } else if matches!(self, InvalidTypeExpression::Concatenate) {
             diagnostic.info("`typing.Concatenate` is only valid:");
             diagnostic.info(" - as the first argument to `Callable`");

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6320,7 +6320,7 @@ impl<'db> Type<'db> {
                 {
                     Some(*bound_typevar)
                 }
-                TypeVarKind::TypeVarTuple
+                TypeVarKind::TypeVarTuple | TypeVarKind::ExtensionsTypeVarTuple
                     if binding_context.is_none_or(|binding_context| {
                         bound_typevar.binding_context(db)
                             == BindingContext::Definition(binding_context)

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -54,7 +54,7 @@ use crate::types::signatures::{
     CallableSignature, Parameter, ParameterKind, Parameters, ParametersKind, PartialApplication,
     PartialSignatureApplication,
 };
-use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
+use crate::types::tuple::{TupleLength, TupleSpec, TupleSpecBuilder, TupleType};
 use crate::types::typed_dict::{TypedDictOpenness, extract_unpacked_typed_dict_from_value_type};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarNonceGenerator};
 use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
@@ -5059,11 +5059,86 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         specialization_errors: &mut Vec<BindingError<'db>>,
     ) -> bool {
         let parameters = self.signature.parameters();
+        let starred_typevartuple_declared_type = |parameter: &Parameter<'db>| {
+            if !parameter.has_starred_annotation() {
+                return None;
+            }
+            if let Type::TypeVar(typevar) = parameter.annotated_type()
+                && typevar.is_typevartuple(self.db)
+            {
+                return Some(Type::tuple(TupleType::new(
+                    self.db,
+                    &TupleSpecBuilder::with_capacity(0)
+                        .concat_variadic_typevar(self.db, typevar)
+                        .build(),
+                )));
+            }
+            let tuple = parameter
+                .annotated_type()
+                .exact_tuple_instance_spec(self.db)?;
+            let TupleSpec::Variable(variable) = tuple.as_ref() else {
+                return None;
+            };
+            if matches!(
+                variable.variable(),
+                Type::TypeVar(typevar) if typevar.is_typevartuple(self.db)
+            ) {
+                Some(parameter.annotated_type())
+            } else {
+                None
+            }
+        };
+
+        let starred_typevartuple_declared_types = parameters
+            .iter()
+            .map(starred_typevartuple_declared_type)
+            .collect::<Vec<_>>();
+        let mut starred_typevartuple_arguments = starred_typevartuple_declared_types
+            .iter()
+            .map(|declared_type| declared_type.map(|_| Vec::new()))
+            .collect::<Vec<_>>();
+        if starred_typevartuple_arguments.iter().any(Option::is_some) {
+            for (argument_index, _, _, argument_types) in self.enumerate_argument_types() {
+                for matched_parameter in self.argument_matches[argument_index].iter() {
+                    let parameter_index = matched_parameter.index;
+                    if let Some(typevartuple_arguments) =
+                        &mut starred_typevartuple_arguments[parameter_index]
+                    {
+                        typevartuple_arguments
+                            .push(argument_types.get_default().unwrap_or(Type::unknown()));
+                    }
+                }
+            }
+        }
+
+        for (declared_type, argument_types) in starred_typevartuple_declared_types
+            .iter()
+            .zip(&starred_typevartuple_arguments)
+        {
+            let Some((declared_type, argument_types)) =
+                declared_type.as_ref().zip(argument_types.as_ref())
+            else {
+                continue;
+            };
+            let argument_type = Type::heterogeneous_tuple(self.db, argument_types.iter().copied());
+            let specialization_result = builder.infer(*declared_type, argument_type);
+
+            if let Err(error) = specialization_result {
+                specialization_errors.push(BindingError::SpecializationError {
+                    error,
+                    argument_index: None,
+                });
+            }
+        }
+
         for (argument_index, adjusted_argument_index, _, argument_types) in
             self.enumerate_argument_types()
         {
             for matched_parameter in self.argument_matches[argument_index].iter() {
                 let parameter_index = matched_parameter.index;
+                if starred_typevartuple_arguments[parameter_index].is_some() {
+                    continue;
+                }
                 if self.is_gradual_variadic_parameter(parameter_index) {
                     continue;
                 }
@@ -5231,6 +5306,67 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let is_paramspec_component_parameter = |parameter_index: usize| {
             paramspec_component_start.is_some_and(|start| parameter_index >= start)
         };
+
+        for (parameter_index, parameter) in self.signature.parameters().iter().enumerate() {
+            if !parameter.is_variadic()
+                || !parameter.has_starred_annotation()
+                || parameter
+                    .annotated_type()
+                    .exact_tuple_instance_spec(self.db)
+                    .is_none()
+            {
+                continue;
+            }
+
+            let mut positional_types = Vec::new();
+            let mut diagnostic_argument_index = None;
+            let mut has_unpacked_argument = false;
+            for (argument_index, adjusted_argument_index, argument, argument_types) in
+                self.enumerate_argument_types()
+            {
+                if !self.argument_matches[argument_index]
+                    .iter()
+                    .any(|matched_parameter| matched_parameter.index == parameter_index)
+                {
+                    continue;
+                }
+                if matches!(argument, Argument::Variadic) {
+                    has_unpacked_argument = true;
+                    break;
+                }
+                if !matches!(argument, Argument::Positional | Argument::Synthetic) {
+                    continue;
+                }
+                positional_types
+                    .push(argument_types.get_for_declared_type(parameter.annotated_type()));
+                diagnostic_argument_index = diagnostic_argument_index.or(adjusted_argument_index);
+            }
+            if has_unpacked_argument {
+                continue;
+            }
+
+            let provided_ty = Type::heterogeneous_tuple(self.db, positional_types);
+            let expected_ty = self.specialization.map_or_else(
+                || parameter.annotated_type(),
+                |specialization| {
+                    parameter
+                        .annotated_type()
+                        .apply_specialization(self.db, specialization)
+                },
+            );
+            if provided_ty
+                .when_assignable_to(self.db, expected_ty, constraints, self.inferable_typevars)
+                .is_never_satisfied(self.db)
+            {
+                self.errors.push(BindingError::InvalidArgumentType {
+                    parameter: ParameterContext::new(parameter, parameter_index, false),
+                    argument_index: diagnostic_argument_index,
+                    expected_ty,
+                    provided_ty,
+                    provenance: InvalidArgumentTypeProvenance::Argument,
+                });
+            }
+        }
 
         for (argument_index, adjusted_argument_index, argument, argument_types) in
             self.enumerate_argument_types()

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4688,6 +4688,11 @@ struct ArgumentTypeChecker<'a, 'db> {
     /// TODO: Once specialization inference fully owns generic argument validation, this field can
     /// be removed.
     constraint_set_errors: Vec<bool>,
+
+    /// Argument indices where legacy inference deliberately deferred a callable relation involving
+    /// a `TypeVarTuple`. The fallback specialization is not gradual in callable arity, so checking
+    /// it again would produce a false-positive diagnostic.
+    deferred_typevartuple_callable_relations: Vec<bool>,
 }
 
 /// Result of checking only the key type of a keyword-unpack argument.
@@ -4759,6 +4764,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             inferable_typevars: InferableTypeVars::None,
             specialization: None,
             constraint_set_errors: vec![false; arguments.len()],
+            deferred_typevartuple_callable_relations: vec![false; arguments.len()],
         }
     }
 
@@ -5095,17 +5101,67 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             .collect::<Vec<_>>();
         let mut starred_typevartuple_arguments = starred_typevartuple_declared_types
             .iter()
-            .map(|declared_type| declared_type.map(|_| Vec::new()))
+            .map(|declared_type| {
+                declared_type.map(|_| TupleSpecBuilder::with_capacity(self.arguments.len()))
+            })
             .collect::<Vec<_>>();
         if starred_typevartuple_arguments.iter().any(Option::is_some) {
-            for (argument_index, _, _, argument_types) in self.enumerate_argument_types() {
+            for (argument_index, _, argument, argument_types) in self.enumerate_argument_types() {
+                let mut variadic_parameters = FxHashSet::default();
+                let matched_parameters = &self.argument_matches[argument_index].parameters;
                 for matched_parameter in self.argument_matches[argument_index].iter() {
                     let parameter_index = matched_parameter.index;
-                    if let Some(typevartuple_arguments) =
-                        &mut starred_typevartuple_arguments[parameter_index]
-                    {
-                        typevartuple_arguments
-                            .push(argument_types.get_default().unwrap_or(Type::unknown()));
+                    let typevartuple_arguments =
+                        &mut starred_typevartuple_arguments[parameter_index];
+                    let Some(builder) = typevartuple_arguments.as_mut() else {
+                        continue;
+                    };
+
+                    if matches!(argument, Argument::Variadic) {
+                        let Some(tuple) = argument_types
+                            .get_default()
+                            .and_then(|ty| ty.exact_tuple_instance_spec(self.db))
+                        else {
+                            *typevartuple_arguments = None;
+                            continue;
+                        };
+                        let only_matches_this_parameter = matched_parameters
+                            .iter()
+                            .all(|matched| matched.index == parameter_index);
+                        if !only_matches_this_parameter {
+                            if matches!(tuple.as_ref(), TupleSpec::Variable(_)) {
+                                // Splitting an arbitrary-length tuple between fixed parameters and
+                                // a `TypeVarTuple` is ambiguous. Leave the pack unmapped.
+                                *typevartuple_arguments = None;
+                            } else if let Some(argument_type) = matched_parameter.argument_type {
+                                builder.push(argument_type);
+                            }
+                            continue;
+                        }
+
+                        // A fixed splat can match the same variadic parameter multiple times. Append
+                        // its complete tuple specification once instead of appending the tuple
+                        // container for every matched element.
+                        if !variadic_parameters.insert(parameter_index) {
+                            continue;
+                        }
+                        if matches!(builder, TupleSpecBuilder::Variable { .. })
+                            && matches!(tuple.as_ref(), TupleSpec::Variable(_))
+                        {
+                            // Concatenating multiple arbitrary-length tuple specs loses their
+                            // ordering. Leave the pack unmapped so it receives the gradual fallback.
+                            *typevartuple_arguments = None;
+                            continue;
+                        }
+                        *builder = std::mem::replace(
+                            builder,
+                            TupleSpecBuilder::with_capacity(self.arguments.len()),
+                        )
+                        .concat(self.db, &tuple);
+                    } else {
+                        builder.push(matched_parameter.argument_type.unwrap_or_else(|| {
+                            argument_types.get_default().unwrap_or(Type::unknown())
+                        }));
                     }
                 }
             }
@@ -5120,7 +5176,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             else {
                 continue;
             };
-            let argument_type = Type::heterogeneous_tuple(self.db, argument_types.iter().copied());
+            let argument_type =
+                Type::tuple(TupleType::new(self.db, &argument_types.clone().build()));
             let specialization_result = builder.infer(*declared_type, argument_type);
 
             if let Err(error) = specialization_result {
@@ -5136,7 +5193,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         {
             for matched_parameter in self.argument_matches[argument_index].iter() {
                 let parameter_index = matched_parameter.index;
-                if starred_typevartuple_arguments[parameter_index].is_some() {
+                if starred_typevartuple_declared_types[parameter_index].is_some() {
                     continue;
                 }
                 if self.is_gradual_variadic_parameter(parameter_index) {
@@ -5149,6 +5206,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     declared_type,
                     matched_parameter.argument_type.unwrap_or(argument_type),
                 );
+                if builder.take_deferred_typevartuple_callable_relation() {
+                    self.deferred_typevartuple_callable_relations[argument_index] = true;
+                }
 
                 if let Err(error) = specialization_result {
                     specialization_errors.push(BindingError::SpecializationError {
@@ -5203,6 +5263,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         //
         // TODO: handle starred annotations, e.g. `*args: *Ts` or `*args: *tuple[int, *tuple[str, ...]]`
         if !self.constraint_set_errors[argument_index]
+            && !self.deferred_typevartuple_callable_relations[argument_index]
             && !parameter.has_starred_annotation()
             && argument_type
                 .when_assignable_to(self.db, expected_ty, constraints, self.inferable_typevars)

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -107,6 +107,7 @@ pub enum KnownClass {
     ParamSpecKwargs,
     ProtocolMeta,
     TypeVarTuple,
+    ExtensionsTypeVarTuple, // must be distinct from typing.TypeVarTuple, backports new features
     TypeAliasType,
     NoDefaultType,
     NewType,
@@ -186,6 +187,7 @@ impl KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::Super
             | Self::WrapperDescriptorType
@@ -338,6 +340,7 @@ impl KnownClass {
             | KnownClass::ParamSpecArgs
             | KnownClass::ParamSpecKwargs
             | KnownClass::TypeVarTuple
+            | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
             | KnownClass::NoDefaultType
@@ -438,6 +441,7 @@ impl KnownClass {
             | KnownClass::ParamSpecArgs
             | KnownClass::ParamSpecKwargs
             | KnownClass::TypeVarTuple
+            | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
             | KnownClass::NoDefaultType
@@ -538,6 +542,7 @@ impl KnownClass {
             | KnownClass::ParamSpecArgs
             | KnownClass::ParamSpecKwargs
             | KnownClass::TypeVarTuple
+            | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
             | KnownClass::NoDefaultType
@@ -644,6 +649,7 @@ impl KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::TypeAliasType
             | Self::NoDefaultType
@@ -757,6 +763,7 @@ impl KnownClass {
             | KnownClass::ParamSpecKwargs
             | KnownClass::ProtocolMeta
             | KnownClass::TypeVarTuple
+            | KnownClass::ExtensionsTypeVarTuple
             | KnownClass::Sentinel
             | KnownClass::TypeAliasType
             | KnownClass::NoDefaultType
@@ -839,6 +846,7 @@ impl KnownClass {
             Self::ParamSpecArgs => "ParamSpecArgs",
             Self::ParamSpecKwargs => "ParamSpecKwargs",
             Self::TypeVarTuple => "TypeVarTuple",
+            Self::ExtensionsTypeVarTuple => "TypeVarTuple",
             Self::Sentinel => "Sentinel",
             Self::TypeAliasType => "TypeAliasType",
             Self::NoDefaultType => "_NoDefaultType",
@@ -1217,10 +1225,11 @@ impl KnownClass {
             | Self::Mapping
             | Self::ProtocolMeta
             | Self::ParamSpec
+            | Self::TypeVarTuple
             | Self::SupportsIndex => KnownModule::Typing,
             Self::TypeAliasType
             | Self::ExtensionsTypeVar
-            | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::ExtensionsParamSpec
             | Self::ParamSpecArgs
@@ -1322,6 +1331,7 @@ impl KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::Enum
             | Self::EnumProperty
@@ -1427,6 +1437,7 @@ impl KnownClass {
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::Enum
             | Self::EnumProperty
@@ -1526,7 +1537,7 @@ impl KnownClass {
             "ParamSpec" => &[Self::ParamSpec, Self::ExtensionsParamSpec],
             "ParamSpecArgs" => &[Self::ParamSpecArgs],
             "ParamSpecKwargs" => &[Self::ParamSpecKwargs],
-            "TypeVarTuple" => &[Self::TypeVarTuple],
+            "TypeVarTuple" => &[Self::TypeVarTuple, Self::ExtensionsTypeVarTuple],
             "Sentinel" => &[Self::Sentinel],
             "ChainMap" => &[Self::ChainMap],
             "Counter" => &[Self::Counter],
@@ -1645,6 +1656,8 @@ impl KnownClass {
             | Self::ExtensionsTypeVar
             | Self::ParamSpec
             | Self::ExtensionsParamSpec
+            | Self::TypeVarTuple
+            | Self::ExtensionsTypeVarTuple
             | Self::Sentinel
             | Self::NamedTupleLike
             | Self::ConstraintSet
@@ -1667,7 +1680,6 @@ impl KnownClass {
             | Self::SupportsIndex
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
-            | Self::TypeVarTuple
             | Self::Iterable
             | Self::Iterator
             | Self::AsyncIterator
@@ -1959,6 +1971,7 @@ mod tests {
                     KnownClass::BaseExceptionGroup | KnownClass::ExceptionGroup => {
                         PythonVersion::PY311
                     }
+                    KnownClass::TypeVarTuple => PythonVersion::PY311,
                     KnownClass::GenericAlias => PythonVersion::PY39,
                     KnownClass::EnumProperty
                     | KnownClass::Member

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -64,12 +64,7 @@ impl<'db> ClassBase<'db> {
                 | DynamicType::AmbiguousOverload,
             ) => "Unknown",
             ClassBase::Dynamic(DynamicType::UnspecializedTypeVar) => "UnspecializedTypeVar",
-            ClassBase::Dynamic(
-                DynamicType::Todo(_)
-                | DynamicType::TodoUnpack
-                | DynamicType::TodoStarredExpression
-                | DynamicType::TodoTypeVarTuple,
-            ) => "@Todo",
+            ClassBase::Dynamic(DynamicType::Todo(_)) => "@Todo",
             ClassBase::Divergent(_) => "Divergent",
             ClassBase::Protocol => "Protocol",
             ClassBase::Generic => "Generic",

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1503,6 +1503,30 @@ impl<'db> FmtDetailed<'db> for DisplayTuple<'_, 'db> {
             // S is included if there is either a prefix or a suffix. The initial `tuple[` and
             // trailing `]` are printed elsewhere. The `yyy, ...` is printed no matter what.)
             TupleSpec::Variable(tuple) => {
+                if let Type::TypeVar(typevar) = tuple.variable()
+                    && typevar.is_typevartuple(self.db)
+                {
+                    if !tuple.prefix_elements().is_empty() {
+                        tuple
+                            .prefix_elements()
+                            .display_with(self.db, self.settings.singleline())
+                            .fmt_detailed(f)?;
+                        f.write_str(", ")?;
+                    }
+                    f.write_char('*')?;
+                    Type::TypeVar(typevar)
+                        .display_with(self.db, self.settings.singleline())
+                        .fmt_detailed(f)?;
+                    if !tuple.suffix_elements().is_empty() {
+                        f.write_str(", ")?;
+                        tuple
+                            .suffix_elements()
+                            .display_with(self.db, self.settings.singleline())
+                            .fmt_detailed(f)?;
+                    }
+                    f.write_str("]")?;
+                    return Ok(());
+                }
                 if !tuple.prefix_elements().is_empty() {
                     tuple
                         .prefix_elements()
@@ -1849,6 +1873,8 @@ impl<'db> DisplayGenericContext<'_, 'db> {
             let typevar = bound_typevar.typevar(self.db);
             if typevar.is_paramspec(self.db) {
                 f.write_str("**")?;
+            } else if typevar.is_typevartuple(self.db) {
+                f.write_char('*')?;
             }
             write!(
                 f.with_type(Type::TypeVar(bound_typevar)),
@@ -1934,13 +1960,64 @@ struct DisplaySpecialization<'db> {
 impl<'db> DisplaySpecialization<'db> {
     fn fmt_normal(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
         f.write_char('[')?;
+        let variables = self
+            .specialization
+            .generic_context(self.db)
+            .variables(self.db)
+            .collect::<Vec<_>>();
         let types = self.specialization.types(self.db);
-        for (idx, ty) in types.iter().enumerate() {
-            if idx > 0 {
+        let mut wrote_any = false;
+        for (typevar, ty) in variables.iter().zip(types) {
+            if typevar.is_typevartuple(self.db) {
+                let Some(tuple) = ty.exact_tuple_instance_spec(self.db) else {
+                    if wrote_any {
+                        f.write_str(", ")?;
+                    }
+                    ty.display_with(self.db, self.settings.clone())
+                        .fmt_detailed(f)?;
+                    wrote_any = true;
+                    continue;
+                };
+                match tuple.as_ref() {
+                    TupleSpec::Fixed(fixed) if fixed.elements_slice().is_empty() => {
+                        if variables.len() == 1 {
+                            if wrote_any {
+                                f.write_str(", ")?;
+                            }
+                            f.write_str("()")?;
+                            wrote_any = true;
+                        }
+                    }
+                    TupleSpec::Fixed(fixed) => {
+                        for element in fixed.elements_slice() {
+                            if wrote_any {
+                                f.write_str(", ")?;
+                            }
+                            element
+                                .display_with(self.db, self.settings.clone())
+                                .fmt_detailed(f)?;
+                            wrote_any = true;
+                        }
+                    }
+                    TupleSpec::Variable(_) => {
+                        if wrote_any {
+                            f.write_str(", ")?;
+                        }
+                        f.write_char('*')?;
+                        ty.display_with(self.db, self.settings.clone())
+                            .fmt_detailed(f)?;
+                        wrote_any = true;
+                    }
+                }
+                continue;
+            }
+
+            if wrote_any {
                 f.write_str(", ")?;
             }
             ty.display_with(self.db, self.settings.clone())
                 .fmt_detailed(f)?;
+            wrote_any = true;
         }
         if self.tuple_specialization.is_yes() {
             f.write_str(", ...")?;
@@ -2261,11 +2338,16 @@ impl<'db> FmtDetailed<'db> for DisplayParameters<'_, 'db> {
         ) -> fmt::Result {
             let mut star_added = false;
             let mut needs_slash = false;
+            let mut after_synthetic_unpack = false;
             let mut first = true;
 
             for parameter in parameters {
+                let is_synthetic_unpack = parameter.definition().is_none()
+                    && parameter.is_variadic()
+                    && parameter.has_starred_annotation();
+
                 // Handle special separators
-                if parameter.is_positional_only() {
+                if parameter.is_positional_only() && !after_synthetic_unpack {
                     needs_slash = true;
                 } else if needs_slash {
                     if !first {
@@ -2298,6 +2380,7 @@ impl<'db> FmtDetailed<'db> for DisplayParameters<'_, 'db> {
                     .display_with(display.db, display.settings.singleline())
                     .fmt_detailed(&mut f.with_detail(TypeDetail::Parameter(param_name)))?;
 
+                after_synthetic_unpack |= is_synthetic_unpack;
                 first = false;
             }
 
@@ -2410,6 +2493,18 @@ struct DisplayParameter<'a, 'db> {
 
 impl<'db> FmtDetailed<'db> for DisplayParameter<'_, 'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        if self.param.definition().is_none()
+            && self.param.is_variadic()
+            && self.param.has_starred_annotation()
+        {
+            f.write_str("*")?;
+            self.param
+                .annotated_type()
+                .display_with(self.db, self.settings.clone())
+                .fmt_detailed(f)?;
+            return Ok(());
+        }
+
         if let Some(name) = self.param.display_name() {
             f.write_str(&name)?;
             if self.param.should_annotation_be_displayed() {
@@ -3140,6 +3235,8 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
             KnownInstanceType::TypeVar(typevar_instance) => {
                 if typevar_instance.kind(self.db).is_paramspec() {
                     f.with_type(ty).write_str("ParamSpec")
+                } else if typevar_instance.kind(self.db).is_typevartuple() {
+                    f.with_type(ty).write_str("TypeVarTuple")
                 } else {
                     f.with_type(ty).write_str("TypeVar")
                 }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 use itertools::{Either, Itertools};
 use ruff_python_ast as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 
 use crate::types::callable::walk_callable_type;
 use crate::types::class::ClassType;
@@ -18,8 +19,10 @@ use crate::types::infer::original_class_type;
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
-use crate::types::signatures::{CallableSignature, Parameters, SignatureRelationVisitor};
-use crate::types::tuple::{TupleSpec, TupleType, walk_tuple_type};
+use crate::types::signatures::{
+    CallableSignature, Parameter, Parameters, Signature, SignatureRelationVisitor,
+};
+use crate::types::tuple::{TupleSpec, TupleSpecBuilder, TupleType, walk_tuple_type};
 use crate::types::type_alias::{walk_manual_pep_695_type_alias, walk_pep_695_type_alias};
 use crate::types::typevar::{
     BoundTypeVarIdentity, TypeVarIdentity, TypeVarInstance, walk_type_var_bounds,
@@ -1925,10 +1928,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             Option<ConstraintBounds<'db>>,
         ) -> Option<Type<'db>>,
     ) -> FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> {
+        // TODO: Move `ParamSpec` and `TypeVarTuple` handling to the new constraint solver.
         if generic_context
             .variables_inner(self.db)
             .values()
-            .any(|typevar| typevar.is_paramspec(self.db))
+            .any(|typevar| typevar.is_paramspec(self.db) || typevar.is_typevartuple(self.db))
         {
             return self.solve_hash_map_with(generic_context, choose);
         }
@@ -2192,17 +2196,42 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let identity = bound_typevar.identity(self.db);
         match self.types.entry(identity) {
             Entry::Occupied(mut entry) => {
-                // TODO: The spec says that when a ParamSpec is used multiple times in a signature,
-                // the type checker can solve it to a common behavioral supertype. We don't
-                // implement that yet so in case there are multiple ParamSpecs, use the
-                // specialization from the first occurrence.
-                // https://github.com/astral-sh/ty/issues/1778
-                // https://github.com/astral-sh/ruff/pull/21445#discussion_r2591510145
-                if bound_typevar.is_paramspec(self.db) {
-                    return;
+                match bound_typevar.kind(self.db) {
+                    TypeVarKind::ParamSpec | TypeVarKind::Pep695ParamSpec => {
+                        // TODO: The spec says that when a ParamSpec is used multiple times in a signature,
+                        // the type checker can solve it to a common behavioral supertype. We don't
+                        // implement that yet so in case there are multiple ParamSpecs, use the
+                        // specialization from the first occurrence.
+                        // https://github.com/astral-sh/ty/issues/1778
+                        // https://github.com/astral-sh/ruff/pull/21445#discussion_r2591510145
+                    }
+                    TypeVarKind::TypeVarTuple | TypeVarKind::Pep695TypeVarTuple => {
+                        // Repeated uses of a `TypeVarTuple` must have the same length, but the typing
+                        // spec leaves the exact inference behavior unspecified. Merge equal-length
+                        // candidates element-wise using unions.
+                        // https://typing.python.org/en/latest/spec/generics.html#type-variable-tuple-equality
+                        let accumulator = entry.get_mut();
+                        let existing = accumulator.get_or_build(self.db);
+                        let Some(existing_tuple) = existing.exact_tuple_instance_spec(self.db)
+                        else {
+                            return;
+                        };
+                        let Some(new_tuple) = ty.exact_tuple_instance_spec(self.db) else {
+                            return;
+                        };
+                        if existing_tuple.len() != new_tuple.len() {
+                            return;
+                        }
+                        let unioned = TupleSpecBuilder::from(existing_tuple.as_ref())
+                            .union(self.db, &new_tuple)
+                            .build();
+                        *accumulator =
+                            UnionAccumulator::new(Type::tuple(TupleType::new(self.db, &unioned)));
+                    }
+                    _ => {
+                        entry.get_mut().add(self.db, ty);
+                    }
                 }
-
-                entry.get_mut().add(self.db, ty);
             }
             Entry::Vacant(entry) => {
                 entry.insert(UnionAccumulator::new(ty));
@@ -2367,6 +2396,79 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             .then_some(mapping_when)
     }
 
+    fn infer_typevartuple_from_callable_parameters(
+        &mut self,
+        formal_signature: &Signature<'db>,
+        variadic_index: usize,
+        typevartuple: BoundTypeVarInstance<'db>,
+        actual_signature: &Signature<'db>,
+    ) {
+        let formal_parameters = formal_signature.parameters().as_slice();
+        let suffix_len = formal_parameters.len() - variadic_index - 1;
+        if !formal_parameters[..variadic_index]
+            .iter()
+            .chain(&formal_parameters[variadic_index + 1..])
+            .all(Parameter::is_positional)
+        {
+            return;
+        }
+
+        let actual_parameters = actual_signature.parameters().as_slice();
+        if !actual_parameters
+            .iter()
+            .all(|parameter| parameter.is_positional() || parameter.is_variadic())
+        {
+            return;
+        }
+
+        let tuple = if let Some(actual_variadic_index) =
+            actual_parameters.iter().position(Parameter::is_variadic)
+        {
+            // An actual variadic parameter can only satisfy the open-ended portion of the formal
+            // callable. It cannot provide a fixed suffix because callers are not required to pass
+            // any arguments to it.
+            if suffix_len > 0
+                || actual_variadic_index < variadic_index
+                || actual_variadic_index + 1 != actual_parameters.len()
+            {
+                return;
+            }
+
+            Type::tuple(TupleType::new(
+                self.db,
+                &TupleSpecBuilder::Variable {
+                    prefix: actual_parameters[variadic_index..actual_variadic_index]
+                        .iter()
+                        .map(Parameter::annotated_type)
+                        .collect(),
+                    variable: actual_parameters[actual_variadic_index].annotated_type(),
+                    suffix: vec![],
+                }
+                .build(),
+            ))
+        } else {
+            if actual_parameters.len() < variadic_index + suffix_len {
+                return;
+            }
+
+            let middle_end = actual_parameters.len() - suffix_len;
+            Type::heterogeneous_tuple(
+                self.db,
+                actual_parameters[variadic_index..middle_end]
+                    .iter()
+                    .map(Parameter::annotated_type),
+            )
+        };
+        self.add_type_mapping(typevartuple, tuple, TypeVarVariance::Contravariant);
+
+        let _ = self.infer_map_impl(
+            formal_signature.return_ty,
+            actual_signature.return_ty,
+            TypeVarVariance::Covariant,
+            &mut FxHashSet::default(),
+        );
+    }
+
     /// Infer type mappings by comparing formal callable signatures against actual callables.
     fn infer_from_callable_signature(
         &mut self,
@@ -2374,6 +2476,33 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         actual_callables: &CallableTypes<'db>,
     ) -> Result<(), ()> {
         let formal_is_single_paramspec = formal_signature.is_single_paramspec().is_some();
+
+        let typevartuple_formal_overloads: SmallVec<[_; 1]> = if formal_is_single_paramspec {
+            SmallVec::new()
+        } else {
+            formal_signature
+                .iter()
+                .filter_map(|formal_overload| {
+                    formal_overload
+                        .parameters()
+                        .as_slice()
+                        .iter()
+                        .find_position(|parameter| {
+                            parameter.is_variadic() && parameter.has_starred_annotation()
+                        })
+                        .and_then(|(index, parameter)| {
+                            let Type::TypeVar(typevartuple) = parameter.annotated_type() else {
+                                return None;
+                            };
+                            typevartuple.is_typevartuple(self.db).then_some((
+                                formal_overload,
+                                index,
+                                typevartuple,
+                            ))
+                        })
+                })
+                .collect()
+        };
 
         for actual_callable in actual_callables.as_slice() {
             if formal_is_single_paramspec {
@@ -2393,6 +2522,17 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     .overloads
                     .iter()
                     .filter_map(|actual_signature| {
+                        for (formal_overload, variadic_index, typevartuple) in
+                            &typevartuple_formal_overloads
+                        {
+                            self.infer_typevartuple_from_callable_parameters(
+                                formal_overload,
+                                *variadic_index,
+                                *typevartuple,
+                                actual_signature,
+                            );
+                        }
+
                         let when = actual_signature.when_constraint_set_assignable_to_signatures(
                             db,
                             formal_signature,
@@ -2845,6 +2985,46 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     formal.tuple_instance_spec(self.db),
                     actual_nominal.tuple_spec(self.db),
                 ) {
+                    if let TupleSpec::Variable(formal_variable) = formal_tuple.as_ref()
+                        && let Type::TypeVar(typevartuple) = formal_variable.variable()
+                        && typevartuple.is_typevartuple(self.db)
+                        && let TupleSpec::Fixed(actual_fixed) = actual_tuple.as_ref()
+                    {
+                        let prefix_len = formal_variable.prefix_elements().len();
+                        let suffix_len = formal_variable.suffix_elements().len();
+                        let actual_len = actual_fixed.len();
+                        let Some(middle_end) = actual_len.checked_sub(suffix_len) else {
+                            return Ok(());
+                        };
+                        if middle_end < prefix_len {
+                            return Ok(());
+                        }
+
+                        let actual_elements = actual_fixed.elements_slice();
+                        let variance = TypeVarVariance::Covariant.compose(polarity);
+                        for (formal_element, actual_element) in formal_variable
+                            .prefix_elements()
+                            .iter()
+                            .zip(&actual_elements[..prefix_len])
+                        {
+                            self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
+                        }
+                        for (formal_element, actual_element) in formal_variable
+                            .suffix_elements()
+                            .iter()
+                            .zip(&actual_elements[middle_end..])
+                        {
+                            self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
+                        }
+
+                        let packed = Type::heterogeneous_tuple(
+                            self.db,
+                            actual_elements[prefix_len..middle_end].iter().copied(),
+                        );
+                        self.add_type_mapping(typevartuple, packed, variance);
+                        return Ok(());
+                    }
+
                     let Some(most_precise_length) =
                         formal_tuple.len().most_precise(actual_tuple.len())
                     else {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -568,8 +568,16 @@ impl<'db> GenericContext<'db> {
                 };
                 Some(typevar.with_binding_context(db, binding_context))
             }
-            // TODO: Support this!
-            ast::TypeParam::TypeVarTuple(_) => None,
+            ast::TypeParam::TypeVarTuple(node) => {
+                let definition = index.expect_single_definition(node);
+                let declared = inferred_declaration(db, definition).declared()?;
+                let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+                    declared.inner_type()
+                else {
+                    return None;
+                };
+                Some(typevar.with_binding_context(db, binding_context))
+            }
         }
     }
 
@@ -880,12 +888,20 @@ impl<'db> GenericContext<'db> {
     }
 
     pub(crate) fn unknown_specialization(self, db: &'db dyn Db) -> Specialization<'db> {
-        match self.len(db) {
-            0 => self.specialize(db, &[]),
-            1 => self.specialize(db, &[Type::unknown(); 1]),
-            2 => self.specialize(db, &[Type::unknown(); 2]),
-            len => self.specialize(db, vec![Type::unknown(); len]),
-        }
+        self.specialize(
+            db,
+            self.variables(db)
+                .map(|typevar| match typevar.kind(db) {
+                    TypeVarKind::TypeVarTuple | TypeVarKind::Pep695TypeVarTuple => {
+                        Type::homogeneous_tuple(db, Type::unknown())
+                    }
+                    TypeVarKind::ParamSpec | TypeVarKind::Pep695ParamSpec => {
+                        Type::paramspec_value_callable(db, Parameters::unknown())
+                    }
+                    _ => Type::unknown(),
+                })
+                .collect::<Vec<_>>(),
+        )
     }
 
     pub(crate) fn is_subset_of(self, db: &'db dyn Db, other: GenericContext<'db>) -> bool {
@@ -1023,11 +1039,15 @@ impl<'db> GenericContext<'db> {
         // this, we repeatedly apply the specialization to itself, until we reach a fixed point.
         let mut expanded = Vec::with_capacity(types.len());
         for typevar in variables.clone() {
-            if typevar.is_paramspec(db) {
-                expanded.push(Type::paramspec_value_callable(db, Parameters::unknown()));
-            } else {
-                expanded.push(Type::unknown());
-            }
+            expanded.push(match typevar.kind(db) {
+                TypeVarKind::TypeVarTuple | TypeVarKind::Pep695TypeVarTuple => {
+                    Type::homogeneous_tuple(db, Type::unknown())
+                }
+                TypeVarKind::ParamSpec | TypeVarKind::Pep695ParamSpec => {
+                    Type::paramspec_value_callable(db, Parameters::unknown())
+                }
+                _ => Type::unknown(),
+            });
         }
 
         for (idx, (ty, typevar)) in types.zip(variables).enumerate() {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2635,6 +2635,13 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
 
             let actual_signature = &actual_callables.as_slice()[0].signatures(self.db).overloads[0];
+            let normalized_actual_signature = actual_signature.clone().with_parameters(
+                actual_signature
+                    .parameters()
+                    .clone()
+                    .normalize_starred_variadic_annotations(self.db),
+            );
+            let actual_signature = &normalized_actual_signature;
             if actual_signature
                 .parameters()
                 .iter()

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1869,6 +1869,7 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
     pending: ConstraintSet<'db, 'c>,
     types: FxHashMap<BoundTypeVarIdentity<'db>, UnionAccumulator<'db>>,
     paramspec_seen: FxHashSet<BoundTypeVarIdentity<'db>>,
+    deferred_typevartuple_callable_relation: bool,
 }
 
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
@@ -1884,7 +1885,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             pending: ConstraintSet::from_bool(constraints, true),
             types: FxHashMap::default(),
             paramspec_seen: FxHashSet::default(),
+            deferred_typevartuple_callable_relation: false,
         }
+    }
+
+    pub(crate) fn take_deferred_typevartuple_callable_relation(&mut self) -> bool {
+        std::mem::take(&mut self.deferred_typevartuple_callable_relation)
     }
 
     /// Build a specialization, using a caller-provided hook to select the solution for each
@@ -2207,11 +2213,16 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     }
                     TypeVarKind::TypeVarTuple | TypeVarKind::Pep695TypeVarTuple => {
                         // Repeated uses of a `TypeVarTuple` must have the same length, but the typing
-                        // spec leaves the exact inference behavior unspecified. Merge equal-length
-                        // candidates element-wise using unions.
+                        // spec leaves the exact inference behavior unspecified. Preserve identical
+                        // candidates, merge equal-length fixed candidates element-wise, retain an
+                        // assignable broader tuple shape, and otherwise form a conservative common
+                        // tuple supertype.
                         // https://typing.python.org/en/latest/spec/generics.html#type-variable-tuple-equality
                         let accumulator = entry.get_mut();
                         let existing = accumulator.get_or_build(self.db);
+                        if existing == ty {
+                            return;
+                        }
                         let Some(existing_tuple) = existing.exact_tuple_instance_spec(self.db)
                         else {
                             return;
@@ -2219,14 +2230,40 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         let Some(new_tuple) = ty.exact_tuple_instance_spec(self.db) else {
                             return;
                         };
-                        if existing_tuple.len() != new_tuple.len() {
+                        let gradual = Type::homogeneous_tuple(self.db, Type::unknown());
+                        if existing == gradual {
                             return;
                         }
-                        let unioned = TupleSpecBuilder::from(existing_tuple.as_ref())
-                            .union(self.db, &new_tuple)
-                            .build();
-                        *accumulator =
-                            UnionAccumulator::new(Type::tuple(TupleType::new(self.db, &unioned)));
+                        let merged = match (existing_tuple.as_ref(), new_tuple.as_ref()) {
+                            (TupleSpec::Fixed(existing), TupleSpec::Fixed(new)) => {
+                                if existing.len() != new.len() {
+                                    return;
+                                }
+                                let unioned = TupleSpecBuilder::from(existing_tuple.as_ref())
+                                    .union(self.db, &new_tuple)
+                                    .build();
+                                Type::tuple(TupleType::new(self.db, &unioned))
+                            }
+                            _ if existing.is_assignable_to(self.db, ty) => ty,
+                            _ if ty.is_assignable_to(self.db, existing) => return,
+                            (TupleSpec::Variable(_), TupleSpec::Fixed(new))
+                                if new.len() < existing_tuple.len().minimum() =>
+                            {
+                                ty
+                            }
+                            (TupleSpec::Fixed(existing), TupleSpec::Variable(_))
+                                if existing.len() < new_tuple.len().minimum() =>
+                            {
+                                return;
+                            }
+                            _ => {
+                                let unioned = TupleSpecBuilder::from(existing_tuple.as_ref())
+                                    .union(self.db, &new_tuple)
+                                    .build();
+                                Type::tuple(TupleType::new(self.db, &unioned))
+                            }
+                        };
+                        *accumulator = UnionAccumulator::new(merged);
                     }
                     _ => {
                         entry.get_mut().add(self.db, ty);
@@ -2396,30 +2433,52 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             .then_some(mapping_when)
     }
 
-    fn infer_typevartuple_from_callable_parameters(
-        &mut self,
+    fn typevartuple_from_callable_parameters(
+        &self,
         formal_signature: &Signature<'db>,
         variadic_index: usize,
-        typevartuple: BoundTypeVarInstance<'db>,
         actual_signature: &Signature<'db>,
-    ) {
+    ) -> Option<Type<'db>> {
         let formal_parameters = formal_signature.parameters().as_slice();
-        let suffix_len = formal_parameters.len() - variadic_index - 1;
+        let suffix_len = formal_parameters[variadic_index + 1..]
+            .iter()
+            .take_while(|parameter| parameter.is_positional())
+            .count();
+        if let Some(tuple) = formal_parameters[variadic_index]
+            .annotated_type()
+            .exact_tuple_instance_spec(self.db)
+            && let TupleSpec::Variable(variable) = tuple.as_ref()
+            && (!variable.prefix_elements().is_empty() || !variable.suffix_elements().is_empty())
+        {
+            return None;
+        }
         if !formal_parameters[..variadic_index]
             .iter()
-            .chain(&formal_parameters[variadic_index + 1..])
             .all(Parameter::is_positional)
         {
-            return;
+            return None;
         }
 
         let actual_parameters = actual_signature.parameters().as_slice();
-        if !actual_parameters
+        if formal_parameters
             .iter()
-            .all(|parameter| parameter.is_positional() || parameter.is_variadic())
+            .filter(|parameter| !parameter.is_positional() && !parameter.is_variadic())
+            .filter_map(Parameter::keyword_name)
+            .any(|formal_name| {
+                actual_parameters.iter().any(|actual| {
+                    actual.is_positional() && actual.keyword_name() == Some(formal_name)
+                })
+            })
         {
-            return;
+            // A positional-or-keyword parameter can satisfy the formal keyword without belonging
+            // to the positional pack. The old solver cannot represent that split transactionally.
+            return None;
         }
+        let positional_end = actual_parameters
+            .iter()
+            .position(|parameter| !parameter.is_positional() && !parameter.is_variadic())
+            .unwrap_or(actual_parameters.len());
+        let actual_parameters = &actual_parameters[..positional_end];
 
         let tuple = if let Some(actual_variadic_index) =
             actual_parameters.iter().position(Parameter::is_variadic)
@@ -2431,24 +2490,34 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 || actual_variadic_index < variadic_index
                 || actual_variadic_index + 1 != actual_parameters.len()
             {
-                return;
+                return None;
             }
 
-            Type::tuple(TupleType::new(
-                self.db,
-                &TupleSpecBuilder::Variable {
-                    prefix: actual_parameters[variadic_index..actual_variadic_index]
-                        .iter()
-                        .map(Parameter::annotated_type)
-                        .collect(),
-                    variable: actual_parameters[actual_variadic_index].annotated_type(),
-                    suffix: vec![],
-                }
-                .build(),
-            ))
+            let actual_variadic = &actual_parameters[actual_variadic_index];
+            let mut builder =
+                TupleSpecBuilder::with_capacity(actual_variadic_index - variadic_index);
+            for parameter in &actual_parameters[variadic_index..actual_variadic_index] {
+                builder.push(parameter.annotated_type());
+            }
+            if actual_variadic.has_starred_annotation() {
+                let tuple = actual_variadic
+                    .annotated_type()
+                    .exact_tuple_instance_spec(self.db)?;
+                builder = builder.concat(self.db, &tuple);
+            } else {
+                builder = match builder {
+                    TupleSpecBuilder::Fixed(prefix) => TupleSpecBuilder::Variable {
+                        prefix,
+                        variable: actual_variadic.annotated_type(),
+                        suffix: vec![],
+                    },
+                    TupleSpecBuilder::Variable { .. } => return None,
+                };
+            }
+            Type::tuple(TupleType::new(self.db, &builder.build()))
         } else {
             if actual_parameters.len() < variadic_index + suffix_len {
-                return;
+                return None;
             }
 
             let middle_end = actual_parameters.len() - suffix_len;
@@ -2459,14 +2528,42 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     .map(Parameter::annotated_type),
             )
         };
-        self.add_type_mapping(typevartuple, tuple, TypeVarVariance::Contravariant);
+        Some(tuple)
+    }
 
-        let _ = self.infer_map_impl(
-            formal_signature.return_ty,
-            actual_signature.return_ty,
-            TypeVarVariance::Covariant,
-            &mut FxHashSet::default(),
-        );
+    fn defer_typevartuple_callable_relation(
+        &mut self,
+        formal_signature: &CallableSignature<'db>,
+        typevartuple_formals: &[(&Signature<'db>, usize, BoundTypeVarInstance<'db>)],
+        actual_callables: &CallableTypes<'db>,
+    ) {
+        self.deferred_typevartuple_callable_relation = true;
+
+        // Parameter inference is ambiguous for this layout, but independent return TypeVars can
+        // still be inferred. Substitute the packs with their gradual fallback first so this pass
+        // cannot accidentally infer a pack from a callable return type.
+        for actual_callable in actual_callables.as_slice() {
+            for actual in &actual_callable.signatures(self.db).overloads {
+                for formal in formal_signature {
+                    let formal_return = typevartuple_formals.iter().fold(
+                        formal.return_ty,
+                        |return_ty, (_, _, typevartuple)| {
+                            return_ty.substitute_one_typevar(
+                                self.db,
+                                *typevartuple,
+                                Type::homogeneous_tuple(self.db, Type::unknown()),
+                            )
+                        },
+                    );
+                    let _ = self.infer_map_impl(
+                        formal_return,
+                        actual.return_ty,
+                        TypeVarVariance::Covariant,
+                        &mut FxHashSet::default(),
+                    );
+                }
+            }
+        }
     }
 
     /// Infer type mappings by comparing formal callable signatures against actual callables.
@@ -2488,11 +2585,27 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         .as_slice()
                         .iter()
                         .find_position(|parameter| {
-                            parameter.is_variadic() && parameter.has_starred_annotation()
+                            parameter.is_variadic()
+                                && (parameter.has_starred_annotation()
+                                    || matches!(
+                                        parameter.annotated_type(),
+                                        Type::TypeVar(typevartuple)
+                                            if typevartuple.is_typevartuple(self.db)
+                                    ))
                         })
                         .and_then(|(index, parameter)| {
-                            let Type::TypeVar(typevartuple) = parameter.annotated_type() else {
-                                return None;
+                            let typevartuple = match parameter.annotated_type() {
+                                Type::TypeVar(typevartuple) => typevartuple,
+                                annotation => {
+                                    let tuple = annotation.exact_tuple_instance_spec(self.db)?;
+                                    let TupleSpec::Variable(variable) = tuple.as_ref() else {
+                                        return None;
+                                    };
+                                    let Type::TypeVar(typevartuple) = variable.variable() else {
+                                        return None;
+                                    };
+                                    typevartuple
+                                }
                             };
                             typevartuple.is_typevartuple(self.db).then_some((
                                 formal_overload,
@@ -2503,6 +2616,77 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 })
                 .collect()
         };
+
+        if !typevartuple_formal_overloads.is_empty() {
+            let supported = formal_signature.overloads.len() == 1
+                && actual_callables.as_slice().len() == 1
+                && actual_callables.as_slice()[0]
+                    .signatures(self.db)
+                    .overloads
+                    .len()
+                    == 1;
+            if !supported {
+                self.defer_typevartuple_callable_relation(
+                    formal_signature,
+                    &typevartuple_formal_overloads,
+                    actual_callables,
+                );
+                return Ok(());
+            }
+
+            let actual_signature = &actual_callables.as_slice()[0].signatures(self.db).overloads[0];
+            if actual_signature
+                .parameters()
+                .iter()
+                .any(Parameter::has_starred_annotation)
+            {
+                self.defer_typevartuple_callable_relation(
+                    formal_signature,
+                    &typevartuple_formal_overloads,
+                    actual_callables,
+                );
+                return Ok(());
+            }
+
+            let Some((typevartuple, tuple)) = typevartuple_formal_overloads.iter().find_map(
+                |(formal_overload, variadic_index, typevartuple)| {
+                    self.typevartuple_from_callable_parameters(
+                        formal_overload,
+                        *variadic_index,
+                        actual_signature,
+                    )
+                    .map(|tuple| (*typevartuple, tuple))
+                },
+            ) else {
+                self.defer_typevartuple_callable_relation(
+                    formal_signature,
+                    &typevartuple_formal_overloads,
+                    actual_callables,
+                );
+                return Ok(());
+            };
+            let specialized_formal = formal_signature.apply_type_mapping_impl(
+                self.db,
+                &TypeMapping::ApplySpecialization(ApplySpecialization::Single(typevartuple, tuple)),
+                TypeContext::default(),
+                &ApplyTypeMappingVisitor::default(),
+            );
+            let when = actual_signature.when_constraint_set_assignable_to_signatures(
+                self.db,
+                &specialized_formal,
+                self.constraints,
+            );
+            if when.is_never_satisfied(self.db) {
+                // A single incompatible callable still provides useful argument information for
+                // the eventual diagnostic.
+                self.add_type_mapping(typevartuple, tuple, TypeVarVariance::Contravariant);
+                return Err(());
+            }
+            self.add_type_mappings_from_constraint_set(when)?;
+            self.add_type_mapping(typevartuple, tuple, TypeVarVariance::Contravariant);
+            self.pending.intersect(self.db, self.constraints, when);
+            return Ok(());
+        }
 
         for actual_callable in actual_callables.as_slice() {
             if formal_is_single_paramspec {
@@ -2522,17 +2706,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     .overloads
                     .iter()
                     .filter_map(|actual_signature| {
-                        for (formal_overload, variadic_index, typevartuple) in
-                            &typevartuple_formal_overloads
-                        {
-                            self.infer_typevartuple_from_callable_parameters(
-                                formal_overload,
-                                *variadic_index,
-                                *typevartuple,
-                                actual_signature,
-                            );
-                        }
-
                         let when = actual_signature.when_constraint_set_assignable_to_signatures(
                             db,
                             formal_signature,
@@ -2979,6 +3152,86 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
+            // Route callable instances through signature inference before the broad nominal arm.
+            // Otherwise an unresolved `TypeVarTuple` falls through to a non-gradual specialization
+            // and produces a false-positive callable-arity diagnostic.
+            (Type::Callable(formal_callable), actual @ Type::NominalInstance(_)) => {
+                let Some(actual_callables) = actual.try_upcast_to_callable(self.db) else {
+                    return Ok(());
+                };
+                let _ = self.infer_from_callable_signature(
+                    formal_callable.signatures(self.db),
+                    &actual_callables,
+                );
+                return Ok(());
+            }
+
+            (Type::ProtocolInstance(formal_protocol), actual @ Type::NominalInstance(_))
+                if formal_protocol
+                    .interface(self.db)
+                    .call_method(self.db)
+                    .is_some() =>
+            {
+                let Some(call_method) = formal_protocol.interface(self.db).call_method(self.db)
+                else {
+                    return Ok(());
+                };
+                let formal_signature = call_method.bind_self(self.db, None).signatures(self.db);
+
+                let has_typevartuple = formal_signature.iter().any(|signature| {
+                    signature.parameters().iter().any(|parameter| {
+                        if !parameter.is_variadic() {
+                            return false;
+                        }
+                        match parameter.annotated_type() {
+                            Type::TypeVar(typevartuple) => typevartuple.is_typevartuple(self.db),
+                            annotation if parameter.has_starred_annotation() => annotation
+                                .exact_tuple_instance_spec(self.db)
+                                .is_some_and(|tuple| {
+                                    matches!(
+                                        tuple.as_ref(),
+                                        TupleSpec::Variable(variable)
+                                            if matches!(
+                                                variable.variable(),
+                                                Type::TypeVar(typevartuple)
+                                                    if typevartuple.is_typevartuple(self.db)
+                                            )
+                                    )
+                                }),
+                            _ => false,
+                        }
+                    })
+                });
+                if !has_typevartuple {
+                    let formal = Type::ProtocolInstance(formal_protocol);
+                    let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
+                    let when = self.constraints.load(self.db, &when);
+                    if self.add_type_mappings_from_constraint_set(when).is_ok() {
+                        self.pending.intersect(self.db, self.constraints, when);
+                    }
+                    return Ok(());
+                }
+
+                // Preserve inference from non-call protocol members before handling the variadic
+                // call signature. Falling back for a pack must not discard unrelated TypeVars.
+                let formal = Type::protocol_from_interface(
+                    formal_protocol
+                        .interface(self.db)
+                        .without_member(self.db, "__call__"),
+                );
+                let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
+                let when = self.constraints.load(self.db, &when);
+                if self.add_type_mappings_from_constraint_set(when).is_ok() {
+                    self.pending.intersect(self.db, self.constraints, when);
+                }
+
+                let Some(actual_callables) = actual.try_upcast_to_callable(self.db) else {
+                    return Ok(());
+                };
+                let _ = self.infer_from_callable_signature(formal_signature, &actual_callables);
+                return Ok(());
+            }
+
             (formal, Type::NominalInstance(actual_nominal)) => {
                 // Special case: `formal` and `actual` are both tuples.
                 if let (Some(formal_tuple), Some(actual_tuple)) = (
@@ -2988,40 +3241,115 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     if let TupleSpec::Variable(formal_variable) = formal_tuple.as_ref()
                         && let Type::TypeVar(typevartuple) = formal_variable.variable()
                         && typevartuple.is_typevartuple(self.db)
-                        && let TupleSpec::Fixed(actual_fixed) = actual_tuple.as_ref()
                     {
-                        let prefix_len = formal_variable.prefix_elements().len();
-                        let suffix_len = formal_variable.suffix_elements().len();
-                        let actual_len = actual_fixed.len();
-                        let Some(middle_end) = actual_len.checked_sub(suffix_len) else {
-                            return Ok(());
-                        };
-                        if middle_end < prefix_len {
-                            return Ok(());
-                        }
-
-                        let actual_elements = actual_fixed.elements_slice();
                         let variance = TypeVarVariance::Covariant.compose(polarity);
-                        for (formal_element, actual_element) in formal_variable
-                            .prefix_elements()
-                            .iter()
-                            .zip(&actual_elements[..prefix_len])
-                        {
-                            self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
-                        }
-                        for (formal_element, actual_element) in formal_variable
-                            .suffix_elements()
-                            .iter()
-                            .zip(&actual_elements[middle_end..])
-                        {
-                            self.infer_map_impl(*formal_element, *actual_element, variance, seen)?;
+                        if let TupleSpec::Fixed(actual_fixed) = actual_tuple.as_ref() {
+                            let prefix_len = formal_variable.prefix_elements().len();
+                            let suffix_len = formal_variable.suffix_elements().len();
+                            let actual_len = actual_fixed.len();
+                            let Some(middle_end) = actual_len.checked_sub(suffix_len) else {
+                                return Ok(());
+                            };
+                            if middle_end < prefix_len {
+                                return Ok(());
+                            }
+
+                            let actual_elements = actual_fixed.elements_slice();
+                            for (formal_element, actual_element) in formal_variable
+                                .prefix_elements()
+                                .iter()
+                                .zip(&actual_elements[..prefix_len])
+                            {
+                                self.infer_map_impl(
+                                    *formal_element,
+                                    *actual_element,
+                                    variance,
+                                    seen,
+                                )?;
+                            }
+                            for (formal_element, actual_element) in formal_variable
+                                .suffix_elements()
+                                .iter()
+                                .zip(&actual_elements[middle_end..])
+                            {
+                                self.infer_map_impl(
+                                    *formal_element,
+                                    *actual_element,
+                                    variance,
+                                    seen,
+                                )?;
+                            }
+
+                            let packed = Type::heterogeneous_tuple(
+                                self.db,
+                                actual_elements[prefix_len..middle_end].iter().copied(),
+                            );
+                            self.add_type_mapping(typevartuple, packed, variance);
+                            return Ok(());
                         }
 
-                        let packed = Type::heterogeneous_tuple(
-                            self.db,
-                            actual_elements[prefix_len..middle_end].iter().copied(),
-                        );
-                        self.add_type_mapping(typevartuple, packed, variance);
+                        if formal_variable.prefix_elements().is_empty()
+                            && formal_variable.suffix_elements().is_empty()
+                        {
+                            self.add_type_mapping(
+                                typevartuple,
+                                Type::tuple(TupleType::new(self.db, actual_tuple.as_ref())),
+                                variance,
+                            );
+                            return Ok(());
+                        }
+
+                        if let TupleSpec::Variable(actual_variable) = actual_tuple.as_ref() {
+                            let prefix_len = formal_variable.prefix_elements().len();
+                            let suffix_len = formal_variable.suffix_elements().len();
+                            let actual_prefix = actual_variable.prefix_elements();
+                            let actual_suffix = actual_variable.suffix_elements();
+                            if actual_prefix.len() >= prefix_len
+                                && actual_suffix.len() >= suffix_len
+                            {
+                                for (formal_element, actual_element) in formal_variable
+                                    .prefix_elements()
+                                    .iter()
+                                    .zip(&actual_prefix[..prefix_len])
+                                {
+                                    self.infer_map_impl(
+                                        *formal_element,
+                                        *actual_element,
+                                        variance,
+                                        seen,
+                                    )?;
+                                }
+                                for (formal_element, actual_element) in formal_variable
+                                    .suffix_elements()
+                                    .iter()
+                                    .zip(&actual_suffix[actual_suffix.len() - suffix_len..])
+                                {
+                                    self.infer_map_impl(
+                                        *formal_element,
+                                        *actual_element,
+                                        variance,
+                                        seen,
+                                    )?;
+                                }
+
+                                let packed = TupleSpecBuilder::Variable {
+                                    prefix: actual_prefix[prefix_len..].to_vec(),
+                                    variable: actual_variable.variable(),
+                                    suffix: actual_suffix[..actual_suffix.len() - suffix_len]
+                                        .to_vec(),
+                                }
+                                .build();
+                                self.add_type_mapping(
+                                    typevartuple,
+                                    Type::tuple(TupleType::new(self.db, &packed)),
+                                    variance,
+                                );
+                            }
+                        }
+
+                        // Aligning an arbitrary-length actual tuple with fixed prefix or suffix
+                        // elements requires splitting the tuple. Leave the pack unmapped rather than
+                        // letting the generic resize path infer it as a scalar element type.
                         return Ok(());
                     }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -895,7 +895,9 @@ impl<'db> GenericContext<'db> {
             db,
             self.variables(db)
                 .map(|typevar| match typevar.kind(db) {
-                    TypeVarKind::TypeVarTuple | TypeVarKind::Pep695TypeVarTuple => {
+                    TypeVarKind::TypeVarTuple
+                    | TypeVarKind::ExtensionsTypeVarTuple
+                    | TypeVarKind::Pep695TypeVarTuple => {
                         Type::homogeneous_tuple(db, Type::unknown())
                     }
                     TypeVarKind::ParamSpec | TypeVarKind::Pep695ParamSpec => {
@@ -1043,9 +1045,9 @@ impl<'db> GenericContext<'db> {
         let mut expanded = Vec::with_capacity(types.len());
         for typevar in variables.clone() {
             expanded.push(match typevar.kind(db) {
-                TypeVarKind::TypeVarTuple | TypeVarKind::Pep695TypeVarTuple => {
-                    Type::homogeneous_tuple(db, Type::unknown())
-                }
+                TypeVarKind::TypeVarTuple
+                | TypeVarKind::ExtensionsTypeVarTuple
+                | TypeVarKind::Pep695TypeVarTuple => Type::homogeneous_tuple(db, Type::unknown()),
                 TypeVarKind::ParamSpec | TypeVarKind::Pep695ParamSpec => {
                     Type::paramspec_value_callable(db, Parameters::unknown())
                 }
@@ -2211,7 +2213,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         // https://github.com/astral-sh/ty/issues/1778
                         // https://github.com/astral-sh/ruff/pull/21445#discussion_r2591510145
                     }
-                    TypeVarKind::TypeVarTuple | TypeVarKind::Pep695TypeVarTuple => {
+                    TypeVarKind::TypeVarTuple
+                    | TypeVarKind::ExtensionsTypeVarTuple
+                    | TypeVarKind::Pep695TypeVarTuple => {
                         // Repeated uses of a `TypeVarTuple` must have the same length, but the typing
                         // spec leaves the exact inference behavior unspecified. Preserve identical
                         // candidates, merge equal-length fixed candidates element-wise, retain an

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -80,8 +80,11 @@ bitflags::bitflags! {
     /// Metadata for expressions inferred as type expressions.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, salsa::Update)]
     pub(crate) struct TypeExpressionFlags: u8 {
-        /// The expression is syntactically an `Unpack[...]` type expression.
+        /// The expression syntactically unpacks a type using either `Unpack[...]` or `*...`.
         const UNPACK = 1 << 0;
+
+        /// The operand of an `Unpack[...]` expression is neither a tuple nor a `TypeVarTuple`.
+        const INVALID_UNPACK = 1 << 1;
     }
 }
 
@@ -1642,7 +1645,7 @@ bitflags::bitflags! {
         /// Whether the visitor is currently visiting a nested position in a type expression.
         const IN_NESTED_TYPE_EXPRESSION = 1 << 13;
 
-        /// Whether the visitor is currently visiting the argument to `Unpack[...]`.
+        /// Whether the visitor is currently visiting the argument to `Unpack[...]` or `*`.
         const IN_UNPACK_TYPE_ARGUMENT = 1 << 14;
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1141,6 +1141,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             DefinitionKind::ParamSpec(paramspec) => {
                 self.infer_paramspec_deferred(paramspec.node(self.module()));
             }
+            DefinitionKind::TypeVarTuple(typevartuple) => {
+                self.infer_typevartuple_deferred(typevartuple.node(self.module()));
+            }
             DefinitionKind::Assignment(assignment) => {
                 self.infer_assignment_deferred(
                     assignment.target(self.module()),
@@ -1741,6 +1744,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Check that no type parameter with a default follows a TypeVarTuple
         // in the type alias's PEP 695 type parameter list.
         if let Some(type_params) = type_alias.type_params.as_deref() {
+            post_inference::type_param_validation::check_single_typevar_tuple_pep695(
+                &self.context,
+                type_params,
+            );
             post_inference::type_param_validation::check_no_default_after_typevar_tuple_pep695(
                 &self.context,
                 type_params,
@@ -1953,11 +1960,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             for (index, element) in tuple_spec.all_elements().iter().enumerate() {
                 builder = builder.add(
-                    if element.is_assignable_to(self.db(), type_base_exception) {
-                        element.to_instance(self.db()).expect(
-                            "`Type::to_instance()` should always return `Some()` \
-                                if called on a type assignable to `type[BaseException]`",
-                        )
+                    if element.is_assignable_to(self.db(), type_base_exception)
+                        && let Some(instance) = element.to_instance(self.db())
+                    {
+                        instance
                     } else {
                         invalid_elements.push((index, element));
                         Type::unknown()
@@ -2035,10 +2041,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.db(),
                 tuple_spec.all_elements().iter().map(|element| {
                     if element.is_assignable_to(self.db(), type_base_exception) {
-                        Some(element.to_instance(self.db()).expect(
-                            "`Type::to_instance()` should always return `Some()` \
-                                if called on a type assignable to `type[BaseException]`",
-                        ))
+                        element.to_instance(self.db())
                     } else {
                         None
                     }
@@ -2046,10 +2049,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             )
         } else if ty.is_assignable_to(self.db(), type_base_exception) {
             // `except ValueError as e:`
-            Some(ty.to_instance(self.db()).expect(
-                "`Type::to_instance()` should always return `Some()` \
-                    if called on a type assignable to `type[BaseException]`",
-            ))
+            ty.to_instance(self.db())
         } else if ty.is_assignable_to(
             self.db(),
             Type::homogeneous_tuple(self.db(), type_base_exception),
@@ -3700,6 +3700,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 definition,
                                 paramspec_class,
                             ),
+                            Some(
+                                typevartuple_class @ (KnownClass::TypeVarTuple
+                                | KnownClass::ExtensionsTypeVarTuple),
+                            ) => self.infer_legacy_typevartuple(
+                                target,
+                                call_expr,
+                                definition,
+                                typevartuple_class,
+                            ),
                             Some(KnownClass::NewType) => {
                                 self.infer_newtype_expression(target, call_expr, definition)
                             }
@@ -3981,6 +3990,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && function.is_known(self.db(), KnownFunction::NewClass)
         {
             self.infer_new_class_deferred(definition, value);
+            return;
+        }
+        if matches!(
+            known_class,
+            Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple)
+        ) {
+            if let Some(default) = arguments.find_keyword("default") {
+                self.infer_typevartuple_default(&default.value, None);
+            }
             return;
         }
         let mut constraint_tys = Vec::new();
@@ -8484,6 +8502,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         );
                     }
                 }
+                Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple) => {
+                    if let Some(builder) = self
+                        .context
+                        .report_lint(&INVALID_LEGACY_TYPE_VARIABLE, call_expression)
+                    {
+                        builder.into_diagnostic(
+                            "A `TypeVarTuple` definition must be a simple variable assignment",
+                        );
+                    }
+                }
                 Some(KnownClass::NewType) => {
                     if let Some(builder) =
                         self.context.report_lint(&INVALID_NEWTYPE, call_expression)
@@ -8722,6 +8750,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let db = self.db();
         let iterable_type = self.infer_expression(value, tcx);
+        if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = iterable_type
+            && typevar.is_typevartuple(db)
+            && let Some(bound_typevar) = bind_typevar(
+                db,
+                self.index,
+                self.scope().file_scope_id(db),
+                self.typevar_binding_context,
+                typevar,
+            )
+        {
+            return Type::tuple(TupleType::new(
+                db,
+                &TupleSpecBuilder::with_capacity(0)
+                    .concat_variadic_typevar(db, bound_typevar)
+                    .build(),
+            ));
+        }
+        if let Type::TypeVar(typevar) = iterable_type
+            && typevar.is_typevartuple(db)
+        {
+            return Type::tuple(TupleType::new(
+                db,
+                &TupleSpecBuilder::with_capacity(0)
+                    .concat_variadic_typevar(db, typevar)
+                    .build(),
+            ));
+        }
         iterable_type
             .try_iterate(db)
             .map(|spec| Type::tuple(TupleType::new(db, &spec)))

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1998,6 +1998,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.exception_handler_symbol_ty_from_valid_ty(node_ty, type_base_exception)
         {
             symbol_ty
+        } else if is_typevartuple_type_or_instance(self.db(), node_ty) {
+            if let Some(node) = node {
+                report_invalid_exception_caught(&self.context, node, node_ty);
+            }
+            Type::unknown()
         } else if node_ty.is_assignable_to(
             self.db(),
             UnionType::from_two_elements(
@@ -2035,6 +2040,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ty: Type<'db>,
         type_base_exception: Type<'db>,
     ) -> Option<Type<'db>> {
+        if is_typevartuple_type_or_instance(self.db(), ty) {
+            return None;
+        }
+
         if let Some(tuple_spec) = ty.tuple_instance_spec(self.db()) {
             // `except (ValueError, TypeError) as e:`
             UnionType::try_from_elements(
@@ -11536,6 +11545,14 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
                         .zip(safe_mutable_class.generic_origin(db))
                         .is_some_and(|(l, r)| l == r)
             })
+    }
+}
+
+fn is_typevartuple_type_or_instance<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty {
+        Type::TypeVar(typevar) => typevar.is_typevartuple(db),
+        Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => typevar.is_typevartuple(db),
+        _ => false,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -525,26 +525,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 })
             }
 
-            (
-                todo @ Type::Dynamic(
-                    DynamicType::Todo(_)
-                    | DynamicType::TodoUnpack
-                    | DynamicType::TodoStarredExpression
-                    | DynamicType::TodoTypeVarTuple,
-                ),
-                _,
-                _,
-            )
-            | (
-                _,
-                todo @ Type::Dynamic(
-                    DynamicType::Todo(_)
-                    | DynamicType::TodoUnpack
-                    | DynamicType::TodoStarredExpression
-                    | DynamicType::TodoTypeVarTuple,
-                ),
-                _,
-            ) => Some(todo),
+            (todo @ Type::Dynamic(DynamicType::Todo(_)), _, _)
+            | (_, todo @ Type::Dynamic(DynamicType::Todo(_)), _) => Some(todo),
 
             (Type::Never, _, _) | (_, Type::Never, _) => Some(Type::Never),
 

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -27,7 +27,7 @@ use crate::{
         },
         infer_definition_types, infer_scope_types,
         signatures::ReturnCallableTypeVarScope,
-        todo_type,
+        tuple::{TupleSpecBuilder, TupleType},
         typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation,
     },
 };
@@ -884,13 +884,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
 
         if let Some(annotation) = parameter.annotation() {
-            let ty = if annotation.is_starred_expr() {
-                todo_type!("PEP 646")
-            } else {
-                let annotated_type = self.file_expression_type(annotation);
-                if let Type::TypeVar(typevar) = annotated_type
-                    && typevar.is_paramspec(db)
+            let annotated_type = self.file_expression_type(annotation);
+            let has_unpacked_annotation = self
+                .file_type_expression_flags(annotation)
+                .contains(TypeExpressionFlags::UNPACK);
+            let ty = match annotated_type {
+                Type::TypeVar(typevar)
+                    if has_unpacked_annotation && typevar.is_typevartuple(db) =>
                 {
+                    Type::tuple(TupleType::new(
+                        db,
+                        &TupleSpecBuilder::with_capacity(0)
+                            .concat_variadic_typevar(db, typevar)
+                            .build(),
+                    ))
+                }
+                _ if has_unpacked_annotation => annotated_type,
+                Type::TypeVar(typevar) if typevar.is_paramspec(db) => {
                     match typevar.paramspec_attr(db) {
                         // `*args: P.args`
                         Some(ParamSpecAttrKind::Args) => annotated_type,
@@ -920,9 +930,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             Type::homogeneous_tuple(db, Type::unknown())
                         }
                     }
-                } else {
-                    Type::homogeneous_tuple(db, annotated_type)
                 }
+                _ => Type::homogeneous_tuple(db, annotated_type),
             };
 
             self.add_declaration_with_binding(

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -125,7 +125,10 @@ fn check_legacy_typevar_defaults<'db>(
         // by `check_default_for_outer_scope_typevars` in the type parameter scope.
         if !matches!(
             typevar.kind(db),
-            TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::ParamSpec
+            TypeVarKind::Legacy
+                | TypeVarKind::Pep613Alias
+                | TypeVarKind::ParamSpec
+                | TypeVarKind::TypeVarTuple
         ) {
             continue;
         }
@@ -250,7 +253,10 @@ fn check_legacy_typevar_ordering<'db>(
         // Only check legacy TypeVars; PEP 695 ordering is validated by the parser.
         if !matches!(
             typevar.kind(db),
-            TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::ParamSpec
+            TypeVarKind::Legacy
+                | TypeVarKind::Pep613Alias
+                | TypeVarKind::ParamSpec
+                | TypeVarKind::TypeVarTuple
         ) {
             continue;
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -129,6 +129,7 @@ fn check_legacy_typevar_defaults<'db>(
                 | TypeVarKind::Pep613Alias
                 | TypeVarKind::ParamSpec
                 | TypeVarKind::TypeVarTuple
+                | TypeVarKind::ExtensionsTypeVarTuple
         ) {
             continue;
         }
@@ -257,6 +258,7 @@ fn check_legacy_typevar_ordering<'db>(
                 | TypeVarKind::Pep613Alias
                 | TypeVarKind::ParamSpec
                 | TypeVarKind::TypeVarTuple
+                | TypeVarKind::ExtensionsTypeVarTuple
         ) {
             continue;
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -747,6 +747,7 @@ pub(crate) fn check_static_class_definitions<'db>(
     // This is prohibited by the typing spec because a TypeVarTuple consumes
     // all remaining positional type arguments.
     if let Some(type_params) = class_node.type_params.as_deref() {
+        super::type_param_validation::check_single_typevar_tuple_pep695(context, type_params);
         super::type_param_validation::check_no_default_after_typevar_tuple_pep695(
             context,
             type_params,

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/type_param_validation.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/type_param_validation.rs
@@ -2,7 +2,56 @@ use ruff_python_ast as ast;
 use ruff_text_size::Ranged;
 
 use crate::diagnostic::format_enumeration;
-use crate::types::{context::InferContext, diagnostic::INVALID_TYPE_VARIABLE_DEFAULT};
+use crate::types::{
+    context::InferContext,
+    diagnostic::{INVALID_TYPE_FORM, INVALID_TYPE_VARIABLE_DEFAULT},
+};
+
+/// Check that a PEP 695 type parameter list contains at most one `TypeVarTuple`.
+pub(crate) fn check_single_typevar_tuple_pep695(
+    context: &InferContext<'_, '_>,
+    type_params: &ast::TypeParams,
+) {
+    let mut first_typevar_tuple: Option<&ast::TypeParamTypeVarTuple> = None;
+
+    for type_param in type_params {
+        let ast::TypeParam::TypeVarTuple(typevar_tuple) = type_param else {
+            continue;
+        };
+
+        let Some(first_typevar_tuple) = first_typevar_tuple else {
+            first_typevar_tuple = Some(typevar_tuple);
+            continue;
+        };
+
+        let Some(builder) = context.report_lint(&INVALID_TYPE_FORM, typevar_tuple) else {
+            return;
+        };
+
+        let mut diagnostic = builder.into_diagnostic("Only one TypeVarTuple parameter is allowed");
+
+        diagnostic.set_concise_message(format_args!(
+            "TypeVarTuple `{}` cannot appear after TypeVarTuple `{}`",
+            &typevar_tuple.name, &first_typevar_tuple.name
+        ));
+
+        diagnostic.set_primary_message(format_args!(
+            "`{}` is an additional TypeVarTuple",
+            &typevar_tuple.name
+        ));
+
+        diagnostic.annotate(context.secondary(first_typevar_tuple).message(format_args!(
+            "`{}` is the first TypeVarTuple",
+            &first_typevar_tuple.name
+        )));
+
+        diagnostic.info(
+            "See https://typing.python.org/en/latest/spec/generics.html#multiple-type-variable-tuples-not-allowed",
+        );
+
+        return;
+    }
+}
 
 /// Check that no type parameter with a default follows a `TypeVarTuple` in a PEP 695
 /// type parameter list. This is prohibited by the typing spec because a `TypeVarTuple`

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -22,7 +22,7 @@ use crate::types::infer::builder::{ArgExpr, ArgumentsIter, MultiInferenceGuard};
 use crate::types::infer::{InferenceFlags, TypeExpressionFlags};
 use crate::types::special_form::AliasSpec;
 use crate::types::subscript::{LegacyGenericOrigin, SubscriptError, SubscriptErrorKind};
-use crate::types::tuple::{Tuple, TupleType};
+use crate::types::tuple::{Tuple, TupleSpecBuilder, TupleType};
 use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::{
     BoundTypeVarInstance, CallArguments, CallDunderError, CallableBinding, CycleDetector,
@@ -362,6 +362,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     return Type::KnownInstance(KnownInstanceType::Callable(callable));
                 }
+                SpecialFormType::Unpack => {
+                    self.store_type_expression_flags(
+                        ast::ExprRef::from(subscript),
+                        TypeExpressionFlags::UNPACK,
+                    );
+
+                    let previously_in_unpack_type_argument = self
+                        .context
+                        .inference_flags
+                        .replace(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT, true);
+                    let inner_ty = self.infer_type_expression(slice);
+                    self.context.inference_flags.set(
+                        InferenceFlags::IN_UNPACK_TYPE_ARGUMENT,
+                        previously_in_unpack_type_argument,
+                    );
+
+                    return if matches!(
+                        inner_ty,
+                        Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                    ) || inner_ty.exact_tuple_instance_spec(db).is_some()
+                    {
+                        inner_ty
+                    } else {
+                        self.store_type_expression_flags(
+                            ast::ExprRef::from(subscript),
+                            TypeExpressionFlags::INVALID_UNPACK,
+                        );
+                        Type::unknown()
+                    };
+                }
                 SpecialFormType::LegacyStdlibAlias(alias) => {
                     let AliasSpec {
                         class,
@@ -538,6 +568,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         /// A type argument after expanding any allowed `Unpack[tuple[...]]` syntax.
+        #[derive(Clone, Copy)]
         struct TypeArgument<'ast, 'db> {
             /// The source expression used for diagnostics and deferred inference.
             node: &'ast ast::Expr,
@@ -566,11 +597,30 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let typevars = generic_context.variables(db).collect::<Vec<_>>();
         let typevars_len = typevars.len();
+        let typevartuple_index = typevars
+            .iter()
+            .position(|typevar| typevar.is_typevartuple(db));
 
         let mut expanded_type_arguments = Vec::with_capacity(type_arguments.len());
 
         for (source_index, expr) in type_arguments.iter().enumerate() {
-            let typevar = typevars.get(expanded_type_arguments.len()).copied();
+            let typevar = if let Some(typevartuple_index) = typevartuple_index {
+                let suffix_len = typevars_len - typevartuple_index - 1;
+                let suffix_source_start = type_arguments.len().saturating_sub(suffix_len);
+                if suffix_len > 0
+                    && type_arguments.len() >= typevartuple_index + suffix_len
+                    && source_index >= suffix_source_start
+                {
+                    let suffix_index = source_index - suffix_source_start;
+                    typevars
+                        .get(typevars_len - suffix_len + suffix_index)
+                        .copied()
+                } else {
+                    typevars.get(expanded_type_arguments.len()).copied()
+                }
+            } else {
+                typevars.get(expanded_type_arguments.len()).copied()
+            };
             if exactly_one_paramspec || typevar.is_some_and(|typevar| typevar.is_paramspec(db)) {
                 expanded_type_arguments.push(TypeArgument {
                     node: expr,
@@ -600,9 +650,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             inferred_type_arguments[source_index] = Some(provided_type);
 
-            let is_unpack = self
-                .type_expression_flags(expr)
-                .contains(TypeExpressionFlags::UNPACK);
+            let type_expression_flags = self.type_expression_flags(expr);
+            let is_unpack = type_expression_flags.contains(TypeExpressionFlags::UNPACK);
 
             if is_unpack
                 && let Some(tuple) = provided_type.exact_tuple_instance_spec(db)
@@ -628,14 +677,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     && !self
                         .inference_flags()
                         .contains(InferenceFlags::IN_KWARG_ANNOTATION)
-                    && !matches!(
-                        value_ty,
-                        Type::GenericAlias(alias)
-                            if alias
-                                .specialization(db)
-                                .types(db)
-                                .contains(&Type::Dynamic(DynamicType::TodoTypeVarTuple))
-                    )
+                    && typevartuple_index.is_none()
+                    && !type_expression_flags.contains(TypeExpressionFlags::INVALID_UNPACK)
                     && let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, expr)
                 {
                     builder.into_diagnostic(
@@ -650,6 +693,174 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 });
             }
         }
+
+        let expanded_type_arguments = if let Some(typevartuple_index) = typevartuple_index {
+            let suffix_len = typevars_len - typevartuple_index - 1;
+            let typevartuple_end = expanded_type_arguments
+                .len()
+                .saturating_sub(suffix_len)
+                .max(typevartuple_index);
+            let mut packed = Vec::with_capacity(typevars_len);
+
+            let mut tuple_builder = TupleSpecBuilder::with_capacity(
+                typevartuple_end.saturating_sub(typevartuple_index),
+            );
+            for type_argument in
+                &expanded_type_arguments[..expanded_type_arguments.len().min(typevartuple_index)]
+            {
+                let provided_type = type_argument.ty.unwrap_or_else(Type::unknown);
+                let is_unpack = self
+                    .type_expression_flags(type_argument.node)
+                    .contains(TypeExpressionFlags::UNPACK);
+                if is_unpack
+                    && let Some(tuple) = provided_type.exact_tuple_instance_spec(db)
+                    && let Tuple::Variable(variable) = tuple.as_ref()
+                    && variable.prefix_elements().is_empty()
+                    && variable.suffix_elements().is_empty()
+                    && !matches!(
+                        variable.variable(),
+                        Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                    )
+                {
+                    tuple_builder = tuple_builder.concat(db, &tuple);
+                    packed.push(TypeArgument {
+                        ty: Some(variable.variable()),
+                        ..*type_argument
+                    });
+                } else if is_unpack
+                    && (matches!(
+                        provided_type,
+                        Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                    ) || matches!(
+                        provided_type.exact_tuple_instance_spec(db).as_deref(),
+                        Some(Tuple::Variable(variable))
+                            if matches!(
+                                variable.variable(),
+                                Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                            )
+                    ))
+                {
+                    if let Some(builder) = self
+                        .context
+                        .report_lint(&INVALID_TYPE_FORM, type_argument.node)
+                    {
+                        builder.into_diagnostic(
+                            "A TypeVarTuple cannot be split to provide a fixed type argument",
+                        );
+                    }
+                    packed.push(TypeArgument {
+                        ty: Some(Type::unknown()),
+                        ..*type_argument
+                    });
+                } else {
+                    packed.push(*type_argument);
+                }
+            }
+
+            let typevartuple_start = expanded_type_arguments.len().min(typevartuple_index);
+            for type_argument in &expanded_type_arguments
+                [typevartuple_start..expanded_type_arguments.len().min(typevartuple_end)]
+            {
+                let provided_type = type_argument.ty.unwrap_or_else(|| {
+                    let previously_in_valid_unpack_context = self
+                        .context
+                        .inference_flags
+                        .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
+                    let provided_type = self.infer_type_expression(type_argument.node);
+                    self.context.inference_flags.set(
+                        InferenceFlags::IN_VALID_UNPACK_CONTEXT,
+                        previously_in_valid_unpack_context,
+                    );
+                    inferred_type_arguments[type_argument.source_index] = Some(provided_type);
+                    provided_type
+                });
+                let is_unpack = self
+                    .type_expression_flags(type_argument.node)
+                    .contains(TypeExpressionFlags::UNPACK);
+                if is_unpack && let Some(tuple) = provided_type.exact_tuple_instance_spec(db) {
+                    tuple_builder = tuple_builder.concat(db, &tuple);
+                } else if is_unpack
+                    && let Type::TypeVar(typevar) = provided_type
+                    && typevar.is_typevartuple(db)
+                {
+                    tuple_builder = tuple_builder.concat_variadic_typevar(db, typevar);
+                } else {
+                    tuple_builder.push(provided_type);
+                }
+            }
+
+            let mut packed_suffix = Vec::with_capacity(suffix_len);
+            if suffix_len > 0 && expanded_type_arguments.len() >= typevartuple_index + suffix_len {
+                for type_argument in
+                    &expanded_type_arguments[expanded_type_arguments.len() - suffix_len..]
+                {
+                    let provided_type = type_argument.ty.unwrap_or_else(Type::unknown);
+                    let is_unpack = self
+                        .type_expression_flags(type_argument.node)
+                        .contains(TypeExpressionFlags::UNPACK);
+                    if is_unpack
+                        && let Some(tuple) = provided_type.exact_tuple_instance_spec(db)
+                        && let Tuple::Variable(variable) = tuple.as_ref()
+                        && variable.prefix_elements().is_empty()
+                        && variable.suffix_elements().is_empty()
+                        && !matches!(
+                            variable.variable(),
+                            Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                        )
+                    {
+                        tuple_builder = tuple_builder.concat(db, &tuple);
+                        packed_suffix.push(TypeArgument {
+                            ty: Some(variable.variable()),
+                            ..*type_argument
+                        });
+                    } else if is_unpack
+                        && (matches!(
+                            provided_type,
+                            Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                        ) || matches!(
+                            provided_type.exact_tuple_instance_spec(db).as_deref(),
+                            Some(Tuple::Variable(variable))
+                                if matches!(
+                                    variable.variable(),
+                                    Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                                )
+                        ))
+                    {
+                        if let Some(builder) = self
+                            .context
+                            .report_lint(&INVALID_TYPE_FORM, type_argument.node)
+                        {
+                            builder.into_diagnostic(
+                                "A TypeVarTuple cannot be split to provide a fixed type argument",
+                            );
+                        }
+                        packed_suffix.push(TypeArgument {
+                            ty: Some(Type::unknown()),
+                            ..*type_argument
+                        });
+                    } else {
+                        packed_suffix.push(*type_argument);
+                    }
+                }
+            }
+
+            if expanded_type_arguments.len() >= typevartuple_index {
+                packed.push(TypeArgument {
+                    node: expanded_type_arguments
+                        .get(typevartuple_index)
+                        .map_or(slice_node, |argument| argument.node),
+                    ty: Some(Type::tuple(TupleType::new(db, &tuple_builder.build()))),
+                    source_index: expanded_type_arguments
+                        .get(typevartuple_index)
+                        .map_or(0, |argument| argument.source_index),
+                });
+            }
+            packed.extend(packed_suffix);
+
+            packed
+        } else {
+            expanded_type_arguments
+        };
 
         let mut specialization_types = Vec::with_capacity(typevars_len);
         let mut typevar_with_defaults = 0;
@@ -845,15 +1056,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         if let Some(first_excess_type_argument_index) = first_excess_type_argument_index {
-            if let Type::GenericAlias(alias) = value_ty
-                && alias
-                    .specialization(db)
-                    .types(db)
-                    .contains(&Type::Dynamic(DynamicType::TodoTypeVarTuple))
-            {
-                // Avoid false-positive errors when specializing a class
-                // that's generic over a legacy TypeVarTuple
-            } else if typevars_len == 0 {
+            if typevars_len == 0 {
                 // Type parameter list cannot be empty, so if we reach here, `value_ty` is not a generic type.
                 if let Some(builder) = self.context.report_lint(&NOT_SUBSCRIPTABLE, subscript) {
                     let mut diagnostic = builder.into_diagnostic(format_args!(
@@ -924,6 +1127,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .map(|typevar| {
                         Some(if typevar.is_paramspec(db) {
                             Type::paramspec_value_callable(db, Parameters::unknown())
+                        } else if typevar.is_typevartuple(db) {
+                            Type::homogeneous_tuple(db, Type::unknown())
                         } else {
                             Type::unknown()
                         })
@@ -1153,6 +1358,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         expr_context: ExprContext,
     ) -> Type<'db> {
         let db = self.db();
+
+        if let Some(origin) = match value_ty {
+            Type::SpecialForm(SpecialFormType::Generic) => Some(LegacyGenericOrigin::Generic),
+            Type::SpecialForm(SpecialFormType::Protocol) => Some(LegacyGenericOrigin::Protocol),
+            _ => None,
+        } {
+            let has_invalid_unpack_argument = match subscript.slice.as_ref() {
+                ast::Expr::Tuple(tuple) => tuple.elts.iter().any(|argument| {
+                    self.type_expression_flags(argument)
+                        .contains(TypeExpressionFlags::INVALID_UNPACK)
+                }),
+                argument => self
+                    .type_expression_flags(argument)
+                    .contains(TypeExpressionFlags::INVALID_UNPACK),
+            };
+            if has_invalid_unpack_argument {
+                let error = SubscriptError::new(
+                    Type::unknown(),
+                    SubscriptErrorKind::InvalidLegacyGenericArgument {
+                        origin,
+                        argument_ty: Type::SpecialForm(SpecialFormType::Unpack),
+                    },
+                );
+                error.report_diagnostics(&self.context, subscript);
+                return error.result_type();
+            }
+        }
 
         // Special typing forms for which subscriptions are context-dependent are parsed here,
         // outside of `Type::subscript`, which is a pure function that doesn't depend on the
@@ -2097,11 +2329,23 @@ fn legacy_generic_class_context<'db>(
 ) -> Result<GenericContext<'db>, LegacyGenericContextError<'db>> {
     let typevars_class_tuple_spec = typevars.exact_tuple_instance_spec(db);
 
+    let unpacked_typevars;
     let typevars = if let Some(tuple_spec) = typevars_class_tuple_spec.as_deref() {
         match tuple_spec {
             Tuple::Fixed(typevars) => typevars.elements_slice(),
-            Tuple::Variable(_) => {
-                return Err(LegacyGenericContextError::VariadicTupleArguments);
+            Tuple::Variable(variable) => {
+                if let Type::TypeVar(typevartuple) = variable.variable()
+                    && typevartuple.is_typevartuple(db)
+                {
+                    unpacked_typevars = variable
+                        .iter_prefix_elements()
+                        .chain(std::iter::once(Type::TypeVar(typevartuple)))
+                        .chain(variable.iter_suffix_elements())
+                        .collect::<Vec<_>>();
+                    &unpacked_typevars
+                } else {
+                    return Err(LegacyGenericContextError::VariadicTupleArguments);
+                }
             }
         }
     } else {
@@ -2114,18 +2358,32 @@ fn legacy_generic_class_context<'db>(
         if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = argument_ty {
             let bound = bind_typevar(db, index, file_scope_id, typevar_binding_context, typevar)
                 .ok_or(LegacyGenericContextError::InvalidArgument(argument_ty))?;
+            if bound.is_typevartuple(db) {
+                return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked);
+            }
             if !validated_typevars.insert(bound) {
                 return Err(LegacyGenericContextError::DuplicateTypevar(
                     typevar.name(db),
                 ));
             }
+        } else if let Type::TypeVar(bound) = argument_ty
+            && bound.is_typevartuple(db)
+        {
+            if !validated_typevars.insert(bound) {
+                return Err(LegacyGenericContextError::DuplicateTypevar(bound.name(db)));
+            }
         } else if let Type::NominalInstance(instance) = argument_ty
-            && instance.has_known_class(db, KnownClass::TypeVarTuple)
+            && matches!(
+                instance.known_class(db),
+                Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple)
+            )
         {
             return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked);
         } else if any_over_type(db, argument_ty, true, |inner_ty| match inner_ty {
-            Type::Dynamic(DynamicType::TodoUnpack | DynamicType::TodoStarredExpression) => true,
-            Type::NominalInstance(nominal) => nominal.has_known_class(db, KnownClass::TypeVarTuple),
+            Type::NominalInstance(nominal) => matches!(
+                nominal.known_class(db),
+                Some(KnownClass::TypeVarTuple | KnownClass::ExtensionsTypeVarTuple)
+            ),
             _ => false,
         }) {
             return Err(LegacyGenericContextError::NotYetSupported);

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -600,6 +600,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let typevartuple_index = typevars
             .iter()
             .position(|typevar| typevar.is_typevartuple(db));
+        let mut typevartuple_argument_was_supplied =
+            typevartuple_index == Some(0) && type_arguments.is_empty();
 
         let mut expanded_type_arguments = Vec::with_capacity(type_arguments.len());
 
@@ -621,6 +623,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             } else {
                 typevars.get(expanded_type_arguments.len()).copied()
             };
+            if typevar.is_some_and(|typevar| typevar.is_typevartuple(db)) {
+                typevartuple_argument_was_supplied = true;
+            }
             if exactly_one_paramspec || typevar.is_some_and(|typevar| typevar.is_paramspec(db)) {
                 expanded_type_arguments.push(TypeArgument {
                     node: expr,
@@ -694,8 +699,66 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
+        let mut typevartuple_uses_default = false;
         let expanded_type_arguments = if let Some(typevartuple_index) = typevartuple_index {
             let suffix_len = typevars_len - typevartuple_index - 1;
+
+            // A single homogeneous arbitrary-length tuple can be split across fixed type
+            // variables on both sides of the TypeVarTuple. Insert virtual element arguments next
+            // to the unpack so the normal prefix/middle/suffix partition sees the unpack exactly
+            // once in the middle and an element for every otherwise-missing fixed slot.
+            let splittable_unbounded = expanded_type_arguments
+                .iter()
+                .enumerate()
+                .filter_map(|(index, type_argument)| {
+                    let provided_type = type_argument.ty?;
+                    let flags = self.type_expression_flags(type_argument.node);
+                    if !flags.contains(TypeExpressionFlags::UNPACK)
+                        || flags.contains(TypeExpressionFlags::INVALID_UNPACK)
+                    {
+                        return None;
+                    }
+                    let tuple = provided_type.exact_tuple_instance_spec(db)?;
+                    let Tuple::Variable(variable) = tuple.as_ref() else {
+                        return None;
+                    };
+                    if !variable.prefix_elements().is_empty()
+                        || !variable.suffix_elements().is_empty()
+                        || matches!(
+                            variable.variable(),
+                            Type::TypeVar(typevar) if typevar.is_typevartuple(db)
+                        )
+                    {
+                        return None;
+                    }
+                    Some((index, *type_argument, variable.variable()))
+                })
+                .collect::<Vec<_>>();
+            if let [(unbounded_index, unbounded_argument, element_type)] =
+                splittable_unbounded.as_slice()
+            {
+                let prefix_fill = typevartuple_index.saturating_sub(*unbounded_index);
+                expanded_type_arguments.splice(
+                    *unbounded_index..*unbounded_index,
+                    (0..prefix_fill).map(|_| TypeArgument {
+                        ty: Some(*element_type),
+                        ..*unbounded_argument
+                    }),
+                );
+
+                let unbounded_index = *unbounded_index + prefix_fill;
+                let available_suffix = expanded_type_arguments.len() - unbounded_index - 1;
+                let suffix_fill = suffix_len.saturating_sub(available_suffix);
+                let suffix_insertion_index = unbounded_index + 1;
+                expanded_type_arguments.splice(
+                    suffix_insertion_index..suffix_insertion_index,
+                    (0..suffix_fill).map(|_| TypeArgument {
+                        ty: Some(*element_type),
+                        ..*unbounded_argument
+                    }),
+                );
+            }
+
             let typevartuple_end = expanded_type_arguments
                 .len()
                 .saturating_sub(suffix_len)
@@ -723,6 +786,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     )
                 {
                     tuple_builder = tuple_builder.concat(db, &tuple);
+                    typevartuple_argument_was_supplied = true;
                     packed.push(TypeArgument {
                         ty: Some(variable.variable()),
                         ..*type_argument
@@ -758,6 +822,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             let typevartuple_start = expanded_type_arguments.len().min(typevartuple_index);
+            if typevartuple_end > typevartuple_start {
+                typevartuple_argument_was_supplied = true;
+            }
             for type_argument in &expanded_type_arguments
                 [typevartuple_start..expanded_type_arguments.len().min(typevartuple_end)]
             {
@@ -809,6 +876,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         )
                     {
                         tuple_builder = tuple_builder.concat(db, &tuple);
+                        typevartuple_argument_was_supplied = true;
                         packed_suffix.push(TypeArgument {
                             ty: Some(variable.variable()),
                             ..*type_argument
@@ -844,7 +912,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            if expanded_type_arguments.len() >= typevartuple_index {
+            if packed.len() == typevartuple_index {
+                typevartuple_uses_default = !typevartuple_argument_was_supplied
+                    && typevars[typevartuple_index].default_type(db).is_some();
                 packed.push(TypeArgument {
                     node: expanded_type_arguments
                         .get(typevartuple_index)
@@ -879,6 +949,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 EitherOrBoth::Both(typevar, type_argument) => {
                     if typevar.default_type(db).is_some() {
                         typevar_with_defaults += 1;
+                    }
+                    if typevartuple_index == Some(index) && typevartuple_uses_default {
+                        specialization_types.push(None);
+                        continue;
                     }
 
                     let provided_type = if typevar.is_paramspec(db) {

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -378,10 +378,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         previously_in_unpack_type_argument,
                     );
 
-                    return if matches!(
-                        inner_ty,
-                        Type::TypeVar(typevar) if typevar.is_typevartuple(db)
-                    ) || inner_ty.exact_tuple_instance_spec(db).is_some()
+                    return if super::is_typevartuple_type_or_instance(db, inner_ty)
+                        || inner_ty.exact_tuple_instance_spec(db).is_some()
                     {
                         inner_ty
                     } else {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2659,7 +2659,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     previously_in_valid_unpack_context,
                 );
 
-                return Some(Parameters::new(self.db(), parameters));
+                return Some(
+                    Parameters::new(self.db(), parameters)
+                        .normalize_starred_variadic_annotations(self.db()),
+                );
             }
             ast::Expr::Subscript(subscript) => {
                 let value_ty = self.infer_expression(&subscript.value, TypeContext::default());

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1,5 +1,6 @@
 use itertools::Either;
 use ruff_python_ast::helpers::is_dotted_name;
+use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, PythonVersion};
 use ruff_text_size::Ranged;
 
@@ -187,7 +188,29 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let value_ty = self.infer_expression(value, TypeContext::default());
 
                 if is_dotted_name(value) {
-                    self.infer_subscript_type_expression_no_store(subscript, slice, value_ty)
+                    // Preserve the flag for another `Unpack` so that nested unpacking emits a
+                    // diagnostic. Other subscripts are no longer the direct unpack operand.
+                    let previously_in_unpack_type_argument =
+                        if value_ty == Type::SpecialForm(SpecialFormType::Unpack) {
+                            None
+                        } else {
+                            Some(
+                                self.context
+                                    .inference_flags
+                                    .replace(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT, false),
+                            )
+                        };
+                    let ty =
+                        self.infer_subscript_type_expression_no_store(subscript, slice, value_ty);
+                    if let Some(previously_in_unpack_type_argument) =
+                        previously_in_unpack_type_argument
+                    {
+                        self.context.inference_flags.set(
+                            InferenceFlags::IN_UNPACK_TYPE_ARGUMENT,
+                            previously_in_unpack_type_argument,
+                        );
+                    }
+                    ty
                 } else {
                     if !self.in_string_annotation() {
                         self.infer_expression(slice, TypeContext::default());
@@ -850,11 +873,38 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ctx: _,
         } = starred;
 
+        self.store_type_expression_flags(ast::ExprRef::from(starred), TypeExpressionFlags::UNPACK);
+
+        let previously_in_unpack_type_argument = self
+            .context
+            .inference_flags
+            .replace(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT, true);
         let starred_type = self.infer_type_expression(value);
-        if starred_type.exact_tuple_instance_spec(self.db()).is_some() {
+        self.context.inference_flags.set(
+            InferenceFlags::IN_UNPACK_TYPE_ARGUMENT,
+            previously_in_unpack_type_argument,
+        );
+
+        if starred_type.exact_tuple_instance_spec(self.db()).is_some()
+            || matches!(
+                starred_type,
+                Type::TypeVar(typevar) if typevar.is_typevartuple(self.db())
+            )
+        {
             starred_type
         } else {
-            Type::Dynamic(DynamicType::TodoStarredExpression)
+            self.store_type_expression_flags(
+                ast::ExprRef::from(starred),
+                TypeExpressionFlags::INVALID_UNPACK,
+            );
+            if !starred_type.is_unknown()
+                && let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, starred)
+            {
+                diagnostic::add_type_expression_reference_link(
+                    builder.into_diagnostic("`*` can only unpack a tuple type or `TypeVarTuple`"),
+                );
+            }
+            Type::homogeneous_tuple(self.db(), Type::unknown())
         }
     }
 
@@ -931,36 +981,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         &mut self,
         tuple: &ast::ExprSubscript,
     ) -> Option<TupleType<'db>> {
-        /// In most cases, if a subelement of the tuple is inferred as `Todo`,
-        /// we should only infer `Todo` for that specific subelement.
-        /// Certain specific AST nodes can however change the meaning of the entire tuple,
-        /// however: for example, `tuple[int, ...]` or `tuple[int, *tuple[str, ...]]` are a
-        /// homogeneous tuple and a partly homogeneous tuple (respectively) due to the `...`
-        /// and the starred expression (respectively), Neither is supported by us right now,
-        /// so we should infer `Todo` for the *entire* tuple if we encounter one of those elements.
-        fn element_could_alter_type_of_whole_tuple(
-            element: &ast::Expr,
-            element_ty: Type,
-            builder: &mut TypeInferenceBuilder,
-        ) -> bool {
-            if !element_ty.is_todo() {
-                return false;
-            }
-
-            match element {
-                ast::Expr::Starred(_) => {
-                    element_ty.exact_tuple_instance_spec(builder.db()).is_none()
-                }
-                ast::Expr::Subscript(ast::ExprSubscript { value, .. }) => {
-                    let value_ty = builder.expression_type(value);
-
-                    value_ty == Type::SpecialForm(SpecialFormType::Unpack)
-                }
-                _ => false,
-            }
-        }
-
-        // TODO: TypeVarTuple
         match &*tuple.slice {
             ast::Expr::Tuple(elements) => {
                 if let [element, ellipsis @ ast::Expr::EllipsisLiteral(_)] = &*elements.elts {
@@ -989,10 +1009,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                 let mut element_types = TupleSpecBuilder::with_capacity(elements.len());
 
-                // Whether to infer `Todo` for the whole tuple
-                // (see docstring for `element_could_alter_type_of_whole_tuple`)
-                let mut return_todo = false;
-
                 let mut first_unpacked_variadic_tuple = None;
 
                 for element in elements {
@@ -1018,25 +1034,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         InferenceFlags::IN_VALID_UNPACK_CONTEXT,
                         previously_in_valid_unpack_context,
                     );
-                    return_todo |=
-                        element_could_alter_type_of_whole_tuple(element, element_ty, self);
-
                     // Determine if this element unpacks a tuple: either `*expr` or `Unpack[expr]`
-                    let unpack_inner = if let ast::Expr::Starred(ast::ExprStarred {
-                        value, ..
-                    }) = element
-                    {
-                        Some(&**value)
-                    } else if let ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. }) =
-                        element
-                        && self.expression_type(value) == Type::SpecialForm(SpecialFormType::Unpack)
-                    {
-                        Some(&**slice)
-                    } else {
-                        None
-                    };
+                    let is_unpack = matches!(element, ast::Expr::Starred(_))
+                        || matches!(
+                            element,
+                            ast::Expr::Subscript(ast::ExprSubscript { value, .. })
+                                if self.expression_type(value)
+                                    == Type::SpecialForm(SpecialFormType::Unpack)
+                        );
 
-                    if let Some(unpack_inner) = unpack_inner {
+                    if is_unpack {
                         let mut report_too_many_unpacked_tuples = || {
                             if let Some(first_unpacked_variadic_tuple) =
                                 first_unpacked_variadic_tuple
@@ -1070,10 +1077,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             if inner_tuple.is_variadic() {
                                 report_too_many_unpacked_tuples();
                             }
-                        } else if self.expression_type(unpack_inner)
-                            == Type::Dynamic(DynamicType::TodoTypeVarTuple)
+                        } else if let Type::TypeVar(typevar) = element_ty
+                            && typevar.is_typevartuple(self.db())
                         {
                             report_too_many_unpacked_tuples();
+                            element_types =
+                                element_types.concat_variadic_typevar(self.db(), typevar);
                         } else {
                             // TODO: emit a diagnostic
                         }
@@ -1082,14 +1091,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                 }
 
-                let ty = if return_todo {
-                    Some(TupleType::homogeneous(
-                        self.db(),
-                        Type::Dynamic(DynamicType::TodoTypeVarTuple),
-                    ))
-                } else {
-                    TupleType::new(self.db(), &element_types.build())
-                };
+                let ty = TupleType::new(self.db(), &element_types.build());
 
                 // Here, we store the type for the inner `int, str` tuple-expression,
                 // while the type for the outer `tuple[int, str]` slice-expression is
@@ -1120,15 +1122,30 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     InferenceFlags::IN_VALID_UNPACK_CONTEXT,
                     previously_in_valid_unpack_context,
                 );
-                if element_could_alter_type_of_whole_tuple(single_element, single_element_ty, self)
-                {
-                    Some(TupleType::homogeneous(
-                        self.db(),
-                        Type::Dynamic(DynamicType::TodoTypeVarTuple),
-                    ))
-                } else {
-                    TupleType::heterogeneous(self.db(), std::iter::once(single_element_ty))
+                let single_element_is_unpack = matches!(single_element, ast::Expr::Starred(_))
+                    || matches!(
+                        single_element,
+                        ast::Expr::Subscript(ast::ExprSubscript { value, .. })
+                            if self.expression_type(value)
+                                == Type::SpecialForm(SpecialFormType::Unpack)
+                    );
+                if single_element_is_unpack {
+                    if let Some(inner_tuple) =
+                        single_element_ty.exact_tuple_instance_spec(self.db())
+                    {
+                        return TupleType::new(self.db(), &inner_tuple);
+                    } else if let Type::TypeVar(typevar) = single_element_ty
+                        && typevar.is_typevartuple(self.db())
+                    {
+                        return TupleType::new(
+                            self.db(),
+                            &TupleSpecBuilder::with_capacity(0)
+                                .concat_variadic_typevar(self.db(), typevar)
+                                .build(),
+                        );
+                    }
                 }
+                TupleType::heterogeneous(self.db(), std::iter::once(single_element_ty))
             }
         }
     }
@@ -2282,10 +2299,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                 if self
                     .inference_flags()
-                    .contains(InferenceFlags::IN_KWARG_ANNOTATION)
-                    && self
-                        .inference_flags()
-                        .contains(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT)
+                    .contains(InferenceFlags::IN_UNPACK_TYPE_ARGUMENT)
                 {
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                         diagnostic::add_type_expression_reference_link(
@@ -2343,20 +2357,29 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return inner_ty;
                 }
 
-                // When the argument is a tuple type, return it directly so that
-                // `Unpack[tuple[int, ...]]` behaves identically to `*tuple[int, ...]`.
-                //
-                // However, we still need a Todo type for things like
-                // `def f(*args: Unpack[tuple[int, Unpack[tuple[str, ...]]]]): ...`,
-                // which we don't yet support.
-                if self
-                    .inference_flags()
-                    .contains(InferenceFlags::IN_VARARG_ANNOTATION)
-                    || inner_ty.exact_tuple_instance_spec(self.db()).is_none()
+                // Preserve valid unpack targets so that `Unpack[...]` follows the same
+                // argument-binding path as an equivalent starred annotation.
+                if inner_ty.exact_tuple_instance_spec(self.db()).is_some()
+                    || matches!(
+                        inner_ty,
+                        Type::TypeVar(typevar) if typevar.is_typevartuple(self.db())
+                    )
                 {
-                    todo_type!("`Unpack[]` special form")
-                } else {
                     inner_ty
+                } else {
+                    self.store_type_expression_flags(
+                        ast::ExprRef::from(subscript),
+                        TypeExpressionFlags::INVALID_UNPACK,
+                    );
+                    if !inner_ty.is_unknown()
+                        && let Some(builder) =
+                            self.context.report_lint(&INVALID_TYPE_FORM, subscript)
+                    {
+                        diagnostic::add_type_expression_reference_link(builder.into_diagnostic(
+                            "`Unpack` can only unpack a tuple type or `TypeVarTuple`",
+                        ));
+                    }
+                    Type::homogeneous_tuple(self.db(), Type::unknown())
                 }
             }
             SpecialFormType::NoReturn
@@ -2594,10 +2617,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     return None;
                 }
 
-                let mut parameter_types = Vec::with_capacity(params.len());
-
-                // Whether to infer `Todo` for the parameters
-                let mut return_todo = false;
+                let mut parameters = Vec::with_capacity(params.len());
 
                 let previously_in_valid_unpack_context = self
                     .context
@@ -2605,30 +2625,41 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
                 for param in params {
                     let param_type = self.infer_type_expression(param);
-                    // This is similar to what we currently do for inferring tuple type expression.
-                    // We currently infer `Todo` for the parameters to avoid invalid diagnostics
-                    // when trying to check for assignability or any other relation. For example,
-                    // `*tuple[int, str]`, `Unpack[]`, etc. are not yet supported.
-                    return_todo |= param_type.is_todo()
-                        && matches!(param, ast::Expr::Starred(_) | ast::Expr::Subscript(_));
-                    parameter_types.push(param_type);
+                    let is_unpack = self
+                        .type_expression_flags(param)
+                        .contains(TypeExpressionFlags::UNPACK);
+
+                    if is_unpack {
+                        if let Type::TypeVar(typevar) = param_type
+                            && typevar.is_typevartuple(self.db())
+                        {
+                            parameters.push(
+                                Parameter::variadic(Name::new_static("args"))
+                                    .with_annotated_type(Type::TypeVar(typevar))
+                                    .with_starred_annotation(),
+                            );
+                            continue;
+                        }
+
+                        if param_type.exact_tuple_instance_spec(self.db()).is_some() {
+                            parameters.push(
+                                Parameter::variadic(Name::new_static("args"))
+                                    .with_annotated_type(param_type)
+                                    .with_starred_annotation(),
+                            );
+                            continue;
+                        }
+                    }
+
+                    parameters
+                        .push(Parameter::positional_only(None).with_annotated_type(param_type));
                 }
                 self.context.inference_flags.set(
                     InferenceFlags::IN_VALID_UNPACK_CONTEXT,
                     previously_in_valid_unpack_context,
                 );
 
-                return Some(if return_todo {
-                    // TODO: `Unpack`
-                    Parameters::todo()
-                } else {
-                    Parameters::new(
-                        self.db(),
-                        parameter_types.iter().map(|param_type| {
-                            Parameter::positional_only(None).with_annotated_type(*param_type)
-                        }),
-                    )
-                });
+                return Some(Parameters::new(self.db(), parameters));
             }
             ast::Expr::Subscript(subscript) => {
                 let value_ty = self.infer_expression(&subscript.value, TypeContext::default());

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2360,10 +2360,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 // Preserve valid unpack targets so that `Unpack[...]` follows the same
                 // argument-binding path as an equivalent starred annotation.
                 if inner_ty.exact_tuple_instance_spec(self.db()).is_some()
-                    || matches!(
-                        inner_ty,
-                        Type::TypeVar(typevar) if typevar.is_typevartuple(self.db())
-                    )
+                    || super::is_typevartuple_type_or_instance(self.db(), inner_ty)
                 {
                     inner_ty
                 } else {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
@@ -2,7 +2,7 @@ use ruff_python_ast::{self as ast};
 
 use super::TypeInferenceBuilder;
 use crate::types::diagnostic::INVALID_TYPE_FORM;
-use crate::types::{CycleDetector, DynamicType, KnownClass, Type, TypeContext, TypeFormType};
+use crate::types::{CycleDetector, KnownClass, Type, TypeContext, TypeFormType};
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// In a `TypeForm` context, keep the ordinary value interpretation if it is
@@ -56,11 +56,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let contextual_ty = self
                 .speculate()
                 .infer_value_expression_impl(expression, TypeContext::new(Some(target)));
-            // TODO: Remove this exception once `Unpack` produces a precise type instead of a
-            // dynamic placeholder in ordinary expression inference.
-            if contextual_ty.is_assignable_to(self.db(), target)
-                && contextual_ty != Type::Dynamic(DynamicType::TodoUnpack)
-            {
+            if contextual_ty.is_assignable_to(self.db(), target) {
                 return None;
             }
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -10,10 +10,9 @@ use crate::{
             report_mismatched_type_name,
         },
         infer::{
-            InferenceFlags, TypeInferenceBuilder,
+            InferenceFlags, TypeExpressionFlags, TypeInferenceBuilder,
             builder::{BoundOrConstraintsNodes, DeclaredAndInferredType, DeferredExpressionState},
         },
-        todo_type,
         typevar::{
             TypeVarBoundOrConstraintsEvaluation, TypeVarConstraints, TypeVarDefaultEvaluation,
             TypeVarIdentity, TypeVarInstance,
@@ -659,16 +658,348 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let ast::TypeParamTypeVarTuple {
             range: _,
             node_index: _,
-            name: _,
+            name,
             default,
         } = node;
-        self.infer_optional_expression(default.as_deref(), TypeContext::default());
-        let pep_695_todo = todo_type!("PEP-695 TypeVarTuple definition types");
+
+        let db = self.db();
+
+        if default.is_some() {
+            self.deferred.insert(definition);
+        }
+        let identity = TypeVarIdentity::new(
+            db,
+            &name.id,
+            Some(definition),
+            TypeVarKind::Pep695TypeVarTuple,
+        );
+        let ty = Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
+            db,
+            identity,
+            None,
+            None, // explicit_variance
+            default.as_deref().map(|_| TypeVarDefaultEvaluation::Lazy),
+        )));
         self.add_declaration_with_binding(
             node.into(),
             definition,
-            &DeclaredAndInferredType::are_the_same_type(pep_695_todo),
+            &DeclaredAndInferredType::are_the_same_type(ty),
         );
+    }
+
+    pub(super) fn infer_typevartuple_deferred(&mut self, node: &ast::TypeParamTypeVarTuple) {
+        let ast::TypeParamTypeVarTuple {
+            range: _,
+            node_index: _,
+            name,
+            default: Some(default),
+        } = node
+        else {
+            return;
+        };
+        let previous_deferred_state =
+            std::mem::replace(&mut self.deferred_state, DeferredExpressionState::Deferred);
+        self.infer_typevartuple_default(default, Some(&name.id));
+        self.deferred_state = previous_deferred_state;
+    }
+
+    pub(super) fn infer_typevartuple_default(
+        &mut self,
+        default_expr: &ast::Expr,
+        typevartuple_name: Option<&str>,
+    ) {
+        let previously_in_valid_unpack_context = self
+            .context
+            .inference_flags
+            .replace(InferenceFlags::IN_VALID_UNPACK_CONTEXT, true);
+        let default_ty = self.infer_type_expression(default_expr);
+        self.context.inference_flags.set(
+            InferenceFlags::IN_VALID_UNPACK_CONTEXT,
+            previously_in_valid_unpack_context,
+        );
+
+        if let Some(name) = typevartuple_name
+            && self.check_default_for_outer_scope_typevars(default_ty, default_expr, name)
+        {
+            return;
+        }
+
+        if !self
+            .type_expression_flags(default_expr)
+            .contains(TypeExpressionFlags::UNPACK)
+            && !matches!(
+                default_ty,
+                Type::TypeVar(typevar) if typevar.is_typevartuple(self.db())
+            )
+            && let Some(builder) = self
+                .context
+                .report_lint(&INVALID_LEGACY_TYPE_VARIABLE, default_expr)
+        {
+            builder.into_diagnostic(
+                "The default value for `TypeVarTuple` must be an unpacked tuple type \
+                    or another TypeVarTuple",
+            );
+        }
+    }
+
+    pub(super) fn infer_legacy_typevartuple(
+        &mut self,
+        target: &ast::Expr,
+        call_expr: &ast::ExprCall,
+        definition: Definition<'db>,
+        known_class: KnownClass,
+    ) -> Type<'db> {
+        fn error<'db>(
+            context: &InferContext<'db, '_>,
+            message: impl std::fmt::Display,
+            node: impl Ranged,
+        ) -> Type<'db> {
+            if let Some(builder) = context.report_lint(&INVALID_LEGACY_TYPE_VARIABLE, node) {
+                builder.into_diagnostic(message);
+            }
+            KnownClass::TypeVarTuple.to_instance(context.db())
+        }
+
+        let db = self.db();
+        let arguments = &call_expr.arguments;
+        let is_typing_extensions = known_class == KnownClass::ExtensionsTypeVarTuple;
+        let assume_all_features = self.in_stub() || is_typing_extensions;
+        let python_version = Program::get(db).python_version(db);
+        let have_features_from =
+            |version: PythonVersion| assume_all_features || python_version >= version;
+
+        let mut default = None;
+        let mut covariant = false;
+        let mut contravariant = false;
+        let mut infer_variance = false;
+        let mut name_param_ty = None;
+        let mut name_param_node = None;
+
+        if arguments.args.len() > 1 {
+            return error(
+                &self.context,
+                "`TypeVarTuple` can only have one positional argument",
+                call_expr,
+            );
+        }
+
+        if let Some(starred) = arguments.args.iter().find(|arg| arg.is_starred_expr()) {
+            return error(
+                &self.context,
+                "Starred arguments are not supported in `TypeVarTuple` creation",
+                starred,
+            );
+        }
+
+        for kwarg in &arguments.keywords {
+            let Some(identifier) = kwarg.arg.as_ref() else {
+                return error(
+                    &self.context,
+                    "Starred arguments are not supported in `TypeVarTuple` creation",
+                    kwarg,
+                );
+            };
+            match identifier.id().as_str() {
+                "name" => {
+                    if !arguments.args.is_empty() {
+                        return error(
+                            &self.context,
+                            "The `name` parameter of `TypeVarTuple` can only be provided once",
+                            kwarg,
+                        );
+                    }
+                    name_param_node = Some(&kwarg.value);
+                    name_param_ty =
+                        Some(self.infer_expression(&kwarg.value, TypeContext::default()));
+                }
+                "default" => {
+                    if !have_features_from(PythonVersion::PY313) {
+                        error(
+                            &self.context,
+                            "The `default` parameter of `typing.TypeVarTuple` was added in Python 3.13",
+                            kwarg,
+                        );
+                    }
+                    default = Some(TypeVarDefaultEvaluation::Lazy);
+                }
+                "bound" => {
+                    if !have_features_from(PythonVersion::PY315) {
+                        return error(
+                            &self.context,
+                            "The `bound` parameter of `typing.TypeVarTuple` was added in Python 3.15",
+                            kwarg,
+                        );
+                    }
+                    return error(
+                        &self.context,
+                        "The `bound` argument for `TypeVarTuple` is not supported",
+                        call_expr,
+                    );
+                }
+                "covariant" => {
+                    if !have_features_from(PythonVersion::PY315) {
+                        error(
+                            &self.context,
+                            "The `covariant` parameter of `typing.TypeVarTuple` was added in Python 3.15",
+                            kwarg,
+                        );
+                    }
+                    match self
+                        .infer_expression(&kwarg.value, TypeContext::default())
+                        .bool(db)
+                    {
+                        Truthiness::AlwaysTrue => covariant = true,
+                        Truthiness::AlwaysFalse => {}
+                        Truthiness::Ambiguous => {
+                            return error(
+                                &self.context,
+                                "The `covariant` parameter of `TypeVarTuple` \
+                                cannot have an ambiguous truthiness",
+                                &kwarg.value,
+                            );
+                        }
+                    }
+                }
+                "contravariant" => {
+                    if !have_features_from(PythonVersion::PY315) {
+                        error(
+                            &self.context,
+                            "The `contravariant` parameter of `typing.TypeVarTuple` was added in Python 3.15",
+                            kwarg,
+                        );
+                    }
+                    match self
+                        .infer_expression(&kwarg.value, TypeContext::default())
+                        .bool(db)
+                    {
+                        Truthiness::AlwaysTrue => contravariant = true,
+                        Truthiness::AlwaysFalse => {}
+                        Truthiness::Ambiguous => {
+                            return error(
+                                &self.context,
+                                "The `contravariant` parameter of `TypeVarTuple` \
+                                cannot have an ambiguous truthiness",
+                                &kwarg.value,
+                            );
+                        }
+                    }
+                }
+                "infer_variance" => {
+                    if !have_features_from(PythonVersion::PY315) {
+                        error(
+                            &self.context,
+                            "The `infer_variance` parameter of `typing.TypeVarTuple` was added in Python 3.15",
+                            kwarg,
+                        );
+                    }
+                    match self
+                        .infer_expression(&kwarg.value, TypeContext::default())
+                        .bool(db)
+                    {
+                        Truthiness::AlwaysTrue => infer_variance = true,
+                        Truthiness::AlwaysFalse => {}
+                        Truthiness::Ambiguous => {
+                            return error(
+                                &self.context,
+                                "The `infer_variance` parameter of `TypeVarTuple` \
+                                cannot have an ambiguous truthiness",
+                                &kwarg.value,
+                            );
+                        }
+                    }
+                }
+                name => {
+                    error(
+                        &self.context,
+                        format_args!(
+                            "Unknown keyword argument `{name}` in `TypeVarTuple` creation"
+                        ),
+                        kwarg,
+                    );
+                    self.infer_expression(&kwarg.value, TypeContext::default());
+                }
+            }
+        }
+
+        let variance = match (covariant, contravariant, infer_variance) {
+            (true, true, _) => {
+                return error(
+                    &self.context,
+                    "A `TypeVarTuple` cannot be both covariant and contravariant",
+                    call_expr,
+                );
+            }
+            (true, false, true) | (false, true, true) => {
+                return error(
+                    &self.context,
+                    "A `TypeVarTuple` cannot specify variance when `infer_variance=True`",
+                    call_expr,
+                );
+            }
+            (true, false, false) => Some(TypeVarVariance::Covariant),
+            (false, true, false) => Some(TypeVarVariance::Contravariant),
+            (false, false, false) => Some(TypeVarVariance::Invariant),
+            (false, false, true) => None,
+        };
+
+        let Some(name_param_ty) = name_param_ty.or_else(|| {
+            arguments
+                .find_positional(0)
+                .map(|arg| self.infer_expression(arg, TypeContext::default()))
+        }) else {
+            return error(
+                &self.context,
+                "The `name` parameter of `TypeVarTuple` is required.",
+                call_expr,
+            );
+        };
+
+        let Some(name_param) = name_param_ty.as_string_literal().map(|name| name.value(db)) else {
+            return error(
+                &self.context,
+                "The first argument to `TypeVarTuple` must be a string literal",
+                call_expr,
+            );
+        };
+        let name_param_node = name_param_node.or_else(|| arguments.find_positional(0));
+
+        let ast::Expr::Name(ast::ExprName {
+            id: target_name, ..
+        }) = target
+        else {
+            return error(
+                &self.context,
+                "A `TypeVarTuple` definition must be a simple variable assignment",
+                target,
+            );
+        };
+
+        if name_param != target_name {
+            report_mismatched_type_name(
+                &self.context,
+                name_param_node
+                    .map(Ranged::range)
+                    .unwrap_or_else(|| call_expr.range()),
+                "TypeVarTuple",
+                target_name,
+                Some(name_param),
+                name_param_ty,
+            );
+        }
+
+        if default.is_some() {
+            self.deferred.insert(definition);
+        }
+
+        let identity = TypeVarIdentity::new(
+            db,
+            target_name.clone(),
+            Some(definition),
+            TypeVarKind::TypeVarTuple,
+        );
+        Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
+            db, identity, None, variance, default,
+        )))
     }
 
     pub(super) fn infer_legacy_paramspec(

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -677,7 +677,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db,
             identity,
             None,
-            None, // explicit_variance
+            Some(TypeVarVariance::Invariant),
             default.as_deref().map(|_| TypeVarDefaultEvaluation::Lazy),
         )));
         self.add_declaration_with_binding(
@@ -995,7 +995,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db,
             target_name.clone(),
             Some(definition),
-            TypeVarKind::TypeVarTuple,
+            if is_typing_extensions {
+                TypeVarKind::ExtensionsTypeVarTuple
+            } else {
+                TypeVarKind::TypeVarTuple
+            },
         );
         Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
             db, identity, None, variance, default,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -164,6 +164,12 @@ impl<'db> Type<'db> {
             SynthesizedProtocolType::new(ProtocolInterface::with_methods(db, methods)),
         ))
     }
+
+    pub(super) fn protocol_from_interface(interface: ProtocolInterface<'db>) -> Self {
+        Self::ProtocolInstance(ProtocolInstanceType::synthesized(
+            SynthesizedProtocolType::new(interface),
+        ))
+    }
 }
 
 /// A type representing the set of runtime objects which are instances of a certain nominal class.

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -268,6 +268,9 @@ impl<'db> KnownInstanceType<'db> {
             Self::TypeVar(typevar_instance) if typevar_instance.is_paramspec(db) => {
                 KnownClass::ParamSpec
             }
+            Self::TypeVar(typevar_instance) if typevar_instance.is_typevartuple(db) => {
+                KnownClass::TypeVarTuple
+            }
             Self::TypeVar(_) => KnownClass::TypeVar,
             Self::TypeAliasType(TypeAliasType::PEP695(alias)) if alias.is_specialized(db) => {
                 KnownClass::GenericAlias

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -6,7 +6,8 @@ use crate::{
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, CallableType, ClassType, GenericContext,
         InferenceFlags, InvalidTypeExpressionError, KnownClass, StringLiteralType, Type,
-        TypeAliasType, TypeContext, TypeMapping, TypeVarNonce, TypeVarVariance, UnionBuilder,
+        TypeAliasType, TypeContext, TypeMapping, TypeVarKind, TypeVarNonce, TypeVarVariance,
+        UnionBuilder,
         class::NamedTupleSpec,
         constraints::OwnedConstraintSet,
         generics::{Specialization, walk_generic_context},
@@ -267,6 +268,11 @@ impl<'db> KnownInstanceType<'db> {
             Self::SubscriptedProtocol(_) | Self::SubscriptedGeneric(_) => KnownClass::SpecialForm,
             Self::TypeVar(typevar_instance) if typevar_instance.is_paramspec(db) => {
                 KnownClass::ParamSpec
+            }
+            Self::TypeVar(typevar_instance)
+                if typevar_instance.kind(db) == TypeVarKind::ExtensionsTypeVarTuple =>
+            {
+                KnownClass::ExtensionsTypeVarTuple
             }
             Self::TypeVar(typevar_instance) if typevar_instance.is_typevartuple(db) => {
                 KnownClass::TypeVarTuple

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -393,6 +393,7 @@ impl<'db> AllMembers<'db> {
                                     Some(
                                         KnownClass::TypeVar
                                             | KnownClass::TypeVarTuple
+                                            | KnownClass::ExtensionsTypeVarTuple
                                             | KnownClass::ParamSpec
                                             | KnownClass::UnionType
                                     )

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -312,6 +312,17 @@ impl<'db> ProtocolInterface<'db> {
         self.inner(db).contains_key(name)
     }
 
+    pub(super) fn without_member(self, db: &'db dyn Db, excluded: &str) -> Self {
+        Self::new(
+            db,
+            self.inner(db)
+                .iter()
+                .filter(|(name, _)| name.as_str() != excluded)
+                .map(|(name, data)| (name.clone(), data.clone()))
+                .collect::<BTreeMap<_, _>>(),
+        )
+    }
+
     /// Returns the `__call__` method's callable type if this protocol has a `__call__` method member.
     pub(super) fn call_method(self, db: &'db dyn Db) -> Option<CallableType<'db>> {
         self.member_by_name(db, "__call__")

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -15,6 +15,7 @@ use crate::types::enums::is_single_member_enum;
 use crate::types::function::FunctionDecorators;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{ParametersKind, SignatureRelationVisitor};
+use crate::types::tuple::TupleType;
 use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -1354,6 +1355,32 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     .when_some_and(db, self.constraints, |(target_i, source_i)| {
                         self.check_type_pair(db, source_i, Type::TypeVar(target_i))
                     })
+            }
+
+            // A TypeVarTuple specialization is represented by one tuple value. Keep inferable
+            // TypeVarTuples bare for constraint solving, but compare fixed symbolic values using
+            // the same tuple relation as concrete specializations.
+            (Type::TypeVar(bound_typevar), target)
+                if !bound_typevar.is_inferable(db, self.inferable)
+                    && bound_typevar.is_typevartuple(db)
+                    && target.exact_tuple_instance_spec(db).is_some() =>
+            {
+                self.check_type_pair(
+                    db,
+                    Type::tuple(Some(TupleType::unpacked_typevartuple(db, bound_typevar))),
+                    target,
+                )
+            }
+            (source, Type::TypeVar(bound_typevar))
+                if !bound_typevar.is_inferable(db, self.inferable)
+                    && bound_typevar.is_typevartuple(db)
+                    && source.exact_tuple_instance_spec(db).is_some() =>
+            {
+                self.check_type_pair(
+                    db,
+                    source,
+                    Type::tuple(Some(TupleType::unpacked_typevartuple(db, bound_typevar))),
+                )
             }
 
             // A gradual `ParamSpec` value (`...`) is assignability-consistent with any concrete

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -30,6 +30,7 @@ use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
 use crate::types::relation::{
     HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker, TypeVarEvaluation,
 };
+use crate::types::tuple::Tuple;
 use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation;
 use crate::types::typevar::{BoundTypeVarIdentity, max_typevar_freshness_matching_generic_context};
 use crate::types::{
@@ -3673,7 +3674,7 @@ impl<'db> Parameters<'db> {
             .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
             .collect();
 
-        Self::from_parts(value, self.data.kind)
+        Self::from_parts(value, self.data.kind).expand_starred_variadic_annotations(db)
     }
     pub(crate) fn len(&self) -> usize {
         self.data.value.len()
@@ -3740,6 +3741,65 @@ impl<'db> Parameters<'db> {
         self.iter()
             .enumerate()
             .rfind(|(_, parameter)| parameter.is_keyword_variadic())
+    }
+
+    /// Expands an unpacked `*args` annotation into its logical callable parameters.
+    fn expand_starred_variadic_annotations(self, db: &'db dyn Db) -> Self {
+        if !self
+            .data
+            .value
+            .iter()
+            .any(|parameter| parameter.is_variadic() && parameter.has_starred_annotation())
+        {
+            return self;
+        }
+
+        let mut expanded = false;
+        let mut parameters = Vec::with_capacity(self.data.value.len());
+        for parameter in &self.data.value {
+            if parameter.is_variadic()
+                && parameter.has_starred_annotation()
+                && let Some(tuple) = parameter.annotated_type().exact_tuple_instance_spec(db)
+            {
+                expanded = true;
+                match tuple.as_ref() {
+                    Tuple::Fixed(tuple) => {
+                        parameters.extend(
+                            tuple
+                                .iter_all_elements()
+                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
+                        );
+                    }
+                    Tuple::Variable(variable) => {
+                        parameters.extend(
+                            variable
+                                .iter_prefix_elements()
+                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
+                        );
+                        let name = parameter
+                            .name()
+                            .cloned()
+                            .unwrap_or_else(|| Name::new_static("args"));
+                        parameters.push(
+                            Parameter::variadic(name).with_annotated_type(variable.variable()),
+                        );
+                        parameters.extend(
+                            variable
+                                .iter_suffix_elements()
+                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
+                        );
+                    }
+                }
+            } else {
+                parameters.push(parameter.clone());
+            }
+        }
+
+        if expanded {
+            Self::new(db, parameters)
+        } else {
+            self
+        }
     }
 
     /// Expands adjacent `P.args`/`P.kwargs` placeholders into their mapped parameters.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2267,12 +2267,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // self: callable without ParamSpec
                 // other: `Concatenate[<prefix_params>, P]`
                 (None, Some((target_prefix_params, target_bound_typevar))) => {
+                    let source_parameters = source
+                        .parameters
+                        .clone()
+                        .expand_starred_variadic_annotations(db);
                     // Loop over self parameters and target_prefix_params in a similar manner to the
                     // above loop
                     let mut parameters = ParametersZip {
                         current_source: None,
                         current_target: None,
-                        source_iter: source.parameters.iter(),
+                        source_iter: source_parameters.iter(),
                         target_iter: target_prefix_params.iter(),
                     };
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -3927,6 +3927,11 @@ impl<'db> Parameter<'db> {
         self
     }
 
+    pub(crate) fn with_starred_annotation(mut self) -> Self {
+        self.annotation_kind = ParameterAnnotationKind::Starred;
+        self
+    }
+
     pub(crate) fn with_default_type(mut self, default: Type<'db>) -> Self {
         match &mut self.kind {
             ParameterKind::PositionalOnly { default_type, .. }
@@ -4076,28 +4081,29 @@ impl<'db> Parameter<'db> {
         let index = semantic_index(db, function_definition.file(db));
         let definition = Some(index.expect_single_definition(parameter));
 
-        let (annotated_type, inferred_annotation, has_starred_annotation) =
+        let (annotated_type, inferred_annotation, annotation_flags, has_starred_annotation) =
             if let Some(annotation) = parameter.annotation() {
                 (
                     function_signature_expression_type(db, function_definition, annotation),
                     false,
+                    function_signature_type_expression_flags(db, function_definition, annotation),
                     annotation.is_starred_expr(),
                 )
             } else {
-                (Type::unknown(), true, false)
+                (Type::unknown(), true, TypeExpressionFlags::empty(), false)
             };
+        let has_unpacked_variadic_annotation = matches!(&kind, ParameterKind::Variadic { .. })
+            && annotation_flags.contains(TypeExpressionFlags::UNPACK);
         let is_unpacked_typed_dict_kwargs = matches!(&kind, ParameterKind::KeywordVariadic { .. })
-            && parameter.annotation().is_some_and(|annotation| {
-                extract_unpacked_typed_dict_keys_from_kwargs_annotation(
-                    db,
-                    annotated_type,
-                    function_signature_type_expression_flags(db, function_definition, annotation),
-                )
-                .is_some()
-            });
+            && extract_unpacked_typed_dict_keys_from_kwargs_annotation(
+                db,
+                annotated_type,
+                annotation_flags,
+            )
+            .is_some();
         let annotation_kind = if is_unpacked_typed_dict_kwargs {
             ParameterAnnotationKind::UnpackedTypedDictKwargs
-        } else if has_starred_annotation {
+        } else if has_starred_annotation || has_unpacked_variadic_annotation {
             ParameterAnnotationKind::Starred
         } else {
             ParameterAnnotationKind::Normal
@@ -4181,8 +4187,9 @@ impl<'db> Parameter<'db> {
         self.definition
     }
 
-    /// Return `true` if this parameter has a starred annotation,
-    /// e.g. `*args: *Ts` or `*args: *tuple[int, *tuple[str, ...], bytes]`
+    /// Return `true` if this parameter has an unpacked variadic annotation,
+    /// e.g. `*args: *Ts`, `*args: Unpack[Ts]`, or
+    /// `*args: *tuple[int, *tuple[str, ...], bytes]`.
     pub(crate) fn has_starred_annotation(&self) -> bool {
         matches!(self.annotation_kind, ParameterAnnotationKind::Starred)
     }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -30,7 +30,7 @@ use crate::types::infer::{TypeExpressionFlags, infer_deferred_types};
 use crate::types::relation::{
     HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker, TypeVarEvaluation,
 };
-use crate::types::tuple::Tuple;
+use crate::types::tuple::{Tuple, TupleSpecBuilder, TupleType};
 use crate::types::typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation;
 use crate::types::typevar::{BoundTypeVarIdentity, max_typevar_freshness_matching_generic_context};
 use crate::types::{
@@ -1799,6 +1799,21 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             target
         };
 
+        // A starred tuple annotation is lowered to ordinary parameters when its tuple shape has
+        // an exact Python signature representation. Mixed tuples and unresolved TypeVarTuples
+        // retain their starred form; compare those parameter lists gradually for now while still
+        // checking the callable's return type.
+        let normalized_source = source
+            .parameters
+            .normalized_for_callable_relation(db)
+            .map(|parameters| source.clone().with_parameters(parameters));
+        let source = normalized_source.as_ref().unwrap_or(source);
+        let normalized_target = target
+            .parameters
+            .normalized_for_callable_relation(db)
+            .map(|parameters| target.clone().with_parameters(parameters));
+        let target = normalized_target.as_ref().unwrap_or(target);
+
         let source_inferable = source.inferable_typevars(db);
         let target_inferable = target.inferable_typevars(db);
         let inferable = source_inferable.merge(db, target_inferable);
@@ -2267,16 +2282,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // self: callable without ParamSpec
                 // other: `Concatenate[<prefix_params>, P]`
                 (None, Some((target_prefix_params, target_bound_typevar))) => {
-                    let source_parameters = source
-                        .parameters
-                        .clone()
-                        .expand_starred_variadic_annotations(db);
                     // Loop over self parameters and target_prefix_params in a similar manner to the
                     // above loop
                     let mut parameters = ParametersZip {
                         current_source: None,
                         current_target: None,
-                        source_iter: source_parameters.iter(),
+                        source_iter: source.parameters.iter(),
                         target_iter: target_prefix_params.iter(),
                     };
 
@@ -3678,7 +3689,7 @@ impl<'db> Parameters<'db> {
             .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
             .collect();
 
-        Self::from_parts(value, self.data.kind).expand_starred_variadic_annotations(db)
+        Self::from_parts(value, self.data.kind).normalize_starred_variadic_annotations(db)
     }
     pub(crate) fn len(&self) -> usize {
         self.data.value.len()
@@ -3747,8 +3758,9 @@ impl<'db> Parameters<'db> {
             .rfind(|(_, parameter)| parameter.is_keyword_variadic())
     }
 
-    /// Expands an unpacked `*args` annotation into its logical callable parameters.
-    fn expand_starred_variadic_annotations(self, db: &'db dyn Db) -> Self {
+    /// Normalizes an unpacked `*args` annotation into its logical callable parameters when that
+    /// parameter list has an exact Python signature representation.
+    pub(super) fn normalize_starred_variadic_annotations(self, db: &'db dyn Db) -> Self {
         if !self
             .data
             .value
@@ -3758,14 +3770,15 @@ impl<'db> Parameters<'db> {
             return self;
         }
 
-        let mut expanded = false;
+        let mut normalized = false;
         let mut parameters = Vec::with_capacity(self.data.value.len());
-        for parameter in &self.data.value {
+        let mut index = 0;
+        while let Some(parameter) = self.data.value.get(index) {
             if parameter.is_variadic()
                 && parameter.has_starred_annotation()
                 && let Some(tuple) = parameter.annotated_type().exact_tuple_instance_spec(db)
             {
-                expanded = true;
+                normalized = true;
                 match tuple.as_ref() {
                     Tuple::Fixed(tuple) => {
                         parameters.extend(
@@ -3773,37 +3786,78 @@ impl<'db> Parameters<'db> {
                                 .iter_all_elements()
                                 .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
                         );
+                        index += 1;
                     }
                     Tuple::Variable(variable) => {
-                        parameters.extend(
-                            variable
-                                .iter_prefix_elements()
-                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
-                        );
-                        let name = parameter
-                            .name()
-                            .cloned()
-                            .unwrap_or_else(|| Name::new_static("args"));
-                        parameters.push(
-                            Parameter::variadic(name).with_annotated_type(variable.variable()),
-                        );
-                        parameters.extend(
-                            variable
-                                .iter_suffix_elements()
-                                .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
-                        );
+                        let following_positional_end = self.data.value[index + 1..]
+                            .iter()
+                            .take_while(|parameter| parameter.is_positional())
+                            .count()
+                            + index
+                            + 1;
+
+                        if variable.suffix_elements().is_empty()
+                            && following_positional_end == index + 1
+                        {
+                            parameters.extend(variable.iter_prefix_elements().map(|ty| {
+                                Parameter::positional_only(None).with_annotated_type(ty)
+                            }));
+                            let name = parameter
+                                .name()
+                                .cloned()
+                                .unwrap_or_else(|| Name::new_static("args"));
+                            parameters.push(
+                                Parameter::variadic(name).with_annotated_type(variable.variable()),
+                            );
+                            index += 1;
+                        } else {
+                            let mut combined = TupleSpecBuilder::from(tuple.as_ref());
+                            for following in &self.data.value[index + 1..following_positional_end] {
+                                combined.push(following.annotated_type());
+                            }
+                            let combined = combined.build();
+                            parameters.push(
+                                parameter
+                                    .clone()
+                                    .with_annotated_type(Type::tuple(TupleType::new(
+                                        db, &combined,
+                                    ))),
+                            );
+                            index = following_positional_end;
+                        }
                     }
                 }
             } else {
                 parameters.push(parameter.clone());
+                index += 1;
             }
         }
 
-        if expanded {
+        if normalized {
             Self::new(db, parameters)
         } else {
             self
         }
+    }
+
+    fn normalized_for_callable_relation(&self, db: &'db dyn Db) -> Option<Self> {
+        if !self
+            .data
+            .value
+            .iter()
+            .any(|parameter| parameter.is_variadic() && parameter.has_starred_annotation())
+        {
+            return None;
+        }
+
+        let normalized = self.clone().normalize_starred_variadic_annotations(db);
+        Some(
+            normalized
+                .iter()
+                .any(Parameter::has_starred_annotation)
+                .then(Parameters::gradual_form)
+                .unwrap_or(normalized),
+        )
     }
 
     /// Expands adjacent `P.args`/`P.kwargs` placeholders into their mapped parameters.

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -23,8 +23,8 @@ use super::instance::SliceLiteral;
 use super::special_form::SpecialFormType;
 use super::tuple::TupleSpec;
 use super::{
-    DynamicType, IntersectionBuilder, IntersectionType, KnownInstanceType, Type, TypeAliasType,
-    TypedDictType, UnionBuilder, UnionType, todo_type,
+    IntersectionBuilder, IntersectionType, KnownInstanceType, Type, TypeAliasType, TypedDictType,
+    UnionBuilder, UnionType, todo_type,
 };
 
 /// The kind of subscriptable type that had an out-of-bounds index.
@@ -759,7 +759,7 @@ impl<'db> Type<'db> {
             }
 
             (Type::SpecialForm(SpecialFormType::Unpack), _) => {
-                Some(Ok(Type::Dynamic(DynamicType::TodoUnpack)))
+                Some(Ok(Type::unknown()))
             }
 
             (Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar)), _) => {

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -1706,6 +1706,17 @@ impl<'db> TupleSpecBuilder<'db> {
         }
     }
 
+    /// Concatenates an unpacked `TypeVarTuple` as the variable-length portion of this tuple.
+    pub(crate) fn concat_variadic_typevar(
+        self,
+        db: &'db dyn Db,
+        typevar: BoundTypeVarInstance<'db>,
+    ) -> Self {
+        debug_assert!(typevar.is_typevartuple(db));
+        let other = VariableLengthTuple::mixed([], Type::TypeVar(typevar), []);
+        self.concat(db, &other)
+    }
+
     /// Concatenates another tuple to the end of this tuple, returning a new tuple.
     pub(crate) fn concat(mut self, db: &'db dyn Db, other: &TupleSpec<'db>) -> Self {
         match (&mut self, other) {

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -199,6 +199,18 @@ impl<'db> TupleType<'db> {
         }
     }
 
+    /// Packs a `TypeVarTuple` into the tuple value used for generic specialization relations.
+    pub(crate) fn unpacked_typevartuple(
+        db: &'db dyn Db,
+        typevar: BoundTypeVarInstance<'db>,
+    ) -> Self {
+        debug_assert!(typevar.is_typevartuple(db));
+        TupleType::new_internal(
+            db,
+            VariableLengthTuple::mixed([], Type::TypeVar(typevar), []),
+        )
+    }
+
     // N.B. If this method is not Salsa-tracked, we take 10 minutes to check
     // `static-frame` as part of the ecosystem analysis. This is because it's called
     // from `NominalInstanceType::class()`, which is a very hot method.
@@ -1130,16 +1142,33 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> TupleSpec<'db> {
-        Self::mixed(
-            self.prefix_elements()
-                .iter()
-                .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
-            self.variable()
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-            self.suffix_elements()
-                .iter()
-                .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
-        )
+        let prefix = self
+            .prefix_elements()
+            .iter()
+            .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+        let variable = self.variable();
+        let mapped_variable = variable.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+        let suffix = self
+            .suffix_elements()
+            .iter()
+            .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+
+        if let Type::TypeVar(typevar) = variable
+            && typevar.is_typevartuple(db)
+            && let Some(mapped_tuple) = mapped_variable.exact_tuple_instance_spec(db)
+        {
+            let mut builder = TupleSpecBuilder::with_capacity(self.elements.len());
+            for element in prefix {
+                builder.push(element);
+            }
+            builder = builder.concat(db, &mapped_tuple);
+            for element in suffix {
+                builder.push(element);
+            }
+            return builder.build();
+        }
+
+        Self::mixed(prefix, mapped_variable, suffix)
     }
 
     fn find_legacy_typevars_impl(

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1252,6 +1252,8 @@ pub enum TypeVarKind {
     Pep695ParamSpec,
     /// `Ts = TypeVarTuple("Ts")`
     TypeVarTuple,
+    /// `Ts = typing_extensions.TypeVarTuple("Ts")`
+    ExtensionsTypeVarTuple,
     /// `def foo[*Ts]() -> None: ...`
     Pep695TypeVarTuple,
     /// `Alias: typing.TypeAlias = T`
@@ -1264,7 +1266,10 @@ impl TypeVarKind {
     }
 
     pub(super) const fn is_typevartuple(self) -> bool {
-        matches!(self, Self::TypeVarTuple | Self::Pep695TypeVarTuple)
+        matches!(
+            self,
+            Self::TypeVarTuple | Self::ExtensionsTypeVarTuple | Self::Pep695TypeVarTuple
+        )
     }
 }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -217,6 +217,10 @@ impl<'db> TypeVarInstance<'db> {
         self.kind(db).is_paramspec()
     }
 
+    pub(crate) fn is_typevartuple(self, db: &'db dyn Db) -> bool {
+        self.kind(db).is_typevartuple()
+    }
+
     pub(crate) fn upper_bound(self, db: &'db dyn Db) -> Option<Type<'db>> {
         if let Some(TypeVarBoundOrConstraints::UpperBound(ty)) = self.bound_or_constraints(db) {
             Some(ty)
@@ -547,10 +551,7 @@ impl<'db> TypeVarInstance<'db> {
                         )
                     }),
                 Type::Dynamic(dynamic) => match dynamic {
-                    DynamicType::Todo(_)
-                    | DynamicType::TodoUnpack
-                    | DynamicType::TodoStarredExpression
-                    | DynamicType::TodoTypeVarTuple => Parameters::todo(),
+                    DynamicType::Todo(_) => Parameters::todo(),
                     DynamicType::Any
                     | DynamicType::Unknown
                     | DynamicType::UnknownGeneric(_)
@@ -602,6 +603,11 @@ impl<'db> TypeVarInstance<'db> {
                 let default_ty =
                     definition_expression_type(db, definition, paramspec_node.default.as_ref()?);
                 convert_type_to_paramspec_value(db, default_ty)
+            }
+            // PEP 695 TypeVarTuple
+            DefinitionKind::TypeVarTuple(typevartuple) => {
+                let typevartuple_node = typevartuple.node(&module);
+                definition_expression_type(db, definition, typevartuple_node.default.as_ref()?)
             }
             _ => return None,
         };
@@ -859,6 +865,10 @@ impl<'db> BoundTypeVarInstance<'db> {
 
     pub(crate) fn is_paramspec(self, db: &'db dyn Db) -> bool {
         self.kind(db).is_paramspec()
+    }
+
+    pub(crate) fn is_typevartuple(self, db: &'db dyn Db) -> bool {
+        self.kind(db).is_typevartuple()
     }
 
     /// Returns a new bound typevar instance with the given `ParamSpec` attribute set.
@@ -1240,6 +1250,10 @@ pub enum TypeVarKind {
     ParamSpec,
     /// `def foo[**P]() -> None: ...`
     Pep695ParamSpec,
+    /// `Ts = TypeVarTuple("Ts")`
+    TypeVarTuple,
+    /// `def foo[*Ts]() -> None: ...`
+    Pep695TypeVarTuple,
     /// `Alias: typing.TypeAlias = T`
     Pep613Alias,
 }
@@ -1247,6 +1261,10 @@ pub enum TypeVarKind {
 impl TypeVarKind {
     pub(super) const fn is_paramspec(self) -> bool {
         matches!(self, Self::ParamSpec | Self::Pep695ParamSpec)
+    }
+
+    pub(super) const fn is_typevartuple(self) -> bool {
+        matches!(self, Self::TypeVarTuple | Self::Pep695TypeVarTuple)
     }
 }
 

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -543,8 +543,7 @@ if __name__ == "__main__":
     )
     # https://stackoverflow.com/a/58840987/3549270
     for signal in [SIGINT, SIGTERM]:
-        # TODO: Remove once starred variadic annotations are expanded for callable matching.
-        loop.add_signal_handler(signal, main_task.cancel)  # ty: ignore[invalid-argument-type]
+        loop.add_signal_handler(signal, main_task.cancel)
     try:
         loop.run_until_complete(main_task)
     finally:

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -543,7 +543,8 @@ if __name__ == "__main__":
     )
     # https://stackoverflow.com/a/58840987/3549270
     for signal in [SIGINT, SIGTERM]:
-        loop.add_signal_handler(signal, main_task.cancel)
+        # TODO: Remove once starred variadic annotations are expanded for callable matching.
+        loop.add_signal_handler(signal, main_task.cancel)  # ty: ignore[invalid-argument-type]
     try:
         loop.run_until_complete(main_task)
     finally:


### PR DESCRIPTION
Stacked on #25240. This draft contains review fixes for TypeVarTuple/Unpack support, with the old solver kept deliberately conservative to avoid false-positive diagnostics. Commits are being pushed and checked independently; this PR should remain draft until the implementation and validation report are complete.