### PR TITLE
[ty] Run benchmarks for avoiding known-class query-key interning

### DIFF
--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -1065,17 +1065,12 @@ impl KnownClass {
     ///
     /// If the class cannot be found in typeshed, a debug-level log message will be emitted stating this.
     pub(crate) fn try_to_class_literal(self, db: &dyn Db) -> Option<StaticClassLiteral<'_>> {
-        #[salsa::interned(heap_size=ruff_memory_usage::heap_size)]
-        struct KnownClassArgument {
+        #[salsa::tracked(cycle_initial=|_, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+        fn known_class_to_class_literal(
+            db: &dyn Db,
+            _program: Program,
             class: KnownClass,
-        }
-
-        #[salsa::tracked(cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
-        fn known_class_to_class_literal<'db>(
-            db: &'db dyn Db,
-            class: KnownClassArgument<'db>,
-        ) -> Option<StaticClassLiteral<'db>> {
-            let class = class.class(db);
+        ) -> Option<StaticClassLiteral<'_>> {
             class
                 .try_to_class_literal_without_logging(db)
                 .or_else(|lookup_error| {
@@ -1102,7 +1097,7 @@ impl KnownClass {
                 .ok()
         }
 
-        known_class_to_class_literal(db, KnownClassArgument::new(db, self))
+        known_class_to_class_literal(db, Program::get(db), self)
     }
 
     /// Lookup a [`KnownClass`] in typeshed and return a [`Type`] representing that class-literal.


### PR DESCRIPTION
## Summary

`KnownClass::try_to_class_literal` caches class-literal resolution in a tracked query, but every lookup first interns the small `KnownClass` enum into a separate Salsa ingredient. On parallel project checks, profiles show contention in that synthetic interner even when the tracked result is already cached.

This draft uses the existing `Program` input as the tracked query's Salsa identity and passes `KnownClass` directly as the remaining key. The query continues to register the same module-resolution and program-setting dependencies, while removing the extra interner lookup from every known-class conversion.

## Local results

The Home Assistant diagnostics are byte-identical to the baseline. However, across 20 paired profiling-profile runs against the current parsed-handle and path-cache stack, total CPU time regressed by 2.0%. Wall time contained several large candidate-side outliers and was also negative overall. This draft is intended to measure the isolated change in CodSpeed before deciding whether the interner contention seen in the local profile is worth addressing this way.

The three existing `KnownClass` tests pass, and formatting and diff checks are clean.
