### PR TITLE
[ty] Initial support for `__match_args__` and matching on builtins

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -40,9 +40,10 @@ use crate::frozen::{FrozenMap, FrozenSet};
 use crate::member::MemberExprBuilder;
 use crate::place::{PlaceExpr, PlaceTableBuilder, PossiblyNarrowedPlacesBuilder, ScopedPlaceId};
 use crate::predicate::{
-    CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
-    PredicateNode, PredicateOrLiteral, ScopedPredicateId, SequencePatternPredicateKind,
-    StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
+    CallableAndCallExpr, ClassPatternKeywordPredicate, ClassPatternKind, ClassPatternPredicateKind,
+    PatternPredicate, PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral,
+    ScopedPredicateId, SequencePatternPredicateKind, StarImportPlaceholderPredicate,
+    SubjectElementPatternPredicate,
 };
 use crate::program::Program;
 use crate::re_exports::exported_names;
@@ -1934,31 +1935,50 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 PatternPredicateKind::Singleton(singleton.value)
             }
             ast::Pattern::MatchClass(pattern) => {
-                let cls = self.add_standalone_expression(&pattern.cls);
+                let class = self.add_standalone_expression(&pattern.cls);
 
                 // TODO: A class pattern with only irrefutable subpatterns can still fail if
                 // extracting an attribute named by `__match_args__` or a keyword fails. We retain
                 // this existing approximation because treating all class patterns with arguments
                 // as refutable caused a large ecosystem change. Follow-up work should determine
                 // irrefutability by analyzing the class's attributes and `__match_args__`.
-                PatternPredicateKind::Class(
-                    cls,
-                    if pattern
+                let kind = if pattern
+                    .arguments
+                    .patterns
+                    .iter()
+                    .all(ast::Pattern::is_irrefutable)
+                    && pattern
                         .arguments
-                        .patterns
+                        .keywords
                         .iter()
-                        .all(ast::Pattern::is_irrefutable)
-                        && pattern
-                            .arguments
-                            .keywords
-                            .iter()
-                            .all(|kw| kw.pattern.is_irrefutable())
-                    {
-                        ClassPatternKind::Irrefutable
-                    } else {
-                        ClassPatternKind::Refutable
-                    },
-                )
+                        .all(|kw| kw.pattern.is_irrefutable())
+                {
+                    ClassPatternKind::Irrefutable
+                } else {
+                    ClassPatternKind::Refutable
+                };
+                let positional_patterns = pattern
+                    .arguments
+                    .patterns
+                    .iter()
+                    .map(|pattern| self.predicate_kind(pattern))
+                    .collect();
+                let keyword_patterns = pattern
+                    .arguments
+                    .keywords
+                    .iter()
+                    .map(|keyword| ClassPatternKeywordPredicate {
+                        name: keyword.attr.id.clone(),
+                        pattern: self.predicate_kind(&keyword.pattern),
+                    })
+                    .collect();
+
+                PatternPredicateKind::Class(ClassPatternPredicateKind {
+                    class,
+                    kind,
+                    positional_patterns,
+                    keyword_patterns,
+                })
             }
             ast::Pattern::MatchMapping(pattern) => {
                 // `case {}` and `case {**rest}` match every mapping, while keyed mapping

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -157,6 +157,21 @@ impl ClassPatternKind {
     }
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct ClassPatternKeywordPredicate<'db> {
+    pub name: Name,
+    pub pattern: PatternPredicateKind<'db>,
+}
+
+/// Structural details for class patterns that affect narrowing and reachability.
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct ClassPatternPredicateKind<'db> {
+    pub class: Expression<'db>,
+    pub kind: ClassPatternKind,
+    pub positional_patterns: Box<[PatternPredicateKind<'db>]>,
+    pub keyword_patterns: Box<[ClassPatternKeywordPredicate<'db>]>,
+}
+
 /// Structural details for sequence patterns that affect narrowing and reachability.
 ///
 /// `patterns` stores one predicate per syntactic element, with a starred element
@@ -202,7 +217,7 @@ pub enum PatternPredicateKind<'db> {
     Singleton(Singleton),
     Value(Expression<'db>),
     Or(Vec<PatternPredicateKind<'db>>),
-    Class(Expression<'db>, ClassPatternKind),
+    Class(ClassPatternPredicateKind<'db>),
     Mapping(ClassPatternKind),
     Sequence(SequencePatternPredicateKind<'db>),
     As(Option<Box<PatternPredicateKind<'db>>>, Option<Name>),

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1027,21 +1027,24 @@ fn analyze_single_pattern_predicate_kind<'db>(
                 });
             truthiness
         }
-        PatternPredicateKind::Class(class_expr, kind) => {
-            let class_ty =
-                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
-                    Type::ClassLiteral(class) => {
-                        Some(Type::instance(db, class.top_materialization(db)))
-                    }
-                    Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                        Some(callable_pattern_type(db))
-                    }
-                    _ => None,
-                };
+        PatternPredicateKind::Class(class_pattern) => {
+            let class_ty = match infer_same_file_expression_type(
+                db,
+                class_pattern.class,
+                TypeContext::default(),
+            ) {
+                Type::ClassLiteral(class) => {
+                    Some(Type::instance(db, class.top_materialization(db)))
+                }
+                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
+                    Some(callable_pattern_type(db))
+                }
+                _ => None,
+            };
 
             class_ty.map_or(Truthiness::Ambiguous, |class_ty| {
                 if subject_ty.is_subtype_of(db, class_ty) {
-                    if kind.is_irrefutable() {
+                    if class_pattern.kind.is_irrefutable() {
                         Truthiness::AlwaysTrue
                     } else {
                         // A class pattern like `case Point(x=0, y=0)` is not irrefutable,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -35,7 +35,8 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    callable_pattern_type, definite_match_pattern_type, definite_sequence_pattern_type,
+    ClassPatternSubpatternId, ClassPatternSubpatternTarget, callable_pattern_type,
+    class_pattern_targets, definite_match_pattern_type, definite_sequence_pattern_type,
     exact_sequence_pattern_type, mapping_pattern_type, sequence_pattern_type_builder,
     singleton_pattern_type, starred_sequence_pattern_type,
 };

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -1,14 +1,17 @@
 use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
-use ty_python_core::predicate::{PatternPredicateKind, SequencePatternPredicateKind};
+use ty_python_core::predicate::{
+    ClassPatternPredicateKind, PatternPredicateKind, SequencePatternPredicateKind,
+};
 
 use crate::Db;
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::signatures::CallableSignature;
-use crate::types::tuple::TupleType;
+use crate::types::tuple::{TupleSpec, TupleType};
 use crate::types::{
-    CallableType, IntersectionBuilder, KnownClass, Parameter, Parameters, Signature,
-    SpecialFormType, Type, TypeContext, UnionType, infer_same_file_expression_type,
+    CallableType, ClassLiteral, IntersectionBuilder, KnownClass, MemberLookupPolicy, Parameter,
+    Parameters, Signature, SpecialFormType, Type, TypeContext, UnionType,
+    infer_same_file_expression_type,
 };
 
 pub(crate) fn singleton_pattern_type(db: &dyn Db, singleton: ast::Singleton) -> Type<'_> {
@@ -37,6 +40,199 @@ pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<
         .add_negative(KnownClass::Str.to_instance(db))
         .add_negative(KnownClass::Bytes.to_instance(db))
         .add_negative(KnownClass::Bytearray.to_instance(db))
+}
+
+/// A resolved target for one subpattern inside a class pattern.
+///
+/// The target captures what the subpattern is matched against after applying class-pattern
+/// semantics: either the subject itself for match-self builtins like `int(x)`, or an attribute
+/// selected by `__match_args__` / an explicit keyword. It stores a subpattern id rather than
+/// borrowing the pattern so narrowing and inference can both map the target back to their own
+/// class-pattern representation.
+#[derive(Debug)]
+pub(crate) enum ClassPatternSubpatternTarget {
+    /// A subpattern matched directly against the match subject itself, as in `case int(x)`.
+    Subject {
+        subpattern: ClassPatternSubpatternId,
+    },
+    /// A subpattern matched against an attribute of the match subject.
+    ///
+    /// The attribute name comes either from `__match_args__` for positional subpatterns, or from
+    /// the explicit keyword name in the pattern.
+    Attribute {
+        name: Name,
+        subpattern: ClassPatternSubpatternId,
+    },
+}
+
+/// Identifies the source slot of a class-pattern subpattern.
+///
+/// Positional ids index the class pattern's positional subpatterns, and keyword ids index its
+/// keyword subpatterns. Callers use the id to retrieve the concrete pattern node or predicate that
+/// corresponds to a [`ClassPatternSubpatternTarget`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ClassPatternSubpatternId {
+    /// A subpattern from the positional pattern list.
+    Positional(usize),
+    /// A subpattern from the keyword pattern list.
+    Keyword(usize),
+}
+
+/// Return the semantic target for each subpattern in a class pattern.
+///
+/// ```text
+/// case Point(0, y=1)
+///            ^  ^
+///            |  +-- targets subject.y
+///            +----- targets the attribute named by Point.__match_args__[0]
+///
+/// case int(x)
+///          ^
+///          +-- targets the match subject itself
+/// ```
+pub(crate) fn class_pattern_targets<'db>(
+    db: &'db dyn Db,
+    class_pattern: &ClassPatternPredicateKind<'db>,
+    class_type: Type<'db>,
+) -> Vec<ClassPatternSubpatternTarget> {
+    class_pattern_targets_from_parts(
+        db,
+        class_type,
+        class_pattern.positional_patterns.len(),
+        class_pattern
+            .keyword_patterns
+            .iter()
+            .enumerate()
+            .map(|(index, keyword)| (index, keyword.name.clone())),
+    )
+}
+
+pub(crate) fn class_pattern_targets_from_parts<'db>(
+    db: &'db dyn Db,
+    class_type: Type<'db>,
+    positional_count: usize,
+    keyword_patterns: impl IntoIterator<Item = (usize, Name)>,
+) -> Vec<ClassPatternSubpatternTarget> {
+    let mut positional_targets = class_pattern_positional_targets(db, class_type, positional_count);
+
+    let keyword_targets = class_pattern_keyword_targets(keyword_patterns);
+
+    positional_targets.extend(keyword_targets);
+    positional_targets
+}
+
+/// Return the targets for a set of keyword sub-patterns.
+///
+/// Targets are resolved just via attribute name.
+fn class_pattern_keyword_targets(
+    keyword_patterns: impl IntoIterator<Item = (usize, Name)>,
+) -> Vec<ClassPatternSubpatternTarget> {
+    keyword_patterns
+        .into_iter()
+        .map(|(index, name)| ClassPatternSubpatternTarget::Attribute {
+            name,
+            subpattern: ClassPatternSubpatternId::Keyword(index),
+        })
+        .collect()
+}
+
+/// Return the target(s) for a set of positional sub-patterns
+///
+/// The targets are determined in 2 different ways:
+/// 1. If there is a `__match_args__` class member defined with a tuple of strings referencing
+///    attribute names, those are returned.
+/// 2. If the class is a builtin (ie `int`, `str`, etc), the target is `self`.
+///    From the PEP: "a single positional sub-pattern is allowed to be passed to the call.
+///    Rather than being matched against any particular attribute on the subject,
+///    it is instead matched against the subject itself".
+fn class_pattern_positional_targets<'db>(
+    db: &'db dyn Db,
+    class_type: Type<'db>,
+    positional_count: usize,
+) -> Vec<ClassPatternSubpatternTarget> {
+    if positional_count == 0 {
+        return Vec::new();
+    }
+
+    let Type::ClassLiteral(class) = class_type else {
+        return Vec::new();
+    };
+
+    if let Some(match_args_ty) = class
+        .class_member(db, "__match_args__", MemberLookupPolicy::default())
+        .ignore_possibly_undefined()
+    {
+        let Some(names) = match_args_attribute_names(db, match_args_ty, positional_count) else {
+            return Vec::new();
+        };
+
+        return names
+            .into_iter()
+            .enumerate()
+            .map(|(index, name)| ClassPatternSubpatternTarget::Attribute {
+                name,
+                subpattern: ClassPatternSubpatternId::Positional(index),
+            })
+            .collect();
+    }
+
+    if is_match_self_class(db, class) && positional_count == 1 {
+        return vec![ClassPatternSubpatternTarget::Subject {
+            subpattern: ClassPatternSubpatternId::Positional(0),
+        }];
+    }
+
+    Vec::new()
+}
+
+fn match_args_attribute_names<'db>(
+    db: &'db dyn Db,
+    match_args_ty: Type<'db>,
+    positional_count: usize,
+) -> Option<Vec<Name>> {
+    let tuple_spec = match_args_ty.exact_tuple_instance_spec(db)?;
+    let TupleSpec::Fixed(match_args) = tuple_spec.as_ref() else {
+        return None;
+    };
+    if match_args.len() < positional_count {
+        return None;
+    }
+
+    match_args
+        .elements_slice()
+        .iter()
+        .take(positional_count)
+        .map(|element| {
+            element
+                .as_string_literal()
+                .map(|literal| Name::new(literal.value(db)))
+        })
+        .collect()
+}
+
+fn is_match_self_class<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
+    let class_instance = Type::instance(db, class.default_specialization(db));
+
+    [
+        KnownClass::Bool,
+        KnownClass::Bytearray,
+        KnownClass::Bytes,
+        KnownClass::Dict,
+        KnownClass::Float,
+        KnownClass::FrozenSet,
+        KnownClass::Int,
+        KnownClass::List,
+        KnownClass::Set,
+        KnownClass::Str,
+        KnownClass::Tuple,
+    ]
+    .into_iter()
+    .any(|known_class| {
+        known_class
+            .to_class_literal(db)
+            .to_class_type(db)
+            .is_some_and(|target| class_instance.is_subtype_of(db, Type::instance(db, target)))
+    })
 }
 
 fn sequence_pattern_getitem_method<'db>(
@@ -182,9 +378,13 @@ pub(crate) fn definite_match_pattern_type<'db>(
                 Type::Never
             }
         }
-        PatternPredicateKind::Class(class_expr, kind) => {
-            if kind.is_irrefutable() {
-                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
+        PatternPredicateKind::Class(class_pattern) => {
+            if class_pattern.kind.is_irrefutable() {
+                match infer_same_file_expression_type(
+                    db,
+                    class_pattern.class,
+                    TypeContext::default(),
+                ) {
                     Type::ClassLiteral(class) => Type::instance(db, class.top_materialization(db)),
                     Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
                         callable_pattern_type(db)

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -9,18 +9,20 @@ use crate::types::typed_dict::{
     TypedDictField, TypedDictFieldBuilder, TypedDictSchema, TypedDictType,
 };
 use crate::types::{
-    CallableType, ClassLiteral, ClassType, IntersectionBuilder, IntersectionType, KnownClass,
-    KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature, SpecialFormType,
-    SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionBuilder, callable_pattern_type, definite_sequence_pattern_type,
-    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
-    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
+    CallableType, ClassLiteral, ClassPatternSubpatternId, ClassPatternSubpatternTarget, ClassType,
+    IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
+    Parameter, Parameters, Signature, SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness,
+    Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type,
+    class_pattern_targets, definite_sequence_pattern_type, exact_sequence_pattern_type,
+    infer_expression_types, mapping_pattern_type, sequence_pattern_type_builder,
+    singleton_pattern_type, starred_sequence_pattern_type,
 };
 use ty_python_core::expression::Expression;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
 use ty_python_core::predicate::{
-    CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
-    PredicateNode, SequencePatternPredicateKind, SubjectElementPatternPredicate,
+    CallableAndCallExpr, ClassPatternKind, ClassPatternPredicateKind, PatternPredicate,
+    PatternPredicateKind, Predicate, PredicateNode, SequencePatternPredicateKind,
+    SubjectElementPatternPredicate,
 };
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
@@ -256,6 +258,19 @@ fn all_narrowing_constraints_for_subject_element_pattern<'db>(
         true,
     )
     .finish()
+}
+
+fn class_pattern_subpattern<'a, 'db>(
+    class_pattern: &'a ClassPatternPredicateKind<'db>,
+    subpattern: ClassPatternSubpatternId,
+) -> Option<&'a PatternPredicateKind<'db>> {
+    match subpattern {
+        ClassPatternSubpatternId::Positional(index) => class_pattern.positional_patterns.get(index),
+        ClassPatternSubpatternId::Keyword(index) => class_pattern
+            .keyword_patterns
+            .get(index)
+            .map(|keyword| &keyword.pattern),
+    }
 }
 
 /// Functions that can be used to narrow the type of a first argument using a "classinfo" second argument.
@@ -971,8 +986,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PatternPredicateKind::Singleton(singleton) => PatternNarrowingResult::Possible(
                 self.evaluate_match_pattern_singleton(subject, *singleton, is_positive),
             ),
-            PatternPredicateKind::Class(cls, kind) => PatternNarrowingResult::Possible(
-                self.evaluate_match_pattern_class(subject, *cls, *kind, is_positive),
+            PatternPredicateKind::Class(class_pattern) => PatternNarrowingResult::Possible(
+                self.evaluate_match_pattern_class(subject, class_pattern, is_positive),
             ),
             PatternPredicateKind::Mapping(kind) => PatternNarrowingResult::Possible(
                 self.evaluate_match_pattern_mapping(subject, *kind, is_positive),
@@ -2115,11 +2130,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     fn evaluate_match_pattern_class(
         &mut self,
         subject: Expression<'db>,
-        cls: Expression<'db>,
-        kind: ClassPatternKind,
+        class_pattern: &ClassPatternPredicateKind<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        if !kind.is_irrefutable() && !is_positive {
+        if !class_pattern.kind.is_irrefutable() && !is_positive {
             // A class pattern like `case Point(x=0, y=0)` is not irrefutable. In the positive case,
             // we can still narrow the type of the match subject to `Point`. But in the negative case,
             // we cannot exclude `Point` as a possibility.
@@ -2129,7 +2143,29 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
         let place = self.expect_place(&subject);
 
-        let class_type = infer_same_file_expression_type(self.db, cls, TypeContext::default());
+        let class_type =
+            infer_same_file_expression_type(self.db, class_pattern.class, TypeContext::default());
+
+        // Construct constraints based on positional + keyword sub-patterns
+        let sub_pattern_targets = class_pattern_targets(self.db, class_pattern, class_type);
+        for target in &sub_pattern_targets {
+            match target {
+                ClassPatternSubpatternTarget::Subject { subpattern } => {
+                    let Some(pattern) = class_pattern_subpattern(class_pattern, *subpattern) else {
+                        continue;
+                    };
+                    // TODO: Evaluate a single-subpattern predicate against the subject itself
+                    let _ = pattern;
+                }
+                ClassPatternSubpatternTarget::Attribute { name, subpattern } => {
+                    let Some(pattern) = class_pattern_subpattern(class_pattern, *subpattern) else {
+                        continue;
+                    };
+                    // TODO: Narrow subject type based on attribute type
+                    let _ = (name, pattern);
+                }
+            }
+        }
 
         let narrowed_type = match class_type {
             Type::ClassLiteral(class) => {
@@ -2198,8 +2234,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PatternPredicateKind::Singleton(singleton) => {
                 singleton_pattern_type(self.db, *singleton)
             }
-            PatternPredicateKind::Class(cls, _) => {
-                match infer_same_file_expression_type(self.db, *cls, TypeContext::default()) {
+            PatternPredicateKind::Class(class_pattern) => {
+                match infer_same_file_expression_type(
+                    self.db,
+                    class_pattern.class,
+                    TypeContext::default(),
+                ) {
                     Type::ClassLiteral(class) => {
                         Type::instance(self.db, class.top_materialization(self.db))
                     }


### PR DESCRIPTION
## Summary

WIP and ready for some early feedback

The goal of this is to unblock a few remaining items in https://github.com/astral-sh/ty/issues/887:
- `__match_args__`
- Matching on builtins
- Type inference for names that are bound in patterns

### Design

- Positional and keyword sub-patterns are collected during semantic indexing, and stored on class pattern predicates
- Downstream, there are helpers that take these and normalize them into targets on the subject, based on:
  - explicit attribute name
  - attribute names in `__match_args__` 
  - `self` in the case of builtins
- Both inference/narrowing can use these helpers to:
  - Infer types of names bound in patterns (`infer_match_pattern_definition`)
  - Emit diagnostics on invalid `__match_args__` or sub-patterns (`validate_class_pattern`)
  - Add constraints during narrowing (`evaluate_match_pattern_class`)

## Test Plan
TODO