### PR TITLE
[ty] Parse Google docstrings for parameter docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4720,6 +4720,7 @@ dependencies = [
  "ruff_python_importer",
  "ruff_python_literal",
  "ruff_python_parser",
+ "ruff_python_stdlib",
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",

--- a/crates/ty_ide/Cargo.toml
+++ b/crates/ty_ide/Cargo.toml
@@ -23,6 +23,7 @@ ruff_python_ast = { workspace = true }
 ruff_python_codegen = { workspace = true }
 ruff_python_importer = { workspace = true }
 ruff_python_literal = { workspace = true }
+ruff_python_stdlib = { workspace = true }
 ruff_python_trivia = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -17,17 +17,6 @@ use std::sync::LazyLock;
 
 use crate::MarkupKind;
 
-// Static regex instances to avoid recompilation
-static GOOGLE_SECTION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^\s*(Args|Arguments|Parameters)\s*:\s*$")
-        .expect("Google section regex should be valid")
-});
-
-static GOOGLE_PARAM_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^\s*(\*?\*?\w+)\s*(\(.*?\))?\s*:\s*(.+)")
-        .expect("Google parameter regex should be valid")
-});
-
 static NUMPY_SECTION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)^\s*Parameters\s*$").expect("NumPy section regex should be valid")
 });
@@ -69,18 +58,7 @@ impl Docstring {
     /// Extract parameter documentation from popular docstring formats.
     /// Returns a map of parameter names to their documentation.
     pub fn parameter_documentation(&self) -> IndexMap<String, String> {
-        let mut param_docs = IndexMap::new();
-
-        // Google-style docstrings
-        param_docs.extend(extract_google_style_params(&self.0));
-
-        // NumPy-style docstrings
-        param_docs.extend(extract_numpy_style_params(&self.0));
-
-        // reST/Sphinx-style docstrings
-        param_docs.extend(document::parameter_documentation(&self.0));
-
-        param_docs
+        document::parameter_documentation(&self.0, extract_numpy_style_params(&self.0))
     }
 }
 
@@ -175,89 +153,6 @@ fn documentation_trim(docs: &str) -> String {
     }
 
     output
-}
-
-/// Extract parameter documentation from Google-style docstrings.
-fn extract_google_style_params(docstring: &str) -> IndexMap<String, String> {
-    let mut param_docs = IndexMap::new();
-
-    let mut in_args_section = false;
-    let mut current_param: Option<String> = None;
-    let mut current_doc = String::new();
-
-    for line_obj in docstring.universal_newlines() {
-        let line = line_obj.as_str();
-        if GOOGLE_SECTION_REGEX.is_match(line) {
-            in_args_section = true;
-            continue;
-        }
-
-        if in_args_section {
-            // Check if we hit another section (starts with a word followed by colon at line start)
-            if !line.starts_with(' ') && !line.starts_with('\t') && line.contains(':') {
-                if let Some(colon_pos) = line.find(':') {
-                    let section_name = line[..colon_pos].trim();
-                    // If this looks like another section, stop processing args
-                    if !section_name.is_empty()
-                        && section_name
-                            .chars()
-                            .all(|c| c.is_alphabetic() || c.is_whitespace())
-                    {
-                        // Check if this is a known section name
-                        let known_sections = [
-                            "Returns", "Return", "Raises", "Yields", "Yield", "Examples",
-                            "Example", "Note", "Notes", "Warning", "Warnings",
-                        ];
-                        if known_sections.contains(&section_name) {
-                            if let Some(param_name) = current_param.take() {
-                                param_docs.insert(param_name, current_doc.trim().to_string());
-                                current_doc.clear();
-                            }
-                            in_args_section = false;
-                            continue;
-                        }
-                    }
-                }
-            }
-
-            if let Some(captures) = GOOGLE_PARAM_REGEX.captures(line) {
-                // Save previous parameter if exists
-                if let Some(param_name) = current_param.take() {
-                    param_docs.insert(param_name, current_doc.trim().to_string());
-                    current_doc.clear();
-                }
-
-                // Start new parameter
-                if let (Some(param), Some(desc)) = (captures.get(1), captures.get(3)) {
-                    current_param = Some(param.as_str().to_string());
-                    current_doc = desc.as_str().to_string();
-                }
-            } else if line.starts_with(' ') || line.starts_with('\t') {
-                // This is a continuation of the current parameter documentation
-                if current_param.is_some() {
-                    if !current_doc.is_empty() {
-                        current_doc.push('\n');
-                    }
-                    current_doc.push_str(line.trim());
-                }
-            } else {
-                // This is a line that doesn't start with whitespace and isn't a parameter
-                // It might be a section or other content, so stop processing args
-                if let Some(param_name) = current_param.take() {
-                    param_docs.insert(param_name, current_doc.trim().to_string());
-                    current_doc.clear();
-                }
-                in_args_section = false;
-            }
-        }
-    }
-
-    // Don't forget the last parameter
-    if let Some(param_name) = current_param {
-        param_docs.insert(param_name, current_doc.trim().to_string());
-    }
-
-    param_docs
 }
 
 /// Calculate the indentation level of a line.
@@ -1035,12 +930,13 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(docstring.render_markdown(), @r"
         My cool func:<HB>
         <HB>
-        ``````we still think this is a codefence```
-            x_y = thing_do();
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;``````we still think this is a codefence```<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;x\_y = thing\_do();<HB>
         ```````````` and are sloppy as heck with indentation and closing shrugggg
+        ````````````
         ");
     }
 

--- a/crates/ty_ide/src/docstring/document.rs
+++ b/crates/ty_ide/src/docstring/document.rs
@@ -1,9 +1,30 @@
 use indexmap::IndexMap;
 
+/// Google-style docstring parsing.
+mod google;
 pub(super) mod preformatted;
 pub(super) mod rst;
+/// Syntax utilities shared by docstring format parsers and renderers.
+pub(in crate::docstring) mod syntax;
 
 /// Returns docs for all parameters recognized in the given docstring.
-pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
-    rst::parameter_documentation(raw)
+pub(super) fn parameter_documentation(
+    raw: &str,
+    numpy_parameters: IndexMap<String, String>,
+) -> IndexMap<String, String> {
+    let mut parameters = google::parameter_documentation(raw);
+    parameters.extend(numpy_parameters);
+    parameters.extend(rst::parameter_documentation(raw));
+    parameters
+}
+
+/// Parameter sections shared by supported docstring formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::docstring) enum SectionKind {
+    /// Function or method parameters.
+    Parameters,
+    /// Keyword arguments documented separately from the main parameter section.
+    KeywordArguments,
+    /// Less commonly used parameters listed separately from the main parameter section.
+    OtherParameters,
 }

--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -1,0 +1,1042 @@
+//! Parsing for Google-style docstring sections.
+//!
+//! The [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#s3.8.3-functions-and-methods)
+//! describes the canonical conventions but does not define a formal grammar. This parser recognizes
+//! these parameter section headings:
+//!
+//! - `Args`, `Arguments`, and `Parameters`
+//! - `Keyword Args` and `Keyword Arguments`
+//! - `Other Args`, `Other Arguments`, and `Other Parameters`
+//!
+//! It accepts comma-separated Python names with optional parenthesized types, preserves
+//! continuation text, and skips section-like text inside preformatted or container blocks. Other
+//! known headings only delimit parameter sections; their contents are not parsed here.
+//!
+//! Example:
+//!
+//! ```text
+//! Copy a file with retry controls.
+//!
+//! Args:
+//!     source (str): Path to copy.
+//!     destination: Destination path.
+//!
+//! Keyword Args:
+//!     timeout, deadline (float): Time limits in seconds.
+//!
+//! Other Parameters:
+//!     retries: Number of retries.
+//! ```
+
+use std::cmp::Ordering;
+
+use indexmap::IndexMap;
+use ruff_python_stdlib::identifiers::is_identifier;
+use ruff_text_size::{TextRange, TextSize};
+
+use super::SectionKind;
+use super::preformatted::PreformattedBlockScanner;
+use super::syntax::{
+    ParsedLine, container_block_end, parse_parenthesized_type, parsed_lines,
+    split_once_unbracketed_colon,
+};
+
+/// Returns parameter documentation from recognized Google-style parameter sections.
+pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
+    let lines = parsed_lines(raw);
+    let mut parameters = Parameters::default();
+    for section in sections(&lines) {
+        if matches!(
+            section.kind,
+            SectionKind::Parameters | SectionKind::KeywordArguments | SectionKind::OtherParameters
+        ) {
+            extend_parameter_documentation(&mut parameters, section.body);
+        }
+    }
+    parameters.into_inner()
+}
+
+/// Returns recognized Google-style sections in source order.
+pub(in crate::docstring) fn sections<'a>(
+    lines: &'a [ParsedLine<'a>],
+) -> impl Iterator<Item = Section<'a>> + 'a {
+    let mut preformatted_blocks = PreformattedBlockScanner::default();
+    let mut index = 0;
+
+    std::iter::from_fn(move || {
+        while index < lines.len() {
+            // Skip blocks that "own" all internal content (in which we should not
+            // recognize content that might otherwise look like a Google section header)
+            if preformatted_blocks.consume_preformatted_line(lines[index].text) {
+                index += 1;
+                continue;
+            }
+            if let Some(end) = container_block_end(lines, index) {
+                index = end;
+                continue;
+            }
+
+            let Some(header) = parse_section_header(lines, index) else {
+                preformatted_blocks.observe_line_outside_preformatted_block(lines[index].text);
+                index += 1;
+                continue;
+            };
+
+            let (range, body_end_line_index) = section_body_end(lines, header);
+            index = body_end_line_index;
+            if let HeaderKind::Structured(kind) = header.kind {
+                return Some(Section {
+                    kind,
+                    body: &lines[header.body_start_line_index..body_end_line_index],
+                    range,
+                    header_indent: header.indent,
+                });
+            }
+        }
+
+        None
+    })
+}
+
+/// A recognized Google-style docstring section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::docstring) struct Section<'a> {
+    /// The recognized section kind.
+    pub(in crate::docstring) kind: SectionKind,
+    /// The lines in the section body.
+    pub(in crate::docstring) body: &'a [ParsedLine<'a>],
+    /// The section's source range, including its header.
+    pub(in crate::docstring) range: TextRange,
+    /// The indentation of the section header.
+    pub(in crate::docstring) header_indent: TextSize,
+}
+
+/// Extends `parameters` with the documented items in one parameter section body.
+fn extend_parameter_documentation(parameters: &mut Parameters, lines: &[ParsedLine<'_>]) {
+    let mut current: Option<(String, String)> = None;
+    let mut item_indent = None;
+
+    for line in lines {
+        let trimmed = line.text.trim();
+
+        // The first recognized item establishes the sibling indentation.
+        // Each item at that indentation starts a new sibling and completes its predecessor.
+        if item_indent.is_none_or(|indent| line.raw_indent == indent)
+            && let Some((names, description)) = parse_parameter(trimmed)
+        {
+            parameters.insert_documentation(
+                current.replace((names.to_string(), description.to_string())),
+            );
+            item_indent = Some(line.raw_indent);
+            continue;
+        }
+
+        // Ignore prose until the first item has started.
+        let Some((_, description)) = &mut current else {
+            continue;
+        };
+
+        // Lines that are not sibling items extend the current description.
+        // Empty lines preserve paragraph breaks.
+        if !description.is_empty() && !description.ends_with('\n') {
+            description.push('\n');
+        }
+        description.push_str(if trimmed.is_empty() { "\n" } else { trimmed });
+    }
+
+    // A following item completes its predecessor in the loop, so complete the final item here.
+    parameters.insert_documentation(current);
+}
+
+/// Parses a parameter item into its display name and description.
+fn parse_parameter(line: &str) -> Option<(&str, &str)> {
+    let (name, description) = split_once_unbracketed_colon(line)?;
+    let (display_name, _) = parse_parenthesized_type(name.trim());
+
+    google_parameter_names(display_name)
+        .is_some()
+        .then_some((display_name, description.trim()))
+}
+
+/// Returns whether `name` is a valid Python parameter name, including variadic prefixes.
+fn is_parameter_name(name: &str) -> bool {
+    let identifier = name.strip_prefix('*').unwrap_or(name);
+    let identifier = identifier.strip_prefix('*').unwrap_or(identifier);
+    is_identifier(identifier)
+}
+
+#[derive(Default)]
+struct Parameters(IndexMap<String, String>);
+
+impl Parameters {
+    /// Inserts a completed parameter item under each of its comma-separated names.
+    fn insert_documentation(&mut self, parameter: Option<(String, String)>) {
+        let Some((names, description)) = parameter else {
+            return;
+        };
+        let description = description.trim();
+        if !description.is_empty()
+            && let Some(names) = google_parameter_names(&names)
+        {
+            for name in names {
+                self.0.insert(name.to_string(), description.to_string());
+            }
+        }
+    }
+
+    fn into_inner(self) -> IndexMap<String, String> {
+        self.0
+    }
+}
+
+fn google_parameter_names(display_name: &str) -> Option<impl Iterator<Item = &str>> {
+    let names = display_name.split(',').map(str::trim);
+    names.clone().all(is_parameter_name).then_some(names)
+}
+
+/// Parses a recognized Google-style section header at `index`.
+fn parse_section_header(lines: &[ParsedLine<'_>], index: usize) -> Option<SectionHeader> {
+    let line = lines[index];
+    let kind = section_kind(line.text)?;
+
+    Some(SectionHeader {
+        kind,
+        indent: line.raw_indent,
+        structural_indent: line.structural_indent,
+        body_start_line_index: index + 1,
+        range: line.range,
+    })
+}
+
+fn section_kind(line: &str) -> Option<HeaderKind> {
+    let name = line.trim().strip_suffix(':')?.trim();
+    HeaderKind::from_name(name)
+}
+
+/// Returns the section's source range and the index of the first line outside its body.
+fn section_body_end(lines: &[ParsedLine<'_>], header: SectionHeader) -> (TextRange, usize) {
+    let mut body_end_index = header.body_start_line_index;
+    let mut preformatted_blocks = PreformattedBlockScanner::default();
+    let mut item_indent = None;
+
+    while let Some(line) = lines.get(body_end_index) {
+        // Once a preformatted block begins, its contents cannot end the section.
+        if preformatted_blocks.is_active()
+            && preformatted_blocks.consume_preformatted_line(line.text)
+        {
+            body_end_index += 1;
+            continue;
+        }
+
+        let Some((leading_blank_lines, line)) =
+            section_body_continuation(&lines[body_end_index..], header, item_indent)
+        else {
+            break;
+        };
+        body_end_index += leading_blank_lines;
+
+        item_indent = item_indent.or_else(|| section_item_indent(header, line));
+
+        if !preformatted_blocks.consume_preformatted_line(line.text) {
+            preformatted_blocks.observe_line_outside_preformatted_block(line.text);
+        }
+        body_end_index += 1;
+    }
+
+    let body = &lines[header.body_start_line_index..body_end_index];
+    let range = match body.last() {
+        Some(last) => header.range.cover(last.range),
+        None => header.range,
+    };
+    (range, body_end_index)
+}
+
+/// Returns the number of leading blank lines and first nonblank line that continue
+/// `header`'s body.
+fn section_body_continuation<'a>(
+    lines: &[ParsedLine<'a>],
+    header: SectionHeader,
+    item_indent: Option<TextSize>,
+) -> Option<(usize, ParsedLine<'a>)> {
+    let (leading_blank_lines, next_line) = lines
+        .iter()
+        .enumerate()
+        .find(|(_, line)| !line.text.trim().is_empty())?;
+
+    if leading_blank_lines == 0 && section_header_ends_body(lines, 0, header) {
+        return None;
+    }
+
+    if leading_blank_lines > 0
+        && next_line.structural_indent <= header.structural_indent
+        && (parse_section_header(lines, leading_blank_lines).is_some()
+            || is_inline_section_header(next_line.text))
+    {
+        return None;
+    }
+
+    // A blank line ends a parameter section when the following aligned text is
+    // not another parameter item.
+    if leading_blank_lines > 0
+        && matches!(
+            header.kind,
+            HeaderKind::Structured(
+                SectionKind::Parameters
+                    | SectionKind::KeywordArguments
+                    | SectionKind::OtherParameters
+            )
+        )
+        && item_indent == Some(next_line.raw_indent)
+        && section_item_indent(header, *next_line).is_none()
+    {
+        return None;
+    }
+
+    line_belongs_to_body(header, *next_line, item_indent)
+        .then_some((leading_blank_lines, *next_line))
+}
+
+/// Returns whether a recognized header at `index` ends the current section body.
+fn section_header_ends_body(lines: &[ParsedLine<'_>], index: usize, header: SectionHeader) -> bool {
+    let Some(line) = lines.get(index) else {
+        return false;
+    };
+    if line.structural_indent <= header.structural_indent && is_inline_section_header(line.text) {
+        return true;
+    }
+
+    parse_section_header(lines, index)
+        .is_some_and(|next| next.structural_indent <= header.structural_indent)
+}
+
+/// Returns whether `line` belongs to `header` under Google-style indentation rules.
+fn line_belongs_to_body(
+    header: SectionHeader,
+    line: ParsedLine<'_>,
+    item_indent: Option<TextSize>,
+) -> bool {
+    match line.raw_indent.cmp(&header.indent) {
+        Ordering::Less => false,
+        Ordering::Greater => true,
+        Ordering::Equal => {
+            let item_indent_matches_line =
+                item_indent.is_none_or(|indent| indent == line.raw_indent);
+            let is_parameter_section = matches!(
+                header.kind,
+                HeaderKind::Structured(
+                    SectionKind::Parameters
+                        | SectionKind::KeywordArguments
+                        | SectionKind::OtherParameters
+                )
+            );
+
+            // Parameter sections can start with aligned prose before an item establishes the
+            // sibling indentation. Once established, aligned lines must match that indentation.
+            item_indent_matches_line
+                && (is_parameter_section || section_item_indent(header, line).is_some())
+        }
+    }
+}
+
+/// Returns the indentation of an item recognized in the current section.
+///
+/// The first recognized item establishes the indentation for sibling items.
+/// Item-like lines at a different indentation within the section are treated as
+/// continuation text.
+fn section_item_indent(header: SectionHeader, line: ParsedLine<'_>) -> Option<TextSize> {
+    let trimmed = line.text.trim();
+    let is_item = match header.kind {
+        HeaderKind::Structured(
+            SectionKind::Parameters | SectionKind::KeywordArguments | SectionKind::OtherParameters,
+        ) => parse_parameter(trimmed).is_some(),
+        HeaderKind::Container => false,
+    };
+    is_item.then_some(line.raw_indent)
+}
+
+/// Returns whether `line` is a recognized section header followed by inline content.
+fn is_inline_section_header(line: &str) -> bool {
+    let line = line.trim();
+    // A trailing double colon introduces a reST literal block, not an inline section.
+    if line.ends_with("::") {
+        return false;
+    }
+
+    let Some((name, description)) = split_once_unbracketed_colon(line) else {
+        return false;
+    };
+
+    let name = name.trim();
+    let description = description.trim();
+    !description.is_empty()
+        && name.chars().next().is_some_and(char::is_uppercase)
+        && HeaderKind::from_name(name).is_some()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SectionHeader {
+    kind: HeaderKind,
+    indent: TextSize,
+    structural_indent: TextSize,
+    body_start_line_index: usize,
+    range: TextRange,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeaderKind {
+    Structured(SectionKind),
+    Container,
+}
+
+impl HeaderKind {
+    fn from_name(name: &str) -> Option<Self> {
+        let normalized = name
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_ascii_lowercase();
+        Some(match normalized.as_str() {
+            "args" | "arguments" | "parameters" => Self::Structured(SectionKind::Parameters),
+            "keyword args" | "keyword arguments" => Self::Structured(SectionKind::KeywordArguments),
+            "other args" | "other arguments" | "other parameters" => {
+                Self::Structured(SectionKind::OtherParameters)
+            }
+            "attributes" | "return" | "returns" | "yield" | "yields" | "raise" | "raises"
+            | "attention" | "caution" | "danger" | "error" | "example" | "examples" | "hint"
+            | "important" | "methods" | "note" | "notes" | "references" | "see also" | "tip"
+            | "todo" | "todos" | "warning" | "warnings" | "warns" => Self::Container,
+            _ => return None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+    use itertools::Itertools;
+    use ruff_text_size::TextSize;
+
+    use super::{SectionKind, parameter_documentation, parsed_lines, sections};
+
+    #[test]
+    fn extracts_aligned_parameter_items() {
+        let raw = "\
+Arguments:
+first: First parameter.
+Aligned continuation.
+second: Second parameter.
+Returns:
+bool: Result.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        first:
+          │ First parameter.
+          │ Aligned continuation.
+        second:
+          │ Second parameter.
+        ");
+    }
+
+    #[test]
+    fn uses_visual_indentation_for_parameter_items() {
+        let raw = "\
+Args:
+  \tfirst: First parameter.
+        second: Second parameter.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        first:
+          │ First parameter.
+        second:
+          │ Second parameter.
+        ");
+    }
+
+    #[test]
+    fn extracts_comma_separated_parameter_names() {
+        let raw = "\
+Args:
+    x, y: Coordinates.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        x:
+          │ Coordinates.
+        y:
+          │ Coordinates.
+        ");
+    }
+
+    #[test]
+    fn ignores_prose_before_first_parameter() {
+        let raw = "\
+Args:
+Partition into non-overlapping windows with padding if needed.
+    hidden_states (tensor): Input tokens.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        hidden_states:
+          │ Input tokens.
+        ");
+    }
+
+    #[test]
+    fn extracts_parameter_with_unbalanced_type_brackets() {
+        let raw = "\
+Args:
+    query_embeddings (`Union[torch.Tensor, list[torch.Tensor]`): Query embeddings.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        query_embeddings:
+          │ Query embeddings.
+        ");
+    }
+
+    #[test]
+    fn accepts_dashed_parameter_section_underline() {
+        let raw = "\
+Args:
+----
+    value: Parameter documentation.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        value:
+          │ Parameter documentation.
+        ");
+    }
+
+    #[test]
+    fn treats_invalid_parameter_name_as_continuation() {
+        let raw = "\
+Args:
+    value: Initial documentation.
+    value, for example: can be omitted.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        value:
+          │ Initial documentation.
+          │ value, for example: can be omitted.
+        ");
+    }
+
+    #[test]
+    fn uses_last_documentation_for_duplicate_parameter() {
+        let raw = "\
+Args:
+    value: First documentation.
+    value: Replacement documentation.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        value:
+          │ Replacement documentation.
+        ");
+    }
+
+    #[test]
+    fn parses_parenthesized_type_with_quoted_parenthesis() {
+        let raw = "\
+Args:
+    value (Literal[\"(\"]): Quoted parenthesis.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        value:
+          │ Quoted parenthesis.
+        ");
+    }
+
+    #[test]
+    fn ignores_callable_like_parameter_names() {
+        let raw = "\
+Args:
+    callback() (Callable): Not a parameter.
+    value: Documentation.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        value:
+          │ Documentation.
+        ");
+    }
+
+    #[test]
+    fn preserves_parameter_paragraph_breaks() {
+        let raw = "\
+Args:
+    value: First paragraph.
+
+
+        Second paragraph.";
+
+        assert_snapshot!(display_parameters(raw), @"
+        value:
+          │ First paragraph.
+          │
+          │
+          │ Second paragraph.
+        ");
+    }
+
+    #[test]
+    fn recognizes_parameter_section_headings() {
+        for heading in [
+            "Args",
+            "Arguments",
+            "Parameters",
+            "Keyword Args",
+            "Keyword Arguments",
+            "Other Args",
+            "Other Arguments",
+            "Other Parameters",
+        ] {
+            let raw = format!(
+                "\
+{heading}:
+    value: Parameter documentation."
+            );
+            assert_parameter_documentation(&raw, &[("value", "Parameter documentation.")]);
+        }
+    }
+
+    #[test]
+    fn ends_parameter_section_at_structured_section_header() {
+        assert_parameter_documentation(
+            "\
+Args:
+    value: Parameter documentation.
+Methods:
+    helper: Method documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn ends_unindented_parameter_section_at_aligned_prose() {
+        assert_parameter_documentation(
+            "\
+Args:
+value: Parameter documentation.
+
+Additional details.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn ends_indented_parameter_section_at_aligned_prose() {
+        assert_parameter_documentation(
+            "\
+Args:
+    value: Parameter documentation.
+
+    Additional details.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn ends_indented_parameter_section_at_inline_section_header() {
+        assert_parameter_documentation(
+            "\
+Args:
+    first: First parameter.
+    last: Last parameter.
+
+Returns: Result.",
+            &[("first", "First parameter."), ("last", "Last parameter.")],
+        );
+    }
+
+    #[test]
+    fn ends_unindented_parameter_section_at_inline_section_header() {
+        assert_parameter_documentation(
+            "\
+Args:
+first: First parameter.
+last: Last parameter.
+Returns: Result.",
+            &[("first", "First parameter."), ("last", "Last parameter.")],
+        );
+    }
+
+    #[test]
+    fn pep257_normalization_recognizes_shifted_sibling_section() {
+        assert_parameter_documentation(
+            "\
+Note:
+        context
+
+    Args:
+        value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn pep257_normalization_preserves_nested_section() {
+        assert_parameter_documentation(
+            "
+    Note:
+        context
+
+        Args:
+            nested: Not parameter documentation.",
+            &[],
+        );
+    }
+
+    #[test]
+    fn pep257_normalization_ends_section_at_dedented_header() {
+        assert_parameter_documentation(
+            "\
+Args:
+        value: Parameter documentation.
+    Returns:
+        bool: Result.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn adjacent_aligned_section_headers_are_siblings() {
+        assert_parameter_documentation(
+            "\
+Example:
+Args:
+    value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn finds_shifted_top_level_section() {
+        assert_parameter_documentation(
+            "\
+A decoded newline follows:
+This line starts at column zero.
+
+    Keyword Args:
+        shifted: Documentation in a shifted section.",
+            &[("shifted", "Documentation in a shifted section.")],
+        );
+    }
+
+    #[test]
+    fn keeps_colon_prose_in_parameter_documentation() {
+        assert_parameter_documentation(
+            "\
+Args:
+    param1 (str): The first parameter description.
+    For example: pass an absolute path.
+    param2: The second parameter description.",
+            &[
+                (
+                    "param1",
+                    "The first parameter description.\nFor example: pass an absolute path.",
+                ),
+                ("param2", "The second parameter description."),
+            ],
+        );
+    }
+
+    #[test]
+    fn keeps_rest_literal_blocks_in_parameter_documentation() {
+        assert_parameter_documentation(
+            "\
+Args:
+    value: Documentation.
+        Example::
+            Args:
+                nested: Not parameter documentation.
+    other: Other documentation.",
+            &[
+                (
+                    "value",
+                    "Documentation.\nExample::\nArgs:\nnested: Not parameter documentation.",
+                ),
+                ("other", "Other documentation."),
+            ],
+        );
+    }
+
+    #[test]
+    fn extracts_variadic_parameters() {
+        assert_parameter_documentation(
+            "\
+Args:
+    *args: Extra positional arguments.
+    **kwargs: Extra keyword arguments.",
+            &[
+                ("*args", "Extra positional arguments."),
+                ("**kwargs", "Extra keyword arguments."),
+            ],
+        );
+    }
+
+    #[test]
+    fn ignores_parameter_section_nested_in_container_section() {
+        assert_parameter_documentation(
+            "\
+Example:
+    Args:
+        nested: Not parameter documentation.
+Args:
+    value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn ignores_parameter_section_in_rest_directive() {
+        assert_parameter_documentation(
+            "\
+.. note::
+    Args:
+        nested: Not parameter documentation.",
+            &[],
+        );
+    }
+
+    #[test]
+    fn ignores_parameter_section_after_blank_line_in_rest_directive() {
+        assert_parameter_documentation(
+            "\
+.. note::
+
+        Keyword Args:
+            nested: Not parameter documentation.",
+            &[],
+        );
+    }
+
+    #[test]
+    fn ignores_parameter_section_in_unordered_markdown_list_item() {
+        assert_parameter_documentation(
+            "\
+- Example:
+    Args:
+        nested: Not parameter documentation.",
+            &[],
+        );
+    }
+
+    #[test]
+    fn ignores_parameter_section_after_blank_line_in_markdown_list_item() {
+        assert_parameter_documentation(
+            "\
+- Example:
+
+        Args:
+            nested: Not parameter documentation.",
+            &[],
+        );
+    }
+
+    #[test]
+    fn ignores_parameter_section_in_ordered_markdown_list_item() {
+        assert_parameter_documentation(
+            "\
+1. Example:
+    Args:
+        nested: Not parameter documentation.",
+            &[],
+        );
+    }
+
+    #[test]
+    fn ignores_parameter_section_in_rest_field_list() {
+        assert_parameter_documentation(
+            "\
+:param value: Example input.
+    Args:
+        nested: Not parameter documentation.",
+            &[],
+        );
+    }
+
+    #[test]
+    fn ignores_parameter_section_in_rest_literal_block() {
+        assert_parameter_documentation(
+            "\
+Example::
+
+        Args:
+            nested: Not parameter documentation.",
+            &[],
+        );
+    }
+
+    #[test]
+    fn resumes_after_markdown_fence() {
+        assert_parameter_documentation(
+            "\
+Summary.
+
+    ```text
+    Args:
+        nested: Not parameter documentation.
+    ```
+
+    Args:
+        value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn resumes_after_rest_literal_block() {
+        assert_parameter_documentation(
+            "\
+Summary.
+
+    Example::
+
+        Args:
+            nested: Not parameter documentation.
+
+    Args:
+        value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn resumes_after_rest_directive() {
+        assert_parameter_documentation(
+            "\
+.. note::
+    Args:
+        nested: Not parameter documentation.
+Args:
+    value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn resumes_after_unindented_markdown_fence_following_rest_literal_marker() {
+        assert_parameter_documentation(
+            "\
+Example::
+
+```
+sample
+```
+
+Args:
+    value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn backticks_in_fence_info_do_not_hide_parameter_sections() {
+        assert_parameter_documentation(
+            "\
+```PRNGKey`` is accepted.
+
+Args:
+    value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn ignores_doctest_content_and_resumes_after_it() {
+        assert_parameter_documentation(
+            "        >>> example()
+        Args:
+            nested: Not parameter documentation.
+
+        Args:
+            value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn returns_parameter_section_kinds_in_source_order() {
+        let raw = "\
+Args:
+    value: Documentation.
+Keyword Args:
+    option: Optional.
+Other Parameters:
+    other: Other.
+Returns:
+    bool: Result.";
+        let lines = parsed_lines(raw);
+        let kinds = sections(&lines)
+            .map(|section| section.kind)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            kinds,
+            [
+                SectionKind::Parameters,
+                SectionKind::KeywordArguments,
+                SectionKind::OtherParameters,
+            ]
+        );
+    }
+
+    #[test]
+    fn returns_section_body_range_and_header_indent() {
+        let raw = "    Args:
+        value: Documentation.
+Returns:
+    bool: Result.";
+        let lines = parsed_lines(raw);
+        let sections = sections(&lines)
+            .map(|section| {
+                (
+                    section.kind,
+                    section
+                        .body
+                        .iter()
+                        .map(|line| line.text)
+                        .collect::<Vec<_>>(),
+                    &raw[section.range],
+                    section.header_indent,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            sections,
+            vec![(
+                SectionKind::Parameters,
+                vec!["        value: Documentation."],
+                "    Args:\n        value: Documentation.",
+                TextSize::new(4),
+            )]
+        );
+    }
+
+    fn display_parameters(raw: &str) -> String {
+        parameter_documentation(raw)
+            .into_iter()
+            .map(|(name, documentation)| {
+                let documentation = documentation
+                    .lines()
+                    .map(|line| match line {
+                        "" => "  │".to_string(),
+                        _ => format!("  │ {line}"),
+                    })
+                    .join("\n");
+                format!("{name}:\n{documentation}")
+            })
+            .join("\n")
+    }
+
+    #[track_caller]
+    fn assert_parameter_documentation(raw: &str, expected: &[(&str, &str)]) {
+        let parameters = parameter_documentation(raw);
+        assert_eq!(parameters.len(), expected.len(), "{raw}");
+
+        for &(name, documentation) in expected {
+            assert_eq!(
+                parameters.get(name).map(String::as_str),
+                Some(documentation),
+                "{raw}"
+            );
+        }
+    }
+}

--- a/crates/ty_ide/src/docstring/document/preformatted.rs
+++ b/crates/ty_ide/src/docstring/document/preformatted.rs
@@ -1,6 +1,8 @@
 use ruff_python_trivia::leading_indentation;
 use ruff_text_size::TextSize;
 
+use super::syntax::indentation as visual_indentation;
+
 /// Represents a fenced Markdown code block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::docstring) struct MarkdownFence<'a> {
@@ -30,8 +32,11 @@ impl<'a> MarkdownFence<'a> {
         let fence_len = line.len() - without_leading_fence.len();
         let fence = &line[..fence_len];
 
-        // We *don't* want to consider ```hello``` as a codefence; that's inline code!
-        (!without_leading_fence.contains(fence)).then_some(Self { marker: fence })
+        // Backticks are not allowed in a backtick fence's info string.
+        // This also keeps code spans such as ```hello``` from being mistaken for fenced blocks.
+        //
+        // <https://spec.commonmark.org/0.31.2/#fenced-code-blocks>
+        (!has_tick_fence || !without_leading_fence.contains('`')).then_some(Self { marker: fence })
     }
 
     /// Returns whether `line` closes this fenced code block.
@@ -54,6 +59,16 @@ pub(super) struct PreformattedBlockScanner<'a> {
 const QUOTED_LITERAL_BLOCK_QUOTE_CHARACTERS: &str = r##"!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"##;
 
 impl<'a> PreformattedBlockScanner<'a> {
+    /// Returns whether the scanner is currently inside an accepted preformatted block.
+    pub(super) fn is_active(&self) -> bool {
+        self.active_markdown_fence.is_some()
+            || self.active_doctest_indent.is_some()
+            || matches!(
+                self.rest_literal_blocks.state,
+                RestLiteralBlockState::Active(_)
+            )
+    }
+
     /// Updates internal state to reflect the given line and returns whether or
     /// not the given line is contained within a preformatted block.
     pub(super) fn consume_preformatted_line(&mut self, line: &'a str) -> bool {
@@ -69,10 +84,10 @@ impl<'a> PreformattedBlockScanner<'a> {
         }
 
         if let Some(doctest_indent) = self.active_doctest_indent {
-            if line.trim_start_matches(' ').is_empty() {
+            if line.bytes().all(|byte| matches!(byte, b' ' | b'\t')) {
                 self.active_doctest_indent = None;
                 return true;
-            } else if indentation(line) < doctest_indent {
+            } else if visual_indentation(line) < doctest_indent {
                 self.active_doctest_indent = None;
             } else {
                 return true;
@@ -80,7 +95,7 @@ impl<'a> PreformattedBlockScanner<'a> {
         }
 
         if Self::line_starts_doctest(line) {
-            self.active_doctest_indent = Some(indentation(line));
+            self.active_doctest_indent = Some(visual_indentation(line));
             return true;
         }
 
@@ -165,6 +180,11 @@ impl RestLiteralBlockScanner {
                         marker_indent,
                     });
                     true
+                } else if MarkdownFence::find(line).is_some() {
+                    // Without indentation to start a reST literal, let the outer scanner handle
+                    // the Markdown fence.
+                    self.state = RestLiteralBlockState::Inactive;
+                    false
                 } else if allows_quoted_literal_block
                     && let Some(quote) = Self::quote_character(line, marker_indent)
                 {

--- a/crates/ty_ide/src/docstring/document/rst.rs
+++ b/crates/ty_ide/src/docstring/document/rst.rs
@@ -13,6 +13,11 @@ fn field_lists(raw: &str) -> Vec<FieldList> {
     FieldList::parse_all(raw)
 }
 
+/// Returns whether `line` starts a reST field-list item.
+pub(in crate::docstring) fn is_field_list_marker(line: &str) -> bool {
+    FieldHeader::parse_list_member(line).is_some()
+}
+
 /// Returns top-level field lists that begin at a reST block boundary.
 ///
 /// `source` must have already undergone PEP-257 trimming and universal newline

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -1,0 +1,212 @@
+use ruff_python_trivia::leading_indentation;
+use ruff_source_file::UniversalNewlines;
+use ruff_text_size::{TextRange, TextSize};
+
+use super::rst::is_field_list_marker;
+
+/// Collects docstring lines without their universal-newline terminators while preserving their
+/// source ranges.
+///
+/// For example, `first\r\nsecond` yields `first` at offset 0 and `second` at offset 7.
+pub(super) fn parsed_lines(raw: &str) -> Vec<ParsedLine<'_>> {
+    let mut lines = raw
+        .universal_newlines()
+        .map(|line| ParsedLine {
+            text: line.as_str(),
+            range: line.range(),
+            raw_indent: indentation(line.as_str()),
+            structural_indent: TextSize::new(0),
+        })
+        .collect::<Vec<_>>();
+
+    // PEP 257 ignores indentation on the first physical line and removes the common margin from
+    // all later lines. Keep the raw indentation as well because item and block indentation can
+    // still disambiguate content within a section.
+    let continuation_margin = lines
+        .iter()
+        .skip(1)
+        .filter(|line| !line.text.trim().is_empty())
+        .map(|line| line.raw_indent)
+        .min()
+        .unwrap_or(TextSize::new(0));
+
+    for line in lines.iter_mut().skip(1) {
+        line.structural_indent = line.raw_indent.saturating_sub(continuation_margin);
+    }
+
+    lines
+}
+
+/// A docstring line and its source range, excluding the newline terminator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ParsedLine<'a> {
+    /// The line text, excluding its newline terminator.
+    pub(super) text: &'a str,
+    /// The byte range of `text` within the source document.
+    pub(super) range: TextRange,
+    /// The indentation in the raw docstring text.
+    pub(super) raw_indent: TextSize,
+    /// The indentation after removing the PEP 257 continuation margin.
+    pub(super) structural_indent: TextSize,
+}
+
+/// Returns whether `line` starts with a `CommonMark` list-item marker.
+///
+/// `CommonMark` limits ordered-list markers to nine digits to avoid integer
+/// overflow in browsers: <https://spec.commonmark.org/0.31.2/#list-items>.
+pub(in crate::docstring) fn starts_with_markdown_list_item(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    if matches!(bytes, [b'-' | b'+' | b'*', b' ' | b'\t', ..]) {
+        return true;
+    }
+
+    let digits = bytes
+        .iter()
+        .take(9)
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    digits > 0
+        && matches!(bytes.get(digits), Some(b'.' | b')'))
+        && matches!(bytes.get(digits + 1), Some(b' ' | b'\t'))
+}
+
+/// Returns the end of an indented Markdown or reStructuredText container block.
+pub(super) fn container_block_end(lines: &[ParsedLine<'_>], index: usize) -> Option<usize> {
+    let marker = lines.get(index)?;
+    if !is_rest_directive_marker(marker.text)
+        && !is_field_list_marker(marker.text)
+        && !starts_with_markdown_list_item(marker.text.trim_start())
+    {
+        return None;
+    }
+
+    // Container membership is determined before PEP 257 normalization. This keeps raw-indented
+    // section-like text inside lists, directives, and field-list entries.
+    Some(
+        (index + 1..lines.len())
+            .find(|&end| {
+                let line = lines[end];
+                !line.text.trim().is_empty() && line.raw_indent <= marker.raw_indent
+            })
+            .unwrap_or(lines.len()),
+    )
+}
+
+fn is_rest_directive_marker(line: &str) -> bool {
+    let Some(directive) = line.trim_start().strip_prefix(".. ") else {
+        return false;
+    };
+    let Some((name, _)) = directive.split_once("::") else {
+        return false;
+    };
+
+    !name.is_empty() && !name.chars().any(char::is_whitespace)
+}
+
+/// Splits the input once at the first colon outside bracket pairs and quoted strings.
+pub(super) fn split_once_unbracketed_colon(line: &str) -> Option<(&str, &str)> {
+    let mut depths = [0usize; 3];
+    let mut quote = None;
+    let mut escaped = false;
+    let mut fallback_colon = None;
+
+    for (index, character) in line.char_indices() {
+        if let Some(quote_character) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == quote_character {
+                quote = None;
+            }
+            continue;
+        }
+
+        match character {
+            '\'' | '"' => quote = Some(character),
+            '(' => depths[0] += 1,
+            ')' => depths[0] = depths[0].saturating_sub(1),
+            '[' => depths[1] += 1,
+            ']' => depths[1] = depths[1].saturating_sub(1),
+            '{' => depths[2] += 1,
+            '}' => depths[2] = depths[2].saturating_sub(1),
+            ':' if depths == [0; 3] => {
+                return Some((&line[..index], &line[index + character.len_utf8()..]));
+            }
+            // Retain a colon outside parentheses as a fallback. This recovers an item delimiter
+            // after malformed square or curly brackets while preferring a fully balanced split.
+            ':' if depths[0] == 0 && fallback_colon.is_none() => fallback_colon = Some(index),
+            _ => {}
+        }
+    }
+
+    fallback_colon.map(|index| (&line[..index], &line[index + ':'.len_utf8()..]))
+}
+
+/// Splits a trailing parenthesized type from a parameter display name.
+pub(super) fn parse_parenthesized_type(name: &str) -> (&str, Option<&str>) {
+    if !name.ends_with(')') {
+        return (name, None);
+    }
+
+    let mut depth = 0usize;
+    let mut opening = None;
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (index, character) in name.char_indices() {
+        if let Some(quote_character) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == quote_character {
+                quote = None;
+            }
+            continue;
+        }
+
+        match character {
+            '\'' | '"' => quote = Some(character),
+            '(' => {
+                if depth == 0 {
+                    opening = Some(index);
+                }
+                depth += 1;
+            }
+            ')' => {
+                depth = match depth.checked_sub(1) {
+                    Some(depth) => depth,
+                    None => return (name, None),
+                };
+                if depth == 0 && index + character.len_utf8() == name.len() {
+                    let Some(opening) = opening else {
+                        return (name, None);
+                    };
+                    let display_name = name[..opening].trim();
+                    let ty = name[opening + '('.len_utf8()..index].trim();
+
+                    return if display_name.is_empty() || ty.is_empty() {
+                        (name, None)
+                    } else {
+                        (display_name, Some(ty))
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+    (name, None)
+}
+
+/// Calculates indentation width, advancing tabs to the next multiple of eight columns.
+pub(super) fn indentation(line: &str) -> TextSize {
+    TextSize::new(
+        leading_indentation(line)
+            .bytes()
+            .fold(0u32, |column, byte| match byte {
+                b'\t' => (column / 8 + 1) * 8,
+                _ => column + 1,
+            }),
+    )
+}

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -6,6 +6,7 @@ use strum_macros::EnumIter;
 
 use super::general;
 use crate::docstring::document::preformatted::MarkdownFence;
+use crate::docstring::document::syntax::starts_with_markdown_list_item;
 
 mod rst;
 
@@ -306,45 +307,9 @@ fn render_markdown_section<'a>(
     rendered_field
 }
 
-fn starts_with_markdown_list_item(line: &str) -> bool {
-    starts_with_unordered_markdown_list_item(line) || starts_with_ordered_markdown_list_item(line)
-}
-
 fn line_starts_markdown_block_content(line: &str, at_description_start: bool) -> bool {
     MarkdownFence::find(line).is_some()
         || (at_description_start && starts_with_markdown_list_item(line))
-}
-
-/// Returns whether `line` begins with `-`, `+`, or `*` followed by whitespace.
-fn starts_with_unordered_markdown_list_item(line: &str) -> bool {
-    matches!(line.as_bytes(), [b'-' | b'+' | b'*', b' ' | b'\t', ..])
-}
-
-/// Returns whether `line` begins with one to nine ASCII digits followed by
-/// `.` or `)`, then whitespace.
-///
-/// `CommonMark` limits ordered-list markers to nine digits to avoid integer
-/// overflow in browsers: <https://spec.commonmark.org/0.31.2/#list-items>.
-fn starts_with_ordered_markdown_list_item(line: &str) -> bool {
-    let bytes = line.as_bytes();
-    let mut digit_count = 0;
-
-    for byte in bytes {
-        if digit_count < 9 && byte.is_ascii_digit() {
-            digit_count += 1;
-            continue;
-        }
-
-        if digit_count > 0 && matches!(*byte, b'.' | b')') {
-            return bytes
-                .get(digit_count + 1)
-                .is_some_and(|byte| matches!(*byte, b' ' | b'\t'));
-        }
-
-        return false;
-    }
-
-    false
 }
 
 /// Returns the byte offset where `description` first needs block-style rendering.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This refactors how we extract parameter documentation from Google-style docstrings. It replaces the existing regex-based scanner in `ty_ide/src/docstring.rs` with a parser that should strictly improve parameter documentation extraction along the following dimensions:

- We will now recognize parameters from `Keyword Args` and `Other Args` sections (as well their other common spellings), where previously we only recognized parameters from `Args` and `Parameters` sections.
- We now respect PEP 257 indentation and container boundaries, thereby ignoring parameter-like text that appears inside Markdown fences/lists, doctests, and reStructuredText directives, field lists, and literal blocks.
- We now recognize continuation prose in parameter documentation more consistently.
- We now extract docs for all parameters in a comma-separated list.

In addition, to those immediate improvements, this new section visitor provides the source text range tracking that will allow us to render Google-style docstring as markdown in an [upcoming change](https://github.com/astral-sh/ruff/pull/26599).

Please note that I have intentionally biased this parser towards successfully parsing shapes that were actually found in the wild during a corpus review of popular public repositories that use Google-style docstrings. As such, there are theoretically possible shapes that we do not bother to support because they are very unlikely to occur in real docstrings. I think this is an acceptable compromise in favour of maintainability.

## Test Plan

Please see included tests.
<!-- How was it tested? -->
