### PR TITLE
[ty] Infer class and mapping pattern bindings

### DIFF
--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -1382,7 +1382,20 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No type definitions found");
+        assert_snapshot!(test.goto_type_definition(), @"
+        info[goto-type definition]: Go to type definition
+          --> main.py:LL:17
+           |
+        LL |             x = ab
+           |                 ^^ Clicking here
+           |
+        info: Found 1 type definition
+          --> stdlib/builtins.pyi:LL:7
+           |
+        LL | class str(Sequence[str]):
+           |       ---
+           |
+        ");
     }
 
     #[test]

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -3844,10 +3844,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        @Todo
+        str
         ---------------------------------------------
         ```python
-        @Todo
+        str
         ```
         ---------------------------------------------
         info[hover]: Hovered content is

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -2301,7 +2301,30 @@ Source with applied edits:
         def my_func(event: Click):
             match event:
                 case Click(x, button=ab):
-                    x[: @Todo] = ab
+                    x[: str] = ab
+
+        ---------------------------------------------
+        info[inlay-hint-location]: Inlay Hint Target
+          --> stdlib/builtins.pyi:LL:7
+           |
+        LL | class str(Sequence[str]):
+           |       ^^^
+           |
+        info: Source
+          --> main2.py:LL:17
+           |
+        LL |             x[: str] = ab
+           |                 ^^^
+           |
+
+        ---------------------------------------------
+        info[inlay-hint-edit]: Inlay hint edits
+        --> main.py:1:1
+        8  | def my_func(event: Click):
+        9  |     match event:
+        10 |         case Click(x, button=ab):
+           -             x = ab
+        11 +             x: str = ab
         "#);
     }
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -40,9 +40,11 @@ use crate::frozen::{FrozenMap, FrozenSet};
 use crate::member::MemberExprBuilder;
 use crate::place::{PlaceExpr, PlaceTableBuilder, PossiblyNarrowedPlacesBuilder, ScopedPlaceId};
 use crate::predicate::{
-    CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
-    PredicateNode, PredicateOrLiteral, ScopedPredicateId, SequencePatternPredicateKind,
-    StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
+    CallableAndCallExpr, ClassPatternKeywordPredicateKind, ClassPatternKind,
+    ClassPatternPredicateKind, MappingPatternEntryPredicateKind, MappingPatternPredicateKind,
+    PatternPredicate, PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral,
+    ScopedPredicateId, SequencePatternPredicateKind, StarImportPlaceholderPredicate,
+    SubjectElementPatternPredicate,
 };
 use crate::program::Program;
 use crate::re_exports::exported_names;
@@ -1941,32 +1943,56 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // this existing approximation because treating all class patterns with arguments
                 // as refutable caused a large ecosystem change. Follow-up work should determine
                 // irrefutability by analyzing the class's attributes and `__match_args__`.
-                PatternPredicateKind::Class(
-                    cls,
-                    if pattern
+                let kind = if pattern
+                    .arguments
+                    .patterns
+                    .iter()
+                    .all(ast::Pattern::is_irrefutable)
+                    && pattern
+                        .arguments
+                        .keywords
+                        .iter()
+                        .all(|keyword| keyword.pattern.is_irrefutable())
+                {
+                    ClassPatternKind::Irrefutable
+                } else {
+                    ClassPatternKind::Refutable
+                };
+
+                PatternPredicateKind::Class(ClassPatternPredicateKind {
+                    class: cls,
+                    positional: pattern
                         .arguments
                         .patterns
                         .iter()
-                        .all(ast::Pattern::is_irrefutable)
-                        && pattern
-                            .arguments
-                            .keywords
-                            .iter()
-                            .all(|kw| kw.pattern.is_irrefutable())
-                    {
-                        ClassPatternKind::Irrefutable
-                    } else {
-                        ClassPatternKind::Refutable
-                    },
-                )
+                        .map(|pattern| self.predicate_kind(pattern))
+                        .collect(),
+                    keywords: pattern
+                        .arguments
+                        .keywords
+                        .iter()
+                        .map(|keyword| ClassPatternKeywordPredicateKind {
+                            attr: keyword.attr.id.clone(),
+                            pattern: self.predicate_kind(&keyword.pattern),
+                        })
+                        .collect(),
+                    kind,
+                })
             }
             ast::Pattern::MatchMapping(pattern) => {
                 // `case {}` and `case {**rest}` match every mapping, while keyed mapping
                 // patterns are refutable (`case {"x": _}` may fail for some mappings).
-                PatternPredicateKind::Mapping(if pattern.keys.is_empty() {
-                    ClassPatternKind::Irrefutable
-                } else {
-                    ClassPatternKind::Refutable
+                PatternPredicateKind::Mapping(MappingPatternPredicateKind {
+                    entries: pattern
+                        .keys
+                        .iter()
+                        .zip(&pattern.patterns)
+                        .map(|(key, pattern)| MappingPatternEntryPredicateKind {
+                            key: self.add_standalone_expression(key),
+                            pattern: self.predicate_kind(pattern),
+                        })
+                        .collect(),
+                    rest: pattern.rest.as_ref().map(|name| name.id.clone()),
                 })
             }
             ast::Pattern::MatchSequence(pattern) => {

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -814,6 +814,24 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
                     places.extend(self.pattern_aliases_kind(pattern));
                 }
             }
+            PatternPredicateKind::Class(kind) => {
+                for pattern in &kind.positional {
+                    places.extend(self.pattern_aliases_kind(pattern));
+                }
+                for keyword in &kind.keywords {
+                    places.extend(self.pattern_aliases_kind(&keyword.pattern));
+                }
+            }
+            PatternPredicateKind::Mapping(kind) => {
+                for entry in &kind.entries {
+                    places.extend(self.pattern_aliases_kind(&entry.pattern));
+                }
+                if let Some(name) = &kind.rest
+                    && let Some(place) = self.places.symbol_id(name.as_str())
+                {
+                    places.insert(place.into());
+                }
+            }
             PatternPredicateKind::As(pattern, name) => {
                 if let Some(name) = name
                     && let Some(place) = self.places.symbol_id(name.as_str())

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -183,14 +183,48 @@ impl<'db> SequencePatternPredicateKind<'db> {
     }
 }
 
+/// Structural details for a class pattern.
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct ClassPatternPredicateKind<'db> {
+    pub class: Expression<'db>,
+    pub positional: Box<[PatternPredicateKind<'db>]>,
+    pub keywords: Box<[ClassPatternKeywordPredicateKind<'db>]>,
+    pub kind: ClassPatternKind,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct ClassPatternKeywordPredicateKind<'db> {
+    pub attr: Name,
+    pub pattern: PatternPredicateKind<'db>,
+}
+
+/// Structural details for a mapping pattern.
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct MappingPatternPredicateKind<'db> {
+    pub entries: Box<[MappingPatternEntryPredicateKind<'db>]>,
+    pub rest: Option<Name>,
+}
+
+impl MappingPatternPredicateKind<'_> {
+    pub fn is_irrefutable(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct MappingPatternEntryPredicateKind<'db> {
+    pub key: Expression<'db>,
+    pub pattern: PatternPredicateKind<'db>,
+}
+
 /// Pattern kinds for which we support type narrowing and/or static reachability analysis.
 #[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 pub enum PatternPredicateKind<'db> {
     Singleton(Singleton),
     Value(Expression<'db>),
     Or(Vec<PatternPredicateKind<'db>>),
-    Class(Expression<'db>, ClassPatternKind),
-    Mapping(ClassPatternKind),
+    Class(ClassPatternPredicateKind<'db>),
+    Mapping(MappingPatternPredicateKind<'db>),
     Sequence(SequencePatternPredicateKind<'db>),
     As(Option<Box<PatternPredicateKind<'db>>>, Option<Name>),
     Star(Option<Name>),

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -349,7 +349,7 @@ def match_exhaustive_generic[T](obj: GenericClass[T]) -> GenericClass[T]:
             reveal_type(obj)  # revealed: GenericClass[T@match_exhaustive_generic]
             return obj
         case GenericClass(x=x):
-            reveal_type(x)  # revealed: @Todo(`match` pattern definition types)
+            reveal_type(x)  # revealed: T@match_exhaustive_generic
             reveal_type(obj)  # revealed: GenericClass[T@match_exhaustive_generic]
             return obj
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -511,53 +511,197 @@ def test_match_class_alias_rejects_disjoint_final_class(value: FinalA) -> None:
             reveal_type(item)  # revealed: Never
 ```
 
-Bindings nested inside class and mapping patterns are not inferred yet. A surrounding `as` pattern
-is supported because it binds the matched subject itself, rather than a value extracted by the inner
-pattern.
+Class patterns pass the type of each extracted attribute to their nested patterns. The surrounding
+`as` pattern keeps the subject's original generic type or type variable.
 
 ```py
-from collections.abc import Mapping
-from typing import Generic, TypedDict, TypeVar
+from dataclasses import dataclass
+from typing import Generic, TypeVar
 
 T = TypeVar("T")
 
 class PatternBox(Generic[T]):
+    __match_args__ = ("value",)
     value: T
 
-def test_match_class_nested_capture_is_not_yet_inferred(
-    value: PatternBox[int],
-) -> None:
+def test_match_class_keyword_capture(value: PatternBox[T]) -> T:
     match value:
         case PatternBox(value=item) as whole:
-            reveal_type(item)  # revealed: @Todo(`match` pattern definition types)
-            reveal_type(whole)  # revealed: PatternBox[int]
+            reveal_type(item)  # revealed: T@test_match_class_keyword_capture
+            reveal_type(whole)  # revealed: PatternBox[T@test_match_class_keyword_capture]
+            return item
 
-def test_match_mapping_nested_capture_is_not_yet_inferred(
-    value: Mapping[str, int],
+@dataclass
+class DataclassBox(Generic[T]):
+    value: T
+
+def test_match_dataclass_positional_capture(dataclass_box: DataclassBox[T]) -> None:
+    match dataclass_box:
+        case DataclassBox(item):
+            reveal_type(item)  # revealed: T@test_match_dataclass_positional_capture
+```
+
+`__match_args__` is read from the pattern class and must identify literal attribute names. A
+metaclass member is not used by the runtime class pattern, while an explicit widened annotation does
+not tell us which attribute a positional pattern extracts.
+
+```py
+class MatchArgsMeta(type):
+    __match_args__ = ("value",)
+
+class MetaclassMatchArgs(metaclass=MatchArgsMeta):
+    value: int
+
+def test_metaclass_match_args_is_not_used(value: MetaclassMatchArgs) -> None:
+    match value:
+        case MetaclassMatchArgs(item):
+            reveal_type(item)  # revealed: Unknown
+
+class WidenedMatchArgs:
+    __match_args__: tuple[str, ...] = ("value",)
+    value: int
+
+def test_widened_match_args_does_not_select_an_attribute(value: WidenedMatchArgs) -> None:
+    match value:
+        case WidenedMatchArgs(item):
+            reveal_type(item)  # revealed: Unknown
+```
+
+Each union arm is checked against the complete class pattern before the extracted values are
+combined. This keeps a tag, its payload, and the whole-pattern alias correlated. The same rule
+applies through an `or` pattern.
+
+```py
+from typing import Generic, Literal, TypeVar
+
+TagT = TypeVar("TagT")
+PayloadT = TypeVar("PayloadT")
+
+class TaggedPayload(Generic[TagT, PayloadT]):
+    __match_args__ = ("tag", "payload")
+    tag: TagT
+    payload: PayloadT
+
+def test_match_class_capture_filters_union_arms(
+    value: TaggedPayload[Literal["int"], int] | TaggedPayload[Literal["str"], str],
 ) -> None:
     match value:
-        case {"item": item} as whole:
-            reveal_type(item)  # revealed: @Todo(`match` pattern definition types)
-            reveal_type(whole)  # revealed: Mapping[str, int]
+        case TaggedPayload("int", item) as whole:
+            reveal_type(item)  # revealed: int
+            reveal_type(whole)  # revealed: TaggedPayload[Literal["int"], int]
 
-class PatternPayload(TypedDict):
-    item: int
-
-def test_match_typed_dict_nested_capture_is_not_yet_inferred(
-    value: PatternPayload,
+def test_match_class_or_pattern_filters_union_arms(
+    value: TaggedPayload[Literal["int"], int] | TaggedPayload[Literal["str"], str] | TaggedPayload[Literal["bool"], bool],
 ) -> None:
     match value:
-        case {"item": item} as whole:
-            reveal_type(item)  # revealed: @Todo(`match` pattern definition types)
-            reveal_type(whole)  # revealed: PatternPayload
+        case (TaggedPayload("int", item) | TaggedPayload("str", item)) as whole:
+            reveal_type(item)  # revealed: int | str
+            # revealed: TaggedPayload[Literal["int"], int] | TaggedPayload[Literal["str"], str]
+            reveal_type(whole)
 
-def test_match_mapping_rest_capture_is_not_yet_inferred(
-    value: Mapping[str, int],
+def test_match_builtin_match_self(
+    value: list[int] | dict[str, int] | int,
 ) -> None:
     match value:
-        case {**rest} as whole:
-            reveal_type(rest)  # revealed: @Todo(`match` pattern definition types)
-            reveal_type(whole)  # revealed: Mapping[str, int]
+        case list(contents):
+            reveal_type(contents)  # revealed: list[int]
+        case dict(contents):
+            reveal_type(contents)  # revealed: dict[str, int]
+        case int(contents):
+            reveal_type(contents)  # revealed: int
+```
+
+Mapping patterns use the mapping's key and value types. A successful keyed pattern can filter union
+arms, while `**rest` is always a new `dict` containing the unmatched items.
+
+```py
+from collections.abc import Mapping
+from typing import Literal, TypeVar
+
+MappingValueT = TypeVar("MappingValueT")
+
+def test_match_mapping_bindings(value: Mapping[str, MappingValueT]) -> MappingValueT:
+    match value:
+        case {"item": item, **rest} as whole:
+            reveal_type(item)  # revealed: MappingValueT@test_match_mapping_bindings
+            reveal_type(rest)  # revealed: dict[str, MappingValueT@test_match_mapping_bindings]
+            # revealed: Mapping[str, MappingValueT@test_match_mapping_bindings]
+            reveal_type(whole)
+            return item
+    raise ValueError
+
+def test_match_dict_bindings(value: dict[str, int]) -> None:
+    match value:
+        case {"item": item, **rest} as whole:
+            reveal_type(item)  # revealed: int
+            reveal_type(rest)  # revealed: dict[str, int]
+            reveal_type(whole)  # revealed: dict[str, int]
+
+def test_match_mapping_key_filters_union_arms(
+    value: dict[Literal["a"], int] | dict[Literal["b"], str],
+) -> None:
+    match value:
+        case {"a": item} as whole:
+            reveal_type(item)  # revealed: int
+            reveal_type(whole)  # revealed: dict[Literal["a"], int]
+
+def test_match_mapping_nested_sequence(
+    value: Mapping[str, tuple[int, str]],
+) -> None:
+    match value:
+        case {"pair": [number, text]}:
+            reveal_type(number)  # revealed: int
+            reveal_type(text)  # revealed: str
+```
+
+For a `TypedDict`, a literal key uses the declared field type. Closed dictionaries can rule out
+missing keys, and tagged unions remain correlated through `or` patterns.
+
+```py
+from typing import Literal
+from typing_extensions import TypedDict
+
+class IntPayload(TypedDict):
+    tag: Literal["int"]
+    value: int
+
+class StrPayload(TypedDict):
+    tag: Literal["str"]
+    value: str
+
+def test_match_typed_dict_capture_filters_union_arms(
+    value: IntPayload | StrPayload,
+) -> None:
+    match value:
+        case {"tag": "int", "value": item, **rest} as whole:
+            reveal_type(item)  # revealed: int
+            reveal_type(rest)  # revealed: dict[str, object]
+            reveal_type(whole)  # revealed: IntPayload
+
+class ClosedIntPayload(TypedDict, closed=True):
+    tag: Literal["int"]
+    value: int
+
+class ClosedStrPayload(TypedDict, closed=True):
+    tag: Literal["str"]
+    value: str
+
+class ClosedBoolPayload(TypedDict, closed=True):
+    tag: Literal["bool"]
+    value: bool
+
+def test_match_closed_typed_dict_rest(value: ClosedIntPayload) -> None:
+    match value:
+        case {"tag": "int", **rest}:
+            reveal_type(rest)  # revealed: dict[str, object]
+
+def test_match_typed_dict_or_pattern_filters_union_arms(
+    value: ClosedIntPayload | ClosedStrPayload | ClosedBoolPayload,
+) -> None:
+    match value:
+        case ({"tag": "int", "value": item} | {"tag": "str", "value": item}) as whole:
+            reveal_type(item)  # revealed: int | str
+            reveal_type(whole)  # revealed: ClosedIntPayload | ClosedStrPayload
 ```
 
 ## Sequence exhaustiveness

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -609,6 +609,21 @@ def test_match_builtin_match_self(
             reveal_type(contents)  # revealed: dict[str, int]
         case int(contents):
             reveal_type(contents)  # revealed: int
+
+class OverlapCaptureA: ...
+
+class OverlapCaptureB:
+    member: int
+
+class OverlapCaptureC(OverlapCaptureA, OverlapCaptureB): ...
+
+def test_match_class_capture_preserves_possible_multiple_inheritance(
+    value: OverlapCaptureA,
+) -> None:
+    match value:
+        case OverlapCaptureB(member=item) as whole:
+            reveal_type(item)  # revealed: int
+            reveal_type(whole)  # revealed: OverlapCaptureA & OverlapCaptureB
 ```
 
 Mapping patterns use the mapping's key and value types. A successful keyed pattern can filter union
@@ -617,6 +632,7 @@ arms, while `**rest` is always a new `dict` containing the unmatched items.
 ```py
 from collections.abc import Mapping
 from typing import Literal, TypeVar
+from typing_extensions import Never
 
 MappingValueT = TypeVar("MappingValueT")
 
@@ -652,6 +668,13 @@ def test_match_mapping_nested_sequence(
         case {"pair": [number, text]}:
             reveal_type(number)  # revealed: int
             reveal_type(text)  # revealed: str
+
+def test_match_mapping_rejects_empty_key_domain(
+    value: dict[Never, int],
+) -> None:
+    match value:
+        case {"item": item}:
+            reveal_type(item)  # revealed: Never
 ```
 
 For a `TypedDict`, a literal key uses the declared field type. Closed dictionaries can rule out
@@ -689,6 +712,16 @@ class ClosedStrPayload(TypedDict, closed=True):
 class ClosedBoolPayload(TypedDict, closed=True):
     tag: Literal["bool"]
     value: bool
+
+class ClosedPayload(TypedDict, closed=True):
+    x: int
+
+def test_match_closed_typed_dict_rejects_non_string_key(
+    value: ClosedPayload,
+) -> None:
+    match value:
+        case {1: item}:
+            reveal_type(item)  # revealed: Never
 
 def test_match_closed_typed_dict_rest(value: ClosedIntPayload) -> None:
     match value:

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1028,9 +1028,9 @@ fn analyze_single_pattern_predicate_kind<'db>(
                 });
             truthiness
         }
-        PatternPredicateKind::Class(class_expr, kind) => {
+        PatternPredicateKind::Class(kind) => {
             let class_ty =
-                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
+                match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
                     Type::ClassLiteral(class) => {
                         Some(Type::instance(db, class.top_materialization(db)))
                     }
@@ -1042,7 +1042,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
 
             class_ty.map_or(Truthiness::Ambiguous, |class_ty| {
                 if subject_ty.is_subtype_of(db, class_ty) {
-                    if kind.is_irrefutable() {
+                    if kind.kind.is_irrefutable() {
                         Truthiness::AlwaysTrue
                     } else {
                         // A class pattern like `case Point(x=0, y=0)` is not irrefutable,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -35,9 +35,10 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    callable_pattern_type, definite_match_pattern_type, definite_sequence_pattern_type,
-    exact_sequence_pattern_type, mapping_pattern_type, sequence_pattern_type_builder,
-    singleton_pattern_type, starred_sequence_pattern_type,
+    ClassMatchArgs, callable_pattern_type, class_has_match_self_flag, class_match_args_type,
+    definite_match_pattern_type, definite_sequence_pattern_type, exact_sequence_pattern_type,
+    mapping_pattern_type, sequence_pattern_type_builder, singleton_pattern_type,
+    starred_sequence_pattern_type,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -159,6 +159,25 @@ impl KnownClass {
         matches!(self, Self::SpecialForm)
     }
 
+    /// Return whether class patterns with a single positional subpattern match against the
+    /// subject itself when `__match_args__` is undefined.
+    pub(crate) const fn has_match_self_flag(self) -> bool {
+        matches!(
+            self,
+            Self::Bool
+                | Self::Bytearray
+                | Self::Bytes
+                | Self::Dict
+                | Self::Float
+                | Self::FrozenSet
+                | Self::Int
+                | Self::List
+                | Self::Set
+                | Self::Str
+                | Self::Tuple
+        )
+    }
+
     /// Determine whether instances of this class are always truthy, always falsy,
     /// or have an ambiguous truthiness.
     ///

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2478,7 +2478,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     rest: _,
                 } = match_mapping;
                 for key in keys {
-                    self.infer_expression(key, TypeContext::default());
+                    self.infer_maybe_standalone_expression(key, TypeContext::default());
                 }
                 for pattern in patterns {
                     self.infer_nested_match_pattern(pattern);

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -4,13 +4,14 @@ use ty_python_core::Truthiness;
 use ty_python_core::predicate::{PatternPredicateKind, SequencePatternPredicateKind};
 
 use crate::Db;
+use crate::place::{DefinedPlace, Place};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::signatures::CallableSignature;
 use crate::types::tuple::TupleType;
 use crate::types::{
-    CallableType, IntersectionBuilder, KnownClass, Parameter, Parameters, Signature,
-    SpecialFormType, Type, TypeContext, UnionType, equality_truthiness,
-    infer_same_file_expression_type,
+    CallableType, ClassBase, ClassLiteral, IntersectionBuilder, KnownClass, MemberLookupPolicy,
+    Parameter, Parameters, Signature, SpecialFormType, Type, TypeContext, UnionType, binding_type,
+    equality_truthiness, infer_same_file_expression_type,
 };
 
 pub(crate) fn singleton_pattern_type(db: &dyn Db, singleton: ast::Singleton) -> Type<'_> {
@@ -39,6 +40,50 @@ pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<
         .add_negative(KnownClass::Str.to_instance(db))
         .add_negative(KnownClass::Bytes.to_instance(db))
         .add_negative(KnownClass::Bytearray.to_instance(db))
+}
+
+pub(crate) enum ClassMatchArgs<'db> {
+    Undefined,
+    Defined(Type<'db>),
+    PossiblyUndefined,
+}
+
+pub(crate) fn class_match_args_type<'db>(
+    db: &'db dyn Db,
+    class: ClassLiteral<'db>,
+) -> ClassMatchArgs<'db> {
+    match class
+        .class_member(db, "__match_args__", MemberLookupPolicy::default())
+        .place
+    {
+        Place::Defined(
+            place @ DefinedPlace {
+                ty,
+                origin,
+                provenance,
+                ..
+            },
+        ) if place.is_definitely_defined() => ClassMatchArgs::Defined(if origin.is_declared() {
+            ty
+        } else {
+            provenance
+                .definition()
+                .map_or(ty, |definition| binding_type(db, definition))
+        }),
+        Place::Defined(_) => ClassMatchArgs::PossiblyUndefined,
+        Place::Undefined => ClassMatchArgs::Undefined,
+    }
+}
+
+pub(crate) fn class_has_match_self_flag(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
+    class
+        .iter_mro(db)
+        .filter_map(ClassBase::into_class)
+        .any(|base| {
+            base.class_literal(db)
+                .known(db)
+                .is_some_and(KnownClass::has_match_self_flag)
+        })
 }
 
 fn sequence_pattern_getitem_method<'db>(
@@ -184,9 +229,9 @@ pub(crate) fn definite_match_pattern_type<'db>(
                 Type::Never
             }
         }
-        PatternPredicateKind::Class(class_expr, kind) => {
-            if kind.is_irrefutable() {
-                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
+        PatternPredicateKind::Class(kind) => {
+            if kind.kind.is_irrefutable() {
+                match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
                     Type::ClassLiteral(class) => Type::instance(db, class.top_materialization(db)),
                     Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
                         callable_pattern_type(db)

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1424,6 +1424,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> Option<Type<'db>> {
         if let Type::TypedDict(typed_dict) = subject_ty.resolve_type_alias(self.db) {
             let key_ty = key_ty.resolve_type_alias(self.db);
+            let typed_dict_key_ty = typed_dict.key_type(self.db);
+            if typed_dict_key_ty.is_never()
+                || !could_compare_equal(self.db, typed_dict_key_ty, key_ty)
+            {
+                return None;
+            }
             if let Some(key) = key_ty.as_string_literal() {
                 return typed_dict
                     .item(self.db, key.value(self.db))
@@ -1443,6 +1449,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             return Some(Type::unknown());
         };
 
+        if mapping_key_ty.is_never() {
+            return None;
+        }
         could_compare_equal(self.db, mapping_key_ty, key_ty).then_some(mapping_value_ty)
     }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -11,18 +11,20 @@ use crate::types::typed_dict::{
     TypedDictField, TypedDictFieldBuilder, TypedDictSchema, TypedDictType,
 };
 use crate::types::{
-    CallableType, ClassLiteral, ClassType, IntersectionBuilder, IntersectionType, KnownClass,
-    KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature, SpecialFormType,
-    SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionBuilder, callable_pattern_type, definite_match_pattern_type,
-    definite_sequence_pattern_type, exact_sequence_pattern_type, infer_expression_types,
-    mapping_pattern_type, singleton_pattern_type, starred_sequence_pattern_type,
+    CallableType, ClassLiteral, ClassMatchArgs, ClassType, IntersectionBuilder, IntersectionType,
+    KnownClass, KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature,
+    SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext,
+    TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type, class_has_match_self_flag,
+    class_match_args_type, definite_match_pattern_type, definite_sequence_pattern_type,
+    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
+    singleton_pattern_type, starred_sequence_pattern_type,
 };
 use ty_python_core::expression::Expression;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
 use ty_python_core::predicate::{
-    CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
-    PredicateNode, SequencePatternPredicateKind, SubjectElementPatternPredicate,
+    CallableAndCallExpr, ClassPatternKind, ClassPatternPredicateKind, MappingPatternPredicateKind,
+    PatternPredicate, PatternPredicateKind, Predicate, PredicateNode, SequencePatternPredicateKind,
+    SubjectElementPatternPredicate,
 };
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
@@ -811,6 +813,13 @@ struct NarrowingConstraintsBuilder<'db, 'ast> {
     is_positive: bool,
 }
 
+#[derive(Clone)]
+enum ClassPatternPositionalSource {
+    MatchSelf,
+    Attribute(Name),
+    Unknown,
+}
+
 impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     fn new(
         db: &'db dyn Db,
@@ -974,11 +983,11 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PatternPredicateKind::Singleton(singleton) => PatternNarrowingResult::Possible(
                 self.evaluate_match_pattern_singleton(subject, *singleton, is_positive),
             ),
-            PatternPredicateKind::Class(cls, kind) => PatternNarrowingResult::Possible(
-                self.evaluate_match_pattern_class(subject, *cls, *kind, is_positive),
+            PatternPredicateKind::Class(kind) => PatternNarrowingResult::Possible(
+                self.evaluate_match_pattern_class(subject, kind.class, kind.kind, is_positive),
             ),
             PatternPredicateKind::Mapping(kind) => PatternNarrowingResult::Possible(
-                self.evaluate_match_pattern_mapping(subject, *kind, is_positive),
+                self.evaluate_match_pattern_mapping(subject, kind.is_irrefutable(), is_positive),
             ),
             PatternPredicateKind::Sequence(kind) => {
                 self.evaluate_match_pattern_sequence(subject, kind, is_positive)
@@ -1041,6 +1050,41 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         subject_ty: Type<'db>,
     ) -> Option<NarrowingConstraints<'db>> {
         match pattern {
+            PatternPredicateKind::Class(kind) => {
+                let argument_types = self.match_class_pattern_argument_types(kind, subject_ty);
+                kind.positional
+                    .iter()
+                    .chain(kind.keywords.iter().map(|keyword| &keyword.pattern))
+                    .zip(argument_types)
+                    .fold(None, |constraints, (pattern, argument_ty)| {
+                        Self::merge_optional_constraints_and(
+                            constraints,
+                            self.evaluate_match_pattern_bindings(pattern, argument_ty),
+                        )
+                    })
+            }
+            PatternPredicateKind::Mapping(kind) => {
+                let value_types = self.match_mapping_pattern_value_types(kind, subject_ty);
+                let nested = kind.entries.iter().zip(value_types).fold(
+                    None,
+                    |constraints, (entry, value_ty)| {
+                        Self::merge_optional_constraints_and(
+                            constraints,
+                            self.evaluate_match_pattern_bindings(&entry.pattern, value_ty),
+                        )
+                    },
+                );
+                let rest = kind.rest.as_ref().and_then(|name| {
+                    let place = self.places().symbol_id(name.as_str())?;
+                    Some(NarrowingConstraints::from_iter([(
+                        place.into(),
+                        NarrowingConstraint::replacement(
+                            self.match_mapping_pattern_rest_type(kind, subject_ty),
+                        ),
+                    )]))
+                });
+                Self::merge_optional_constraints_and(nested, rest)
+            }
             PatternPredicateKind::Sequence(kind) => {
                 let element_types = self.match_sequence_pattern_element_types(kind, subject_ty);
                 kind.patterns.iter().zip(element_types).fold(
@@ -1146,12 +1190,11 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PatternPredicateKind::Sequence(kind) => {
                 self.match_sequence_pattern_subject_type(kind, subject_ty)
             }
-            PatternPredicateKind::Class(class_expr, _) => {
-                let class_ty = self.necessary_match_pattern_type(pattern);
-                let class =
-                    infer_same_file_expression_type(self.db, *class_expr, TypeContext::default())
-                        .as_class_literal();
-                self.match_class_pattern_subject_type(class, class_ty, subject_ty, false)
+            PatternPredicateKind::Class(kind) => {
+                self.match_class_pattern_subject_type(kind, subject_ty)
+            }
+            PatternPredicateKind::Mapping(kind) => {
+                self.match_mapping_pattern_subject_type(kind, subject_ty)
             }
             _ => self.intersect_types(subject_ty, self.necessary_match_pattern_type(pattern)),
         }
@@ -1173,7 +1216,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ///             for child in children:
     ///                 visit(child)
     /// ```
-    fn match_class_pattern_subject_type(
+    fn filter_class_pattern_subject_type(
         &self,
         class: Option<ClassLiteral<'db>>,
         class_ty: Type<'db>,
@@ -1181,14 +1224,14 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         filter_nominal_arms: bool,
     ) -> Type<'db> {
         match subject_ty {
-            Type::TypeAlias(alias) => self.match_class_pattern_subject_type(
+            Type::TypeAlias(alias) => self.filter_class_pattern_subject_type(
                 class,
                 class_ty,
                 alias.value_type(self.db),
                 true,
             ),
             Type::Union(union) => union.map(self.db, |element| {
-                self.match_class_pattern_subject_type(class, class_ty, *element, true)
+                self.filter_class_pattern_subject_type(class, class_ty, *element, true)
             }),
             Type::Intersection(intersection) => {
                 let filter_nominal_arms = filter_nominal_arms
@@ -1197,7 +1240,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                         .iter()
                         .any(|positive| matches!(positive, Type::TypeAlias(_) | Type::Union(_)));
                 intersection.map_positive(self.db, |positive| {
-                    self.match_class_pattern_subject_type(
+                    self.filter_class_pattern_subject_type(
                         class,
                         class_ty,
                         *positive,
@@ -1233,6 +1276,268 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
     }
 
+    fn class_pattern_positional_sources(
+        &self,
+        kind: &ClassPatternPredicateKind<'db>,
+    ) -> Vec<ClassPatternPositionalSource> {
+        let Some(class) =
+            infer_same_file_expression_type(self.db, kind.class, TypeContext::default())
+                .as_class_literal()
+        else {
+            return vec![ClassPatternPositionalSource::Unknown; kind.positional.len()];
+        };
+
+        let fixed = match class_match_args_type(self.db, class) {
+            ClassMatchArgs::Undefined if class_has_match_self_flag(self.db, class) => {
+                return (0..kind.positional.len())
+                    .map(|index| {
+                        if index == 0 {
+                            ClassPatternPositionalSource::MatchSelf
+                        } else {
+                            ClassPatternPositionalSource::Unknown
+                        }
+                    })
+                    .collect();
+            }
+            ClassMatchArgs::Defined(match_args) => match_args
+                .exact_tuple_instance_spec(self.db)
+                .and_then(|tuple| tuple.as_fixed_length().cloned()),
+            ClassMatchArgs::Undefined | ClassMatchArgs::PossiblyUndefined => None,
+        };
+
+        (0..kind.positional.len())
+            .map(|index| {
+                fixed
+                    .as_ref()
+                    .and_then(|tuple| tuple.elements_slice().get(index))
+                    .and_then(|ty| ty.as_string_literal())
+                    .map(|literal| {
+                        ClassPatternPositionalSource::Attribute(Name::new(literal.value(self.db)))
+                    })
+                    .unwrap_or(ClassPatternPositionalSource::Unknown)
+            })
+            .collect()
+    }
+
+    fn class_pattern_argument_types_for_arm(
+        &self,
+        kind: &ClassPatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> Vec<Type<'db>> {
+        let member_type = |name: &Name| {
+            subject_ty
+                .member(self.db, name.as_str())
+                .place
+                .ignore_possibly_undefined()
+                .unwrap_or_else(Type::unknown)
+        };
+
+        self.class_pattern_positional_sources(kind)
+            .into_iter()
+            .map(|source| match source {
+                ClassPatternPositionalSource::MatchSelf => subject_ty,
+                ClassPatternPositionalSource::Attribute(name) => member_type(&name),
+                ClassPatternPositionalSource::Unknown => Type::unknown(),
+            })
+            .chain(
+                kind.keywords
+                    .iter()
+                    .map(|keyword| member_type(&keyword.attr)),
+            )
+            .collect()
+    }
+
+    fn matching_class_pattern_arm(
+        &mut self,
+        kind: &ClassPatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> Option<(Type<'db>, Vec<Type<'db>>)> {
+        let class_expr_ty =
+            infer_same_file_expression_type(self.db, kind.class, TypeContext::default());
+        let class = class_expr_ty.as_class_literal();
+        let class_ty = match class_expr_ty {
+            Type::ClassLiteral(class) => {
+                Type::instance(self.db, class.top_materialization(self.db))
+            }
+            Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
+                callable_pattern_type(self.db)
+            }
+            _ => Type::object(),
+        };
+        let narrowed_subject_ty =
+            self.filter_class_pattern_subject_type(class, class_ty, subject_ty, true);
+        if narrowed_subject_ty.is_never() {
+            return None;
+        }
+
+        let argument_types = self.class_pattern_argument_types_for_arm(kind, narrowed_subject_ty);
+        kind.positional
+            .iter()
+            .chain(kind.keywords.iter().map(|keyword| &keyword.pattern))
+            .zip(&argument_types)
+            .all(|(pattern, argument_ty)| {
+                !self
+                    .match_pattern_subject_type(pattern, *argument_ty)
+                    .is_never()
+            })
+            .then_some((narrowed_subject_ty, argument_types))
+    }
+
+    fn match_class_pattern_argument_types(
+        &mut self,
+        kind: &ClassPatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> Vec<Type<'db>> {
+        let argument_count = kind.positional.len() + kind.keywords.len();
+        let mut builders: Vec<_> = std::iter::repeat_with(|| UnionBuilder::new(self.db))
+            .take(argument_count)
+            .collect();
+        for (_, filtering_subject_ty) in self.match_pattern_subject_arms(subject_ty) {
+            if let Some((_, argument_types)) =
+                self.matching_class_pattern_arm(kind, filtering_subject_ty)
+            {
+                for (builder, argument_ty) in builders.iter_mut().zip(argument_types) {
+                    builder.add_in_place(argument_ty);
+                }
+            }
+        }
+
+        builders.into_iter().map(UnionBuilder::build).collect()
+    }
+
+    fn match_class_pattern_subject_type(
+        &mut self,
+        kind: &ClassPatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> Type<'db> {
+        self.match_pattern_subject_type_from_arms(subject_ty, true, |builder, subject_ty| {
+            builder
+                .matching_class_pattern_arm(kind, subject_ty)
+                .map(|(narrowed_subject_ty, _)| narrowed_subject_ty)
+        })
+    }
+
+    fn mapping_pattern_value_type_for_arm(
+        &self,
+        subject_ty: Type<'db>,
+        key_ty: Type<'db>,
+    ) -> Option<Type<'db>> {
+        if let Type::TypedDict(typed_dict) = subject_ty.resolve_type_alias(self.db) {
+            let key_ty = key_ty.resolve_type_alias(self.db);
+            if let Some(key) = key_ty.as_string_literal() {
+                return typed_dict
+                    .item(self.db, key.value(self.db))
+                    .map(|field| field.declared_ty)
+                    .or_else(|| {
+                        typed_dict
+                            .openness(self.db)
+                            .is_implicitly_open()
+                            .then_some(Type::object())
+                    });
+            }
+            return Some(typed_dict.value_type(self.db));
+        }
+
+        let Some((mapping_key_ty, mapping_value_ty)) = subject_ty.unpack_keys_and_items(self.db)
+        else {
+            return Some(Type::unknown());
+        };
+
+        could_compare_equal(self.db, mapping_key_ty, key_ty).then_some(mapping_value_ty)
+    }
+
+    fn matching_mapping_pattern_arm(
+        &mut self,
+        kind: &MappingPatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> Option<(Type<'db>, Vec<Type<'db>>)> {
+        let narrowed_subject_ty = self.intersect_types(subject_ty, mapping_pattern_type(self.db));
+        if narrowed_subject_ty.is_never() {
+            return None;
+        }
+
+        let value_types: Option<Vec<_>> = kind
+            .entries
+            .iter()
+            .map(|entry| {
+                let key_ty =
+                    infer_same_file_expression_type(self.db, entry.key, TypeContext::default());
+                self.mapping_pattern_value_type_for_arm(subject_ty, key_ty)
+            })
+            .collect();
+        let value_types = value_types?;
+
+        kind.entries
+            .iter()
+            .zip(&value_types)
+            .all(|(entry, value_ty)| {
+                !self
+                    .match_pattern_subject_type(&entry.pattern, *value_ty)
+                    .is_never()
+            })
+            .then_some((narrowed_subject_ty, value_types))
+    }
+
+    fn match_mapping_pattern_value_types(
+        &mut self,
+        kind: &MappingPatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> Vec<Type<'db>> {
+        let mut builders: Vec<_> = std::iter::repeat_with(|| UnionBuilder::new(self.db))
+            .take(kind.entries.len())
+            .collect();
+        for (_, filtering_subject_ty) in self.match_pattern_subject_arms(subject_ty) {
+            if let Some((_, value_types)) =
+                self.matching_mapping_pattern_arm(kind, filtering_subject_ty)
+            {
+                for (builder, value_ty) in builders.iter_mut().zip(value_types) {
+                    builder.add_in_place(value_ty);
+                }
+            }
+        }
+
+        builders.into_iter().map(UnionBuilder::build).collect()
+    }
+
+    fn mapping_pattern_rest_type_for_arm(&self, subject_ty: Type<'db>) -> Type<'db> {
+        let (key_ty, value_ty) = match subject_ty.resolve_type_alias(self.db) {
+            Type::TypedDict(_) => (KnownClass::Str.to_instance(self.db), Type::object()),
+            _ => subject_ty
+                .unpack_keys_and_items(self.db)
+                .unwrap_or_else(|| (Type::unknown(), Type::unknown())),
+        };
+        KnownClass::Dict.to_specialized_instance(self.db, &[key_ty, value_ty])
+    }
+
+    fn match_mapping_pattern_rest_type(
+        &mut self,
+        kind: &MappingPatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> Type<'db> {
+        UnionType::from_elements(
+            self.db,
+            self.match_pattern_subject_arms(subject_ty)
+                .into_iter()
+                .filter_map(|(_, filtering_subject_ty)| {
+                    let (narrowed_subject_ty, _) =
+                        self.matching_mapping_pattern_arm(kind, filtering_subject_ty)?;
+                    Some(self.mapping_pattern_rest_type_for_arm(narrowed_subject_ty))
+                }),
+        )
+    }
+
+    fn match_mapping_pattern_subject_type(
+        &mut self,
+        kind: &MappingPatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> Type<'db> {
+        self.match_pattern_subject_type_from_arms(subject_ty, true, |builder, subject_ty| {
+            builder
+                .matching_mapping_pattern_arm(kind, subject_ty)
+                .map(|(narrowed_subject_ty, _)| narrowed_subject_ty)
+        })
+    }
+
     /// Return the type at each position of a successful sequence pattern.
     ///
     /// Each union member is checked against the complete pattern before element types are combined.
@@ -1253,7 +1558,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> Vec<Type<'db>> {
         let target_len = Self::sequence_pattern_target_len(kind);
         let mut unpacker = TupleUnpacker::new(self.db, target_len);
-        let subject_arms = self.sequence_pattern_subject_arms(subject_ty);
+        let subject_arms = self.match_pattern_subject_arms(subject_ty);
         let sequence_ty = self.necessary_sequence_pattern_type(kind);
 
         let mut matched = false;
@@ -1296,44 +1601,11 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> Type<'db> {
         let target_len = Self::sequence_pattern_target_len(kind);
         let sequence_ty = self.necessary_sequence_pattern_type(kind);
-        let subject_arms = self.sequence_pattern_subject_arms(subject_ty);
-        let grouped_arms = subject_arms
-            .into_iter()
-            .chunk_by(|(original_subject_ty, _)| *original_subject_ty);
-
-        UnionType::from_elements(
-            self.db,
-            (&grouped_arms)
-                .into_iter()
-                .map(|(original_subject_ty, arms)| {
-                    let filtering_types = original_subject_ty
-                        .flatten_typevars(self.db)
-                        .resolve_type_alias(self.db);
-                    let mut matched_types = UnionBuilder::new(self.db);
-
-                    for (_, filtering_subject_ty) in arms {
-                        if let Some((narrowed_subject_ty, _)) = self.matching_sequence_pattern_arm(
-                            kind,
-                            filtering_subject_ty,
-                            target_len,
-                            sequence_ty,
-                        ) {
-                            matched_types.add_in_place(narrowed_subject_ty);
-                        }
-                    }
-
-                    let matched_types = matched_types.build();
-                    if original_subject_ty.has_typevar(self.db) {
-                        if matched_types.is_equivalent_to(self.db, filtering_types) {
-                            original_subject_ty
-                        } else {
-                            self.intersect_types(original_subject_ty, matched_types)
-                        }
-                    } else {
-                        matched_types
-                    }
-                }),
-        )
+        self.match_pattern_subject_type_from_arms(subject_ty, false, |builder, subject_ty| {
+            builder
+                .matching_sequence_pattern_arm(kind, subject_ty, target_len, sequence_ty)
+                .map(|(narrowed_subject_ty, _)| narrowed_subject_ty)
+        })
     }
 
     /// Check one subject union member against the complete sequence pattern.
@@ -1373,11 +1645,52 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             .then_some((narrowed_subject_ty, tuple))
     }
 
+    fn match_pattern_subject_type_from_arms(
+        &mut self,
+        subject_ty: Type<'db>,
+        preserve_equivalent_type: bool,
+        mut match_arm: impl FnMut(&mut Self, Type<'db>) -> Option<Type<'db>>,
+    ) -> Type<'db> {
+        let subject_arms = self.match_pattern_subject_arms(subject_ty);
+        let grouped_arms = subject_arms
+            .into_iter()
+            .chunk_by(|(original_subject_ty, _)| *original_subject_ty);
+
+        UnionType::from_elements(
+            self.db,
+            (&grouped_arms)
+                .into_iter()
+                .map(|(original_subject_ty, arms)| {
+                    let filtering_types = original_subject_ty
+                        .flatten_typevars(self.db)
+                        .resolve_type_alias(self.db);
+                    let mut matched_types = UnionBuilder::new(self.db);
+
+                    for (_, filtering_subject_ty) in arms {
+                        if let Some(narrowed_subject_ty) = match_arm(self, filtering_subject_ty) {
+                            matched_types.add_in_place(narrowed_subject_ty);
+                        }
+                    }
+
+                    let matched_types = matched_types.build();
+                    if matched_types.is_equivalent_to(self.db, filtering_types)
+                        && (preserve_equivalent_type || original_subject_ty.has_typevar(self.db))
+                    {
+                        original_subject_ty
+                    } else if original_subject_ty.has_typevar(self.db) {
+                        self.intersect_types(original_subject_ty, matched_types)
+                    } else {
+                        matched_types
+                    }
+                }),
+        )
+    }
+
     /// Pair each original subject type with the union members used to test the pattern.
     ///
     /// Type variables are expanded for matching, but the original type is kept so a successful
     /// whole-sequence binding can still use that type variable.
-    fn sequence_pattern_subject_arms(
+    fn match_pattern_subject_arms(
         &self,
         subject_ty: Type<'db>,
     ) -> SmallVec<[(Type<'db>, Type<'db>); 2]> {
@@ -2471,10 +2784,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     fn evaluate_match_pattern_mapping(
         &mut self,
         subject: Expression<'db>,
-        kind: ClassPatternKind,
+        is_irrefutable: bool,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        if !kind.is_irrefutable() && !is_positive {
+        if !is_irrefutable && !is_positive {
             return None;
         }
 
@@ -2517,8 +2830,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PatternPredicateKind::Singleton(singleton) => {
                 singleton_pattern_type(self.db, *singleton)
             }
-            PatternPredicateKind::Class(cls, _) => {
-                match infer_same_file_expression_type(self.db, *cls, TypeContext::default()) {
+            PatternPredicateKind::Class(kind) => {
+                match infer_same_file_expression_type(self.db, kind.class, TypeContext::default()) {
                     Type::ClassLiteral(class) => {
                         Type::instance(self.db, class.top_materialization(self.db))
                     }


### PR DESCRIPTION
## Summary

This extends match-pattern binding inference to class and mapping patterns.

```python
from dataclasses import dataclass
from typing import Generic, TypeVar

T = TypeVar("T")

@dataclass
class Box(Generic[T]):
    value: T

def unwrap(box: Box[T]) -> T:
    match box:
        case Box(value):
            return value
```

Class patterns now pass the type of each extracted attribute to the nested pattern that matches it. Mapping patterns similarly pass the declared value type to each nested pattern and infer a new `dict` type for `**rest`.

We evaluate each union member against the complete pattern before combining the resulting bindings. This preserves relationships between tags, payloads, generic type arguments, and whole-pattern aliases rather than combining each capture independently. Literal `TypedDict` keys use their declared field types, while ordinary mappings use their declared key and value types.
