### PR TITLE
[ty] Render Google docstrings as structured Markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4720,6 +4720,7 @@ dependencies = [
  "ruff_python_importer",
  "ruff_python_literal",
  "ruff_python_parser",
+ "ruff_python_stdlib",
  "ruff_python_trivia",
  "ruff_source_file",
  "ruff_text_size",

--- a/crates/ty_ide/Cargo.toml
+++ b/crates/ty_ide/Cargo.toml
@@ -23,6 +23,7 @@ ruff_python_ast = { workspace = true }
 ruff_python_codegen = { workspace = true }
 ruff_python_importer = { workspace = true }
 ruff_python_literal = { workspace = true }
+ruff_python_stdlib = { workspace = true }
 ruff_python_trivia = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -51,8 +51,7 @@ impl Docstring {
 
     /// Render the docstring for markdown display
     pub fn render_markdown(&self) -> String {
-        let trimmed = documentation_trim(&self.0);
-        markdown::render(&trimmed)
+        markdown::render(&self.0)
     }
 
     /// Extract parameter documentation from popular docstring formats.
@@ -823,16 +822,17 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func...<HB>
-        <HB>
-        Returns:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;Some details<HB>
+        My cool func...
+
+        ## Returns
+        Some details
+
         `````python
-            x_y = thing_do();
-            ``` # this should't close the fence!
-            a_b = other_thing();
+        x_y = thing_do();
+        ``` # this should't close the fence!
+        a_b = other_thing();
         `````<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;And so on.
+        And so on.
         ");
     }
 
@@ -858,16 +858,17 @@ mod tests {
         let docstring = Docstring::new(docstring.to_owned());
 
         assert_snapshot!(docstring.render_markdown(), @"
-        My cool func...<HB>
-        <HB>
-        Returns:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;Some details<HB>
+        My cool func...
+
+        ## Returns
+        Some details
+
         ~~~~~~python
-            x_y = thing_do();
-            ~~~ # this should't close the fence!
-            a_b = other_thing();
+        x_y = thing_do();
+        ~~~ # this should't close the fence!
+        a_b = other_thing();
         ~~~~~~<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;And so on.
+        And so on.
         ");
     }
 
@@ -1236,20 +1237,30 @@ mod tests {
                 This is a continuation of param2 description.
             param3: A parameter without type annotation
 
+        Keyword Args:
+            keyword_only (bool): Keyword-only parameter description
+
         Returns:
             str: The return value description
+
+        Yields:
+            int: The next value
         "#;
 
         let docstring = Docstring::new(docstring.to_owned());
         let param_docs = docstring.parameter_documentation();
 
-        assert_eq!(param_docs.len(), 3);
+        assert_eq!(param_docs.len(), 4);
         assert_eq!(&param_docs["param1"], "The first parameter description");
         assert_eq!(
             &param_docs["param2"],
             "The second parameter description\nThis is a continuation of param2 description."
         );
         assert_eq!(&param_docs["param3"], "A parameter without type annotation");
+        assert_eq!(
+            &param_docs["keyword_only"],
+            "Keyword-only parameter description"
+        );
 
         assert_snapshot!(docstring.render_plaintext(), @"
         This is a function description.
@@ -1260,22 +1271,351 @@ mod tests {
                 This is a continuation of param2 description.
             param3: A parameter without type annotation
 
+        Keyword Args:
+            keyword_only (bool): Keyword-only parameter description
+
         Returns:
             str: The return value description
+
+        Yields:
+            int: The next value
         ");
 
-        assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter description<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter description<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param3: A parameter without type annotation<HB>
-        <HB>
-        Returns:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;str: The return value description
+        assert_snapshot!(docstring.render_markdown(), @r"
+        This is a function description.
+
+        ## Parameters
+        **param1**: `str`<HB>
+        The first parameter description
+
+        **param2**: `int`<HB>
+        The second parameter description<HB>
+        This is a continuation of param2 description.
+
+        **param3**<HB>
+        A parameter without type annotation
+
+        ## Keyword Arguments
+        **keyword\_only**: `bool`<HB>
+        Keyword-only parameter description
+
+        ## Returns
+        `str`<HB>
+        The return value description
+
+        ## Yields
+        `int`<HB>
+        The next value
         ");
+    }
+
+    #[test]
+    fn google_markdown_renders_first_line_section() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+Args:
+    value: Description.
+    Aligned continuation.
+    other: More."
+                .to_owned(),
+        );
+
+        assert_eq!(
+            docstring.parameter_documentation()["value"],
+            "Description.\nAligned continuation."
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Parameters
+        **value**<HB>
+        Description.<HB>
+        Aligned continuation.
+
+        **other**<HB>
+        More.
+        ");
+    }
+
+    #[test]
+    fn google_note_uses_pep257_section_hierarchy() {
+        let docstring = Docstring::new(
+            "Note:\n        context\n\n    Args:\n        value: Parameter documentation."
+                .to_owned(),
+        );
+
+        assert_eq!(
+            docstring.parameter_documentation()["value"],
+            "Parameter documentation."
+        );
+        assert!(docstring.render_markdown().contains("## Parameters"));
+    }
+
+    #[test]
+    fn raw_indented_containers_keep_google_sections_nested() {
+        for raw in [
+            "Example::\n\n        Args:\n            nested: Literal content.",
+            ".. note::\n\n        Keyword Args:\n            nested: Directive content.",
+            "- Example\n\n        Args:\n            nested: List content.",
+        ] {
+            let docstring = Docstring::new(raw.to_owned());
+
+            assert!(docstring.parameter_documentation().is_empty(), "{raw}");
+            assert!(
+                !docstring.render_markdown().contains("## Parameters"),
+                "{raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn google_markdown_renders_sections_shifted_by_decoded_newlines() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+A decoded newline follows:
+This line starts at column zero.
+
+    Keyword Args:
+        shifted: Documentation in a shifted section.
+
+    Returns:
+        bool: Result."
+                .to_owned(),
+        );
+
+        assert_eq!(
+            docstring.parameter_documentation()["shifted"],
+            "Documentation in a shifted section."
+        );
+        assert_snapshot!(docstring.render_markdown(), @"
+        A decoded newline follows:<HB>
+        This line starts at column zero.
+
+        ## Keyword Arguments
+        **shifted**<HB>
+        Documentation in a shifted section.
+
+        ## Returns
+        `bool`<HB>
+        Result.
+        ");
+    }
+
+    #[test]
+    fn google_markdown_renders_non_parameter_first_line_sections() {
+        for (source, expected) in [
+            (
+                "Returns:\n    bool: Whether validation passed.\n    Additional details.",
+                "## Returns\n`bool`  \nWhether validation passed.  \nAdditional details.",
+            ),
+            ("Yields:\n    The next item.", "## Yields\nThe next item."),
+            (
+                "Raises:\n    ValueError: If invalid.",
+                "## Raises\n`ValueError`  \nIf invalid.",
+            ),
+            (
+                "Raises:\n    Warning:\n        Emitted for legacy input.\n    Error: Generic failure.",
+                "## Raises\n`Warning`  \nEmitted for legacy input.\n\n`Error`  \nGeneric failure.",
+            ),
+            (
+                "Attributes:\n    name (str): Display name.",
+                "## Attributes\n**name**: `str`  \nDisplay name.",
+            ),
+            (
+                "Other Parameters:\n    timeout (float): Maximum wait in seconds.",
+                "## Other Parameters\n**timeout**: `float`  \nMaximum wait in seconds.",
+            ),
+        ] {
+            assert_eq!(
+                Docstring::new(source.to_owned()).render_markdown(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn google_sections_render_edge_cases() {
+        let _snap = bind_docstring_snapshot_filters();
+        let docstring = Docstring::new(
+            "\
+Attributes:
+    name (str): Display name.
+    coords (tuple(int, int)): Coordinate pair.
+    callback (Callable(int, str)): Converts raw values.
+        if name:
+            return name
+
+Raises:
+    ValueError: If invalid."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        ## Attributes
+        **name**: `str`<HB>
+        Display name.
+
+        **coords**: `tuple(int, int)`<HB>
+        Coordinate pair.
+
+        **callback**: `Callable(int, str)`<HB>
+        Converts raw values.<HB>
+        if name:<HB>
+            return name
+
+        ## Raises
+        `ValueError`<HB>
+        If invalid.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Args:
+    value: Description.
+        ```python
+        Args:
+            nested: Still code.
+        Returns:
+            Still code.
+        ```
+    url (Literal[\"http://\"]): URL."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @r#"
+        Summary.
+
+        ## Parameters
+        **value**<HB>
+        Description.
+
+        ```python
+        Args:
+            nested: Still code.
+        Returns:
+            Still code.
+        ```
+
+        **url**: `Literal["http://"]`<HB>
+        URL.
+        "#);
+
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Returns:
+    Literal[\"http://\"]: First paragraph.
+
+    Second paragraph."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @r#"
+        Summary.
+
+        ## Returns
+        `Literal["http://"]`<HB>
+        First paragraph.
+
+        Second paragraph.
+        "#);
+
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Returns:
+    str | None: Optional value.
+
+Yields:
+    :obj:`list` of :obj:`str`: Result chunks."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Summary.
+
+        ## Returns
+        `str | None`<HB>
+        Optional value.
+
+        ## Yields
+        `` :obj:`list` of :obj:`str` ``<HB>
+        Result chunks.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Args:
+    value: Description.
+>>> value
+42"
+            .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Summary.
+
+        ## Parameters
+        **value**<HB>
+        Description.
+
+        ```````````python
+        >>> value
+        42
+        ```````````
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Returns:
+    https://example.com: more details."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Summary.
+
+        ## Returns
+        https://example.com: more details.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Summary.
+
+Returns:
+    str:Description without whitespace."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Summary.
+
+        ## Returns
+        `str`<HB>
+        Description without whitespace.
+        ");
+
+        let docstring = Docstring::new(
+            "\
+Args:
+    : Missing name."
+                .to_owned(),
+        );
+
+        assert_snapshot!(docstring.render_markdown(), @"
+        Args:<HB>
+        : Missing name.
+    ");
     }
 
     #[test]
@@ -1476,12 +1816,15 @@ mod tests {
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): Another Google-style parameter<HB>
-        <HB>
+        This is a function description.
+
+        ## Parameters
+        **param1**: `str`<HB>
+        Google-style parameter
+
+        **param2**: `int`<HB>
+        Another Google-style parameter
+
         Parameters<HB>
         ----------<HB>
         param3 : bool<HB>
@@ -1630,11 +1973,14 @@ mod tests {
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): Google-style duplicate parameter
+        This is a function description.
+
+        ## Parameters
+        **param1**: `str`<HB>
+        Google-style parameter
+
+        **param2**: `int`<HB>
+        Google-style duplicate parameter
 
         ## Parameters
         **param2**: `int`<HB>
@@ -1841,11 +2187,14 @@ mod tests {
         ");
 
         assert_snapshot!(docstring_windows.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter
+        This is a function description.
+
+        ## Parameters
+        **param1**: `str`<HB>
+        The first parameter
+
+        **param2**: `int`<HB>
+        The second parameter
         ");
 
         assert_snapshot!(docstring_mac.render_plaintext(), @"
@@ -1857,11 +2206,14 @@ mod tests {
         ");
 
         assert_snapshot!(docstring_mac.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter
+        This is a function description.
+
+        ## Parameters
+        **param1**: `str`<HB>
+        The first parameter
+
+        **param2**: `int`<HB>
+        The second parameter
         ");
 
         assert_snapshot!(docstring_unix.render_plaintext(), @"
@@ -1873,11 +2225,14 @@ mod tests {
         ");
 
         assert_snapshot!(docstring_unix.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): The first parameter<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): The second parameter
+        This is a function description.
+
+        ## Parameters
+        **param1**: `str`<HB>
+        The first parameter
+
+        **param2**: `int`<HB>
+        The second parameter
         ");
     }
 

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -17,17 +17,6 @@ use std::sync::LazyLock;
 
 use crate::MarkupKind;
 
-// Static regex instances to avoid recompilation
-static GOOGLE_SECTION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^\s*(Args|Arguments|Parameters)\s*:\s*$")
-        .expect("Google section regex should be valid")
-});
-
-static GOOGLE_PARAM_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^\s*(\*?\*?\w+)\s*(\(.*?\))?\s*:\s*(.+)")
-        .expect("Google parameter regex should be valid")
-});
-
 static NUMPY_SECTION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)^\s*Parameters\s*$").expect("NumPy section regex should be valid")
 });
@@ -69,18 +58,7 @@ impl Docstring {
     /// Extract parameter documentation from popular docstring formats.
     /// Returns a map of parameter names to their documentation.
     pub fn parameter_documentation(&self) -> IndexMap<String, String> {
-        let mut param_docs = IndexMap::new();
-
-        // Google-style docstrings
-        param_docs.extend(extract_google_style_params(&self.0));
-
-        // NumPy-style docstrings
-        param_docs.extend(extract_numpy_style_params(&self.0));
-
-        // reST/Sphinx-style docstrings
-        param_docs.extend(document::parameter_documentation(&self.0));
-
-        param_docs
+        document::parameter_documentation(&self.0, extract_numpy_style_params(&self.0))
     }
 }
 
@@ -175,89 +153,6 @@ fn documentation_trim(docs: &str) -> String {
     }
 
     output
-}
-
-/// Extract parameter documentation from Google-style docstrings.
-fn extract_google_style_params(docstring: &str) -> IndexMap<String, String> {
-    let mut param_docs = IndexMap::new();
-
-    let mut in_args_section = false;
-    let mut current_param: Option<String> = None;
-    let mut current_doc = String::new();
-
-    for line_obj in docstring.universal_newlines() {
-        let line = line_obj.as_str();
-        if GOOGLE_SECTION_REGEX.is_match(line) {
-            in_args_section = true;
-            continue;
-        }
-
-        if in_args_section {
-            // Check if we hit another section (starts with a word followed by colon at line start)
-            if !line.starts_with(' ') && !line.starts_with('\t') && line.contains(':') {
-                if let Some(colon_pos) = line.find(':') {
-                    let section_name = line[..colon_pos].trim();
-                    // If this looks like another section, stop processing args
-                    if !section_name.is_empty()
-                        && section_name
-                            .chars()
-                            .all(|c| c.is_alphabetic() || c.is_whitespace())
-                    {
-                        // Check if this is a known section name
-                        let known_sections = [
-                            "Returns", "Return", "Raises", "Yields", "Yield", "Examples",
-                            "Example", "Note", "Notes", "Warning", "Warnings",
-                        ];
-                        if known_sections.contains(&section_name) {
-                            if let Some(param_name) = current_param.take() {
-                                param_docs.insert(param_name, current_doc.trim().to_string());
-                                current_doc.clear();
-                            }
-                            in_args_section = false;
-                            continue;
-                        }
-                    }
-                }
-            }
-
-            if let Some(captures) = GOOGLE_PARAM_REGEX.captures(line) {
-                // Save previous parameter if exists
-                if let Some(param_name) = current_param.take() {
-                    param_docs.insert(param_name, current_doc.trim().to_string());
-                    current_doc.clear();
-                }
-
-                // Start new parameter
-                if let (Some(param), Some(desc)) = (captures.get(1), captures.get(3)) {
-                    current_param = Some(param.as_str().to_string());
-                    current_doc = desc.as_str().to_string();
-                }
-            } else if line.starts_with(' ') || line.starts_with('\t') {
-                // This is a continuation of the current parameter documentation
-                if current_param.is_some() {
-                    if !current_doc.is_empty() {
-                        current_doc.push('\n');
-                    }
-                    current_doc.push_str(line.trim());
-                }
-            } else {
-                // This is a line that doesn't start with whitespace and isn't a parameter
-                // It might be a section or other content, so stop processing args
-                if let Some(param_name) = current_param.take() {
-                    param_docs.insert(param_name, current_doc.trim().to_string());
-                    current_doc.clear();
-                }
-                in_args_section = false;
-            }
-        }
-    }
-
-    // Don't forget the last parameter
-    if let Some(param_name) = current_param {
-        param_docs.insert(param_name, current_doc.trim().to_string());
-    }
-
-    param_docs
 }
 
 /// Calculate the indentation level of a line.

--- a/crates/ty_ide/src/docstring/document.rs
+++ b/crates/ty_ide/src/docstring/document.rs
@@ -1,9 +1,30 @@
 use indexmap::IndexMap;
 
+/// Google-style docstring parsing.
+pub(in crate::docstring) mod google;
 pub(super) mod preformatted;
 pub(super) mod rst;
+/// Syntax utilities shared by docstring format parsers and renderers.
+pub(in crate::docstring) mod syntax;
 
 /// Returns docs for all parameters recognized in the given docstring.
-pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
-    rst::parameter_documentation(raw)
+pub(super) fn parameter_documentation(
+    raw: &str,
+    numpy_parameters: IndexMap<String, String>,
+) -> IndexMap<String, String> {
+    let mut parameters = google::parameter_documentation(raw);
+    parameters.extend(numpy_parameters);
+    parameters.extend(rst::parameter_documentation(raw));
+    parameters
+}
+
+/// Parameter sections shared by supported docstring formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::docstring) enum SectionKind {
+    /// Function or method parameters.
+    Parameters,
+    /// Keyword arguments documented separately from the main parameter section.
+    KeywordArguments,
+    /// Less commonly used parameters listed separately from the main parameter section.
+    OtherParameters,
 }

--- a/crates/ty_ide/src/docstring/document.rs
+++ b/crates/ty_ide/src/docstring/document.rs
@@ -18,8 +18,8 @@ pub(super) fn parameter_documentation(
     parameters
 }
 
-/// Parameter sections shared by supported docstring formats.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Canonical docstring sections shared by supported formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::EnumIter)]
 pub(in crate::docstring) enum SectionKind {
     /// Function or method parameters.
     Parameters,
@@ -27,4 +27,27 @@ pub(in crate::docstring) enum SectionKind {
     KeywordArguments,
     /// Less commonly used parameters listed separately from the main parameter section.
     OtherParameters,
+    /// Class or module attributes.
+    Attributes,
+    /// A returned value.
+    Returns,
+    /// A yielded value.
+    Yields,
+    /// Exceptions raised by a callable.
+    Raises,
+}
+
+impl SectionKind {
+    /// Returns the canonical display heading for this section.
+    pub(super) const fn heading(self) -> &'static str {
+        match self {
+            SectionKind::Parameters => "Parameters",
+            SectionKind::KeywordArguments => "Keyword Arguments",
+            SectionKind::OtherParameters => "Other Parameters",
+            SectionKind::Attributes => "Attributes",
+            SectionKind::Returns => "Returns",
+            SectionKind::Yields => "Yields",
+            SectionKind::Raises => "Raises",
+        }
+    }
 }

--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -1,0 +1,630 @@
+use indexmap::IndexMap;
+use ruff_python_stdlib::identifiers::is_identifier;
+use ruff_text_size::{TextRange, TextSize};
+
+use super::SectionKind;
+use super::preformatted::PreformattedBlockScanner;
+use super::syntax::{
+    ParsedLine, indented_container_end, parse_parenthesized_type, parsed_lines,
+    split_once_unbracketed_colon,
+};
+
+/// Returns parameter documentation from recognized Google-style parameter sections.
+pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
+    let mut parameters = IndexMap::new();
+    visit_sections(raw, |kind, _, _, body| {
+        if matches!(
+            kind,
+            SectionKind::Parameters | SectionKind::KeywordArguments | SectionKind::OtherParameters
+        ) {
+            extend_parameter_documentation(&mut parameters, body);
+        }
+    });
+    parameters
+}
+
+/// Visits recognized Google-style parameter sections in source order.
+pub(in crate::docstring) fn visit_sections<'a>(
+    raw: &'a str,
+    mut visit: impl FnMut(SectionKind, TextRange, TextSize, &[ParsedLine<'a>]),
+) {
+    let lines = parsed_lines(raw);
+    let mut preformatted_blocks = PreformattedBlockScanner::default();
+    let mut index = 0;
+
+    while index < lines.len() {
+        // Content in another block can resemble a top-level Google section.
+        if preformatted_blocks.consume_preformatted_line(lines[index].text) {
+            index += 1;
+            continue;
+        }
+        if let Some(end) = indented_container_end(&lines, index) {
+            index = end;
+            continue;
+        }
+
+        let Some(header) = parse_section_header(&lines, index) else {
+            preformatted_blocks.observe_line_outside_preformatted_block(lines[index].text);
+            index += 1;
+            continue;
+        };
+        let (body_end, range) = section_body_end(&lines, header);
+        if let HeaderKind::Structured(kind) = header.kind {
+            visit(
+                kind,
+                range,
+                header.indent,
+                &lines[header.body_start..body_end],
+            );
+        }
+        index = body_end;
+    }
+}
+
+/// Returns whether `name` is a valid Python parameter name, including variadic prefixes.
+fn is_parameter_name(name: &str) -> bool {
+    let identifier = name
+        .strip_prefix("**")
+        .or_else(|| name.strip_prefix('*'))
+        .unwrap_or(name);
+    is_identifier(identifier)
+}
+
+/// Returns the index of the first line outside `header`'s body.
+fn section_body_end(lines: &[ParsedLine<'_>], header: SectionHeader) -> (usize, TextRange) {
+    let mut body_end = header.body_start;
+    let mut preformatted_blocks = PreformattedBlockScanner::default();
+    let mut item_indent = None;
+
+    while let Some(line) = lines.get(body_end) {
+        // Once a preformatted block begins, its contents cannot end the section.
+        if preformatted_blocks.is_active()
+            && preformatted_blocks.consume_preformatted_line(line.text)
+        {
+            body_end += 1;
+            continue;
+        }
+
+        if line.text.trim().is_empty() {
+            if !blank_line_continues_section(&lines[body_end..], header, item_indent) {
+                break;
+            }
+            while let Some(line) = lines.get(body_end)
+                && line.text.trim().is_empty()
+            {
+                body_end += 1;
+            }
+            continue;
+        }
+
+        if section_header_ends_body(lines, body_end, header, item_indent)
+            || !line_belongs_to_body(header, *line, item_indent)
+        {
+            break;
+        }
+
+        item_indent = item_indent.or_else(|| section_item_indent(header, *line));
+
+        if !preformatted_blocks.consume_preformatted_line(line.text) {
+            preformatted_blocks.observe_line_outside_preformatted_block(line.text);
+        }
+        body_end += 1;
+    }
+
+    let range = lines[header.body_start..body_end]
+        .last()
+        .map_or(header.range, |line| {
+            TextRange::new(header.range.start(), line.range.end())
+        });
+    (body_end, range)
+}
+
+/// Returns whether content after leading blank lines still belongs to `header`.
+fn blank_line_continues_section(
+    lines: &[ParsedLine<'_>],
+    header: SectionHeader,
+    item_indent: Option<TextSize>,
+) -> bool {
+    let Some((offset, next)) = lines
+        .iter()
+        .enumerate()
+        .find(|(_, line)| !line.text.trim().is_empty())
+    else {
+        return false;
+    };
+
+    if next.structural_indent <= header.structural_indent {
+        if parse_section_header(lines, offset).is_some() || is_inline_section_header(next.text) {
+            return false;
+        }
+    }
+
+    // A blank line separates prose aligned with parameter items from the section body.
+    if item_indent == Some(next.raw_indent)
+        && matches!(
+            header.kind,
+            HeaderKind::Structured(
+                SectionKind::Parameters
+                    | SectionKind::KeywordArguments
+                    | SectionKind::OtherParameters
+            )
+        )
+        && section_item_indent(header, *next).is_none()
+    {
+        return false;
+    }
+
+    line_belongs_to_body(header, *next, item_indent)
+}
+
+/// Returns whether a recognized header at `index` ends the current section body.
+fn section_header_ends_body(
+    lines: &[ParsedLine<'_>],
+    index: usize,
+    header: SectionHeader,
+    item_indent: Option<TextSize>,
+) -> bool {
+    let Some(line) = lines.get(index) else {
+        return false;
+    };
+    let prefer_item = prefer_item_over_section_header(header, *line, item_indent);
+    if line.structural_indent <= header.structural_indent && is_inline_section_header(line.text) {
+        return !prefer_item;
+    }
+
+    parse_section_header(lines, index).is_some_and(|next| {
+        next.structural_indent <= header.structural_indent && !prefer_item
+    })
+}
+
+/// Returns whether `line` belongs to `header` under Google-style indentation rules.
+fn line_belongs_to_body(
+    header: SectionHeader,
+    line: ParsedLine<'_>,
+    item_indent: Option<TextSize>,
+) -> bool {
+    let item_indent_matches_line = item_indent.is_none_or(|indent| indent == line.raw_indent);
+    let is_same_indent_parameter_continuation = item_indent == Some(line.raw_indent)
+        && matches!(
+            header.kind,
+            HeaderKind::Structured(
+                SectionKind::Parameters
+                    | SectionKind::KeywordArguments
+                    | SectionKind::OtherParameters
+            )
+        );
+
+    line.raw_indent > header.indent
+        || (line.raw_indent == header.indent
+            && (is_same_indent_parameter_continuation
+                || (item_indent_matches_line && section_item_indent(header, line).is_some())))
+}
+
+/// Returns whether an ambiguous section header is an item in the current section.
+fn prefer_item_over_section_header(
+    header: SectionHeader,
+    line: ParsedLine<'_>,
+    item_indent: Option<TextSize>,
+) -> bool {
+    item_indent.is_none_or(|indent| indent == line.raw_indent)
+        && section_item_indent(header, line).is_some()
+        && (line.raw_indent > header.indent
+            || line
+                .text
+                .trim()
+                .chars()
+                .next()
+                .is_some_and(char::is_lowercase))
+}
+
+/// Returns the indentation of an item recognized in the current section.
+fn section_item_indent(header: SectionHeader, line: ParsedLine<'_>) -> Option<TextSize> {
+    let trimmed = line.text.trim();
+    let is_item = match header.kind {
+        HeaderKind::Structured(
+            SectionKind::Parameters | SectionKind::KeywordArguments | SectionKind::OtherParameters,
+        ) => parse_parameter(trimmed).is_some(),
+        HeaderKind::Container => false,
+    };
+    is_item.then_some(line.raw_indent)
+}
+
+/// Parses a recognized Google-style section header at `index`.
+fn parse_section_header(lines: &[ParsedLine<'_>], index: usize) -> Option<SectionHeader> {
+    let line = lines.get(index)?;
+    let kind = section_kind(line.text)?;
+
+    Some(SectionHeader {
+        kind,
+        indent: line.raw_indent,
+        structural_indent: line.structural_indent,
+        body_start: index + 1,
+        range: line.range,
+    })
+}
+
+fn section_kind(line: &str) -> Option<HeaderKind> {
+    let name = line.trim().strip_suffix(':')?.trim();
+    section_kind_from_name(name)
+}
+
+fn section_kind_from_name(name: &str) -> Option<HeaderKind> {
+    let normalized = name
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    Some(match normalized.as_str() {
+        "args" | "arguments" | "parameters" => HeaderKind::Structured(SectionKind::Parameters),
+        "keyword args" | "keyword arguments" => {
+            HeaderKind::Structured(SectionKind::KeywordArguments)
+        }
+        "other args" | "other arguments" | "other parameters" => {
+            HeaderKind::Structured(SectionKind::OtherParameters)
+        }
+        "attributes" | "return" | "returns" | "yield" | "yields" | "raise" | "raises"
+        | "attention" | "caution" | "danger" | "error" | "example" | "examples" | "hint"
+        | "important" | "methods" | "note" | "notes" | "references" | "see also" | "tip"
+        | "todo" | "todos" | "warning" | "warnings" | "warns" => HeaderKind::Container,
+        _ => return None,
+    })
+}
+
+/// Returns whether `line` is a recognized section header followed by inline content.
+fn is_inline_section_header(line: &str) -> bool {
+    let Some((name, description)) = split_once_unbracketed_colon(line.trim()) else {
+        return false;
+    };
+    let name = name.trim();
+    let description = description.trim();
+    !description.is_empty()
+        && !description.starts_with(':')
+        && name.chars().next().is_some_and(char::is_uppercase)
+        && section_kind_from_name(name).is_some()
+}
+
+/// Parses a parameter item into its display name and description.
+fn parse_parameter(line: &str) -> Option<(&str, &str)> {
+    let (name, description) = split_once_unbracketed_colon(line)?;
+    let (display_name, _) = parse_parenthesized_type(name.trim());
+    google_parameter_names(display_name)
+        .all(is_parameter_name)
+        .then_some((display_name, description.trim()))
+}
+
+/// Extends `parameters` with the documented items in one parameter section body.
+fn extend_parameter_documentation(
+    parameters: &mut IndexMap<String, String>,
+    lines: &[ParsedLine<'_>],
+) {
+    let mut current: Option<(String, String)> = None;
+    let mut item_indent = None;
+
+    // The first item fixes the indentation. Colons at other levels remain continuation prose.
+    for line in lines {
+        let trimmed = line.text.trim();
+        if trimmed.is_empty() {
+            if let Some((_, description)) = &mut current {
+                if !description.is_empty() && !description.ends_with('\n') {
+                    description.push('\n');
+                }
+                description.push('\n');
+            }
+        } else if item_indent.is_none_or(|indent| line.raw_indent == indent)
+            && let Some((names, description)) = parse_parameter(trimmed)
+        {
+            insert_parameter_documentation(
+                parameters,
+                current.replace((names.to_string(), description.to_string())),
+            );
+            item_indent.get_or_insert(line.raw_indent);
+        } else if let Some((_, description)) = &mut current {
+            if !description.is_empty() && !description.ends_with('\n') {
+                description.push('\n');
+            }
+            description.push_str(trimmed);
+        }
+    }
+
+    insert_parameter_documentation(parameters, current);
+}
+
+/// Inserts a completed parameter item under each of its comma-separated names.
+fn insert_parameter_documentation(
+    parameters: &mut IndexMap<String, String>,
+    parameter: Option<(String, String)>,
+) {
+    let Some((names, description)) = parameter else {
+        return;
+    };
+    let description = description.trim();
+    if !description.is_empty() {
+        for name in google_parameter_names(&names) {
+            parameters.insert(name.to_string(), description.to_string());
+        }
+    }
+}
+
+fn google_parameter_names(display_name: &str) -> impl Iterator<Item = &str> {
+    display_name.split(',').map(str::trim)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SectionHeader {
+    kind: HeaderKind,
+    indent: TextSize,
+    structural_indent: TextSize,
+    body_start: usize,
+    range: TextRange,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeaderKind {
+    Structured(SectionKind),
+    Container,
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_text_size::TextSize;
+
+    use super::{SectionKind, parameter_documentation, visit_sections};
+
+    #[test]
+    fn extracts_parameter_items() {
+        for (raw, expected) in [
+            (
+                "Arguments:\nfirst: First parameter.\nAligned continuation.\nsecond: Second parameter.\nReturns:\nbool: Result.",
+                &[
+                    ("first", "First parameter.\nAligned continuation."),
+                    ("second", "Second parameter."),
+                ][..],
+            ),
+            (
+                "Args:\n  \tfirst: First parameter.\n        second: Second parameter.",
+                &[
+                    ("first", "First parameter."),
+                    ("second", "Second parameter."),
+                ],
+            ),
+            (
+                "Args:\n    x, y: Coordinates.",
+                &[("x", "Coordinates."), ("y", "Coordinates.")],
+            ),
+            (
+                "Args:\n    value: Initial documentation.\n    value, for example: can be omitted.",
+                &[(
+                    "value",
+                    "Initial documentation.\nvalue, for example: can be omitted.",
+                )],
+            ),
+            (
+                "Args:\n    value: First documentation.\n    value: Replacement documentation.",
+                &[("value", "Replacement documentation.")],
+            ),
+            (
+                "Args:\n    value (Literal[\"(\"]): Quoted parenthesis.",
+                &[("value", "Quoted parenthesis.")],
+            ),
+            (
+                "Args:\n    callback() (Callable): Not a parameter.\n    value: Documentation.",
+                &[("value", "Documentation.")],
+            ),
+            (
+                "Args:\n    value: First paragraph.\n\n\n        Second paragraph.",
+                &[("value", "First paragraph.\n\n\nSecond paragraph.")],
+            ),
+        ] {
+            assert_parameter_documentation(raw, expected);
+        }
+    }
+
+    #[test]
+    fn recognizes_parameter_section_headings() {
+        for heading in [
+            "Args",
+            "Arguments",
+            "Parameters",
+            "Keyword Args",
+            "Keyword Arguments",
+            "Other Args",
+            "Other Arguments",
+            "Other Parameters",
+        ] {
+            let raw = format!("{heading}:\n    value: Parameter documentation.");
+            assert_parameter_documentation(&raw, &[("value", "Parameter documentation.")]);
+        }
+    }
+
+    #[test]
+    fn respects_section_boundaries() {
+        for (raw, expected) in [
+            (
+                "Args:\n    value: Parameter documentation.\nMethods:\n    helper: Method documentation.",
+                &[("value", "Parameter documentation.")][..],
+            ),
+            (
+                "Example:\n    Args:\n        nested: Not parameter documentation.\nArgs:\n    value: Parameter documentation.",
+                &[("value", "Parameter documentation.")],
+            ),
+            (
+                "Args:\n    first: First parameter.\n    last: Last parameter.\n\nReturns: Result.",
+                &[("first", "First parameter."), ("last", "Last parameter.")],
+            ),
+            (
+                "Args:\nerror:\n    Error documentation.\nargs: Args documentation.\nreturns: Return documentation.\nReturns:\nbool: Result.",
+                &[
+                    ("error", "Error documentation."),
+                    ("args", "Args documentation."),
+                    ("returns", "Return documentation."),
+                ],
+            ),
+            (
+                "Args:\nvalue: Parameter documentation.\n\nAdditional details.",
+                &[("value", "Parameter documentation.")],
+            ),
+            (
+                "Args:\n    Warning: Capitalized parameter.\n    following: Following parameter.",
+                &[
+                    ("Warning", "Capitalized parameter."),
+                    ("following", "Following parameter."),
+                ],
+            ),
+            (
+                "Args:\nfirst: First parameter.\nlast: Last parameter.\nReturns: Result.",
+                &[("first", "First parameter."), ("last", "Last parameter.")],
+            ),
+            (
+                "Args:\n    value: Parameter documentation.\n\n    Additional details.",
+                &[("value", "Parameter documentation.")],
+            ),
+        ] {
+            assert_parameter_documentation(raw, expected);
+        }
+    }
+
+    #[test]
+    fn uses_pep257_indentation_for_section_hierarchy() {
+        assert_parameter_documentation(
+            "Note:\n        context\n\n    Args:\n        value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+        assert_parameter_documentation(
+            "\n    Note:\n        context\n\n        Args:\n            nested: Not parameter documentation.",
+            &[],
+        );
+        assert_parameter_documentation(
+            "Example:\nArgs:\n    value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+        assert_parameter_documentation(
+            "Args:\n        value: Parameter documentation.\n    Returns:\n        bool: Result.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn finds_shifted_top_level_section() {
+        assert_parameter_documentation(
+            "A decoded newline follows:\nThis line starts at column zero.\n\n    Keyword Args:\n        shifted: Documentation in a shifted section.",
+            &[("shifted", "Documentation in a shifted section.")],
+        );
+    }
+
+    #[test]
+    fn keeps_colon_prose_with_variadic_parameters() {
+        assert_parameter_documentation(
+            "Args:\n    param1 (str): The first parameter description.\n    For example: pass an absolute path.\n    *args: Extra positional arguments.\n    **kwargs: Extra keyword arguments.",
+            &[
+                (
+                    "param1",
+                    "The first parameter description.\nFor example: pass an absolute path.",
+                ),
+                ("*args", "Extra positional arguments."),
+                ("**kwargs", "Extra keyword arguments."),
+            ],
+        );
+    }
+
+    #[test]
+    fn ignores_sections_in_other_containers() {
+        for raw in [
+            ".. note::\n    Args:\n        nested: Not parameter documentation.",
+            ".. note::\n\n        Keyword Args:\n            nested: Not parameter documentation.",
+            "- Example:\n    Args:\n        nested: Not parameter documentation.",
+            "- Example:\n\n        Args:\n            nested: Not parameter documentation.",
+            "1. Example:\n    Args:\n        nested: Not parameter documentation.",
+            ":param value: Example input.\n    Args:\n        nested: Not parameter documentation.",
+            "Example::\n\n        Args:\n            nested: Not parameter documentation.",
+        ] {
+            assert_parameter_documentation(raw, &[]);
+        }
+
+        for raw in [
+            "Summary.\n\n    ```text\n    Args:\n        nested: Not parameter documentation.\n    ```\n\n    Args:\n        value: Parameter documentation.",
+            "Summary.\n\n    Example::\n\n        Args:\n            nested: Not parameter documentation.\n\n    Args:\n        value: Parameter documentation.",
+        ] {
+            assert_parameter_documentation(raw, &[("value", "Parameter documentation.")]);
+        }
+
+        assert_parameter_documentation(
+            ".. note::\n    Args:\n        nested: Not parameter documentation.\nArgs:\n    value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn ignores_doctest_content_and_resumes_after_it() {
+        for raw in [
+            "        >>> example()\n\tArgs:\n\t    nested: Not parameter documentation.",
+            "        >>> example()\n        \u{a0}\n        Args:\n            nested: Not parameter documentation.",
+        ] {
+            assert_parameter_documentation(raw, &[]);
+        }
+        assert_parameter_documentation(
+            "        >>> example()\n        result\n\t\n        Args:\n            value: Parameter documentation.",
+            &[("value", "Parameter documentation.")],
+        );
+    }
+
+    #[test]
+    fn double_colon_is_not_an_inline_section_header() {
+        assert_parameter_documentation(
+            "Args:\nvalue: Parameter documentation.\nReturns:: reST literal marker.",
+            &[
+                ("value", "Parameter documentation."),
+                ("Returns", ": reST literal marker."),
+            ],
+        );
+    }
+
+    #[test]
+    fn visits_parameter_sections_with_metadata() {
+        let raw = "    Args:\r\n        value: Documentation.\r\nKeyword Args:\r\n    option: Optional.\r\nOther Parameters:\r\n    other: Other.\r\nReturns:\r\n    bool: Result.";
+        let mut sections = Vec::new();
+        visit_sections(raw, |kind, range, header_indent, body| {
+            sections.push((
+                kind,
+                &raw[range],
+                header_indent,
+                body.iter().map(|line| line.text).collect::<Vec<_>>(),
+            ));
+        });
+
+        assert_eq!(
+            sections,
+            vec![
+                (
+                    SectionKind::Parameters,
+                    "    Args:\r\n        value: Documentation.",
+                    TextSize::new(4),
+                    vec!["        value: Documentation."],
+                ),
+                (
+                    SectionKind::KeywordArguments,
+                    "Keyword Args:\r\n    option: Optional.",
+                    TextSize::new(0),
+                    vec!["    option: Optional."],
+                ),
+                (
+                    SectionKind::OtherParameters,
+                    "Other Parameters:\r\n    other: Other.",
+                    TextSize::new(0),
+                    vec!["    other: Other."],
+                ),
+            ]
+        );
+    }
+
+    fn assert_parameter_documentation(raw: &str, expected: &[(&str, &str)]) {
+        let parameters = parameter_documentation(raw);
+        assert_eq!(parameters.len(), expected.len(), "{raw}");
+        for &(name, documentation) in expected {
+            assert_eq!(
+                parameters.get(name).map(String::as_str),
+                Some(documentation),
+                "{raw}"
+            );
+        }
+    }
+}

--- a/crates/ty_ide/src/docstring/document/google.rs
+++ b/crates/ty_ide/src/docstring/document/google.rs
@@ -23,7 +23,7 @@ pub(super) fn parameter_documentation(raw: &str) -> IndexMap<String, String> {
     parameters
 }
 
-/// Visits recognized Google-style parameter sections in source order.
+/// Visits recognized Google-style sections in source order.
 pub(in crate::docstring) fn visit_sections<'a>(
     raw: &'a str,
     mut visit: impl FnMut(SectionKind, TextRange, TextSize, &[ParsedLine<'a>]),
@@ -62,7 +62,7 @@ pub(in crate::docstring) fn visit_sections<'a>(
 }
 
 /// Returns whether `name` is a valid Python parameter name, including variadic prefixes.
-fn is_parameter_name(name: &str) -> bool {
+pub(in crate::docstring) fn is_parameter_name(name: &str) -> bool {
     let identifier = name
         .strip_prefix("**")
         .or_else(|| name.strip_prefix('*'))
@@ -137,6 +137,17 @@ fn blank_line_continues_section(
         if parse_section_header(lines, offset).is_some() || is_inline_section_header(next.text) {
             return false;
         }
+        // Returns and yields have no item syntax that distinguishes an aligned body from prose
+        // following an empty section.
+        if next.raw_indent <= header.indent
+            && item_indent.is_none()
+            && matches!(
+                header.kind,
+                HeaderKind::Structured(SectionKind::Returns | SectionKind::Yields)
+            )
+        {
+            return false;
+        }
     }
 
     // A blank line separates prose aligned with parameter items from the section body.
@@ -172,9 +183,8 @@ fn section_header_ends_body(
         return !prefer_item;
     }
 
-    parse_section_header(lines, index).is_some_and(|next| {
-        next.structural_indent <= header.structural_indent && !prefer_item
-    })
+    parse_section_header(lines, index)
+        .is_some_and(|next| next.structural_indent <= header.structural_indent && !prefer_item)
 }
 
 /// Returns whether `line` belongs to `header` under Google-style indentation rules.
@@ -206,15 +216,28 @@ fn prefer_item_over_section_header(
     line: ParsedLine<'_>,
     item_indent: Option<TextSize>,
 ) -> bool {
+    let has_named_items = matches!(
+        header.kind,
+        HeaderKind::Structured(
+            SectionKind::Parameters
+                | SectionKind::KeywordArguments
+                | SectionKind::OtherParameters
+                | SectionKind::Attributes
+                | SectionKind::Raises
+        )
+    );
     item_indent.is_none_or(|indent| indent == line.raw_indent)
         && section_item_indent(header, line).is_some()
-        && (line.raw_indent > header.indent
+        && ((has_named_items && line.raw_indent > header.indent)
             || line
                 .text
                 .trim()
                 .chars()
                 .next()
-                .is_some_and(char::is_lowercase))
+                .is_some_and(char::is_lowercase)
+            || (matches!(header.kind, HeaderKind::Structured(SectionKind::Raises))
+                && split_once_unbracketed_colon(line.text.trim())
+                    .is_some_and(|(name, _)| has_exception_name_suffix(name.trim()))))
 }
 
 /// Returns the indentation of an item recognized in the current section.
@@ -224,6 +247,10 @@ fn section_item_indent(header: SectionHeader, line: ParsedLine<'_>) -> Option<Te
         HeaderKind::Structured(
             SectionKind::Parameters | SectionKind::KeywordArguments | SectionKind::OtherParameters,
         ) => parse_parameter(trimmed).is_some(),
+        HeaderKind::Structured(SectionKind::Attributes | SectionKind::Raises) => {
+            split_once_unbracketed_colon(trimmed).is_some_and(|(name, _)| !name.trim().is_empty())
+        }
+        HeaderKind::Structured(SectionKind::Returns | SectionKind::Yields) => !trimmed.is_empty(),
         HeaderKind::Container => false,
     };
     is_item.then_some(line.raw_indent)
@@ -262,8 +289,11 @@ fn section_kind_from_name(name: &str) -> Option<HeaderKind> {
         "other args" | "other arguments" | "other parameters" => {
             HeaderKind::Structured(SectionKind::OtherParameters)
         }
-        "attributes" | "return" | "returns" | "yield" | "yields" | "raise" | "raises"
-        | "attention" | "caution" | "danger" | "error" | "example" | "examples" | "hint"
+        "attributes" => HeaderKind::Structured(SectionKind::Attributes),
+        "return" | "returns" => HeaderKind::Structured(SectionKind::Returns),
+        "yield" | "yields" => HeaderKind::Structured(SectionKind::Yields),
+        "raise" | "raises" => HeaderKind::Structured(SectionKind::Raises),
+        "attention" | "caution" | "danger" | "error" | "example" | "examples" | "hint"
         | "important" | "methods" | "note" | "notes" | "references" | "see also" | "tip"
         | "todo" | "todos" | "warning" | "warnings" | "warns" => HeaderKind::Container,
         _ => return None,
@@ -281,6 +311,18 @@ fn is_inline_section_header(line: &str) -> bool {
         && !description.starts_with(':')
         && name.chars().next().is_some_and(char::is_uppercase)
         && section_kind_from_name(name).is_some()
+}
+
+/// Returns whether `line` is a recognized Google-style section header.
+pub(in crate::docstring) fn is_section_like_header(line: &str) -> bool {
+    section_kind(line).is_some() || is_inline_section_header(line)
+}
+
+/// Returns whether `name` ends with a conventional exception-class suffix.
+pub(in crate::docstring) fn has_exception_name_suffix(name: &str) -> bool {
+    ["Error", "Exception", "Warning"]
+        .iter()
+        .any(|suffix| name.ends_with(suffix))
 }
 
 /// Parses a parameter item into its display name and description.
@@ -347,6 +389,11 @@ fn insert_parameter_documentation(
 
 fn google_parameter_names(display_name: &str) -> impl Iterator<Item = &str> {
     display_name.split(',').map(str::trim)
+}
+
+/// Returns whether every component of `name` is a Python identifier.
+pub(in crate::docstring) fn is_dotted_identifier(name: &str) -> bool {
+    !name.is_empty() && name.split('.').all(is_identifier)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -579,7 +626,7 @@ mod tests {
     }
 
     #[test]
-    fn visits_parameter_sections_with_metadata() {
+    fn visits_structured_sections_with_final_metadata() {
         let raw = "    Args:\r\n        value: Documentation.\r\nKeyword Args:\r\n    option: Optional.\r\nOther Parameters:\r\n    other: Other.\r\nReturns:\r\n    bool: Result.";
         let mut sections = Vec::new();
         visit_sections(raw, |kind, range, header_indent, body| {
@@ -611,6 +658,12 @@ mod tests {
                     "Other Parameters:\r\n    other: Other.",
                     TextSize::new(0),
                     vec!["    other: Other."],
+                ),
+                (
+                    SectionKind::Returns,
+                    "Returns:\r\n    bool: Result.",
+                    TextSize::new(0),
+                    vec!["    bool: Result."],
                 ),
             ]
         );

--- a/crates/ty_ide/src/docstring/document/preformatted.rs
+++ b/crates/ty_ide/src/docstring/document/preformatted.rs
@@ -1,6 +1,8 @@
 use ruff_python_trivia::leading_indentation;
 use ruff_text_size::TextSize;
 
+use super::syntax::indentation as visual_indentation;
+
 /// Represents a fenced Markdown code block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::docstring) struct MarkdownFence<'a> {
@@ -54,6 +56,16 @@ pub(super) struct PreformattedBlockScanner<'a> {
 const QUOTED_LITERAL_BLOCK_QUOTE_CHARACTERS: &str = r##"!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"##;
 
 impl<'a> PreformattedBlockScanner<'a> {
+    /// Returns whether the scanner is currently inside an accepted preformatted block.
+    pub(super) fn is_active(&self) -> bool {
+        self.active_markdown_fence.is_some()
+            || self.active_doctest_indent.is_some()
+            || matches!(
+                self.rest_literal_blocks.state,
+                RestLiteralBlockState::Active(_)
+            )
+    }
+
     /// Updates internal state to reflect the given line and returns whether or
     /// not the given line is contained within a preformatted block.
     pub(super) fn consume_preformatted_line(&mut self, line: &'a str) -> bool {
@@ -69,10 +81,10 @@ impl<'a> PreformattedBlockScanner<'a> {
         }
 
         if let Some(doctest_indent) = self.active_doctest_indent {
-            if line.trim_start_matches(' ').is_empty() {
+            if line.bytes().all(|byte| matches!(byte, b' ' | b'\t')) {
                 self.active_doctest_indent = None;
                 return true;
-            } else if indentation(line) < doctest_indent {
+            } else if visual_indentation(line) < doctest_indent {
                 self.active_doctest_indent = None;
             } else {
                 return true;
@@ -80,7 +92,7 @@ impl<'a> PreformattedBlockScanner<'a> {
         }
 
         if Self::line_starts_doctest(line) {
-            self.active_doctest_indent = Some(indentation(line));
+            self.active_doctest_indent = Some(visual_indentation(line));
             return true;
         }
 

--- a/crates/ty_ide/src/docstring/document/preformatted.rs
+++ b/crates/ty_ide/src/docstring/document/preformatted.rs
@@ -44,7 +44,7 @@ impl<'a> MarkdownFence<'a> {
 
 /// Recognizes preformatted blocks that may occur within a docstring.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub(super) struct PreformattedBlockScanner<'a> {
+pub(in crate::docstring) struct PreformattedBlockScanner<'a> {
     active_markdown_fence: Option<MarkdownFence<'a>>,
     active_doctest_indent: Option<TextSize>,
     rest_literal_blocks: RestLiteralBlockScanner,
@@ -57,7 +57,7 @@ const QUOTED_LITERAL_BLOCK_QUOTE_CHARACTERS: &str = r##"!"#$%&'()*+,-./:;<=>?@[\
 
 impl<'a> PreformattedBlockScanner<'a> {
     /// Returns whether the scanner is currently inside an accepted preformatted block.
-    pub(super) fn is_active(&self) -> bool {
+    pub(in crate::docstring) fn is_active(&self) -> bool {
         self.active_markdown_fence.is_some()
             || self.active_doctest_indent.is_some()
             || matches!(
@@ -68,7 +68,7 @@ impl<'a> PreformattedBlockScanner<'a> {
 
     /// Updates internal state to reflect the given line and returns whether or
     /// not the given line is contained within a preformatted block.
-    pub(super) fn consume_preformatted_line(&mut self, line: &'a str) -> bool {
+    pub(in crate::docstring) fn consume_preformatted_line(&mut self, line: &'a str) -> bool {
         if let Some(fence) = self.active_markdown_fence {
             if fence.is_closed_by(line) {
                 self.active_markdown_fence = None;
@@ -105,8 +105,13 @@ impl<'a> PreformattedBlockScanner<'a> {
     }
 
     /// Updates internal state for a line outside of any active preformatted block.
-    pub(super) fn observe_line_outside_preformatted_block(&mut self, line: &str) {
+    pub(in crate::docstring) fn observe_line_outside_preformatted_block(&mut self, line: &str) {
         self.rest_literal_blocks.observe_marker_in_line(line);
+    }
+
+    /// Returns whether the line introduces a reST literal block.
+    pub(in crate::docstring) fn line_starts_rest_literal_block(line: &str) -> bool {
+        RestLiteralBlockScanner::line_starts_literal_block(line.trim_start())
     }
 
     /// Whether or not the given line marks the start of a doctest.

--- a/crates/ty_ide/src/docstring/document/rst.rs
+++ b/crates/ty_ide/src/docstring/document/rst.rs
@@ -13,6 +13,11 @@ fn field_lists(raw: &str) -> Vec<FieldList> {
     FieldList::parse_all(raw)
 }
 
+/// Returns whether `line` starts a reST field-list item.
+pub(in crate::docstring) fn is_field_list_marker(line: &str) -> bool {
+    FieldHeader::parse_list_member(line).is_some()
+}
+
 /// Returns top-level field lists that begin at a reST block boundary.
 ///
 /// `source` must have already undergone PEP-257 trimming and universal newline

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -58,14 +58,14 @@ pub(in crate::docstring) fn starts_with_markdown_list_item(line: &str) -> bool {
         return true;
     }
 
-    let digits = bytes
+    let digit_count = bytes
         .iter()
         .take(9)
         .take_while(|byte| byte.is_ascii_digit())
         .count();
-    digits > 0
-        && matches!(bytes.get(digits), Some(b'.' | b')'))
-        && matches!(bytes.get(digits + 1), Some(b' ' | b'\t'))
+    digit_count > 0
+        && matches!(bytes.get(digit_count), Some(b'.' | b')'))
+        && matches!(bytes.get(digit_count + 1), Some(b' ' | b'\t'))
 }
 
 /// Returns the end of an indented Markdown or reStructuredText container block.
@@ -106,63 +106,110 @@ fn is_rest_directive_marker(line: &str) -> bool {
 
 /// Splits the input once at the first colon outside bracket pairs and quoted strings.
 pub(in crate::docstring) fn split_once_unbracketed_colon(line: &str) -> Option<(&str, &str)> {
-    let mut depths = [0usize; 3];
+    // Track each bracket kind independently because type expressions can nest them in any order.
+    let mut parentheses = 0usize;
+    let mut brackets = 0usize;
+    let mut braces = 0usize;
     let mut quote = None;
     let mut escaped = false;
+    let mut code_span_delimiter_len = None;
+    let mut index = 0;
 
-    for (index, character) in line.char_indices() {
-        if let Some(quote_character) = quote {
-            if escaped {
-                escaped = false;
-            } else if character == '\\' {
-                escaped = true;
-            } else if character == quote_character {
-                quote = None;
+    while index < line.len() {
+        let rest = &line[index..];
+        let char = rest.chars().next()?;
+        if let Some(opening_len) = code_span_delimiter_len {
+            if char == '`' {
+                let delimiter_len = rest.bytes().take_while(|byte| *byte == b'`').count();
+                if opening_len == delimiter_len {
+                    code_span_delimiter_len = None;
+                }
+                index += delimiter_len;
+            } else {
+                index += char.len_utf8();
             }
             continue;
         }
 
-        match character {
-            '\'' | '"' => quote = Some(character),
-            '(' => depths[0] += 1,
-            ')' => depths[0] = depths[0].saturating_sub(1),
-            '[' => depths[1] += 1,
-            ']' => depths[1] = depths[1].saturating_sub(1),
-            '{' => depths[2] += 1,
-            '}' => depths[2] = depths[2].saturating_sub(1),
-            ':' if depths == [0; 3] => {
-                return Some((&line[..index], &line[index + character.len_utf8()..]));
+        if let Some(quote_char) = quote {
+            // Brackets and colons inside a quoted literal are not structural.
+            if escaped {
+                escaped = false;
+            } else if char == '\\' {
+                escaped = true;
+            } else if char == quote_char {
+                quote = None;
+            }
+            index += char.len_utf8();
+            continue;
+        }
+
+        if char == '`' {
+            let delimiter_len = rest.bytes().take_while(|byte| *byte == b'`').count();
+            code_span_delimiter_len = Some(delimiter_len);
+            index += delimiter_len;
+            continue;
+        }
+
+        // Saturating depth updates tolerate unmatched closing brackets in malformed input.
+        match char {
+            '\'' | '"' => quote = Some(char),
+            '(' => parentheses += 1,
+            ')' => parentheses = parentheses.saturating_sub(1),
+            '[' => brackets += 1,
+            ']' => brackets = brackets.saturating_sub(1),
+            '{' => braces += 1,
+            '}' => braces = braces.saturating_sub(1),
+            ':' if parentheses == 0 && brackets == 0 && braces == 0 => {
+                return Some((&line[..index], &line[index + ':'.len_utf8()..]));
             }
             _ => {}
         }
+        index += char.len_utf8();
     }
+
     None
 }
 
 /// Splits a trailing parenthesized type from a parameter display name.
 pub(in crate::docstring) fn parse_parenthesized_type(name: &str) -> (&str, Option<&str>) {
-    if !name.ends_with(')') {
+    let Some((display_name, ty)) = split_parenthesized_suffix(name) else {
         return (name, None);
+    };
+    let display_name = display_name.trim();
+    let ty = ty.trim();
+    if display_name.is_empty() || ty.is_empty() {
+        (name, None)
+    } else {
+        (display_name, Some(ty))
+    }
+}
+
+fn split_parenthesized_suffix(value: &str) -> Option<(&str, &str)> {
+    if !value.ends_with(')') {
+        return None;
     }
 
     let mut depth = 0usize;
     let mut opening = None;
     let mut quote = None;
     let mut escaped = false;
-    for (index, character) in name.char_indices() {
-        if let Some(quote_character) = quote {
+
+    // Only a balanced group that closes at the end can be a type suffix.
+    for (index, char) in value.char_indices() {
+        if let Some(quote_char) = quote {
             if escaped {
                 escaped = false;
-            } else if character == '\\' {
+            } else if char == '\\' {
                 escaped = true;
-            } else if character == quote_character {
+            } else if char == quote_char {
                 quote = None;
             }
             continue;
         }
 
-        match character {
-            '\'' | '"' => quote = Some(character),
+        match char {
+            '\'' | '"' => quote = Some(char),
             '(' => {
                 if depth == 0 {
                     opening = Some(index);
@@ -170,30 +217,121 @@ pub(in crate::docstring) fn parse_parenthesized_type(name: &str) -> (&str, Optio
                 depth += 1;
             }
             ')' => {
-                depth = match depth.checked_sub(1) {
-                    Some(depth) => depth,
-                    None => return (name, None),
-                };
-                if depth == 0 && index + character.len_utf8() == name.len() {
-                    let Some(opening) = opening else {
-                        return (name, None);
-                    };
-                    let display_name = name[..opening].trim();
-                    let ty = name[opening + '('.len_utf8()..index].trim();
-                    return if display_name.is_empty() || ty.is_empty() {
-                        (name, None)
-                    } else {
-                        (display_name, Some(ty))
-                    };
+                let new_depth = depth.checked_sub(1)?;
+                depth = new_depth;
+                if depth == 0 && index + char.len_utf8() == value.len() {
+                    let opening = opening?;
+                    return Some((&value[..opening], &value[opening + '('.len_utf8()..index]));
                 }
             }
             _ => {}
         }
     }
-    (name, None)
+
+    None
 }
 
-/// Calculates indentation width, advancing tabs to the next multiple of eight columns.
+/// Removes a balanced Markdown code-span wrapper from a documented type.
+pub(in crate::docstring) fn strip_code_span_wrapper(ty: &str) -> &str {
+    let delimiter_len = ty.bytes().take_while(|byte| *byte == b'`').count();
+    let closing_delimiter_len = ty.bytes().rev().take_while(|byte| *byte == b'`').count();
+    if delimiter_len == 0 || delimiter_len != closing_delimiter_len || delimiter_len > ty.len() / 2
+    {
+        return ty;
+    }
+
+    let inner = &ty[delimiter_len..ty.len() - delimiter_len];
+    if inner
+        .split(|character| character != '`')
+        .any(|run| run.len() == delimiter_len)
+    {
+        return ty;
+    }
+
+    let inner = inner.trim();
+    if inner.is_empty() { ty } else { inner }
+}
+
+/// Returns whether `ty` resembles a type expression used in docstrings.
+pub(in crate::docstring) fn is_docstring_type_expression(ty: &str) -> bool {
+    let ty = strip_code_span_wrapper(ty);
+    if !has_docstring_type_expression_characters(ty) {
+        return false;
+    }
+
+    if !ty.chars().any(char::is_whitespace) {
+        return true;
+    }
+
+    // Whitespace makes prose ambiguous, so require syntax that strongly indicates a type.
+    is_subscript_style_docstring_type_expression(ty)
+        || ty.contains('|')
+        || is_call_style_docstring_type_expression(ty)
+        || is_conventional_spaced_docstring_type_expression(ty)
+}
+
+fn is_subscript_style_docstring_type_expression(ty: &str) -> bool {
+    ty.split_once('[')
+        .is_some_and(|(name, _)| is_docstring_type_expression_atom(name) && ty.ends_with(']'))
+}
+
+fn is_call_style_docstring_type_expression(ty: &str) -> bool {
+    split_parenthesized_suffix(ty).is_some_and(|(name, arguments)| {
+        !name.contains(['(', ')'])
+            && is_docstring_type_expression_atom(name)
+            && arguments
+                .split(',')
+                .all(|argument| is_docstring_type_expression_atom(argument.trim()))
+    })
+}
+
+fn is_conventional_spaced_docstring_type_expression(ty: &str) -> bool {
+    let mut tokens = ty.split_whitespace();
+    let Some(first) = tokens.next() else {
+        return false;
+    };
+    if !is_docstring_type_expression_atom(first) {
+        return false;
+    }
+
+    let mut found_connector = false;
+    while let Some(connector) = tokens.next() {
+        if !matches!(connector, "of" | "or") {
+            return false;
+        }
+        let Some(atom) = tokens.next() else {
+            return false;
+        };
+        if !is_docstring_type_expression_atom(atom) {
+            return false;
+        }
+        found_connector = true;
+    }
+
+    found_connector
+}
+
+fn is_docstring_type_expression_atom(atom: &str) -> bool {
+    !atom.chars().any(char::is_whitespace) && has_docstring_type_expression_characters(atom)
+}
+
+fn has_docstring_type_expression_characters(expression: &str) -> bool {
+    expression
+        .chars()
+        .next()
+        .is_some_and(is_docstring_type_expression_start)
+        && expression.chars().all(is_docstring_type_expression_char)
+}
+
+fn is_docstring_type_expression_start(ch: char) -> bool {
+    ch.is_ascii_alphabetic() || matches!(ch, '_' | '~' | ':' | '`' | '(')
+}
+
+fn is_docstring_type_expression_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || "_.[](){},|\"':/ `~-".contains(ch)
+}
+
+/// Calculates indentation width, treating tabs like Python does.
 pub(in crate::docstring) fn indentation(line: &str) -> TextSize {
     TextSize::new(
         leading_indentation(line)

--- a/crates/ty_ide/src/docstring/document/syntax.rs
+++ b/crates/ty_ide/src/docstring/document/syntax.rs
@@ -1,0 +1,206 @@
+use ruff_python_trivia::leading_indentation;
+use ruff_source_file::UniversalNewlines;
+use ruff_text_size::{TextRange, TextSize};
+
+use super::rst::is_field_list_marker;
+
+/// Collects docstring lines without their universal-newline terminators while preserving their
+/// source ranges.
+///
+/// For example, `first\r\nsecond` yields `first` at offset 0 and `second` at offset 7.
+pub(in crate::docstring) fn parsed_lines(raw: &str) -> Vec<ParsedLine<'_>> {
+    let mut lines = raw
+        .universal_newlines()
+        .map(|line| ParsedLine {
+            text: line.as_str(),
+            range: line.range(),
+            raw_indent: indentation(line.as_str()),
+            structural_indent: TextSize::new(0),
+        })
+        .collect::<Vec<_>>();
+
+    // PEP 257 ignores indentation on the first physical line and removes the common margin from
+    // all later lines. Keep the raw indentation as well because item and block indentation can
+    // still disambiguate content within a section.
+    let continuation_margin = lines
+        .iter()
+        .skip(1)
+        .filter(|line| !line.text.trim().is_empty())
+        .map(|line| line.raw_indent)
+        .min()
+        .unwrap_or(TextSize::new(0));
+    for line in lines.iter_mut().skip(1) {
+        line.structural_indent = line.raw_indent.saturating_sub(continuation_margin);
+    }
+
+    lines
+}
+
+/// A docstring line and its source range, excluding the newline terminator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::docstring) struct ParsedLine<'a> {
+    /// The line text, excluding its newline terminator.
+    pub(in crate::docstring) text: &'a str,
+    /// The byte range of `text` within the source document.
+    pub(in crate::docstring) range: TextRange,
+    /// The indentation in the decoded docstring text.
+    pub(in crate::docstring) raw_indent: TextSize,
+    /// The indentation after removing the PEP 257 continuation margin.
+    pub(in crate::docstring) structural_indent: TextSize,
+}
+
+/// Returns whether `line` starts with a `CommonMark` list-item marker.
+///
+/// Ordered markers are limited to nine digits, as required by `CommonMark`.
+pub(in crate::docstring) fn starts_with_markdown_list_item(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    if matches!(bytes, [b'-' | b'+' | b'*', b' ' | b'\t', ..]) {
+        return true;
+    }
+
+    let digits = bytes
+        .iter()
+        .take(9)
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    digits > 0
+        && matches!(bytes.get(digits), Some(b'.' | b')'))
+        && matches!(bytes.get(digits + 1), Some(b' ' | b'\t'))
+}
+
+/// Returns the end of an indented Markdown or reStructuredText container block.
+pub(in crate::docstring) fn indented_container_end(
+    lines: &[ParsedLine<'_>],
+    index: usize,
+) -> Option<usize> {
+    let marker = lines.get(index)?;
+    if !is_rest_directive_marker(marker.text)
+        && !is_field_list_marker(marker.text)
+        && !starts_with_markdown_list_item(marker.text.trim_start())
+    {
+        return None;
+    }
+
+    // Container membership is determined before PEP 257 normalization. This keeps raw-indented
+    // section-like text inside lists, directives, and field-list entries.
+    Some(
+        (index + 1..lines.len())
+            .find(|&end| {
+                let line = lines[end];
+                !line.text.trim().is_empty() && line.raw_indent <= marker.raw_indent
+            })
+            .unwrap_or(lines.len()),
+    )
+}
+
+fn is_rest_directive_marker(line: &str) -> bool {
+    let Some(directive) = line.trim_start().strip_prefix(".. ") else {
+        return false;
+    };
+    let Some((name, _)) = directive.split_once("::") else {
+        return false;
+    };
+
+    !name.is_empty() && !name.chars().any(char::is_whitespace)
+}
+
+/// Splits the input once at the first colon outside bracket pairs and quoted strings.
+pub(in crate::docstring) fn split_once_unbracketed_colon(line: &str) -> Option<(&str, &str)> {
+    let mut depths = [0usize; 3];
+    let mut quote = None;
+    let mut escaped = false;
+
+    for (index, character) in line.char_indices() {
+        if let Some(quote_character) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == quote_character {
+                quote = None;
+            }
+            continue;
+        }
+
+        match character {
+            '\'' | '"' => quote = Some(character),
+            '(' => depths[0] += 1,
+            ')' => depths[0] = depths[0].saturating_sub(1),
+            '[' => depths[1] += 1,
+            ']' => depths[1] = depths[1].saturating_sub(1),
+            '{' => depths[2] += 1,
+            '}' => depths[2] = depths[2].saturating_sub(1),
+            ':' if depths == [0; 3] => {
+                return Some((&line[..index], &line[index + character.len_utf8()..]));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Splits a trailing parenthesized type from a parameter display name.
+pub(in crate::docstring) fn parse_parenthesized_type(name: &str) -> (&str, Option<&str>) {
+    if !name.ends_with(')') {
+        return (name, None);
+    }
+
+    let mut depth = 0usize;
+    let mut opening = None;
+    let mut quote = None;
+    let mut escaped = false;
+    for (index, character) in name.char_indices() {
+        if let Some(quote_character) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == quote_character {
+                quote = None;
+            }
+            continue;
+        }
+
+        match character {
+            '\'' | '"' => quote = Some(character),
+            '(' => {
+                if depth == 0 {
+                    opening = Some(index);
+                }
+                depth += 1;
+            }
+            ')' => {
+                depth = match depth.checked_sub(1) {
+                    Some(depth) => depth,
+                    None => return (name, None),
+                };
+                if depth == 0 && index + character.len_utf8() == name.len() {
+                    let Some(opening) = opening else {
+                        return (name, None);
+                    };
+                    let display_name = name[..opening].trim();
+                    let ty = name[opening + '('.len_utf8()..index].trim();
+                    return if display_name.is_empty() || ty.is_empty() {
+                        (name, None)
+                    } else {
+                        (display_name, Some(ty))
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+    (name, None)
+}
+
+/// Calculates indentation width, advancing tabs to the next multiple of eight columns.
+pub(in crate::docstring) fn indentation(line: &str) -> TextSize {
+    TextSize::new(
+        leading_indentation(line)
+            .bytes()
+            .fold(0u32, |column, byte| match byte {
+                b'\t' => (column / 8 + 1) * 8,
+                _ => column + 1,
+            }),
+    )
+}

--- a/crates/ty_ide/src/docstring/markdown.rs
+++ b/crates/ty_ide/src/docstring/markdown.rs
@@ -1,15 +1,13 @@
 mod general;
 mod structured;
 
-use super::DocstringFragment;
+use super::{DocstringFragment, documentation_trim};
 
-/// Render Markdown for a source docstring.
-///
-/// `source` must have already undergone PEP-257 trimming and universal newline
-/// normalization (typically via `docstring::documentation_trim`).
-pub(super) fn render(source: &str) -> String {
+/// Renders Markdown for a decoded source docstring.
+pub(super) fn render(raw: &str) -> String {
+    let source = documentation_trim(raw);
     let mut output = String::new();
-    structured::render_into(&mut output, source);
+    structured::render_into(&mut output, raw, &source);
     output
 }
 

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -2,19 +2,66 @@ use std::borrow::Cow;
 
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use strum::IntoEnumIterator;
-use strum_macros::EnumIter;
 
 use super::general;
 use crate::docstring::document::preformatted::MarkdownFence;
+use crate::docstring::document::syntax::{parsed_lines, starts_with_markdown_list_item};
+use crate::docstring::document::{SectionKind, google as google_document};
 
+mod body;
+mod google;
 mod rst;
 
-/// Renders a docstring as Markdown.
+/// Renders a decoded docstring as Markdown.
 ///
+/// `raw` preserves the indentation that determines container ownership.
 /// `source` must have already undergone PEP-257 trimming and universal newline
 /// normalization (typically via `docstring::documentation_trim`).
-pub(super) fn render_into(output: &mut String, source: &str) {
-    render_sections_into(output, source, rst::structured_sections(source));
+pub(super) fn render_into(output: &mut String, raw: &str, source: &str) {
+    let line_offsets = NormalizedLineOffsets::new(raw, source);
+    let mut google_starts = Vec::new();
+    google_document::visit_sections(raw, |_, range, _, _| {
+        if let Some(start) = line_offsets.normalized(range.start()) {
+            google_starts.push(start);
+        }
+    });
+
+    let mut sections = rst::structured_sections(source);
+    sections.extend(
+        google::structured_sections(source)
+            .into_iter()
+            .filter(|section| google_starts.binary_search(&section.start()).is_ok()),
+    );
+    render_sections_into(output, source, sections);
+}
+
+/// Maps source-line starts to their offsets after PEP 257 normalization.
+struct NormalizedLineOffsets {
+    offsets: Vec<(TextSize, TextSize)>,
+}
+
+impl NormalizedLineOffsets {
+    fn new(raw: &str, source: &str) -> Self {
+        let raw_lines = parsed_lines(raw);
+        let source_lines = parsed_lines(source);
+        let first_content_line = raw_lines
+            .iter()
+            .position(|line| !line.text.trim().is_empty())
+            .unwrap_or(raw_lines.len());
+        let offsets = raw_lines[first_content_line..]
+            .iter()
+            .zip(source_lines)
+            .map(|(raw, normalized)| (raw.range.start(), normalized.range.start()))
+            .collect();
+        Self { offsets }
+    }
+
+    fn normalized(&self, raw: TextSize) -> Option<TextSize> {
+        self.offsets
+            .binary_search_by_key(&raw, |&(raw_start, _)| raw_start)
+            .ok()
+            .map(|index| self.offsets[index].1)
+    }
 }
 
 /// Renders a docstring from non-overlapping structured sections and general source fragments.
@@ -252,32 +299,6 @@ impl SectionItem {
     }
 }
 
-/// Canonical docstring sections shared by supported formats.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter)]
-enum SectionKind {
-    Parameters,
-    KeywordArguments,
-    OtherParameters,
-    Attributes,
-    Returns,
-    Yields,
-    Raises,
-}
-
-impl SectionKind {
-    const fn heading(self) -> &'static str {
-        match self {
-            SectionKind::Parameters => "Parameters",
-            SectionKind::KeywordArguments => "Keyword Arguments",
-            SectionKind::OtherParameters => "Other Parameters",
-            SectionKind::Attributes => "Attributes",
-            SectionKind::Returns => "Returns",
-            SectionKind::Yields => "Yields",
-            SectionKind::Raises => "Raises",
-        }
-    }
-}
-
 fn render_markdown_section<'a>(
     output: &mut String,
     heading: &str,
@@ -306,45 +327,9 @@ fn render_markdown_section<'a>(
     rendered_field
 }
 
-fn starts_with_markdown_list_item(line: &str) -> bool {
-    starts_with_unordered_markdown_list_item(line) || starts_with_ordered_markdown_list_item(line)
-}
-
 fn line_starts_markdown_block_content(line: &str, at_description_start: bool) -> bool {
     MarkdownFence::find(line).is_some()
         || (at_description_start && starts_with_markdown_list_item(line))
-}
-
-/// Returns whether `line` begins with `-`, `+`, or `*` followed by whitespace.
-fn starts_with_unordered_markdown_list_item(line: &str) -> bool {
-    matches!(line.as_bytes(), [b'-' | b'+' | b'*', b' ' | b'\t', ..])
-}
-
-/// Returns whether `line` begins with one to nine ASCII digits followed by
-/// `.` or `)`, then whitespace.
-///
-/// `CommonMark` limits ordered-list markers to nine digits to avoid integer
-/// overflow in browsers: <https://spec.commonmark.org/0.31.2/#list-items>.
-fn starts_with_ordered_markdown_list_item(line: &str) -> bool {
-    let bytes = line.as_bytes();
-    let mut digit_count = 0;
-
-    for byte in bytes {
-        if digit_count < 9 && byte.is_ascii_digit() {
-            digit_count += 1;
-            continue;
-        }
-
-        if digit_count > 0 && matches!(*byte, b'.' | b')') {
-            return bytes
-                .get(digit_count + 1)
-                .is_some_and(|byte| matches!(*byte, b' ' | b'\t'));
-        }
-
-        return false;
-    }
-
-    false
 }
 
 /// Returns the byte offset where `description` first needs block-style rendering.
@@ -466,7 +451,7 @@ mod tests {
     use insta::{Settings, assert_snapshot};
     use ruff_text_size::{TextRange, TextSize};
 
-    use super::{Section, SectionItem, SectionKind, render_sections_into};
+    use super::{Section, SectionItem, SectionKind, render_into, render_sections_into};
 
     #[test]
     fn sections_render_in_canonical_order() {
@@ -720,6 +705,703 @@ Rendered as code:
     }
 
     #[test]
+    fn google_sections_render_markdown_sections() {
+        let docstring = "\
+Summary.
+
+Args:
+    value (str): The value.
+        More detail.
+    *items: Extra items.
+
+Keyword Args:
+    optional (int): Optional value.
+
+Returns:
+    bool: Whether validation passed.
+
+Yields:
+    int: Next value.
+";
+        let rendered = render_docstring(docstring);
+
+        assert_snapshot!(rendered, @r"
+        Summary.
+
+        ## Parameters
+        **value**: `str`  
+        The value.  
+        More detail.
+
+        **\*items**  
+        Extra items.
+
+        ## Keyword Arguments
+        **optional**: `int`  
+        Optional value.
+
+        ## Returns
+        `bool`  
+        Whether validation passed.
+
+        ## Yields
+        `int`  
+        Next value.
+        ");
+
+        let docstring = "\
+Args:
+    x, y: Coordinates.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Parameters
+        **x, y**  
+        Coordinates.
+        ");
+
+        let docstring = "\
+Keyword Arguments:
+    retries: Retry count.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Keyword Arguments
+        **retries**  
+        Retry count.
+        ");
+
+        let docstring = "\
+Args:
+    value: The value.
+Additional details.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Parameters
+        **value**  
+        The value.
+
+        Additional details.
+        ");
+
+        let docstring = "\
+Args:
+    value: The value.
+Methods:
+    work: Does work.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Parameters
+        **value**  
+        The value.
+
+        Methods:  
+        &nbsp;&nbsp;&nbsp;&nbsp;work: Does work.
+        ");
+
+        let docstring = "\
+Returns:
+    bool: Whether validation passed.
+Additional details.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Returns
+        `bool`  
+        Whether validation passed.
+
+        Additional details.
+        ");
+
+        let docstring = "\
+Returns:
+    str | None: Optional value.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Returns
+        `str | None`  
+        Optional value.
+        ");
+
+        let docstring = "\
+Returns:
+    One of the known values: foo or bar.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Returns
+        One of the known values: foo or bar.
+        ");
+
+        let docstring = "\
+Returns:
+    True if it succeeded.
+    False otherwise.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Returns
+        True if it succeeded.  
+        False otherwise.
+        ");
+
+        let docstring = "\
+Yields:
+    The next item.
+    Nothing when exhausted.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Yields
+        The next item.  
+        Nothing when exhausted.
+        ");
+
+        let docstring = "\
+Returns:
+    str:Path/to/file.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Returns
+        `str`  
+        Path/to/file.
+        ");
+
+        let docstring = "\
+Returns:
+    Path:foo@bar.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Returns
+        `Path`  
+        foo@bar.
+        ");
+
+        let docstring = "\
+Returns:
+    https://example.com/path
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Returns
+        https://example.com/path
+        ");
+
+        let docstring = "\
+Yields:
+    :obj:`list` of :obj:`str`: Result chunks.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Yields
+        `` :obj:`list` of :obj:`str` ``  
+        Result chunks.
+        ");
+
+        let docstring = "\
+Returns:
+    str: Example output.
+        ```python
+        Args:
+            value: still code.
+        Returns:
+            still code.
+        ```
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Returns
+        `str`  
+        Example output.
+
+        ```python
+        Args:
+            value: still code.
+        Returns:
+            still code.
+        ```
+        ");
+
+        let docstring = "\
+Yields:
+    int: Example output.
+        Example::
+            Args:
+                still code.
+            Yields:
+                still code.
+";
+        assert_snapshot!(render_docstring(docstring), @"
+        ## Yields
+        `int`  
+        Example output.  
+        Example:
+
+        ```````````python
+            Args:
+                still code.
+            Yields:
+                still code.
+        ```````````
+        ");
+    }
+
+    #[test]
+    fn other_parameter_sections_render_markdown_sections() {
+        let docstring = "\
+Other Parameters:
+    timeout (float): Maximum wait in seconds.
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Other Parameters\n**timeout**: `float`  \nMaximum wait in seconds."
+        );
+    }
+
+    #[test]
+    fn lowercase_parameter_names_that_resemble_sections_render() {
+        let docstring = "\
+Args:
+    error:
+        Error callback.
+    returns:
+        Whether to return the result.
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Parameters\n**error**  \nError callback.\n\n\
+             **returns**  \nWhether to return the result."
+        );
+    }
+
+    #[test]
+    fn google_item_continuation_paragraphs_use_common_indent() {
+        let docstring = "\
+Args:
+    value: First paragraph.
+
+        Second paragraph.
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Parameters\n**value**  \nFirst paragraph.\n\nSecond paragraph."
+        );
+    }
+
+    #[test]
+    fn mixed_space_and_tab_continuation_indentation_is_stripped() {
+        let docstring = "\
+Args:
+    value: First line.
+  \tSecond line.
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Parameters\n**value**  \nFirst line.  \nSecond line."
+        );
+    }
+
+    #[test]
+    fn google_parameter_uri_and_path_continuations_stay_raw() {
+        for continuation in ["https://example.com/api", "C:\\temp\\result.txt"] {
+            let docstring = format!(
+                "Args:\n    endpoint: Service endpoint, for example:\n    {continuation}\n"
+            );
+
+            assert_eq!(render_docstring(&docstring), render_general(&docstring));
+        }
+    }
+
+    #[test]
+    fn google_parameter_colon_prose_stays_raw() {
+        let docstring = "\
+Args:
+    param1 (str): The first parameter description.
+    For example: pass an absolute path.
+    *args: Extra positional arguments.
+    **kwargs: Extra keyword arguments.
+";
+
+        assert_eq!(render_docstring(docstring), render_general(docstring));
+    }
+
+    #[test]
+    fn google_existing_code_spans_in_types_are_not_nested() {
+        for (docstring, expected) in [
+            (
+                "Args:\n    signature (``bytes``): Signature bytes.\n",
+                "## Parameters\n**signature**: `bytes`  \nSignature bytes.",
+            ),
+            (
+                "Returns:\n    `str`: The result.\n",
+                "## Returns\n`str`  \nThe result.",
+            ),
+        ] {
+            assert_eq!(render_docstring(docstring), expected);
+        }
+    }
+
+    #[test]
+    fn google_return_colons_inside_code_spans_are_not_fields() {
+        for (docstring, expected) in [
+            ("Returns:\n    `key: value`\n", "## Returns\n`key: value`"),
+            ("Yields:\n    ``key: value``\n", "## Yields\n``key: value``"),
+            (
+                "Returns:\n    `dict[str, int]`: Mapping.\n",
+                "## Returns\n`dict[str, int]`  \nMapping.",
+            ),
+        ] {
+            assert_eq!(render_docstring(docstring), expected);
+        }
+    }
+
+    #[test]
+    fn google_multiple_return_entries_stay_raw() {
+        for heading in ["Returns", "Yields"] {
+            let docstring = format!("{heading}:\n    int: Count.\n    str: Name.\n");
+
+            assert_eq!(render_docstring(&docstring), render_general(&docstring));
+        }
+    }
+
+    #[test]
+    fn google_empty_return_sections_do_not_claim_following_prose() {
+        for heading in ["Returns", "Yields"] {
+            let docstring = format!("Summary.\n\n{heading}:\n\nAfter.\n");
+
+            assert_eq!(render_docstring(&docstring), render_general(&docstring));
+        }
+    }
+
+    #[test]
+    fn google_conventional_spaced_return_types_render() {
+        for (docstring, expected) in [
+            (
+                "Returns:\n    list of int: A new list.\n",
+                "## Returns\n`list of int`  \nA new list.",
+            ),
+            (
+                "Yields:\n    int or float: The next number.\n",
+                "## Yields\n`int or float`  \nThe next number.",
+            ),
+            (
+                "Returns:\n    tuple(int, int): A pair.\n",
+                "## Returns\n`tuple(int, int)`  \nA pair.",
+            ),
+        ] {
+            assert_eq!(render_docstring(docstring), expected);
+        }
+    }
+
+    #[test]
+    fn google_return_prose_with_commas_is_not_a_type() {
+        let docstring = "\
+Returns:
+    (count, results) tuples where:
+    count is the number of matches.
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Returns\n(count, results) tuples where:  \ncount is the number of matches."
+        );
+
+        let docstring = "Returns:\n    mapping of user IDs: Preserved as prose.\n";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Returns\nmapping of user IDs: Preserved as prose."
+        );
+    }
+
+    #[test]
+    fn google_return_prose_with_inline_markdown_is_not_a_type() {
+        for description in [
+            "A `Result` object: When successful.",
+            "A [Result] object: When successful.",
+        ] {
+            let docstring = format!("Returns:\n    {description}\n");
+
+            assert_eq!(
+                render_docstring(&docstring),
+                format!("## Returns\n{description}")
+            );
+        }
+    }
+
+    #[test]
+    fn google_return_prose_with_parenthetical_is_not_a_type() {
+        let docstring = "Returns:\n    The result (if any): Additional context.\n";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Returns\nThe result (if any): Additional context."
+        );
+    }
+
+    #[test]
+    fn google_return_lowercase_labels_remain_descriptions() {
+        let docstring = "\
+Returns:
+    A mapping. For example:
+    example:
+        {\"key\": \"value\"}
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Returns\nA mapping. For example:  \nexample:  \n    {\"key\": \"value\"}"
+        );
+    }
+
+    #[test]
+    fn google_return_bare_literals_are_not_types() {
+        for description in ["42: int.", "200: Success"] {
+            let docstring = format!("Returns:\n    {description}\n");
+
+            assert_eq!(
+                render_docstring(&docstring),
+                format!("## Returns\n{description}")
+            );
+        }
+    }
+
+    #[test]
+    fn google_return_windows_paths_remain_intact() {
+        let docstring = "Returns:\n    C:\\temp\\result.txt\n";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Returns\nC:\\temp\\result.txt"
+        );
+    }
+
+    #[test]
+    fn google_return_opaque_uris_remain_intact() {
+        for uri in ["mailto:user@example.com", "urn:isbn:9780141036144"] {
+            let docstring = format!("Returns:\n    {uri}\n");
+
+            assert_eq!(render_docstring(&docstring), format!("## Returns\n{uri}"));
+        }
+    }
+
+    #[test]
+    fn google_return_preformatted_first_lines_render() {
+        let docstring = "\
+Returns:
+    ```text
+    Args:
+    ```
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Returns\n```text\nArgs:\n```"
+        );
+
+        let docstring = "\
+Returns:
+    ```text:example
+    value
+    ```
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Returns\n```text:example\nvalue\n```"
+        );
+
+        let docstring = "\
+Yields:
+    ~~~text:example
+    value
+    ~~~
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Yields\n~~~text:example\nvalue\n~~~"
+        );
+
+        let docstring = "\
+Yields:
+    >>> print(\"Returns:\")
+    Returns:
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Yields\n```````````python\n>>> print(\"Returns:\")\nReturns:\n```````````"
+        );
+    }
+
+    #[test]
+    fn google_raises_section_like_exception_names_render() {
+        let docstring = "\
+Raises:
+    Warning:
+        Emitted for legacy input.
+    Error:
+        Raised for a generic failure.
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "## Raises\n`Warning`  \nEmitted for legacy input.\n\n\
+             `Error`  \nRaised for a generic failure."
+        );
+    }
+
+    #[test]
+    fn google_headers_nested_in_indented_containers_stay_raw() {
+        for docstring in [
+            "\
+.. note::
+    Args:
+        nested: Note content.
+",
+            "\
+- Example:
+    Args:
+        nested: List content.
+",
+        ] {
+            assert_eq!(render_docstring(docstring), render_general(docstring));
+        }
+
+        let rst_field = "\
+:param value: Example input.
+    Args:
+        nested: Field content.
+:param other: Other input.
+";
+        assert_eq!(
+            render_docstring(rst_field),
+            "## Parameters\n**value**  \nExample input.  \nArgs:  \n    nested: Field content.\n\n\
+             **other**  \nOther input."
+        );
+    }
+
+    #[test]
+    fn unsupported_google_sections_stay_raw() {
+        for docstring in [
+            "\
+Summary.
+
+Args:
+    Inputs are normalized first.
+    value: The value.
+",
+            "\
+Summary.
+
+Examples:
+    Args:
+        value: demo input.
+",
+            "\
+Summary.
+
+Returns:
+    bool: Whether validation passed.
+
+    Examples:
+        Use it.
+",
+            "\
+Summary.
+
+Yields:
+    int: Next value.
+
+    Examples:
+        Use it.
+",
+            "\
+Summary.
+
+Args:
+    Inputs are normalized first.
+    Args:
+        value: demo input.
+",
+            "\
+Summary.
+
+Args:
+    value: The value.
+
+    Examples:
+        Use it.
+",
+            "\
+Summary.
+
+Args:
+    value: The value.
+    Examples: Try it.
+",
+            "\
+Summary.
+
+Returns:
+    Examples:
+        Use it.
+",
+            "\
+Summary.
+
+Raises:
+    ValueError: If invalid.
+
+    Examples:
+        Use it.
+",
+            "\
+Summary.
+
+Args:
+    value: Example.
+        ```python
+
+Args:
+    nested = 1
+        ```
+",
+        ] {
+            assert_eq!(render_docstring(docstring), render_general(docstring));
+        }
+    }
+
+    #[test]
+    fn first_line_google_container_uses_pep257_section_hierarchy() {
+        let docstring = "\
+Examples:
+Args:
+    value: demo input.
+Returns:
+    str: demo output.
+";
+
+        assert_eq!(
+            render_docstring(docstring),
+            "Examples:\n\n## Parameters\n**value**  \ndemo input.\n\n## Returns\n`str`  \ndemo output."
+        );
+    }
+
+    #[test]
+    fn google_return_literal_block_first_lines_preserve_literal_rendering() {
+        for heading in ["Returns", "Yields"] {
+            for marker in ["Result::", "list[str]::"] {
+                let docstring = format!("{heading}:\n    {marker}\n\n        value = 1\n");
+
+                assert_eq!(
+                    render_docstring(&docstring),
+                    format!(
+                        "## {heading}\n{}:\n\n```````````python\nvalue = 1\n```````````",
+                        marker.trim_end_matches(':')
+                    )
+                );
+            }
+        }
+    }
+
+    #[test]
     fn following_prose_is_rendered_outside_a_parameter_doctest() {
         let rendered = render_parameter_docstring(">>> value\n1", "After.");
 
@@ -861,6 +1543,18 @@ Rendered as code:
     fn render_markdown(section: &Section) -> String {
         let mut output = String::new();
         section.render_markdown(&mut output);
+        output
+    }
+
+    fn render_docstring(raw: &str) -> String {
+        let mut output = String::new();
+        render_into(&mut output, raw, raw);
+        output
+    }
+
+    fn render_general(raw: &str) -> String {
+        let mut output = String::new();
+        crate::docstring::markdown::general::render_into(&mut output, raw);
         output
     }
 

--- a/crates/ty_ide/src/docstring/markdown/structured/body.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured/body.rs
@@ -1,0 +1,190 @@
+use ruff_text_size::TextSize;
+
+use crate::docstring::document::preformatted::PreformattedBlockScanner;
+use crate::docstring::document::syntax::{ParsedLine, indentation, strip_code_span_wrapper};
+
+use super::{SectionItem, SectionKind};
+
+/// Builds one structured section item from its heading and description lines.
+pub(super) struct SectionItemBuilder<'a> {
+    display_name: Option<&'a str>,
+    ty: Option<&'a str>,
+    inline_description: Option<&'a str>,
+    continuation_lines: Vec<&'a str>,
+}
+
+impl<'a> SectionItemBuilder<'a> {
+    /// Creates a section item builder from the fields parsed on its first line.
+    pub(super) fn new(
+        display_name: Option<&'a str>,
+        ty: Option<&'a str>,
+        inline_description: &'a str,
+    ) -> Self {
+        let inline_description = inline_description.trim();
+        Self {
+            display_name,
+            ty: ty.map(strip_code_span_wrapper),
+            inline_description: (!inline_description.is_empty()).then_some(inline_description),
+            continuation_lines: Vec::new(),
+        }
+    }
+
+    /// Finishes the item for the given section kind.
+    pub(super) fn finish(self, kind: SectionKind) -> SectionItem {
+        let description = self.description_source();
+        SectionItem::new(kind, self.display_name, self.ty, description)
+    }
+
+    /// Appends a continuation line to the item's description.
+    pub(super) fn push_description(&mut self, line: &'a str) {
+        self.continuation_lines.push(line);
+    }
+
+    fn description_source(&self) -> String {
+        let continuation_indent = self
+            .continuation_lines
+            .iter()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| indentation(line))
+            .min()
+            .unwrap_or_default();
+
+        let mut lines = Vec::with_capacity(
+            self.continuation_lines.len() + usize::from(self.inline_description.is_some()),
+        );
+        if let Some(inline_description) = &self.inline_description {
+            lines.push((*inline_description).to_string());
+        }
+        lines.extend(self.continuation_lines.iter().map(|line| {
+            if line.trim().is_empty() {
+                String::new()
+            } else {
+                strip_indentation(line, continuation_indent)
+                    .trim_end()
+                    .to_string()
+            }
+        }));
+
+        let Some(start) = lines.iter().position(|line| !line.is_empty()) else {
+            return String::new();
+        };
+        let end = lines
+            .iter()
+            .rposition(|line| !line.is_empty())
+            .map_or(start, |index| index + 1);
+        lines[start..end].join("\n")
+    }
+}
+
+/// Parses a section body containing named items.
+pub(super) fn parse_named_items<'a>(
+    kind: SectionKind,
+    body: &[ParsedLine<'a>],
+    parse_item: impl FnMut(&ParsedLine<'a>) -> Option<SectionItemBuilder<'a>>,
+) -> Option<Vec<SectionItem>> {
+    parse_named_items_impl(kind, None, body, parse_item)
+}
+
+/// Parses named items while accepting continuations aligned with a first-line section heading.
+pub(super) fn parse_named_items_with_aligned_continuations<'a>(
+    kind: SectionKind,
+    header_indent: TextSize,
+    body: &[ParsedLine<'a>],
+    parse_item: impl FnMut(&ParsedLine<'a>) -> Option<SectionItemBuilder<'a>>,
+) -> Option<Vec<SectionItem>> {
+    parse_named_items_impl(kind, Some(header_indent), body, parse_item)
+}
+
+fn parse_named_items_impl<'a>(
+    kind: SectionKind,
+    aligned_continuation_indent: Option<TextSize>,
+    body: &[ParsedLine<'a>],
+    mut parse_item: impl FnMut(&ParsedLine<'a>) -> Option<SectionItemBuilder<'a>>,
+) -> Option<Vec<SectionItem>> {
+    let mut items = Vec::new();
+    let mut current: Option<SectionItemBuilder<'a>> = None;
+    let mut item_indent = None;
+    let mut preformatted = PreformattedBlockScanner::default();
+
+    for line in body {
+        if let Some(current) = &mut current
+            && preformatted.consume_preformatted_line(line.text)
+        {
+            if !line.text.trim().is_empty()
+                && item_indent.is_some_and(|indent| indentation(line.text) < indent)
+            {
+                return None;
+            }
+            current.push_description(line.text);
+            continue;
+        }
+
+        let trimmed = line.text.trim();
+        if trimmed.is_empty() {
+            if let Some(current) = &mut current {
+                current.push_description("");
+            }
+            continue;
+        }
+
+        let line_indent = indentation(line.text);
+        if item_indent.is_none_or(|indent| line_indent == indent) {
+            if let Some(item) = parse_item(line) {
+                if let Some(current) = current.replace(item) {
+                    items.push(current.finish(kind));
+                }
+                item_indent.get_or_insert(line_indent);
+                preformatted = PreformattedBlockScanner::default();
+                preformatted.observe_line_outside_preformatted_block(line.text);
+                continue;
+            }
+            // PEP 257 can align a first-line parameter section with its items. Only in that
+            // layout is a same-indent non-item unambiguously a continuation.
+            if item_indent.is_some()
+                && !(item_indent == aligned_continuation_indent
+                    && matches!(
+                        kind,
+                        SectionKind::Parameters
+                            | SectionKind::KeywordArguments
+                            | SectionKind::OtherParameters
+                    ))
+            {
+                return None;
+            }
+        }
+        if item_indent.is_some_and(|indent| line_indent < indent) {
+            return None;
+        }
+
+        let current = current.as_mut()?;
+        current.push_description(line.text);
+        preformatted.observe_line_outside_preformatted_block(line.text);
+    }
+
+    if let Some(current) = current {
+        items.push(current.finish(kind));
+    }
+    (!items.is_empty()).then_some(items)
+}
+
+fn strip_indentation(line: &str, width: TextSize) -> &str {
+    let mut indentation_width = TextSize::default();
+    for (index, char) in line.char_indices() {
+        let next_indentation_width = match char {
+            ' ' => indentation_width + TextSize::new(1),
+            '\t' => TextSize::new((indentation_width.to_u32() / 8 + 1) * 8),
+            _ => return &line[index..],
+        };
+
+        if next_indentation_width > width {
+            return &line[index..];
+        }
+
+        indentation_width = next_indentation_width;
+        if indentation_width == width {
+            return &line[index + char.len_utf8()..];
+        }
+    }
+
+    ""
+}

--- a/crates/ty_ide/src/docstring/markdown/structured/google.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured/google.rs
@@ -1,0 +1,219 @@
+use ruff_text_size::{TextRange, TextSize};
+
+use crate::docstring::document::google;
+use crate::docstring::document::preformatted::PreformattedBlockScanner;
+use crate::docstring::document::syntax::{
+    ParsedLine, indentation, is_docstring_type_expression, parse_parenthesized_type,
+    split_once_unbracketed_colon,
+};
+
+use super::body::{
+    SectionItemBuilder, parse_named_items, parse_named_items_with_aligned_continuations,
+};
+use super::{Section, SectionItem, SectionKind};
+
+/// Returns Google-style sections that can be rendered structurally.
+pub(super) fn structured_sections(source: &str) -> Vec<Section> {
+    let mut sections = Vec::new();
+
+    google::visit_sections(source, |kind, range, header_indent, body| {
+        if let Some(section) = google_section(kind, range, header_indent, body) {
+            sections.push(section);
+        }
+    });
+
+    sections
+}
+
+fn google_section(
+    kind: SectionKind,
+    range: TextRange,
+    header_indent: TextSize,
+    body: &[ParsedLine<'_>],
+) -> Option<Section> {
+    let items = match kind {
+        SectionKind::Returns | SectionKind::Yields => parse_return_item(kind, body),
+        SectionKind::Parameters | SectionKind::KeywordArguments | SectionKind::OtherParameters => {
+            parse_named_items_with_aligned_continuations(kind, header_indent, body, |line| {
+                parse_named_item(kind, line)
+            })
+        }
+        SectionKind::Attributes | SectionKind::Raises => {
+            parse_named_items(kind, body, |line| parse_named_item(kind, line))
+        }
+    }?;
+    Section::new(range, items)
+}
+
+fn parse_named_item<'a>(
+    kind: SectionKind,
+    line: &ParsedLine<'a>,
+) -> Option<SectionItemBuilder<'a>> {
+    let line_text = line.text.trim();
+    let section_like_header = is_uppercase_section_like_header(line_text);
+
+    let (name, description) = split_field_colon(line_text)?;
+    let name = name.trim();
+    if name.is_empty() {
+        return None;
+    }
+    if is_uri_scheme_prefix(name, description) {
+        return None;
+    }
+    if section_like_header
+        && !(kind == SectionKind::Raises && google::has_exception_name_suffix(name))
+    {
+        return None;
+    }
+
+    let (display_name, ty) = match kind {
+        SectionKind::Parameters | SectionKind::KeywordArguments | SectionKind::OtherParameters => {
+            let (display_name, ty) = parse_parenthesized_type(name);
+            if !is_parameter_display_name(display_name) {
+                return None;
+            }
+            (display_name, ty)
+        }
+        SectionKind::Attributes => {
+            let (display_name, ty) = parse_parenthesized_type(name);
+            if !is_attribute_display_name(display_name) {
+                return None;
+            }
+            (display_name, ty)
+        }
+        SectionKind::Raises => {
+            if !google::is_dotted_identifier(name) {
+                return None;
+            }
+            (name, None)
+        }
+        SectionKind::Returns | SectionKind::Yields => return None,
+    };
+
+    Some(SectionItemBuilder::new(Some(display_name), ty, description))
+}
+
+fn parse_return_item(kind: SectionKind, body: &[ParsedLine<'_>]) -> Option<Vec<SectionItem>> {
+    let mut lines = body.iter().skip_while(|line| line.text.trim().is_empty());
+    let first_line = lines.next()?;
+    let first = first_line.text.trim();
+    if is_uppercase_section_like_header(first) {
+        return None;
+    }
+
+    let mut preformatted = PreformattedBlockScanner::default();
+    let first_is_preformatted = preformatted.consume_preformatted_line(first_line.text);
+    let (ty, first_description) = if first_is_preformatted {
+        (None, first)
+    } else {
+        split_return_type(first).map_or((None, first), |(ty, description)| (Some(ty), description))
+    };
+    let first_indent = indentation(first_line.text);
+    let has_type = ty.is_some();
+    let mut item = SectionItemBuilder::new(None, ty, first_description);
+    if !first_is_preformatted {
+        preformatted.observe_line_outside_preformatted_block(first_line.text);
+    }
+
+    for line in lines {
+        if preformatted.consume_preformatted_line(line.text) {
+            item.push_description(line.text);
+            continue;
+        }
+        if is_uppercase_section_like_header(line.text.trim()) {
+            return None;
+        }
+        if has_type
+            && indentation(line.text) == first_indent
+            && split_return_type(line.text.trim()).is_some()
+        {
+            return None;
+        }
+        preformatted.observe_line_outside_preformatted_block(line.text);
+        item.push_description(line.text);
+    }
+
+    Some(vec![item.finish(kind)])
+}
+
+fn split_return_type(line: &str) -> Option<(&str, &str)> {
+    if PreformattedBlockScanner::line_starts_rest_literal_block(line) {
+        return None;
+    }
+
+    let (ty, description) = split_field_colon(line)?;
+    let ty = ty.trim();
+    if is_uri_scheme_prefix(ty, description) {
+        return None;
+    }
+
+    is_docstring_type_expression(ty).then_some((ty, description.trim()))
+}
+
+fn split_field_colon(line: &str) -> Option<(&str, &str)> {
+    let mut start = 0;
+    while start < line.len() {
+        let (before_colon, after_colon) = split_once_unbracketed_colon(line.get(start..)?)?;
+        let colon = start + before_colon.len();
+        if let Some(role_end) = rst_role_markup_end(line, colon) {
+            start = role_end;
+            continue;
+        }
+        return Some((&line[..colon], after_colon));
+    }
+    None
+}
+
+fn rst_role_markup_end(line: &str, start: usize) -> Option<usize> {
+    let rest = line.get(start..)?;
+    let after_initial_colon = rest.strip_prefix(':')?;
+    let role_end = after_initial_colon.find(":`")?;
+    let role = &after_initial_colon[..role_end];
+    if role.is_empty()
+        || !role
+            .chars()
+            .all(|char| char.is_ascii_alphanumeric() || matches!(char, ':' | '_' | '-' | '.'))
+    {
+        return None;
+    }
+
+    let content_start = start + ':'.len_utf8() + role_end + ":`".len();
+    let content = line.get(content_start..)?;
+    let closing_backtick = content.find('`')?;
+    Some(content_start + closing_backtick + '`'.len_utf8())
+}
+
+fn is_uri_scheme_prefix(prefix: &str, description: &str) -> bool {
+    let mut chars = prefix.chars();
+    let is_scheme = chars.next().is_some_and(|char| char.is_ascii_alphabetic())
+        && chars.all(|char| char.is_ascii_alphanumeric() || matches!(char, '+' | '-' | '.'));
+    is_scheme
+        && description.chars().next().is_some_and(|first| {
+            !first.is_whitespace()
+                && (matches!(first, '/' | '\\' | '?' | '#' | '@' | ':')
+                    || matches_opaque_uri_scheme(prefix))
+        })
+}
+
+fn matches_opaque_uri_scheme(scheme: &str) -> bool {
+    // Keep this list narrow so type-and-description forms like `Path:foo` remain types.
+    ["data", "geo", "mailto", "news", "sms", "tel", "urn"]
+        .iter()
+        .any(|known| scheme.eq_ignore_ascii_case(known))
+}
+
+fn is_uppercase_section_like_header(line: &str) -> bool {
+    line.chars().next().is_some_and(char::is_uppercase) && google::is_section_like_header(line)
+}
+
+fn is_parameter_display_name(display_name: &str) -> bool {
+    display_name
+        .split(',')
+        .all(|name| google::is_parameter_name(name.trim()))
+}
+
+fn is_attribute_display_name(display_name: &str) -> bool {
+    display_name
+        .split(',')
+        .all(|name| google::is_dotted_identifier(name.trim()))
+}

--- a/crates/ty_ide/src/docstring/markdown/structured/rst.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured/rst.rs
@@ -818,7 +818,7 @@ Summary.
 
     fn render_docstring(raw: &str) -> String {
         let mut output = String::new();
-        render_into(&mut output, raw);
+        render_into(&mut output, raw, raw);
         output
     }
 

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -494,11 +494,14 @@ mod tests {
         ) -> Unknown
         ```
         ---
-        This is such a great func!!<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
+        This is such a great func!!
+
+        ## Parameters
+        **a**<HB>
+        first for a reason
+
+        **b**<HB>
+        coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
           --> main.py:11:1
@@ -547,11 +550,14 @@ mod tests {
         ) -> Unknown
         ```
         ---
-        This is such a great func!!<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
+        This is such a great func!!
+
+        ## Parameters
+        **a**<HB>
+        first for a reason
+
+        **b**<HB>
+        coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
          --> main.py:2:5
@@ -1577,11 +1583,14 @@ mod tests {
         ) -> Unknown
         ```
         ---
-        This is such a great func!!<HB>
-        <HB>
-        Args:<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;a: first for a reason<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;b: coming for `a`'s title
+        This is such a great func!!
+
+        ## Parameters
+        **a**<HB>
+        first for a reason
+
+        **b**<HB>
+        coming for `a`'s title
         ---------------------------------------------
         info[hover]: Hovered content is
           --> main.py:25:3


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
