### PR TITLE
[ty] Narrow match subjects through class and mapping patterns

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -737,6 +737,72 @@ def test_match_typed_dict_or_pattern_filters_union_arms(
             reveal_type(whole)  # revealed: ClosedIntPayload | ClosedStrPayload
 ```
 
+## Direct subject narrowing
+
+The same structural analysis can narrow the original match subject, even when the pattern does not
+bind an alias for the whole value. Nested class and mapping patterns can rule out union arms, and
+the result is preserved through an `or` pattern. This analysis does not yet narrow expressions used
+to construct tuple or dictionary display subjects.
+
+```py
+from typing import Generic, Literal, TypeVar
+from typing_extensions import TypedDict
+
+TagT = TypeVar("TagT")
+PayloadT = TypeVar("PayloadT")
+
+class TaggedPayload(Generic[TagT, PayloadT]):
+    __match_args__ = ("tag", "payload")
+    tag: TagT
+    payload: PayloadT
+
+def test_match_class_narrows_subject(
+    value: TaggedPayload[Literal["int"], int] | TaggedPayload[Literal["str"], str],
+) -> None:
+    match value:
+        case TaggedPayload("int", _):
+            reveal_type(value)  # revealed: TaggedPayload[Literal["int"], int]
+
+def test_match_class_or_pattern_narrows_subject(
+    value: TaggedPayload[Literal["int"], int] | TaggedPayload[Literal["str"], str] | TaggedPayload[Literal["bool"], bool],
+) -> None:
+    match value:
+        case TaggedPayload("int", _) | TaggedPayload("str", _):
+            # revealed: TaggedPayload[Literal["int"], int] | TaggedPayload[Literal["str"], str]
+            reveal_type(value)
+
+class IntPayload(TypedDict):
+    tag: Literal["int"]
+    value: int
+
+class StrPayload(TypedDict):
+    tag: Literal["str"]
+    value: str
+
+def test_match_mapping_narrows_subject(value: IntPayload | StrPayload) -> None:
+    match value:
+        case {"tag": "int"}:
+            reveal_type(value)  # revealed: IntPayload
+
+def test_match_mapping_does_not_narrow_tuple_display_element(
+    value: IntPayload | StrPayload,
+) -> None:
+    match (value,):
+        case ({"tag": "int"},):
+            # TODO: This should reveal `IntPayload`. Structural mapping analysis is not yet
+            # applied to expressions used to construct tuple display subjects.
+            reveal_type(value)  # revealed: IntPayload | StrPayload
+
+def test_match_mapping_does_not_narrow_dictionary_display_element(
+    value: IntPayload | StrPayload,
+) -> None:
+    match {"payload": value}:
+        case {"payload": {"tag": "int"}}:
+            # TODO: This should reveal `IntPayload`. Dictionary display subjects do not yet
+            # retain the correspondence between their values and mapping patterns.
+            reveal_type(value)  # revealed: IntPayload | StrPayload
+```
+
 ## Sequence exhaustiveness
 
 Sequence patterns also contribute to negative narrowing and exhaustiveness. Exact tuple shapes can

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1023,10 +1023,63 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
         let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
         let subject_ty = type_narrowed_by_previous_patterns(self.db, pattern, subject_ty);
-        Self::merge_optional_constraints_and(
+        let constraints = Self::merge_optional_constraints_and(
             constraints,
             self.evaluate_match_pattern_bindings(kind, subject_ty),
+        );
+        Self::merge_optional_constraints_and(
+            constraints,
+            self.evaluate_structural_pattern_subject(kind, subject, subject_ty),
         )
+    }
+
+    fn evaluate_structural_pattern_subject(
+        &mut self,
+        pattern: &PatternPredicateKind<'db>,
+        subject: Expression<'db>,
+        subject_ty: Type<'db>,
+    ) -> Option<NarrowingConstraints<'db>> {
+        let narrowed = match pattern {
+            PatternPredicateKind::Class(kind)
+                if matches!(kind.kind, ClassPatternKind::Refutable) =>
+            {
+                self.match_class_pattern_subject_type(kind, subject_ty)
+            }
+            PatternPredicateKind::Mapping(kind) if !kind.entries.is_empty() => {
+                self.match_mapping_pattern_subject_type(kind, subject_ty)
+            }
+            PatternPredicateKind::Or(patterns)
+                if patterns.iter().any(Self::contains_class_or_mapping_pattern) =>
+            {
+                self.match_pattern_subject_type(pattern, subject_ty)
+            }
+            PatternPredicateKind::As(Some(pattern), _) => {
+                return self.evaluate_structural_pattern_subject(pattern, subject, subject_ty);
+            }
+            _ => return None,
+        };
+        if narrowed.is_equivalent_to(self.db, subject_ty) {
+            return None;
+        }
+
+        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
+        Some(NarrowingConstraints::from_iter([(
+            self.expect_place(&subject),
+            NarrowingConstraint::replacement(narrowed),
+        )]))
+    }
+
+    fn contains_class_or_mapping_pattern(pattern: &PatternPredicateKind<'db>) -> bool {
+        match pattern {
+            PatternPredicateKind::Class(_) | PatternPredicateKind::Mapping(_) => true,
+            PatternPredicateKind::Or(patterns) => {
+                patterns.iter().any(Self::contains_class_or_mapping_pattern)
+            }
+            PatternPredicateKind::As(Some(pattern), _) => {
+                Self::contains_class_or_mapping_pattern(pattern)
+            }
+            _ => false,
+        }
     }
 
     /// Record the types of names bound by a successful pattern.


### PR DESCRIPTION
## Summary

After a class or keyed mapping pattern succeeds, its nested patterns can identify which union members remain possible. This PR applies that result to the original match subject.

```python
from typing import Literal, TypedDict

class IntPayload(TypedDict):
    tag: Literal["int"]
    value: int

class StrPayload(TypedDict):
    tag: Literal["str"]
    value: str

def handle(payload: IntPayload | StrPayload) -> None:
    match payload:
        case {"tag": "int"}:
            reveal_type(payload)  # IntPayload
```

The preceding binding-inference PR already determines which class or mapping union members satisfy the complete pattern. We reuse that analysis to narrow the subject itself, including when structural patterns appear inside an `or` pattern.
