### PR TITLE
[ty] Compact retained type-check diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4743,6 +4743,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "test-case",
+ "thin-vec",
  "thiserror 2.0.18",
  "tracing",
  "ty_module_resolver",

--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -30,7 +30,7 @@ ty_python_core = { workspace = true }
 bitflags = { workspace = true }
 compact_str = { workspace = true }
 drop_bomb = { workspace = true }
-get-size2 = { workspace = true, features = ["indexmap", "ordermap"] }
+get-size2 = { workspace = true, features = ["indexmap", "ordermap", "thin-vec"] }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
@@ -45,6 +45,7 @@ static_assertions = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
+thin-vec = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -507,6 +507,18 @@ impl fmt::Display for SuppressionKind {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize)]
 pub(crate) struct FileSuppressionId(TextRange);
 
+impl Ord for FileSuppressionId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (self.0.start(), self.0.end()).cmp(&(other.0.start(), other.0.end()))
+    }
+}
+
+impl PartialOrd for FileSuppressionId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq, get_size2::GetSize)]
 enum SuppressionTarget {
     /// Suppress all lints

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -44,8 +44,9 @@ use ruff_python_ast::token::parentheses_iterator;
 use ruff_python_ast::{self as ast, AnyNodeRef, HasNodeIndex, StringFlags};
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use std::fmt::{self, Formatter};
+use thin_vec::ThinVec;
 use ty_module_resolver::{KnownModule, Module, ModuleName, file_to_module};
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place::{PlaceTable, ScopedPlaceId};
@@ -3575,8 +3576,11 @@ declare_lint! {
 /// A collection of type check diagnostics.
 #[derive(Default, Eq, PartialEq, get_size2::GetSize)]
 pub struct TypeCheckDiagnostics {
-    diagnostics: Vec<Diagnostic>,
-    used_suppressions: FxHashSet<FileSuppressionId>,
+    /// Most inference regions do not emit any diagnostics.
+    diagnostics: ThinVec<Diagnostic>,
+
+    /// Most inference regions do not use any suppressions.
+    used_suppressions: ThinVec<FileSuppressionId>,
 }
 
 pub(crate) fn report_mismatched_type_name<'db>(
@@ -3611,7 +3615,10 @@ impl TypeCheckDiagnostics {
 
     pub(super) fn extend(&mut self, other: &TypeCheckDiagnostics) {
         self.diagnostics.extend_from_slice(&other.diagnostics);
-        self.used_suppressions.extend(&other.used_suppressions);
+        self.used_suppressions
+            .extend_from_slice(&other.used_suppressions);
+        self.used_suppressions.sort_unstable();
+        self.used_suppressions.dedup();
     }
 
     pub(super) fn extend_diagnostics(&mut self, diagnostics: impl IntoIterator<Item = Diagnostic>) {
@@ -3619,11 +3626,15 @@ impl TypeCheckDiagnostics {
     }
 
     pub(crate) fn mark_used(&mut self, suppression_id: FileSuppressionId) {
-        self.used_suppressions.insert(suppression_id);
+        if let Err(index) = self.used_suppressions.binary_search(&suppression_id) {
+            self.used_suppressions.insert(index, suppression_id);
+        }
     }
 
     pub(crate) fn is_used(&self, suppression_id: FileSuppressionId) -> bool {
-        self.used_suppressions.contains(&suppression_id)
+        self.used_suppressions
+            .binary_search(&suppression_id)
+            .is_ok()
     }
 
     pub(crate) fn used_len(&self) -> usize {
@@ -3636,7 +3647,7 @@ impl TypeCheckDiagnostics {
     }
 
     pub(crate) fn into_diagnostics(self) -> Vec<Diagnostic> {
-        self.diagnostics
+        self.diagnostics.into()
     }
 
     pub(crate) fn is_empty(&self) -> bool {


### PR DESCRIPTION
## Summary

Use `ThinVec` for diagnostics and used suppression IDs so empty inference results avoid retaining full-sized collection headers. This reduced retained inference memory by 7.3 MiB on Home Assistant.

## Test Plan

Testing: The ty Python semantic test suite and pre-commit hooks passed.