### PR TITLE
[ty] Test diagnostic output for exception causes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/exception/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/exception/basic.md
@@ -208,19 +208,19 @@ def _(e: Exception | type[Exception] | None):
 ```py
 def _():
     try:
-        raise EOFError() from GeneratorExit  # fine
+        raise EOFError() from GeneratorExit  # error: [invalid-raise]
     except:
         pass
 
 def _():
     try:
-        raise StopIteration from MemoryError()  # fine
+        raise StopIteration from MemoryError()  # error: [invalid-raise]
     except:
         pass
 
 def _():
     try:
-        raise BufferError() from None  # fine
+        raise BufferError() from None  # error: [invalid-raise]
     except:
         pass
 
@@ -241,20 +241,20 @@ def _():
         raise
     except KeyboardInterrupt as e:  # fine
         reveal_type(e)  # revealed: KeyboardInterrupt
-        raise LookupError from e  # fine
+        raise LookupError from e  # error: [invalid-raise]
 
 def _():
     try:
         raise
     except int as e:  # error: [invalid-exception-caught]
         reveal_type(e)  # revealed: Unknown
-        raise KeyError from e
+        raise KeyError from e  # error: [invalid-raise]
 
 def _(e: Exception | type[Exception]):
-    raise ModuleNotFoundError from e  # fine
+    raise ModuleNotFoundError from e  # error: [invalid-raise]
 
 def _(e: Exception | type[Exception] | None):
-    raise IndexError from e  # fine
+    raise IndexError from e  # error: [invalid-raise]
 
 def _(e: int | None):
     raise IndexError from e  # error: [invalid-raise]

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5159,9 +5159,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let can_be_raised =
             UnionType::from_two_elements(self.db(), base_exception_type, base_exception_instance);
-        let can_be_exception_cause =
-            UnionType::from_two_elements(self.db(), can_be_raised, Type::none(self.db()));
-
         if let Some(raised) = exc {
             let raised_type = self.infer_expression(raised, TypeContext::default());
 
@@ -5172,10 +5169,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if let Some(cause) = cause {
             let cause_type = self.infer_expression(cause, TypeContext::default());
-
-            if !cause_type.is_assignable_to(self.db(), can_be_exception_cause) {
-                report_invalid_exception_cause(&self.context, cause, cause_type);
-            }
+            report_invalid_exception_cause(&self.context, cause, cause_type);
         }
     }
 


### PR DESCRIPTION
> [!WARNING]
> This is an intentionally incorrect, test-only draft PR. It introduces false-positive diagnostics and is not intended to merge.

## Summary

- Report the existing `invalid-raise` diagnostic for every explicit exception cause.
- Update the exception mdtest expectations for valid exception classes, instances, unions, and `None`.

## Why

This creates an invasive diagnostic-output change for exercising ecosystem and reporting workflows. Correct code such as `raise RuntimeError from ValueError()` now emits `invalid-raise`.

## Validation

- `CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ty_python_semantic -- mdtest::exception/basic.md`
- `cargo run --bin ty -- check --output-format=concise /private/tmp/ty-test-pr4.py` (confirmed the intentional diagnostic)
- `uvx prek run --files crates/ty_python_semantic/src/types/infer/builder.rs crates/ty_python_semantic/resources/mdtest/exception/basic.md`
