### PR TITLE
[ty] Reuse parsed module handles

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -642,7 +642,7 @@ MY_CONSTANT: Final[int] = 1
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ignore-comment-unknown-rule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L84" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L85" target="_blank">View source</a>
 </small>
 
 
@@ -1464,7 +1464,7 @@ x: G[int]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L109" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L110" target="_blank">View source</a>
 </small>
 
 
@@ -4160,7 +4160,7 @@ async def main() -> None:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L25" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L26" target="_blank">View source</a>
 </small>
 
 
@@ -4196,7 +4196,7 @@ to `false` to prevent this rule from reporting unused `type: ignore` comments.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-type-ignore-comment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L54" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fsuppression.rs#L55" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2522,6 +2522,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         );
 
         SemanticIndex {
+            parsed_module: self.module.module().clone(),
             place_tables: place_tables.into(),
             scopes: self.scopes.into(),
             definitions_by_node: DefinitionsByNode::from_map(self.definitions_by_node),

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -7,7 +7,7 @@ use std::iter::{FusedIterator, once};
 use std::sync::Arc;
 
 use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
+use ruff_db::parsed::{ParsedModule, parsed_module};
 use ruff_index::{FrozenIndexVec, IndexSlice};
 use ruff_python_ast::NodeIndex;
 use ruff_python_parser::semantic_errors::SemanticSyntaxError;
@@ -302,6 +302,13 @@ impl<'db> DefinitionsByNode<'db> {
 /// The place tables and use-def maps for all scopes in a file.
 #[derive(Debug, Update, get_size2::GetSize)]
 pub struct SemanticIndex<'db> {
+    /// The parsed-module handle used to build this index.
+    ///
+    /// Keeping the handle here lets queries that require both the semantic index and the AST avoid
+    /// a second `parsed_module` query. Clearing the handle still drops the shared AST payload.
+    #[get_size(ignore)]
+    parsed_module: ParsedModule,
+
     /// List of all place tables in this file, indexed by scope.
     place_tables: FrozenIndexVec<FileScopeId, Arc<PlaceTable>>,
 
@@ -372,6 +379,11 @@ pub struct NarrowingAliasPredicate<'db> {
 }
 
 impl<'db> SemanticIndex<'db> {
+    /// Returns the parsed-module handle used to build this index.
+    pub fn parsed_module(&self) -> ParsedModule {
+        self.parsed_module.clone()
+    }
+
     /// Returns the place table for a specific scope.
     ///
     /// Use the Salsa cached [`place_table()`] query if you only need the
@@ -1082,7 +1094,9 @@ impl HasTrackedScope for ast::Identifier {}
 
 #[cfg(test)]
 mod tests {
-    use ruff_db::{files::system_path_to_file, parsed::ParsedModuleRef};
+    use ruff_db::{
+        files::system_path_to_file, parsed::ParsedModuleRef, system::DbWithWritableSystem as _,
+    };
     use ruff_python_ast as ast;
     use ruff_text_size::{Ranged, TextRange};
 
@@ -1138,6 +1152,53 @@ mod tests {
             .symbols()
             .map(|expr| expr.name().to_string())
             .collect()
+    }
+
+    fn first_assigned_name(module: &ParsedModuleRef) -> &str {
+        let ast::Stmt::Assign(assign) = &module.syntax().body[0] else {
+            panic!("expected an assignment");
+        };
+        let ast::Expr::Name(name) = &assign.targets[0] else {
+            panic!("expected a name target");
+        };
+        name.id.as_str()
+    }
+
+    #[test]
+    fn semantic_index_parsed_module_is_invalidated_by_source_edit() -> anyhow::Result<()> {
+        let TestCase { mut db, file } = test_case("x = 1");
+        let path = file
+            .path(&db)
+            .as_system_path()
+            .expect("test file should have a system path")
+            .to_path_buf();
+
+        let before = semantic_index(&db, file).parsed_module();
+        assert_eq!(first_assigned_name(&before.load(&db)), "x");
+
+        db.write_file(path, "y = 2")?;
+
+        let after = semantic_index(&db, file).parsed_module();
+        assert_ne!(before, after);
+        assert_eq!(first_assigned_name(&after.load(&db)), "y");
+
+        Ok(())
+    }
+
+    #[test]
+    fn semantic_index_parsed_module_reloads_after_clear() {
+        let TestCase { db, file } = test_case("x = 1");
+
+        let parsed = semantic_index(&db, file).parsed_module();
+        let before_clear = parsed.load(&db);
+        parsed.clear();
+        drop(parsed);
+
+        let retained = semantic_index(&db, file).parsed_module();
+        let after_clear = retained.load(&db);
+
+        assert!(!std::ptr::eq(before_clear.syntax(), after_clear.syntax()));
+        assert_eq!(first_assigned_name(&after_clear), "x");
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -185,9 +185,8 @@ pub fn check_file(db: &dyn Db, file: File) -> Result<Box<[Diagnostic]>, Diagnost
         .to_diagnostic());
     }
 
-    let parsed = parsed_module(db, file);
-
-    let parsed_ref = parsed.load(db);
+    let index = semantic_index(db, file);
+    let parsed_ref = index.parsed_module().load(db);
     diagnostics.extend(
         parsed_ref
             .errors()

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -8,9 +8,10 @@ use std::fmt;
 use ruff_db::diagnostic::{
     Annotation, Diagnostic, DiagnosticId, IntoDiagnosticMessage, LintName, Severity, Span,
 };
-use ruff_db::{files::File, parsed::parsed_module, source::source_text};
+use ruff_db::{files::File, source::source_text};
 use ruff_python_ast::token::TokenKind;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
+use ty_python_core::semantic_index;
 
 use crate::diagnostic::DiagnosticGuard;
 use crate::lint::{GetLintError, Level, LintMetadata, LintRegistry, LintStatus};
@@ -136,7 +137,7 @@ pub fn is_unused_ignore_comment_lint(name: LintName) -> bool {
 
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
 pub(crate) fn suppressions(db: &dyn Db, file: File) -> Suppressions {
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = semantic_index(db, file).parsed_module().load(db);
     let source = source_text(db, file);
 
     let respect_type_ignore = db.analysis_settings(file).respect_type_ignore_comments;

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2193,8 +2193,8 @@ impl<'db> StaticClassLiteral<'db> {
         let mut provenance = Provenance::Unknown;
 
         let file = class_body_scope.file(db);
-        let module = parsed_module(db, file).load(db);
         let index = semantic_index(db, file);
+        let module = index.parsed_module().load(db);
         let class_map = use_def_map(db, class_body_scope);
         let class_table = place_table(db, class_body_scope);
         let is_valid_scope = |method_scope: &Scope| {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -372,9 +372,12 @@ impl<'db> OverloadLiteral<'db> {
         db: &'db dyn Db,
         predicate: impl Fn(Type<'db>) -> bool,
     ) -> Option<Span> {
-        let definition = self.definition(db);
-        let file = definition.file(db);
-        self.node(db, file, &parsed_module(db, file).load(db))
+        let body_scope = self.body_scope(db);
+        let file = body_scope.file(db);
+        let index = semantic_index(db, file);
+        let definition = index.expect_single_definition(body_scope.node(db).expect_function());
+        let module = index.parsed_module().load(db);
+        self.node(db, file, &module)
             .decorator_list
             .iter()
             .find(|decorator| {
@@ -432,9 +435,12 @@ impl<'db> OverloadLiteral<'db> {
     fn previous_overload(self, db: &'db dyn Db) -> Option<FunctionLiteral<'db>> {
         // The semantic model records a use for each function on the name node. This is used
         // here to get the previous function definition with the same name.
-        let scope = self.definition(db).scope(db);
-        let module = parsed_module(db, self.file(db)).load(db);
-        let use_def = semantic_index(db, scope.file(db)).use_def_map(scope.file_scope_id(db));
+        let body_scope = self.body_scope(db);
+        let index = semantic_index(db, body_scope.file(db));
+        let definition = index.expect_single_definition(body_scope.node(db).expect_function());
+        let scope = definition.scope(db);
+        let module = index.parsed_module().load(db);
+        let use_def = index.use_def_map(scope.file_scope_id(db));
         let use_id = self
             .body_scope(db)
             .node(db)
@@ -485,9 +491,9 @@ impl<'db> OverloadLiteral<'db> {
         let mut signature = self.raw_signature(db, ReturnCallableTypeVarScope::Public);
 
         let scope = self.body_scope(db);
-        let module = parsed_module(db, self.file(db)).load(db);
-        let function_node = scope.node(db).expect_function().node(&module);
         let index = semantic_index(db, scope.file(db));
+        let module = index.parsed_module().load(db);
+        let function_node = scope.node(db).expect_function().node(&module);
         let file_scope_id = scope.file_scope_id(db);
         let is_generator = file_scope_id.is_generator_function(index);
 
@@ -570,10 +576,10 @@ impl<'db> OverloadLiteral<'db> {
         }
 
         let scope = self.body_scope(db);
-        let module = parsed_module(db, self.file(db)).load(db);
-        let function_stmt_node = scope.node(db).expect_function().node(&module);
-        let definition = self.definition(db);
         let index = semantic_index(db, scope.file(db));
+        let module = index.parsed_module().load(db);
+        let function_stmt_node = scope.node(db).expect_function().node(&module);
+        let definition = index.expect_single_definition(scope.node(db).expect_function());
         let pep695_ctx = function_stmt_node.type_params.as_ref().map(|type_params| {
             GenericContext::from_type_params(db, index, definition, type_params)
         });
@@ -921,9 +927,11 @@ impl<'db> FunctionLiteral<'db> {
             db: &'db dyn Db,
             implementation: OverloadLiteral<'db>,
         ) -> FunctionBodyKind {
-            let definition = implementation.definition(db);
-            let file = definition.file(db);
-            let module = parsed_module(db, file).load(db);
+            let body_scope = implementation.body_scope(db);
+            let file = body_scope.file(db);
+            let index = semantic_index(db, file);
+            let definition = index.expect_single_definition(body_scope.node(db).expect_function());
+            let module = index.parsed_module().load(db);
             let node = implementation.node(db, file, &module);
             function_body_kind(db, node, |expr| {
                 definition_expression_type(db, definition, expr)

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -110,15 +110,14 @@ pub(crate) fn infer_definition_types<'db>(
     definition: Definition<'db>,
 ) -> DefinitionInference<'db> {
     let file = definition.file(db);
-    let module = parsed_module(db, file).load(db);
+    let index = semantic_index(db, file);
+    let module = index.parsed_module().load(db);
     let _span = tracing::trace_span!(
         "infer_definition_types",
         range = ?definition.kind(db).target_range(&module),
         ?file
     )
     .entered();
-
-    let index = semantic_index(db, file);
 
     TypeInferenceBuilder::new(db, InferenceRegion::Definition(definition), index, &module)
         .finish_definition(definition)
@@ -160,8 +159,8 @@ pub(crate) fn function_known_decorators<'db>(
     definition: Definition<'db>,
 ) -> FunctionDecoratorInference<'db> {
     let file = definition.file(db);
-    let module = parsed_module(db, file).load(db);
     let index = semantic_index(db, file);
+    let module = index.parsed_module().load(db);
 
     TypeInferenceBuilder::new(
         db,
@@ -245,7 +244,8 @@ pub(crate) fn infer_deferred_types<'db>(
     definition: Definition<'db>,
 ) -> DefinitionInference<'db> {
     let file = definition.file(db);
-    let module = parsed_module(db, file).load(db);
+    let index = semantic_index(db, file);
+    let module = index.parsed_module().load(db);
     let _span = tracing::trace_span!(
         "infer_deferred_types",
         definition = ?definition.as_id(),
@@ -253,8 +253,6 @@ pub(crate) fn infer_deferred_types<'db>(
         ?file
     )
     .entered();
-
-    let index = semantic_index(db, file);
 
     TypeInferenceBuilder::new(db, InferenceRegion::Deferred(definition), index, &module)
         .finish_definition(definition)
@@ -318,11 +316,10 @@ pub(crate) fn infer_scope_types_impl<'db>(
     let file = scope.file(db);
     let _span = tracing::trace_span!("infer_scope_types", scope=?scope.as_id(), ?file).entered();
 
-    let module = parsed_module(db, file).load(db);
-
     // Using the index here is fine because the code below depends on the AST anyway.
     // The isolation of the query is by the return inferred types.
     let index = semantic_index(db, file);
+    let module = index.parsed_module().load(db);
 
     TypeInferenceBuilder::new(db, InferenceRegion::Scope(scope, tcx), index, &module).finish_scope()
 }
@@ -354,7 +351,8 @@ pub(super) fn infer_expression_types_impl<'db>(
     let (expression, tcx) = input.into_inner(db);
 
     let file = expression.file(db);
-    let module = parsed_module(db, file).load(db);
+    let index = semantic_index(db, file);
+    let module = index.parsed_module().load(db);
     let _span = tracing::trace_span!(
         "infer_expression_types",
         expression = ?expression.as_id(),
@@ -362,8 +360,6 @@ pub(super) fn infer_expression_types_impl<'db>(
         ?file
     )
     .entered();
-
-    let index = semantic_index(db, file);
 
     TypeInferenceBuilder::new(
         db,
@@ -465,7 +461,8 @@ fn infer_statement_types_impl<'db>(
     statement: StatementInner<'db>,
 ) -> StatementInferenceInner<'db> {
     let file = statement.file(db);
-    let module = parsed_module(db, file).load(db);
+    let index = semantic_index(db, file);
+    let module = index.parsed_module().load(db);
     let _span = tracing::trace_span!(
         "infer_statement_types",
         statement = ?statement.as_id(),
@@ -473,8 +470,6 @@ fn infer_statement_types_impl<'db>(
         ?file
     )
     .entered();
-
-    let index = semantic_index(db, file);
 
     TypeInferenceBuilder::new(db, InferenceRegion::Statement(statement), index, &module)
         .finish_statement()


### PR DESCRIPTION
## Summary

`parsed_module` uses an LRU cache, so every lookup updates synchronized recency state. Semantic index construction already loads the parsed module, but type inference and other semantic queries frequently looked it up again when they needed both the index and the AST. On highly parallel checks, those cached lookups contend on the LRU mutex even though no parsing is required.

This retains the cheap `ParsedModule` handle on `SemanticIndex` and reuses it in code paths that already depend on the semantic index. The shared handle preserves the existing behavior: source edits rebuild the index with a new handle, and clearing the handle still drops the AST payload so it can be reloaded later.

## Performance

Across 20 paired runs of the Home Assistant benchmark with the profiling profile, this reduced geometric-mean wall time by 8.1% and total CPU time by 6.0%. The candidate won 19 of 20 wall-time pairs and all 20 CPU-time pairs. Matching profiles showed a 94.7% reduction in `Lru::insert` samples while actual parser work remained flat.
