### PR TITLE
[ty] Fast path exact collection type contexts

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6948,7 +6948,40 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mut elt_tcx_variance: FxHashMap<BoundTypeVarIdentity<'_>, TypeVarVariance> =
                 FxHashMap::default();
 
-            if let Some(tcx) = tcx.annotation
+            if let Some(tcx) = tcx.annotation.map(|tcx| tcx.resolve_type_alias(self.db()))
+                && matches!(tcx, Type::NominalInstance(_))
+                && let Some(specialization) = tcx.known_specialization(self.db(), collection_class)
+                && specialization.generic_context(self.db()) == generic_context
+                && generic_context.variables(self.db()).all(|typevar| {
+                    !typevar.is_paramspec(self.db())
+                        && typevar
+                            .typevar(self.db())
+                            .bound_or_constraints(self.db())
+                            .is_none()
+                })
+            {
+                // For an instance of the collection class itself, the identity specialization
+                // maps directly to the contextual specialization. Avoid constructing and solving
+                // a general assignability constraint set for this common case.
+                for (typevar, inferred_ty) in generic_context
+                    .variables(self.db())
+                    .zip(specialization.types(self.db()))
+                {
+                    let inferred_ty = inferred_ty
+                        .filter_union(self.db(), |ty| {
+                            !ty.as_typevar()
+                                .is_some_and(|tv| tv.is_inferable(self.db(), inferable))
+                        })
+                        .filter_union(self.db(), |ty| !ty.has_unspecialized_type_var(self.db()));
+                    if inferred_ty.has_unspecialized_type_var(self.db()) {
+                        continue;
+                    }
+
+                    let identity = typevar.identity(self.db());
+                    elt_tcx_constraints.insert(identity, UnionAccumulator::new(inferred_ty));
+                    elt_tcx_variance.insert(identity, typevar.variance(self.db()));
+                }
+            } else if let Some(tcx) = tcx.annotation
                 && tcx.class_specialization(self.db()).is_some()
             {
                 let db = self.db();


### PR DESCRIPTION
## Summary

- Map exact nominal collection type contexts directly to their generic specialization.
- Reuse the existing empty-collection early return once all type variables are known.
- Keep aliases, constrained generics, ParamSpecs, unions, and other complex contexts on the existing assignability-solver path.

Collection literal inference currently invokes the general assignability constraint solver even when the context is the same nominal collection class, such as `dict[Hashable, CoreSchema]`. In that case, the contextual type arguments already provide the specialization directly.

This isolates the Pydantic-relevant part of #25878 without adding its speculative inference pass for non-empty literals. The `ty_micro[pydantic_core_schema_dict]` benchmark is an empty dictionary with an exact `dict[...]` annotation, so it only needs this shortcut.

The fast path applies only when the context resolves to a nominal instance of the collection class, its generic context matches exactly, and its type variables have no ParamSpec, bound, or constraints. All other cases continue through the existing solver.

## Test Plan

- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG=line-tables-only MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic -- mdtest::assignment/annotations.md`
- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG=line-tables-only MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic`
- `cargo clippy -p ty_python_semantic --all-targets --all-features -- -D warnings`
- `uvx prek run --files crates/ty_python_semantic/src/types/infer/builder.rs`
