### PR TITLE
[ty] Infer class and mapping pattern bindings

### DIFF
--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -1429,10 +1429,10 @@ mod tests {
            |                 ^^ Clicking here
            |
         info: Found 1 type definition
-          --> stdlib/ty_extensions.pyi:LL:1
+          --> stdlib/builtins.pyi:LL:7
            |
-        LL | Unknown: _SpecialForm
-           | -------
+        LL | class str(Sequence[str]):
+           |       ---
            |
         ");
     }

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -3937,10 +3937,10 @@ def function():
         );
 
         assert_snapshot!(test.hover(), @"
-        Unknown
+        str
         ---------------------------------------------
         ```python
-        Unknown
+        str
         ```
         ---------------------------------------------
         info[hover]: Hovered content is

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -2301,32 +2301,29 @@ Source with applied edits:
         def my_func(event: Click):
             match event:
                 case Click(x, button=ab):
-                    x[: Unknown] = ab
+                    x[: str] = ab
 
         ---------------------------------------------
         info[inlay-hint-location]: Inlay Hint Target
-          --> stdlib/ty_extensions.pyi:LL:1
+          --> stdlib/builtins.pyi:LL:7
            |
-        LL | Unknown: _SpecialForm
-           | ^^^^^^^
+        LL | class str(Sequence[str]):
+           |       ^^^
            |
         info: Source
           --> main2.py:LL:17
            |
-        LL |             x[: Unknown] = ab
-           |                 ^^^^^^^
+        LL |             x[: str] = ab
+           |                 ^^^
            |
 
         ---------------------------------------------
         info[inlay-hint-edit]: Inlay hint edits
         --> main.py:1:1
            |
-        1  + from ty_extensions import Unknown
-        2  |
-        --------------------------------------------------------------------------------
-        11 |         case Click(x, button=ab):
+        10 |         case Click(x, button=ab):
            -             x = ab
-        12 +             x: Unknown = ab
+        11 +             x: str = ab
            |
         "#);
     }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -44,9 +44,9 @@ use crate::place::{
 };
 use crate::predicate::{
     CallableAndCallExpr, ClassPatternKeywordPredicateKind, ClassPatternPredicateKind,
-    MappingPatternEntryPredicateKind, PatternPredicate, PatternPredicateKind, Predicate,
-    PredicateNode, PredicateOrLiteral, ScopedPredicateId, SequencePatternPredicateKind,
-    StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
+    MappingPatternEntryPredicateKind, MappingPatternPredicateKind, PatternPredicate,
+    PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral, ScopedPredicateId,
+    SequencePatternPredicateKind, StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
 };
 use crate::program::Program;
 use crate::re_exports::exported_names;
@@ -2063,8 +2063,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
             ast::Pattern::MatchMapping(pattern) => {
                 // Retain keyed entries for subject-aware exhaustiveness analysis.
-                PatternPredicateKind::Mapping(
-                    pattern
+                PatternPredicateKind::Mapping(MappingPatternPredicateKind {
+                    entries: pattern
                         .keys
                         .iter()
                         .zip(&pattern.patterns)
@@ -2073,7 +2073,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             pattern: self.predicate_kind(pattern),
                         })
                         .collect(),
-                )
+                    rest: pattern.rest.as_ref().map(|name| name.id.clone()),
+                })
             }
             ast::Pattern::MatchSequence(pattern) => {
                 PatternPredicateKind::Sequence(SequencePatternPredicateKind {

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -195,6 +195,19 @@ pub struct ClassPatternKeywordPredicateKind<'db> {
     pub pattern: PatternPredicateKind<'db>,
 }
 
+/// Structural details for a mapping pattern.
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct MappingPatternPredicateKind<'db> {
+    pub entries: Box<[MappingPatternEntryPredicateKind<'db>]>,
+    pub rest: Option<Name>,
+}
+
+impl MappingPatternPredicateKind<'_> {
+    pub fn is_irrefutable(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 pub struct MappingPatternEntryPredicateKind<'db> {
     pub key: Expression<'db>,
@@ -209,7 +222,7 @@ pub enum PatternPredicateKind<'db> {
     Value(Expression<'db>),
     Or(Box<[PatternPredicateKind<'db>]>),
     Class(ClassPatternPredicateKind<'db>),
-    Mapping(Box<[MappingPatternEntryPredicateKind<'db>]>),
+    Mapping(MappingPatternPredicateKind<'db>),
     Sequence(SequencePatternPredicateKind<'db>),
     As(Option<Box<PatternPredicateKind<'db>>>, Option<Name>),
     Star(Option<Name>),

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -220,8 +220,9 @@ DynamicClass: Any = int
 
 def _(target: int | str):
     match target:
-        case DynamicClass():
+        case DynamicClass() as whole:
             reveal_type(target)  # revealed: (int & Any) | (str & Any)
+            reveal_type(whole)  # revealed: (int & Any) | (str & Any)
             y = 1
         case _:
             reveal_type(target)  # revealed: int | str

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -430,7 +430,7 @@ def match_exhaustive_generic[T](obj: GenericClass[T]) -> GenericClass[T]:
             reveal_type(obj)  # revealed: GenericClass[T@match_exhaustive_generic]
             return obj
         case GenericClass(x=x):
-            reveal_type(x)  # revealed: Unknown
+            reveal_type(x)  # revealed: T@match_exhaustive_generic
             reveal_type(obj)  # revealed: GenericClass[T@match_exhaustive_generic]
             return obj
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -474,9 +474,9 @@ def test_ordered_or_alias_excludes_cross_type_equal_values(
 
 ## Ordered `or`-pattern bindings
 
-Alternatives are tried from left to right, but a later alternative must keep any value for which an
-earlier pattern can fail. Here, `Values.x` is only an annotation, so `HasX()` can fail at runtime
-and the sequence alternative can still bind the value:
+Alternatives are tried from left to right. Under the static member model, the declaration of
+`Values.x` makes the protocol pattern exhaustive, so the later sequence alternative cannot
+contribute to the binding:
 
 ```py
 from typing import Protocol, runtime_checkable
@@ -488,35 +488,34 @@ class HasX(Protocol):
 class Values(list[str]):
     x: int
 
-def test_or_binding_keeps_values_that_can_fail_a_class_pattern(value: Values) -> None:
+def test_or_binding_omits_values_consumed_by_a_class_pattern(value: Values) -> None:
     match value:
         case (HasX() as item) | [item]:
-            # Class child bindings are added by a later change, so this branch cannot yet combine
-            # the supported whole-pattern alias with the sequence capture.
-            reveal_type(item)  # revealed: Unknown
+            reveal_type(item)  # revealed: Values
 ```
 
-Class and mapping child bindings are added by a later change. Until then, an `or` pattern that mixes
-one of those patterns with a supported alternative falls back to `Unknown` instead of inferring a
-type from only the supported alternative.
+Class and mapping child bindings combine with bindings from other alternatives:
 
 ```py
 from typing import final
-from ty_extensions import Unknown
+from typing_extensions import TypedDict
 
 @final
 class TextValue:
     value: str = ""
 
+class StringMapping(TypedDict):
+    value: str
+
 def class_or_sequence_binding(value: TextValue | tuple[int]) -> None:
     match value:
         case TextValue(value=item) | [item]:
-            reveal_type(item)  # revealed: Unknown
+            reveal_type(item)  # revealed: str | int
 
-def mapping_or_sequence_binding(value: dict[str, str] | tuple[int]) -> None:
+def mapping_or_singleton_binding(value: StringMapping | None) -> None:
     match value:
-        case {"value": item} | [item]:
-            reveal_type(item)  # revealed: Unknown
+        case {"value": item} | (None as item):
+            reveal_type(item)  # revealed: str | None
 ```
 
 ## Declared pattern captures
@@ -730,6 +729,642 @@ def test_match_class_alias_rejects_disjoint_final_class(value: FinalA) -> None:
     match value:
         case FinalB() as item:
             reveal_type(item)  # revealed: Never
+```
+
+## Class patterns for runtime dictionary values
+
+A `TypedDict` type does not inherit from `dict`, but its values are dictionaries at runtime. Those
+values can therefore match `dict`, the mapping abstract base classes, and runtime-checkable
+protocols implemented by dictionaries.
+
+```py
+from collections.abc import Mapping
+from typing import Protocol, TypedDict, runtime_checkable
+
+class ProtocolPayload(TypedDict):
+    value: int
+
+@runtime_checkable
+class SizedProtocol(Protocol):
+    def __len__(self) -> int: ...
+
+def test_match_typed_dict_alias_preserves_runtime_protocol_overlap(
+    value: ProtocolPayload,
+) -> None:
+    match value:
+        case SizedProtocol() as item:
+            reveal_type(item)  # revealed: ProtocolPayload
+
+def test_match_typed_dict_alias_preserves_mapping_runtime_type(
+    value: ProtocolPayload,
+) -> None:
+    match value:
+        case Mapping() as item:
+            reveal_type(item)  # revealed: ProtocolPayload
+```
+
+## Class pattern captures
+
+Class patterns pass the type of each extracted attribute to their nested patterns. This also works
+when the pattern class is held in a variable typed as `type[Class]`. The surrounding `as` pattern
+keeps the subject's original generic type or type variable.
+
+```py
+from dataclasses import dataclass
+from typing import Generic, NamedTuple, TypeVar
+
+T = TypeVar("T")
+
+class PatternBox(Generic[T]):
+    __match_args__ = ("value",)
+    value: T
+
+class IndirectCapture:
+    value: int
+
+def test_match_class_keyword_capture(value: PatternBox[T]) -> T:
+    match value:
+        case PatternBox(value=item) as whole:
+            reveal_type(item)  # revealed: T@test_match_class_keyword_capture
+            reveal_type(whole)  # revealed: PatternBox[T@test_match_class_keyword_capture]
+            return item
+
+def test_match_indirect_class_keyword_capture(
+    value: object,
+    CapturePattern: type[IndirectCapture],
+) -> None:
+    match value:
+        case CapturePattern(value=item):
+            reveal_type(item)  # revealed: int
+
+@dataclass
+class DataclassBox(Generic[T]):
+    value: T
+
+def test_match_dataclass_positional_capture(dataclass_box: DataclassBox[T]) -> None:
+    match dataclass_box:
+        case DataclassBox(item):
+            reveal_type(item)  # revealed: T@test_match_dataclass_positional_capture
+
+class NamedPoint(NamedTuple):
+    x: int
+    label: str
+
+def test_match_named_tuple_positional_captures(point: NamedPoint) -> None:
+    match point:
+        case NamedPoint(x, label):
+            reveal_type(x)  # revealed: int
+            reveal_type(label)  # revealed: str
+
+def test_incompatible_declared_class_capture(value: PatternBox[int]) -> None:
+    item: str
+    match value:
+        case PatternBox(value=item):  # error: [invalid-assignment]
+            reveal_type(item)  # revealed: str
+```
+
+## Generic subclass captures
+
+When a value is typed as a generic base class and the pattern matches one of its subclasses, the
+base class's type argument is not yet preserved on the subclass. The extracted attribute is
+therefore `Unknown`, rather than the default `object` specialization that would produce false
+positive errors.
+
+```py
+from typing import Generic, TypeVar
+
+GenericPatternT = TypeVar("GenericPatternT")
+
+class GenericPatternBase(Generic[GenericPatternT]): ...
+
+class GenericPatternChild(GenericPatternBase[GenericPatternT]):
+    item: GenericPatternT
+    items: list[GenericPatternT]
+
+class GenericMemberBase(Generic[GenericPatternT]):
+    item: GenericPatternT
+
+class GenericMemberChild(GenericMemberBase[GenericPatternT]): ...
+
+def test_match_generic_subclass_capture(value: GenericPatternBase[int]) -> None:
+    match value:
+        case GenericPatternChild(item=item):
+            # TODO: This should be `int` once generic subclass specialization is supported.
+            reveal_type(item)  # revealed: Unknown
+
+def test_match_nested_generic_subclass_capture(value: GenericPatternBase[int]) -> list[int]:
+    match value:
+        case GenericPatternChild(items=items):
+            reveal_type(items)  # revealed: Unknown
+            return items
+    return []
+
+def test_match_inherited_generic_subclass_capture(
+    value: GenericMemberBase[GenericPatternT],
+) -> GenericPatternT:
+    match value:
+        case GenericMemberChild(item=item):
+            # revealed: GenericPatternT@test_match_inherited_generic_subclass_capture
+            reveal_type(item)
+            return item
+        case _:
+            raise ValueError
+```
+
+## Positional class patterns
+
+`__match_args__` is read through the pattern class and must identify literal attribute names. This
+includes attributes provided by a metaclass. An explicit widened annotation does not tell us which
+attribute a positional pattern extracts.
+
+```py
+class MatchArgsMeta(type):
+    __match_args__ = ("value",)
+
+class MetaclassMatchArgs(metaclass=MatchArgsMeta):
+    value: int
+
+def test_metaclass_match_args(value: MetaclassMatchArgs) -> None:
+    match value:
+        case MetaclassMatchArgs(item):
+            reveal_type(item)  # revealed: int
+
+class WidenedMatchArgs:
+    __match_args__: tuple[str, ...] = ("value",)
+    value: int
+
+def test_widened_match_args_does_not_select_an_attribute(value: WidenedMatchArgs) -> None:
+    match value:
+        case WidenedMatchArgs(item):
+            reveal_type(item)  # revealed: Unknown
+```
+
+## Class patterns and union members
+
+Each member of a union is checked against the complete class pattern before the extracted values are
+combined. This keeps a tag together with its payload and any alias around the whole pattern. The
+same rule applies through an `or` pattern.
+
+```py
+from typing import Generic, Literal, TypeVar
+
+TagT = TypeVar("TagT")
+PayloadT = TypeVar("PayloadT")
+
+class TaggedPayload(Generic[TagT, PayloadT]):
+    __match_args__ = ("tag", "payload")
+    tag: TagT
+    payload: PayloadT
+
+def test_match_class_capture_filters_union_members(
+    value: TaggedPayload[Literal["int"], int] | TaggedPayload[Literal["str"], str],
+) -> None:
+    match value:
+        case TaggedPayload("int", item) as whole:
+            reveal_type(item)  # revealed: int
+            reveal_type(whole)  # revealed: TaggedPayload[Literal["int"], int]
+```
+
+A name is bound only when the complete class pattern succeeds. If a later subpattern cannot match,
+an earlier capture has type `Never`. A missing attribute rejects a final-class alternative, while a
+non-final class remains possible because a subclass can provide the attribute:
+
+```py
+from typing import final
+
+class ImpossibleClassPattern:
+    __match_args__ = ("first", "second")
+    first: str
+    second: str
+
+def test_later_class_pattern_failure_rejects_earlier_capture(
+    value: ImpossibleClassPattern,
+) -> None:
+    match value:
+        case ImpossibleClassPattern(item, int()):
+            reveal_type(item)  # revealed: Never
+
+@final
+class MissingClassPatternAttribute: ...
+
+def test_missing_final_class_attribute_rejects_or_alternative(
+    value: MissingClassPatternAttribute | int,
+) -> None:
+    match value:
+        case MissingClassPatternAttribute(missing=item) | (int() as item):
+            reveal_type(item)  # revealed: int
+
+class NonFinalMissingClassPatternAttribute: ...
+
+def test_missing_non_final_class_attribute_preserves_or_alternative(
+    value: NonFinalMissingClassPatternAttribute | int,
+) -> None:
+    match value:
+        case NonFinalMissingClassPatternAttribute(missing=item) | (int() as item):
+            reveal_type(item)  # revealed: Unknown | int
+
+def test_match_class_or_pattern_filters_union_members(
+    value: TaggedPayload[Literal["int"], int] | TaggedPayload[Literal["str"], str] | TaggedPayload[Literal["bool"], bool],
+) -> None:
+    match value:
+        case (TaggedPayload("int", item) | TaggedPayload("str", item)) as whole:
+            reveal_type(item)  # revealed: int | str
+            # revealed: TaggedPayload[Literal["int"], int] | TaggedPayload[Literal["str"], str]
+            reveal_type(whole)
+```
+
+## Ordered class pattern alternatives
+
+`OrderedBase.member` is definitely bound on `OrderedChild`, so the first alternative consumes the
+complete subject and the later alternative cannot contribute to the binding:
+
+```py
+class OrderedBase:
+    member: int = 0
+
+class OrderedChild(OrderedBase): ...
+
+def test_match_ordered_class_alternatives_remove_later_bindings(
+    value: OrderedChild,
+) -> None:
+    match value:
+        case OrderedBase(member=item) | (OrderedChild() as item):
+            reveal_type(item)  # revealed: int
+```
+
+An argumentless class pattern cannot fail after its class check. If it matches the entire subject
+type, a later alternative cannot contribute to the binding:
+
+```py
+class DefiniteFirst: ...
+
+class UnreachableLater:
+    payload: str
+
+def test_definite_class_alternative_removes_later_bindings(value: DefiniteFirst) -> None:
+    match value:
+        case (DefiniteFirst() as item) | UnreachableLater(payload=item):
+            reveal_type(item)  # revealed: DefiniteFirst
+```
+
+## Positional patterns for built-in classes
+
+For Python's built-in scalar and container classes, the single positional pattern receives the
+entire subject instead of reading an attribute:
+
+```py
+from typing import Literal, TypeVar
+
+MatchSelfIntT = TypeVar("MatchSelfIntT", bound=int)
+
+def builtin_positional_patterns_capture_subject(
+    value: list[int] | dict[str, int] | int,
+) -> None:
+    match value:
+        case list(contents):
+            reveal_type(contents)  # revealed: list[int]
+        case dict(contents):
+            reveal_type(contents)  # revealed: dict[str, int]
+        case int(contents):
+            reveal_type(contents)  # revealed: int
+
+def builtin_positional_pattern_preserves_typevar(value: MatchSelfIntT) -> MatchSelfIntT:
+    match value:
+        case int(contents):
+            # revealed: MatchSelfIntT@builtin_positional_pattern_preserves_typevar
+            reveal_type(contents)
+            return contents
+        case _:
+            raise AssertionError
+
+def builtin_positional_pattern_refines_subject_alias(value: bool) -> Literal[True]:
+    match value:
+        case bool(True as item) as whole:
+            reveal_type(item)  # revealed: Literal[True]
+            reveal_type(whole)  # revealed: Literal[True]
+            return whole
+        case _:
+            raise AssertionError
+```
+
+## Overlapping class patterns
+
+Two unrelated non-final classes can have a common subclass through multiple inheritance. The
+successful pattern therefore preserves both class types:
+
+```py
+class OverlapCaptureA: ...
+
+class OverlapCaptureB:
+    member: int
+
+class OverlapCaptureC(OverlapCaptureA, OverlapCaptureB): ...
+
+def test_match_class_capture_preserves_possible_multiple_inheritance(
+    value: OverlapCaptureA,
+) -> None:
+    match value:
+        case OverlapCaptureB(member=item) as whole:
+            reveal_type(item)  # revealed: int
+            reveal_type(whole)  # revealed: OverlapCaptureA & OverlapCaptureB
+
+class OverlapMemberA:
+    member: int
+
+class OverlapMemberB:
+    member: str
+
+class OverlapMemberC(OverlapMemberA, OverlapMemberB): ...
+
+def test_match_class_capture_combines_overlapping_member_types(
+    value: OverlapMemberA,
+) -> None:
+    match value:
+        case OverlapMemberB(member=item):
+            reveal_type(item)  # revealed: int | str
+```
+
+## Class pattern captures from `Any` and `Unknown`
+
+For an `Any` or `Unknown` subject, a capture keeps that uncertainty together with the attribute type
+declared by the pattern class.
+
+```py
+from typing import Any
+from ty_extensions import Unknown
+
+class GradualPatternBox:
+    value: int
+
+def test_match_gradual_class_captures(any_value: Any, unknown_value: Unknown) -> None:
+    match any_value:
+        case GradualPatternBox(value=item):
+            reveal_type(item)  # revealed: Any & int
+
+    match unknown_value:
+        case GradualPatternBox(value=item):
+            reveal_type(item)  # revealed: Unknown & int
+```
+
+## Mapping pattern captures
+
+Python reads an explicit mapping entry by calling `get` with a sentinel. A custom `get` method can
+therefore produce a broader type than `__getitem__`; the sentinel's type is treated as `object` when
+calling a custom override. The key type of an ordinary `Mapping` does not prove that another key is
+absent because a custom `get` method may accept a broader set of keys. `**rest` is always a new
+`dict` containing the unmatched items.
+
+```py
+from collections.abc import Iterator, Mapping
+from typing import Literal, overload, Protocol, TypeVar
+
+MappingValueT = TypeVar("MappingValueT")
+Default = TypeVar("Default")
+
+def test_match_mapping_bindings(value: Mapping[str, MappingValueT]) -> MappingValueT:
+    match value:
+        case {"item": item, **rest} as whole:
+            reveal_type(item)  # revealed: MappingValueT@test_match_mapping_bindings
+            reveal_type(rest)  # revealed: dict[str, MappingValueT@test_match_mapping_bindings]
+            # revealed: Mapping[str, MappingValueT@test_match_mapping_bindings]
+            reveal_type(whole)
+            return item
+    raise ValueError
+
+def test_match_dict_alias_preserves_concrete_type(value: dict[str, int]) -> None:
+    match value:
+        case {"item": item, **rest} as whole:
+            reveal_type(whole)  # revealed: dict[str, int]
+
+class CustomGet(Mapping[str, int | str]):
+    def __getitem__(self, key: str) -> int:
+        return 1
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(("item",))
+
+    def __len__(self) -> int:
+        return 1
+
+    @overload
+    def get(self, key: object) -> int | str | None: ...
+    @overload
+    def get(self, key: object, default: Default) -> int | str | Default: ...
+    def get(self, key: object, default: Default | None = None) -> int | str | Default | None:
+        if key == "item":
+            return "custom value"
+        return default
+
+def test_match_mapping_uses_get(value: CustomGet) -> None:
+    match value:
+        case {"item": item}:
+            reveal_type(item)  # revealed: object
+
+class InstanceGet(Protocol):
+    @overload
+    def __call__(self, key: object) -> str | None: ...
+    @overload
+    def __call__(self, key: object, default: Default) -> str | Default: ...
+
+class InstanceGetImpl:
+    @overload
+    def __call__(self, key: object) -> str | None: ...
+    @overload
+    def __call__(self, key: object, default: Default) -> str | Default: ...
+    def __call__(self, key: object, default: object = None) -> object:
+        return "custom" if key == "item" else default
+
+class InstanceGetMapping(Mapping[str, int]):
+    def __init__(self) -> None:
+        self.get: InstanceGet = InstanceGetImpl()
+
+    def __getitem__(self, key: str) -> int:
+        return 1
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(())
+
+    def __len__(self) -> int:
+        return 0
+
+def test_match_mapping_instance_get(value: InstanceGetMapping) -> None:
+    match value:
+        case {"item": item}:
+            reveal_type(item)  # revealed: object
+
+def test_incompatible_declared_mapping_captures(value: Mapping[str, int]) -> None:
+    item: str
+    rest: dict[str, str]
+    match value:
+        # error: [invalid-assignment]
+        # error: [invalid-assignment]
+        case {"item": item, **rest}:
+            reveal_type(item)  # revealed: str
+            reveal_type(rest)  # revealed: dict[str, str]
+
+def test_match_mapping_key_keeps_union_members(
+    value: dict[Literal["a"], int] | dict[Literal["b"], str],
+) -> None:
+    match value:
+        case {"a": item} as whole:
+            reveal_type(item)  # revealed: int | str
+            # revealed: dict[Literal["a"], int] | dict[Literal["b"], str]
+            reveal_type(whole)
+```
+
+Mapping values are passed to nested patterns. If any nested pattern cannot match, the mapping
+pattern binds no names:
+
+```py
+def test_match_mapping_nested_sequence(
+    value: Mapping[str, tuple[int, str]],
+) -> None:
+    match value:
+        case {"pair": [number, text]}:
+            reveal_type(number)  # revealed: int
+            reveal_type(text)  # revealed: str
+
+def test_later_mapping_pattern_failure_rejects_bindings(
+    value: Mapping[str, str],
+) -> None:
+    match value:
+        case {"first": item, "second": int(), **rest}:
+            reveal_type(item)  # revealed: Never
+            reveal_type(rest)  # revealed: Never
+```
+
+Even a dictionary whose declared key type is `Never` may be a subclass with a custom `get` method.
+The annotation therefore does not prove that a keyed pattern is impossible:
+
+```py
+from typing_extensions import Never
+
+def test_match_mapping_keeps_empty_key_domain(
+    value: dict[Never, int],
+) -> None:
+    match value:
+        case {"item": item}:
+            reveal_type(item)  # revealed: int
+```
+
+## Mapping captures from `Any` and `Unknown`
+
+The rest pattern is a new dictionary. For an `Any` or `Unknown` subject, its key and value types
+keep the same uncertainty as the subject.
+
+```py
+from typing import Any
+from ty_extensions import Unknown
+
+def test_match_gradual_mapping_captures(any_value: Any, unknown_value: Unknown) -> None:
+    match any_value:
+        case {"item": item, **rest}:
+            reveal_type(item)  # revealed: Any
+            reveal_type(rest)  # revealed: dict[Any, Any]
+
+    match unknown_value:
+        case {"item": item, **rest}:
+            reveal_type(item)  # revealed: Unknown
+            reveal_type(rest)  # revealed: dict[Unknown, Unknown]
+```
+
+## `TypedDict` mapping patterns
+
+For a `TypedDict`, a literal key uses the declared field type. An undeclared key on an implicitly
+open `TypedDict` has type `object` because it may be a hidden item. For a closed `TypedDict`, a
+pattern using an undeclared key is impossible. Tags keep each `TypedDict` together with its
+corresponding value type through an `or` pattern.
+
+```py
+from typing import Literal, final
+from typing_extensions import NotRequired, TypedDict
+
+class IntPayload(TypedDict):
+    tag: Literal["int"]
+    value: int
+
+class StrPayload(TypedDict):
+    tag: Literal["str"]
+    value: str
+
+def test_match_typed_dict_capture_filters_union_members(
+    value: IntPayload | StrPayload,
+) -> None:
+    match value:
+        case {"tag": "int", "value": item, **rest} as whole:
+            reveal_type(item)  # revealed: int
+            reveal_type(rest)  # revealed: dict[str, object]
+            reveal_type(whole)  # revealed: IntPayload
+
+class OptionalPayload(TypedDict):
+    value: NotRequired[int]
+
+def test_match_optional_typed_dict_field(value: OptionalPayload) -> None:
+    match value:
+        case {"value": item}:
+            reveal_type(item)  # revealed: int
+
+def test_match_implicitly_open_typed_dict_field(value: IntPayload) -> None:
+    match value:
+        case {"other": item}:
+            reveal_type(item)  # revealed: object
+
+class ClosedIntPayload(TypedDict, closed=True):
+    tag: Literal["int"]
+    value: int
+
+class ClosedStrPayload(TypedDict, closed=True):
+    tag: Literal["str"]
+    value: str
+
+class ClosedBoolPayload(TypedDict, closed=True):
+    tag: Literal["bool"]
+    value: bool
+
+class ClosedPayload(TypedDict, closed=True):
+    x: int
+
+class ExtraItemsPayload(TypedDict, extra_items=int):
+    tag: Literal["extra"]
+
+def test_match_closed_typed_dict_rejects_non_string_key(
+    value: ClosedPayload,
+) -> None:
+    match value:
+        case {1: item}:
+            reveal_type(item)  # revealed: Never
+
+def test_match_closed_typed_dict_rest(value: ClosedIntPayload) -> None:
+    match value:
+        case {"tag": "int", **rest}:
+            reveal_type(rest)  # revealed: dict[str, object]
+
+def test_match_typed_dict_extra_items(
+    value: ClosedPayload | ExtraItemsPayload,
+) -> None:
+    match value:
+        case {"other": item} as whole:
+            reveal_type(item)  # revealed: int
+            reveal_type(whole)  # revealed: ExtraItemsPayload
+
+def test_match_typed_dict_or_pattern_filters_union_members(
+    value: ClosedIntPayload | ClosedStrPayload | ClosedBoolPayload,
+) -> None:
+    match value:
+        case ({"tag": "int", "value": item} | {"tag": "str", "value": item}) as whole:
+            reveal_type(item)  # revealed: int | str
+            reveal_type(whole)  # revealed: ClosedIntPayload | ClosedStrPayload
+
+@final
+class Token: ...
+
+def test_required_typed_dict_key_excludes_fallback_binding(
+    value: IntPayload | Token,
+) -> int | Token:
+    match value:
+        case {"value": item} | item:
+            reveal_type(item)  # revealed: int | Token
+            return item
 ```
 
 ## Exhaustive positional patterns for built-in classes
@@ -1514,8 +2149,8 @@ def match_named_expression_subject_capture(value: tuple[int]) -> None:
 ## Cycles in pattern binding types
 
 Pattern captures can affect the type of a later match subject, including through a loop or a
-function defined before the capture. These cycles should resolve to the same concrete binding types
-as equivalent code without a cycle.
+function defined before the capture. Direct, sequence, class, and match-self captures resolve to a
+concrete type. A mapping capture conservatively retains `Unknown` from cycle recovery.
 
 ```py
 def match_loop_carried_capture(flag: bool, x: int) -> None:
@@ -1530,6 +2165,29 @@ def match_loop_carried_sequence_capture(flag: bool) -> None:
         match x:
             case [x]:
                 reveal_type(x)  # revealed: Literal[1]
+
+class CycleBox:
+    value: int
+
+def match_loop_carried_class_capture(flag: bool) -> None:
+    x = CycleBox()
+    while flag:
+        match x:
+            case CycleBox(value=x):
+                reveal_type(x)  # revealed: int
+
+def match_loop_carried_mapping_capture(flag: bool) -> None:
+    x = {"value": 1}
+    while flag:
+        match x:
+            case {"value": x}:
+                reveal_type(x)  # revealed: int | Unknown
+
+def match_loop_carried_match_self_capture(flag: bool, x: int) -> None:
+    while flag:
+        match x:
+            case int(x):
+                reveal_type(x)  # revealed: int
 
 def capture_from_later_global() -> int:
     return captured

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -474,9 +474,9 @@ def test_ordered_or_alias_excludes_cross_type_equal_values(
 
 ## Ordered `or`-pattern bindings
 
-Alternatives are tried from left to right. Under the static member model, the declaration of
-`Values.x` makes the protocol pattern exhaustive, so the later sequence alternative cannot
-contribute to the binding:
+Alternatives are tried from left to right. We assume the declaration of `Values.x` means that every
+`Values` instance has an `x` attribute. This makes the protocol pattern exhaustive, so the later
+sequence alternative cannot contribute to the binding:
 
 ```py
 from typing import Protocol, runtime_checkable
@@ -734,8 +734,8 @@ def test_match_class_alias_rejects_disjoint_final_class(value: FinalA) -> None:
 ## Class patterns for runtime dictionary values
 
 A `TypedDict` type does not inherit from `dict`, but its values are dictionaries at runtime. Those
-values can therefore match `dict`, the mapping abstract base classes, and runtime-checkable
-protocols implemented by dictionaries.
+values can therefore match `dict`, `collections.abc.Mapping`, and runtime-checkable protocols
+implemented by dictionaries.
 
 ```py
 from collections.abc import Mapping
@@ -825,10 +825,10 @@ def test_incompatible_declared_class_capture(value: PatternBox[int]) -> None:
 
 ## Generic subclass captures
 
-When a value is typed as a generic base class and the pattern matches one of its subclasses, the
-base class's type argument is not yet preserved on the subclass. The extracted attribute is
-therefore `Unknown`, rather than the default `object` specialization that would produce false
-positive errors.
+We do not yet infer a generic subclass's specialization from its base class. In the first two
+examples, ty therefore cannot infer `GenericPatternChild[int]` from `GenericPatternBase[int]`, so
+attributes declared only on the subclass are `Unknown`. Attributes inherited from the generic base
+class can still use the subject's specialization, as shown in the final example.
 
 ```py
 from typing import Generic, TypeVar
@@ -874,8 +874,9 @@ def test_match_inherited_generic_subclass_capture(
 ## Positional class patterns
 
 `__match_args__` is read through the pattern class and must identify literal attribute names. This
-includes attributes provided by a metaclass. An explicit widened annotation does not tell us which
-attribute a positional pattern extracts.
+includes attributes provided by a metaclass. An annotation such as `tuple[str, ...]` does not
+preserve the literal attribute names, so we cannot tell which attribute a positional pattern
+extracts.
 
 ```py
 class MatchArgsMeta(type):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -855,6 +855,7 @@ def test_match_generic_subclass_capture(value: GenericPatternBase[int]) -> None:
 def test_match_nested_generic_subclass_capture(value: GenericPatternBase[int]) -> list[int]:
     match value:
         case GenericPatternChild(items=items):
+            # TODO: This should be `list[int]` once generic subclass specialization is supported.
             reveal_type(items)  # revealed: Unknown
             return items
     return []
@@ -994,18 +995,39 @@ def test_match_ordered_class_alternatives_remove_later_bindings(
 ```
 
 An argumentless class pattern cannot fail after its class check. If it matches the entire subject
-type, a later alternative cannot contribute to the binding:
+type, a later alternative cannot contribute to the binding. When the argumentless pattern comes
+second, an earlier class pattern can still contribute if the subject class is not final because a
+subclass could match both classes. A final subject class rules out that overlap:
 
 ```py
+from typing import final
+
 class DefiniteFirst: ...
 
 class UnreachableLater:
     payload: str
 
+@final
+class FinalDefiniteFirst: ...
+
 def test_definite_class_alternative_removes_later_bindings(value: DefiniteFirst) -> None:
     match value:
         case (DefiniteFirst() as item) | UnreachableLater(payload=item):
             reveal_type(item)  # revealed: DefiniteFirst
+
+def test_later_non_final_class_alternative_preserves_earlier_bindings(
+    value: DefiniteFirst,
+) -> None:
+    match value:
+        case UnreachableLater(payload=item) | (DefiniteFirst() as item):
+            reveal_type(item)  # revealed: str | DefiniteFirst
+
+def test_later_final_class_alternative_removes_earlier_bindings(
+    value: FinalDefiniteFirst,
+) -> None:
+    match value:
+        case UnreachableLater(payload=item) | (FinalDefiniteFirst() as item):
+            reveal_type(item)  # revealed: FinalDefiniteFirst
 ```
 
 ## Positional patterns for built-in classes
@@ -1059,8 +1081,6 @@ class OverlapCaptureA: ...
 class OverlapCaptureB:
     member: int
 
-class OverlapCaptureC(OverlapCaptureA, OverlapCaptureB): ...
-
 def test_match_class_capture_preserves_possible_multiple_inheritance(
     value: OverlapCaptureA,
 ) -> None:
@@ -1074,8 +1094,6 @@ class OverlapMemberA:
 
 class OverlapMemberB:
     member: str
-
-class OverlapMemberC(OverlapMemberA, OverlapMemberB): ...
 
 def test_match_class_capture_combines_overlapping_member_types(
     value: OverlapMemberA,

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1202,7 +1202,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
         PatternPredicateKind::Mapping(kind) => {
             let mapping_ty = mapping_pattern_type(db);
             if subject_ty.is_subtype_of(db, mapping_ty) {
-                if kind.is_empty() {
+                if kind.is_irrefutable() {
                     Truthiness::AlwaysTrue
                 } else {
                     Truthiness::Ambiguous

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -35,10 +35,11 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    callable_pattern_type, definite_match_pattern_type, definite_match_pattern_type_for_subject,
+    ClassPatternPositionalSource, callable_pattern_type, class_pattern_positional_sources,
+    definite_match_pattern_type, definite_match_pattern_type_for_subject,
     exact_sequence_pattern_type, mapping_pattern_type, pattern_binding_fallthrough_type,
     pattern_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type,
+    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -505,10 +505,10 @@ fn sequence_pattern_is_exhaustive_for_subject(
 /// answer depends on the subject.
 ///
 /// This is an under-approximation used for negative narrowing and ordered alternatives: callers
-/// may subtract the result from `subject_ty` under ty's static member model. A subject-independent
-/// pattern can return a type wider than `subject_ty`; for example, `case Base()` returns `Base`
-/// even for a `Child` subject. Class patterns need the current subject type when member extraction
-/// depends on the subject's statically known members.
+/// may subtract the result from `subject_ty`. A subject-independent pattern can return a type wider
+/// than `subject_ty`; for example, `case Base()` returns `Base` even for a `Child` subject. Class
+/// patterns need the current subject type when member extraction depends on the subject's statically
+/// known members.
 /// A subject-independent pattern can return its context-free definite-match type directly. A
 /// mapping pattern can use required `TypedDict` fields to establish that every subject value
 /// contains its keys.

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -2,7 +2,7 @@ use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ty_python_core::Truthiness;
 use ty_python_core::predicate::{
-    ClassPatternPredicateKind, MappingPatternEntryPredicateKind, PatternPredicateKind,
+    ClassPatternPredicateKind, MappingPatternPredicateKind, PatternPredicateKind,
     SequencePatternPredicateKind,
 };
 
@@ -42,7 +42,7 @@ pub(crate) fn callable_pattern_type(db: &dyn Db) -> Type<'_> {
 /// `TypedDict` is not a nominal subtype of `dict` in the static type system, but every runtime
 /// value is a dictionary. A `TypedDict` therefore matches class patterns such as `dict()`,
 /// `Mapping()`, and `MutableMapping()`.
-fn typed_dict_matches_class_pattern(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
+pub(crate) fn typed_dict_matches_class_pattern(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
     let Some(dict) = KnownClass::Dict.to_class_literal(db).as_class_literal() else {
         return false;
     };
@@ -284,7 +284,8 @@ enum ClassMatchArgs<'db> {
 }
 
 /// The value supplied to one positional subpattern in a class pattern.
-enum ClassPatternPositionalSource {
+#[derive(Clone)]
+pub(crate) enum ClassPatternPositionalSource {
     /// The complete subject, as used by Python's special built-in class patterns.
     MatchSelf,
     /// The named attribute extracted from the subject according to `__match_args__`.
@@ -368,7 +369,7 @@ fn class_has_match_self_flag(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
 ///     case int(_):  # The positional subpattern receives `number` itself.
 ///         pass
 /// ```
-fn class_pattern_positional_sources(
+pub(crate) fn class_pattern_positional_sources(
     db: &dyn Db,
     class: ClassLiteral<'_>,
     positional_count: usize,
@@ -438,11 +439,11 @@ fn pattern_is_exhaustive_for_subject(
 /// guarantee that a particular key is present.
 fn mapping_pattern_is_exhaustive(
     db: &dyn Db,
-    entries: &[MappingPatternEntryPredicateKind<'_>],
+    kind: &MappingPatternPredicateKind<'_>,
     subject_ty: Type<'_>,
 ) -> bool {
     typed_dict_pattern_domain_satisfies(db, subject_ty, &|typed_dict| {
-        entries.iter().all(|entry| {
+        kind.entries.iter().all(|entry| {
             let key_ty = infer_same_file_expression_type(db, entry.key, TypeContext::default());
             let Some(key) = key_ty.as_string_literal() else {
                 return false;
@@ -784,7 +785,7 @@ fn subject_independent_definite_match_pattern_type<'db>(
             })
         }
         PatternPredicateKind::Mapping(kind) => {
-            if kind.is_empty() {
+            if kind.is_irrefutable() {
                 Some(mapping_pattern_type(db))
             } else {
                 None
@@ -835,7 +836,7 @@ pub(crate) fn definite_match_pattern_type<'db>(
             }
         }
         PatternPredicateKind::Mapping(kind) => {
-            if kind.is_empty() {
+            if kind.is_irrefutable() {
                 mapping_pattern_type(db)
             } else {
                 Type::Never

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -12,20 +12,22 @@ use crate::types::typed_dict::{
     TypedDictField, TypedDictFieldBuilder, TypedDictSchema, TypedDictType,
 };
 use crate::types::{
-    CallableType, ClassLiteral, ClassType, IntersectionBuilder, IntersectionType, KnownClass,
-    KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature, SpecialFormType,
-    SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionBuilder, callable_pattern_type, definite_match_pattern_type_for_subject,
+    CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
+    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
+    Parameter, Parameters, Signature, SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness,
+    Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type,
+    class_pattern_positional_sources, definite_match_pattern_type_for_subject,
     exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
     pattern_binding_fallthrough_type, pattern_fallthrough_type, sequence_pattern_type_builder,
-    singleton_pattern_type, starred_sequence_pattern_type,
+    singleton_pattern_type, starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
 use ty_python_core::predicate::{
-    CallableAndCallExpr, PatternPredicate, PatternPredicateKind, Predicate, PredicateNode,
-    SequencePatternPredicateKind, SubjectElementPatternPredicate,
+    CallableAndCallExpr, ClassPatternPredicateKind, MappingPatternPredicateKind, PatternPredicate,
+    PatternPredicateKind, Predicate, PredicateNode, SequencePatternPredicateKind,
+    SubjectElementPatternPredicate,
 };
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
@@ -35,8 +37,10 @@ use ruff_python_ast::name::Name;
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use super::UnionType;
+use super::call::CallArguments;
 use super::equality::{
-    equality_exclusion_constraint, evaluate_type_equality, evaluate_type_inequality,
+    equality_exclusion_constraint, equality_truthiness, evaluate_type_equality,
+    evaluate_type_inequality,
 };
 use itertools::Itertools;
 use ruff_python_ast as ast;
@@ -186,9 +190,9 @@ pub(crate) struct PatternSuccessTypes<'db> {
 impl<'db> PatternSuccessTypes<'db> {
     /// Return the inferred binding type.
     ///
-    /// A missing entry is `Never` when the whole pattern cannot match and `Unknown` when the
-    /// analysis does not support that binding. During cycle recovery, it is the divergent type for
-    /// that cycle.
+    /// A missing entry is `Never` when the whole pattern cannot match. Otherwise, it is `Unknown`
+    /// as defensive recovery for a malformed pattern or a binding that was not recorded. During
+    /// cycle recovery, it is the divergent type for that cycle.
     pub(crate) fn binding_type(&self, place: ScopedPlaceId) -> Type<'db> {
         // An OR pattern's alternatives define one runtime binding, so their types are merged by
         // place.
@@ -268,6 +272,18 @@ struct PatternBindingType<'db> {
     aliases_subject: bool,
 }
 
+/// Controls when pattern analysis restores an original subject type after filtering its arms.
+///
+/// Class and mapping patterns use [`Self::EquivalentTypes`] because their successful subject type
+/// only filters the original type. Sequence and OR patterns can construct a more precise success
+/// type, so they use [`Self::TypeVariablesOnly`] to retain that precision while still preserving
+/// the identity of an original type variable.
+#[derive(Clone, Copy)]
+enum OriginalSubjectPreservation {
+    EquivalentTypes,
+    TypeVariablesOnly,
+}
+
 impl<'db> PatternBindingTypes<'db> {
     /// Create a binding that aliases the current subject.
     fn subject(subject_ty: Type<'db>) -> Self {
@@ -275,6 +291,15 @@ impl<'db> PatternBindingTypes<'db> {
             contributions: smallvec![PatternBindingType {
                 ty: subject_ty,
                 aliases_subject: true,
+            }],
+        }
+    }
+
+    fn extracted(extracted_ty: Type<'db>) -> Self {
+        Self {
+            contributions: smallvec![PatternBindingType {
+                ty: extracted_ty,
+                aliases_subject: false,
             }],
         }
     }
@@ -324,6 +349,23 @@ impl<'db> PatternBindingTypes<'db> {
             true
         });
     }
+}
+
+struct ClassPatternContext<'db> {
+    class: Option<ClassLiteral<'db>>,
+    class_ty: Type<'db>,
+    positional_sources: Vec<ClassPatternPositionalSource>,
+}
+
+struct ClassPatternArgument<'db> {
+    ty: Type<'db>,
+    source: PatternValueSource,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PatternValueSource {
+    Subject,
+    Extracted,
 }
 
 /// Computes the subject and binding types produced by successful match patterns.
@@ -1220,6 +1262,12 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
         match pattern {
+            PatternPredicateKind::Class(kind) => {
+                self.analyze_successful_class_pattern(kind, subject_ty)
+            }
+            PatternPredicateKind::Mapping(kind) => {
+                self.analyze_successful_mapping_pattern(kind, subject_ty)
+            }
             PatternPredicateKind::Sequence(kind) => {
                 self.analyze_successful_sequence_pattern(kind, subject_ty)
             }
@@ -1270,20 +1318,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     bindings: BTreeMap::new(),
                 }
             }
-            PatternPredicateKind::Class(kind) => {
-                let class_ty = necessary_match_pattern_type(self.db, pattern);
-                let class =
-                    infer_same_file_expression_type(self.db, kind.class, TypeContext::default())
-                        .as_class_literal();
-                let matched_subject_ty =
-                    self.match_class_pattern_subject_type(class, class_ty, subject_ty, false);
-                PatternSuccessResult {
-                    matched_subject_ty,
-                    binding_subject_ty: matched_subject_ty,
-                    bindings: BTreeMap::new(),
-                }
-            }
-            PatternPredicateKind::Mapping(_) | PatternPredicateKind::Singleton(_) => {
+            PatternPredicateKind::Singleton(_) => {
                 let matched_subject_ty = self
                     .intersect_types(subject_ty, necessary_match_pattern_type(self.db, pattern));
                 PatternSuccessResult {
@@ -1319,42 +1354,18 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             .unwrap_or(subject_ty)
     }
 
-    fn contains_unsupported_binding_pattern(pattern: &PatternPredicateKind<'_>) -> bool {
-        match pattern {
-            PatternPredicateKind::Class(..) | PatternPredicateKind::Mapping(_) => true,
-            PatternPredicateKind::Sequence(kind) => kind
-                .patterns
-                .iter()
-                .any(Self::contains_unsupported_binding_pattern),
-            PatternPredicateKind::Or(patterns) => patterns
-                .iter()
-                .any(Self::contains_unsupported_binding_pattern),
-            PatternPredicateKind::As(Some(pattern), _) => {
-                Self::contains_unsupported_binding_pattern(pattern)
-            }
-            _ => false,
-        }
-    }
-
     fn analyze_successful_or_pattern(
         &self,
         patterns: &[PatternPredicateKind<'db>],
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
-        let mut result = self.analyze_pattern_subject_arms(subject_ty, |analyzer, subject_ty| {
-            Some(analyzer.analyze_successful_or_pattern_arm(patterns, subject_ty))
-        });
-        if patterns
-            .iter()
-            .any(Self::contains_unsupported_binding_pattern)
-        {
-            // Class and mapping child patterns are not retained yet, so a reachable alternative can
-            // bind a name that is absent from its analysis result. Discard every contribution rather
-            // than infer a type from only the supported alternatives. The class and mapping binding
-            // analysis removes this conservative fallback in the next PR.
-            result.bindings.clear();
-        }
-        result
+        self.analyze_pattern_subject_arms(
+            subject_ty,
+            OriginalSubjectPreservation::TypeVariablesOnly,
+            |analyzer, _, arm_ty| {
+                Some(analyzer.analyze_successful_or_pattern_arm(patterns, arm_ty))
+            },
+        )
     }
 
     fn analyze_successful_or_pattern_arm(
@@ -1412,42 +1423,26 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ///             for child in children:
     ///                 visit(child)
     /// ```
-    fn match_class_pattern_subject_type(
+    fn filter_class_pattern_subject_type(
         &self,
         class: Option<ClassLiteral<'db>>,
         class_ty: Type<'db>,
         subject_ty: Type<'db>,
-        filter_nominal_arms: bool,
     ) -> Type<'db> {
         match subject_ty {
-            Type::TypeAlias(alias) => self.match_class_pattern_subject_type(
-                class,
-                class_ty,
-                alias.value_type(self.db),
-                true,
-            ),
+            Type::TypeAlias(alias) => {
+                self.filter_class_pattern_subject_type(class, class_ty, alias.value_type(self.db))
+            }
             Type::Union(union) => union.map(self.db, |element| {
-                self.match_class_pattern_subject_type(class, class_ty, *element, true)
+                self.filter_class_pattern_subject_type(class, class_ty, *element)
             }),
             Type::Intersection(intersection) if intersection.positive(self.db).is_empty() => {
                 self.intersect_types(subject_ty, class_ty)
             }
-            Type::Intersection(intersection) => {
-                let filter_nominal_arms = filter_nominal_arms
-                    || intersection
-                        .positive(self.db)
-                        .iter()
-                        .any(|positive| matches!(positive, Type::TypeAlias(_) | Type::Union(_)));
-                intersection.map_positive(self.db, |positive| {
-                    self.match_class_pattern_subject_type(
-                        class,
-                        class_ty,
-                        *positive,
-                        filter_nominal_arms,
-                    )
-                })
-            }
-            Type::NominalInstance(instance) if filter_nominal_arms => {
+            Type::Intersection(intersection) => intersection.map_positive(self.db, |positive| {
+                self.filter_class_pattern_subject_type(class, class_ty, *positive)
+            }),
+            Type::NominalInstance(instance) => {
                 let Some(class) = class else {
                     return self.intersect_types(subject_ty, class_ty);
                 };
@@ -1460,19 +1455,325 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     self.intersect_types(subject_ty, class_ty)
                 }
             }
-            Type::TypedDict(_) if filter_nominal_arms => {
-                if class.is_some_and(|class| {
-                    KnownClass::Dict.is_subclass_of(self.db, ClassType::NonGeneric(class))
-                }) {
-                    subject_ty
-                } else {
-                    Type::Never
-                }
+            Type::TypedDict(_)
+                if class.is_some_and(|class| typed_dict_matches_class_pattern(self.db, class)) =>
+            {
+                subject_ty
             }
             _ if subject_ty.is_subtype_of(self.db, class_ty) => subject_ty,
             _ if subject_ty.is_disjoint_from(self.db, class_ty) => Type::Never,
             _ => self.intersect_types(subject_ty, class_ty),
         }
+    }
+
+    fn class_pattern_arguments_for_arm(
+        &self,
+        kind: &ClassPatternPredicateKind<'db>,
+        context: &ClassPatternContext<'db>,
+        original_subject_ty: Type<'db>,
+        subject_ty: Type<'db>,
+    ) -> Option<Vec<ClassPatternArgument<'db>>> {
+        let subject_is_final = subject_ty
+            .nominal_class(self.db)
+            .is_some_and(|class| class.is_final(self.db));
+        let member_type = |name: &Name| {
+            let original_member_ty = original_subject_ty
+                .member(self.db, name.as_str())
+                .place
+                .ignore_possibly_undefined();
+            let place = subject_ty.member(self.db, name.as_str()).place;
+            let mut member_ty = place.ignore_possibly_undefined();
+            if member_ty.is_some_and(|ty| ty.is_never())
+                && let Type::Intersection(intersection) = subject_ty
+            {
+                let overlapping_member_ty = UnionType::from_elements(
+                    self.db,
+                    intersection
+                        .positive(self.db)
+                        .iter()
+                        .filter_map(|positive| {
+                            positive
+                                .member(self.db, name.as_str())
+                                .place
+                                .ignore_possibly_undefined()
+                        }),
+                );
+                if !overlapping_member_ty.is_never() {
+                    member_ty = Some(overlapping_member_ty);
+                }
+            }
+
+            if context.class.is_some_and(|pattern_class| {
+                pattern_class
+                    .generic_context(self.db)
+                    .and_then(|generic_context| {
+                        pattern_class
+                            .instance_member(
+                                self.db,
+                                Some(generic_context.identity_specialization(self.db)),
+                                name.as_str(),
+                            )
+                            .place
+                            .ignore_possibly_undefined()
+                    })
+                    .is_some_and(|ty| ty.has_typevar(self.db))
+            }) {
+                // The pattern subclass's default specialization loses the type arguments from the
+                // subject's generic base. Prefer a member type already known from the subject;
+                // otherwise, do not treat the subclass's fallback as a declared type.
+                member_ty = Some(original_member_ty.unwrap_or_else(Type::unknown));
+            }
+            member_ty.or_else(|| (!subject_is_final).then_some(Type::unknown()))
+        };
+
+        context
+            .positional_sources
+            .iter()
+            .map(|source| match source {
+                ClassPatternPositionalSource::MatchSelf => Some(ClassPatternArgument {
+                    ty: subject_ty,
+                    source: PatternValueSource::Subject,
+                }),
+                ClassPatternPositionalSource::Attribute(name) => {
+                    member_type(name).map(|ty| ClassPatternArgument {
+                        ty,
+                        source: PatternValueSource::Extracted,
+                    })
+                }
+                ClassPatternPositionalSource::Unknown => Some(ClassPatternArgument {
+                    ty: Type::unknown(),
+                    source: PatternValueSource::Extracted,
+                }),
+            })
+            .chain(kind.keywords.iter().map(|keyword| {
+                member_type(&keyword.attr).map(|ty| ClassPatternArgument {
+                    ty,
+                    source: PatternValueSource::Extracted,
+                })
+            }))
+            .collect()
+    }
+
+    fn analyze_successful_class_pattern(
+        &self,
+        kind: &ClassPatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> PatternSuccessResult<'db> {
+        let class_expr_ty =
+            infer_same_file_expression_type(self.db, kind.class, TypeContext::default());
+        let class = class_expr_ty.as_class_literal();
+        let class_ty =
+            positive_class_pattern_type(self.db, class_expr_ty).unwrap_or_else(Type::object);
+        let context = ClassPatternContext {
+            class,
+            class_ty,
+            positional_sources: class.map_or_else(
+                || vec![ClassPatternPositionalSource::Unknown; kind.positional.len()],
+                |class| class_pattern_positional_sources(self.db, class, kind.positional.len()),
+            ),
+        };
+        self.analyze_pattern_subject_arms(
+            subject_ty,
+            OriginalSubjectPreservation::EquivalentTypes,
+            |analyzer, original_subject_ty, subject_ty| {
+                let narrowed_subject_ty = analyzer.filter_class_pattern_subject_type(
+                    context.class,
+                    context.class_ty,
+                    subject_ty,
+                );
+                if narrowed_subject_ty.is_never() {
+                    return None;
+                }
+
+                let arguments = analyzer.class_pattern_arguments_for_arm(
+                    kind,
+                    &context,
+                    original_subject_ty,
+                    narrowed_subject_ty,
+                )?;
+                let mut matched_subject_ty = narrowed_subject_ty;
+                let mut binding_subject_ty = narrowed_subject_ty;
+                let mut bindings = BTreeMap::new();
+                for (pattern, argument) in kind
+                    .positional
+                    .iter()
+                    .chain(kind.keywords.iter().map(|keyword| &keyword.pattern))
+                    .zip(arguments)
+                {
+                    let mut child = analyzer.analyze_successful_pattern(pattern, argument.ty);
+                    if child.matched_subject_ty.is_never() {
+                        return None;
+                    }
+                    if argument.source != PatternValueSource::Subject {
+                        Self::demote_subject_bindings(&mut child.bindings);
+                    } else {
+                        matched_subject_ty = child.matched_subject_ty;
+                        binding_subject_ty = child.binding_subject_ty;
+                    }
+                    Self::merge_bindings(&mut bindings, child.bindings);
+                }
+
+                Some(PatternSuccessResult {
+                    matched_subject_ty,
+                    binding_subject_ty,
+                    bindings,
+                })
+            },
+        )
+    }
+
+    fn mapping_pattern_value_type_for_arm(
+        &self,
+        subject_ty: Type<'db>,
+        key_ty: Type<'db>,
+    ) -> Option<Type<'db>> {
+        if let Type::TypedDict(typed_dict) = subject_ty.resolve_type_alias(self.db) {
+            let key_ty = key_ty.resolve_type_alias(self.db);
+            let typed_dict_key_ty = typed_dict.key_type(self.db);
+            if typed_dict_key_ty.is_never()
+                || equality_truthiness(self.db, typed_dict_key_ty, key_ty)
+                    == Truthiness::AlwaysFalse
+            {
+                return None;
+            }
+            if let Some(key) = key_ty.as_string_literal() {
+                return typed_dict
+                    .item(self.db, key.value(self.db))
+                    .map(|field| field.declared_ty)
+                    .or_else(|| {
+                        typed_dict
+                            .openness(self.db)
+                            .is_implicitly_open()
+                            .then_some(Type::object())
+                    });
+            }
+            return Some(typed_dict.value_type(self.db));
+        }
+
+        let Some((_, mapping_value_ty)) = subject_ty.unpack_keys_and_items(self.db) else {
+            return Some(Type::unknown());
+        };
+        let Some(get_method) = subject_ty
+            .member(self.db, "get")
+            .place
+            .ignore_possibly_undefined()
+        else {
+            return Some(Type::unknown());
+        };
+        let default_ty = if self.mapping_pattern_uses_standard_get(subject_ty) {
+            mapping_value_ty
+        } else {
+            Type::object()
+        };
+        Some(
+            get_method
+                .try_call(self.db, &CallArguments::positional([key_ty, default_ty]))
+                .map(|bindings| bindings.return_type(self.db))
+                .unwrap_or_else(|error| error.return_type(self.db)),
+        )
+    }
+
+    fn mapping_pattern_uses_standard_get(&self, subject_ty: Type<'db>) -> bool {
+        let Some(class) = subject_ty.nominal_class(self.db) else {
+            return false;
+        };
+        for base in class.iter_mro(self.db) {
+            let class = match base {
+                ClassBase::Class(class) => class,
+                ClassBase::Generic | ClassBase::Protocol => continue,
+                ClassBase::Any
+                | ClassBase::Dynamic(_)
+                | ClassBase::Divergent(_)
+                | ClassBase::TypedDict(_) => {
+                    return false;
+                }
+            };
+            if !class.own_instance_member(self.db, "get").is_undefined() {
+                return false;
+            }
+            if class.own_class_member(self.db, None, "get").is_undefined() {
+                continue;
+            }
+            return matches!(
+                class.known(self.db),
+                Some(KnownClass::Dict | KnownClass::Mapping)
+            );
+        }
+        false
+    }
+
+    fn analyze_successful_mapping_pattern(
+        &self,
+        kind: &MappingPatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> PatternSuccessResult<'db> {
+        let key_types: Vec<_> = kind
+            .entries
+            .iter()
+            .map(|entry| {
+                infer_same_file_expression_type(self.db, entry.key, TypeContext::default())
+            })
+            .collect();
+        self.analyze_pattern_subject_arms(
+            subject_ty,
+            OriginalSubjectPreservation::EquivalentTypes,
+            |analyzer, _, subject_ty| {
+                let narrowed_subject_ty =
+                    analyzer.intersect_types(subject_ty, mapping_pattern_type(analyzer.db));
+                if narrowed_subject_ty.is_never() {
+                    return None;
+                }
+
+                let value_types: Option<Vec<_>> = kind
+                    .entries
+                    .iter()
+                    .zip(&key_types)
+                    .map(|(_, key_ty)| {
+                        analyzer.mapping_pattern_value_type_for_arm(subject_ty, *key_ty)
+                    })
+                    .collect();
+                let value_types = value_types?;
+                let mut bindings = BTreeMap::new();
+                for (entry, value_ty) in kind.entries.iter().zip(value_types) {
+                    let mut child = analyzer.analyze_successful_pattern(&entry.pattern, value_ty);
+                    if child.matched_subject_ty.is_never() {
+                        return None;
+                    }
+                    Self::demote_subject_bindings(&mut child.bindings);
+                    Self::merge_bindings(&mut bindings, child.bindings);
+                }
+
+                if let Some(place) = kind
+                    .rest
+                    .as_ref()
+                    .and_then(|name| analyzer.places().symbol_id(name.as_str()))
+                {
+                    Self::merge_binding(
+                        &mut bindings,
+                        place.into(),
+                        PatternBindingTypes::extracted(
+                            analyzer.mapping_pattern_rest_type_for_arm(narrowed_subject_ty),
+                        ),
+                    );
+                }
+
+                Some(PatternSuccessResult {
+                    matched_subject_ty: narrowed_subject_ty,
+                    binding_subject_ty: narrowed_subject_ty,
+                    bindings,
+                })
+            },
+        )
+    }
+
+    fn mapping_pattern_rest_type_for_arm(&self, subject_ty: Type<'db>) -> Type<'db> {
+        let (key_ty, value_ty) = match subject_ty.resolve_type_alias(self.db) {
+            Type::TypedDict(_) => (KnownClass::Str.to_instance(self.db), Type::object()),
+            _ => subject_ty
+                .unpack_keys_and_items(self.db)
+                .unwrap_or_else(|| (Type::unknown(), Type::unknown())),
+        };
+        KnownClass::Dict.to_specialized_instance(self.db, &[key_ty, value_ty])
     }
 
     /// Return the subject and binding types of a successful sequence pattern.
@@ -1494,36 +1795,43 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
         let target_len = Self::sequence_pattern_target_len(kind);
-        self.analyze_pattern_subject_arms(subject_ty, |analyzer, subject_ty| {
-            let (narrowed_subject_ty, element_types) =
-                analyzer.sequence_pattern_arm(subject_ty, target_len)?;
-            let mut bindings = BTreeMap::new();
-            let mut matched_element_types = Vec::with_capacity(kind.patterns.len());
-            let mut binding_element_types = Vec::with_capacity(kind.patterns.len());
-            for (pattern, element_ty) in kind.patterns.iter().zip(element_types) {
-                let mut child = analyzer.analyze_successful_pattern(pattern, element_ty);
-                if child.matched_subject_ty.is_never() {
-                    return None;
+        self.analyze_pattern_subject_arms(
+            subject_ty,
+            OriginalSubjectPreservation::TypeVariablesOnly,
+            |analyzer, _, subject_ty| {
+                let (narrowed_subject_ty, element_types) =
+                    analyzer.sequence_pattern_arm(subject_ty, target_len)?;
+                let mut bindings = BTreeMap::new();
+                let mut matched_element_types = Vec::with_capacity(kind.patterns.len());
+                let mut binding_element_types = Vec::with_capacity(kind.patterns.len());
+                for (pattern, element_ty) in kind.patterns.iter().zip(element_types) {
+                    let mut child = analyzer.analyze_successful_pattern(pattern, element_ty);
+                    if child.matched_subject_ty.is_never() {
+                        return None;
+                    }
+                    matched_element_types.push(child.matched_subject_ty);
+                    binding_element_types.push(child.binding_subject_ty);
+                    Self::demote_subject_bindings(&mut child.bindings);
+                    Self::merge_bindings(&mut bindings, child.bindings);
                 }
-                matched_element_types.push(child.matched_subject_ty);
-                binding_element_types.push(child.binding_subject_ty);
-                Self::demote_subject_bindings(&mut child.bindings);
-                Self::merge_bindings(&mut bindings, child.bindings);
-            }
-            let matched_subject_ty = analyzer.successful_sequence_subject_type(
-                kind,
-                subject_ty,
-                narrowed_subject_ty,
-                &matched_element_types,
-            );
-            let binding_subject_ty =
-                analyzer.successful_sequence_binding_type(kind, subject_ty, &binding_element_types);
-            Some(PatternSuccessResult {
-                matched_subject_ty,
-                binding_subject_ty,
-                bindings,
-            })
-        })
+                let matched_subject_ty = analyzer.successful_sequence_subject_type(
+                    kind,
+                    subject_ty,
+                    narrowed_subject_ty,
+                    &matched_element_types,
+                );
+                let binding_subject_ty = analyzer.successful_sequence_binding_type(
+                    kind,
+                    subject_ty,
+                    &binding_element_types,
+                );
+                Some(PatternSuccessResult {
+                    matched_subject_ty,
+                    binding_subject_ty,
+                    bindings,
+                })
+            },
+        )
     }
 
     /// Return the type established while a sequence pattern is being evaluated.
@@ -1619,7 +1927,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     fn analyze_pattern_subject_arms(
         &self,
         subject_ty: Type<'db>,
-        analyze_arm: impl Fn(&Self, Type<'db>) -> Option<PatternSuccessResult<'db>>,
+        preservation: OriginalSubjectPreservation,
+        analyze_arm: impl Fn(&Self, Type<'db>, Type<'db>) -> Option<PatternSuccessResult<'db>>,
     ) -> PatternSuccessResult<'db> {
         let subject_arms = self.match_pattern_subject_arms(subject_ty);
         let grouped_arms = subject_arms
@@ -1635,7 +1944,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             let mut arm_bindings = BTreeMap::new();
 
             for (_, filtering_subject_ty) in arms {
-                if let Some(arm) = analyze_arm(self, filtering_subject_ty) {
+                if let Some(arm) = analyze_arm(self, original_subject_ty, filtering_subject_ty) {
                     matched_types.add_in_place(arm.matched_subject_ty);
                     binding_types.add_in_place(arm.binding_subject_ty);
                     Self::merge_bindings(&mut arm_bindings, arm.bindings);
@@ -1645,19 +1954,25 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             for binding in arm_bindings.values_mut() {
                 let subject_ty = binding.subject_ty(self.db);
                 if !subject_ty.is_never() {
-                    binding.restore_subject(
-                        self.matched_subject_type_for_original(original_subject_ty, subject_ty),
-                    );
+                    binding.restore_subject(self.preserve_original_subject_type(
+                        original_subject_ty,
+                        subject_ty,
+                        preservation,
+                    ));
                 }
             }
             Self::merge_bindings(&mut bindings, arm_bindings);
 
-            matched_subject_types.add_in_place(
-                self.matched_subject_type_for_original(original_subject_ty, matched_types.build()),
-            );
-            binding_subject_types.add_in_place(
-                self.matched_subject_type_for_original(original_subject_ty, binding_types.build()),
-            );
+            matched_subject_types.add_in_place(self.preserve_original_subject_type(
+                original_subject_ty,
+                matched_types.build(),
+                preservation,
+            ));
+            binding_subject_types.add_in_place(self.preserve_original_subject_type(
+                original_subject_ty,
+                binding_types.build(),
+                preservation,
+            ));
         }
 
         PatternSuccessResult {
@@ -1667,20 +1982,22 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         }
     }
 
-    fn matched_subject_type_for_original(
+    fn preserve_original_subject_type(
         &self,
         original_subject_ty: Type<'db>,
-        matched_types: Type<'db>,
+        filtered_ty: Type<'db>,
+        preservation: OriginalSubjectPreservation,
     ) -> Type<'db> {
-        let filtering_types = self.pattern_filtering_type(original_subject_ty);
-        if matched_types.is_equivalent_to(self.db, filtering_types)
-            && original_subject_ty.has_typevar(self.db)
+        let filtering_ty = self.pattern_filtering_type(original_subject_ty);
+        if filtered_ty.is_equivalent_to(self.db, filtering_ty)
+            && (matches!(preservation, OriginalSubjectPreservation::EquivalentTypes)
+                || original_subject_ty.has_typevar(self.db))
         {
             original_subject_ty
         } else if original_subject_ty.has_typevar(self.db) {
-            self.intersect_types(original_subject_ty, matched_types)
+            self.intersect_types(original_subject_ty, filtered_ty)
         } else {
-            matched_types
+            filtered_ty
         }
     }
 


### PR DESCRIPTION
## Summary

We already infer the types of captures and aliases in sequence patterns by following the values passed from each pattern node to its children. This PR extends the same recursive analysis to class and mapping patterns.

```python
from dataclasses import dataclass
from typing import Literal, TypedDict

class IntPayload(TypedDict):
    tag: Literal["int"]
    value: int

class StrPayload(TypedDict):
    tag: Literal["str"]
    value: str

@dataclass
class Box:
    payload: IntPayload | StrPayload

def handle(box: Box) -> None:
    match box:
        case Box({"tag": "int", "value": value}) as whole:
            reveal_type(value)  # int
            reveal_type(whole)  # Box
```

A class pattern passes the selected instance member to each child pattern. Positional patterns resolve that member through `__match_args__`; keyword patterns use the named attribute. A mapping pattern passes the value associated with each matched key, while `**rest` receives the new dictionary built from the remaining entries.

