### PR TITLE
[ty] Publish diagnostics for all open files after a single file is saved

### DIFF
--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -1,9 +1,9 @@
 use lsp_types::{
     self as types, ClientCapabilities, CodeActionKind, CodeActionOptions, CompletionOptions,
     DiagnosticOptions, DiagnosticProvider, InlayHintOptions, MarkupKind, NotebookCellLanguage,
-    NotebookDocumentFilterWithCells, NotebookSelector, RenameOptions, SemanticTokensLegend,
-    SemanticTokensOptions, ServerCapabilities, SignatureHelpOptions, TextDocumentSyncKind,
-    TextDocumentSyncOptions, WorkDoneProgressOptions,
+    NotebookDocumentFilterWithCells, NotebookSelector, RenameOptions, Save, SaveOptions,
+    SemanticTokensLegend, SemanticTokensOptions, ServerCapabilities, SignatureHelpOptions,
+    TextDocumentSyncKind, TextDocumentSyncOptions, WorkDoneProgressOptions,
 };
 use std::str::FromStr;
 
@@ -416,6 +416,9 @@ pub(crate) fn server_capabilities(
             TextDocumentSyncOptions {
                 open_close: Some(true),
                 change: Some(TextDocumentSyncKind::Incremental),
+                save: Some(Save::SaveOptions(SaveOptions {
+                    include_text: Some(false),
+                })),
                 ..Default::default()
             }
             .into(),

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -196,6 +196,9 @@ pub(super) fn notification(notif: server::Notification) -> Task {
         notifications::DidCloseNotebookHandler::METHOD => {
             sync_notification_task::<notifications::DidCloseNotebookHandler>(notif)
         }
+        notifications::DidSaveTextDocumentHandler::METHOD => {
+            sync_notification_task::<notifications::DidSaveTextDocumentHandler>(notif)
+        }
         notifications::DidChangeWatchedFiles::METHOD => {
             sync_notification_task::<notifications::DidChangeWatchedFiles>(notif)
         }

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -208,13 +208,14 @@ pub(super) fn publish_diagnostics(document: &DocumentHandle, session: &Session, 
     };
 
     // Sends a notification to the client with the diagnostics for the document.
-    let publish_diagnostics_notification = |uri: Uri, diagnostics: Vec<Diagnostic>| {
-        client.send_notification::<PublishDiagnosticsNotification>(PublishDiagnosticsParams {
-            uri,
-            diagnostics,
-            version: Some(document.version()),
-        });
-    };
+    let publish_diagnostics_notification =
+        |uri: Uri, version: Option<i32>, diagnostics: Vec<Diagnostic>| {
+            client.send_notification::<PublishDiagnosticsNotification>(PublishDiagnosticsParams {
+                uri,
+                diagnostics,
+                version,
+            });
+        };
 
     match diagnostics.to_lsp_diagnostics(
         db,
@@ -222,7 +223,11 @@ pub(super) fn publish_diagnostics(document: &DocumentHandle, session: &Session, 
         session.global_settings(),
     ) {
         LspDiagnostics::TextDocument(diagnostics) => {
-            publish_diagnostics_notification(document.uri().clone(), diagnostics);
+            publish_diagnostics_notification(
+                document.uri().clone(),
+                Some(document.version()),
+                diagnostics,
+            );
         }
         LspDiagnostics::NotebookDocument(cell_diagnostics) => {
             #[expect(
@@ -230,7 +235,11 @@ pub(super) fn publish_diagnostics(document: &DocumentHandle, session: &Session, 
                 reason = "diagnostic notifications for distinct cell URIs are independent"
             )]
             for (cell_uri, diagnostics) in cell_diagnostics {
-                publish_diagnostics_notification(cell_uri, diagnostics);
+                let version = session
+                    .document_handle(&cell_uri)
+                    .map(|document| document.version())
+                    .ok();
+                publish_diagnostics_notification(cell_uri, version, diagnostics);
             }
         }
     }

--- a/crates/ty_server/src/server/api/notifications.rs
+++ b/crates/ty_server/src/server/api/notifications.rs
@@ -7,6 +7,7 @@ mod did_close;
 mod did_close_notebook;
 mod did_open;
 mod did_open_notebook;
+mod did_save;
 
 pub(super) use cancel::CancelNotificationHandler;
 pub(super) use did_change::DidChangeTextDocumentHandler;
@@ -17,3 +18,4 @@ pub(super) use did_close::DidCloseTextDocumentHandler;
 pub(super) use did_close_notebook::DidCloseNotebookHandler;
 pub(super) use did_open::DidOpenTextDocumentHandler;
 pub(super) use did_open_notebook::DidOpenNotebookHandler;
+pub(super) use did_save::DidSaveTextDocumentHandler;

--- a/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
@@ -85,8 +85,8 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         if client_capabilities.supports_workspace_diagnostic_refresh() {
             client.send_request::<types::DiagnosticRefreshRequest>(session, (), |_, ()| {});
         } else {
-            for key in session.text_document_handles() {
-                publish_diagnostics_if_needed(&key, session, client);
+            for document in session.file_document_handles() {
+                publish_diagnostics_if_needed(&document, session, client);
             }
         }
 

--- a/crates/ty_server/src/server/api/notifications/did_save.rs
+++ b/crates/ty_server/src/server/api/notifications/did_save.rs
@@ -1,0 +1,27 @@
+use lsp_types::{DidSaveTextDocumentNotification, DidSaveTextDocumentParams};
+
+use crate::server::Result;
+use crate::server::api::diagnostics::publish_diagnostics_if_needed;
+use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::Session;
+use crate::session::client::Client;
+
+pub(crate) struct DidSaveTextDocumentHandler;
+
+impl NotificationHandler for DidSaveTextDocumentHandler {
+    type NotificationType = DidSaveTextDocumentNotification;
+}
+
+impl SyncNotificationHandler for DidSaveTextDocumentHandler {
+    fn run(
+        session: &mut Session,
+        client: &Client,
+        _params: DidSaveTextDocumentParams,
+    ) -> Result<()> {
+        for document in session.file_document_handles() {
+            publish_diagnostics_if_needed(&document, session, client);
+        }
+
+        Ok(())
+    }
+}

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -1169,6 +1169,16 @@ impl Session {
             .map(|(_, document)| DocumentHandle::from_text_document(document))
     }
 
+    /// Iterates over all open file-level documents.
+    ///
+    /// Notebook cells are excluded because their file-level representation is the containing
+    /// notebook.
+    pub(super) fn file_document_handles(&self) -> impl Iterator<Item = DocumentHandle> + '_ {
+        self.index()
+            .file_documents()
+            .map(DocumentHandle::from_document)
+    }
+
     /// Returns a handle to the document specified by its URI.
     ///
     /// # Errors

--- a/crates/ty_server/src/session/index.rs
+++ b/crates/ty_server/src/session/index.rs
@@ -31,6 +31,18 @@ impl Index {
         })
     }
 
+    /// Iterates over open documents that correspond to file-level documents.
+    ///
+    /// The index only stores documents that the client has opened. This filter keeps normal text
+    /// documents and whole notebook documents, but excludes notebook cell text documents (because
+    /// the file-level representation for a cell is its containing notebook).
+    pub(super) fn file_documents(&self) -> impl Iterator<Item = &Document> + '_ {
+        self.documents.values().filter(|document| match document {
+            Document::Text(text_document) => text_document.notebook().is_none(),
+            Document::Notebook(_) => true,
+        })
+    }
+
     pub(crate) fn document_handle(
         &self,
         uri: &lsp_types::Uri,

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -63,19 +63,19 @@ use lsp_types::{
     DidChangeWatchedFilesClientCapabilities, DidChangeWatchedFilesNotification,
     DidChangeWatchedFilesParams, DidChangeWorkspaceFoldersNotification,
     DidChangeWorkspaceFoldersParams, DidCloseTextDocumentNotification, DidCloseTextDocumentParams,
-    DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DocumentDiagnosticParams,
-    DocumentDiagnosticReport, DocumentDiagnosticRequest, ExitNotification, FileEvent, FoldingRange,
-    FoldingRangeParams, Hover, HoverParams, HoverRequest, InitializeParams, InitializeRequest,
-    InitializeResult, InitializedNotification, InitializedParams, InlayHint,
-    InlayHintClientCapabilities, InlayHintParams, InlayHintRequest, LanguageKind, Notification,
-    PartialResultParams, Position, PrepareRenameRequest, PreviousResultId,
-    PublishDiagnosticsClientCapabilities, Range, Request, SemanticTokens, ShutdownRequest,
-    SignatureHelp, SignatureHelpParams, SignatureHelpRequest, SignatureHelpTriggerKind,
-    TextDocumentClientCapabilities, TextDocumentContentChangeEvent, TextDocumentIdentifier,
-    TextDocumentItem, TextDocumentPositionParams, Uri, VersionedTextDocumentIdentifier,
-    WorkDoneProgressParams, WorkspaceClientCapabilities, WorkspaceDiagnosticParams,
-    WorkspaceDiagnosticReport, WorkspaceDiagnosticRequest, WorkspaceEdit, WorkspaceFolder,
-    WorkspaceFoldersChangeEvent, WorkspaceFoldersInitializeParams,
+    DidOpenTextDocumentNotification, DidOpenTextDocumentParams, DidSaveTextDocumentNotification,
+    DidSaveTextDocumentParams, DocumentDiagnosticParams, DocumentDiagnosticReport,
+    DocumentDiagnosticRequest, ExitNotification, FileEvent, FoldingRange, FoldingRangeParams,
+    Hover, HoverParams, HoverRequest, InitializeParams, InitializeRequest, InitializeResult,
+    InitializedNotification, InitializedParams, InlayHint, InlayHintClientCapabilities,
+    InlayHintParams, InlayHintRequest, LanguageKind, Notification, PartialResultParams, Position,
+    PrepareRenameRequest, PreviousResultId, PublishDiagnosticsClientCapabilities, Range, Request,
+    SemanticTokens, ShutdownRequest, SignatureHelp, SignatureHelpParams, SignatureHelpRequest,
+    SignatureHelpTriggerKind, TextDocumentClientCapabilities, TextDocumentContentChangeEvent,
+    TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, Uri,
+    VersionedTextDocumentIdentifier, WorkDoneProgressParams, WorkspaceClientCapabilities,
+    WorkspaceDiagnosticParams, WorkspaceDiagnosticReport, WorkspaceDiagnosticRequest,
+    WorkspaceEdit, WorkspaceFolder, WorkspaceFoldersChangeEvent, WorkspaceFoldersInitializeParams,
 };
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf, TestSystem};
 use rustc_hash::FxHashMap;
@@ -839,6 +839,17 @@ impl TestServer {
             content_changes: changes,
         };
         self.send_notification::<DidChangeTextDocumentNotification>(params);
+    }
+
+    /// Send a `textDocument/didSave` notification
+    pub(crate) fn save_text_document(&mut self, path: impl AsRef<SystemPath>) {
+        let params = DidSaveTextDocumentParams {
+            text_document: TextDocumentIdentifier {
+                uri: self.file_uri(path),
+            },
+            text: None,
+        };
+        self.send_notification::<DidSaveTextDocumentNotification>(params);
     }
 
     /// Send a `textDocument/didClose` notification

--- a/crates/ty_server/tests/e2e/notebook.rs
+++ b/crates/ty_server/tests/e2e/notebook.rs
@@ -580,8 +580,8 @@ fn semantic_tokens_full_for_cell(
 #[derive(Debug)]
 pub(crate) struct NotebookBuilder {
     notebook_uri: lsp_types::Uri,
-    // The cells: (cell_metadata, content, language_id)
-    cells: Vec<(lsp_types::NotebookCell, String, String)>,
+    // The cells: (cell_metadata, content, language_id, version)
+    cells: Vec<(lsp_types::NotebookCell, String, String, i32)>,
 }
 
 impl NotebookBuilder {
@@ -594,6 +594,14 @@ impl NotebookBuilder {
     }
 
     pub(crate) fn add_python_cell(&mut self, content: &str) -> lsp_types::Uri {
+        self.add_python_cell_with_version(content, 0)
+    }
+
+    pub(crate) fn add_python_cell_with_version(
+        &mut self,
+        content: &str,
+        version: i32,
+    ) -> lsp_types::Uri {
         let index = self.cells.len();
         let id = format!(
             "vscode-notebook-cell:/{}#{}",
@@ -612,6 +620,7 @@ impl NotebookBuilder {
             },
             content.to_string(),
             "python".to_string(),
+            version,
         ));
 
         uri
@@ -625,17 +634,23 @@ impl NotebookBuilder {
                     notebook_type: "jupyter-notebook".to_string(),
                     version: 0,
                     metadata: None,
-                    cells: self.cells.iter().map(|(cell, _, _)| cell.clone()).collect(),
+                    cells: self
+                        .cells
+                        .iter()
+                        .map(|(cell, _, _, _)| cell.clone())
+                        .collect(),
                 },
                 cell_text_documents: self
                     .cells
                     .iter()
-                    .map(|(cell, content, language_id)| lsp_types::TextDocumentItem {
-                        uri: cell.document.clone(),
-                        language_id: language_id.clone().into(),
-                        version: 0,
-                        text: content.clone(),
-                    })
+                    .map(
+                        |(cell, content, language_id, version)| lsp_types::TextDocumentItem {
+                            uri: cell.document.clone(),
+                            language_id: language_id.clone().into(),
+                            version: *version,
+                            text: content.clone(),
+                        },
+                    )
                     .collect(),
             },
         );

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use lsp_types::{
     DidOpenTextDocumentNotification, DidOpenTextDocumentParams, FileChangeType, FileEvent,
     LanguageKind, Message, Position, PublishDiagnosticsNotification, Range,
@@ -486,19 +486,39 @@ def foo() -> str:
         .wait_until_workspaces_are_initialized();
 
     let foo = server.file_path(foo);
+    let foo_uri = server.file_uri(&foo);
 
     server.open_text_document(&foo, "", 1);
 
     let _open_diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
+    let mut notebook = NotebookBuilder::virtual_file("src/notebook.ipynb");
+    let first_cell = notebook.add_python_cell("x = 1\n");
+    let second_cell = notebook.add_python_cell("x\n");
+    notebook.open(&mut server);
+    server.collect_publish_diagnostic_notifications(2);
+
     std::fs::write(&foo, foo_content)?;
 
     server.did_change_watched_files(vec![FileEvent {
-        uri: server.file_uri(foo),
+        uri: foo_uri.clone(),
         kind: FileChangeType::Changed,
     }]);
 
-    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
+    let mut diagnostics = collect_publish_diagnostic_notifications_with_versions(&mut server, 3);
+    assert_eq!(diagnostics[&first_cell].version, Some(0));
+    assert_eq!(diagnostics[&second_cell].version, Some(0));
+
+    let extra_diagnostics = server
+        .try_await_notification::<PublishDiagnosticsNotification>(Some(Duration::from_millis(100)));
+    assert!(
+        extra_diagnostics.is_err(),
+        "Server should publish diagnostics once per open document"
+    );
+
+    let diagnostics = diagnostics
+        .remove(&foo_uri)
+        .with_context(|| format!("Expected diagnostics for {foo_uri}"))?;
 
     // Note how ty reports no diagnostics here. This is because
     // the contents received by didOpen/didChange take precedence over the file

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -10,7 +11,8 @@ use lsp_types::{
 use ruff_db::system::SystemPath;
 use ty_server::ClientOptions;
 
-use crate::TestServerBuilder;
+use crate::notebook::NotebookBuilder;
+use crate::{TestServer, TestServerBuilder};
 
 #[test]
 fn on_did_open() -> Result<()> {
@@ -214,6 +216,80 @@ def foo() -> str:
     assert_eq!(diagnostics.version, Some(2));
 
     insta::assert_debug_snapshot!(diagnostics);
+
+    Ok(())
+}
+
+#[test]
+fn on_did_save_publishes_open_file_documents() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let lib = SystemPath::new("src/lib.py");
+    let main = SystemPath::new("src/main.py");
+
+    let lib_content = "x: str = ''\n";
+    let main_content = "\
+from typing import assert_type
+from lib import x
+
+assert_type(x, str)
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(lib, lib_content)?
+        .with_file(main, main_content)?
+        .enable_pull_diagnostics(false)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(lib, lib_content, 1);
+    server.await_notification::<PublishDiagnosticsNotification>();
+
+    server.open_text_document(main, main_content, 1);
+    server.await_notification::<PublishDiagnosticsNotification>();
+
+    let mut notebook = NotebookBuilder::virtual_file("src/notebook.ipynb");
+    let notebook_import = notebook.add_python_cell("from lib import x\n");
+    let notebook_main_content = "\
+from typing import assert_type
+
+assert_type(x, str)
+";
+    let notebook_main = notebook.add_python_cell_with_version(notebook_main_content, 1);
+    notebook.open(&mut server);
+    // Opening the notebook publishes diagnostics for both notebook cells:
+    // `src/notebook.ipynb#0` and `src/notebook.ipynb#1`.
+    server.collect_publish_diagnostic_notifications(2);
+
+    server.change_text_document(
+        lib,
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: "x: int = 1\n".to_string(),
+                },
+            ),
+        ],
+        2,
+    );
+    // Drain the diagnostics for `src/lib.py` triggered by `textDocument/didChange`
+    // before asserting on the diagnostics triggered by `textDocument/didSave`.
+    server.await_notification::<PublishDiagnosticsNotification>();
+
+    server.save_text_document(lib);
+
+    // Saving `src/lib.py` publishes four diagnostic notifications:
+    // - one for `src/lib.py`,
+    // - one for `src/main.py`, and
+    // - two for `src/notebook.ipynb`, one per notebook cell (`#0` and `#1`).
+    let diagnostics = collect_publish_diagnostic_notifications_with_versions(&mut server, 4);
+    assert_eq!(diagnostics[&notebook_import].version, Some(0));
+    assert_eq!(diagnostics[&notebook_main].version, Some(1));
+    let diagnostics = diagnostics
+        .into_iter()
+        .map(|(uri, diagnostics)| (uri, diagnostics.diagnostics))
+        .collect::<BTreeMap<_, _>>();
+    insta::assert_json_snapshot!(diagnostics);
 
     Ok(())
 }
@@ -597,4 +673,23 @@ def foo(
     insta::assert_debug_snapshot!(diagnostics);
 
     Ok(())
+}
+
+fn collect_publish_diagnostic_notifications_with_versions(
+    server: &mut TestServer,
+    count: usize,
+) -> BTreeMap<Uri, lsp_types::PublishDiagnosticsParams> {
+    let mut results = BTreeMap::new();
+
+    for _ in 0..count {
+        let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
+        let uri = diagnostics.uri.clone();
+
+        assert!(
+            results.insert(uri.clone(), diagnostics).is_none(),
+            "Received multiple publish diagnostic notifications for {uri}"
+        );
+    }
+
+    results
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
@@ -7,7 +7,10 @@ expression: initialization_result
     "positionEncoding": "utf-16",
     "textDocumentSync": {
       "openClose": true,
-      "change": 2
+      "change": 2,
+      "save": {
+        "includeText": false
+      }
     },
     "notebookDocumentSync": {
       "notebookSelector": [

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
@@ -7,7 +7,10 @@ expression: initialization_result
     "positionEncoding": "utf-16",
     "textDocumentSync": {
       "openClose": true,
-      "change": 2
+      "change": 2,
+      "save": {
+        "includeText": false
+      }
     },
     "notebookDocumentSync": {
       "notebookSelector": [

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_save_publishes_open_file_documents.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__on_did_save_publishes_open_file_documents.snap
@@ -1,0 +1,50 @@
+---
+source: crates/ty_server/tests/e2e/publish_diagnostics.rs
+expression: diagnostics
+---
+{
+  "file://<temp_dir>/src/lib.py": [],
+  "file://<temp_dir>/src/main.py": [
+    {
+      "range": {
+        "start": {
+          "line": 3,
+          "character": 0
+        },
+        "end": {
+          "line": 3,
+          "character": 19
+        }
+      },
+      "severity": 1,
+      "code": "type-assertion-failure",
+      "codeDescription": {
+        "href": "https://ty.dev/rules#type-assertion-failure"
+      },
+      "source": "ty",
+      "message": "Type `int` does not match asserted type `str`\n\ninfo: `str` and `int` are not equivalent types"
+    }
+  ],
+  "vscode-notebook-cell://src/notebook.ipynb#0": [],
+  "vscode-notebook-cell://src/notebook.ipynb#1": [
+    {
+      "range": {
+        "start": {
+          "line": 2,
+          "character": 0
+        },
+        "end": {
+          "line": 2,
+          "character": 19
+        }
+      },
+      "severity": 1,
+      "code": "type-assertion-failure",
+      "codeDescription": {
+        "href": "https://ty.dev/rules#type-assertion-failure"
+      },
+      "source": "ty",
+      "message": "Type `int` does not match asserted type `str`\n\ninfo: `str` and `int` are not equivalent types"
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This updates the language server to publish diagnostics for all open files after any single open file is saved. Note that this new capability applies differently to regular text documents than to notebooks:

- For regular text documents, it only applies when the client does not support pull diagnostics. If the client _does_ support pull diagnostics, then it is the client's responsibility to request new diagnostics on save.
- For notebooks this always applies, because we only support push diagnostics for notebooks.

This implementation handles the `didSave` notification (and publishes the new diagnostics) synchronously. This follows precedent and I hope will be good enough, but if we receive feedback that this feels slow then we can consider handling the notification in the background instead.

Closes https://github.com/astral-sh/ty/issues/1652.

## Test Plan

Please see included tests.
<!-- How was it tested? -->
