### PR TITLE
[ty] Preserve negative narrowing for starred sequence patterns

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -66,9 +66,20 @@ def sequence_prefix_star_pattern_is_not_catch_all(paths: Sequence[str]) -> None:
         case [_first, _second, *_paths]:
             raise ValueError
 
-    # Exact sequence alternatives remain as negative protocol constraints.
-    # revealed: (Sequence[str] & ~<Protocol with members '__len__'> & ~<Protocol with members '__getitem__', '__len__'>) | str | (Sequence[str] & bytes) | (Sequence[str] & bytearray)
+    # Exact sequence alternatives and the definitely matched tuple subset of the
+    # starred alternative remain as negative constraints.
+    # revealed: (Sequence[str] & ~<Protocol with members '__len__'> & ~<Protocol with members '__getitem__', '__len__'> & ~tuple[object, object, *tuple[object, ...]]) | str | (Sequence[str] & bytes) | (Sequence[str] & bytearray)
     reveal_type(paths)
+
+def normalize_version(
+    version: str | tuple[int, int] | tuple[int, int, int],
+) -> str:
+    match version:
+        case [major, minor, *_rest]:
+            return f"{major}.{minor}"
+
+    reveal_type(version)  # revealed: str
+    return version.strip()
 
 def exact_sequence_pattern_is_exhaustive(value: tuple[int, str]) -> int:
     match value:

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -5,6 +5,7 @@ use ty_python_core::predicate::{PatternPredicateKind, SequencePatternPredicateKi
 use crate::Db;
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::signatures::CallableSignature;
+use crate::types::tuple::TupleType;
 use crate::types::{
     CallableType, IntersectionBuilder, KnownClass, Parameter, Parameters, Signature,
     SpecialFormType, Type, TypeContext, UnionType, infer_same_file_expression_type,
@@ -238,6 +239,19 @@ pub(crate) fn definite_sequence_pattern_type<'db>(
             exact_sequence_pattern_type(db, element_types.into_iter())
         }
     } else {
-        Type::Never
+        let Some((prefix, suffix)) = kind.split_around_star() else {
+            return Type::Never;
+        };
+
+        Type::tuple(TupleType::mixed(
+            db,
+            prefix
+                .iter()
+                .map(|pattern| definite_match_pattern_type(db, pattern)),
+            Type::object(),
+            suffix
+                .iter()
+                .map(|pattern| definite_match_pattern_type(db, pattern)),
+        ))
     }
 }

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -182,7 +182,6 @@ impl<'db> TupleType<'db> {
         TupleType::new(db, &TupleSpec::heterogeneous(types))
     }
 
-    #[cfg(test)]
     pub(crate) fn mixed(
         db: &'db dyn Db,
         prefix: impl IntoIterator<Item = Type<'db>>,


### PR DESCRIPTION
## Summary

Starred sequence patterns currently do not contribute a definite matched type to negative narrowing. After a case such as `[first, second, *rest]`, we retain only the sequence protocol constraints even though the pattern definitely consumes tuples with at least two elements.

This matters for APIs that accept either text or a fixed-shape structured value:

```python
def normalize_version(
    version: str | tuple[int, int] | tuple[int, int, int],
) -> str:
    match version:
        case [major, minor, *_rest]:
            return f"{major}.{minor}"

    return version.strip()
```

The starred case consumes every tuple alternative, so the fallback can narrow `version` to `str` and use string methods normally.
