### PR TITLE
[ty] Refactor reStructuredText parameter documentation extraction to use an `IndexMap` from the start.

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -80,9 +80,7 @@ impl Docstring {
         param_docs.extend(extract_numpy_style_params(&self.0));
 
         // reST/Sphinx-style docstrings
-        for parameter in Formats::parse(&self.0).parameter_documentation() {
-            param_docs.insert(parameter.name, parameter.description);
-        }
+        param_docs.extend(Formats::parse(&self.0).parameter_documentation());
 
         param_docs
     }

--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -1628,12 +1628,15 @@ mod tests {
 
         Args:
             param1 (str): Google-style parameter
+            param2 (int): Google-style duplicate parameter
 
         :param int param2: reST-style parameter
         :param param3: Another reST-style parameter
 
         Parameters
         ----------
+        param3 : str
+            NumPy-style duplicate parameter
         param4 : bool
             NumPy-style parameter
         "#;
@@ -1664,12 +1667,15 @@ mod tests {
 
         Args:
             param1 (str): Google-style parameter
+            param2 (int): Google-style duplicate parameter
 
         :param int param2: reST-style parameter
         :param param3: Another reST-style parameter
 
         Parameters
         ----------
+        param3 : str
+            NumPy-style duplicate parameter
         param4 : bool
             NumPy-style parameter
         ");
@@ -1679,12 +1685,15 @@ mod tests {
         <HB>
         Args:<HB>
         &nbsp;&nbsp;&nbsp;&nbsp;param1 (str): Google-style parameter<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;param2 (int): Google-style duplicate parameter<HB>
         <HB>
         :param int param2: reST-style parameter<HB>
         :param param3: Another reST-style parameter<HB>
         <HB>
         Parameters<HB>
         ----------<HB>
+        param3 : str<HB>
+        &nbsp;&nbsp;&nbsp;&nbsp;NumPy-style duplicate parameter<HB>
         param4 : bool<HB>
         &nbsp;&nbsp;&nbsp;&nbsp;NumPy-style parameter
         ");

--- a/crates/ty_ide/src/docstring/formats.rs
+++ b/crates/ty_ide/src/docstring/formats.rs
@@ -1,11 +1,6 @@
-pub(super) mod rst;
+use indexmap::IndexMap;
 
-/// Represents documentation for a single parameter parsed from a docstring.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct ParameterDocumentation {
-    pub(super) name: String,
-    pub(super) description: String,
-}
+pub(super) mod rst;
 
 /// Encapsulates the set of docstring formats for which we support the following
 /// features:
@@ -25,7 +20,7 @@ impl Formats {
     }
 
     /// Returns docs for all parameters recognized in a parsed docstring.
-    pub(super) fn parameter_documentation(&self) -> Vec<ParameterDocumentation> {
+    pub(super) fn parameter_documentation(&self) -> IndexMap<String, String> {
         self.rst.parameter_documentation()
     }
 }

--- a/crates/ty_ide/src/docstring/formats/rst.rs
+++ b/crates/ty_ide/src/docstring/formats/rst.rs
@@ -1,6 +1,7 @@
 use std::iter::{Enumerate, Peekable};
 
 use compact_str::{CompactString, ToCompactString};
+use indexmap::IndexMap;
 use ruff_python_trivia::leading_indentation;
 use ruff_source_file::{Line as SourceLine, UniversalNewlineIterator, UniversalNewlines};
 use ruff_text_size::{TextRange, TextSize};
@@ -20,8 +21,8 @@ impl Docstring {
     }
 
     /// Returns the parameter documentation that we were able to recognize in a docstring.
-    pub(super) fn parameter_documentation(&self) -> Vec<super::ParameterDocumentation> {
-        let mut parameters = Vec::new();
+    pub(super) fn parameter_documentation(&self) -> IndexMap<String, String> {
+        let mut parameters = IndexMap::new();
 
         for field_list in &self.field_lists {
             for field in &field_list.fields {
@@ -38,10 +39,7 @@ impl Docstring {
                     continue;
                 }
 
-                parameters.push(super::ParameterDocumentation {
-                    name: lookup_name.clone(),
-                    description: description.clone(),
-                });
+                parameters.insert(lookup_name.clone(), description.clone());
             }
         }
 
@@ -968,15 +966,15 @@ Section::
         let parameters = Docstring::parse(docstring).parameter_documentation();
         let mut rendered = String::new();
 
-        for parameter in parameters {
+        for (name, description) in parameters {
             if !rendered.is_empty() {
                 rendered.push('\n');
             }
 
-            rendered.push_str(parameter.name.as_str());
+            rendered.push_str(name.as_str());
             rendered.push_str(": ");
 
-            let mut lines = parameter.description.lines();
+            let mut lines = description.lines();
             let Some(first_line) = lines.next() else {
                 continue;
             };


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This helps make the final container type for parameter docs clearer.

Along the way I've also added a few regression tests that lock in the current precedence of parameter docs across formats.

## Test Plan

Please see included tests.
<!-- How was it tested? -->
