### PR TITLE
[ty] Infer types for names bound in sequence match patterns

### DIFF
--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -1275,7 +1275,20 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No type definitions found");
+        assert_snapshot!(test.goto_type_definition(), @r#"
+        info[goto-type definition]: Go to type definition
+          --> main.py:LL:17
+           |
+        LL |             x = ab
+           |                 ^^ Clicking here
+           |
+        info: Found 1 type definition
+          --> stdlib/builtins.pyi:LL:7
+           |
+        LL | class str(Sequence[str]):
+           |       ---
+           |
+        "#);
     }
 
     #[test]
@@ -1303,7 +1316,20 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No type definitions found");
+        assert_snapshot!(test.goto_type_definition(), @r#"
+        info[goto-type definition]: Go to type definition
+          --> main.py:LL:17
+           |
+        LL |             x = ab
+           |                 ^^ Clicking here
+           |
+        info: Found 1 type definition
+          --> stdlib/builtins.pyi:LL:7
+           |
+        LL | class list(MutableSequence[_T]):
+           |       ----
+           |
+        "#);
     }
 
     #[test]
@@ -1331,7 +1357,20 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No type definitions found");
+        assert_snapshot!(test.goto_type_definition(), @r#"
+        info[goto-type definition]: Go to type definition
+          --> main.py:LL:17
+           |
+        LL |             x = ab
+           |                 ^^ Clicking here
+           |
+        info: Found 1 type definition
+          --> stdlib/builtins.pyi:LL:7
+           |
+        LL | class str(Sequence[str]):
+           |       ---
+           |
+        "#);
     }
 
     #[test]
@@ -1371,7 +1410,20 @@ mod tests {
             "#,
         );
 
-        assert_snapshot!(test.goto_type_definition(), @"No type definitions found");
+        assert_snapshot!(test.goto_type_definition(), @"
+        info[goto-type definition]: Go to type definition
+          --> main.py:LL:17
+           |
+        LL |             x = ab
+           |                 ^^ Clicking here
+           |
+        info: Found 1 type definition
+          --> stdlib/ty_extensions.pyi:LL:1
+           |
+        LL | Unknown: _SpecialForm
+           | -------
+           |
+        ");
     }
 
     #[test]

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -3793,10 +3793,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        @Todo
+        str
         ---------------------------------------------
         ```python
-        @Todo
+        str
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -3837,10 +3837,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        @Todo
+        list[str]
         ---------------------------------------------
         ```python
-        @Todo
+        list[str]
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -3881,10 +3881,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        @Todo
+        str
         ---------------------------------------------
         ```python
-        @Todo
+        str
         ```
         ---------------------------------------------
         info[hover]: Hovered content is
@@ -3937,10 +3937,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        @Todo
+        Unknown
         ---------------------------------------------
         ```python
-        @Todo
+        Unknown
         ```
         ---------------------------------------------
         info[hover]: Hovered content is

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -2147,7 +2147,30 @@ Source with applied edits:
         def my_func(command: str):
             match command.split():
                 case ["get", ab]:
-                    x[: @Todo] = ab
+                    x[: str] = ab
+
+        ---------------------------------------------
+        info[inlay-hint-location]: Inlay Hint Target
+          --> stdlib/builtins.pyi:LL:7
+           |
+        LL | class str(Sequence[str]):
+           |       ^^^
+           |
+        info: Source
+          --> main2.py:LL:17
+           |
+        LL |             x[: str] = ab
+           |                 ^^^
+           |
+
+        ---------------------------------------------
+        info[inlay-hint-edit]: Inlay hint edits
+        --> main.py:1:1
+        2 | def my_func(command: str):
+        3 |     match command.split():
+        4 |         case ["get", ab]:
+          -             x = ab
+        5 +             x: str = ab
         "#);
     }
 
@@ -2167,7 +2190,43 @@ Source with applied edits:
         def my_func(command: str):
             match command.split():
                 case ["get", *ab]:
-                    x[: @Todo] = ab
+                    x[: list[str]] = ab
+
+        ---------------------------------------------
+        info[inlay-hint-location]: Inlay Hint Target
+          --> stdlib/builtins.pyi:LL:7
+           |
+        LL | class list(MutableSequence[_T]):
+           |       ^^^^
+           |
+        info: Source
+          --> main2.py:LL:17
+           |
+        LL |             x[: list[str]] = ab
+           |                 ^^^^
+           |
+
+        info[inlay-hint-location]: Inlay Hint Target
+          --> stdlib/builtins.pyi:LL:7
+           |
+        LL | class str(Sequence[str]):
+           |       ^^^
+           |
+        info: Source
+          --> main2.py:LL:22
+           |
+        LL |             x[: list[str]] = ab
+           |                      ^^^
+           |
+
+        ---------------------------------------------
+        info[inlay-hint-edit]: Inlay hint edits
+        --> main.py:1:1
+        2 | def my_func(command: str):
+        3 |     match command.split():
+        4 |         case ["get", *ab]:
+          -             x = ab
+        5 +             x: list[str] = ab
         "#);
     }
 
@@ -2187,7 +2246,30 @@ Source with applied edits:
         def my_func(command: str):
             match command.split():
                 case ["get", ("a" | "b") as ab]:
-                    x[: @Todo] = ab
+                    x[: str] = ab
+
+        ---------------------------------------------
+        info[inlay-hint-location]: Inlay Hint Target
+          --> stdlib/builtins.pyi:LL:7
+           |
+        LL | class str(Sequence[str]):
+           |       ^^^
+           |
+        info: Source
+          --> main2.py:LL:17
+           |
+        LL |             x[: str] = ab
+           |                 ^^^
+           |
+
+        ---------------------------------------------
+        info[inlay-hint-edit]: Inlay hint edits
+        --> main.py:1:1
+        2 | def my_func(command: str):
+        3 |     match command.split():
+        4 |         case ["get", ("a" | "b") as ab]:
+          -             x = ab
+        5 +             x: str = ab
         "#);
     }
 
@@ -2219,7 +2301,35 @@ Source with applied edits:
         def my_func(event: Click):
             match event:
                 case Click(x, button=ab):
-                    x[: @Todo] = ab
+                    x[: Unknown] = ab
+
+        ---------------------------------------------
+        info[inlay-hint-location]: Inlay Hint Target
+          --> stdlib/ty_extensions.pyi:LL:1
+           |
+        LL | Unknown: _SpecialForm
+           | ^^^^^^^
+           |
+        info: Source
+          --> main2.py:LL:17
+           |
+        LL |             x[: Unknown] = ab
+           |                 ^^^^^^^
+           |
+
+        ---------------------------------------------
+        info[inlay-hint-edit]: Inlay hint edits
+        --> main.py:1:1
+        1  + from ty_extensions import Unknown
+        2  |
+        3  | class Click:
+        4  |     __match_args__ = ("position", "button")
+        --------------------------------------------------------------------------------
+        9  | def my_func(event: Click):
+        10 |     match event:
+        11 |         case Click(x, button=ab):
+           -             x = ab
+        12 +             x: Unknown = ab
         "#);
     }
 

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -2166,11 +2166,11 @@ Source with applied edits:
         ---------------------------------------------
         info[inlay-hint-edit]: Inlay hint edits
         --> main.py:1:1
-        2 | def my_func(command: str):
-        3 |     match command.split():
+          |
         4 |         case ["get", ab]:
           -             x = ab
         5 +             x: str = ab
+          |
         "#);
     }
 
@@ -2222,11 +2222,11 @@ Source with applied edits:
         ---------------------------------------------
         info[inlay-hint-edit]: Inlay hint edits
         --> main.py:1:1
-        2 | def my_func(command: str):
-        3 |     match command.split():
+          |
         4 |         case ["get", *ab]:
           -             x = ab
         5 +             x: list[str] = ab
+          |
         "#);
     }
 
@@ -2265,11 +2265,11 @@ Source with applied edits:
         ---------------------------------------------
         info[inlay-hint-edit]: Inlay hint edits
         --> main.py:1:1
-        2 | def my_func(command: str):
-        3 |     match command.split():
+          |
         4 |         case ["get", ("a" | "b") as ab]:
           -             x = ab
         5 +             x: str = ab
+          |
         "#);
     }
 
@@ -2320,16 +2320,14 @@ Source with applied edits:
         ---------------------------------------------
         info[inlay-hint-edit]: Inlay hint edits
         --> main.py:1:1
+           |
         1  + from ty_extensions import Unknown
         2  |
-        3  | class Click:
-        4  |     __match_args__ = ("position", "button")
         --------------------------------------------------------------------------------
-        9  | def my_func(event: Click):
-        10 |     match event:
         11 |         case Click(x, button=ab):
            -             x = ab
         12 +             x: Unknown = ab
+           |
         "#);
     }
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -38,7 +38,10 @@ use crate::definition::{
 use crate::expression::{Expression, ExpressionKind};
 use crate::frozen::{FrozenMap, FrozenSet};
 use crate::member::MemberExprBuilder;
-use crate::place::{PlaceExpr, PlaceTableBuilder, PossiblyNarrowedPlacesBuilder, ScopedPlaceId};
+use crate::place::{
+    PlaceExpr, PlaceTableBuilder, PossiblyNarrowedPlacesBuilder, ScopedPlaceId,
+    match_subject_place_expressions,
+};
 use crate::predicate::{
     CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
     PredicateNode, PredicateOrLiteral, ScopedPredicateId, SequencePatternPredicateKind,
@@ -57,8 +60,8 @@ use crate::statement::StatementInner;
 use crate::symbol::{ScopedSymbolId, Symbol};
 use crate::unpack::{Unpack, UnpackKind, UnpackPosition, UnpackValue};
 use crate::use_def::{
-    EnclosingSnapshotKey, FlowSnapshot, FutureDefinitions, PreviousDefinitions, ScopedDefinitionId,
-    ScopedEnclosingSnapshotId, UseDefMapBuilder,
+    EnclosingSnapshotKey, FlowSnapshot, FutureDefinitions, LiveBinding, PreviousDefinitions,
+    ScopedDefinitionId, ScopedEnclosingSnapshotId, UseDefMapBuilder,
 };
 use crate::{Db, Statement, StatementNodeKey};
 use crate::{
@@ -238,7 +241,7 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     /// the most recent visit at the end of the Vec.
     current_statements: Vec<CurrentStatement<'ast, 'db>>,
     /// The match case we're currently visiting.
-    current_match_case: Option<CurrentMatchCase<'ast>>,
+    current_match_case: Option<CurrentMatchCase<'ast, 'db>>,
     /// The name of the first function parameter of the innermost function that we're currently visiting.
     current_first_parameter_name: Option<&'ast str>,
 
@@ -1712,7 +1715,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             reason = "bindings for distinct places are collected independently"
         )]
         for place_id in loop_header_places {
-            for live_binding in use_def.loop_back_bindings(*place_id) {
+            for live_binding in use_def.current_bindings(*place_id) {
                 if live_binding.binding() >= loop_min_definition_id {
                     loop_header.add_binding(*place_id, live_binding);
                 }
@@ -2076,25 +2079,21 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 })
             }
             ast::Pattern::MatchSequence(pattern) => {
-                let mut has_star = false;
-                let patterns = pattern
-                    .patterns
-                    .iter()
-                    .map(|pattern| {
-                        if matches!(pattern, ast::Pattern::MatchStar(_)) {
-                            has_star = true;
-                        }
-                        self.predicate_kind(pattern)
-                    })
-                    .collect();
-                PatternPredicateKind::Sequence(SequencePatternPredicateKind { patterns, has_star })
+                PatternPredicateKind::Sequence(SequencePatternPredicateKind {
+                    patterns: pattern
+                        .patterns
+                        .iter()
+                        .map(|pattern| self.predicate_kind(pattern))
+                        .collect(),
+                })
             }
             ast::Pattern::MatchOr(pattern) => {
                 let predicates = pattern
                     .patterns
                     .iter()
                     .map(|pattern| self.predicate_kind(pattern))
-                    .collect();
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice();
                 PatternPredicateKind::Or(predicates)
             }
             ast::Pattern::MatchAs(pattern) => PatternPredicateKind::As(
@@ -2104,23 +2103,19 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     .map(|p| Box::new(self.predicate_kind(p))),
                 pattern.name.as_ref().map(|name| name.id.clone()),
             ),
-            ast::Pattern::MatchStar(_) => PatternPredicateKind::MatchStar,
+            ast::Pattern::MatchStar(pattern) => {
+                PatternPredicateKind::Star(pattern.name.as_ref().map(|name| name.id.clone()))
+            }
         }
     }
 
-    fn add_pattern_narrowing_constraint(
+    fn create_pattern_predicate(
         &mut self,
         subject: Expression<'db>,
         pattern: &ast::Pattern,
-        sequence_subject_targets: &[(ScopedPlaceId, ScopedUseId, ExpressionNodeKey)],
         guard: Option<&ast::Expr>,
         previous_pattern: Option<PatternPredicate<'db>>,
-        is_catchall: bool,
-    ) -> (
-        PredicateOrLiteral<'db>,
-        ScopedPredicateId,
-        PatternPredicate<'db>,
-    ) {
+    ) -> PatternPredicate<'db> {
         // This is called for the top-level pattern of each match arm. We need to create a
         // standalone expression for each arm of a match statement, since they can introduce
         // constraints on the match subject. (Or more accurately, for the match arm's pattern,
@@ -2135,7 +2130,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let kind = self.predicate_kind(pattern);
         let guard = guard.map(|guard| self.add_standalone_expression(guard));
 
-        let pattern_predicate = PatternPredicate::new(
+        PatternPredicate::new(
             self.db,
             self.file,
             self.current_scope(),
@@ -2143,8 +2138,16 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             kind,
             guard,
             previous_pattern.map(Box::new),
-        );
+        )
+    }
 
+    fn add_pattern_narrowing_constraint(
+        &mut self,
+        pattern_predicate: PatternPredicate<'db>,
+        subject_targets: &[(ScopedPlaceId, SmallVec<[ScopedDefinitionId; 2]>)],
+        sequence_subject_targets: &[(ScopedPlaceId, ScopedUseId, ExpressionNodeKey)],
+        is_catchall: bool,
+    ) -> (PredicateOrLiteral<'db>, ScopedPredicateId) {
         let predicate = PredicateOrLiteral::Predicate(Predicate {
             node: PredicateNode::Pattern(pattern_predicate),
             is_positive: true,
@@ -2158,10 +2161,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // predicates are still created normally for proper control flow tracking.
         let predicate_id = if is_catchall {
             ScopedPredicateId::ALWAYS_TRUE
-        } else if sequence_subject_targets.is_empty() {
-            self.record_narrowing_constraint(predicate)
         } else {
             let predicate_id = self.add_predicate(predicate);
+            for (place, bindings) in subject_targets {
+                self.current_use_def_map_mut()
+                    .record_narrowing_constraint_for_bindings(predicate_id, *place, bindings);
+            }
             for &(place, use_id, target) in sequence_subject_targets {
                 let subject_element_id =
                     self.add_predicate(PredicateOrLiteral::Predicate(Predicate {
@@ -2182,7 +2187,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
             predicate_id
         };
-        (predicate, predicate_id, pattern_predicate)
+        (predicate, predicate_id)
     }
 
     /// Record an expression that needs to be a Salsa ingredient, because we need to infer its type
@@ -3545,6 +3550,33 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 // A match subject is evaluated once. Retain the bindings read by each place so
                 // that case predicates constrain those values rather than later rebindings.
+                let mut subject_targets =
+                    SmallVec::<[(ScopedPlaceId, SmallVec<[ScopedDefinitionId; 2]>); 2]>::new();
+                let subject_places = match_subject_place_expressions(subject)
+                    .into_iter()
+                    .filter_map(|expression| {
+                        let place = PlaceExpr::try_from_expr(expression).and_then(|place| {
+                            self.current_place_table().place_id((&place).into())
+                        })?;
+                        Some((place, self.current_ast_ids().try_use_id(expression)))
+                    })
+                    .collect::<SmallVec<[_; 2]>>();
+                for (place, use_id) in subject_places {
+                    let bindings = if let Some(use_id) = use_id {
+                        self.current_use_def_map()
+                            .bindings_at_use(use_id)
+                            .map(LiveBinding::binding)
+                            .collect()
+                    } else {
+                        // A named-expression subject creates its target binding instead of
+                        // reading one, so snapshot the binding that was just created.
+                        self.current_use_def_map_mut()
+                            .current_bindings(place)
+                            .map(|binding| LiveBinding::binding(&binding))
+                            .collect()
+                    };
+                    subject_targets.push((place, bindings));
+                }
                 let places = self.current_place_table();
                 let ast_ids = self.current_ast_ids();
                 let mut sequence_subject_targets =
@@ -3584,7 +3616,16 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let mut previous_pattern: Option<PatternPredicate<'_>> = None;
 
                 for (i, case) in cases.iter().enumerate() {
-                    self.current_match_case = Some(CurrentMatchCase::new(&case.pattern));
+                    let match_pattern_predicate = self.create_pattern_predicate(
+                        subject_expr,
+                        &case.pattern,
+                        case.guard.as_deref(),
+                        previous_pattern,
+                    );
+                    self.current_match_case = Some(CurrentMatchCase::new(
+                        &case.pattern,
+                        match_pattern_predicate,
+                    ));
                     self.visit_pattern(&case.pattern);
                     self.current_match_case = None;
                     // unlike in [Stmt::If], we don't reset [no_case_matched]
@@ -3592,13 +3633,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     // symbols, and this doesn't occur unless the pattern
                     // actually matches
                     let is_catchall = has_catchall && i == cases.len() - 1;
-                    let (match_predicate, match_narrowing_id, match_pattern_predicate) = self
+                    let (match_predicate, match_narrowing_id) = self
                         .add_pattern_narrowing_constraint(
-                            subject_expr,
-                            &case.pattern,
+                            match_pattern_predicate,
+                            &subject_targets,
                             &sequence_subject_targets,
-                            case.guard.as_deref(),
-                            previous_pattern,
                             is_catchall,
                         );
                     previous_pattern = Some(match_pattern_predicate);
@@ -4541,7 +4580,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 MatchPatternDefinitionNodeRef {
                     pattern: state.pattern,
                     identifier: name,
-                    index: state.index,
+                    predicate: state.predicate,
                 },
             );
         }
@@ -4562,12 +4601,10 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 MatchPatternDefinitionNodeRef {
                     pattern: state.pattern,
                     identifier: name,
-                    index: state.index,
+                    predicate: state.predicate,
                 },
             );
         }
-
-        self.current_match_case.as_mut().unwrap().index += 1;
     }
 }
 
@@ -4815,27 +4852,17 @@ struct CurrentStatement<'ast, 'db> {
 }
 
 #[derive(Debug, PartialEq)]
-struct CurrentMatchCase<'ast> {
+struct CurrentMatchCase<'ast, 'db> {
     /// The pattern that's part of the current match case.
     pattern: &'ast ast::Pattern,
 
-    /// The index of the sub-pattern that's being currently visited within the pattern.
-    ///
-    /// For example:
-    /// ```py
-    /// match subject:
-    ///     case a as b: ...
-    ///     case [a, b]: ...
-    ///     case a | b: ...
-    /// ```
-    ///
-    /// In all of the above cases, the index would be 0 for `a` and 1 for `b`.
-    index: u32,
+    /// The predicate for the complete match case.
+    predicate: PatternPredicate<'db>,
 }
 
-impl<'a> CurrentMatchCase<'a> {
-    fn new(pattern: &'a ast::Pattern) -> Self {
-        Self { pattern, index: 0 }
+impl<'ast, 'db> CurrentMatchCase<'ast, 'db> {
+    fn new(pattern: &'ast ast::Pattern, predicate: PatternPredicate<'db>) -> Self {
+        Self { pattern, predicate }
     }
 }
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2109,75 +2109,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         }
     }
 
-    fn pattern_binds_any_symbol(
-        pattern: &ast::Pattern,
-        matches: &mut impl FnMut(&str) -> bool,
-    ) -> bool {
-        match pattern {
-            ast::Pattern::MatchValue(_) | ast::Pattern::MatchSingleton(_) => false,
-            ast::Pattern::MatchSequence(pattern) => pattern
-                .patterns
-                .iter()
-                .any(|pattern| Self::pattern_binds_any_symbol(pattern, matches)),
-            ast::Pattern::MatchMapping(pattern) => {
-                pattern
-                    .rest
-                    .as_ref()
-                    .is_some_and(|name| matches(name.as_str()))
-                    || pattern
-                        .patterns
-                        .iter()
-                        .any(|pattern| Self::pattern_binds_any_symbol(pattern, matches))
-            }
-            ast::Pattern::MatchClass(pattern) => pattern
-                .arguments
-                .patterns
-                .iter()
-                .chain(
-                    pattern
-                        .arguments
-                        .keywords
-                        .iter()
-                        .map(|keyword| &keyword.pattern),
-                )
-                .any(|pattern| Self::pattern_binds_any_symbol(pattern, matches)),
-            ast::Pattern::MatchStar(pattern) => pattern
-                .name
-                .as_ref()
-                .is_some_and(|name| matches(name.as_str())),
-            ast::Pattern::MatchAs(pattern) => {
-                pattern
-                    .name
-                    .as_ref()
-                    .is_some_and(|name| matches(name.as_str()))
-                    || pattern
-                        .pattern
-                        .as_deref()
-                        .is_some_and(|pattern| Self::pattern_binds_any_symbol(pattern, matches))
-            }
-            ast::Pattern::MatchOr(pattern) => pattern
-                .patterns
-                .iter()
-                .any(|pattern| Self::pattern_binds_any_symbol(pattern, matches)),
-        }
-    }
-
-    fn pattern_rebinds_subject(
-        &self,
-        pattern: &ast::Pattern,
-        subject_places: &[(ScopedPlaceId, Option<ScopedUseId>)],
-    ) -> bool {
-        let places = self.current_place_table();
-        let mut matches = |name: &str| {
-            places.symbol_id(name).is_some_and(|symbol| {
-                subject_places.iter().any(|(place, _)| {
-                    matches!(place, ScopedPlaceId::Symbol(target) if *target == symbol)
-                })
-            })
-        };
-        Self::pattern_binds_any_symbol(pattern, &mut matches)
-    }
-
     fn create_pattern_predicate(
         &mut self,
         subject: Expression<'db>,
@@ -2215,7 +2146,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         pattern_predicate: PatternPredicate<'db>,
         subject_targets: &[(ScopedPlaceId, SmallVec<[ScopedDefinitionId; 2]>)],
         sequence_subject_targets: &[(ScopedPlaceId, ScopedUseId, ExpressionNodeKey)],
-        preserve_subject_bindings: bool,
         is_catchall: bool,
     ) -> (PredicateOrLiteral<'db>, ScopedPredicateId) {
         let predicate = PredicateOrLiteral::Predicate(Predicate {
@@ -2231,15 +2161,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // predicates are still created normally for proper control flow tracking.
         let predicate_id = if is_catchall {
             ScopedPredicateId::ALWAYS_TRUE
-        } else if !preserve_subject_bindings && sequence_subject_targets.is_empty() {
+        } else if subject_targets.is_empty() && sequence_subject_targets.is_empty() {
             self.record_narrowing_constraint(predicate)
         } else {
             let predicate_id = self.add_predicate(predicate);
-            if preserve_subject_bindings {
-                for (place, bindings) in subject_targets {
-                    self.current_use_def_map_mut()
-                        .record_narrowing_constraint_for_bindings(predicate_id, *place, bindings);
-                }
+            for (place, bindings) in subject_targets {
+                self.current_use_def_map_mut()
+                    .record_narrowing_constraint_for_bindings(predicate_id, *place, bindings);
             }
             for &(place, use_id, target) in sequence_subject_targets {
                 let subject_element_id =
@@ -3633,6 +3561,24 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         Some((place, self.current_ast_ids().try_use_id(expression)))
                     })
                     .collect::<SmallVec<[_; 2]>>();
+                let mut subject_targets =
+                    SmallVec::<[(ScopedPlaceId, SmallVec<[ScopedDefinitionId; 2]>); 2]>::new();
+                for &(place, use_id) in &subject_places {
+                    let bindings = if let Some(use_id) = use_id {
+                        self.current_use_def_map()
+                            .bindings_at_use(use_id)
+                            .map(LiveBinding::binding)
+                            .collect()
+                    } else {
+                        // A named-expression subject creates its target binding instead of reading
+                        // one, so snapshot the binding that was just created.
+                        self.current_use_def_map_mut()
+                            .current_bindings(place)
+                            .map(|binding| LiveBinding::binding(&binding))
+                            .collect()
+                    };
+                    subject_targets.push((place, bindings));
+                }
                 let places = self.current_place_table();
                 let ast_ids = self.current_ast_ids();
                 let mut sequence_subject_targets =
@@ -3678,28 +3624,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         case.guard.as_deref(),
                         previous_pattern,
                     );
-                    let preserve_subject_bindings =
-                        self.pattern_rebinds_subject(&case.pattern, &subject_places);
-                    let mut subject_targets =
-                        SmallVec::<[(ScopedPlaceId, SmallVec<[ScopedDefinitionId; 2]>); 2]>::new();
-                    if preserve_subject_bindings {
-                        for &(place, use_id) in &subject_places {
-                            let bindings = if let Some(use_id) = use_id {
-                                self.current_use_def_map()
-                                    .bindings_at_use(use_id)
-                                    .map(LiveBinding::binding)
-                                    .collect()
-                            } else {
-                                // A named-expression subject creates its target binding instead of
-                                // reading one, so snapshot the binding that was just created.
-                                self.current_use_def_map_mut()
-                                    .current_bindings(place)
-                                    .map(|binding| LiveBinding::binding(&binding))
-                                    .collect()
-                            };
-                            subject_targets.push((place, bindings));
-                        }
-                    }
                     self.current_match_case = Some(CurrentMatchCase::new(
                         &case.pattern,
                         match_pattern_predicate,
@@ -3716,7 +3640,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             match_pattern_predicate,
                             &subject_targets,
                             &sequence_subject_targets,
-                            preserve_subject_bindings,
                             is_catchall,
                         );
                     previous_pattern = Some(match_pattern_predicate);

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2109,6 +2109,75 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         }
     }
 
+    fn pattern_binds_any_symbol(
+        pattern: &ast::Pattern,
+        matches: &mut impl FnMut(&str) -> bool,
+    ) -> bool {
+        match pattern {
+            ast::Pattern::MatchValue(_) | ast::Pattern::MatchSingleton(_) => false,
+            ast::Pattern::MatchSequence(pattern) => pattern
+                .patterns
+                .iter()
+                .any(|pattern| Self::pattern_binds_any_symbol(pattern, matches)),
+            ast::Pattern::MatchMapping(pattern) => {
+                pattern
+                    .rest
+                    .as_ref()
+                    .is_some_and(|name| matches(name.as_str()))
+                    || pattern
+                        .patterns
+                        .iter()
+                        .any(|pattern| Self::pattern_binds_any_symbol(pattern, matches))
+            }
+            ast::Pattern::MatchClass(pattern) => pattern
+                .arguments
+                .patterns
+                .iter()
+                .chain(
+                    pattern
+                        .arguments
+                        .keywords
+                        .iter()
+                        .map(|keyword| &keyword.pattern),
+                )
+                .any(|pattern| Self::pattern_binds_any_symbol(pattern, matches)),
+            ast::Pattern::MatchStar(pattern) => pattern
+                .name
+                .as_ref()
+                .is_some_and(|name| matches(name.as_str())),
+            ast::Pattern::MatchAs(pattern) => {
+                pattern
+                    .name
+                    .as_ref()
+                    .is_some_and(|name| matches(name.as_str()))
+                    || pattern
+                        .pattern
+                        .as_deref()
+                        .is_some_and(|pattern| Self::pattern_binds_any_symbol(pattern, matches))
+            }
+            ast::Pattern::MatchOr(pattern) => pattern
+                .patterns
+                .iter()
+                .any(|pattern| Self::pattern_binds_any_symbol(pattern, matches)),
+        }
+    }
+
+    fn pattern_rebinds_subject(
+        &self,
+        pattern: &ast::Pattern,
+        subject_places: &[(ScopedPlaceId, Option<ScopedUseId>)],
+    ) -> bool {
+        let places = self.current_place_table();
+        let mut matches = |name: &str| {
+            places.symbol_id(name).is_some_and(|symbol| {
+                subject_places.iter().any(|(place, _)| {
+                    matches!(place, ScopedPlaceId::Symbol(target) if *target == symbol)
+                })
+            })
+        };
+        Self::pattern_binds_any_symbol(pattern, &mut matches)
+    }
+
     fn create_pattern_predicate(
         &mut self,
         subject: Expression<'db>,
@@ -2146,6 +2215,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         pattern_predicate: PatternPredicate<'db>,
         subject_targets: &[(ScopedPlaceId, SmallVec<[ScopedDefinitionId; 2]>)],
         sequence_subject_targets: &[(ScopedPlaceId, ScopedUseId, ExpressionNodeKey)],
+        preserve_subject_bindings: bool,
         is_catchall: bool,
     ) -> (PredicateOrLiteral<'db>, ScopedPredicateId) {
         let predicate = PredicateOrLiteral::Predicate(Predicate {
@@ -2161,11 +2231,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // predicates are still created normally for proper control flow tracking.
         let predicate_id = if is_catchall {
             ScopedPredicateId::ALWAYS_TRUE
+        } else if !preserve_subject_bindings && sequence_subject_targets.is_empty() {
+            self.record_narrowing_constraint(predicate)
         } else {
             let predicate_id = self.add_predicate(predicate);
-            for (place, bindings) in subject_targets {
-                self.current_use_def_map_mut()
-                    .record_narrowing_constraint_for_bindings(predicate_id, *place, bindings);
+            if preserve_subject_bindings {
+                for (place, bindings) in subject_targets {
+                    self.current_use_def_map_mut()
+                        .record_narrowing_constraint_for_bindings(predicate_id, *place, bindings);
+                }
             }
             for &(place, use_id, target) in sequence_subject_targets {
                 let subject_element_id =
@@ -3550,8 +3624,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 // A match subject is evaluated once. Retain the bindings read by each place so
                 // that case predicates constrain those values rather than later rebindings.
-                let mut subject_targets =
-                    SmallVec::<[(ScopedPlaceId, SmallVec<[ScopedDefinitionId; 2]>); 2]>::new();
                 let subject_places = match_subject_place_expressions(subject)
                     .into_iter()
                     .filter_map(|expression| {
@@ -3561,22 +3633,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         Some((place, self.current_ast_ids().try_use_id(expression)))
                     })
                     .collect::<SmallVec<[_; 2]>>();
-                for (place, use_id) in subject_places {
-                    let bindings = if let Some(use_id) = use_id {
-                        self.current_use_def_map()
-                            .bindings_at_use(use_id)
-                            .map(LiveBinding::binding)
-                            .collect()
-                    } else {
-                        // A named-expression subject creates its target binding instead of
-                        // reading one, so snapshot the binding that was just created.
-                        self.current_use_def_map_mut()
-                            .current_bindings(place)
-                            .map(|binding| LiveBinding::binding(&binding))
-                            .collect()
-                    };
-                    subject_targets.push((place, bindings));
-                }
                 let places = self.current_place_table();
                 let ast_ids = self.current_ast_ids();
                 let mut sequence_subject_targets =
@@ -3622,6 +3678,28 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         case.guard.as_deref(),
                         previous_pattern,
                     );
+                    let preserve_subject_bindings =
+                        self.pattern_rebinds_subject(&case.pattern, &subject_places);
+                    let mut subject_targets =
+                        SmallVec::<[(ScopedPlaceId, SmallVec<[ScopedDefinitionId; 2]>); 2]>::new();
+                    if preserve_subject_bindings {
+                        for &(place, use_id) in &subject_places {
+                            let bindings = if let Some(use_id) = use_id {
+                                self.current_use_def_map()
+                                    .bindings_at_use(use_id)
+                                    .map(LiveBinding::binding)
+                                    .collect()
+                            } else {
+                                // A named-expression subject creates its target binding instead of
+                                // reading one, so snapshot the binding that was just created.
+                                self.current_use_def_map_mut()
+                                    .current_bindings(place)
+                                    .map(|binding| LiveBinding::binding(&binding))
+                                    .collect()
+                            };
+                            subject_targets.push((place, bindings));
+                        }
+                    }
                     self.current_match_case = Some(CurrentMatchCase::new(
                         &case.pattern,
                         match_pattern_predicate,
@@ -3638,6 +3716,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             match_pattern_predicate,
                             &subject_targets,
                             &sequence_subject_targets,
+                            preserve_subject_bindings,
                             is_catchall,
                         );
                     previous_pattern = Some(match_pattern_predicate);

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -15,6 +15,7 @@ use crate::ast_node_ref::AstNodeRef;
 use crate::member::ScopedMemberId;
 use crate::node_key::NodeKey;
 use crate::place::ScopedPlaceId;
+use crate::predicate::PatternPredicate;
 use crate::scope::{FileScopeId, ScopeId};
 use crate::symbol::ScopedSymbolId;
 use crate::unpack::{Unpack, UnpackPosition};
@@ -347,7 +348,7 @@ pub(crate) enum DefinitionNodeRef<'ast, 'db> {
     Parameter(ParameterDefinitionNodeRef<'ast>),
     LambdaParameter(LambdaParameterDefinitionNodeRef<'ast>),
     WithItem(WithItemDefinitionNodeRef<'ast, 'db>),
-    MatchPattern(MatchPatternDefinitionNodeRef<'ast>),
+    MatchPattern(MatchPatternDefinitionNodeRef<'ast, 'db>),
     ExceptHandler(ExceptHandlerDefinitionNodeRef<'ast>),
     TypeVar(&'ast ast::TypeParamTypeVar),
     ParamSpec(&'ast ast::TypeParamParamSpec),
@@ -475,8 +476,8 @@ impl<'ast> From<LambdaParameterDefinitionNodeRef<'ast>> for DefinitionNodeRef<'a
     }
 }
 
-impl<'ast> From<MatchPatternDefinitionNodeRef<'ast>> for DefinitionNodeRef<'ast, '_> {
-    fn from(node: MatchPatternDefinitionNodeRef<'ast>) -> Self {
+impl<'ast, 'db> From<MatchPatternDefinitionNodeRef<'ast, 'db>> for DefinitionNodeRef<'ast, 'db> {
+    fn from(node: MatchPatternDefinitionNodeRef<'ast, 'db>) -> Self {
         Self::MatchPattern(node)
     }
 }
@@ -617,14 +618,13 @@ pub(crate) struct LambdaParameterDefinitionNodeRef<'ast> {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct MatchPatternDefinitionNodeRef<'ast> {
+pub(crate) struct MatchPatternDefinitionNodeRef<'ast, 'db> {
     /// The outermost pattern node in which the identifier being defined occurs.
     pub(crate) pattern: &'ast ast::Pattern,
     /// The identifier being defined.
     pub(crate) identifier: &'ast ast::Identifier,
-    /// The index of the identifier in the pattern when visiting the `pattern` node in evaluation
-    /// order.
-    pub(crate) index: u32,
+    /// The predicate for the complete match case containing this binding.
+    pub(crate) predicate: PatternPredicate<'db>,
 }
 
 impl<'db> DefinitionNodeRef<'_, 'db> {
@@ -759,11 +759,11 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
             DefinitionNodeRef::MatchPattern(MatchPatternDefinitionNodeRef {
                 pattern,
                 identifier,
-                index,
+                predicate,
             }) => DefinitionKind::MatchPattern(MatchPatternDefinitionKind {
                 pattern: AstNodeRef::new(parsed, pattern),
                 identifier: AstNodeRef::new(parsed, identifier),
-                index,
+                predicate,
             }),
             DefinitionNodeRef::ExceptHandler(ExceptHandlerDefinitionNodeRef {
                 handler,
@@ -929,7 +929,7 @@ pub enum DefinitionKind<'db> {
     Parameter(ParameterDefinitionNodeKind),
     LambdaParameter(LambdaParameterDefinitionNodeKind),
     WithItem(WithItemDefinitionKind<'db>),
-    MatchPattern(MatchPatternDefinitionKind),
+    MatchPattern(MatchPatternDefinitionKind<'db>),
     ExceptHandler(ExceptHandlerDefinitionKind),
     TypeVar(AstNodeRef<ast::TypeParamTypeVar>),
     ParamSpec(AstNodeRef<ast::TypeParamParamSpec>),
@@ -1215,19 +1215,19 @@ impl StarImportDefinitionKind {
 }
 
 #[derive(Clone, Debug, get_size2::GetSize)]
-pub struct MatchPatternDefinitionKind {
+pub struct MatchPatternDefinitionKind<'db> {
     pattern: AstNodeRef<ast::Pattern>,
     identifier: AstNodeRef<ast::Identifier>,
-    index: u32,
+    predicate: PatternPredicate<'db>,
 }
 
-impl MatchPatternDefinitionKind {
+impl<'db> MatchPatternDefinitionKind<'db> {
     pub fn pattern<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Pattern {
         self.pattern.node(module)
     }
 
-    pub fn index(&self) -> u32 {
-        self.index
+    pub fn predicate(&self) -> PatternPredicate<'db> {
+        self.predicate
     }
 }
 

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -1937,28 +1937,11 @@ match subject:
         );
 
         let use_def = use_def_map(&db, global_scope_id);
-        for (name, expected_index) in [
-            ("a", 0),
-            ("b", 0),
-            ("c", 1),
-            ("d", 2),
-            ("e", 0),
-            ("f", 1),
-            ("g", 0),
-            ("h", 1),
-            ("i", 0),
-            ("j", 1),
-            ("k", 0),
-            ("l", 1),
-        ] {
+        for name in ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"] {
             let binding = use_def
                 .first_public_binding(global_table.symbol_id(name).expect("symbol exists"))
                 .expect("Expected with item definition for {name}");
-            if let DefinitionKind::MatchPattern(pattern) = binding.kind(&db) {
-                assert_eq!(pattern.index(), expected_index);
-            } else {
-                panic!("Expected match pattern definition for {name}");
-            }
+            assert!(matches!(binding.kind(&db), DefinitionKind::MatchPattern(_)));
         }
     }
 
@@ -1980,15 +1963,11 @@ match 1:
         assert_eq!(names(global_table), vec!["first", "second"]);
 
         let use_def = use_def_map(&db, global_scope_id);
-        for (name, expected_index) in [("first", 0), ("second", 0)] {
+        for name in ["first", "second"] {
             let binding = use_def
                 .first_public_binding(global_table.symbol_id(name).expect("symbol exists"))
                 .expect("Expected with item definition for {name}");
-            if let DefinitionKind::MatchPattern(pattern) = binding.kind(&db) {
-                assert_eq!(pattern.index(), expected_index);
-            } else {
-                panic!("Expected match pattern definition for {name}");
-            }
+            assert!(matches!(binding.kind(&db), DefinitionKind::MatchPattern(_)));
         }
     }
 

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -3,7 +3,7 @@ use crate::member::{
     Member, MemberExpr, MemberExprBuilder, MemberExprRef, MemberTable, MemberTableBuilder,
     ScopedMemberId,
 };
-use crate::predicate::{PatternPredicate, PatternPredicateKind};
+use crate::predicate::PatternPredicate;
 use crate::scope::FileScopeId;
 use crate::symbol::{ScopedSymbolId, Symbol, SymbolTable, SymbolTableBuilder};
 use crate::{Db, PossiblyNarrowedPlaces};
@@ -13,6 +13,20 @@ use ruff_python_ast as ast;
 use smallvec::SmallVec;
 use std::hash::Hash;
 use std::iter::FusedIterator;
+
+/// Return the expressions whose existing bindings a match pattern can narrow.
+///
+/// In addition to the subject itself, matching an attribute or subscript can narrow its base.
+pub(crate) fn match_subject_place_expressions(subject: &ast::Expr) -> SmallVec<[&ast::Expr; 2]> {
+    let mut expressions: SmallVec<[&ast::Expr; 2]> = SmallVec::new();
+    expressions.push(subject);
+    match subject {
+        ast::Expr::Subscript(subscript) => expressions.push(&subscript.value),
+        ast::Expr::Attribute(attribute) => expressions.push(&attribute.value),
+        _ => {}
+    }
+    expressions
+}
 
 /// An expression that can be the target of a `Definition`.
 #[derive(Eq, PartialEq, Debug, get_size2::GetSize)]
@@ -601,7 +615,7 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
         pattern: PatternPredicate<'db>,
         module: &ParsedModuleRef,
     ) -> PossiblyNarrowedPlaces {
-        self.pattern_kind(pattern.kind(self.db), pattern.subject(self.db), module)
+        self.pattern_kind(pattern.subject(self.db), module)
     }
 
     fn expression_node(&self, expr: &ast::Expr) -> PossiblyNarrowedPlaces {
@@ -762,47 +776,19 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
     /// Pattern predicates narrow the match subject.
     fn pattern_kind(
         &self,
-        kind: &PatternPredicateKind<'db>,
         subject: Expression<'db>,
         module: &ParsedModuleRef,
     ) -> PossiblyNarrowedPlaces {
         let mut places = PossiblyNarrowedPlaces::default();
 
-        // The match subject can always be narrowed by a pattern
         let subject_node = subject.node_ref(self.db).node(module);
-        if let Some(subject_place_expr) = PlaceExpr::try_from_expr(subject_node) {
-            if let Some(place) = self.places.place_id((&subject_place_expr).into()) {
+        for expression in match_subject_place_expressions(subject_node) {
+            if let Some(place) = PlaceExpr::try_from_expr(expression)
+                .and_then(|place| self.places.place_id((&place).into()))
+            {
                 places.insert(place);
             }
         }
-
-        // For subscript subjects, the subscript base can also be narrowed (TypedDict/tuple narrowing)
-        if let ast::Expr::Subscript(subscript) = subject_node {
-            if let Some(place_expr) = PlaceExpr::try_from_expr(&subscript.value) {
-                if let Some(place) = self.places.place_id((&place_expr).into()) {
-                    places.insert(place);
-                }
-            }
-        }
-        if let ast::Expr::Attribute(attribute) = subject_node
-            && let Some(place_expr) = PlaceExpr::try_from_expr(&attribute.value)
-            && let Some(place) = self.places.place_id((&place_expr).into())
-        {
-            places.insert(place);
-        }
-
-        // Handle Or patterns by recursing into each alternative
-        if let PatternPredicateKind::Or(predicates) = kind {
-            for predicate in predicates {
-                places.extend(self.pattern_kind(predicate, subject, module));
-            }
-        }
-
-        // Handle As patterns by recursing into the inner pattern
-        if let PatternPredicateKind::As(Some(inner), _) = kind {
-            places.extend(self.pattern_kind(inner, subject, module));
-        }
-
         places
     }
 }

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -17,6 +17,13 @@ use std::iter::FusedIterator;
 /// Return the expressions whose existing bindings a match pattern can narrow.
 ///
 /// In addition to the subject itself, matching an attribute or subscript can narrow its base.
+/// For example, this match can narrow both `value.kind` and `value`:
+///
+/// ```python
+/// match value.kind:
+///     case "ready":
+///         ...
+/// ```
 pub(crate) fn match_subject_place_expressions(subject: &ast::Expr) -> SmallVec<[&ast::Expr; 2]> {
     let mut expressions: SmallVec<[&ast::Expr; 2]> = SmallVec::new();
     expressions.push(subject);

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -157,55 +157,43 @@ impl ClassPatternKind {
 }
 
 /// Structural details for sequence patterns that affect narrowing and reachability.
-///
-/// `patterns` stores one predicate per syntactic element, with a starred element
-/// represented by [`PatternPredicateKind::MatchStar`]. `has_star` records
-/// whether the pattern accepts additional sequence elements.
 #[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 pub struct SequencePatternPredicateKind<'db> {
     pub patterns: Box<[PatternPredicateKind<'db>]>,
-    pub has_star: bool,
 }
 
 impl<'db> SequencePatternPredicateKind<'db> {
     /// Return `true` for `case [*rest]`, the only sequence pattern with no
     /// length or element constraints.
     pub fn is_irrefutable(&self) -> bool {
-        self.patterns.len() == 1 && self.has_star
-    }
-
-    pub const fn is_exact_length(&self) -> bool {
-        !self.has_star
+        matches!(self.patterns.as_ref(), [PatternPredicateKind::Star(_)])
     }
 
     /// Return the patterns before and after the starred element.
     pub fn split_around_star(
         &self,
     ) -> Option<(&[PatternPredicateKind<'db>], &[PatternPredicateKind<'db>])> {
-        if !self.has_star {
-            return None;
-        }
-
         let star_index = self
             .patterns
             .iter()
-            .position(|pattern| matches!(pattern, PatternPredicateKind::MatchStar))?;
+            .position(|pattern| matches!(pattern, PatternPredicateKind::Star(_)))?;
         let (prefix, star_and_suffix) = self.patterns.split_at(star_index);
         Some((prefix, &star_and_suffix[1..]))
     }
 }
 
-/// Pattern kinds for which we support type narrowing and/or static reachability analysis.
+/// Pattern structure used for type narrowing, static reachability, and inferring the types of
+/// names bound by a successful match.
 #[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 pub enum PatternPredicateKind<'db> {
     Singleton(Singleton),
     Value(Expression<'db>),
-    Or(Vec<PatternPredicateKind<'db>>),
+    Or(Box<[PatternPredicateKind<'db>]>),
     Class(Expression<'db>, ClassPatternKind),
     Mapping(ClassPatternKind),
     Sequence(SequencePatternPredicateKind<'db>),
     As(Option<Box<PatternPredicateKind<'db>>>, Option<Name>),
-    MatchStar,
+    Star(Option<Name>),
 }
 
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1729,6 +1729,35 @@ impl<'db> UseDefMapBuilder<'db> {
         );
     }
 
+    /// Records a narrowing constraint on the current live bindings selected by definition ID.
+    pub(super) fn record_narrowing_constraint_for_bindings(
+        &mut self,
+        predicate: ScopedPredicateId,
+        place: ScopedPlaceId,
+        bindings: &[ScopedDefinitionId],
+    ) {
+        if predicate == ScopedPredicateId::ALWAYS_TRUE
+            || predicate == ScopedPredicateId::ALWAYS_FALSE
+        {
+            return;
+        }
+
+        let constraint = self.narrowing_constraints.add_atom(predicate);
+        let pending = self.pending_reachability.current;
+        let state =
+            pending_place_state_mut(place, &mut self.symbol_states, &mut self.member_states);
+        let state = self.pending_reachability.materialize(
+            state,
+            pending,
+            &mut self.reachability_constraints,
+        );
+        state.record_narrowing_constraint_for_bindings(
+            &mut self.narrowing_constraints,
+            constraint,
+            bindings,
+        );
+    }
+
     /// Records a negated narrowing constraint for only the specified places.
     ///
     /// The positive and negative constraints use the same predicate ID. This lets `P or not P`
@@ -2257,10 +2286,8 @@ impl<'db> UseDefMapBuilder<'db> {
         }
     }
 
-    /// Get a snapshot of the current bindings for a place. We use this at the end of loop bodies
-    /// to populate the loop header definitions (bindings in the loop body that are visible via
-    /// loop-back to prior uses in the loop body and also to the loop condition).
-    pub(super) fn loop_back_bindings(
+    /// Get the current live bindings for a place.
+    pub(super) fn current_bindings(
         &mut self,
         place: ScopedPlaceId,
     ) -> impl Iterator<Item = LiveBinding> + '_ {

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -528,6 +528,21 @@ impl PlaceState {
         }
     }
 
+    /// Add the given constraint to live bindings selected by definition ID.
+    pub(super) fn record_narrowing_constraint_for_bindings(
+        &mut self,
+        narrowing_constraints: &mut NarrowingConstraintsBuilder,
+        constraint: ScopedNarrowingConstraint,
+        bindings: &[ScopedDefinitionId],
+    ) {
+        for binding in &mut self.bindings.live_bindings {
+            if bindings.contains(&binding.binding()) {
+                binding.narrowing_constraint = narrowing_constraints
+                    .add_and_constraint(binding.narrowing_constraint, constraint);
+            }
+        }
+    }
+
     /// Add given reachability constraint to all live bindings.
     pub(super) fn record_reachability_constraint(
         &mut self,

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -688,8 +688,7 @@ def _(val: object, Valid1: type | Any, Valid2: Intersection[type, Any], Valid3: 
 
     match val:
         # error: [invalid-match-pattern] "`<types.UnionType special-form 'int | str'>` cannot be used in a class pattern because it is not a type"
-        case Invalid2() as item:
-            reveal_type(item)  # revealed: object
+        case Invalid2(): ...
         case Valid1():  # fine
             pass
         case Valid2():  # fine

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -539,6 +539,16 @@ def _(target: None | Foo):
 
 ## `as` patterns
 
+An `as` pattern binds the value matched by the pattern on its left. The bound name gets the type of
+the subject after that pattern succeeds.
+
+### Value-pattern aliases
+
+Value patterns use `==`, and `as` binds the original subject rather than the value written in the
+pattern. An `int` or `str` subclass can define `__eq__` so that it compares equal to `1`, so `x`
+remains `int | str` in the first branch. If that branch fails, we can rule out the exact integer
+literal `1`, but not the rest of either class.
+
 ```py
 def _(target: int | str):
     y = 1
@@ -546,14 +556,47 @@ def _(target: int | str):
     match target:
         case 1 as x:
             y = 2
-            reveal_type(x)  # revealed: @Todo(`match` pattern definition types)
+            reveal_type(x)  # revealed: int | str
         case "foo" as x:
             y = 3
-            reveal_type(x)  # revealed: @Todo(`match` pattern definition types)
+            reveal_type(x)  # revealed: (int & ~Literal[1]) | str
         case _:
             y = 4
 
     reveal_type(y)  # revealed: Literal[2, 3, 4]
+```
+
+### Narrowing a value alias
+
+When every possible value has known equality behavior, the value pattern can narrow the bound name.
+Here, matching `1` narrows `item` to `Literal[1]`.
+
+```py
+from typing import Literal
+
+def value_alias(target: Literal[1, 2]):
+    match target:
+        case 1 as item:
+            reveal_type(item)  # revealed: Literal[1]
+```
+
+### Bindings that always match
+
+A wildcard alias and a capture pattern both match every subject, so they bind the subject's full
+type.
+
+```py
+from typing import Literal
+
+def wildcard_alias(target: Literal[1, 2]):
+    match target:
+        case _ as item:
+            reveal_type(item)  # revealed: Literal[1, 2]
+
+def capture_pattern(target: Literal[1, 2]):
+    match target:
+        case item:
+            reveal_type(item)  # revealed: Literal[1, 2]
 ```
 
 ## Guard with object that implements `__bool__` incorrectly
@@ -634,7 +677,7 @@ If the match pattern is not an instance of `type`, we raise a diagnostic:
 from typing import Any
 from ty_extensions import Intersection
 
-def _(val, Valid1: type | Any, Valid2: Intersection[type, Any], Valid3: type[Any], Valid4: type[int]):
+def _(val: object, Valid1: type | Any, Valid2: Intersection[type, Any], Valid3: type[Any], Valid4: type[int]):
     Invalid1 = "foo"
 
     match val:
@@ -645,8 +688,8 @@ def _(val, Valid1: type | Any, Valid2: Intersection[type, Any], Valid3: type[Any
 
     match val:
         # error: [invalid-match-pattern] "`<types.UnionType special-form 'int | str'>` cannot be used in a class pattern because it is not a type"
-        case Invalid2():
-            pass
+        case Invalid2() as item:
+            reveal_type(item)  # revealed: object
         case Valid1():  # fine
             pass
         case Valid2():  # fine

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -66,10 +66,8 @@ def sequence_prefix_star_pattern_is_not_catch_all(paths: Sequence[str]) -> None:
         case [_first, _second, *_paths]:
             raise ValueError
 
-    # Exact sequence alternatives and the definitely matched tuple subset of the
-    # starred alternative remain as negative constraints.
-    # revealed: (Sequence[str] & ~<Protocol with members '__len__'> & ~<Protocol with members '__getitem__', '__len__'> & ~tuple[object, object, *tuple[object, ...]]) | str | (Sequence[str] & bytes) | (Sequence[str] & bytearray)
-    reveal_type(paths)
+    # The failed length checks are not retained for a sequence whose length can change.
+    reveal_type(paths)  # revealed: Sequence[str]
 
 def normalize_version(
     version: str | tuple[int, int] | tuple[int, int, int],
@@ -547,7 +545,7 @@ the subject after that pattern succeeds.
 Value patterns use `==`, and `as` binds the original subject rather than the value written in the
 pattern. An `int` or `str` subclass can define `__eq__` so that it compares equal to `1`, so `x`
 remains `int | str` in the first branch. If that branch fails, we can rule out the exact integer
-literal `1`, but not the rest of either class.
+literal `1` and `True`, which compares equal to `1`, but not the rest of either class.
 
 ```py
 def _(target: int | str):
@@ -559,7 +557,7 @@ def _(target: int | str):
             reveal_type(x)  # revealed: int | str
         case "foo" as x:
             y = 3
-            reveal_type(x)  # revealed: (int & ~Literal[1]) | str
+            reveal_type(x)  # revealed: (int & ~Literal[1] & ~Literal[True]) | str
         case _:
             y = 4
 

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -677,7 +677,7 @@ If the match pattern is not an instance of `type`, we raise a diagnostic:
 from typing import Any
 from ty_extensions import Intersection
 
-def _(val: object, Valid1: type | Any, Valid2: Intersection[type, Any], Valid3: type[Any], Valid4: type[int]):
+def _(val, Valid1: type | Any, Valid2: Intersection[type, Any], Valid3: type[Any], Valid4: type[int]):
     Invalid1 = "foo"
 
     match val:
@@ -688,7 +688,8 @@ def _(val: object, Valid1: type | Any, Valid2: Intersection[type, Any], Valid3: 
 
     match val:
         # error: [invalid-match-pattern] "`<types.UnionType special-form 'int | str'>` cannot be used in a class pattern because it is not a type"
-        case Invalid2(): ...
+        case Invalid2():
+            pass
         case Valid1():  # fine
             pass
         case Valid2():  # fine

--- a/crates/ty_python_semantic/resources/mdtest/directives/assert_never.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/assert_never.md
@@ -213,6 +213,16 @@ def if_else_singletons_error(obj: Literal[1, "a"] | None):
     else:
         # error: [type-assertion-failure] "Type `Literal["a"]` is not equivalent to `Never`"
         assert_never(obj)
+```
+
+## Match statement exhaustiveness
+
+The final `_ as obj` pattern binds anything not handled by an earlier case. If the earlier cases are
+exhaustive, `obj` is `Never`. In the second example, the misspelled string pattern leaves
+`Literal["a"]` uncovered.
+
+```py
+from typing_extensions import Literal, assert_never
 
 def match_singletons_success(obj: Literal[1, "a"] | None):
     match obj:
@@ -234,10 +244,6 @@ def match_singletons_error(obj: Literal[1, "a"] | None):
         case None:
             pass
         case _ as obj:
-            # TODO: We should emit an error here, but the message should
-            # show the type `Literal["a"]` instead of `@Todo(…)`. We only
-            # assert on the first part of the message because the `@Todo`
-            # message is not available in release mode builds.
-            # error: [type-assertion-failure] "Type `@Todo"
+            # error: [type-assertion-failure] "Type `Literal["a"]` is not equivalent to `Never`"
             assert_never(obj)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -404,7 +404,7 @@ def match_exhaustive_generic[T](obj: GenericClass[T]) -> GenericClass[T]:
             reveal_type(obj)  # revealed: GenericClass[T@match_exhaustive_generic]
             return obj
         case GenericClass(x=x):
-            reveal_type(x)  # revealed: @Todo(`match` pattern definition types)
+            reveal_type(x)  # revealed: Unknown
             reveal_type(obj)  # revealed: GenericClass[T@match_exhaustive_generic]
             return obj
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -274,8 +274,10 @@ A capture gets its type from the sequence element it binds. A starred capture is
 a fixed-length tuple, we can determine exactly which elements appear in that list.
 
 ```py
-from typing import Any
+from typing import Any, TypeVar
 from ty_extensions import Unknown
+
+BoundTupleT = TypeVar("BoundTupleT", bound=tuple[int] | tuple[str])
 
 def test_match_star_capture(value: tuple[int, str, bool]) -> None:
     match value:
@@ -315,6 +317,13 @@ def test_later_failure_rejects_earlier_capture(value: tuple[str, str]) -> None:
     match value:
         case [item, int()]:
             reveal_type(item)  # revealed: Never
+
+# A nested capture receives the element type from a type variable's bound, rather than the type
+# variable that represents the complete sequence.
+def test_capture_from_typevar_bound(value: BoundTupleT) -> None:
+    match value:
+        case [item]:
+            reveal_type(item)  # revealed: int | str
 ```
 
 ## Captures from unions of tuples

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -511,6 +511,34 @@ def test_compatible_declared_alias(subject: object) -> None:
             reveal_type(item)  # revealed: int
 ```
 
+Pattern captures also respect declarations in global, enclosing function, and class scopes:
+
+```py
+global_capture: str
+
+def capture_respects_global_declaration(subject: int) -> None:
+    global global_capture
+    match subject:
+        case global_capture:  # error: [invalid-assignment]
+            reveal_type(global_capture)  # revealed: str
+
+def outer() -> None:
+    nonlocal_capture: str = ""
+
+    def capture_respects_nonlocal_declaration(subject: int) -> None:
+        nonlocal nonlocal_capture
+        match subject:
+            case nonlocal_capture:  # error: [invalid-assignment]
+                reveal_type(nonlocal_capture)  # revealed: str
+
+class CaptureRespectsClassDeclaration:
+    class_capture: str
+
+    match 1:
+        case class_capture:  # error: [invalid-assignment]
+            reveal_type(class_capture)  # revealed: str
+```
+
 ## Binding the whole pattern
 
 Binding an entire pattern with `as` keeps the subject's original type variable. For a tuple,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -634,10 +634,10 @@ def test_match_indirect_class_pattern(
             reveal_type(value)  # revealed: IndirectPattern
 ```
 
-## Recursive class pattern aliases
+## Class pattern aliases
 
-The same rule applies outside sequence patterns. Preserving a recursive alias lets later code keep
-using the recursive relationship after a class pattern matches.
+The same rule applies outside sequence patterns. A class pattern keeps the generic arguments of a
+matched alias.
 
 ```toml
 [environment]
@@ -645,22 +645,16 @@ python-version = "3.12"
 ```
 
 ```py
-type RecursiveContainer = int | dict[str, RecursiveContainer] | list[RecursiveContainer]
+type Container = int | dict[str, int] | list[int]
 
-def test_match_class_alias_preserves_recursive_containers(
-    value: RecursiveContainer,
-) -> None:
+def class_pattern_preserves_alias(value: Container) -> None:
     match value:
         case dict() as mapping:
-            reveal_type(mapping)  # revealed: dict[str, RecursiveContainer]
+            reveal_type(mapping)  # revealed: dict[str, int]
             mapping["bad"] = "bad"  # error: [invalid-assignment]
-            for item in mapping.values():
-                test_match_class_alias_preserves_recursive_containers(item)
         case list() as sequence:
-            reveal_type(sequence)  # revealed: list[RecursiveContainer]
+            reveal_type(sequence)  # revealed: list[int]
             sequence.append("bad")  # error: [invalid-argument-type]
-            for item in sequence:
-                test_match_class_alias_preserves_recursive_containers(item)
 ```
 
 ## Binding overlapping classes with `as`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -321,10 +321,10 @@ def test_later_failure_rejects_earlier_capture(value: tuple[str, str]) -> None:
 
 When a union contains several tuple types, matching one element can determine the types of the other
 captures. A wildcard keeps every tuple type that can match. The same rules apply through type
-aliases and constrained type variables.
+aliases.
 
 ```py
-from typing import Literal, TypeAlias, TypeVar
+from typing import Literal, TypeAlias
 
 def test_match_star_capture_filters_union_members(
     value: tuple[Literal[1], int, int] | tuple[Literal[2], str, str],
@@ -354,18 +354,8 @@ def test_match_capture_filters_union_members(
             return 0
 
 MatchPair: TypeAlias = tuple[Literal[1], int] | tuple[Literal[2], str]
-MatchPairT = TypeVar(
-    "MatchPairT",
-    tuple[Literal[1], int],
-    tuple[Literal[2], str],
-)
 
 def test_match_capture_filters_aliased_union_members(value: MatchPair) -> None:
-    match value:
-        case [1, item]:
-            reveal_type(item)  # revealed: int
-
-def test_match_capture_filters_constrained_typevar_members(value: MatchPairT) -> None:
     match value:
         case [1, item]:
             reveal_type(item)  # revealed: int
@@ -414,6 +404,24 @@ def test_match_sequence_as_pattern_excludes_previous_cases(
             pass
         case [int() as item, _]:
             reveal_type(item)  # revealed: Literal[2]
+
+def test_match_alias_excludes_cross_type_equal_values(
+    value: Literal[True, 1, 2],
+) -> None:
+    match value:
+        case 1:
+            pass
+        case _ as item:
+            # Both `True` and `1` compare equal to the first pattern.
+            reveal_type(item)  # revealed: Literal[2]
+
+def test_ordered_or_alias_excludes_cross_type_equal_values(
+    value: tuple[Literal[True], str] | tuple[Literal[2], bytes],
+) -> None:
+    match value:
+        case [1, *item] | [item, _]:
+            # The first alternative consumes the `Literal[True]` tuple.
+            reveal_type(item)  # revealed: list[str] | Literal[2]
 ```
 
 ## Ordered `or`-pattern bindings
@@ -476,32 +484,13 @@ def test_compatible_declared_alias(subject: object) -> None:
 
 ## Binding the whole pattern
 
-Binding an entire pattern with `as` keeps the subject's original type variable. If only some
-constraints can match, the binding also keeps the sequence shape established by the pattern. For a
-tuple, successful child patterns can also refine the types at fixed indices.
+Binding an entire pattern with `as` keeps the subject's original type variable. For a tuple,
+successful child patterns can also refine the types at fixed indices.
 
 ```py
-from typing import final, Literal, TypeVar
-
-@final
-class BoundA: ...
-
-@final
-class BoundB: ...
-
-BoundChoiceT = TypeVar("BoundChoiceT", BoundA, BoundB)
+from typing import Literal, TypeVar
 
 BoundSequenceT = TypeVar("BoundSequenceT", bound=tuple[object])
-ConstrainedSequenceT = TypeVar(
-    "ConstrainedSequenceT",
-    tuple[int],
-    tuple[str],
-)
-PartiallyMatchedSequenceT = TypeVar(
-    "PartiallyMatchedSequenceT",
-    tuple[int],
-    tuple[int, int],
-)
 
 def test_match_sequence_alias_preserves_bound_typevar(
     value: BoundSequenceT,
@@ -510,26 +499,6 @@ def test_match_sequence_alias_preserves_bound_typevar(
         case [_] as whole:
             reveal_type(whole)  # revealed: BoundSequenceT@test_match_sequence_alias_preserves_bound_typevar
             return whole
-
-def test_match_sequence_alias_preserves_constrained_typevar(
-    value: ConstrainedSequenceT,
-) -> ConstrainedSequenceT:
-    match value:
-        case [_] as whole:
-            # revealed: ConstrainedSequenceT@test_match_sequence_alias_preserves_constrained_typevar
-            reveal_type(whole)
-            return whole
-
-def test_match_sequence_alias_narrows_constrained_typevar(
-    value: PartiallyMatchedSequenceT,
-) -> PartiallyMatchedSequenceT:
-    match value:
-        case [_] as whole:
-            # revealed: PartiallyMatchedSequenceT@test_match_sequence_alias_narrows_constrained_typevar & tuple[int]
-            reveal_type(whole)
-            return whole
-        case _:
-            raise ValueError
 
 def test_match_sequence_alias_preserves_typevar_union_member(
     value: BoundSequenceT | str,
@@ -589,33 +558,6 @@ def test_nested_mutable_sequence_alias_does_not_keep_length(
         case _:
             raise ValueError
 
-def test_match_or_alias_preserves_constrained_typevar(
-    value: BoundChoiceT | str,
-) -> BoundChoiceT:
-    match value:
-        case (BoundA() | BoundB()) as whole:
-            reveal_type(whole)  # revealed: BoundChoiceT@test_match_or_alias_preserves_constrained_typevar
-            return whole
-        case _:
-            raise ValueError
-
-def test_match_or_alternative_alias_preserves_constrained_typevar(
-    value: BoundChoiceT,
-) -> BoundChoiceT:
-    match value:
-        case (BoundA() as whole) | (BoundB() as whole):
-            # revealed: BoundChoiceT@test_match_or_alternative_alias_preserves_constrained_typevar
-            reveal_type(whole)
-            return whole
-
-def test_match_ordered_or_preserves_nested_constrained_typevar(
-    value: tuple[BoundChoiceT] | BoundChoiceT,
-) -> BoundChoiceT:
-    match value:
-        case [item] | item:
-            # revealed: BoundChoiceT@test_match_ordered_or_preserves_nested_constrained_typevar
-            reveal_type(item)
-            return item
 ```
 
 ## Indirect class patterns

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -557,7 +557,6 @@ def test_nested_mutable_sequence_alias_does_not_keep_length(
                     return 1
         case _:
             raise ValueError
-
 ```
 
 ## Indirect class patterns

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -502,7 +502,6 @@ PartiallyMatchedSequenceT = TypeVar(
     tuple[int],
     tuple[int, int],
 )
-SequenceElementT = TypeVar("SequenceElementT")
 
 def test_match_sequence_alias_preserves_bound_typevar(
     value: BoundSequenceT,
@@ -543,17 +542,6 @@ def test_match_sequence_alias_preserves_typevar_union_member(
         case _:
             raise ValueError
 
-def test_match_sequence_alias_preserves_element_narrowing(
-    value: list[SequenceElementT],
-) -> int:
-    match value:
-        case [int()] as whole:
-            # revealed: SequenceElementT@test_match_sequence_alias_preserves_element_narrowing & int
-            reveal_type(whole[0])
-            return whole[0]
-        case _:
-            return 0
-
 def test_match_sequence_alias_keeps_matched_element_types(
     value: tuple[Literal[1, 2]],
 ) -> None:
@@ -569,13 +557,37 @@ def test_match_starred_sequence_alias_keeps_matched_element_types(
             reveal_type(whole[0])  # revealed: Literal[1]
             reveal_type(whole[-1])  # revealed: Literal[4]
 
-def test_mutable_sequence_alias_does_not_keep_matched_element_types(
-    value: list[Literal[1, 2]],
+def test_mutable_sequence_alias_does_not_keep_index_types(
+    value: list[int | str],
 ) -> None:
     match value:
-        case [1] as whole:
-            whole[0] = 2
-            reveal_type(whole[0])  # revealed: Literal[1, 2]
+        case [int(), str()] as whole:
+            whole.reverse()
+            reveal_type(whole[0])  # revealed: int | str
+
+def test_constructed_mutable_sequence_alias_does_not_keep_length(
+    value: list[int],
+) -> int:  # error: [invalid-return-type]
+    match value.copy():
+        case [_] as whole:
+            whole.append(2)
+            match whole:
+                case [_]:
+                    return 1
+        case _:
+            raise ValueError
+
+def test_nested_mutable_sequence_alias_does_not_keep_length(
+    value: tuple[list[int]],
+) -> int:  # error: [invalid-return-type]
+    match value:
+        case [[_] as inner] as whole:
+            inner.append(2)
+            match whole:
+                case [[_]]:
+                    return 1
+        case _:
+            raise ValueError
 
 def test_match_or_alias_preserves_constrained_typevar(
     value: BoundChoiceT | str,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -199,22 +199,25 @@ def test_match_star_excludes_text_and_bytes(x: str | bytes | bytearray | list[in
 
 def test_match_exact_sequence_excludes_str(x: str | tuple[int, int]) -> None:
     match x:
-        case (_, _):
-            pass
+        case (a, b):
+            reveal_type(a)  # revealed: int
+            reveal_type(b)  # revealed: int
         case _:
             reveal_type(x)  # revealed: str
 
 def test_match_exact_sequence_excludes_bytes(x: bytes | tuple[int, int]) -> None:
     match x:
-        case (_, _):
-            pass
+        case (a, b):
+            reveal_type(a)  # revealed: int
+            reveal_type(b)  # revealed: int
         case _:
             reveal_type(x)  # revealed: bytes
 
 def test_match_exact_sequence_excludes_bytearray(x: bytearray | tuple[int, int]) -> None:
     match x:
-        case (_, _):
-            pass
+        case (a, b):
+            reveal_type(a)  # revealed: int
+            reveal_type(b)  # revealed: int
         case _:
             reveal_type(x)  # revealed: bytearray
 
@@ -274,7 +277,7 @@ A capture gets its type from the sequence element it binds. A starred capture is
 a fixed-length tuple, we can determine exactly which elements appear in that list.
 
 ```py
-from typing import Any, TypeVar
+from typing import Any, Literal, TypeVar
 from ty_extensions import Unknown
 
 BoundTupleT = TypeVar("BoundTupleT", bound=tuple[int] | tuple[str])
@@ -324,6 +327,21 @@ def test_capture_from_typevar_bound(value: BoundTupleT) -> None:
     match value:
         case [item]:
             reveal_type(item)  # revealed: int | str
+
+def match_nested_tuple_captures(
+    subject: tuple[Literal[1], str, tuple[Literal[2], int]],
+) -> None:
+    match subject:
+        case [1, item1, [2, item2]]:
+            reveal_type(item1)  # revealed: str
+            reveal_type(item2)  # revealed: int
+
+def match_nested_list_of_tuples_captures(
+    subject: list[tuple[Literal[1], bytes]],
+) -> None:
+    match subject:
+        case [(1, item)]:
+            reveal_type(item)  # revealed: bytes
 ```
 
 ## Captures from unions of tuples
@@ -335,6 +353,26 @@ aliases.
 ```py
 from typing import Literal, TypeAlias
 
+def match_capture_filters_union_members_by_length(
+    value: (tuple[Literal[1], int] | tuple[Literal[1], Literal[2], str] | tuple[Literal[1], Literal[2], Literal[3], bytes]),
+) -> None:
+    match value:
+        case [1, item]:
+            reveal_type(item)  # revealed: int
+        case [1, 2, item]:
+            reveal_type(item)  # revealed: str
+        case [1, 2, 3, item]:
+            reveal_type(item)  # revealed: bytes
+
+def match_capture_rejects_wrong_tuple_length(
+    value: tuple[Literal[1], Literal[2], str],
+) -> None:
+    match value:
+        case [1, item]:
+            reveal_type(item)  # revealed: Never
+        case [1, 2, item]:
+            reveal_type(item)  # revealed: str
+
 def test_match_star_capture_filters_union_members(
     value: tuple[Literal[1], int, int] | tuple[Literal[2], str, str],
 ) -> list[int]:
@@ -343,6 +381,7 @@ def test_match_star_capture_filters_union_members(
             reveal_type(rest)  # revealed: list[int]
             return rest
         case _:
+            reveal_type(value)  # revealed: tuple[Literal[2], str, str]
             return []
 
 def test_match_star_capture_preserves_compatible_union_members(
@@ -602,29 +641,6 @@ def test_mutable_sequence_alias_does_not_keep_index_types(
             whole.reverse()
             reveal_type(whole[0])  # revealed: int | str
 
-def test_constructed_mutable_sequence_alias_does_not_keep_length(
-    value: list[int],
-) -> int:  # error: [invalid-return-type]
-    match value.copy():
-        case [_] as whole:
-            whole.append(2)
-            match whole:
-                case [_]:
-                    return 1
-        case _:
-            raise ValueError
-
-def test_nested_mutable_sequence_alias_does_not_keep_length(
-    value: tuple[list[int]],
-) -> int:  # error: [invalid-return-type]
-    match value:
-        case [[_] as inner] as whole:
-            inner.append(2)
-            match whole:
-                case [[_]]:
-                    return 1
-        case _:
-            raise ValueError
 ```
 
 ## Indirect class patterns
@@ -678,7 +694,6 @@ from typing import final
 
 class OverlapA: ...
 class OverlapB: ...
-class OverlapC(OverlapA, OverlapB): ...
 
 def test_match_class_alias_preserves_possible_multiple_inheritance(
     value: OverlapA,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -188,7 +188,7 @@ def test_match_star(x: Sequence[int] | int) -> None:
             # TODO: After https://github.com/astral-sh/ty/issues/3314 is
             # fixed, the `Sequence[int] & str` intersection should simplify to
             # `Never`.
-            reveal_type(x)  # revealed: (int & ~Sequence[object]) | (Sequence[int] & str) | bytes | bytearray
+            reveal_type(x)  # revealed: (Sequence[int] & str) | bytes | bytearray | (int & ~Sequence[object])
 
 def test_match_star_excludes_text_and_bytes(x: str | bytes | bytearray | list[int]) -> None:
     match x:
@@ -224,49 +224,49 @@ def test_match_exact_sequence_excludes_bytearray(x: bytearray | tuple[int, int])
 def test_match_exact_object_sequence(value: object) -> None:
     match value:
         case int(), str():
-            # revealed: Sequence[object] & <Protocol with members '__getitem__', '__len__'> & ~str & ~bytes & ~bytearray
+            # revealed: Sequence[object] & ~str & ~bytes & ~bytearray
             reveal_type(value)
-            reveal_type(len(value))  # revealed: Literal[2]
-            reveal_type(value[0])  # revealed: int
-            reveal_type(value[1])  # revealed: str
+            reveal_type(len(value))  # revealed: int
+            reveal_type(value[0])  # revealed: object
+            reveal_type(value[1])  # revealed: object
 
 def test_match_empty_object_sequence(value: object) -> None:
     match value:
         case []:
-            # revealed: Sequence[object] & <Protocol with members '__len__'> & ~str & ~bytes & ~bytearray
+            # revealed: Sequence[object] & ~str & ~bytes & ~bytearray
             reveal_type(value)
-            reveal_type(len(value))  # revealed: Literal[0]
+            reveal_type(len(value))  # revealed: int
 
 def test_match_singleton_object_sequence(value: object) -> None:
     match value:
         case [int()]:
-            # revealed: Sequence[object] & <Protocol with members '__getitem__', '__len__'> & ~bytearray & ~bytes
+            # revealed: Sequence[object] & ~str & ~bytes & ~bytearray
             reveal_type(value)
-            reveal_type(len(value))  # revealed: Literal[1]
-            reveal_type(value[0])  # revealed: int
+            reveal_type(len(value))  # revealed: int
+            reveal_type(value[0])  # revealed: object
 
 def test_match_prefix_star_object_sequence(value: object) -> None:
     match value:
         case [int(), *rest]:
-            # revealed: Sequence[object] & <Protocol with members '__getitem__'> & ~str & ~bytes & ~bytearray
+            # revealed: Sequence[object] & ~str & ~bytes & ~bytearray
             reveal_type(value)
             reveal_type(len(value))  # revealed: int
-            reveal_type(value[0])  # revealed: int
+            reveal_type(value[0])  # revealed: object
             reveal_type(value[1])  # revealed: object
 
 def test_match_prefix_and_suffix_star_object_sequence(value: object) -> None:
     match value:
         case [int(), *rest, str()]:
-            # revealed: Sequence[object] & <Protocol with members '__getitem__'> & ~str & ~bytes & ~bytearray
+            # revealed: Sequence[object] & ~str & ~bytes & ~bytearray
             reveal_type(value)
-            reveal_type(value[0])  # revealed: int
-            reveal_type(value[-1])  # revealed: str
+            reveal_type(value[0])  # revealed: object
+            reveal_type(value[-1])  # revealed: object
             reveal_type(value[1])  # revealed: object
 
 def test_match_prefix_star_known_sequence(value: Sequence[int | str]) -> None:
     match value:
         case [int(), *rest]:
-            reveal_type(value[0])  # revealed: int
+            reveal_type(value[0])  # revealed: int | str
             reveal_type(value[1])  # revealed: int | str
             reveal_type(rest)  # revealed: list[int | str]
 ```
@@ -641,6 +641,17 @@ def test_mutable_sequence_alias_does_not_keep_index_types(
             whole.reverse()
             reveal_type(whole[0])  # revealed: int | str
 
+def mutable_sequence_alias_does_not_keep_previous_shape_constraints(
+    value: list[int],
+) -> None:
+    match value:
+        case []:
+            pass
+        case whole:
+            whole.clear()
+            match whole:
+                case []:
+                    reveal_type(whole)  # revealed: list[int]
 ```
 
 ## Indirect class patterns
@@ -774,20 +785,19 @@ def test_match_exact_mutable_sequence_negative(value: list[int]) -> None:
         case [int()]:
             pass
         case _:
-            # revealed: list[int] & ~<Protocol with members '__getitem__', '__len__'>
-            reveal_type(value)
+            reveal_type(value)  # revealed: list[int]
 ```
 
 ## Nested sequence patterns
 
-Nested patterns narrow the fixed positions they inspect. The narrowed element types remain available
-through later indexing and destructuring.
+Nested patterns narrow values captured from the positions they inspect. For subjects without a known
+tuple shape, length and indexed-element facts are not retained on the original subject.
 
 ```py
 def normalize_nested_record(value: object) -> tuple[None, int, int] | None:
     match value:
-        case [None, [int()], {}]:
-            ret = value[0], value[1][0], len(value[2])
+        case [None as first, [int() as number], {} as mapping]:
+            ret = first, number, len(mapping)
             reveal_type(ret)  # revealed: tuple[None, int, int]
             return ret
     return None
@@ -795,8 +805,8 @@ def normalize_nested_record(value: object) -> tuple[None, int, int] | None:
 def unwrap_number_or_label(value: object) -> int | str | None:
     match value:
         case [(int() | str()) as item]:
-            reveal_type(value[0])  # revealed: int | str
-            return value[0]
+            reveal_type(item)  # revealed: int | str
+            return item
     return None
 ```
 
@@ -984,6 +994,15 @@ def match_capture_shadows_subject() -> None:
     match x:
         case [x]:
             reveal_type(x)  # revealed: Literal[1]
+
+def later_case_uses_saved_subject_after_guarded_capture(flag: bool) -> None:
+    x = (1,)
+    match x:
+        case [x] if flag:
+            pass
+        case [1]:
+            reveal_type(x)  # revealed: Literal[1]
+            x + "bad"  # error: [unsupported-operator]
 
 def match_tuple_expression_guard_rebinding(
     a: TupleSubjectA,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -443,7 +443,32 @@ class Values(list[str]):
 def test_or_binding_keeps_values_that_can_fail_a_class_pattern(value: Values) -> None:
     match value:
         case (HasX() as item) | [item]:
-            reveal_type(item)  # revealed: Values | str
+            # Class child bindings are added by a later change, so this branch cannot yet combine
+            # the supported whole-pattern alias with the sequence capture.
+            reveal_type(item)  # revealed: Unknown
+```
+
+Class and mapping child bindings are added by a later change. Until then, an `or` pattern that mixes
+one of those patterns with a supported alternative falls back to `Unknown` instead of inferring a
+type from only the supported alternative.
+
+```py
+from typing import final
+from ty_extensions import Unknown
+
+@final
+class TextValue:
+    value: str = ""
+
+def class_or_sequence_binding(value: TextValue | tuple[int]) -> None:
+    match value:
+        case TextValue(value=item) | [item]:
+            reveal_type(item)  # revealed: Unknown
+
+def mapping_or_sequence_binding(value: dict[str, str] | tuple[int]) -> None:
+    match value:
+        case {"value": item} | [item]:
+            reveal_type(item)  # revealed: Unknown
 ```
 
 ## Declared pattern captures
@@ -453,6 +478,8 @@ assignment checks as other bindings; the declaration remains the authoritative t
 captured value is incompatible.
 
 ```py
+from typing import Literal
+
 def test_incompatible_declared_capture(subject: int) -> None:
     item: str
     match subject:
@@ -465,14 +492,16 @@ def test_incompatible_declared_star_capture(subject: tuple[int, int]) -> None:
         case [*rest]:  # error: [invalid-assignment]
             reveal_type(rest)  # revealed: list[str]
 
-def test_incompatible_declared_or_capture(subject: int | str) -> None:
+def test_incompatible_declared_or_capture(
+    subject: tuple[Literal[1]] | tuple[Literal["x"]],
+) -> None:
     item: int
     match subject:
         # TODO: Report one error for the logical OR-pattern binding instead of validating each
         # syntactic definition separately.
         # error: [invalid-assignment]
         # error: [invalid-assignment]
-        case (int() as item) | (str() as item):
+        case [1 as item] | ["x" as item]:
             reveal_type(item)  # revealed: int
 
 def test_compatible_declared_alias(subject: object) -> None:
@@ -1413,10 +1442,12 @@ left to right, a later alternative sees only values not matched earlier.
 ```py
 from typing import Literal
 
-def test_match_sequence_or_as_pattern(value: object) -> None:
+def test_match_sequence_or_as_pattern(
+    value: tuple[None] | tuple[Literal[True]],
+) -> None:
     match value:
-        case [int() as item, _] | [str() as item, _]:
-            reveal_type(item)  # revealed: int | str
+        case [None as item] | [True as item]:
+            reveal_type(item)  # revealed: None | Literal[True]
 
 def test_match_ordered_or_capture(value: tuple[int] | str) -> int | str:
     match value:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -586,6 +586,24 @@ def test_match_or_alias_preserves_constrained_typevar(
             return whole
         case _:
             raise ValueError
+
+def test_match_or_alternative_alias_preserves_constrained_typevar(
+    value: BoundChoiceT,
+) -> BoundChoiceT:
+    match value:
+        case (BoundA() as whole) | (BoundB() as whole):
+            # revealed: BoundChoiceT@test_match_or_alternative_alias_preserves_constrained_typevar
+            reveal_type(whole)
+            return whole
+
+def test_match_ordered_or_preserves_nested_constrained_typevar(
+    value: tuple[BoundChoiceT] | BoundChoiceT,
+) -> BoundChoiceT:
+    match value:
+        case [item] | item:
+            # revealed: BoundChoiceT@test_match_ordered_or_preserves_nested_constrained_typevar
+            reveal_type(item)
+            return item
 ```
 
 ## Indirect class patterns
@@ -1579,6 +1597,12 @@ class Answer(Enum):
             case _:
                 reveal_type(self)  # revealed: Self@assert_yes & ~Literal[Answer.YES]
                 raise ValueError("Answer is not YES")
+
+    def alias_through_alternatives(self) -> Self:
+        match self:
+            case (Answer.NO as item) | (Answer.YES as item) | (Answer.MAYBE as item):
+                reveal_type(item)  # revealed: Self@alias_through_alternatives
+                return item
 
 Answer.YES.is_yes_through_class_member()
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -582,6 +582,7 @@ def test_match_sequence_alias_keeps_matched_element_types(
 ) -> None:
     match value:
         case [1] as whole:
+            reveal_type(len(whole))  # revealed: Literal[1]
             reveal_type(whole[0])  # revealed: Literal[1]
 
 def test_match_starred_sequence_alias_keeps_matched_element_types(
@@ -597,6 +598,7 @@ def test_mutable_sequence_alias_does_not_keep_index_types(
 ) -> None:
     match value:
         case [int(), str()] as whole:
+            reveal_type(len(whole))  # revealed: int
             whole.reverse()
             reveal_type(whole[0])  # revealed: int | str
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -176,7 +176,6 @@ def test_match_refutable(x: dict[Any, Any] | int) -> None:
 
 ```py
 from collections.abc import Sequence
-from typing_extensions import assert_never
 
 def test_match_star(x: Sequence[int] | int) -> None:
     match x:
@@ -200,25 +199,22 @@ def test_match_star_excludes_text_and_bytes(x: str | bytes | bytearray | list[in
 
 def test_match_exact_sequence_excludes_str(x: str | tuple[int, int]) -> None:
     match x:
-        case (a, b):
-            reveal_type(a)  # revealed: @Todo(`match` pattern definition types)
-            reveal_type(b)  # revealed: @Todo(`match` pattern definition types)
+        case (_, _):
+            pass
         case _:
             reveal_type(x)  # revealed: str
 
 def test_match_exact_sequence_excludes_bytes(x: bytes | tuple[int, int]) -> None:
     match x:
-        case (a, b):
-            reveal_type(a)  # revealed: @Todo(`match` pattern definition types)
-            reveal_type(b)  # revealed: @Todo(`match` pattern definition types)
+        case (_, _):
+            pass
         case _:
             reveal_type(x)  # revealed: bytes
 
 def test_match_exact_sequence_excludes_bytearray(x: bytearray | tuple[int, int]) -> None:
     match x:
-        case (a, b):
-            reveal_type(a)  # revealed: @Todo(`match` pattern definition types)
-            reveal_type(b)  # revealed: @Todo(`match` pattern definition types)
+        case (_, _):
+            pass
         case _:
             reveal_type(x)  # revealed: bytearray
 
@@ -269,6 +265,421 @@ def test_match_prefix_star_known_sequence(value: Sequence[int | str]) -> None:
         case [int(), *rest]:
             reveal_type(value[0])  # revealed: int
             reveal_type(value[1])  # revealed: int | str
+            reveal_type(rest)  # revealed: list[int | str]
+```
+
+## Sequence capture types
+
+A capture gets its type from the sequence element it binds. A starred capture is always a list. For
+a fixed-length tuple, we can determine exactly which elements appear in that list.
+
+```py
+from typing import Any
+from ty_extensions import Unknown
+
+def test_match_star_capture(value: tuple[int, str, bool]) -> None:
+    match value:
+        case [first, *rest]:
+            reveal_type(first)  # revealed: int
+            reveal_type(rest)  # revealed: list[str | bool]
+
+def test_match_star_capture_between_patterns(value: tuple[int, bytes, str]) -> None:
+    match value:
+        case [int(), *rest, str()]:
+            reveal_type(rest)  # revealed: list[bytes]
+
+def test_match_dynamic_sequence_captures(any_value: Any, unknown_value: Unknown) -> None:
+    match any_value:
+        case [item, *rest]:
+            reveal_type(item)  # revealed: Any
+            reveal_type(rest)  # revealed: list[Any]
+
+    match unknown_value:
+        case [item, *rest]:
+            reveal_type(item)  # revealed: Unknown
+            reveal_type(rest)  # revealed: list[Unknown]
+
+def test_match_capture_in_guard(value: tuple[int]) -> None:
+    match value:
+        case [item] if reveal_type(item):  # revealed: int
+            pass
+
+def test_impossible_sequence_capture(value: tuple[str]) -> None:
+    match value:
+        case [int() as item]:
+            reveal_type(item)  # revealed: Never
+
+# A pattern only binds names if the complete pattern succeeds. The first element would bind `str`
+# on its own, but the second element makes this pattern impossible.
+def test_later_failure_rejects_earlier_capture(value: tuple[str, str]) -> None:
+    match value:
+        case [item, int()]:
+            reveal_type(item)  # revealed: Never
+```
+
+## Captures from unions of tuples
+
+When a union contains several tuple types, matching one element can determine the types of the other
+captures. A wildcard keeps every tuple type that can match. The same rules apply through type
+aliases and constrained type variables.
+
+```py
+from typing import Literal, TypeAlias, TypeVar
+
+def test_match_star_capture_filters_union_members(
+    value: tuple[Literal[1], int, int] | tuple[Literal[2], str, str],
+) -> list[int]:
+    match value:
+        case [1, *rest]:
+            reveal_type(rest)  # revealed: list[int]
+            return rest
+        case _:
+            return []
+
+def test_match_star_capture_preserves_compatible_union_members(
+    value: tuple[Literal[1], int, int] | tuple[Literal[2], str, str],
+) -> None:
+    match value:
+        case [_, *rest]:
+            reveal_type(rest)  # revealed: list[int] | list[str]
+
+def test_match_capture_filters_union_members(
+    value: tuple[Literal[1], int] | tuple[Literal[2], str],
+) -> int:
+    match value:
+        case [1, item]:
+            reveal_type(item)  # revealed: int
+            return item
+        case _:
+            return 0
+
+MatchPair: TypeAlias = tuple[Literal[1], int] | tuple[Literal[2], str]
+MatchPairT = TypeVar(
+    "MatchPairT",
+    tuple[Literal[1], int],
+    tuple[Literal[2], str],
+)
+
+def test_match_capture_filters_aliased_union_members(value: MatchPair) -> None:
+    match value:
+        case [1, item]:
+            reveal_type(item)  # revealed: int
+
+def test_match_capture_filters_constrained_typevar_members(value: MatchPairT) -> None:
+    match value:
+        case [1, item]:
+            reveal_type(item)  # revealed: int
+```
+
+## Pattern aliases
+
+An `as` pattern binds the original matched value. The binding keeps facts already known about the
+subject as well as facts established by the nested pattern. A later case also starts with the values
+not handled by earlier cases.
+
+```py
+from typing import Literal
+
+def test_match_sequence_as_pattern(value: object) -> None:
+    match value:
+        case [int() as item, _]:
+            reveal_type(item)  # revealed: int
+
+def test_match_sequence_as_pattern_preserves_subject_type(
+    value: tuple[Literal[1], object],
+) -> None:
+    match value:
+        case [int() as item, _]:
+            reveal_type(item)  # revealed: Literal[1]
+
+def test_match_sequence_value_as_pattern_preserves_subject_type(
+    value: tuple[Literal[1]],
+) -> None:
+    match value:
+        case [1 as item]:
+            reveal_type(item)  # revealed: Literal[1]
+
+def test_match_sequence_wildcard_as_pattern_preserves_subject_type(
+    value: tuple[Literal[1]],
+) -> None:
+    match value:
+        case [_ as item]:
+            reveal_type(item)  # revealed: Literal[1]
+
+def test_match_sequence_as_pattern_excludes_previous_cases(
+    value: tuple[Literal[1], object] | tuple[Literal[2], object],
+) -> None:
+    match value:
+        case [1, _]:
+            pass
+        case [int() as item, _]:
+            reveal_type(item)  # revealed: Literal[2]
+```
+
+## Ordered `or`-pattern bindings
+
+Alternatives are tried from left to right, but a later alternative must keep any value for which an
+earlier pattern can fail. Here, `Values.x` is only an annotation, so `HasX()` can fail at runtime
+and the sequence alternative can still bind the value:
+
+```py
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class HasX(Protocol):
+    x: int
+
+class Values(list[str]):
+    x: int
+
+def test_or_binding_keeps_values_that_can_fail_a_class_pattern(value: Values) -> None:
+    match value:
+        case (HasX() as item) | [item]:
+            reveal_type(item)  # revealed: Values | str
+```
+
+## Declared pattern captures
+
+A capture still has to satisfy an earlier declaration for the same name. This uses the same
+assignment checks as other bindings; the declaration remains the authoritative type when the
+captured value is incompatible.
+
+```py
+def test_incompatible_declared_capture(subject: int) -> None:
+    item: str
+    match subject:
+        case item:  # error: [invalid-assignment]
+            reveal_type(item)  # revealed: str
+
+def test_incompatible_declared_star_capture(subject: tuple[int, int]) -> None:
+    rest: list[str]
+    match subject:
+        case [*rest]:  # error: [invalid-assignment]
+            reveal_type(rest)  # revealed: list[str]
+
+def test_incompatible_declared_or_capture(subject: int | str) -> None:
+    item: int
+    match subject:
+        # TODO: Report one error for the logical OR-pattern binding instead of validating each
+        # syntactic definition separately.
+        # error: [invalid-assignment]
+        # error: [invalid-assignment]
+        case (int() as item) | (str() as item):
+            reveal_type(item)  # revealed: int
+
+def test_compatible_declared_alias(subject: object) -> None:
+    item: int
+    match subject:
+        case int() as item:
+            reveal_type(item)  # revealed: int
+```
+
+## Binding the whole pattern
+
+Binding an entire pattern with `as` keeps the subject's original type variable. If only some
+constraints can match, the binding also keeps the sequence shape established by the pattern. For a
+tuple, successful child patterns can also refine the types at fixed indices.
+
+```py
+from typing import final, Literal, TypeVar
+
+@final
+class BoundA: ...
+
+@final
+class BoundB: ...
+
+BoundChoiceT = TypeVar("BoundChoiceT", BoundA, BoundB)
+
+BoundSequenceT = TypeVar("BoundSequenceT", bound=tuple[object])
+ConstrainedSequenceT = TypeVar(
+    "ConstrainedSequenceT",
+    tuple[int],
+    tuple[str],
+)
+PartiallyMatchedSequenceT = TypeVar(
+    "PartiallyMatchedSequenceT",
+    tuple[int],
+    tuple[int, int],
+)
+SequenceElementT = TypeVar("SequenceElementT")
+
+def test_match_sequence_alias_preserves_bound_typevar(
+    value: BoundSequenceT,
+) -> BoundSequenceT:
+    match value:
+        case [_] as whole:
+            reveal_type(whole)  # revealed: BoundSequenceT@test_match_sequence_alias_preserves_bound_typevar
+            return whole
+
+def test_match_sequence_alias_preserves_constrained_typevar(
+    value: ConstrainedSequenceT,
+) -> ConstrainedSequenceT:
+    match value:
+        case [_] as whole:
+            # revealed: ConstrainedSequenceT@test_match_sequence_alias_preserves_constrained_typevar
+            reveal_type(whole)
+            return whole
+
+def test_match_sequence_alias_narrows_constrained_typevar(
+    value: PartiallyMatchedSequenceT,
+) -> PartiallyMatchedSequenceT:
+    match value:
+        case [_] as whole:
+            # revealed: PartiallyMatchedSequenceT@test_match_sequence_alias_narrows_constrained_typevar & tuple[int]
+            reveal_type(whole)
+            return whole
+        case _:
+            raise ValueError
+
+def test_match_sequence_alias_preserves_typevar_union_member(
+    value: BoundSequenceT | str,
+) -> BoundSequenceT:
+    match value:
+        case [_] as whole:
+            # revealed: BoundSequenceT@test_match_sequence_alias_preserves_typevar_union_member
+            reveal_type(whole)
+            return whole
+        case _:
+            raise ValueError
+
+def test_match_sequence_alias_preserves_element_narrowing(
+    value: list[SequenceElementT],
+) -> int:
+    match value:
+        case [int()] as whole:
+            # revealed: SequenceElementT@test_match_sequence_alias_preserves_element_narrowing & int
+            reveal_type(whole[0])
+            return whole[0]
+        case _:
+            return 0
+
+def test_match_sequence_alias_keeps_matched_element_types(
+    value: tuple[Literal[1, 2]],
+) -> None:
+    match value:
+        case [1] as whole:
+            reveal_type(whole[0])  # revealed: Literal[1]
+
+def test_match_starred_sequence_alias_keeps_matched_element_types(
+    value: tuple[Literal[1, 2], str, Literal[3, 4]],
+) -> None:
+    match value:
+        case [1, *_, 4] as whole:
+            reveal_type(whole[0])  # revealed: Literal[1]
+            reveal_type(whole[-1])  # revealed: Literal[4]
+
+def test_mutable_sequence_alias_does_not_keep_matched_element_types(
+    value: list[Literal[1, 2]],
+) -> None:
+    match value:
+        case [1] as whole:
+            whole[0] = 2
+            reveal_type(whole[0])  # revealed: Literal[1, 2]
+
+def test_match_or_alias_preserves_constrained_typevar(
+    value: BoundChoiceT | str,
+) -> BoundChoiceT:
+    match value:
+        case (BoundA() | BoundB()) as whole:
+            reveal_type(whole)  # revealed: BoundChoiceT@test_match_or_alias_preserves_constrained_typevar
+            return whole
+        case _:
+            raise ValueError
+```
+
+## Indirect class patterns
+
+A class pattern can use a variable whose type is `type[Class]`. Both the subject and an `as` binding
+use the instance type described by that annotation.
+
+```py
+class IndirectPattern: ...
+
+def test_match_indirect_class_pattern(
+    value: object,
+    PatternClass: type[IndirectPattern],
+) -> None:
+    match value:
+        case PatternClass() as item:
+            reveal_type(item)  # revealed: IndirectPattern
+            reveal_type(value)  # revealed: IndirectPattern
+```
+
+## Recursive class pattern aliases
+
+The same rule applies outside sequence patterns. Preserving a recursive alias lets later code keep
+using the recursive relationship after a class pattern matches.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type RecursiveContainer = int | dict[str, RecursiveContainer] | list[RecursiveContainer]
+
+def test_match_class_alias_preserves_recursive_containers(
+    value: RecursiveContainer,
+) -> None:
+    match value:
+        case dict() as mapping:
+            reveal_type(mapping)  # revealed: dict[str, RecursiveContainer]
+            mapping["bad"] = "bad"  # error: [invalid-assignment]
+            for item in mapping.values():
+                test_match_class_alias_preserves_recursive_containers(item)
+        case list() as sequence:
+            reveal_type(sequence)  # revealed: list[RecursiveContainer]
+            sequence.append("bad")  # error: [invalid-argument-type]
+            for item in sequence:
+                test_match_class_alias_preserves_recursive_containers(item)
+```
+
+## Binding overlapping classes with `as`
+
+Unrelated classes can share a subclass through multiple inheritance. Binding the whole class pattern
+therefore preserves their intersection unless the classes are known to be disjoint.
+
+```py
+from typing import final
+
+class OverlapA: ...
+class OverlapB: ...
+class OverlapC(OverlapA, OverlapB): ...
+
+def test_match_class_alias_preserves_possible_multiple_inheritance(
+    value: OverlapA,
+) -> None:
+    match value:
+        case OverlapB() as item:
+            reveal_type(item)  # revealed: OverlapA & OverlapB
+
+def test_match_class_alias_preserves_negative_narrowing(value: object) -> None:
+    if isinstance(value, OverlapA):
+        return
+
+    match value:
+        case OverlapB() as item:
+            reveal_type(item)  # revealed: OverlapB & ~OverlapA
+
+@final
+class FinalA: ...
+
+class FinalB: ...
+
+def test_match_class_alias_rejects_disjoint_final_class(value: FinalA) -> None:
+    match value:
+        case FinalB() as item:
+            reveal_type(item)  # revealed: Never
+```
+
+## Sequence exhaustiveness
+
+Sequence patterns also contribute to negative narrowing and exhaustiveness. Exact tuple shapes can
+make a match exhaustive.
+
+```py
+from typing_extensions import assert_never
 
 def test_match_exact_tuple_sequence(subj: tuple[int | str, int | str]) -> None:
     match subj:
@@ -317,7 +728,14 @@ def test_match_exact_mutable_sequence_negative(value: list[int]) -> None:
         case _:
             # revealed: list[int] & ~<Protocol with members '__getitem__', '__len__'>
             reveal_type(value)
+```
 
+## Nested sequence patterns
+
+Nested patterns narrow the fixed positions they inspect. The narrowed element types remain available
+through later indexing and destructuring.
+
+```py
 def normalize_nested_record(value: object) -> tuple[None, int, int] | None:
     match value:
         case [None, [int()], {}]:
@@ -332,13 +750,6 @@ def unwrap_number_or_label(value: object) -> int | str | None:
             reveal_type(value[0])  # revealed: int | str
             return value[0]
     return None
-
-def test_match_value_sequence(value: object) -> None:
-    match value:
-        case [1]:
-            # Value patterns use equality, so matching `1` does not prove that
-            # the element is an `int`.
-            reveal_type(value[0])  # revealed: object
 ```
 
 ## Sequence display subjects
@@ -473,10 +884,11 @@ def match_tuple_expression_starred_pattern(
             reveal_type(b)  # revealed: TupleSubjectB1
 ```
 
-## Subject-time bindings in display subjects
+## Bindings used in match subjects
 
-Each element constraint applies to the binding read while that subject element was evaluated. It
-does not constrain a binding introduced by a later subject element, pattern capture, or guard.
+Each element is narrowed using the binding that Python read when it evaluated that part of the
+subject. A later assignment in another element, pattern capture, or guard does not change which
+binding the earlier element referred to.
 
 ```py
 from typing import final
@@ -511,10 +923,19 @@ def match_tuple_expression_multiple_bindings(flag: bool, b: TupleSubjectB) -> No
             reveal_type(a)  # revealed: TupleSubjectA1
             reveal_type(b)  # revealed: TupleSubjectB1
 
-def match_tuple_expression_subject_capture(a: TupleSubjectA, b: TupleSubjectB) -> None:
+def match_tuple_expression_subject_capture(
+    a: TupleSubjectA | TupleSubjectB,
+    b: TupleSubjectB,
+) -> None:
     match a, b:
         case [TupleSubjectA1(), a]:
-            reveal_type(a)  # revealed: @Todo(`match` pattern definition types)
+            reveal_type(a)  # revealed: TupleSubjectB
+
+def match_capture_shadows_subject() -> None:
+    x = (1,)
+    match x:
+        case [x]:
+            reveal_type(x)  # revealed: Literal[1]
 
 def match_tuple_expression_guard_rebinding(
     a: TupleSubjectA,
@@ -527,6 +948,58 @@ def match_tuple_expression_guard_rebinding(
         case [TupleSubjectA1(), TupleSubjectB1()]:
             reveal_type(a)  # revealed: TupleSubjectA1 | TupleSubjectA2
             reveal_type(b)  # revealed: TupleSubjectB1
+```
+
+## Named-expression subjects
+
+A named expression creates a new binding for the subject. The successful pattern narrows that
+binding just like it narrows a subject that was already bound.
+
+```py
+class NamedSubject: ...
+
+class NamedSubjectChild(NamedSubject):
+    child: int
+
+def match_named_expression_subject(value: NamedSubject) -> None:
+    match subject := value:
+        case NamedSubjectChild():
+            reveal_type(subject)  # revealed: NamedSubjectChild
+            reveal_type(subject.child)  # revealed: int
+
+def match_named_expression_subject_capture(value: tuple[int]) -> None:
+    match subject := value:
+        case [subject]:
+            # The capture shadows the named-expression binding and receives the element type.
+            reveal_type(subject)  # revealed: int
+```
+
+## Cycles in pattern binding types
+
+Pattern captures can affect the type of a later match subject, including through a loop or a
+function defined before the capture. These cycles should resolve to the same concrete binding types
+as equivalent code without a cycle.
+
+```py
+def match_loop_carried_capture(flag: bool, x: int) -> None:
+    while flag:
+        match x:
+            case x:
+                reveal_type(x)  # revealed: int
+
+def match_loop_carried_sequence_capture(flag: bool) -> None:
+    x = (1,)
+    while flag:
+        match x:
+            case [x]:
+                reveal_type(x)  # revealed: Literal[1]
+
+def capture_from_later_global() -> int:
+    return captured
+
+match capture_from_later_global():
+    case captured:
+        reveal_type(captured)  # revealed: int
 ```
 
 ## Value patterns
@@ -572,7 +1045,7 @@ def _(value: FinalPatternInt):
     match value:
         case 1 as captured:
             reveal_type(value)  # revealed: FinalPatternInt
-            reveal_type(captured)  # revealed: @Todo(`match` pattern definition types)
+            reveal_type(captured)  # revealed: FinalPatternInt
 
     match value:
         case PatternValues.ONE:
@@ -660,6 +1133,16 @@ def _(x: Literal["foo", "bar", 42, b"foo"] | bool | complex):
             reveal_type(x)  # revealed: (int & ~Literal[42]) | Literal[b"foo"] | float | complex
         case _:
             reveal_type(x)  # revealed: Literal["bar"] | (int & ~Literal[42]) | float | complex
+```
+
+The same limitation applies inside a sequence. Matching a literal proves only that the element
+compares equal to that literal, not that the element has the same type.
+
+```py
+def test_match_value_sequence(value: object) -> None:
+    match value:
+        case [1]:
+            reveal_type(value[0])  # revealed: object
 ```
 
 ## Enum equality semantics
@@ -801,6 +1284,83 @@ def custom_eq(value: AlwaysEqual) -> None:
             reveal_type(value)  # revealed: AlwaysEqual
 ```
 
+Equality also determines the type of captures later in a sequence. An `IntEnum` member can match an
+integer, and custom equality can make otherwise distinct enum members compare equal, so the capture
+keeps the type of the subject that actually matched.
+
+```py
+from enum import Enum, IntEnum
+from typing import Literal
+
+class Number(IntEnum):
+    ONE = 1
+
+def test_match_capture_preserves_int_enum_equal_member(
+    value: tuple[Literal[1], int],
+) -> None:
+    match value:
+        case [Number.ONE, item]:
+            reveal_type(item)  # revealed: int
+
+class AlwaysEqualEnum(Enum):
+    A = 1
+    B = 2
+
+    def __eq__(self, other: object) -> Literal[True]:
+        return True
+
+def test_match_capture_preserves_custom_equal_enum_member() -> None:
+    value = (AlwaysEqualEnum.B, "actual")
+    match value:
+        case [AlwaysEqualEnum.A, item]:
+            reveal_type(item)  # revealed: Literal["actual"]
+```
+
+A fallback alias can still receive a value that failed an earlier value pattern. Match patterns use
+`==`, so a non-reflexive value can fail to match itself, while a custom `__ne__` has no effect.
+
+```py
+from typing import Literal
+
+class AliasNeverEqualMeta(type):
+    def __eq__(cls, other: object) -> Literal[False]:
+        return False
+
+class AliasNeverEqualValue(metaclass=AliasNeverEqualMeta):
+    pass
+
+class NeverEqualConstants:
+    VALUE = AliasNeverEqualValue
+
+def test_match_alias_preserves_nonreflexive_value(flag: bool) -> None:
+    value = AliasNeverEqualValue if flag else "fallback"
+    match value:
+        case NeverEqualConstants.VALUE:
+            pass
+        case _ as item:
+            # revealed: <class 'AliasNeverEqualValue'> | Literal["fallback"]
+            reveal_type(item)
+
+class CustomNeMeta(type):
+    def __ne__(cls, other: object) -> Literal[True]:
+        return True
+
+class CustomNeA(metaclass=CustomNeMeta):
+    pass
+
+class CustomNeConstants:
+    A = CustomNeA
+
+def test_match_alias_ignores_custom_ne(flag: bool) -> str:
+    value = CustomNeA if flag else "fallback"
+    match value:
+        case CustomNeConstants.A:
+            return ""
+        case _ as item:
+            reveal_type(item)  # revealed: Literal["fallback"]
+            return item
+```
+
 ## Value patterns with guard
 
 ```py
@@ -873,6 +1433,33 @@ def _(x: A | B | C):
             reveal_type(x)  # revealed: A
         case _:
             reveal_type(x)  # revealed: (B & ~A) | (C & ~A)
+```
+
+Every `or` alternative binds the same names, but each alternative can give them a different type.
+The binding combines the type from each reachable alternative. Because alternatives are tried from
+left to right, a later alternative sees only values not matched earlier.
+
+```py
+from typing import Literal
+
+def test_match_sequence_or_as_pattern(value: object) -> None:
+    match value:
+        case [int() as item, _] | [str() as item, _]:
+            reveal_type(item)  # revealed: int | str
+
+def test_match_ordered_or_capture(value: tuple[int] | str) -> int | str:
+    match value:
+        case [item] | item:
+            reveal_type(item)  # revealed: int | str
+            return item
+
+def test_match_ordered_or_capture_after_star(
+    value: tuple[Literal[1], int] | tuple[Literal[2], str],
+) -> list[int] | Literal[2]:
+    match value:
+        case [1, *item] | [item, _]:
+            reveal_type(item)  # revealed: list[int] | Literal[2]
+            return item
 ```
 
 ## Or patterns with guard

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -202,8 +202,8 @@ use crate::{
     types::{
         CallableTypes, EnumClassLiteral, IntersectionBuilder, NarrowingConstraint, SpecialFormType,
         Type, TypeContext, UnionType, callable_pattern_type, definite_match_pattern_type,
-        definite_match_pattern_type_for_subject, equality_truthiness, expand_type,
-        infer_narrowing_constraints, infer_same_file_expression_type, mapping_pattern_type,
+        equality_truthiness, expand_type, infer_narrowing_constraints,
+        infer_same_file_expression_type, mapping_pattern_type, pattern_fallthrough_type,
         sequence_pattern_type_builder, singleton_pattern_type,
     },
 };
@@ -272,14 +272,7 @@ fn type_narrowed_by_pattern<'db>(
     predicate: PatternPredicate<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
-    IntersectionBuilder::new(db)
-        .add_positive(subject_ty)
-        .add_negative(definite_match_pattern_type_for_subject(
-            db,
-            predicate.kind(db),
-            subject_ty,
-        ))
-        .build()
+    pattern_fallthrough_type(db, predicate.kind(db), subject_ty)
 }
 
 /// Return the enum class and canonical member names represented by an enum-literal subject type.

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -238,7 +238,7 @@ use ty_python_core::{
     },
     heap_size = ruff_memory_usage::heap_size
 )]
-fn type_narrowed_by_previous_patterns<'db>(
+pub(crate) fn type_narrowed_by_previous_patterns<'db>(
     db: &'db dyn Db,
     predicate: PatternPredicate<'db>,
     subject_ty: Type<'db>,
@@ -1097,7 +1097,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
             .as_deref()
             .map(|p| analyze_single_pattern_predicate_kind(db, p, subject_ty))
             .unwrap_or(Truthiness::AlwaysTrue),
-        PatternPredicateKind::MatchStar => Truthiness::Ambiguous,
+        PatternPredicateKind::Star(_) => Truthiness::AlwaysTrue,
     }
 }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -202,9 +202,9 @@ use crate::{
     types::{
         CallableTypes, EnumClassLiteral, IntersectionBuilder, NarrowingConstraint, SpecialFormType,
         Type, TypeContext, UnionType, callable_pattern_type, definite_match_pattern_type,
-        equality_truthiness, expand_type, infer_narrowing_constraints,
-        infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
-        singleton_pattern_type,
+        definite_match_pattern_type_for_subject, equality_truthiness, expand_type,
+        infer_narrowing_constraints, infer_same_file_expression_type, mapping_pattern_type,
+        sequence_pattern_type_builder, singleton_pattern_type,
     },
 };
 use ruff_index::{Idx, IndexSlice};
@@ -274,7 +274,11 @@ fn type_narrowed_by_pattern<'db>(
 ) -> Type<'db> {
     IntersectionBuilder::new(db)
         .add_positive(subject_ty)
-        .add_negative(definite_match_pattern_type(db, predicate.kind(db)))
+        .add_negative(definite_match_pattern_type_for_subject(
+            db,
+            predicate.kind(db),
+            subject_ty,
+        ))
         .build()
 }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -203,7 +203,7 @@ use crate::{
         CallableTypes, EnumClassLiteral, IntersectionBuilder, NarrowingConstraint, SpecialFormType,
         Type, TypeContext, UnionType, callable_pattern_type, definite_match_pattern_type,
         equality_truthiness, expand_type, infer_narrowing_constraints,
-        infer_same_file_expression_type, mapping_pattern_type, pattern_fallthrough_type,
+        infer_same_file_expression_type, mapping_pattern_type, pattern_binding_fallthrough_type,
         sequence_pattern_type_builder, singleton_pattern_type,
     },
 };
@@ -272,7 +272,7 @@ fn type_narrowed_by_pattern<'db>(
     predicate: PatternPredicate<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
-    pattern_fallthrough_type(db, predicate.kind(db), subject_ty)
+    pattern_binding_fallthrough_type(db, predicate.kind(db), subject_ty)
 }
 
 /// Return the enum class and canonical member names represented by an enum-literal subject type.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -35,8 +35,8 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    callable_pattern_type, definite_match_pattern_type, definite_match_pattern_type_for_subject,
-    definite_sequence_pattern_type, exact_sequence_pattern_type, mapping_pattern_type,
+    callable_pattern_type, definite_match_pattern_type, definite_sequence_pattern_type,
+    exact_sequence_pattern_type, mapping_pattern_type, pattern_fallthrough_type,
     sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -35,9 +35,9 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    callable_pattern_type, definite_match_pattern_type, definite_sequence_pattern_type,
-    exact_sequence_pattern_type, mapping_pattern_type, sequence_pattern_type_builder,
-    singleton_pattern_type, starred_sequence_pattern_type,
+    callable_pattern_type, definite_match_pattern_type, definite_match_pattern_type_for_subject,
+    definite_sequence_pattern_type, exact_sequence_pattern_type, mapping_pattern_type,
+    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -35,9 +35,10 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    callable_pattern_type, definite_match_pattern_type, definite_sequence_pattern_type,
-    exact_sequence_pattern_type, mapping_pattern_type, pattern_fallthrough_type,
-    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
+    callable_pattern_type, definite_match_pattern_type, exact_sequence_pattern_type,
+    has_known_tuple_shape, mapping_pattern_type, pattern_binding_fallthrough_type,
+    pattern_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
+    starred_sequence_pattern_type,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -36,9 +36,8 @@ pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
     callable_pattern_type, definite_match_pattern_type, exact_sequence_pattern_type,
-    has_known_tuple_shape, mapping_pattern_type, pattern_binding_fallthrough_type,
-    pattern_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type,
+    mapping_pattern_type, pattern_binding_fallthrough_type, pattern_fallthrough_type,
+    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -662,7 +662,11 @@ fn enum_literal_constraint<'db>(
 }
 
 /// Return whether every possible value of `ty` belongs to the same enum as `right`.
-fn is_same_enum_domain<'db>(db: &'db dyn Db, ty: Type<'db>, right: EnumLiteralType<'db>) -> bool {
+pub(super) fn is_same_enum_domain<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    right: EnumLiteralType<'db>,
+) -> bool {
     match ty.resolve_type_alias(db) {
         Type::LiteralValue(literal) => matches!(
             literal.kind(),

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -86,6 +86,7 @@ use crate::types::infer::{
     nearest_enclosing_function, original_class_type,
 };
 use crate::types::narrow::NarrowingEvaluatorExtension;
+use crate::types::narrow::pattern_success_types;
 use crate::types::newtype::NewType;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{CallableSignature, ReturnCallableTypeVarScope};
@@ -120,6 +121,7 @@ use ty_python_core::expression::{Expression, ExpressionKind};
 use ty_python_core::narrowing_constraints::ConstraintKey;
 use ty_python_core::node_key::NodeKey;
 use ty_python_core::place::{PlaceExpr, PlaceExprRef};
+use ty_python_core::predicate::PatternPredicate;
 use ty_python_core::scope::{FileScopeId, NodeWithScopeKind, NodeWithScopeRef, ScopeId, ScopeKind};
 use ty_python_core::symbol::{ScopedSymbolId, Symbol};
 use ty_python_core::{
@@ -1138,7 +1140,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             DefinitionKind::MatchPattern(match_pattern) => {
                 self.infer_match_pattern_definition(
                     match_pattern.pattern(self.module()),
-                    match_pattern.index(),
+                    match_pattern.predicate(),
                     definition,
                 );
             }
@@ -2375,15 +2377,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn infer_match_pattern_definition(
         &mut self,
         pattern: &'ast ast::Pattern,
-        _index: u32,
+        predicate: PatternPredicate<'db>,
         definition: Definition<'db>,
     ) {
-        // TODO(dhruvmanila): The correct way to infer types here is to perform structural matching
-        // against the subject expression type (which we can query via `infer_expression_types`)
-        // and extract the type at the `index` position if the pattern matches. This will be
-        // similar to the logic in `self.infer_assignment_definition`.
+        let ty =
+            pattern_success_types(self.db(), predicate).binding_type(definition.place(self.db()));
         self.add_binding(pattern.into(), definition)
-            .insert(self, todo_type!("`match` pattern definition types"));
+            .insert(self, ty);
     }
 
     fn validate_class_pattern(&mut self, pattern: &ast::PatternMatchClass, cls_ty: Type<'db>) {
@@ -2424,22 +2424,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // we need to choose an Expr that can “stand in” for the pattern, which we can wrap in a
         // standalone expression.
         //
-        // That said, when inferring the type of a standalone expression, we don't have access to
-        // its parent or sibling nodes.  That means, for instance, that in a class pattern, where
-        // we are currently using the class name as the standalone expression, we do not have
-        // access to the class pattern's arguments in the standalone expression inference scope.
-        // At the moment, we aren't trying to do anything with those arguments when creating a
-        // narrowing constraint for the pattern.  But in the future, if we do, we will have to
-        // either wrap those arguments in their own standalone expressions, or update Expression to
-        // be able to wrap other AST node types besides just ast::Expr.
+        // The structural pattern is stored separately on `PatternPredicate`, so analyses that need
+        // the complete pattern can inspect its arguments without making them standalone
+        // expressions.
         //
         // This function is only called for the top-level pattern of a match arm, and is
         // responsible for inferring the standalone expression for each supported pattern type. It
         // then hands off to `infer_nested_match_pattern` for any subexpressions and subpatterns,
         // where we do NOT have any additional standalone expressions to infer through.
         //
-        // TODO(dhruvmanila): Add a Salsa query for inferring pattern types and matching against
-        // the subject expression: https://github.com/astral-sh/ruff/pull/13147#discussion_r1739424510
         match pattern {
             ast::Pattern::MatchValue(match_value) => {
                 self.infer_standalone_expression(&match_value.value, TypeContext::default());
@@ -2487,13 +2480,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     node_index: _,
                     keys,
                     patterns,
-                    rest: _,
+                    rest,
                 } = match_mapping;
                 for key in keys {
                     self.infer_expression(key, TypeContext::default());
                 }
                 for pattern in patterns {
                     self.infer_nested_match_pattern(pattern);
+                }
+                if let Some(rest) = rest {
+                    self.infer_definition(rest);
                 }
             }
             ast::Pattern::MatchClass(match_class) => {
@@ -2516,13 +2512,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if let Some(pattern) = &match_as.pattern {
                     self.infer_nested_match_pattern(pattern);
                 }
+                if let Some(name) = &match_as.name {
+                    self.infer_definition(name);
+                }
             }
             ast::Pattern::MatchOr(match_or) => {
                 for pattern in &match_or.patterns {
                     self.infer_nested_match_pattern(pattern);
                 }
             }
-            ast::Pattern::MatchStar(_) | ast::Pattern::MatchSingleton(_) => {}
+            ast::Pattern::MatchStar(match_star) => {
+                if let Some(name) = &match_star.name {
+                    self.infer_definition(name);
+                }
+            }
+            ast::Pattern::MatchSingleton(_) => {}
         }
     }
 

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -7,6 +7,7 @@ use ty_python_core::predicate::{
 
 use crate::Db;
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
+use crate::types::equality::evaluate_type_equality;
 use crate::types::signatures::CallableSignature;
 use crate::types::tuple::TupleType;
 use crate::types::{
@@ -312,6 +313,44 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
             .add_positive(definite_match_pattern_type(db, kind))
             .build(),
     }
+}
+
+/// Return the part of `subject_ty` that can reach a later alternative after `kind` fails.
+///
+/// Value patterns use Python equality. Reusing the equality constraint here both accounts for
+/// cross-type equal values and avoids checking every member of a large literal union separately:
+///
+/// ```python
+/// from typing import Literal
+///
+/// def f(value: Literal[True, 1, 2]) -> None:
+///     match value:
+///         case 1:
+///             pass
+///         case other:
+///             reveal_type(other)  # Literal[2]
+/// ```
+pub(crate) fn pattern_fallthrough_type<'db>(
+    db: &'db dyn Db,
+    kind: &PatternPredicateKind<'db>,
+    subject_ty: Type<'db>,
+) -> Type<'db> {
+    if let PatternPredicateKind::Value(value) = kind {
+        let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
+        if let Some(constraint) = evaluate_type_equality(db, subject_ty, value_ty, false) {
+            return IntersectionBuilder::new(db)
+                .add_positive(subject_ty)
+                .add_positive(constraint)
+                .build();
+        }
+    }
+
+    IntersectionBuilder::new(db)
+        .add_positive(subject_ty)
+        .add_negative(definite_match_pattern_type_for_subject(
+            db, kind, subject_ty,
+        ))
+        .build()
 }
 
 /// Return the values that are guaranteed to match `kind`.

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -1,7 +1,9 @@
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ty_python_core::Truthiness;
-use ty_python_core::predicate::{PatternPredicateKind, SequencePatternPredicateKind};
+use ty_python_core::predicate::{
+    ClassPatternKind, PatternPredicateKind, SequencePatternPredicateKind,
+};
 
 use crate::Db;
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
@@ -162,6 +164,154 @@ pub(crate) fn starred_sequence_pattern_type<'db>(
     sequence_pattern_type_builder(db)
         .add_positive(protocol)
         .build()
+}
+
+fn pattern_is_exhaustive_for_subject(
+    db: &dyn Db,
+    pattern: &PatternPredicateKind<'_>,
+    subject_ty: Type<'_>,
+) -> bool {
+    subject_ty.is_subtype_of(
+        db,
+        definite_match_pattern_type_for_subject(db, pattern, subject_ty),
+    )
+}
+
+fn sequence_pattern_is_exhaustive_for_subject(
+    db: &dyn Db,
+    kind: &SequencePatternPredicateKind<'_>,
+    subject_ty: Type<'_>,
+) -> bool {
+    if !subject_ty.is_subtype_of(db, sequence_pattern_type_builder(db).build()) {
+        return false;
+    }
+
+    if kind.is_irrefutable() {
+        return true;
+    }
+
+    let Some(tuple) = subject_ty.exact_tuple_instance_spec(db) else {
+        return false;
+    };
+    let Some(tuple) = tuple.as_fixed_length() else {
+        return false;
+    };
+    let elements = tuple.all_elements();
+
+    let Some((prefix, suffix)) = kind.split_around_star() else {
+        return elements.len() == kind.patterns.len()
+            && elements
+                .iter()
+                .zip(kind.patterns.iter())
+                .all(|(element, pattern)| {
+                    pattern_is_exhaustive_for_subject(db, pattern, *element)
+                });
+    };
+    if elements.len() < prefix.len() + suffix.len() {
+        return false;
+    }
+
+    elements
+        .iter()
+        .zip(prefix)
+        .chain(elements.iter().rev().zip(suffix.iter().rev()))
+        .all(|(element, pattern)| pattern_is_exhaustive_for_subject(db, pattern, *element))
+}
+
+fn subject_independent_definite_match_pattern_type<'db>(
+    db: &'db dyn Db,
+    kind: &PatternPredicateKind<'db>,
+) -> Option<Type<'db>> {
+    match kind {
+        PatternPredicateKind::Singleton(_)
+        | PatternPredicateKind::Class(_, ClassPatternKind::Irrefutable)
+        | PatternPredicateKind::Mapping(ClassPatternKind::Irrefutable) => {
+            Some(definite_match_pattern_type(db, kind))
+        }
+        PatternPredicateKind::Sequence(sequence) if sequence.is_irrefutable() => {
+            Some(definite_match_pattern_type(db, kind))
+        }
+        PatternPredicateKind::Or(patterns) => {
+            let patterns = patterns
+                .iter()
+                .map(|pattern| subject_independent_definite_match_pattern_type(db, pattern))
+                .collect::<Option<Vec<_>>>()?;
+            Some(UnionType::from_elements(db, patterns))
+        }
+        PatternPredicateKind::As(Some(pattern), _) => {
+            subject_independent_definite_match_pattern_type(db, pattern)
+        }
+        PatternPredicateKind::As(None, _) | PatternPredicateKind::Star(_) => Some(Type::object()),
+        PatternPredicateKind::Value(_)
+        | PatternPredicateKind::Class(_, ClassPatternKind::Refutable)
+        | PatternPredicateKind::Mapping(ClassPatternKind::Refutable)
+        | PatternPredicateKind::Sequence(_) => None,
+    }
+}
+
+/// Return the values in `subject_ty` that are statically guaranteed to match `kind`.
+///
+/// Unlike [`definite_match_pattern_type`], this can recognize guarantees that depend on the
+/// current subject. For example, both `Literal[True]` and `Literal[1]` are guaranteed to match the
+/// value pattern `1` because match value patterns use equality.
+pub(crate) fn definite_match_pattern_type_for_subject<'db>(
+    db: &'db dyn Db,
+    kind: &PatternPredicateKind<'db>,
+    subject_ty: Type<'db>,
+) -> Type<'db> {
+    if let Some(subject_independent_ty) = subject_independent_definite_match_pattern_type(db, kind)
+    {
+        return subject_independent_ty;
+    }
+
+    let resolved_subject_ty = subject_ty.resolve_type_alias(db);
+    if let Type::Union(union) = resolved_subject_ty {
+        return UnionType::from_elements(
+            db,
+            union
+                .elements(db)
+                .iter()
+                .map(|element| definite_match_pattern_type_for_subject(db, kind, *element)),
+        );
+    }
+
+    match kind {
+        PatternPredicateKind::Value(value) => {
+            let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
+            if equality_truthiness(db, resolved_subject_ty, value_ty) == Truthiness::AlwaysTrue {
+                subject_ty
+            } else {
+                IntersectionBuilder::new(db)
+                    .add_positive(subject_ty)
+                    .add_positive(definite_match_pattern_type(db, kind))
+                    .build()
+            }
+        }
+        PatternPredicateKind::Sequence(kind) => {
+            if sequence_pattern_is_exhaustive_for_subject(db, kind, resolved_subject_ty) {
+                subject_ty
+            } else {
+                IntersectionBuilder::new(db)
+                    .add_positive(subject_ty)
+                    .add_positive(definite_sequence_pattern_type(db, kind))
+                    .build()
+            }
+        }
+        PatternPredicateKind::Or(patterns) => UnionType::from_elements(
+            db,
+            patterns
+                .iter()
+                .map(|pattern| definite_match_pattern_type_for_subject(db, pattern, subject_ty)),
+        ),
+        PatternPredicateKind::As(Some(pattern), _) => {
+            definite_match_pattern_type_for_subject(db, pattern, subject_ty)
+        }
+        PatternPredicateKind::As(None, _) | PatternPredicateKind::Star(_) => subject_ty,
+        _ => IntersectionBuilder::new(db)
+            .add_positive(subject_ty)
+            .add_positive(definite_match_pattern_type(db, kind))
+            .build(),
+    }
 }
 
 /// Return the values that are guaranteed to match `kind`.

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -215,7 +215,7 @@ pub(crate) fn definite_match_pattern_type<'db>(
             .as_deref()
             .map(|p| definite_match_pattern_type(db, p))
             .unwrap_or_else(Type::object),
-        PatternPredicateKind::MatchStar => Type::Never,
+        PatternPredicateKind::Star(_) => Type::object(),
     }
 }
 
@@ -228,24 +228,8 @@ pub(crate) fn definite_sequence_pattern_type<'db>(
         return sequence_pattern_type_builder(db).build();
     }
 
-    if kind.is_exact_length() {
-        let element_types: Vec<_> = kind
-            .patterns
-            .iter()
-            .map(|pattern| definite_match_pattern_type(db, pattern))
-            .collect();
-
-        if element_types.iter().any(Type::is_never) {
-            Type::Never
-        } else {
-            exact_sequence_pattern_type(db, element_types.into_iter())
-        }
-    } else {
-        let Some((prefix, suffix)) = kind.split_around_star() else {
-            return Type::Never;
-        };
-
-        Type::tuple(TupleType::mixed(
+    if let Some((prefix, suffix)) = kind.split_around_star() {
+        return Type::tuple(TupleType::mixed(
             db,
             prefix
                 .iter()
@@ -254,6 +238,18 @@ pub(crate) fn definite_sequence_pattern_type<'db>(
             suffix
                 .iter()
                 .map(|pattern| definite_match_pattern_type(db, pattern)),
-        ))
+        ));
+    }
+
+    let element_types: Vec<_> = kind
+        .patterns
+        .iter()
+        .map(|pattern| definite_match_pattern_type(db, pattern))
+        .collect();
+
+    if element_types.iter().any(Type::is_never) {
+        Type::Never
+    } else {
+        exact_sequence_pattern_type(db, element_types.into_iter())
     }
 }

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -250,11 +250,15 @@ fn subject_independent_definite_match_pattern_type<'db>(
     }
 }
 
-/// Return the values in `subject_ty` that are statically guaranteed to match `kind`.
+/// Return values that are statically guaranteed to match `kind`, using `subject_ty` to recognize
+/// cases where the pattern covers a complete subject arm.
 ///
 /// Unlike [`definite_match_pattern_type`], this can recognize guarantees that depend on the
 /// current subject. For example, both `Literal[True]` and `Literal[1]` are guaranteed to match the
-/// value pattern `1` because match value patterns use equality.
+/// value pattern `1` because match value patterns use equality. The returned type can include
+/// values outside `subject_ty`; callers intersect it with the subject before using it for negative
+/// narrowing. Keeping the non-exhaustive part independent of the subject also prevents each case
+/// in a long match statement from embedding all previous negative constraints again.
 pub(crate) fn definite_match_pattern_type_for_subject<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
@@ -282,20 +286,14 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
             if equality_truthiness(db, resolved_subject_ty, value_ty) == Truthiness::AlwaysTrue {
                 subject_ty
             } else {
-                IntersectionBuilder::new(db)
-                    .add_positive(subject_ty)
-                    .add_positive(definite_match_pattern_type(db, kind))
-                    .build()
+                definite_match_pattern_type(db, kind)
             }
         }
         PatternPredicateKind::Sequence(kind) => {
             if sequence_pattern_is_exhaustive_for_subject(db, kind, resolved_subject_ty) {
                 subject_ty
             } else {
-                IntersectionBuilder::new(db)
-                    .add_positive(subject_ty)
-                    .add_positive(definite_sequence_pattern_type(db, kind))
-                    .build()
+                definite_sequence_pattern_type(db, kind)
             }
         }
         PatternPredicateKind::Or(patterns) => UnionType::from_elements(
@@ -308,10 +306,7 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
             definite_match_pattern_type_for_subject(db, pattern, subject_ty)
         }
         PatternPredicateKind::As(None, _) | PatternPredicateKind::Star(_) => subject_ty,
-        _ => IntersectionBuilder::new(db)
-            .add_positive(subject_ty)
-            .add_positive(definite_match_pattern_type(db, kind))
-            .build(),
+        _ => definite_match_pattern_type(db, kind),
     }
 }
 

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -44,16 +44,6 @@ pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<
         .add_negative(KnownClass::Bytearray.to_instance(db))
 }
 
-pub(crate) fn has_known_tuple_shape(db: &dyn Db, ty: Type<'_>) -> bool {
-    let resolved = ty.resolve_type_alias(db);
-    match resolved {
-        Type::Intersection(intersection) => intersection
-            .iter_positive(db)
-            .any(|positive| has_known_tuple_shape(db, positive)),
-        _ => resolved.exact_tuple_instance_spec(db).is_some(),
-    }
-}
-
 fn sequence_pattern_getitem_method<'db>(
     db: &'db dyn Db,
     indexed_element_types: impl IntoIterator<Item = (i64, Type<'db>)>,
@@ -418,7 +408,7 @@ fn sequence_pattern_binding_fallthrough_type<'db>(
         {
             Type::Never
         }
-        _ if has_known_tuple_shape(db, resolved) => {
+        _ if resolved.exact_tuple_instance_spec(db).is_some() => {
             pattern_fallthrough_type(db, &PatternPredicateKind::Sequence(kind.clone()), resolved)
         }
         // An irrefutable sequence pattern can only fail if the subject is not eligible for sequence

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -44,6 +44,16 @@ pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<
         .add_negative(KnownClass::Bytearray.to_instance(db))
 }
 
+pub(crate) fn has_known_tuple_shape(db: &dyn Db, ty: Type<'_>) -> bool {
+    let resolved = ty.resolve_type_alias(db);
+    match resolved {
+        Type::Intersection(intersection) => intersection
+            .iter_positive(db)
+            .any(|positive| has_known_tuple_shape(db, positive)),
+        _ => resolved.exact_tuple_instance_spec(db).is_some(),
+    }
+}
+
 fn sequence_pattern_getitem_method<'db>(
     db: &'db dyn Db,
     indexed_element_types: impl IntoIterator<Item = (i64, Type<'db>)>,
@@ -359,6 +369,72 @@ pub(crate) fn pattern_fallthrough_type<'db>(
             db, kind, subject_ty,
         ))
         .build()
+}
+
+/// Return the fallthrough type for a binding that can reach a later match case.
+///
+/// Failure of a sequence pattern establishes length and indexed-element facts at the instant of
+/// matching, but those facts can become stale for mutable or stateful sequences. Exact tuples are
+/// immutable, so they retain normal sequence-pattern fallthrough narrowing.
+pub(crate) fn pattern_binding_fallthrough_type<'db>(
+    db: &'db dyn Db,
+    kind: &PatternPredicateKind<'db>,
+    subject_ty: Type<'db>,
+) -> Type<'db> {
+    match kind {
+        PatternPredicateKind::Sequence(sequence) => {
+            sequence_pattern_binding_fallthrough_type(db, sequence, subject_ty)
+        }
+        PatternPredicateKind::Or(patterns) => {
+            patterns.iter().fold(subject_ty, |remaining, pattern| {
+                pattern_binding_fallthrough_type(db, pattern, remaining)
+            })
+        }
+        PatternPredicateKind::As(Some(pattern), _) => {
+            pattern_binding_fallthrough_type(db, pattern, subject_ty)
+        }
+        _ => pattern_fallthrough_type(db, kind, subject_ty),
+    }
+}
+
+fn sequence_pattern_binding_fallthrough_type<'db>(
+    db: &'db dyn Db,
+    kind: &SequencePatternPredicateKind<'db>,
+    subject_ty: Type<'db>,
+) -> Type<'db> {
+    let resolved = subject_ty.resolve_type_alias(db);
+    let narrowed = match resolved {
+        Type::Union(union) => union.map(db, |element| {
+            sequence_pattern_binding_fallthrough_type(db, kind, *element)
+        }),
+        Type::Intersection(intersection) => intersection.map_positive(db, |element| {
+            sequence_pattern_binding_fallthrough_type(db, kind, *element)
+        }),
+        Type::TypeVar(typevar)
+            if typevar.typevar(db).upper_bound(db).is_some_and(|bound| {
+                pattern_fallthrough_type(db, &PatternPredicateKind::Sequence(kind.clone()), bound)
+                    .is_never()
+            }) =>
+        {
+            Type::Never
+        }
+        _ if has_known_tuple_shape(db, resolved) => {
+            pattern_fallthrough_type(db, &PatternPredicateKind::Sequence(kind.clone()), resolved)
+        }
+        // An irrefutable sequence pattern can only fail if the subject is not eligible for sequence
+        // matching. Unlike length and indexed-element facts, eligibility is unaffected by mutation.
+        _ if kind.is_irrefutable() => IntersectionBuilder::new(db)
+            .add_positive(resolved)
+            .add_negative(sequence_pattern_type_builder(db).build())
+            .build(),
+        _ => resolved,
+    };
+
+    if narrowed == resolved {
+        subject_ty
+    } else {
+        narrowed
+    }
 }
 
 /// Return whether every possible value of `ty` belongs to the same enum as `right`, including

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -7,12 +7,12 @@ use ty_python_core::predicate::{
 
 use crate::Db;
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
-use crate::types::equality::evaluate_type_equality;
+use crate::types::equality::{evaluate_type_equality, is_same_enum_domain};
 use crate::types::signatures::CallableSignature;
 use crate::types::tuple::TupleType;
 use crate::types::{
-    CallableType, IntersectionBuilder, KnownClass, Parameter, Parameters, Signature,
-    SpecialFormType, Type, TypeContext, UnionType, equality_truthiness,
+    CallableType, EnumLiteralType, IntersectionBuilder, KnownClass, Parameter, Parameters,
+    Signature, SpecialFormType, Type, TypeContext, UnionType, equality_truthiness,
     infer_same_file_expression_type,
 };
 
@@ -332,6 +332,19 @@ pub(crate) fn pattern_fallthrough_type<'db>(
 ) -> Type<'db> {
     if let PatternPredicateKind::Value(value) = kind {
         let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
+        // A subject confined to the same enum cannot contain cross-type values that compare equal
+        // to the pattern, so direct subtraction avoids repeated equality evaluation in large enum
+        // matches. This includes narrowed intersections containing `Self` or another type variable
+        // whose upper bound is that enum.
+        if let Some(enum_literal) = value_ty.as_enum_literal()
+            && is_same_enum_pattern_domain(db, subject_ty, enum_literal)
+            && equality_truthiness(db, value_ty, value_ty) == Truthiness::AlwaysTrue
+        {
+            return IntersectionBuilder::new(db)
+                .add_positive(subject_ty)
+                .add_negative(value_ty)
+                .build();
+        }
         if let Some(constraint) = evaluate_type_equality(db, subject_ty, value_ty, false) {
             return IntersectionBuilder::new(db)
                 .add_positive(subject_ty)
@@ -346,6 +359,34 @@ pub(crate) fn pattern_fallthrough_type<'db>(
             db, kind, subject_ty,
         ))
         .build()
+}
+
+/// Return whether every possible value of `ty` belongs to the same enum as `right`, including
+/// bounded type variables nested inside unions or intersections.
+fn is_same_enum_pattern_domain<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    right: EnumLiteralType<'db>,
+) -> bool {
+    if is_same_enum_domain(db, ty, right) {
+        return true;
+    }
+
+    match ty.resolve_type_alias(db) {
+        Type::TypeVar(typevar) => typevar
+            .typevar(db)
+            .upper_bound(db)
+            .is_some_and(|bound| is_same_enum_domain(db, bound, right)),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| is_same_enum_pattern_domain(db, *element, right)),
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .any(|element| is_same_enum_pattern_domain(db, *element, right)),
+        _ => false,
+    }
 }
 
 /// Return the values that are guaranteed to match `kind`.

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -15,7 +15,7 @@ use crate::types::{
     CallableType, ClassLiteral, ClassType, IntersectionBuilder, IntersectionType, KnownClass,
     KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature, SpecialFormType,
     SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionBuilder, callable_pattern_type, definite_match_pattern_type,
+    UnionBuilder, callable_pattern_type, definite_match_pattern_type_for_subject,
     definite_sequence_pattern_type, exact_sequence_pattern_type, infer_expression_types,
     mapping_pattern_type, sequence_pattern_type_builder, singleton_pattern_type,
     starred_sequence_pattern_type,
@@ -1485,13 +1485,15 @@ impl<'db> PatternSuccessAnalyzer<'db> {
 
         for pattern in patterns {
             let definitely_matched_ty = if Self::contains_class_pattern(previous_pattern) {
-                // A class pattern can fail after its runtime type check, for example when a
-                // protocol member is only declared but is absent at runtime. Without the subject
-                // type, `definite_match_pattern_type` cannot distinguish those cases, so leave the
-                // later alternative intact.
+                // Attribute extraction can still fail after the runtime class check. The next PR
+                // refines this with subject-aware class-pattern exhaustiveness.
                 Type::Never
             } else {
-                definite_match_pattern_type(self.db, previous_pattern)
+                definite_match_pattern_type_for_subject(
+                    self.db,
+                    previous_pattern,
+                    remaining_subject_ty,
+                )
             };
             remaining_subject_ty = IntersectionBuilder::new(self.db)
                 .add_positive(remaining_subject_ty)
@@ -1772,9 +1774,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         original_subject_ty: Type<'db>,
         matched_types: Type<'db>,
     ) -> Type<'db> {
-        let filtering_types = original_subject_ty
-            .flatten_typevars(self.db)
-            .resolve_type_alias(self.db);
+        let filtering_types = self.pattern_filtering_type(original_subject_ty);
         if matched_types.is_equivalent_to(self.db, filtering_types)
             && original_subject_ty.has_typevar(self.db)
         {
@@ -1788,8 +1788,9 @@ impl<'db> PatternSuccessAnalyzer<'db> {
 
     /// Pair each original subject type with the union members used to test the pattern.
     ///
-    /// Type variables are expanded for matching, but each arm keeps the original type so a
-    /// successful pattern result can preserve that type variable.
+    /// An upper-bounded type variable uses its bound for matching, but each arm keeps the original
+    /// type so a successful result can preserve that type variable. Constrained type variables are
+    /// left opaque; selecting and correlating one of their constraints is handled separately.
     fn match_pattern_subject_arms(
         &self,
         subject_ty: Type<'db>,
@@ -1797,9 +1798,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let subject_ty = subject_ty.resolve_type_alias(self.db);
         let mut arms = SmallVec::new();
         let mut add_arm = |original_subject_ty: Type<'db>| {
-            let filtering_subject_ty = original_subject_ty
-                .flatten_typevars(self.db)
-                .resolve_type_alias(self.db);
+            let filtering_subject_ty = self.pattern_filtering_type(original_subject_ty);
             match filtering_subject_ty {
                 Type::Union(union) => arms.extend(
                     union
@@ -1821,6 +1820,17 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         }
 
         arms
+    }
+
+    fn pattern_filtering_type(&self, ty: Type<'db>) -> Type<'db> {
+        let ty = ty.resolve_type_alias(self.db);
+        if let Type::TypeVar(typevar) = ty
+            && let Some(bound) = typevar.typevar(self.db).upper_bound(self.db)
+        {
+            bound.resolve_type_alias(self.db)
+        } else {
+            ty
+        }
     }
 
     fn sequence_pattern_target_len(kind: &SequencePatternPredicateKind<'db>) -> TupleLength {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1282,7 +1282,6 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     }
 
     fn merge_binding(
-        &self,
         bindings: &mut BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
         place: ScopedPlaceId,
         binding: PatternBindingTypes<'db>,
@@ -1298,19 +1297,15 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     }
 
     fn merge_bindings(
-        &self,
         into: &mut BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
         from: BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
     ) {
         for (place, binding) in from {
-            self.merge_binding(into, place, binding);
+            Self::merge_binding(into, place, binding);
         }
     }
 
-    fn demote_subject_bindings(
-        &self,
-        bindings: &mut BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
-    ) {
+    fn demote_subject_bindings(bindings: &mut BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>) {
         for binding in bindings.values_mut() {
             binding.demote_subject();
         }
@@ -1355,7 +1350,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     .as_ref()
                     .and_then(|name| self.places().symbol_id(name.as_str()))
                 {
-                    self.merge_binding(
+                    Self::merge_binding(
                         &mut result.bindings,
                         place.into(),
                         PatternBindingTypes::subject(result.matched_subject_ty),
@@ -1486,7 +1481,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 .build();
             let alternative = self.analyze_successful_pattern(pattern, remaining_subject_ty);
             matched_subject_types.add_in_place(alternative.matched_subject_ty);
-            self.merge_bindings(&mut bindings, alternative.bindings);
+            Self::merge_bindings(&mut bindings, alternative.bindings);
             previous_pattern = pattern;
         }
 
@@ -1604,8 +1599,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     return None;
                 }
                 matched_element_types.push(child.matched_subject_ty);
-                analyzer.demote_subject_bindings(&mut child.bindings);
-                analyzer.merge_bindings(&mut bindings, child.bindings);
+                Self::demote_subject_bindings(&mut child.bindings);
+                Self::merge_bindings(&mut bindings, child.bindings);
             }
             let matched_subject_ty = analyzer.successful_sequence_subject_type(
                 kind,
@@ -1704,7 +1699,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             for (_, filtering_subject_ty) in arms {
                 if let Some(arm) = analyze_arm(self, filtering_subject_ty) {
                     matched_types.add_in_place(arm.matched_subject_ty);
-                    self.merge_bindings(&mut arm_bindings, arm.bindings);
+                    Self::merge_bindings(&mut arm_bindings, arm.bindings);
                 }
             }
 
@@ -1716,7 +1711,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     );
                 }
             }
-            self.merge_bindings(&mut bindings, arm_bindings);
+            Self::merge_bindings(&mut bindings, arm_bindings);
 
             matched_subject_types.add_in_place(
                 self.matched_subject_type_for_original(original_subject_ty, matched_types.build()),

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -15,10 +15,9 @@ use crate::types::{
     CallableType, ClassLiteral, ClassType, IntersectionBuilder, IntersectionType, KnownClass,
     KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature, SpecialFormType,
     SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionBuilder, callable_pattern_type, exact_sequence_pattern_type, has_known_tuple_shape,
-    infer_expression_types, mapping_pattern_type, pattern_binding_fallthrough_type,
-    pattern_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type,
+    UnionBuilder, callable_pattern_type, exact_sequence_pattern_type, infer_expression_types,
+    mapping_pattern_type, pattern_binding_fallthrough_type, pattern_fallthrough_type,
+    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
 };
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
@@ -1105,19 +1104,6 @@ fn necessary_sequence_pattern_type<'db>(
     }
 }
 
-fn sequence_pattern_narrowing_type<'db>(
-    db: &'db dyn Db,
-    kind: &SequencePatternPredicateKind<'db>,
-    subject_ty: Type<'db>,
-) -> Type<'db> {
-    let resolved = subject_ty.resolve_type_alias(db);
-    if has_known_tuple_shape(db, resolved) {
-        necessary_sequence_pattern_type(db, kind)
-    } else {
-        sequence_pattern_type_builder(db).build()
-    }
-}
-
 struct NarrowingConstraintsBuilder<'db, 'ast> {
     db: &'db dyn Db,
     module: &'ast ParsedModuleRef,
@@ -1668,9 +1654,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> PatternSuccessResult<'db> {
         let target_len = Self::sequence_pattern_target_len(kind);
         self.analyze_pattern_subject_arms(subject_ty, |analyzer, subject_ty| {
-            let sequence_ty = sequence_pattern_narrowing_type(analyzer.db, kind, subject_ty);
             let (narrowed_subject_ty, element_types) =
-                analyzer.sequence_pattern_arm(subject_ty, target_len, sequence_ty)?;
+                analyzer.sequence_pattern_arm(subject_ty, target_len)?;
             let mut bindings = BTreeMap::new();
             let mut matched_element_types = Vec::with_capacity(kind.patterns.len());
             let mut binding_element_types = Vec::with_capacity(kind.patterns.len());
@@ -1770,9 +1755,9 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         &self,
         subject_ty: Type<'db>,
         target_len: TupleLength,
-        sequence_ty: Type<'db>,
     ) -> Option<(Type<'db>, Vec<Type<'db>>)> {
-        let narrowed_subject_ty = self.intersect_types(subject_ty, sequence_ty);
+        let narrowed_subject_ty =
+            self.intersect_types(subject_ty, sequence_pattern_type_builder(self.db).build());
         if narrowed_subject_ty.is_never() {
             return None;
         }
@@ -2078,10 +2063,17 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     Self::narrow_type_by_sequence_pattern(db, *element, kind)
                 })
             }
-            _ => IntersectionBuilder::new(db)
-                .add_positive(resolved)
-                .add_positive(sequence_pattern_narrowing_type(db, kind, resolved))
-                .build(),
+            _ => {
+                let sequence_ty = if resolved.exact_tuple_instance_spec(db).is_some() {
+                    necessary_sequence_pattern_type(db, kind)
+                } else {
+                    sequence_pattern_type_builder(db).build()
+                };
+                IntersectionBuilder::new(db)
+                    .add_positive(resolved)
+                    .add_positive(sequence_ty)
+                    .build()
+            }
         };
 
         if narrowed == resolved { ty } else { narrowed }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -15,8 +15,8 @@ use crate::types::{
     CallableType, ClassLiteral, ClassType, IntersectionBuilder, IntersectionType, KnownClass,
     KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature, SpecialFormType,
     SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionBuilder, callable_pattern_type, definite_sequence_pattern_type,
-    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
+    UnionBuilder, callable_pattern_type, exact_sequence_pattern_type, has_known_tuple_shape,
+    infer_expression_types, mapping_pattern_type, pattern_binding_fallthrough_type,
     pattern_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
     starred_sequence_pattern_type,
 };
@@ -326,7 +326,8 @@ struct PatternSuccessResult<'db> {
     /// The subject type safe to assign to a binding created by this pattern.
     ///
     /// Exact tuples can retain matched length and element facts. Other sequence types can have
-    /// mutable or stateful length and item access, so their bindings retain only durable facts.
+    /// mutable or stateful length and item access, so their bindings retain only facts that remain
+    /// valid after the pattern finishes.
     binding_subject_ty: Type<'db>,
     bindings: BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
 }
@@ -1104,6 +1105,19 @@ fn necessary_sequence_pattern_type<'db>(
     }
 }
 
+fn sequence_pattern_narrowing_type<'db>(
+    db: &'db dyn Db,
+    kind: &SequencePatternPredicateKind<'db>,
+    subject_ty: Type<'db>,
+) -> Type<'db> {
+    let resolved = subject_ty.resolve_type_alias(db);
+    if has_known_tuple_shape(db, resolved) {
+        necessary_sequence_pattern_type(db, kind)
+    } else {
+        sequence_pattern_type_builder(db).build()
+    }
+}
+
 struct NarrowingConstraintsBuilder<'db, 'ast> {
     db: &'db dyn Db,
     module: &'ast ParsedModuleRef,
@@ -1653,8 +1667,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
         let target_len = Self::sequence_pattern_target_len(kind);
-        let sequence_ty = necessary_sequence_pattern_type(self.db, kind);
         self.analyze_pattern_subject_arms(subject_ty, |analyzer, subject_ty| {
+            let sequence_ty = sequence_pattern_narrowing_type(analyzer.db, kind, subject_ty);
             let (narrowed_subject_ty, element_types) =
                 analyzer.sequence_pattern_arm(subject_ty, target_len, sequence_ty)?;
             let mut bindings = BTreeMap::new();
@@ -2045,6 +2059,32 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             }
             _ => None,
         }
+    }
+
+    /// Narrow a successful sequence-pattern subject without retaining observed length or indexed
+    /// element types for mutable or stateful sequences.
+    fn narrow_type_by_sequence_pattern(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        kind: &SequencePatternPredicateKind<'db>,
+    ) -> Type<'db> {
+        let resolved = ty.resolve_type_alias(db);
+        let narrowed = match resolved {
+            Type::Union(union) => union.map(db, |element| {
+                Self::narrow_type_by_sequence_pattern(db, *element, kind)
+            }),
+            Type::Intersection(intersection) if !intersection.positive(db).is_empty() => {
+                intersection.map_positive(db, |element| {
+                    Self::narrow_type_by_sequence_pattern(db, *element, kind)
+                })
+            }
+            _ => IntersectionBuilder::new(db)
+                .add_positive(resolved)
+                .add_positive(sequence_pattern_narrowing_type(db, kind, resolved))
+                .build(),
+        };
+
+        if narrowed == resolved { ty } else { narrowed }
     }
 
     /// Filter a type based on an equality or inequality comparison against an exact length.
@@ -3008,24 +3048,29 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             );
         }
 
+        let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
         let Some(subject) = PlaceExpr::try_from_expr(subject_node) else {
             return PatternNarrowingResult::Possible(None);
         };
 
-        let constraint = if is_positive {
-            NarrowingConstraint::intersection(necessary_sequence_pattern_type(self.db, kind))
+        let narrowed_ty = if is_positive {
+            Self::narrow_type_by_sequence_pattern(self.db, subject_ty, kind)
         } else {
-            let sequence_type = definite_sequence_pattern_type(self.db, kind);
-            if sequence_type.is_never() {
-                return PatternNarrowingResult::Possible(None);
-            }
-            NarrowingConstraint::intersection(sequence_type.negate(self.db))
+            pattern_binding_fallthrough_type(
+                self.db,
+                &PatternPredicateKind::Sequence(kind.clone()),
+                subject_ty,
+            )
         };
+        if narrowed_ty == subject_ty {
+            return PatternNarrowingResult::Possible(None);
+        }
 
         let place = self.expect_place(&subject);
 
         PatternNarrowingResult::Possible(Some(NarrowingConstraints::from_iter([(
-            place, constraint,
+            place,
+            NarrowingConstraint::replacement(narrowed_ty),
         )])))
     }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -323,11 +323,11 @@ impl<'db> PatternSuccessTypes<'db> {
 struct PatternSuccessResult<'db> {
     /// The type established while this pattern is being evaluated.
     matched_subject_ty: Type<'db>,
-    /// The type that remains valid after the pattern has finished evaluating.
+    /// The subject type safe to assign to a binding created by this pattern.
     ///
-    /// These differ for mutable sequences: a sequence pattern temporarily establishes its length
-    /// and indexed element types, but later mutation can invalidate those facts.
-    stable_subject_ty: Type<'db>,
+    /// Exact tuples can retain matched length and element facts. Other sequence types can have
+    /// mutable or stateful length and item access, so their bindings retain only durable facts.
+    binding_subject_ty: Type<'db>,
     bindings: BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
 }
 
@@ -1372,7 +1372,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 let mut result = pattern.as_deref().map_or_else(
                     || PatternSuccessResult {
                         matched_subject_ty: subject_ty,
-                        stable_subject_ty: subject_ty,
+                        binding_subject_ty: subject_ty,
                         bindings: BTreeMap::new(),
                     },
                     |pattern| self.analyze_successful_pattern(pattern, subject_ty),
@@ -1385,7 +1385,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     Self::merge_binding(
                         &mut result.bindings,
                         place.into(),
-                        PatternBindingTypes::subject(result.stable_subject_ty),
+                        PatternBindingTypes::subject(result.binding_subject_ty),
                     );
                 }
                 result
@@ -1400,7 +1400,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 }
                 PatternSuccessResult {
                     matched_subject_ty: subject_ty,
-                    stable_subject_ty: subject_ty,
+                    binding_subject_ty: subject_ty,
                     bindings,
                 }
             }
@@ -1408,7 +1408,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 let matched_subject_ty = self.match_value_pattern_subject_type(*value, subject_ty);
                 PatternSuccessResult {
                     matched_subject_ty,
-                    stable_subject_ty: matched_subject_ty,
+                    binding_subject_ty: matched_subject_ty,
                     bindings: BTreeMap::new(),
                 }
             }
@@ -1421,7 +1421,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     self.match_class_pattern_subject_type(class, class_ty, subject_ty, false);
                 PatternSuccessResult {
                     matched_subject_ty,
-                    stable_subject_ty: matched_subject_ty,
+                    binding_subject_ty: matched_subject_ty,
                     bindings: BTreeMap::new(),
                 }
             }
@@ -1430,7 +1430,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     .intersect_types(subject_ty, necessary_match_pattern_type(self.db, pattern));
                 PatternSuccessResult {
                     matched_subject_ty,
-                    stable_subject_ty: matched_subject_ty,
+                    binding_subject_ty: matched_subject_ty,
                     bindings: BTreeMap::new(),
                 }
             }
@@ -1520,15 +1520,15 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let Some(first_pattern) = patterns.next() else {
             return PatternSuccessResult {
                 matched_subject_ty: Type::Never,
-                stable_subject_ty: Type::Never,
+                binding_subject_ty: Type::Never,
                 bindings: BTreeMap::new(),
             };
         };
         let first = self.analyze_successful_pattern(first_pattern, subject_ty);
         let mut matched_subject_types = UnionBuilder::new(self.db);
         matched_subject_types.add_in_place(first.matched_subject_ty);
-        let mut stable_subject_types = UnionBuilder::new(self.db);
-        stable_subject_types.add_in_place(first.stable_subject_ty);
+        let mut binding_subject_types = UnionBuilder::new(self.db);
+        binding_subject_types.add_in_place(first.binding_subject_ty);
         // All alternatives bind the same names. Merge by logical place so the case body sees the
         // union even though the semantic walk visits the definitions in order.
         let mut bindings = first.bindings;
@@ -1545,14 +1545,14 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             };
             let alternative = self.analyze_successful_pattern(pattern, remaining_subject_ty);
             matched_subject_types.add_in_place(alternative.matched_subject_ty);
-            stable_subject_types.add_in_place(alternative.stable_subject_ty);
+            binding_subject_types.add_in_place(alternative.binding_subject_ty);
             Self::merge_bindings(&mut bindings, alternative.bindings);
             previous_pattern = pattern;
         }
 
         PatternSuccessResult {
             matched_subject_ty: matched_subject_types.build(),
-            stable_subject_ty: stable_subject_types.build(),
+            binding_subject_ty: binding_subject_types.build(),
             bindings,
         }
     }
@@ -1659,14 +1659,14 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 analyzer.sequence_pattern_arm(subject_ty, target_len, sequence_ty)?;
             let mut bindings = BTreeMap::new();
             let mut matched_element_types = Vec::with_capacity(kind.patterns.len());
-            let mut stable_element_types = Vec::with_capacity(kind.patterns.len());
+            let mut binding_element_types = Vec::with_capacity(kind.patterns.len());
             for (pattern, element_ty) in kind.patterns.iter().zip(element_types) {
                 let mut child = analyzer.analyze_successful_pattern(pattern, element_ty);
                 if child.matched_subject_ty.is_never() {
                     return None;
                 }
                 matched_element_types.push(child.matched_subject_ty);
-                stable_element_types.push(child.stable_subject_ty);
+                binding_element_types.push(child.binding_subject_ty);
                 Self::demote_subject_bindings(&mut child.bindings);
                 Self::merge_bindings(&mut bindings, child.bindings);
             }
@@ -1676,20 +1676,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 narrowed_subject_ty,
                 &matched_element_types,
             );
-            let stable_subject_ty = if subject_ty.exact_tuple_instance_spec(analyzer.db).is_some() {
-                analyzer.intersect_types(
-                    subject_ty,
-                    analyzer.successful_sequence_pattern_type(kind, &stable_element_types),
-                )
-            } else {
-                analyzer.intersect_types(
-                    subject_ty,
-                    sequence_pattern_type_builder(analyzer.db).build(),
-                )
-            };
+            let binding_subject_ty =
+                analyzer.successful_sequence_binding_type(kind, subject_ty, &binding_element_types);
             Some(PatternSuccessResult {
                 matched_subject_ty,
-                stable_subject_ty,
+                binding_subject_ty,
                 bindings,
             })
         })
@@ -1697,8 +1688,9 @@ impl<'db> PatternSuccessAnalyzer<'db> {
 
     /// Return the type established while a sequence pattern is being evaluated.
     ///
-    /// Exact tuples can also use the types established by successful child patterns. For mutable
-    /// sequences, those child types are not retained after the pattern has finished evaluating.
+    /// Exact tuples can refine their tuple element types with the facts established by successful
+    /// child patterns. Other sequences retain the structural constraints already present in
+    /// `narrowed_subject_ty`.
     fn successful_sequence_subject_type(
         &self,
         kind: &SequencePatternPredicateKind<'db>,
@@ -1713,6 +1705,28 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             )
         } else {
             narrowed_subject_ty
+        }
+    }
+
+    /// Return the sequence type safe to assign to a binding created by the pattern.
+    ///
+    /// An exact tuple encodes immutable length and element types, so it can retain facts established
+    /// by successful child patterns. Other sequence types retain only sequence-pattern eligibility;
+    /// observed length and indexed element facts could become stale after mutation or stateful
+    /// access.
+    fn successful_sequence_binding_type(
+        &self,
+        kind: &SequencePatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+        binding_element_types: &[Type<'db>],
+    ) -> Type<'db> {
+        if subject_ty.exact_tuple_instance_spec(self.db).is_some() {
+            self.intersect_types(
+                subject_ty,
+                self.successful_sequence_pattern_type(kind, binding_element_types),
+            )
+        } else {
+            self.intersect_types(subject_ty, sequence_pattern_type_builder(self.db).build())
         }
     }
 
@@ -1772,18 +1786,18 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             .into_iter()
             .chunk_by(|(original_subject_ty, _)| *original_subject_ty);
         let mut matched_subject_types = UnionBuilder::new(self.db);
-        let mut stable_subject_types = UnionBuilder::new(self.db);
+        let mut binding_subject_types = UnionBuilder::new(self.db);
         let mut bindings = BTreeMap::new();
 
         for (original_subject_ty, arms) in &grouped_arms {
             let mut matched_types = UnionBuilder::new(self.db);
-            let mut stable_types = UnionBuilder::new(self.db);
+            let mut binding_types = UnionBuilder::new(self.db);
             let mut arm_bindings = BTreeMap::new();
 
             for (_, filtering_subject_ty) in arms {
                 if let Some(arm) = analyze_arm(self, filtering_subject_ty) {
                     matched_types.add_in_place(arm.matched_subject_ty);
-                    stable_types.add_in_place(arm.stable_subject_ty);
+                    binding_types.add_in_place(arm.binding_subject_ty);
                     Self::merge_bindings(&mut arm_bindings, arm.bindings);
                 }
             }
@@ -1801,14 +1815,14 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             matched_subject_types.add_in_place(
                 self.matched_subject_type_for_original(original_subject_ty, matched_types.build()),
             );
-            stable_subject_types.add_in_place(
-                self.matched_subject_type_for_original(original_subject_ty, stable_types.build()),
+            binding_subject_types.add_in_place(
+                self.matched_subject_type_for_original(original_subject_ty, binding_types.build()),
             );
         }
 
         PatternSuccessResult {
             matched_subject_ty: matched_subject_types.build(),
-            stable_subject_ty: stable_subject_types.build(),
+            binding_subject_ty: binding_subject_types.build(),
             bindings,
         }
     }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -321,7 +321,13 @@ impl<'db> PatternSuccessTypes<'db> {
 /// The pattern produces `Never` for the matched subject and commits no `item` binding, because the
 /// second element prevents the complete sequence pattern from matching.
 struct PatternSuccessResult<'db> {
+    /// The type established while this pattern is being evaluated.
     matched_subject_ty: Type<'db>,
+    /// The type that remains valid after the pattern has finished evaluating.
+    ///
+    /// These differ for mutable sequences: a sequence pattern temporarily establishes its length
+    /// and indexed element types, but later mutation can invalidate those facts.
+    stable_subject_ty: Type<'db>,
     bindings: BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
 }
 
@@ -1342,6 +1348,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 let mut result = pattern.as_deref().map_or_else(
                     || PatternSuccessResult {
                         matched_subject_ty: subject_ty,
+                        stable_subject_ty: subject_ty,
                         bindings: BTreeMap::new(),
                     },
                     |pattern| self.analyze_successful_pattern(pattern, subject_ty),
@@ -1353,7 +1360,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     Self::merge_binding(
                         &mut result.bindings,
                         place.into(),
-                        PatternBindingTypes::subject(result.matched_subject_ty),
+                        PatternBindingTypes::subject(result.stable_subject_ty),
                     );
                 }
                 result
@@ -1368,30 +1375,37 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 }
                 PatternSuccessResult {
                     matched_subject_ty: subject_ty,
+                    stable_subject_ty: subject_ty,
                     bindings,
                 }
             }
-            PatternPredicateKind::Value(value) => PatternSuccessResult {
-                matched_subject_ty: self.match_value_pattern_subject_type(*value, subject_ty),
-                bindings: BTreeMap::new(),
-            },
+            PatternPredicateKind::Value(value) => {
+                let matched_subject_ty = self.match_value_pattern_subject_type(*value, subject_ty);
+                PatternSuccessResult {
+                    matched_subject_ty,
+                    stable_subject_ty: matched_subject_ty,
+                    bindings: BTreeMap::new(),
+                }
+            }
             PatternPredicateKind::Class(class_expr, _) => {
                 let class_ty = necessary_match_pattern_type(self.db, pattern);
                 let class =
                     infer_same_file_expression_type(self.db, *class_expr, TypeContext::default())
                         .as_class_literal();
+                let matched_subject_ty =
+                    self.match_class_pattern_subject_type(class, class_ty, subject_ty, false);
                 PatternSuccessResult {
-                    matched_subject_ty: self
-                        .match_class_pattern_subject_type(class, class_ty, subject_ty, false),
+                    matched_subject_ty,
+                    stable_subject_ty: matched_subject_ty,
                     bindings: BTreeMap::new(),
                 }
             }
             PatternPredicateKind::Mapping(_) | PatternPredicateKind::Singleton(_) => {
+                let matched_subject_ty = self
+                    .intersect_types(subject_ty, necessary_match_pattern_type(self.db, pattern));
                 PatternSuccessResult {
-                    matched_subject_ty: self.intersect_types(
-                        subject_ty,
-                        necessary_match_pattern_type(self.db, pattern),
-                    ),
+                    matched_subject_ty,
+                    stable_subject_ty: matched_subject_ty,
                     bindings: BTreeMap::new(),
                 }
             }
@@ -1453,12 +1467,15 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let Some(first_pattern) = patterns.next() else {
             return PatternSuccessResult {
                 matched_subject_ty: Type::Never,
+                stable_subject_ty: Type::Never,
                 bindings: BTreeMap::new(),
             };
         };
         let first = self.analyze_successful_pattern(first_pattern, subject_ty);
         let mut matched_subject_types = UnionBuilder::new(self.db);
         matched_subject_types.add_in_place(first.matched_subject_ty);
+        let mut stable_subject_types = UnionBuilder::new(self.db);
+        stable_subject_types.add_in_place(first.stable_subject_ty);
         // All alternatives bind the same names. Merge by logical place so the case body sees the
         // union even though the semantic walk visits the definitions in order.
         let mut bindings = first.bindings;
@@ -1481,12 +1498,14 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 .build();
             let alternative = self.analyze_successful_pattern(pattern, remaining_subject_ty);
             matched_subject_types.add_in_place(alternative.matched_subject_ty);
+            stable_subject_types.add_in_place(alternative.stable_subject_ty);
             Self::merge_bindings(&mut bindings, alternative.bindings);
             previous_pattern = pattern;
         }
 
         PatternSuccessResult {
             matched_subject_ty: matched_subject_types.build(),
+            stable_subject_ty: stable_subject_types.build(),
             bindings,
         }
     }
@@ -1593,12 +1612,14 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 analyzer.sequence_pattern_arm(subject_ty, target_len, sequence_ty)?;
             let mut bindings = BTreeMap::new();
             let mut matched_element_types = Vec::with_capacity(kind.patterns.len());
+            let mut stable_element_types = Vec::with_capacity(kind.patterns.len());
             for (pattern, element_ty) in kind.patterns.iter().zip(element_types) {
                 let mut child = analyzer.analyze_successful_pattern(pattern, element_ty);
                 if child.matched_subject_ty.is_never() {
                     return None;
                 }
                 matched_element_types.push(child.matched_subject_ty);
+                stable_element_types.push(child.stable_subject_ty);
                 Self::demote_subject_bindings(&mut child.bindings);
                 Self::merge_bindings(&mut bindings, child.bindings);
             }
@@ -1608,17 +1629,29 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 narrowed_subject_ty,
                 &matched_element_types,
             );
+            let stable_subject_ty = if subject_ty.exact_tuple_instance_spec(analyzer.db).is_some() {
+                analyzer.intersect_types(
+                    subject_ty,
+                    analyzer.successful_sequence_pattern_type(kind, &stable_element_types),
+                )
+            } else {
+                analyzer.intersect_types(
+                    subject_ty,
+                    sequence_pattern_type_builder(analyzer.db).build(),
+                )
+            };
             Some(PatternSuccessResult {
                 matched_subject_ty,
+                stable_subject_ty,
                 bindings,
             })
         })
     }
 
-    /// Refine a fixed tuple using the types that matched its child patterns.
+    /// Return the type established while a sequence pattern is being evaluated.
     ///
-    /// Mutable sequences keep only the type established before matching the children because a
-    /// later mutation can invalidate facts about individual elements.
+    /// Exact tuples can also use the types established by successful child patterns. For mutable
+    /// sequences, those child types are not retained after the pattern has finished evaluating.
     fn successful_sequence_subject_type(
         &self,
         kind: &SequencePatternPredicateKind<'db>,
@@ -1669,12 +1702,14 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             return None;
         }
 
-        let tuple = subject_ty
-            .try_iterate(self.db)
-            .or_else(|_| narrowed_subject_ty.try_iterate(self.db))
-            .unwrap_or_else(|error| {
-                Cow::Owned(Tuple::homogeneous(error.fallback_element_type(self.db)))
-            });
+        let tuple = subject_ty.try_iterate(self.db).unwrap_or_else(|error| {
+            let fallback_element_ty = error.fallback_element_type(self.db);
+            Cow::Owned(Tuple::homogeneous(if fallback_element_ty.is_unknown() {
+                Type::object()
+            } else {
+                fallback_element_ty
+            }))
+        });
         let mut unpacker = TupleUnpacker::new(self.db, target_len);
         unpacker.unpack_tuple(tuple.as_ref()).ok()?;
         Some((narrowed_subject_ty, unpacker.into_types().collect()))
@@ -1690,15 +1725,18 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             .into_iter()
             .chunk_by(|(original_subject_ty, _)| *original_subject_ty);
         let mut matched_subject_types = UnionBuilder::new(self.db);
+        let mut stable_subject_types = UnionBuilder::new(self.db);
         let mut bindings = BTreeMap::new();
 
         for (original_subject_ty, arms) in &grouped_arms {
             let mut matched_types = UnionBuilder::new(self.db);
+            let mut stable_types = UnionBuilder::new(self.db);
             let mut arm_bindings = BTreeMap::new();
 
             for (_, filtering_subject_ty) in arms {
                 if let Some(arm) = analyze_arm(self, filtering_subject_ty) {
                     matched_types.add_in_place(arm.matched_subject_ty);
+                    stable_types.add_in_place(arm.stable_subject_ty);
                     Self::merge_bindings(&mut arm_bindings, arm.bindings);
                 }
             }
@@ -1716,10 +1754,14 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             matched_subject_types.add_in_place(
                 self.matched_subject_type_for_original(original_subject_ty, matched_types.build()),
             );
+            stable_subject_types.add_in_place(
+                self.matched_subject_type_for_original(original_subject_ty, stable_types.build()),
+            );
         }
 
         PatternSuccessResult {
             matched_subject_ty: matched_subject_types.build(),
+            stable_subject_ty: stable_subject_types.build(),
             bindings,
         }
     }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -331,18 +331,35 @@ struct PatternSuccessResult<'db> {
     bindings: BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
 }
 
+/// The candidate types for one name bound by a successful pattern.
+///
+/// Contributions from distinct subject or `or`-pattern arms remain separate until captures that
+/// alias the current subject have been restored to the original subject type:
+///
+/// ```python
+/// match value:
+///     case [item] as whole:
+///         ...
+/// ```
+///
+/// Here, `whole` aliases the subject, while `item` refers to a value extracted from it. Keeping
+/// that distinction prevents `item` from being restored as if it referred to `value`.
 #[derive(Clone)]
 struct PatternBindingTypes<'db> {
     contributions: SmallVec<[PatternBindingType<'db>; 2]>,
 }
 
+/// One successful pattern arm's contribution to a binding type.
 #[derive(Clone, Copy)]
 struct PatternBindingType<'db> {
+    /// The type inferred for the binding in this arm.
     ty: Type<'db>,
+    /// Whether the binding aliases the subject at the current level of pattern analysis.
     aliases_subject: bool,
 }
 
 impl<'db> PatternBindingTypes<'db> {
+    /// Create a binding that aliases the current subject.
     fn subject(subject_ty: Type<'db>) -> Self {
         Self {
             contributions: smallvec![PatternBindingType {
@@ -352,20 +369,24 @@ impl<'db> PatternBindingTypes<'db> {
         }
     }
 
+    /// Return the union of all contributions to this binding.
     fn ty(&self, db: &'db dyn Db) -> Type<'db> {
         UnionType::from_elements(db, self.contributions.iter().map(|binding| binding.ty))
     }
 
+    /// Mark every contribution as referring to a value extracted from the current subject.
     fn demote_subject(&mut self) {
         for contribution in &mut self.contributions {
             contribution.aliases_subject = false;
         }
     }
 
+    /// Add the contributions from another successful pattern arm.
     fn merge(&mut self, other: Self) {
         self.contributions.extend(other.contributions);
     }
 
+    /// Return the union of the contributions that alias the current subject.
     fn subject_ty(&self, db: &'db dyn Db) -> Type<'db> {
         UnionType::from_elements(
             db,
@@ -376,6 +397,9 @@ impl<'db> PatternBindingTypes<'db> {
         )
     }
 
+    /// Replace all subject-aliasing contributions with one restored subject type.
+    ///
+    /// Contributions for extracted values remain unchanged.
     fn restore_subject(&mut self, restored_subject_ty: Type<'db>) {
         let mut restored = false;
         self.contributions.retain_mut(|contribution| {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -15,9 +15,9 @@ use crate::types::{
     CallableType, ClassLiteral, ClassType, IntersectionBuilder, IntersectionType, KnownClass,
     KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature, SpecialFormType,
     SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionBuilder, callable_pattern_type, definite_match_pattern_type_for_subject,
-    definite_sequence_pattern_type, exact_sequence_pattern_type, infer_expression_types,
-    mapping_pattern_type, sequence_pattern_type_builder, singleton_pattern_type,
+    UnionBuilder, callable_pattern_type, definite_sequence_pattern_type,
+    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
+    pattern_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
     starred_sequence_pattern_type,
 };
 use ty_python_core::expression::Expression;
@@ -1512,21 +1512,13 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let mut previous_pattern = first_pattern;
 
         for pattern in patterns {
-            let definitely_matched_ty = if Self::contains_class_pattern(previous_pattern) {
+            remaining_subject_ty = if Self::contains_class_pattern(previous_pattern) {
                 // Attribute extraction can still fail after the runtime class check. The next PR
                 // refines this with subject-aware class-pattern exhaustiveness.
-                Type::Never
+                remaining_subject_ty
             } else {
-                definite_match_pattern_type_for_subject(
-                    self.db,
-                    previous_pattern,
-                    remaining_subject_ty,
-                )
+                pattern_fallthrough_type(self.db, previous_pattern, remaining_subject_ty)
             };
-            remaining_subject_ty = IntersectionBuilder::new(self.db)
-                .add_positive(remaining_subject_ty)
-                .add_negative(definitely_matched_ty)
-                .build();
             let alternative = self.analyze_successful_pattern(pattern, remaining_subject_ty);
             matched_subject_types.add_in_place(alternative.matched_subject_ty);
             stable_subject_types.add_in_place(alternative.stable_subject_ty);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,10 +1,13 @@
+use std::borrow::Cow;
+use std::collections::{BTreeMap, btree_map::Entry as BTreeEntry, hash_map::Entry};
+
 use crate::Db;
-use crate::reachability::narrow_type_by_constraint;
+use crate::reachability::{narrow_type_by_constraint, type_narrowed_by_previous_patterns};
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
 use crate::types::special_form::TypeQualifier;
-use crate::types::tuple::{TupleLength, TupleType};
+use crate::types::tuple::{Tuple, TupleLength, TupleType, TupleUnpacker};
 use crate::types::typed_dict::{
     TypedDictField, TypedDictFieldBuilder, TypedDictSchema, TypedDictType,
 };
@@ -12,11 +15,13 @@ use crate::types::{
     CallableType, ClassLiteral, ClassType, IntersectionBuilder, IntersectionType, KnownClass,
     KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature, SpecialFormType,
     SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionBuilder, callable_pattern_type, definite_sequence_pattern_type,
-    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
-    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
+    UnionBuilder, callable_pattern_type, definite_match_pattern_type,
+    definite_sequence_pattern_type, exact_sequence_pattern_type, infer_expression_types,
+    mapping_pattern_type, sequence_pattern_type_builder, singleton_pattern_type,
+    starred_sequence_pattern_type,
 };
 use ty_python_core::expression::Expression;
+use ty_python_core::frozen::FrozenMap;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
 use ty_python_core::predicate::{
     CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
@@ -37,8 +42,6 @@ use ruff_python_ast as ast;
 use ruff_python_ast::{BoolOp, ExprBoolOp};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec, smallvec_inline};
-use std::collections::hash_map::Entry;
-use ty_python_core::frozen::FrozenMap;
 
 fn is_union_of_single_valued<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     let ty = ty.resolve_type_alias(db);
@@ -258,6 +261,117 @@ fn all_narrowing_constraints_for_subject_element_pattern<'db>(
         true,
     )
     .finish()
+}
+
+/// The types produced when a match pattern succeeds.
+///
+/// This positive structural analysis infers the type of each supported name bound by a successful
+/// pattern. Definite-match analysis, which is used for negative narrowing and exhaustiveness,
+/// intentionally remains separate.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct PatternSuccessTypes<'db> {
+    bindings: FrozenMap<ScopedPlaceId, Type<'db>>,
+    missing_binding_ty: Type<'db>,
+}
+
+impl<'db> PatternSuccessTypes<'db> {
+    /// Return the inferred binding type.
+    ///
+    /// A missing entry is `Never` when the whole pattern cannot match and `Unknown` when the
+    /// analysis does not support that binding. During cycle recovery, it is the divergent type for
+    /// that cycle.
+    pub(crate) fn binding_type(&self, place: ScopedPlaceId) -> Type<'db> {
+        // An OR pattern's alternatives define one runtime binding, so their types are merged by
+        // place.
+        self.bindings
+            .get(&place)
+            .copied()
+            .unwrap_or(self.missing_binding_ty)
+    }
+
+    fn cycle_initial(missing_binding_ty: Type<'db>) -> Self {
+        Self {
+            bindings: FrozenMap::default(),
+            missing_binding_ty,
+        }
+    }
+
+    fn cycle_normalized(mut self, db: &'db dyn Db, previous: &Self, cycle: &salsa::Cycle) -> Self {
+        for (place, ty) in &mut self.bindings {
+            *ty = ty.cycle_normalized(db, previous.binding_type(*place), cycle);
+        }
+        self.missing_binding_ty =
+            self.missing_binding_ty
+                .cycle_normalized(db, previous.missing_binding_ty, cycle);
+        self
+    }
+}
+
+/// The types produced by one pattern node when that complete node succeeds.
+///
+/// Bindings are transactional:
+///
+/// ```python
+/// def f(value: tuple[str, str]) -> None:
+///     match value:
+///         case [item, int()]:
+///             ...
+/// ```
+///
+/// The pattern produces `Never` for the matched subject and commits no `item` binding, because the
+/// second element prevents the complete sequence pattern from matching.
+struct PatternSuccessResult<'db> {
+    matched_subject_ty: Type<'db>,
+    bindings: BTreeMap<ScopedPlaceId, Type<'db>>,
+}
+
+/// Computes the subject and binding types produced by successful match patterns.
+///
+/// Structural patterns pass the type of each extracted value to their child patterns. Results from
+/// a subject union are combined only after each complete union arm has been checked.
+struct PatternSuccessAnalyzer<'db> {
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+}
+
+/// Infer the types of all names bound when `pattern` succeeds.
+///
+/// The subject starts with its inferred type after removing values definitely matched by earlier
+/// unguarded cases. The analysis then checks the complete pattern before recording any bindings:
+///
+/// ```python
+/// def f(value: int | str) -> None:
+///     match value:
+///         case int():
+///             pass
+///         case item:
+///             reveal_type(item)  # str
+/// ```
+#[salsa::tracked(
+    returns(ref),
+    cycle_initial=|_, id, _| PatternSuccessTypes::cycle_initial(Type::divergent(id)),
+    cycle_fn=|db, cycle, previous: &PatternSuccessTypes<'db>, result: PatternSuccessTypes<'db>, _| {
+        result.cycle_normalized(db, previous, cycle)
+    },
+    heap_size=ruff_memory_usage::heap_size
+)]
+pub(crate) fn pattern_success_types<'db>(
+    db: &'db dyn Db,
+    pattern: PatternPredicate<'db>,
+) -> PatternSuccessTypes<'db> {
+    let subject = pattern.subject(db);
+    let incoming_subject_ty = infer_same_file_expression_type(db, subject, TypeContext::default());
+    let incoming_subject_ty = type_narrowed_by_previous_patterns(db, pattern, incoming_subject_ty);
+    let analyzer = PatternSuccessAnalyzer::new(db, pattern.scope(db));
+    let result = analyzer.analyze_successful_pattern(pattern.kind(db), incoming_subject_ty);
+    PatternSuccessTypes {
+        bindings: FrozenMap::from(result.bindings),
+        missing_binding_ty: if result.matched_subject_ty.is_never() {
+            Type::Never
+        } else {
+            Type::unknown()
+        },
+    }
 }
 
 /// Functions that can be used to narrow the type of a first argument using a "classinfo" second argument.
@@ -804,6 +918,97 @@ fn is_exact_membership_value_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool
     ty == Type::Never || ty.is_single_valued(db)
 }
 
+/// Return the type established by a successful class pattern.
+///
+/// This also handles indirect class expressions such as `PatternClass: type[A]`. It is only a
+/// positive constraint: failing to match `PatternClass()` does not exclude every `A`, because the
+/// value of `PatternClass` may be a subclass of `A`.
+fn positive_class_pattern_type<'db>(
+    db: &'db dyn Db,
+    class_expression_ty: Type<'db>,
+) -> Option<Type<'db>> {
+    match class_expression_ty {
+        Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
+            Some(callable_pattern_type(db))
+        }
+        _ if class_expression_ty.is_assignable_to(db, KnownClass::Type.to_instance(db)) => {
+            ClassInfoConstraintFunction::IsInstance.generate_constraint(
+                db,
+                class_expression_ty,
+                true,
+            )
+        }
+        _ => None,
+    }
+}
+
+/// Return a type that contains every value that can match `pattern`.
+///
+/// For example, given:
+///
+/// ```python
+/// def f(x: list[object]):
+///     match x:
+///         case [int(real=0)]:
+///             reveal_type(x)
+/// ```
+///
+/// Every `x` that matches `[int(real=0)]` must be a one-element sequence
+/// containing an `int`. We can represent this information in the returned
+/// type; however, that type omits the `real=0` constraint, and so includes
+/// values like `[1]`, which do not match the pattern. In other words, the
+/// returned type may include values that do not match, but it must include
+/// every value that does.
+fn necessary_match_pattern_type<'db>(
+    db: &'db dyn Db,
+    pattern: &PatternPredicateKind<'db>,
+) -> Type<'db> {
+    match pattern {
+        PatternPredicateKind::Singleton(singleton) => singleton_pattern_type(db, *singleton),
+        PatternPredicateKind::Class(cls, _) => positive_class_pattern_type(
+            db,
+            infer_same_file_expression_type(db, *cls, TypeContext::default()),
+        )
+        .unwrap_or_else(Type::object),
+        PatternPredicateKind::Mapping(_) => mapping_pattern_type(db),
+        PatternPredicateKind::Sequence(kind) => necessary_sequence_pattern_type(db, kind),
+        PatternPredicateKind::Or(predicates) => UnionType::from_elements(
+            db,
+            predicates
+                .iter()
+                .map(|predicate| necessary_match_pattern_type(db, predicate)),
+        ),
+        PatternPredicateKind::As(pattern, _) => pattern
+            .as_deref()
+            .map(|pattern| necessary_match_pattern_type(db, pattern))
+            .unwrap_or_else(Type::object),
+        PatternPredicateKind::Value(_) | PatternPredicateKind::Star(_) => Type::object(),
+    }
+}
+
+/// Preserve the sequence element constraints that can be addressed at fixed indices.
+fn necessary_sequence_pattern_type<'db>(
+    db: &'db dyn Db,
+    kind: &SequencePatternPredicateKind<'db>,
+) -> Type<'db> {
+    if let Some((prefix_patterns, suffix_patterns)) = kind.split_around_star() {
+        let prefix_element_types = prefix_patterns
+            .iter()
+            .map(|pattern| necessary_match_pattern_type(db, pattern));
+        let suffix_element_types = suffix_patterns
+            .iter()
+            .map(|pattern| necessary_match_pattern_type(db, pattern));
+
+        starred_sequence_pattern_type(db, prefix_element_types, suffix_element_types)
+    } else {
+        let element_types = kind
+            .patterns
+            .iter()
+            .map(|pattern| necessary_match_pattern_type(db, pattern));
+        exact_sequence_pattern_type(db, element_types)
+    }
+}
+
 struct NarrowingConstraintsBuilder<'db, 'ast> {
     db: &'db dyn Db,
     module: &'ast ParsedModuleRef,
@@ -988,7 +1193,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PatternPredicateKind::As(Some(pattern), _) => {
                 self.evaluate_pattern_predicate_kind(pattern, subject, is_positive)
             }
-            PatternPredicateKind::As(None, _) | PatternPredicateKind::MatchStar => {
+            PatternPredicateKind::As(None, _) | PatternPredicateKind::Star(_) => {
                 PatternNarrowingResult::Possible(None)
             }
         }
@@ -999,14 +1204,522 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         pattern: PatternPredicate<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        self.evaluate_pattern_predicate_kind(
-            pattern.kind(self.db),
-            pattern.subject(self.db),
-            is_positive,
-        )
-        .into_constraints()
+        let kind = pattern.kind(self.db);
+        let subject = pattern.subject(self.db);
+        self.evaluate_pattern_predicate_kind(kind, subject, is_positive)
+            .into_constraints()
+    }
+}
+
+impl<'db> PatternSuccessAnalyzer<'db> {
+    fn new(db: &'db dyn Db, scope: ScopeId<'db>) -> Self {
+        Self { db, scope }
     }
 
+    fn merge_binding(
+        &self,
+        bindings: &mut BTreeMap<ScopedPlaceId, Type<'db>>,
+        place: ScopedPlaceId,
+        ty: Type<'db>,
+    ) {
+        match bindings.entry(place) {
+            BTreeEntry::Occupied(mut entry) => {
+                *entry.get_mut() = UnionType::from_elements(self.db, [*entry.get(), ty]);
+            }
+            BTreeEntry::Vacant(entry) => {
+                entry.insert(ty);
+            }
+        }
+    }
+
+    fn merge_bindings(
+        &self,
+        into: &mut BTreeMap<ScopedPlaceId, Type<'db>>,
+        from: BTreeMap<ScopedPlaceId, Type<'db>>,
+    ) {
+        for (place, ty) in from {
+            self.merge_binding(into, place, ty);
+        }
+    }
+
+    /// Compute the subject and binding types produced by a successful pattern.
+    ///
+    /// `subject_ty` is the type of the value reaching this pattern node. Structural patterns
+    /// determine the type reaching each child before recursively recording that child's bindings:
+    ///
+    /// ```python
+    /// def f(value: tuple[int, str, bool]) -> None:
+    ///     match value:
+    ///         case [first, *rest]:
+    ///             reveal_type(first)  # int
+    ///             reveal_type(rest)  # list[str | bool]
+    /// ```
+    ///
+    /// A failed pattern binds no names. For an `or` pattern, each later alternative sees only the
+    /// values not definitely matched by an earlier alternative.
+    fn analyze_successful_pattern(
+        &self,
+        pattern: &PatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> PatternSuccessResult<'db> {
+        match pattern {
+            PatternPredicateKind::Sequence(kind) => {
+                self.analyze_successful_sequence_pattern(kind, subject_ty)
+            }
+            PatternPredicateKind::Or(patterns) => {
+                self.analyze_successful_or_pattern(patterns, subject_ty)
+            }
+            PatternPredicateKind::As(pattern, name) => {
+                let mut result = pattern.as_deref().map_or_else(
+                    || PatternSuccessResult {
+                        matched_subject_ty: subject_ty,
+                        bindings: BTreeMap::new(),
+                    },
+                    |pattern| self.analyze_successful_pattern(pattern, subject_ty),
+                );
+                if let Some(place) = name
+                    .as_ref()
+                    .and_then(|name| self.places().symbol_id(name.as_str()))
+                {
+                    self.merge_binding(
+                        &mut result.bindings,
+                        place.into(),
+                        result.matched_subject_ty,
+                    );
+                }
+                result
+            }
+            PatternPredicateKind::Star(name) => {
+                let mut bindings = BTreeMap::new();
+                if let Some(place) = name
+                    .as_ref()
+                    .and_then(|name| self.places().symbol_id(name.as_str()))
+                {
+                    bindings.insert(place.into(), subject_ty);
+                }
+                PatternSuccessResult {
+                    matched_subject_ty: subject_ty,
+                    bindings,
+                }
+            }
+            PatternPredicateKind::Value(value) => PatternSuccessResult {
+                matched_subject_ty: self.match_value_pattern_subject_type(*value, subject_ty),
+                bindings: BTreeMap::new(),
+            },
+            PatternPredicateKind::Class(class_expr, _) => {
+                let class_ty = necessary_match_pattern_type(self.db, pattern);
+                let class =
+                    infer_same_file_expression_type(self.db, *class_expr, TypeContext::default())
+                        .as_class_literal();
+                PatternSuccessResult {
+                    matched_subject_ty: self
+                        .match_class_pattern_subject_type(class, class_ty, subject_ty, false),
+                    bindings: BTreeMap::new(),
+                }
+            }
+            PatternPredicateKind::Mapping(_) | PatternPredicateKind::Singleton(_) => {
+                PatternSuccessResult {
+                    matched_subject_ty: self.intersect_types(
+                        subject_ty,
+                        necessary_match_pattern_type(self.db, pattern),
+                    ),
+                    bindings: BTreeMap::new(),
+                }
+            }
+        }
+    }
+
+    /// Return the type of the subject when a value pattern succeeds.
+    ///
+    /// A value pattern uses Python equality, so a successful match does not always narrow to the
+    /// type of the value in the pattern:
+    ///
+    /// ```python
+    /// def f(target: int | str) -> None:
+    ///     match target:
+    ///         case 1 as item:
+    ///             reveal_type(item)  # int | str
+    /// ```
+    ///
+    /// The `str` arm remains because a `str` subclass can compare equal to `1`.
+    fn match_value_pattern_subject_type(
+        &self,
+        value: Expression<'db>,
+        subject_ty: Type<'db>,
+    ) -> Type<'db> {
+        let value_ty = infer_same_file_expression_type(self.db, value, TypeContext::default());
+        evaluate_type_equality(self.db, subject_ty, value_ty, true)
+            .map(|constraint| self.intersect_types(subject_ty, constraint))
+            .unwrap_or(subject_ty)
+    }
+
+    fn contains_class_pattern(pattern: &PatternPredicateKind<'_>) -> bool {
+        match pattern {
+            PatternPredicateKind::Class(..) => true,
+            PatternPredicateKind::Sequence(kind) => {
+                kind.patterns.iter().any(Self::contains_class_pattern)
+            }
+            PatternPredicateKind::Or(patterns) => patterns.iter().any(Self::contains_class_pattern),
+            PatternPredicateKind::As(Some(pattern), _) => Self::contains_class_pattern(pattern),
+            _ => false,
+        }
+    }
+
+    fn analyze_successful_or_pattern(
+        &self,
+        patterns: &[PatternPredicateKind<'db>],
+        subject_ty: Type<'db>,
+    ) -> PatternSuccessResult<'db> {
+        self.analyze_pattern_subject_arms(subject_ty, |analyzer, subject_ty| {
+            Some(analyzer.analyze_successful_or_pattern_arm(patterns, subject_ty))
+        })
+    }
+
+    fn analyze_successful_or_pattern_arm(
+        &self,
+        patterns: &[PatternPredicateKind<'db>],
+        subject_ty: Type<'db>,
+    ) -> PatternSuccessResult<'db> {
+        let mut patterns = patterns.iter();
+        let Some(first_pattern) = patterns.next() else {
+            return PatternSuccessResult {
+                matched_subject_ty: Type::Never,
+                bindings: BTreeMap::new(),
+            };
+        };
+        let first = self.analyze_successful_pattern(first_pattern, subject_ty);
+        let mut matched_subject_types = UnionBuilder::new(self.db);
+        matched_subject_types.add_in_place(first.matched_subject_ty);
+        // All alternatives bind the same names. Merge by logical place so the case body sees the
+        // union even though the semantic walk visits the definitions in order.
+        let mut bindings = first.bindings;
+        let mut remaining_subject_ty = subject_ty;
+        let mut previous_pattern = first_pattern;
+
+        for pattern in patterns {
+            let definitely_matched_ty = if Self::contains_class_pattern(previous_pattern) {
+                // A class pattern can fail after its runtime type check, for example when a
+                // protocol member is only declared but is absent at runtime. Without the subject
+                // type, `definite_match_pattern_type` cannot distinguish those cases, so leave the
+                // later alternative intact.
+                Type::Never
+            } else {
+                definite_match_pattern_type(self.db, previous_pattern)
+            };
+            remaining_subject_ty = IntersectionBuilder::new(self.db)
+                .add_positive(remaining_subject_ty)
+                .add_negative(definitely_matched_ty)
+                .build();
+            let alternative = self.analyze_successful_pattern(pattern, remaining_subject_ty);
+            matched_subject_types.add_in_place(alternative.matched_subject_ty);
+            self.merge_bindings(&mut bindings, alternative.bindings);
+            previous_pattern = pattern;
+        }
+
+        PatternSuccessResult {
+            matched_subject_ty: matched_subject_types.build(),
+            bindings,
+        }
+    }
+
+    /// Narrow a class-pattern binding while keeping the original type arguments and aliases.
+    ///
+    /// For example, `children` keeps the recursive element type from `Node` instead of becoming a
+    /// broad `list` type:
+    ///
+    /// ```python
+    /// type Node = int | list[Node]
+    ///
+    /// def visit(node: Node) -> None:
+    ///     match node:
+    ///         case list() as children:
+    ///             for child in children:
+    ///                 visit(child)
+    /// ```
+    fn match_class_pattern_subject_type(
+        &self,
+        class: Option<ClassLiteral<'db>>,
+        class_ty: Type<'db>,
+        subject_ty: Type<'db>,
+        filter_nominal_arms: bool,
+    ) -> Type<'db> {
+        match subject_ty {
+            Type::TypeAlias(alias) => self.match_class_pattern_subject_type(
+                class,
+                class_ty,
+                alias.value_type(self.db),
+                true,
+            ),
+            Type::Union(union) => union.map(self.db, |element| {
+                self.match_class_pattern_subject_type(class, class_ty, *element, true)
+            }),
+            Type::Intersection(intersection) if intersection.positive(self.db).is_empty() => {
+                self.intersect_types(subject_ty, class_ty)
+            }
+            Type::Intersection(intersection) => {
+                let filter_nominal_arms = filter_nominal_arms
+                    || intersection
+                        .positive(self.db)
+                        .iter()
+                        .any(|positive| matches!(positive, Type::TypeAlias(_) | Type::Union(_)));
+                intersection.map_positive(self.db, |positive| {
+                    self.match_class_pattern_subject_type(
+                        class,
+                        class_ty,
+                        *positive,
+                        filter_nominal_arms,
+                    )
+                })
+            }
+            Type::NominalInstance(instance) if filter_nominal_arms => {
+                let Some(class) = class else {
+                    return self.intersect_types(subject_ty, class_ty);
+                };
+                let subject_class = instance.class(self.db);
+                if subject_class.is_subtype_of_class_literal(self.db, class) {
+                    subject_ty
+                } else if subject_ty.is_disjoint_from(self.db, class_ty) {
+                    Type::Never
+                } else {
+                    self.intersect_types(subject_ty, class_ty)
+                }
+            }
+            Type::TypedDict(_) if filter_nominal_arms => {
+                if class.is_some_and(|class| {
+                    KnownClass::Dict.is_subclass_of(self.db, ClassType::NonGeneric(class))
+                }) {
+                    subject_ty
+                } else {
+                    Type::Never
+                }
+            }
+            _ if subject_ty.is_subtype_of(self.db, class_ty) => subject_ty,
+            _ if subject_ty.is_disjoint_from(self.db, class_ty) => Type::Never,
+            _ => self.intersect_types(subject_ty, class_ty),
+        }
+    }
+
+    /// Return the subject and binding types of a successful sequence pattern.
+    ///
+    /// Each union member is checked against the complete pattern before element types are combined.
+    /// This keeps related tuple elements together:
+    ///
+    /// ```python
+    /// from typing import Literal
+    ///
+    /// def f(value: tuple[Literal[1], int] | tuple[Literal[2], str]) -> None:
+    ///     match value:
+    ///         case [1, item]:
+    ///             reveal_type(item)  # int
+    /// ```
+    fn analyze_successful_sequence_pattern(
+        &self,
+        kind: &SequencePatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> PatternSuccessResult<'db> {
+        let target_len = Self::sequence_pattern_target_len(kind);
+        let sequence_ty = necessary_sequence_pattern_type(self.db, kind);
+        self.analyze_pattern_subject_arms(subject_ty, |analyzer, subject_ty| {
+            let (narrowed_subject_ty, element_types) =
+                analyzer.sequence_pattern_arm(subject_ty, target_len, sequence_ty)?;
+            let mut bindings = BTreeMap::new();
+            let mut matched_element_types = Vec::with_capacity(kind.patterns.len());
+            for (pattern, element_ty) in kind.patterns.iter().zip(element_types) {
+                let child = analyzer.analyze_successful_pattern(pattern, element_ty);
+                if child.matched_subject_ty.is_never() {
+                    return None;
+                }
+                matched_element_types.push(child.matched_subject_ty);
+                analyzer.merge_bindings(&mut bindings, child.bindings);
+            }
+            let matched_subject_ty = analyzer.successful_sequence_subject_type(
+                kind,
+                subject_ty,
+                narrowed_subject_ty,
+                &matched_element_types,
+            );
+            Some(PatternSuccessResult {
+                matched_subject_ty,
+                bindings,
+            })
+        })
+    }
+
+    /// Refine a fixed tuple using the types that matched its child patterns.
+    ///
+    /// Mutable sequences keep only the type established before matching the children because a
+    /// later mutation can invalidate facts about individual elements.
+    fn successful_sequence_subject_type(
+        &self,
+        kind: &SequencePatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+        narrowed_subject_ty: Type<'db>,
+        matched_element_types: &[Type<'db>],
+    ) -> Type<'db> {
+        if subject_ty.exact_tuple_instance_spec(self.db).is_some() {
+            self.intersect_types(
+                narrowed_subject_ty,
+                self.successful_sequence_pattern_type(kind, matched_element_types),
+            )
+        } else {
+            narrowed_subject_ty
+        }
+    }
+
+    fn successful_sequence_pattern_type(
+        &self,
+        kind: &SequencePatternPredicateKind<'db>,
+        matched_element_types: &[Type<'db>],
+    ) -> Type<'db> {
+        if let Some((prefix, suffix)) = kind.split_around_star() {
+            let prefix_types = matched_element_types.iter().copied().take(prefix.len());
+            let suffix_types = matched_element_types
+                .iter()
+                .copied()
+                .skip(matched_element_types.len().saturating_sub(suffix.len()));
+            starred_sequence_pattern_type(self.db, prefix_types, suffix_types)
+        } else {
+            exact_sequence_pattern_type(self.db, matched_element_types.iter().copied())
+        }
+    }
+
+    /// Check one subject union member against the complete sequence pattern.
+    ///
+    /// Return the narrowed sequence and its elements when the length and every element can match.
+    /// Return `None` when any part cannot match, so callers can discard the whole union member
+    /// before combining capture types.
+    fn sequence_pattern_arm(
+        &self,
+        subject_ty: Type<'db>,
+        target_len: TupleLength,
+        sequence_ty: Type<'db>,
+    ) -> Option<(Type<'db>, Vec<Type<'db>>)> {
+        let narrowed_subject_ty = self.intersect_types(subject_ty, sequence_ty);
+        if narrowed_subject_ty.is_never() {
+            return None;
+        }
+
+        let tuple = subject_ty
+            .try_iterate(self.db)
+            .or_else(|_| narrowed_subject_ty.try_iterate(self.db))
+            .unwrap_or_else(|error| {
+                Cow::Owned(Tuple::homogeneous(error.fallback_element_type(self.db)))
+            });
+        let mut unpacker = TupleUnpacker::new(self.db, target_len);
+        unpacker.unpack_tuple(tuple.as_ref()).ok()?;
+        Some((narrowed_subject_ty, unpacker.into_types().collect()))
+    }
+
+    fn analyze_pattern_subject_arms(
+        &self,
+        subject_ty: Type<'db>,
+        analyze_arm: impl Fn(&Self, Type<'db>) -> Option<PatternSuccessResult<'db>>,
+    ) -> PatternSuccessResult<'db> {
+        let subject_arms = self.match_pattern_subject_arms(subject_ty);
+        let grouped_arms = subject_arms
+            .into_iter()
+            .chunk_by(|(original_subject_ty, _)| *original_subject_ty);
+        let mut matched_subject_types = UnionBuilder::new(self.db);
+        let mut bindings = BTreeMap::new();
+
+        for (original_subject_ty, arms) in &grouped_arms {
+            let mut matched_types = UnionBuilder::new(self.db);
+
+            for (_, filtering_subject_ty) in arms {
+                if let Some(arm) = analyze_arm(self, filtering_subject_ty) {
+                    matched_types.add_in_place(arm.matched_subject_ty);
+                    self.merge_bindings(&mut bindings, arm.bindings);
+                }
+            }
+
+            matched_subject_types.add_in_place(
+                self.matched_subject_type_for_original(original_subject_ty, matched_types.build()),
+            );
+        }
+
+        PatternSuccessResult {
+            matched_subject_ty: matched_subject_types.build(),
+            bindings,
+        }
+    }
+
+    fn matched_subject_type_for_original(
+        &self,
+        original_subject_ty: Type<'db>,
+        matched_types: Type<'db>,
+    ) -> Type<'db> {
+        let filtering_types = original_subject_ty
+            .flatten_typevars(self.db)
+            .resolve_type_alias(self.db);
+        if matched_types.is_equivalent_to(self.db, filtering_types)
+            && original_subject_ty.has_typevar(self.db)
+        {
+            original_subject_ty
+        } else if original_subject_ty.has_typevar(self.db) {
+            self.intersect_types(original_subject_ty, matched_types)
+        } else {
+            matched_types
+        }
+    }
+
+    /// Pair each original subject type with the union members used to test the pattern.
+    ///
+    /// Type variables are expanded for matching, but each arm keeps the original type so a
+    /// successful pattern result can preserve that type variable.
+    fn match_pattern_subject_arms(
+        &self,
+        subject_ty: Type<'db>,
+    ) -> SmallVec<[(Type<'db>, Type<'db>); 2]> {
+        let subject_ty = subject_ty.resolve_type_alias(self.db);
+        let mut arms = SmallVec::new();
+        let mut add_arm = |original_subject_ty: Type<'db>| {
+            let filtering_subject_ty = original_subject_ty
+                .flatten_typevars(self.db)
+                .resolve_type_alias(self.db);
+            match filtering_subject_ty {
+                Type::Union(union) => arms.extend(
+                    union
+                        .elements(self.db)
+                        .iter()
+                        .map(|element| (original_subject_ty, *element)),
+                ),
+                _ => arms.push((original_subject_ty, filtering_subject_ty)),
+            }
+        };
+
+        match subject_ty {
+            Type::Union(union) => union
+                .elements(self.db)
+                .iter()
+                .copied()
+                .for_each(&mut add_arm),
+            _ => add_arm(subject_ty),
+        }
+
+        arms
+    }
+
+    fn sequence_pattern_target_len(kind: &SequencePatternPredicateKind<'db>) -> TupleLength {
+        if let Some((prefix, suffix)) = kind.split_around_star() {
+            TupleLength::Variable(prefix.len(), suffix.len())
+        } else {
+            TupleLength::Fixed(kind.patterns.len())
+        }
+    }
+
+    fn intersect_types(&self, left: Type<'db>, right: Type<'db>) -> Type<'db> {
+        IntersectionBuilder::new(self.db)
+            .add_positive(left)
+            .add_positive(right)
+            .build()
+    }
+
+    fn places(&self) -> &'db PlaceTable {
+        place_table(self.db, self.scope)
+    }
+}
+
+impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     fn evaluate_subject_element_pattern(
         &mut self,
         subject_element: SubjectElementPatternPredicate<'db>,
@@ -2032,16 +2745,19 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
         let class_type = infer_same_file_expression_type(self.db, cls, TypeContext::default());
 
-        let narrowed_type = match class_type {
-            Type::ClassLiteral(class) => {
-                Type::instance(self.db, class.top_materialization(self.db))
-                    .negate_if(self.db, !is_positive)
+        let narrowed_type = if is_positive {
+            positive_class_pattern_type(self.db, class_type)?
+        } else {
+            match class_type {
+                Type::ClassLiteral(class) => {
+                    Type::instance(self.db, class.top_materialization(self.db)).negate(self.db)
+                }
+                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
+                    callable_pattern_type(self.db).negate(self.db)
+                }
+                dynamic @ Type::Dynamic(_) => dynamic,
+                _ => return None,
             }
-            Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                callable_pattern_type(self.db).negate_if(self.db, !is_positive)
-            }
-            dynamic @ Type::Dynamic(_) => dynamic,
-            _ => return None,
         };
 
         Some(NarrowingConstraints::from_iter([(
@@ -2077,82 +2793,6 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         )]))
     }
 
-    /// Return a type that contains every value that can match `pattern`.
-    ///
-    /// For example, given:
-    ///
-    /// ```python
-    /// def f(x: list[object]):
-    ///     match x:
-    ///         case [int(real=0)]:
-    ///             reveal_type(x)
-    /// ```
-    ///
-    /// Every `x` that matches `[int(real=0)]` must be a one-element sequence
-    /// containing an `int`. We can represent this information in the returned
-    /// type; however, that type omits the `real=0` constraint, and so includes
-    /// values like as `[1]`, which do not match the pattern. In other words,
-    /// the returned type may include values that do not match, but it must include
-    /// every value that does.
-    fn necessary_match_pattern_type(&self, pattern: &PatternPredicateKind<'db>) -> Type<'db> {
-        match pattern {
-            PatternPredicateKind::Singleton(singleton) => {
-                singleton_pattern_type(self.db, *singleton)
-            }
-            PatternPredicateKind::Class(cls, _) => {
-                match infer_same_file_expression_type(self.db, *cls, TypeContext::default()) {
-                    Type::ClassLiteral(class) => {
-                        Type::instance(self.db, class.top_materialization(self.db))
-                    }
-                    Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                        callable_pattern_type(self.db)
-                    }
-                    _ => Type::object(),
-                }
-            }
-            PatternPredicateKind::Mapping(_) => mapping_pattern_type(self.db),
-            PatternPredicateKind::Sequence(kind) => self.necessary_sequence_pattern_type(kind),
-            PatternPredicateKind::Or(predicates) => UnionType::from_elements(
-                self.db,
-                predicates
-                    .iter()
-                    .map(|predicate| self.necessary_match_pattern_type(predicate)),
-            ),
-            PatternPredicateKind::As(pattern, _) => pattern
-                .as_deref()
-                .map(|pattern| self.necessary_match_pattern_type(pattern))
-                .unwrap_or_else(Type::object),
-            PatternPredicateKind::Value(_) | PatternPredicateKind::MatchStar => Type::object(),
-        }
-    }
-
-    /// Preserve the element constraints that can be addressed at fixed indices.
-    fn necessary_sequence_pattern_type(
-        &self,
-        kind: &SequencePatternPredicateKind<'db>,
-    ) -> Type<'db> {
-        if kind.is_exact_length() {
-            let element_types = kind
-                .patterns
-                .iter()
-                .map(|pattern| self.necessary_match_pattern_type(pattern));
-            exact_sequence_pattern_type(self.db, element_types)
-        } else {
-            let Some((prefix_patterns, suffix_patterns)) = kind.split_around_star() else {
-                return sequence_pattern_type_builder(self.db).build();
-            };
-
-            let prefix_element_types = prefix_patterns
-                .iter()
-                .map(|pattern| self.necessary_match_pattern_type(pattern));
-            let suffix_element_types = suffix_patterns
-                .iter()
-                .map(|pattern| self.necessary_match_pattern_type(pattern));
-
-            starred_sequence_pattern_type(self.db, prefix_element_types, suffix_element_types)
-        }
-    }
-
     fn evaluate_match_pattern_sequence(
         &mut self,
         subject: Expression<'db>,
@@ -2181,7 +2821,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         };
 
         let constraint = if is_positive {
-            NarrowingConstraint::intersection(self.necessary_sequence_pattern_type(kind))
+            NarrowingConstraint::intersection(necessary_sequence_pattern_type(self.db, kind))
         } else {
             let sequence_type = definite_sequence_pattern_type(self.db, kind);
             if sequence_type.is_never() {
@@ -2289,7 +2929,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         }
         PatternNarrowingResult::Possible(Some(NarrowingConstraints::from_iter([(
             self.expect_place(&subject),
-            NarrowingConstraint::intersection(self.necessary_match_pattern_type(pattern)),
+            NarrowingConstraint::intersection(necessary_match_pattern_type(self.db, pattern)),
         )])))
     }
 
@@ -2366,7 +3006,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     fn evaluate_match_pattern_or(
         &mut self,
         subject: Expression<'db>,
-        predicates: &Vec<PatternPredicateKind<'db>>,
+        predicates: &[PatternPredicateKind<'db>],
         is_positive: bool,
     ) -> PatternNarrowingResult<'db> {
         let merge_constraints = if is_positive {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -322,7 +322,68 @@ impl<'db> PatternSuccessTypes<'db> {
 /// second element prevents the complete sequence pattern from matching.
 struct PatternSuccessResult<'db> {
     matched_subject_ty: Type<'db>,
-    bindings: BTreeMap<ScopedPlaceId, Type<'db>>,
+    bindings: BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
+}
+
+#[derive(Clone)]
+struct PatternBindingTypes<'db> {
+    contributions: SmallVec<[PatternBindingType<'db>; 2]>,
+}
+
+#[derive(Clone, Copy)]
+struct PatternBindingType<'db> {
+    ty: Type<'db>,
+    aliases_subject: bool,
+}
+
+impl<'db> PatternBindingTypes<'db> {
+    fn subject(subject_ty: Type<'db>) -> Self {
+        Self {
+            contributions: smallvec![PatternBindingType {
+                ty: subject_ty,
+                aliases_subject: true,
+            }],
+        }
+    }
+
+    fn ty(&self, db: &'db dyn Db) -> Type<'db> {
+        UnionType::from_elements(db, self.contributions.iter().map(|binding| binding.ty))
+    }
+
+    fn demote_subject(&mut self) {
+        for contribution in &mut self.contributions {
+            contribution.aliases_subject = false;
+        }
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.contributions.extend(other.contributions);
+    }
+
+    fn subject_ty(&self, db: &'db dyn Db) -> Type<'db> {
+        UnionType::from_elements(
+            db,
+            self.contributions
+                .iter()
+                .filter(|binding| binding.aliases_subject)
+                .map(|binding| binding.ty),
+        )
+    }
+
+    fn restore_subject(&mut self, restored_subject_ty: Type<'db>) {
+        let mut restored = false;
+        self.contributions.retain_mut(|contribution| {
+            if !contribution.aliases_subject {
+                return true;
+            }
+            if restored {
+                return false;
+            }
+            contribution.ty = restored_subject_ty;
+            restored = true;
+            true
+        });
+    }
 }
 
 /// Computes the subject and binding types produced by successful match patterns.
@@ -365,7 +426,11 @@ pub(crate) fn pattern_success_types<'db>(
     let analyzer = PatternSuccessAnalyzer::new(db, pattern.scope(db));
     let result = analyzer.analyze_successful_pattern(pattern.kind(db), incoming_subject_ty);
     PatternSuccessTypes {
-        bindings: FrozenMap::from(result.bindings),
+        bindings: result
+            .bindings
+            .into_iter()
+            .map(|(place, binding)| (place, binding.ty(db)))
+            .collect(),
         missing_binding_ty: if result.matched_subject_ty.is_never() {
             Type::Never
         } else {
@@ -1218,27 +1283,36 @@ impl<'db> PatternSuccessAnalyzer<'db> {
 
     fn merge_binding(
         &self,
-        bindings: &mut BTreeMap<ScopedPlaceId, Type<'db>>,
+        bindings: &mut BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
         place: ScopedPlaceId,
-        ty: Type<'db>,
+        binding: PatternBindingTypes<'db>,
     ) {
         match bindings.entry(place) {
             BTreeEntry::Occupied(mut entry) => {
-                *entry.get_mut() = UnionType::from_elements(self.db, [*entry.get(), ty]);
+                entry.get_mut().merge(binding);
             }
             BTreeEntry::Vacant(entry) => {
-                entry.insert(ty);
+                entry.insert(binding);
             }
         }
     }
 
     fn merge_bindings(
         &self,
-        into: &mut BTreeMap<ScopedPlaceId, Type<'db>>,
-        from: BTreeMap<ScopedPlaceId, Type<'db>>,
+        into: &mut BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
+        from: BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
     ) {
-        for (place, ty) in from {
-            self.merge_binding(into, place, ty);
+        for (place, binding) in from {
+            self.merge_binding(into, place, binding);
+        }
+    }
+
+    fn demote_subject_bindings(
+        &self,
+        bindings: &mut BTreeMap<ScopedPlaceId, PatternBindingTypes<'db>>,
+    ) {
+        for binding in bindings.values_mut() {
+            binding.demote_subject();
         }
     }
 
@@ -1284,7 +1358,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     self.merge_binding(
                         &mut result.bindings,
                         place.into(),
-                        result.matched_subject_ty,
+                        PatternBindingTypes::subject(result.matched_subject_ty),
                     );
                 }
                 result
@@ -1295,7 +1369,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     .as_ref()
                     .and_then(|name| self.places().symbol_id(name.as_str()))
                 {
-                    bindings.insert(place.into(), subject_ty);
+                    bindings.insert(place.into(), PatternBindingTypes::subject(subject_ty));
                 }
                 PatternSuccessResult {
                     matched_subject_ty: subject_ty,
@@ -1525,11 +1599,12 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             let mut bindings = BTreeMap::new();
             let mut matched_element_types = Vec::with_capacity(kind.patterns.len());
             for (pattern, element_ty) in kind.patterns.iter().zip(element_types) {
-                let child = analyzer.analyze_successful_pattern(pattern, element_ty);
+                let mut child = analyzer.analyze_successful_pattern(pattern, element_ty);
                 if child.matched_subject_ty.is_never() {
                     return None;
                 }
                 matched_element_types.push(child.matched_subject_ty);
+                analyzer.demote_subject_bindings(&mut child.bindings);
                 analyzer.merge_bindings(&mut bindings, child.bindings);
             }
             let matched_subject_ty = analyzer.successful_sequence_subject_type(
@@ -1624,13 +1699,24 @@ impl<'db> PatternSuccessAnalyzer<'db> {
 
         for (original_subject_ty, arms) in &grouped_arms {
             let mut matched_types = UnionBuilder::new(self.db);
+            let mut arm_bindings = BTreeMap::new();
 
             for (_, filtering_subject_ty) in arms {
                 if let Some(arm) = analyze_arm(self, filtering_subject_ty) {
                     matched_types.add_in_place(arm.matched_subject_ty);
-                    self.merge_bindings(&mut bindings, arm.bindings);
+                    self.merge_bindings(&mut arm_bindings, arm.bindings);
                 }
             }
+
+            for binding in arm_bindings.values_mut() {
+                let subject_ty = binding.subject_ty(self.db);
+                if !subject_ty.is_never() {
+                    binding.restore_subject(
+                        self.matched_subject_type_for_original(original_subject_ty, subject_ty),
+                    );
+                }
+            }
+            self.merge_bindings(&mut bindings, arm_bindings);
 
             matched_subject_types.add_in_place(
                 self.matched_subject_type_for_original(original_subject_ty, matched_types.build()),

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -309,7 +309,7 @@ impl<'db> PatternSuccessTypes<'db> {
 
 /// The types produced by one pattern node when that complete node succeeds.
 ///
-/// Bindings are transactional:
+/// Bindings are retained only when the complete pattern succeeds:
 ///
 /// ```python
 /// def f(value: tuple[str, str]) -> None:

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1449,14 +1449,42 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         }
     }
 
+    fn contains_unsupported_binding_pattern(pattern: &PatternPredicateKind<'_>) -> bool {
+        match pattern {
+            PatternPredicateKind::Class(..) | PatternPredicateKind::Mapping(_) => true,
+            PatternPredicateKind::Sequence(kind) => kind
+                .patterns
+                .iter()
+                .any(Self::contains_unsupported_binding_pattern),
+            PatternPredicateKind::Or(patterns) => patterns
+                .iter()
+                .any(Self::contains_unsupported_binding_pattern),
+            PatternPredicateKind::As(Some(pattern), _) => {
+                Self::contains_unsupported_binding_pattern(pattern)
+            }
+            _ => false,
+        }
+    }
+
     fn analyze_successful_or_pattern(
         &self,
         patterns: &[PatternPredicateKind<'db>],
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
-        self.analyze_pattern_subject_arms(subject_ty, |analyzer, subject_ty| {
+        let mut result = self.analyze_pattern_subject_arms(subject_ty, |analyzer, subject_ty| {
             Some(analyzer.analyze_successful_or_pattern_arm(patterns, subject_ty))
-        })
+        });
+        if patterns
+            .iter()
+            .any(Self::contains_unsupported_binding_pattern)
+        {
+            // Class and mapping child patterns are not retained yet, so a reachable alternative can
+            // bind a name that is absent from its analysis result. Discard every contribution rather
+            // than infer a type from only the supported alternatives. The class and mapping binding
+            // analysis removes this conservative fallback in the next PR.
+            result.bindings.clear();
+        }
+        result
     }
 
     fn analyze_successful_or_pattern_arm(

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1353,9 +1353,10 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     },
                     |pattern| self.analyze_successful_pattern(pattern, subject_ty),
                 );
-                if let Some(place) = name
-                    .as_ref()
-                    .and_then(|name| self.places().symbol_id(name.as_str()))
+                if !result.matched_subject_ty.is_never()
+                    && let Some(place) = name
+                        .as_ref()
+                        .and_then(|name| self.places().symbol_id(name.as_str()))
                 {
                     Self::merge_binding(
                         &mut result.bindings,


### PR DESCRIPTION
## Summary

This PR infers the types of names introduced by match patterns.

```python
def unpack(value: tuple[int, str]) -> None:
    match value:
        case [first, second] as whole:
            reveal_type(first)   # int
            reveal_type(second)  # str
            reveal_type(whole)   # tuple[int, str]
```

The implementation analyzes a successful match recursively: each pattern receives the type of the value it is matching, computes the type that can successfully match, and passes the appropriate extracted type to its children. A capture binds the type it receives; an `as` pattern binds the successful type of its complete nested pattern.

The analysis also distinguishes facts established while a pattern is being evaluated from the stable type assigned to an alias. An alias for a mutable sequence keeps only its sequence type, because later mutation can invalidate the observed shape; exact tuples can retain facts learned from their children. For example, we don't narrow here:

```python
def f(value: list[int | str]) -> None:
    match value:
        case [int(), str()] as whole:
            reveal_type(whole)       # list[int | str]
            reveal_type(len(whole))  # int, not Literal[2]
            reveal_type(whole[0])    # int | str, not int
            reveal_type(whole[1])    # int | str, not str
```

But we do narrow for an exact tuple:

```python
def f(value: tuple[int | str, int | str]) -> None:
    match value:
        case [int(), str()] as whole:
            reveal_type(len(whole))  # Literal[2]
            reveal_type(whole[0])    # int
            reveal_type(whole[1])    # str
```
