### PR TITLE
[ty] Render NumPy docstrings as structured Markdown

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -1177,22 +1177,22 @@ Summary.
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        Parameters<HB>
-        ----------<HB>
-        param1 : str<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;The first parameter description<HB>
-        param2 : int<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;The second parameter description<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
-        param3<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;A parameter without type annotation<HB>
-        <HB>
-        Returns<HB>
-        -------<HB>
-        str<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;The return value description
+        This is a function description.
+
+        ## Parameters
+        **param1**: `str`<HB>
+        The first parameter description
+
+        **param2**: `int`<HB>
+        The second parameter description<HB>
+        This is a continuation of param2 description.
+
+        **param3**<HB>
+        A parameter without type annotation
+
+        ## Returns
+        `str`<HB>
+        The return value description
         ");
     }
 
@@ -1325,10 +1325,9 @@ Summary.
         **param2**: `int`<HB>
         Another Google-style parameter
 
-        Parameters<HB>
-        ----------<HB>
-        param3 : bool<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;NumPy-style parameter
+        ## Parameters
+        **param3**: `bool`<HB>
+        NumPy-style parameter
         ");
     }
 
@@ -1489,12 +1488,12 @@ Summary.
         **param3**<HB>
         Another reST-style parameter
 
-        Parameters<HB>
-        ----------<HB>
-        param3 : str<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;NumPy-style duplicate parameter<HB>
-        param4 : bool<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;NumPy-style parameter
+        ## Parameters
+        **param3**: `str`<HB>
+        NumPy-style duplicate parameter
+
+        **param4**: `bool`<HB>
+        NumPy-style parameter
         ");
     }
 
@@ -1548,17 +1547,18 @@ Summary.
         ");
 
         assert_snapshot!(docstring.render_markdown(), @"
-        This is a function description.<HB>
-        <HB>
-        Parameters<HB>
-        ----------<HB>
-        param1 : str<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The first parameter description<HB>
-        param2 : int<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The second parameter description<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is a continuation of param2 description.<HB>
-        param3<HB>
-        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;A parameter without type annotation
+        This is a function description.
+
+        ## Parameters
+        **param1**: `str`<HB>
+        The first parameter description
+
+        **param2**: `int`<HB>
+        The second parameter description<HB>
+        This is a continuation of param2 description.
+
+        **param3**<HB>
+        A parameter without type annotation
         ");
     }
 

--- a/crates/ty_ide/src/docstring/document.rs
+++ b/crates/ty_ide/src/docstring/document.rs
@@ -5,7 +5,7 @@ use strum_macros::EnumIter;
 use self::syntax::{indentation, starts_with_markdown_list_item};
 
 pub(super) mod google;
-mod numpy;
+pub(super) mod numpy;
 pub(super) mod preformatted;
 pub(super) mod rst;
 pub(in crate::docstring) mod syntax;

--- a/crates/ty_ide/src/docstring/document/numpy.rs
+++ b/crates/ty_ide/src/docstring/document/numpy.rs
@@ -110,17 +110,17 @@ fn parameter_lookup_names(display_name: &str) -> Option<Vec<String>> {
 ///
 /// `source` must have already undergone PEP-257 trimming and universal newline normalization
 /// (typically via `docstring::documentation_trim`).
-fn sections(source: &str) -> Vec<Section> {
+pub(in crate::docstring) fn sections(source: &str) -> Vec<Section> {
     Parser::new(parsed_lines(source)).parse()
 }
 
 /// A recognized NumPy-style docstring section.
-type Section = super::Section<Option<String>>;
+pub(in crate::docstring) type Section = super::Section<Option<String>>;
 
 type SectionBody = super::SectionBody<Option<String>>;
 
 /// One parsed fragment in a NumPy section body.
-type BodyFragment = super::BodyFragment<Option<String>>;
+pub(in crate::docstring) type BodyFragment = super::BodyFragment<Option<String>>;
 
 /// A named or anonymous item in a NumPy section.
 type Item = super::Item<Option<String>>;

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -9,6 +9,7 @@ use crate::docstring::document::preformatted::MarkdownFence;
 use crate::docstring::document::syntax::{is_markdown_code_span, starts_with_markdown_list_item};
 
 mod google;
+mod numpy;
 mod rst;
 
 /// Renders a docstring as Markdown.
@@ -18,6 +19,7 @@ mod rst;
 pub(super) fn render_into(output: &mut String, source: &str) {
     let mut sections = rst::structured_sections(source);
     sections.extend(google::structured_sections(source));
+    sections.extend(numpy::structured_sections(source));
     render_sections_into(output, source, sections);
 }
 
@@ -249,7 +251,7 @@ impl SectionItem {
 
         if let Some(name) = self.display_name.as_deref() {
             if matches!(self.kind, SectionKind::Raises) {
-                render_code_span_into(output, name);
+                render_type_code_span_into(output, name);
             } else {
                 render_bold_text_into(output, name);
             }

--- a/crates/ty_ide/src/docstring/markdown/structured/numpy.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured/numpy.rs
@@ -1,0 +1,370 @@
+use crate::docstring::document::numpy;
+
+use super::{Section, SectionItem, SectionKind};
+
+/// Returns NumPy-style sections that can be rendered structurally.
+pub(super) fn structured_sections(normalized_source: &str) -> Vec<Section> {
+    numpy::sections(normalized_source)
+        .into_iter()
+        .filter_map(section)
+        .collect()
+}
+
+fn section(parsed: numpy::Section) -> Option<Section> {
+    let kind = parsed.kind();
+    let range = parsed.range();
+    let fragments = parsed.into_renderable_fragments()?;
+
+    if fragments.is_empty() {
+        return None;
+    }
+
+    let items = fragments
+        .into_iter()
+        .map(|fragment| section_item(kind, fragment))
+        .collect();
+
+    Section::new(range, items)
+}
+
+fn section_item(kind: SectionKind, fragment: numpy::BodyFragment) -> SectionItem {
+    match fragment {
+        numpy::BodyFragment::Prose(description) => {
+            SectionItem::from_owned_parts(kind, None, None, description)
+        }
+        numpy::BodyFragment::Item(item) => {
+            let (display_name, ty, description) = item.into_display_name_type_and_description();
+            SectionItem::from_owned_parts(kind, display_name, ty, description)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::{Settings, assert_snapshot};
+
+    use super::super::render_sections_into;
+    use super::structured_sections;
+
+    #[test]
+    fn renders_supported_sections() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Summary.
+
+Parameters
+----------
+value, alias : str
+    The value.
+
+    A second paragraph.
+other
+    Another value.
+*args : object
+    Extra positional arguments.
+**kwargs : object
+    Extra keyword arguments.
+options.mode : str
+    Nested field documentation.
+π : int
+    A Unicode parameter.
+a1, a2, ... : sequence of array_like
+    Arrays to combine.
+override_repr: callable, optional
+    Replacement representation function.
+formats, names :
+undocumented
+
+Other Parameters
+----------------
+kw_only: bool
+    Less common option.
+
+Attributes
+----------
+name : str
+    Display name.
+
+Returns
+-------
+result : bool
+    Whether validation passed.
+
+Yields
+------
+int
+    Next value.
+
+Raises
+------
+ValueError
+    If invalid.
+`TypeError`
+    If unsupported.
+";
+
+        assert_snapshot!(render_numpy(docstring), @r"
+        Summary.
+
+        ## Parameters
+        **value, alias**: `str`<HB>
+        The value.
+
+        A second paragraph.
+
+        **other**<HB>
+        Another value.
+
+        **\*args**: `object`<HB>
+        Extra positional arguments.
+
+        **\*\*kwargs**: `object`<HB>
+        Extra keyword arguments.
+
+        **options.mode**: `str`<HB>
+        Nested field documentation.
+
+        **π**: `int`<HB>
+        A Unicode parameter.
+
+        **a1, a2, ...**: `sequence of array_like`<HB>
+        Arrays to combine.
+
+        **override\_repr**: `callable, optional`<HB>
+        Replacement representation function.
+
+        **formats, names**
+
+        **undocumented**
+
+        ## Other Parameters
+        **kw\_only**: `bool`<HB>
+        Less common option.
+
+        ## Attributes
+        **name**: `str`<HB>
+        Display name.
+
+        ## Returns
+        **result**: `bool`<HB>
+        Whether validation passed.
+
+        ## Yields
+        `int`<HB>
+        Next value.
+
+        ## Raises
+        `ValueError`<HB>
+        If invalid.
+
+        `TypeError`<HB>
+        If unsupported.
+        ");
+    }
+
+    #[test]
+    fn renders_preformatted_parameter_description() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Parameters
+----------
+value : str
+    Example::
+        ```
+other : int
+    Another value.
+";
+
+        assert_snapshot!(render_numpy(docstring), @"
+        ## Parameters
+        **value**: `str`<HB>
+        Example:
+
+        ```````````python
+            ```
+        ```````````
+
+        **other**: `int`<HB>
+        Another value.
+        ");
+    }
+
+    #[test]
+    fn renders_parameter_section_preamble() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Parameters
+----------
+Either x or y must be provided.
+
+beta : float
+    Useful documentation.
+";
+
+        assert_snapshot!(render_numpy(docstring), @"
+        ## Parameters
+        Either x or y must be provided.
+
+        **beta**: `float`<HB>
+        Useful documentation.
+        ");
+    }
+
+    #[test]
+    fn renders_shifted_top_level_sections() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+A decoded newline follows:
+This line starts at column zero.
+
+    Parameters
+    ----------
+    shifted : int
+        Documentation in a shifted section.
+";
+
+        assert_snapshot!(render_numpy(docstring), @"
+        A decoded newline follows:<HB>
+        This line starts at column zero.
+
+        ## Parameters
+        **shifted**: `int`<HB>
+        Documentation in a shifted section.
+        ");
+    }
+
+    #[test]
+    fn renders_parenthesized_return_names() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Returns
+-------
+((node1, node2), ancestor) : tuple[tuple[object, object], object]
+    A node pair and its lowest common ancestor.
+";
+
+        assert_snapshot!(render_numpy(docstring), @"
+        ## Returns
+        **((node1, node2), ancestor)**: `tuple[tuple[object, object], object]`<HB>
+        A node pair and its lowest common ancestor.
+        ");
+    }
+
+    #[test]
+    fn renders_return_prose_outside_the_structured_section() {
+        let _snap = bind_markdown_snapshot_filters();
+        let docstring = "\
+Returns
+-------
+list of nodes
+    The nodes in traversal order
+necessarily returned in a stable order
+";
+
+        assert_snapshot!(render_numpy(docstring), @"
+        ## Returns
+        `list of nodes`<HB>
+        The nodes in traversal order
+
+        necessarily returned in a stable order
+        ");
+    }
+
+    #[test]
+    fn declines_to_render_nested_parameter_items() {
+        let docstring = "\
+Parameters
+----------
+Choose one of the following.
+    nested : int
+        Example-only text.
+beta : float
+    Useful documentation.
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    #[test]
+    fn declines_to_render_structurally_ambiguous_section() {
+        let docstring = "\
+Parameters
+----------
+    value : int
+        Description.
+    Ambiguous prose.
+    other : str
+        Other.
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    #[test]
+    fn declines_to_render_section_nested_in_container() {
+        let docstring = "\
+Summary.
+
+- Example data:
+    Parameters
+    ----------
+    nested : int
+        Not parameter documentation.
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    #[test]
+    fn declines_to_render_prose_only_return_section() {
+        let docstring = "\
+Returns
+-------
+    The created object.
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    #[test]
+    fn declines_to_render_unclosed_return_fence() {
+        let docstring = "\
+Returns
+-------
+```python
+    result = 1
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    #[test]
+    fn declines_to_render_empty_return_section() {
+        let docstring = "\
+Returns
+-------
+
+Notes
+-----
+Not a return value.
+";
+
+        assert!(parsed_sections(docstring).is_empty());
+    }
+
+    fn render_numpy(source: &str) -> String {
+        let mut output = String::new();
+        render_sections_into(&mut output, source, parsed_sections(source));
+        output
+    }
+
+    fn parsed_sections(source: &str) -> Vec<super::Section> {
+        structured_sections(source)
+    }
+
+    fn bind_markdown_snapshot_filters() -> impl Drop {
+        let mut settings = Settings::clone_current();
+        settings.add_filter("  \n", "<HB>\n");
+        settings.bind_to_scope()
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

This introduces Markdown rendering for NumPy-style sections in docstrings. Supported sections are rendered with canonical Markdown headings, bold item names, inline code spans for types and raised exceptions, and descriptions passed through the existing general Markdown renderer. Here's what it looks like in VSCode[^1]:

[^1]: Note that even before this change (specifically, as of https://github.com/astral-sh/ruff/pull/26599) we already render section headers but we don't yet render section contents properly.

| Before | After |
| :--- | :--- |
| <img width="836" height="376" alt="numpy-before-1" src="https://github.com/user-attachments/assets/c50f2fe2-7538-40ae-9a93-7a98cc3b028a" /> <img width="836" height="154" alt="numpy-before-2" src="https://github.com/user-attachments/assets/833d8cad-1406-4e1b-bea3-d10340917f23" /> <img width="836" height="150" alt="numpy-before-3" src="https://github.com/user-attachments/assets/8035dc43-dbf2-4530-9afc-23895e23d66b" /> | <img width="814" height="418" alt="numpy-after-1" src="https://github.com/user-attachments/assets/467f8ab7-e5bf-4af0-9160-2d2c13a153c3" /> <img width="804" height="154" alt="numpy-after-2" src="https://github.com/user-attachments/assets/2d6fd289-37cf-48ee-9b5a-bbeb70fa1701" /> <img width="808" height="154" alt="numpy-after-3" src="https://github.com/user-attachments/assets/2e517983-365a-43f8-9f38-1392b565d4a6" /> |

The implementation includes the following judgement calls that I think are acceptable, but that we may want to revisit based on user feedback:

- We only render Markdown headings for a fixed subset of NumPy sections that map cleanly to a shared document model: parameters, attributes, returns, yields, and raises. That list can be expanded in the future.
- We carry forward a few of the rendering policies that were [established for the reStructuredText format](https://github.com/astral-sh/ruff/pull/25903):
  - Malformed, unsupported, or ambiguous content still causes us to leave an entire section raw (i.e. source content, not structured Markdown). Other well-formed sections in the same docstring are rendered as usual.
  - Types are rendered with inline code spans, and so do not receive syntax highlighting.
  - Physical line breaks in descriptions are preserved as Markdown hard breaks rather than being reflowed.

Lastly, please note that rendering should improve further after these two additional fixes land:

- https://github.com/astral-sh/ruff/pull/26923
- https://github.com/astral-sh/ruff/pull/26924

Those are both general fixes that affect multiple docstring formats, and so are intentionally separated from this change.

Closes https://github.com/astral-sh/ty/issues/1667

## Test Plan

See included tests.
<!-- How was it tested? -->
