### PR TITLE
Improve generic handling and diagnostics in ruff_macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,6 +3276,7 @@ dependencies = [
  "regex",
  "ruff_python_trivia",
  "syn",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,6 +3338,7 @@ dependencies = [
 name = "ruff_options_metadata"
 version = "0.0.0"
 dependencies = [
+ "ruff_macros",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,6 +4523,7 @@ version = "0.0.0"
 dependencies = [
  "ordermap",
  "ruff_db",
+ "ruff_macros",
  "ruff_python_ast",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ strum = { version = "0.28.0", features = ["strum_macros"] }
 strum_macros = { version = "0.28.0" }
 supports-hyperlinks = { version = "3.1.0" }
 syn = { version = "2.0.55" }
+synstructure = { version = "0.13.2" }
 tempfile = { version = "3.9.0" }
 test-case = { version = "3.3.1" }
 thiserror = { version = "2.0.0" }

--- a/crates/ruff_cache/tests/cache_key.rs
+++ b/crates/ruff_cache/tests/cache_key.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 use ruff_cache::{CacheKey, CacheKeyHasher};
@@ -87,6 +88,39 @@ fn unnamed_field_struct() {
     unnamed_fields.hash(&mut hash);
 
     assert_eq!(hash.finish(), key.finish());
+}
+
+#[test]
+fn generic_struct() {
+    #[derive(CacheKey)]
+    struct Generic<T>(T);
+
+    let mut key = CacheKeyHasher::new();
+    Generic("Hello").cache_key(&mut key);
+}
+
+#[test]
+fn generic_field_with_additional_bounds() {
+    #[derive(CacheKey)]
+    struct GenericMap<K, V>(HashMap<K, V>);
+
+    let mut key = CacheKeyHasher::new();
+    GenericMap(HashMap::from([(1, "Hello")])).cache_key(&mut key);
+}
+
+#[test]
+fn ignored_generic_field_does_not_require_cache_key() {
+    struct NotCacheKey;
+
+    #[derive(CacheKey)]
+    struct Generic<T> {
+        #[cache_key(ignore)]
+        #[expect(dead_code)]
+        value: T,
+    }
+
+    let mut key = CacheKeyHasher::new();
+    Generic { value: NotCacheKey }.cache_key(&mut key);
 }
 
 #[derive(CacheKey, Hash)]

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -961,7 +961,6 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Flake8UsePathlib, "124") => rules::flake8_use_pathlib::violations::PyPath,
         (Flake8UsePathlib, "201") => rules::flake8_use_pathlib::rules::PathConstructorCurrentDirectory,
         (Flake8UsePathlib, "202") => rules::flake8_use_pathlib::rules::OsPathGetsize,
-        (Flake8UsePathlib, "202") => rules::flake8_use_pathlib::rules::OsPathGetsize,
         (Flake8UsePathlib, "203") => rules::flake8_use_pathlib::rules::OsPathGetatime,
         (Flake8UsePathlib, "204") => rules::flake8_use_pathlib::rules::OsPathGetmtime,
         (Flake8UsePathlib, "205") => rules::flake8_use_pathlib::rules::OsPathGetctime,

--- a/crates/ruff_macros/Cargo.toml
+++ b/crates/ruff_macros/Cargo.toml
@@ -24,6 +24,7 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 regex = { workspace = true }
 syn = { workspace = true, features = ["derive", "parsing", "extra-traits", "full"] }
+synstructure = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruff_macros/src/cache_key.rs
+++ b/crates/ruff_macros/src/cache_key.rs
@@ -1,103 +1,73 @@
 use proc_macro2::{Ident, TokenStream};
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{Data, DeriveInput, Error, Field, Fields, Token};
+use syn::{Data, DeriveInput, Error, Field, Token};
+use synstructure::{AddBounds, Structure};
 
 pub(crate) fn derive_cache_key(item: &DeriveInput) -> syn::Result<TokenStream> {
-    let fields = match &item.data {
-        Data::Enum(item_enum) => {
-            let arms = item_enum.variants.iter().enumerate().map(|(i, variant)| {
-                let variant_name = &variant.ident;
+    if matches!(item.data, Data::Union(_)) {
+        return Err(Error::new(
+            item.span(),
+            "CacheKey does not support unions. Only structs and enums are supported",
+        ));
+    }
 
-                match &variant.fields {
-                    Fields::Named(fields) => {
-                        let field_names: Vec<_> = fields
-                            .named
-                            .iter()
-                            .map(|field| field.ident.clone().unwrap())
-                            .collect();
+    let mut structure = Structure::try_new(item)?;
 
-                        let fields_code = field_names
-                            .iter()
-                            .map(|field| quote!(#field.cache_key(key);));
-
-                        quote! {
-                            Self::#variant_name{#(#field_names),*} => {
-                                key.write_usize(#i);
-                                #(#fields_code)*
-                            }
-                        }
-                    }
-                    Fields::Unnamed(fields) => {
-                        let field_names: Vec<_> = fields
-                            .unnamed
-                            .iter()
-                            .enumerate()
-                            .map(|(i, _)| format_ident!("field_{i}"))
-                            .collect();
-
-                        let fields_code = field_names
-                            .iter()
-                            .map(|field| quote!(#field.cache_key(key);));
-
-                        quote! {
-                            Self::#variant_name(#(#field_names),*) => {
-                                key.write_usize(#i);
-                                #(#fields_code)*
-                            }
-                        }
-                    }
-                    Fields::Unit => {
-                        quote! {
-                            Self::#variant_name => {
-                                key.write_usize(#i);
-                            }
-                        }
-                    }
+    if matches!(item.data, Data::Struct(_)) {
+        let mut attribute_error: Option<Error> = None;
+        structure.filter(|binding| match cache_key_field_attribute(binding.ast()) {
+            Ok(attributes) => !attributes.is_some_and(|attributes| attributes.ignore),
+            Err(error) => {
+                if let Some(attribute_error) = &mut attribute_error {
+                    attribute_error.combine(error);
+                } else {
+                    attribute_error = Some(error);
                 }
-            });
+                true
+            }
+        });
+        if let Some(error) = attribute_error {
+            return Err(error);
+        }
+    }
+
+    let is_enum = matches!(item.data, Data::Enum(_));
+    let arms = structure
+        .variants()
+        .iter()
+        .enumerate()
+        .map(|(index, variant)| {
+            let pattern = variant.pat();
+            let fields = variant
+                .bindings()
+                .iter()
+                .map(|binding| quote!(#binding.cache_key(key);));
+            let discriminant = is_enum.then(|| quote!(key.write_usize(#index);));
 
             quote! {
-                match self {
-                    #(#arms)*
+                #pattern => {
+                    #discriminant
+                    #(#fields)*
                 }
             }
-        }
+        });
 
-        Data::Struct(item_struct) => {
-            let mut fields = Vec::with_capacity(item_struct.fields.len());
-
-            for (i, field) in item_struct.fields.iter().enumerate() {
-                if let Some(cache_field_attribute) = cache_key_field_attribute(field)? {
-                    if cache_field_attribute.ignore {
-                        continue;
-                    }
-                }
-
-                let field_attr = if let Some(ident) = &field.ident {
-                    quote!(self.#ident)
-                } else {
-                    let index = syn::Index::from(i);
-                    quote!(self.#index)
-                };
-
-                fields.push(quote!(#field_attr.cache_key(key);));
-            }
-
-            quote! {#(#fields)*}
-        }
-
-        Data::Union(_) => {
-            return Err(Error::new(
-                item.span(),
-                "CacheKey does not support unions. Only structs and enums are supported",
-            ));
+    let fields = quote! {
+        match *self {
+            #(#arms)*
         }
     };
 
     let name = &item.ident;
-    let (impl_generics, ty_generics, where_clause) = &item.generics.split_for_impl();
+    let mut generics = item.generics.clone();
+    structure.add_trait_bounds(
+        &syn::parse_quote!(ruff_cache::CacheKey),
+        &mut generics.where_clause,
+        AddBounds::Fields,
+    );
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     Ok(quote!(
         #[automatically_derived]

--- a/crates/ruff_macros/src/combine.rs
+++ b/crates/ruff_macros/src/combine.rs
@@ -3,7 +3,12 @@ use syn::spanned::Spanned;
 use syn::{Data, DataStruct, DeriveInput};
 
 pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
-    let DeriveInput { ident, data, .. } = input;
+    let DeriveInput {
+        ident,
+        data,
+        generics,
+        ..
+    } = input;
 
     match data {
         Data::Struct(DataStruct { fields, .. }) => {
@@ -17,9 +22,11 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
                 })
                 .collect();
 
+            let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
             Ok(quote! {
                 #[automatically_derived]
-                impl ty_combine::Combine for #ident {
+                impl #impl_generics ty_combine::Combine for #ident #ty_generics #where_clause {
                     #[allow(deprecated)]
                     fn combine_with(&mut self, other: Self) {
                         #(

--- a/crates/ruff_macros/src/combine_options.rs
+++ b/crates/ruff_macros/src/combine_options.rs
@@ -2,7 +2,12 @@ use quote::{quote, quote_spanned};
 use syn::{Data, DataStruct, DeriveInput, Field, Fields, Path, PathSegment, Type, TypePath};
 
 pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
-    let DeriveInput { ident, data, .. } = input;
+    let DeriveInput {
+        ident,
+        data,
+        generics,
+        ..
+    } = input;
 
     match data {
         Data::Struct(DataStruct {
@@ -15,9 +20,11 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
                 .map(handle_field)
                 .collect::<Result<Vec<_>, _>>()?;
 
+            let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
             Ok(quote! {
                 #[automatically_derived]
-                impl crate::configuration::CombinePluginOptions for #ident {
+                impl #impl_generics crate::configuration::CombinePluginOptions for #ident #ty_generics #where_clause {
                     fn combine(self, other: Self) -> Self {
                         #[expect(deprecated)]
                         Self {

--- a/crates/ruff_macros/src/config.rs
+++ b/crates/ruff_macros/src/config.rs
@@ -4,7 +4,7 @@ use syn::meta::ParseNestedMeta;
 use syn::spanned::Spanned;
 use syn::{
     AngleBracketedGenericArguments, Attribute, Data, DataStruct, DeriveInput, ExprLit, Field,
-    Fields, Lit, LitStr, Meta, Path, PathArguments, PathSegment, Type, TypePath,
+    Fields, GenericArgument, Lit, LitStr, Meta, Path, PathArguments, PathSegment, Type, TypePath,
 };
 
 use ruff_python_trivia::textwrap::dedent;
@@ -124,11 +124,18 @@ fn handle_option_group(field: &Field) -> syn::Result<proc_macro2::TokenStream> {
                 arguments:
                     PathArguments::AngleBracketed(AngleBracketedGenericArguments { args, .. }),
             }) if type_ident == "Option" => {
-                let path = &args[0];
+                let mut args = args.iter();
+                let (Some(GenericArgument::Type(option_type)), None) = (args.next(), args.next())
+                else {
+                    return Err(syn::Error::new_spanned(
+                        &field.ty,
+                        "Expected `Option<T>` with exactly one type argument.",
+                    ));
+                };
                 let kebab_name = LitStr::new(&ident.to_string().replace('_', "-"), ident.span());
 
                 Ok(quote_spanned!(
-                    ident.span() => (visit.record_set(#kebab_name, ruff_options_metadata::OptionSet::of::<#path>()))
+                    ident.span() => (visit.record_set(#kebab_name, ruff_options_metadata::OptionSet::of::<#option_type>()))
                 ))
             }
             _ => Err(syn::Error::new(

--- a/crates/ruff_macros/src/config.rs
+++ b/crates/ruff_macros/src/config.rs
@@ -14,6 +14,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
         ident,
         data,
         attrs: struct_attributes,
+        generics,
         ..
     } = input;
 
@@ -84,9 +85,11 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                 ))
             };
 
+            let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
             Ok(quote! {
                 #[automatically_derived]
-                impl ruff_options_metadata::OptionsMetadata for #ident {
+                impl #impl_generics ruff_options_metadata::OptionsMetadata for #ident #ty_generics #where_clause {
                     fn record(visit: &mut dyn ruff_options_metadata::Visit) {
                         #(#output);*
                     }

--- a/crates/ruff_macros/src/config.rs
+++ b/crates/ruff_macros/src/config.rs
@@ -319,6 +319,16 @@ fn parse_field_attributes(attribute: &Attribute) -> syn::Result<FieldAttributes>
 }
 
 fn parse_deprecated_attribute(attribute: &Attribute) -> syn::Result<DeprecatedAttribute> {
+    if matches!(&attribute.meta, Meta::Path(_)) {
+        return Ok(DeprecatedAttribute::default());
+    }
+    if !matches!(&attribute.meta, Meta::List(_)) {
+        return Err(syn::Error::new_spanned(
+            attribute,
+            "Expected `deprecated` or `deprecated(...)` attribute.",
+        ));
+    }
+
     let mut deprecated = DeprecatedAttribute::default();
     attribute.parse_nested_meta(|meta| {
         if meta.path.is_ident("note") {

--- a/crates/ruff_macros/src/config.rs
+++ b/crates/ruff_macros/src/config.rs
@@ -1,10 +1,12 @@
-use proc_macro2::{TokenStream, TokenTree};
+use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::meta::ParseNestedMeta;
+use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
     AngleBracketedGenericArguments, Attribute, Data, DataStruct, DeriveInput, ExprLit, Field,
-    Fields, GenericArgument, Lit, LitStr, Meta, Path, PathArguments, PathSegment, Type, TypePath,
+    Fields, GenericArgument, Lit, LitStr, Meta, Path, PathArguments, PathSegment, Token, Type,
+    TypePath,
 };
 
 use ruff_python_trivia::textwrap::dedent;
@@ -38,25 +40,13 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                     .any(|attr| attr.path().is_ident("option_group"))
                 {
                     output.push(handle_option_group(field)?);
-                } else if let Some(serde) = field
-                    .attrs
-                    .iter()
-                    .find(|attr| attr.path().is_ident("serde"))
-                {
+                } else if has_serde_flatten(field)? {
                     // If a field has the `serde(flatten)` attribute, flatten the options into the parent
-                    // by calling `Type::record` instead of `visitor.visit_set`
-                    if let (Type::Path(ty), Meta::List(list)) = (&field.ty, &serde.meta) {
-                        for token in list.tokens.clone() {
-                            if let TokenTree::Ident(ident) = token {
-                                if ident == "flatten" {
-                                    output.push(quote_spanned!(
-                                        ty.span() => (<#ty>::record(visit))
-                                    ));
-
-                                    break;
-                                }
-                            }
-                        }
+                    // by calling `Type::record` instead of `visitor.visit_set`.
+                    if let Type::Path(ty) = &field.ty {
+                        output.push(quote_spanned!(
+                            ty.span() => (<#ty as ruff_options_metadata::OptionsMetadata>::record(visit))
+                        ));
                     }
                 }
             }
@@ -103,6 +93,25 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream> {
             "Can only derive ConfigurationOptions from structs with named fields.",
         )),
     }
+}
+
+fn has_serde_flatten(field: &Field) -> syn::Result<bool> {
+    for attribute in field
+        .attrs
+        .iter()
+        .filter(|attribute| attribute.path().is_ident("serde"))
+    {
+        let metadata =
+            attribute.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
+        if metadata
+            .iter()
+            .any(|meta| matches!(meta, Meta::Path(path) if path.is_ident("flatten")))
+        {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 /// For a field with type `Option<Foobar>` where `Foobar` itself is a struct

--- a/crates/ruff_macros/src/derive_message_formats.rs
+++ b/crates/ruff_macros/src/derive_message_formats.rs
@@ -1,49 +1,52 @@
 use proc_macro2::TokenStream;
-use quote::{ToTokens, quote, quote_spanned};
+use quote::{ToTokens, quote};
 use syn::spanned::Spanned;
 use syn::token::{Dot, Paren};
-use syn::{Block, Expr, ExprLit, ExprMethodCall, ItemFn, Lit, Stmt};
+use syn::{Block, Error, Expr, ExprLit, ExprMethodCall, ItemFn, Lit, Stmt};
 
-pub(crate) fn derive_message_formats(func: &ItemFn) -> TokenStream {
+pub(crate) fn derive_message_formats(func: &ItemFn) -> syn::Result<TokenStream> {
     let mut strings = quote!();
 
-    if let Err(err) = parse_block(&func.block, &mut strings) {
-        return err;
-    }
+    parse_block(&func.block, &mut strings)?;
 
-    quote! {
+    Ok(quote! {
         #func
         fn message_formats() -> &'static [&'static str] {
             &[#strings]
         }
-    }
+    })
 }
 
-fn parse_block(block: &Block, strings: &mut TokenStream) -> Result<(), TokenStream> {
+fn parse_block(block: &Block, strings: &mut TokenStream) -> syn::Result<()> {
     let Some(Stmt::Expr(last, _)) = block.stmts.last() else {
-        panic!("expected last statement in block to be an expression")
+        return Err(Error::new_spanned(
+            block,
+            "expected block to end in an expression",
+        ));
     };
     parse_expr(last, strings)?;
     Ok(())
 }
 
-fn parse_expr(expr: &Expr, strings: &mut TokenStream) -> Result<(), TokenStream> {
+fn parse_expr(expr: &Expr, strings: &mut TokenStream) -> syn::Result<()> {
     match expr {
         Expr::Macro(mac) if mac.mac.path.is_ident("format") => {
             let mut tokens = mac.mac.tokens.to_token_stream().into_iter();
             let Some(first_token) = tokens.next() else {
-                return Err(
-                    quote_spanned!(expr.span() => compile_error!("expected `format!` to have an argument")),
-                );
+                return Err(Error::new(
+                    expr.span(),
+                    "expected `format!` to have an argument",
+                ));
             };
             // do not throw an error if the `format!` argument contains a formatting argument
 
             if !first_token.to_string().contains('{') {
                 // comma and string
                 if tokens.next().is_none() || tokens.next().is_none() {
-                    return Err(
-                        quote_spanned!(expr.span() => compile_error!("prefer `String::to_string` over `format!` without arguments")),
-                    );
+                    return Err(Error::new(
+                        expr.span(),
+                        "prefer `String::to_string` over `format!` without arguments",
+                    ));
                 }
             }
             strings.extend(quote! {#first_token,});
@@ -77,9 +80,10 @@ fn parse_expr(expr: &Expr, strings: &mut TokenStream) -> Result<(), TokenStream>
                     ..
                 }) = **receiver
                 else {
-                    return Err(
-                        quote_spanned!(expr.span() => compile_error!("expected `String::to_string` method on str literal")),
-                    );
+                    return Err(Error::new(
+                        expr.span(),
+                        "expected `String::to_string` method on str literal",
+                    ));
                 };
 
                 let str_token = literal_string.token();
@@ -87,9 +91,10 @@ fn parse_expr(expr: &Expr, strings: &mut TokenStream) -> Result<(), TokenStream>
                 strings.extend(quote! {#str_token,});
                 Ok(())
             }
-            _ => Err(
-                quote_spanned!(expr.span() => compile_error!("expected `String::to_string` method on str literal")),
-            ),
+            _ => Err(Error::new(
+                expr.span(),
+                "expected `String::to_string` method on str literal",
+            )),
         },
         Expr::Match(block) => {
             for arm in &block.arms {
@@ -97,9 +102,9 @@ fn parse_expr(expr: &Expr, strings: &mut TokenStream) -> Result<(), TokenStream>
             }
             Ok(())
         }
-        _ => Err(quote_spanned!(
-            expr.span() =>
-            compile_error!("expected last expression to be a `format!` macro, a static String or a match block")
+        _ => Err(Error::new(
+            expr.span(),
+            "expected last expression to be a `format!` macro, a static String or a match block",
         )),
     }
 }

--- a/crates/ruff_macros/src/derive_message_formats.rs
+++ b/crates/ruff_macros/src/derive_message_formats.rs
@@ -1,8 +1,9 @@
 use proc_macro2::TokenStream;
-use quote::{ToTokens, quote};
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::token::{Dot, Paren};
-use syn::{Block, Error, Expr, ExprLit, ExprMethodCall, ItemFn, Lit, Stmt};
+use syn::{Block, Error, Expr, ExprLit, ExprMethodCall, ItemFn, Lit, LitStr, Stmt, Token};
 
 pub(crate) fn derive_message_formats(func: &ItemFn) -> syn::Result<TokenStream> {
     let mut strings = quote!();
@@ -31,25 +32,17 @@ fn parse_block(block: &Block, strings: &mut TokenStream) -> syn::Result<()> {
 fn parse_expr(expr: &Expr, strings: &mut TokenStream) -> syn::Result<()> {
     match expr {
         Expr::Macro(mac) if mac.mac.path.is_ident("format") => {
-            let mut tokens = mac.mac.tokens.to_token_stream().into_iter();
-            let Some(first_token) = tokens.next() else {
-                return Err(Error::new(
-                    expr.span(),
-                    "expected `format!` to have an argument",
-                ));
-            };
+            let arguments = mac.mac.parse_body::<FormatArguments>()?;
             // do not throw an error if the `format!` argument contains a formatting argument
 
-            if !first_token.to_string().contains('{') {
-                // comma and string
-                if tokens.next().is_none() || tokens.next().is_none() {
-                    return Err(Error::new(
-                        expr.span(),
-                        "prefer `String::to_string` over `format!` without arguments",
-                    ));
-                }
+            if !arguments.format.value().contains('{') && !arguments.has_arguments {
+                return Err(Error::new(
+                    expr.span(),
+                    "prefer `String::to_string` over `format!` without arguments",
+                ));
             }
-            strings.extend(quote! {#first_token,});
+            let format = arguments.format;
+            strings.extend(quote! {#format,});
             Ok(())
         }
         Expr::Block(block) => parse_block(&block.block, strings),
@@ -106,5 +99,29 @@ fn parse_expr(expr: &Expr, strings: &mut TokenStream) -> syn::Result<()> {
             expr.span(),
             "expected last expression to be a `format!` macro, a static String or a match block",
         )),
+    }
+}
+
+struct FormatArguments {
+    format: LitStr,
+    has_arguments: bool,
+}
+
+impl Parse for FormatArguments {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let format = input.parse()?;
+        let has_arguments = if input.is_empty() {
+            false
+        } else {
+            input.parse::<Token![,]>()?;
+            let has_arguments = !input.is_empty();
+            input.parse::<TokenStream>()?;
+            has_arguments
+        };
+
+        Ok(Self {
+            format,
+            has_arguments,
+        })
     }
 }

--- a/crates/ruff_macros/src/lib.rs
+++ b/crates/ruff_macros/src/lib.rs
@@ -111,7 +111,9 @@ pub fn map_codes(_attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn derive_message_formats(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let func = parse_macro_input!(item as ItemFn);
-    derive_message_formats::derive_message_formats(&func).into()
+    derive_message_formats::derive_message_formats(&func)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }
 
 /// Derives a newtype wrapper that can be used as an index.

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -68,10 +68,20 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
         }
 
         let rule = Rule::try_from(arm)?;
-        linter_to_rules
-            .entry(rule.linter.clone())
-            .or_default()
-            .insert(rule.code.value(), rule);
+        let rules = linter_to_rules.entry(rule.linter.clone()).or_default();
+        match rules.entry(rule.code.value()) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(rule);
+            }
+            std::collections::btree_map::Entry::Occupied(entry) => {
+                let mut error = Error::new_spanned(&rule.code, "duplicate rule code");
+                error.combine(Error::new_spanned(
+                    &entry.get().code,
+                    "rule code first defined here",
+                ));
+                return Err(error);
+            }
+        }
     }
 
     let linter_idents: Vec<_> = linter_to_rules.keys().collect();

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -4,8 +4,8 @@ use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 use syn::{
-    Attribute, Error, Expr, ExprCall, ExprMatch, Ident, ItemFn, LitStr, Pat, Path, Stmt, Token,
-    parenthesized, parse::Parse, spanned::Spanned,
+    Arm, Attribute, Error, Expr, ExprCall, ExprLit, ExprMatch, Ident, ItemFn, Lit, LitStr, Pat,
+    Path, Stmt, spanned::Spanned,
 };
 
 use crate::{
@@ -67,7 +67,7 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
             break;
         }
 
-        let rule = syn::parse::<Rule>(arm.into_token_stream().into())?;
+        let rule = Rule::try_from(arm)?;
         linter_to_rules
             .entry(rule.linter.clone())
             .or_default()
@@ -485,25 +485,70 @@ fn register_rules<'a>(input: impl Iterator<Item = &'a Rule>) -> TokenStream {
     }
 }
 
-impl Parse for Rule {
+impl TryFrom<&Arm> for Rule {
+    type Error = syn::Error;
+
     /// Parses a match arm such as `(Pycodestyle, "E112") => rules::pycodestyle::rules::logical_lines::NoIndentedBlock,`
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let attrs = Attribute::parse_outer(input)?;
-        let pat_tuple;
-        parenthesized!(pat_tuple in input);
-        let linter: Ident = pat_tuple.parse()?;
-        let _: Token!(,) = pat_tuple.parse()?;
-        let code: LitStr = pat_tuple.parse()?;
-        let _: Token!(=>) = input.parse()?;
-        let rule_path: Path = input.parse()?;
-        let _: Token!(,) = input.parse()?;
-        let rule_name = rule_path.segments.last().unwrap().ident.clone();
-        Ok(Rule {
-            name: rule_name,
-            linter,
-            code,
-            path: rule_path,
+    fn try_from(arm: &Arm) -> syn::Result<Self> {
+        let Arm {
             attrs,
+            pat,
+            guard,
+            body,
+            ..
+        } = arm;
+
+        if let Some((if_token, _)) = guard {
+            return Err(Error::new(
+                if_token.span,
+                "rule match arms cannot have guards",
+            ));
+        }
+
+        let Pat::Tuple(tuple) = pat else {
+            return Err(Error::new_spanned(
+                pat,
+                "expected rule pattern to be `(Linter, \"CODE\")`",
+            ));
+        };
+        let mut elements = tuple.elems.iter();
+        let (Some(linter), Some(code), None) = (elements.next(), elements.next(), elements.next())
+        else {
+            return Err(Error::new_spanned(
+                tuple,
+                "expected rule pattern to be `(Linter, \"CODE\")`",
+            ));
+        };
+
+        let Pat::Ident(linter) = linter else {
+            return Err(Error::new_spanned(linter, "expected a linter name"));
+        };
+        if linter.by_ref.is_some() || linter.mutability.is_some() || linter.subpat.is_some() {
+            return Err(Error::new_spanned(linter, "expected a linter name"));
+        }
+        let linter = linter.ident.clone();
+
+        let Pat::Lit(ExprLit {
+            lit: Lit::Str(code),
+            ..
+        }) = code
+        else {
+            return Err(Error::new_spanned(code, "expected a string rule code"));
+        };
+
+        let Expr::Path(rule_path) = body.as_ref() else {
+            return Err(Error::new_spanned(body, "expected a rule path"));
+        };
+        let Some(rule_name) = rule_path.path.segments.last() else {
+            return Err(Error::new_spanned(rule_path, "expected a rule path"));
+        };
+
+        Ok(Rule {
+            name: rule_name.ident.clone(),
+            linter,
+            code: code.clone(),
+            path: rule_path.path.clone(),
+            attrs: attrs.clone(),
         })
     }
 }

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -62,9 +62,28 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
     // `(Rule::UnaryPrefixIncrement, RuleGroup::Stable, vec![])`).
     let mut linter_to_rules: BTreeMap<Ident, BTreeMap<String, Rule>> = BTreeMap::new();
 
-    for arm in arms {
+    let Some((wildcard, rule_arms)) = arms.split_last() else {
+        return Err(Error::new(
+            func.block.span(),
+            "expected a final wildcard match arm",
+        ));
+    };
+    if !matches!(wildcard.pat, Pat::Wild(_)) {
+        return Err(Error::new_spanned(
+            wildcard,
+            "expected the final match arm to be a wildcard",
+        ));
+    }
+    if let Some((if_token, _)) = &wildcard.guard {
+        return Err(Error::new(
+            if_token.span,
+            "the final wildcard match arm cannot have a guard",
+        ));
+    }
+
+    for arm in rule_arms {
         if matches!(arm.pat, Pat::Wild(..)) {
-            break;
+            return Err(Error::new_spanned(arm, "wildcard match arm must be last"));
         }
 
         let rule = Rule::try_from(arm)?;

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -228,7 +228,7 @@ pub(crate) fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
         }
     });
 
-    let rule_to_code = generate_rule_to_code(&linter_to_rules);
+    let rule_to_code = generate_rule_to_code(&linter_to_rules)?;
     output.extend(rule_to_code);
 
     output.extend(generate_iter_impl(&linter_to_rules, &linter_idents));
@@ -267,7 +267,9 @@ fn rules_by_prefix(
 /// to multiple codes (e.g., if it existed in multiple linters, like Pylint and Flake8, under
 /// different codes). We haven't actually activated this functionality yet, but some work was
 /// done to support it, so the logic exists here.
-fn generate_rule_to_code(linter_to_rules: &BTreeMap<Ident, BTreeMap<String, Rule>>) -> TokenStream {
+fn generate_rule_to_code(
+    linter_to_rules: &BTreeMap<Ident, BTreeMap<String, Rule>>,
+) -> syn::Result<TokenStream> {
     let mut rule_to_codes: HashMap<&Path, Vec<&Rule>> = HashMap::new();
     let mut linter_code_for_rule_match_arms = quote!();
 
@@ -286,39 +288,35 @@ fn generate_rule_to_code(linter_to_rules: &BTreeMap<Ident, BTreeMap<String, Rule
     let mut rule_noqa_code_match_arms = quote!();
 
     // Keep the proc-macro output stable so unchanged code can be reused incrementally.
-    for (rule, codes) in rule_to_codes
+    for (rule_path, codes) in rule_to_codes
         .into_iter()
         .sorted_by_key(|(rule, _)| rule.to_token_stream().to_string())
     {
-        let rule_name = rule.segments.last().unwrap();
-        assert_eq!(
-            codes.len(),
-            1,
-            "
-{} is mapped to multiple codes.
-
-The mapping of multiple codes to one rule has been disabled due to UX concerns (it would
-be confusing if violations were reported under a different code than the code you selected).
-
-We firstly want to allow rules to be selected by their names (and report them by name),
-and before we can do that we have to rename all our rules to match our naming convention
-(see CONTRIBUTING.md) because after that change every rule rename will be a breaking change.
-
-See also https://github.com/astral-sh/ruff/issues/2186.
-",
-            rule_name.ident
-        );
+        let rule = match codes.as_slice() {
+            [rule] => *rule,
+            [first, second, ..] => {
+                let mut error =
+                    Error::new_spanned(&second.path, "rule is mapped to more than one code");
+                error.combine(Error::new_spanned(&first.path, "rule first mapped here"));
+                return Err(error);
+            }
+            [] => {
+                return Err(Error::new_spanned(
+                    rule_path,
+                    "rule must be mapped to a code",
+                ));
+            }
+        };
+        let Some(rule_name) = rule_path.segments.last() else {
+            return Err(Error::new_spanned(rule_path, "expected a rule path"));
+        };
 
         let Rule {
             linter,
             code,
             attrs,
             ..
-        } = codes
-            .iter()
-            .sorted_by_key(|data| data.linter == "Pylint")
-            .next()
-            .unwrap();
+        } = rule;
 
         rule_noqa_code_match_arms.extend(quote! {
             #(#attrs)* Rule::#rule_name => NoqaCode(crate::registry::Linter::#linter.common_prefix(), #code),
@@ -361,7 +359,7 @@ See also https://github.com/astral-sh/ruff/issues/2186.
             }
         }
     };
-    rule_to_code
+    Ok(rule_to_code)
 }
 
 /// Implement `impl IntoIterator for &Linter` and `RuleCodePrefix::iter()`

--- a/crates/ruff_macros/src/rule_namespace.rs
+++ b/crates/ruff_macros/src/rule_namespace.rs
@@ -9,6 +9,7 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
     let DeriveInput {
         ident,
         data: Data::Enum(DataEnum { variants, .. }),
+        generics,
         ..
     } = input
     else {
@@ -110,9 +111,11 @@ pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenS
         }});
     }
 
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
     Ok(quote! {
         #[automatically_derived]
-        impl crate::registry::RuleNamespace for #ident {
+        impl #impl_generics crate::registry::RuleNamespace for #ident #ty_generics #where_clause {
             fn parse_code(code: &str) -> Option<(Self, &str)> {
                 #if_statements
                 None

--- a/crates/ruff_macros/src/violation_metadata.rs
+++ b/crates/ruff_macros/src/violation_metadata.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 use proc_macro2::TokenStream;
 use quote::quote;
 use regex::Regex;
+use syn::spanned::Spanned;
 use syn::{Attribute, DeriveInput, Error, Lit, LitStr, Meta, meta::ParseNestedMeta};
 
 pub(crate) fn violation_metadata(input: DeriveInput) -> syn::Result<TokenStream> {
@@ -77,35 +78,38 @@ fn get_docs(attrs: &[Attribute]) -> syn::Result<String> {
 /// The result is returned as a `TokenStream` so that the version string literal can be combined
 /// with the proper `RuleGroup` variant, e.g. `RuleGroup::Stable` for `stable_since` above.
 fn get_rule_status(attrs: &[Attribute]) -> syn::Result<Option<TokenStream>> {
-    let mut group = None;
+    let mut group: Option<(TokenStream, proc_macro2::Span)> = None;
     for attr in attrs {
         if attr.path().is_ident("violation_metadata") {
             attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("stable_since") {
+                let status = if meta.path.is_ident("stable_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleGroup::Stable { since: #lit }));
-                    return Ok(());
+                    quote!(RuleGroup::Stable { since: #lit })
                 } else if meta.path.is_ident("preview_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleGroup::Preview { since: #lit }));
-                    return Ok(());
+                    quote!(RuleGroup::Preview { since: #lit })
                 } else if meta.path.is_ident("deprecated_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleGroup::Deprecated { since: #lit }));
-                    return Ok(());
+                    quote!(RuleGroup::Deprecated { since: #lit })
                 } else if meta.path.is_ident("removed_since") {
                     let lit: LitStr = parse_version(&meta)?;
-                    group = Some(quote!(RuleGroup::Removed { since: #lit }));
-                    return Ok(());
+                    quote!(RuleGroup::Removed { since: #lit })
+                } else {
+                    return Err(meta.error("unimplemented violation metadata option"));
+                };
+
+                if let Some((_, first_span)) = &group {
+                    let mut error = meta.error("multiple rule statuses are not allowed");
+                    error.combine(Error::new(*first_span, "first rule status specified here"));
+                    return Err(error);
                 }
-                Err(Error::new_spanned(
-                    attr,
-                    "unimplemented violation metadata option",
-                ))
+
+                group = Some((status, meta.path.span()));
+                Ok(())
             })?;
         }
     }
-    Ok(group)
+    Ok(group.map(|(status, _)| status))
 }
 
 fn parse_attr<'a, const LEN: usize>(

--- a/crates/ruff_options_metadata/Cargo.toml
+++ b/crates/ruff_options_metadata/Cargo.toml
@@ -13,6 +13,11 @@ license = { workspace = true }
 [dependencies]
 serde = { workspace = true, optional = true }
 
+[dev-dependencies]
+ruff_macros = { workspace = true }
+
+serde = { workspace = true, features = ["derive"] }
+
 [lints]
 workspace = true
 

--- a/crates/ruff_options_metadata/tests/derive.rs
+++ b/crates/ruff_options_metadata/tests/derive.rs
@@ -1,0 +1,45 @@
+use ruff_options_metadata::{OptionEntry, OptionsMetadata};
+
+#[expect(dead_code)]
+#[derive(Default, ruff_macros::OptionsMetadata, serde::Deserialize)]
+struct NestedOptions {
+    /// A nested option.
+    #[option(default = "false", value_type = "bool", example = "nested = true")]
+    nested: Option<bool>,
+}
+
+#[expect(dead_code)]
+#[derive(ruff_macros::OptionsMetadata, serde::Deserialize)]
+struct FlattenedOptions {
+    #[serde(default)]
+    #[serde(flatten)]
+    nested: NestedOptions,
+}
+
+#[expect(dead_code)]
+#[derive(ruff_macros::OptionsMetadata)]
+struct BareDeprecatedOptions {
+    /// A deprecated option.
+    #[deprecated]
+    #[option(default = "false", value_type = "bool", example = "value = true")]
+    value: Option<bool>,
+}
+
+#[test]
+fn finds_flatten_in_repeated_serde_attributes() {
+    let metadata = FlattenedOptions::metadata();
+    assert!(metadata.has("nested"));
+}
+
+#[test]
+fn accepts_bare_deprecated_attribute() {
+    let metadata = BareDeprecatedOptions::metadata();
+    let deprecated = metadata
+        .find("value")
+        .and_then(OptionEntry::into_field)
+        .and_then(|field| field.deprecated)
+        .expect("field should be deprecated");
+
+    assert_eq!(deprecated.since, None);
+    assert_eq!(deprecated.message, None);
+}

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -4406,10 +4406,33 @@ mod tests {
         nested: NestedOptions,
     }
 
+    #[expect(dead_code)]
+    #[derive(ruff_macros::OptionsMetadata)]
+    struct BareDeprecatedOptions {
+        /// A deprecated option.
+        #[deprecated]
+        #[option(default = "false", value_type = "bool", example = "value = true")]
+        value: Option<bool>,
+    }
+
     #[test]
     fn options_metadata_finds_flatten_in_repeated_serde_attributes() {
         let metadata = <FlattenedOptions as ruff_options_metadata::OptionsMetadata>::metadata();
         assert!(metadata.has("nested"));
+    }
+
+    #[test]
+    fn options_metadata_accepts_bare_deprecated_attribute() {
+        let metadata =
+            <BareDeprecatedOptions as ruff_options_metadata::OptionsMetadata>::metadata();
+        let deprecated = metadata
+            .find("value")
+            .and_then(ruff_options_metadata::OptionEntry::into_field)
+            .and_then(|field| field.deprecated)
+            .expect("field should be deprecated");
+
+        assert_eq!(deprecated.since, None);
+        assert_eq!(deprecated.message, None);
     }
 
     #[test]

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -4390,6 +4390,28 @@ mod tests {
     };
     use ruff_python_ast::name::Name;
 
+    #[expect(dead_code)]
+    #[derive(Default, ruff_macros::OptionsMetadata, serde::Deserialize)]
+    struct NestedOptions {
+        /// A nested option.
+        #[option(default = "false", value_type = "bool", example = "nested = true")]
+        nested: Option<bool>,
+    }
+
+    #[expect(dead_code)]
+    #[derive(ruff_macros::OptionsMetadata, serde::Deserialize)]
+    struct FlattenedOptions {
+        #[serde(default)]
+        #[serde(flatten)]
+        nested: NestedOptions,
+    }
+
+    #[test]
+    fn options_metadata_finds_flatten_in_repeated_serde_attributes() {
+        let metadata = <FlattenedOptions as ruff_options_metadata::OptionsMetadata>::metadata();
+        assert!(metadata.has("nested"));
+    }
+
     #[test]
     fn flake8_self_options() {
         let default_settings = flake8_self::settings::Settings::default();

--- a/crates/ruff_workspace/src/options.rs
+++ b/crates/ruff_workspace/src/options.rs
@@ -4390,51 +4390,6 @@ mod tests {
     };
     use ruff_python_ast::name::Name;
 
-    #[expect(dead_code)]
-    #[derive(Default, ruff_macros::OptionsMetadata, serde::Deserialize)]
-    struct NestedOptions {
-        /// A nested option.
-        #[option(default = "false", value_type = "bool", example = "nested = true")]
-        nested: Option<bool>,
-    }
-
-    #[expect(dead_code)]
-    #[derive(ruff_macros::OptionsMetadata, serde::Deserialize)]
-    struct FlattenedOptions {
-        #[serde(default)]
-        #[serde(flatten)]
-        nested: NestedOptions,
-    }
-
-    #[expect(dead_code)]
-    #[derive(ruff_macros::OptionsMetadata)]
-    struct BareDeprecatedOptions {
-        /// A deprecated option.
-        #[deprecated]
-        #[option(default = "false", value_type = "bool", example = "value = true")]
-        value: Option<bool>,
-    }
-
-    #[test]
-    fn options_metadata_finds_flatten_in_repeated_serde_attributes() {
-        let metadata = <FlattenedOptions as ruff_options_metadata::OptionsMetadata>::metadata();
-        assert!(metadata.has("nested"));
-    }
-
-    #[test]
-    fn options_metadata_accepts_bare_deprecated_attribute() {
-        let metadata =
-            <BareDeprecatedOptions as ruff_options_metadata::OptionsMetadata>::metadata();
-        let deprecated = metadata
-            .find("value")
-            .and_then(ruff_options_metadata::OptionEntry::into_field)
-            .and_then(|field| field.deprecated)
-            .expect("field should be deprecated");
-
-        assert_eq!(deprecated.since, None);
-        assert_eq!(deprecated.message, None);
-    }
-
     #[test]
     fn flake8_self_options() {
         let default_settings = flake8_self::settings::Settings::default();

--- a/crates/ty_combine/Cargo.toml
+++ b/crates/ty_combine/Cargo.toml
@@ -18,5 +18,8 @@ ruff_python_ast = { workspace = true }
 
 ordermap = { workspace = true }
 
+[dev-dependencies]
+ruff_macros = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/ty_combine/tests/derive.rs
+++ b/crates/ty_combine/tests/derive.rs
@@ -1,0 +1,17 @@
+use ty_combine::Combine;
+
+#[derive(Debug, PartialEq, ruff_macros::Combine)]
+struct Generic<T>
+where
+    T: Combine,
+{
+    value: T,
+}
+
+#[test]
+fn generic() {
+    assert_eq!(
+        Generic { value: Some(1) }.combine(Generic { value: Some(2) }),
+        Generic { value: Some(1) }
+    );
+}


### PR DESCRIPTION
## Summary

- Preserve generic parameters and where clauses in derives that previously dropped them.
- Generate the right `CacheKey` bounds for generic fields, using `synstructure` to handle structs and enums consistently.
- Turn invalid message-format bodies into regular compiler diagnostics instead of proc-macro panics.
- Parse the `map_codes` and message-format DSLs from their existing `syn` syntax trees instead of converting them back to tokens.
- Validate `#[option_group]` type arguments before generating metadata.
- Reject conflicting violation statuses instead of silently keeping the last one.
- Find `serde(flatten)` across repeated Serde attributes and call the metadata trait through UFCS.
- Accept bare `#[deprecated]` attributes when building option metadata.
- Reject duplicate rule-code entries instead of silently overwriting one, and remove the existing duplicate `Flake8UsePathlib/202` mapping.
- Require the fallback wildcard arm in `map_codes` to be unguarded and last.
- Report rules mapped to multiple codes as compiler errors instead of panicking.

Testing: Added focused regression coverage and ran the relevant tests, Clippy checks, and repository hooks.
