### PR TITLE
[ty] Cache module resolution directory listings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3063,6 +3063,7 @@ dependencies = [
  "anstyle",
  "arc-swap",
  "camino",
+ "compact_str",
  "dashmap",
  "dunce",
  "etcetera",

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -26,6 +26,7 @@ ty_static = { workspace = true }
 anstyle = { workspace = true }
 arc-swap = { workspace = true }
 camino = { workspace = true }
+compact_str = { workspace = true }
 dashmap = { workspace = true }
 dunce = { workspace = true }
 filetime = { workspace = true }

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use dashmap::mapref::entry::Entry;
+pub use directory::{Directory, DirectoryListing, DirectoryListingError, directory_listing};
 pub use file_root::{FileRoot, FileRootKind};
 pub use path::FilePath;
 use ruff_notebook::{Notebook, NotebookError};
@@ -20,6 +21,7 @@ use crate::system::{SystemPath, SystemPathBuf, SystemVirtualPath, SystemVirtualP
 use crate::vendored::{VendoredPath, VendoredPathBuf};
 use crate::{Db, FxDashMap, vendored};
 
+mod directory;
 mod file_root;
 mod path;
 
@@ -58,6 +60,9 @@ pub struct Files {
 
 #[derive(Default)]
 struct FilesInner {
+    /// Lookup table that maps system directories to Salsa inputs.
+    directories: directory::Directories,
+
     /// Lookup table that maps [`SystemPathBuf`]s to salsa interned [`File`] instances.
     ///
     /// The map also stores entries for files that don't exist on the file system. This is necessary
@@ -75,6 +80,19 @@ struct FilesInner {
 }
 
 impl Files {
+    /// Returns the Salsa input for the system directory at `path`.
+    pub fn directory(&self, db: &dyn Db, path: &SystemPath) -> Directory {
+        let absolute = SystemPath::absolute(path, db.system().current_directory());
+        self.inner.directories.get_or_create(db, absolute)
+    }
+
+    /// Updates the revision of an already-known directory at `path`.
+    pub fn touch_directory(db: &mut dyn Db, path: &SystemPath) {
+        let absolute = SystemPath::absolute(path, db.system().current_directory());
+        let inner = Arc::clone(&db.files().inner);
+        inner.directories.touch(db, &absolute);
+    }
+
     /// Looks up a file by its `path`.
     ///
     /// For a non-existing file, creates a new salsa [`File`] ingredient and stores it for future lookups.
@@ -204,17 +222,6 @@ impl Files {
         roots.at(&absolute)
     }
 
-    /// The same as [`Self::root`] but panics if no root is found.
-    #[track_caller]
-    pub fn expect_root(&self, db: &dyn Db, path: &SystemPath) -> FileRoot {
-        if let Some(root) = self.root(db, path) {
-            return root;
-        }
-
-        let roots = self.inner.roots.read().unwrap();
-        panic!("No root found for path '{path}'. Known roots: {roots:#?}");
-    }
-
     /// Adds a new root for `path` and returns the root.
     ///
     /// The root isn't added nor is the file root's kind updated if a root for `path` already exists.
@@ -223,13 +230,6 @@ impl Files {
 
         let absolute = SystemPath::absolute(path, db.system().current_directory());
         roots.try_add(db, absolute, kind)
-    }
-
-    /// Updates the revision of the root for `path`.
-    pub fn touch_root(db: &mut dyn Db, path: &SystemPath) {
-        if let Some(root) = db.files().root(db, path) {
-            root.set_revision(db).to(FileRevision::now());
-        }
     }
 
     /// Refreshes the state of all known files under `paths` recursively.
@@ -267,18 +267,7 @@ impl Files {
             }
         }
 
-        let roots = inner.roots.read().unwrap();
-
-        for root in roots.all() {
-            let root_path = root.path(db);
-            if paths
-                .range(root_path.to_path_buf()..)
-                .next()
-                .is_some_and(|path| path.starts_with(root_path))
-            {
-                root.set_revision(db).to(FileRevision::now());
-            }
-        }
+        inner.directories.touch_recursive(db, &paths);
     }
 
     /// Refreshes the state of all known files.
@@ -296,11 +285,7 @@ impl Files {
             File::sync_system_path(db, entry.key(), Some(*entry.value()));
         }
 
-        let roots = inner.roots.read().unwrap();
-
-        for root in roots.all() {
-            root.set_revision(db).to(FileRevision::now());
-        }
+        inner.directories.touch_all(db);
     }
 }
 
@@ -315,6 +300,7 @@ impl fmt::Debug for Files {
             map.finish()
         } else {
             f.debug_struct("Files")
+                .field("directories", &self.inner.directories.len())
                 .field("system_by_path", &self.inner.system_by_path.len())
                 .field(
                     "system_virtual_by_path",
@@ -371,6 +357,11 @@ pub struct File {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for File {}
 
+struct SyncPathResult {
+    status_changed: bool,
+    is_directory: bool,
+}
+
 impl File {
     /// Reads the content of the file into a [`String`].
     ///
@@ -425,19 +416,17 @@ impl File {
 
     /// Refreshes the file metadata by querying the file system if needed.
     ///
-    /// This also "touches" the file root associated with the given path.
-    /// This means that any Salsa queries that depend on the corresponding
-    /// root's revision will become invalidated.
+    /// Directory listings are invalidated if the path's file status changed, its prior status is
+    /// unknown, or if `path` is itself a directory.
     pub fn sync_path(db: &mut dyn Db, path: &SystemPath) {
         let absolute = SystemPath::absolute(path, db.system().current_directory());
-        Files::touch_root(db, &absolute);
-        Self::sync_system_path(db, &absolute, None);
+        let result = Self::sync_system_path(db, &absolute, None);
+        Self::touch_directories_after_sync(db, &absolute, result);
     }
 
     /// Refreshes *only* the file metadata by querying the file system if needed.
     ///
-    /// This specifically does not touch any file root associated with the
-    /// given file path.
+    /// This specifically does not invalidate any directory listings.
     pub fn sync_path_only(db: &mut dyn Db, path: &SystemPath) {
         let absolute = SystemPath::absolute(path, db.system().current_directory());
         Self::sync_system_path(db, &absolute, None);
@@ -456,8 +445,8 @@ impl File {
 
         match path {
             FilePath::System(system) => {
-                Files::touch_root(db, &system);
-                Self::sync_system_path(db, &system, Some(self));
+                let result = Self::sync_system_path(db, &system, Some(self));
+                Self::touch_directories_after_sync(db, &system, result);
             }
             FilePath::Vendored(_) => {
                 // Readonly, can never be out of date.
@@ -470,9 +459,12 @@ impl File {
 
     /// Private method providing the implementation for [`Self::sync_path`] and [`Self::sync`] for
     /// system paths.
-    fn sync_system_path(db: &mut dyn Db, path: &SystemPath, file: Option<File>) {
+    fn sync_system_path(db: &mut dyn Db, path: &SystemPath, file: Option<File>) -> SyncPathResult {
         let Some(file) = file.or_else(|| db.files().try_system(db, path)) else {
-            return;
+            return SyncPathResult {
+                status_changed: true,
+                is_directory: true,
+            };
         };
 
         let (status, revision, permission) = match db.system().path_metadata(path) {
@@ -489,7 +481,10 @@ impl File {
 
         let mut clear_override = false;
 
-        if file.status(db) != status {
+        let old_status = file.status(db);
+        let status_changed = old_status != status;
+
+        if status_changed {
             tracing::debug!("Updating the status of `{}`", file.path(db));
             file.set_status(db).to(status);
             clear_override = true;
@@ -508,6 +503,25 @@ impl File {
 
         if clear_override && file.source_text_override(db).is_some() {
             file.set_source_text_override(db).to(None);
+        }
+
+        SyncPathResult {
+            status_changed,
+            is_directory: old_status == FileStatus::IsADirectory
+                || status == FileStatus::IsADirectory,
+        }
+    }
+
+    fn touch_directories_after_sync(db: &mut dyn Db, path: &SystemPath, result: SyncPathResult) {
+        let inner = Arc::clone(&db.files().inner);
+
+        if result.status_changed || result.is_directory {
+            inner.directories.touch(db, path);
+        }
+        if result.status_changed
+            && let Some(parent) = path.parent()
+        {
+            inner.directories.touch(db, parent);
         }
     }
 

--- a/crates/ruff_db/src/files/directory.rs
+++ b/crates/ruff_db/src/files/directory.rs
@@ -1,0 +1,298 @@
+use std::collections::BTreeSet;
+
+use compact_str::CompactString;
+use salsa::{Durability, Setter};
+
+use crate::file_revision::FileRevision;
+use crate::system::{FileType, SystemPath, SystemPathBuf};
+use crate::{Db, FxDashMap};
+
+/// A system directory whose direct children are tracked by Salsa.
+#[salsa::input(debug, heap_size=ruff_memory_usage::heap_size)]
+pub struct Directory {
+    /// The path of the directory (immutable).
+    #[returns(deref)]
+    path: Box<SystemPath>,
+
+    /// Changes whenever an entry is added, removed, or changes type.
+    revision: FileRevision,
+}
+
+impl get_size2::GetSize for Directory {}
+
+/// A cached snapshot of the direct children in a directory.
+#[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize)]
+pub struct DirectoryListing(Box<[(CompactString, FileType)]>);
+
+impl DirectoryListing {
+    /// Returns the type of the entry named `name`, if present.
+    pub fn file_type(&self, name: &str) -> Option<FileType> {
+        self.0
+            .binary_search_by(|(candidate, _)| candidate.as_str().cmp(name))
+            .ok()
+            .map(|index| self.0[index].1)
+    }
+
+    /// Returns whether `name` resolves to a file, following symbolic links.
+    pub fn entry_is_file(&self, db: &dyn Db, directory: Directory, name: &str) -> bool {
+        match self.file_type(name) {
+            Some(FileType::File) => true,
+            Some(FileType::Directory) | None => false,
+            Some(FileType::Symlink) => {
+                super::system_path_to_file(db, directory.path(db).join(name)).is_ok()
+            }
+        }
+    }
+
+    /// Iterates over the entries in the directory in name order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, FileType)> {
+        self.0
+            .iter()
+            .map(|(name, file_type)| (name.as_str(), *file_type))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize, thiserror::Error)]
+#[error("{message}")]
+pub struct DirectoryListingError {
+    #[get_size(ignore)]
+    kind: std::io::ErrorKind,
+    message: Box<str>,
+}
+
+impl From<std::io::Error> for DirectoryListingError {
+    fn from(error: std::io::Error) -> Self {
+        Self {
+            kind: error.kind(),
+            message: error.to_string().into_boxed_str(),
+        }
+    }
+}
+
+#[salsa::tracked(returns(as_ref), heap_size=ruff_memory_usage::heap_size)]
+pub fn directory_listing(
+    db: &dyn Db,
+    directory: Directory,
+) -> Result<DirectoryListing, DirectoryListingError> {
+    directory.revision(db);
+
+    let mut entries = db
+        .system()
+        .read_directory(directory.path(db))?
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let file_type = entry.file_type();
+            let path = entry.into_path();
+            let name = path.file_name()?;
+            Some((CompactString::from(name), file_type))
+        })
+        .collect::<Vec<_>>();
+
+    entries.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    Ok(DirectoryListing(entries.into_boxed_slice()))
+}
+
+#[derive(Default)]
+pub(super) struct Directories {
+    by_path: FxDashMap<SystemPathBuf, Directory>,
+}
+
+impl Directories {
+    pub(super) fn get_or_create(&self, db: &dyn Db, path: SystemPathBuf) -> Directory {
+        if let Some(directory) = self.by_path.get(&path) {
+            return *directory;
+        }
+
+        *self.by_path.entry(path.clone()).or_insert_with(|| {
+            let durability = db
+                .files()
+                .root(db, &path)
+                .map_or(Durability::default(), |root| root.durability(db));
+            let durability = Durability::MEDIUM.max(durability);
+
+            Directory::builder(Box::from(path), FileRevision::now())
+                .durability(durability)
+                .path_durability(Durability::HIGH)
+                .new(db)
+        })
+    }
+
+    pub(super) fn touch(&self, db: &mut dyn Db, path: &SystemPath) {
+        if let Some(directory) = self.by_path.get(path).map(|directory| *directory) {
+            directory.set_revision(db).to(FileRevision::now());
+        }
+    }
+
+    pub(super) fn touch_recursive(&self, db: &mut dyn Db, paths: &BTreeSet<SystemPathBuf>) {
+        let directories = self
+            .by_path
+            .iter()
+            .filter(|entry| {
+                let path = entry.key();
+                paths
+                    .range(..=path.to_path_buf())
+                    .next_back()
+                    .is_some_and(|candidate| path.starts_with(candidate))
+            })
+            .map(|entry| *entry.value())
+            .collect::<Vec<_>>();
+
+        for directory in directories {
+            directory.set_revision(db).to(FileRevision::now());
+        }
+    }
+
+    pub(super) fn touch_all(&self, db: &mut dyn Db) {
+        let directories = self
+            .by_path
+            .iter()
+            .map(|entry| *entry.value())
+            .collect::<Vec<_>>();
+
+        for directory in directories {
+            directory.set_revision(db).to(FileRevision::now());
+        }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.by_path.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Db as _;
+    use crate::files::{File, directory_listing, system_path_to_file};
+    use crate::system::{DbWithWritableSystem as _, SystemPath, WritableSystem as _};
+    use crate::tests::TestDb;
+
+    #[test]
+    fn listing_is_sorted_and_cached() -> std::io::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("src/z.py", "")?;
+        db.write_file("src/a.py", "")?;
+
+        let directory = db.files().directory(&db, SystemPath::new("src"));
+        let listing = directory_listing(&db, directory).unwrap();
+        assert_eq!(
+            listing.iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            ["a.py", "z.py"]
+        );
+
+        db.writable_system()
+            .write_file(SystemPath::new("src/new.py"), "")?;
+        assert_eq!(
+            directory_listing(&db, directory)
+                .unwrap()
+                .file_type("new.py"),
+            None
+        );
+
+        crate::files::Files::touch_directory(&mut db, SystemPath::new("src"));
+        assert!(
+            directory_listing(&db, directory)
+                .unwrap()
+                .file_type("new.py")
+                .is_some()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn empty_and_unavailable_listing() {
+        let db = TestDb::new();
+
+        let empty_directory = db.files().directory(&db, SystemPath::new("/"));
+        assert_eq!(
+            directory_listing(&db, empty_directory)
+                .unwrap()
+                .iter()
+                .next(),
+            None
+        );
+
+        let directory = db.files().directory(&db, SystemPath::new("missing"));
+        assert_eq!(
+            directory_listing(&db, directory).unwrap_err().kind,
+            std::io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn content_change_does_not_invalidate_directory() -> std::io::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("src/a.py", "old")?;
+        system_path_to_file(&db, SystemPath::new("src/a.py")).unwrap();
+
+        let directory = db.files().directory(&db, SystemPath::new("src"));
+        directory_listing(&db, directory).unwrap();
+        let revision = directory.revision(&db);
+
+        db.writable_system()
+            .write_file(SystemPath::new("src/a.py"), "new")?;
+        File::sync_path(&mut db, SystemPath::new("src/a.py"));
+
+        assert_eq!(directory.revision(&db), revision);
+        Ok(())
+    }
+
+    #[test]
+    fn structural_changes_invalidate_directory() -> std::io::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("src/existing.py", "")?;
+        let existing = system_path_to_file(&db, SystemPath::new("src/existing.py")).unwrap();
+
+        let directory = db.files().directory(&db, SystemPath::new("src"));
+        assert!(
+            directory_listing(&db, directory)
+                .unwrap()
+                .file_type("existing.py")
+                .is_some()
+        );
+
+        db.writable_system()
+            .memory_file_system()
+            .remove_file("src/existing.py")?;
+        existing.sync(&mut db);
+        assert_eq!(
+            directory_listing(&db, directory)
+                .unwrap()
+                .file_type("existing.py"),
+            None
+        );
+
+        db.writable_system()
+            .write_file(SystemPath::new("src/new.py"), "")?;
+        File::sync_path(&mut db, SystemPath::new("src/new.py"));
+        assert!(
+            directory_listing(&db, directory)
+                .unwrap()
+                .file_type("new.py")
+                .is_some()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn syncing_directory_invalidates_its_listing() -> std::io::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("src/a.py", "")?;
+
+        let directory = db.files().directory(&db, SystemPath::new("src"));
+        directory_listing(&db, directory).unwrap();
+
+        db.writable_system()
+            .write_file(SystemPath::new("src/new.py"), "")?;
+        File::sync_path(&mut db, SystemPath::new("src"));
+
+        assert!(
+            directory_listing(&db, directory)
+                .unwrap()
+                .file_type("new.py")
+                .is_some()
+        );
+        Ok(())
+    }
+}

--- a/crates/ruff_db/src/files/file_root.rs
+++ b/crates/ruff_db/src/files/file_root.rs
@@ -1,10 +1,7 @@
-use std::fmt::Formatter;
-
 use path_slash::PathExt;
 use salsa::Durability;
 
 use crate::Db;
-use crate::file_revision::FileRevision;
 use crate::system::{SystemPath, SystemPathBuf};
 
 /// A root path for files tracked by the database.
@@ -13,9 +10,7 @@ use crate::system::{SystemPath, SystemPathBuf};
 /// * static module resolution paths
 /// * the project root
 ///
-/// The main usage of file roots is to determine a file's durability. But it can also be used
-/// to make a salsa query dependent on whether a file in a root has changed without writing any
-/// manual invalidation logic.
+/// File roots determine the durability of files and directories.
 #[salsa::input(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct FileRoot {
     /// The path of a root is guaranteed to never change.
@@ -24,11 +19,6 @@ pub struct FileRoot {
 
     /// The kind of the root at the time of its creation.
     pub kind_at_time_of_creation: FileRootKind,
-
-    /// A revision that changes when the contents of the source root change.
-    ///
-    /// The revision changes when a new file was added, removed, or changed inside this source root.
-    pub revision: FileRevision,
 }
 
 impl FileRoot {
@@ -58,7 +48,6 @@ impl FileRootKind {
 #[derive(Default)]
 pub(super) struct FileRoots {
     by_path: matchit::Router<FileRoot>,
-    roots: Vec<FileRoot>,
 }
 
 impl FileRoots {
@@ -88,9 +77,8 @@ impl FileRoots {
         let mut route = normalized_path.replace('{', "{{").replace('}', "}}");
 
         // Insert a new source root
-        let root = FileRoot::builder(path, kind, FileRevision::now())
+        let root = FileRoot::builder(path, kind)
             .durability(Durability::HIGH)
-            .revision_durability(kind.durability())
             .new(db);
 
         // Insert a path that matches the root itself
@@ -103,7 +91,6 @@ impl FileRoots {
         route.push_str("{*filepath}");
 
         self.by_path.insert(route, root).unwrap();
-        self.roots.push(root);
 
         root
     }
@@ -114,21 +101,5 @@ impl FileRoots {
         let normalized_path = path.as_std_path().to_slash().unwrap();
         let entry = self.by_path.at(&normalized_path).ok()?;
         Some(*entry.value)
-    }
-
-    pub(super) fn all(&self) -> impl Iterator<Item = FileRoot> + '_ {
-        self.roots.iter().copied()
-    }
-}
-
-impl std::fmt::Debug for FileRoots {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("FileRoots").field(&self.roots).finish()
-    }
-}
-
-impl PartialEq for FileRoots {
-    fn eq(&self, other: &Self) -> bool {
-        self.roots.eq(&other.roots)
     }
 }

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -124,17 +124,6 @@ pub trait System: Debug + Sync + Send {
         self.path_metadata(path).is_ok()
     }
 
-    /// Returns `true` if `path` exists on disk using the exact casing as specified in `path` for the parts after `prefix`.
-    ///
-    /// This is the same as [`Self::path_exists`] on case-sensitive systems.
-    ///
-    /// ## The use of prefix
-    ///
-    /// Prefix is only intended as an optimization for systems that can't efficiently check
-    /// if an entire path exists with the exact casing as specified in `path`. However,
-    /// implementations are allowed to check the casing of the entire path if they can do so efficiently.
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool;
-
     /// Returns the [`CaseSensitivity`] of the system's file system.
     fn case_sensitivity(&self) -> CaseSensitivity;
 
@@ -341,7 +330,7 @@ impl Metadata {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, get_size2::GetSize)]
 pub enum FileType {
     File,
     Directory,

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -11,9 +11,7 @@ use crate::system::{
 };
 use filetime::FileTime;
 use ruff_notebook::{Notebook, NotebookError};
-use rustc_hash::FxHashSet;
 use std::num::NonZeroUsize;
-use std::panic::RefUnwindSafe;
 use std::sync::Arc;
 use std::{any::Any, path::PathBuf};
 
@@ -26,8 +24,6 @@ pub struct OsSystem {
 #[derive(Default, Debug)]
 struct OsSystemInner {
     cwd: SystemPathBuf,
-
-    real_case_cache: CaseSensitivePathsCache,
 
     case_sensitivity: CaseSensitivity,
 
@@ -118,15 +114,6 @@ impl System for OsSystem {
 
     fn path_exists(&self, path: &SystemPath) -> bool {
         path.as_std_path().exists()
-    }
-
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
-        if self.case_sensitivity().is_case_sensitive() {
-            self.path_exists(path)
-        } else {
-            self.path_exists_case_sensitive_fast(path)
-                .unwrap_or_else(|| self.path_exists_case_sensitive_slow(path, prefix))
-        }
     }
 
     fn case_sensitivity(&self) -> CaseSensitivity {
@@ -242,94 +229,6 @@ impl System for OsSystem {
     }
 }
 
-impl OsSystem {
-    /// Path sensitive testing if a path exists by canonicalization the path and comparing it with `path`.
-    ///
-    /// This is faster than the slow path, because it requires a single system call for each path
-    /// instead of at least one system call for each component between `path` and `prefix`.
-    ///
-    /// However, using `canonicalize` to resolve the path's casing doesn't work in two cases:
-    /// * if `path` is a symlink, `canonicalize` returns the symlink's target and not the symlink's source path.
-    /// * on Windows: If `path` is a mapped network drive, `canonicalize` returns the UNC path
-    ///   (e.g. `Z:\` is mapped to `\\server\share` and `canonicalize` returns `\\?\UNC\server\share`).
-    ///
-    /// Symlinks and mapped network drives should be rare enough that this fast path is worth trying first,
-    /// even if it comes at a cost for those rare use cases.
-    fn path_exists_case_sensitive_fast(&self, path: &SystemPath) -> Option<bool> {
-        // This is a more forgiving version of `dunce::simplified` that removes all `\\?\` prefixes on Windows.
-        // We use this more forgiving version because we don't intend on using either path for anything other than comparison
-        // and the prefix is only relevant when passing the path to other programs and it's longer than 200 something
-        // characters.
-        fn simplify_ignore_verbatim(path: &SystemPath) -> &SystemPath {
-            if cfg!(windows) {
-                if path.as_utf8_path().as_str().starts_with(r"\\?\") {
-                    SystemPath::new(&path.as_utf8_path().as_str()[r"\\?\".len()..])
-                } else {
-                    path
-                }
-            } else {
-                path
-            }
-        }
-
-        let Ok(canonicalized) = path.as_std_path().canonicalize() else {
-            // The path doesn't exist or can't be accessed. The path doesn't exist.
-            return Some(false);
-        };
-
-        let Ok(canonicalized) = SystemPathBuf::from_path_buf(canonicalized) else {
-            // The original path is valid UTF8 but the canonicalized path isn't. This definitely suggests
-            // that a symlink is involved. Fall back to the slow path.
-            tracing::debug!(
-                "Falling back to the slow case-sensitive path existence check because the canonicalized path of `{path}` is not valid UTF-8"
-            );
-            return None;
-        };
-
-        let simplified_canonicalized = simplify_ignore_verbatim(&canonicalized);
-        let simplified = simplify_ignore_verbatim(path);
-
-        // Test if the paths differ by anything other than casing. If so, that suggests that
-        // `path` pointed to a symlink (or some other none reversible path normalization happened).
-        // In this case, fall back to the slow path.
-        if simplified_canonicalized.as_str().to_lowercase() != simplified.as_str().to_lowercase() {
-            tracing::debug!(
-                "Falling back to the slow case-sensitive path existence check for `{simplified}` because the canonicalized path `{simplified_canonicalized}` differs not only by casing"
-            );
-            return None;
-        }
-
-        // If there are no symlinks involved, then `path` exists only if it is the same as the canonicalized path.
-        Some(simplified_canonicalized == simplified)
-    }
-
-    fn path_exists_case_sensitive_slow(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
-        // Iterate over the sub-paths up to prefix and check if they match the casing as on disk.
-        for ancestor in path.ancestors() {
-            if ancestor == prefix {
-                break;
-            }
-
-            match self.inner.real_case_cache.has_name_case(ancestor) {
-                Ok(true) => {
-                    // Component has correct casing, continue with next component
-                }
-                Ok(false) => {
-                    // Component has incorrect casing
-                    return false;
-                }
-                Err(_) => {
-                    // Directory doesn't exist or can't be accessed. We can assume that the file with
-                    // the given casing doesn't exist.
-                    return false;
-                }
-            }
-        }
-
-        true
-    }
-}
-
 impl WritableSystem for OsSystem {
     fn create_new_file(&self, path: &SystemPath) -> Result<()> {
         std::fs::File::create_new(path).map(drop)
@@ -355,84 +254,6 @@ impl Default for OsSystem {
                 .unwrap_or_default(),
         )
     }
-}
-
-#[derive(Debug, Default)]
-struct CaseSensitivePathsCache {
-    by_lower_case: dashmap::DashMap<SystemPathBuf, ListedDirectory>,
-}
-
-impl CaseSensitivePathsCache {
-    /// Test if `path`'s file name uses the exact same casing as the file on disk.
-    ///
-    /// Returns `false` if the file doesn't exist.
-    ///
-    /// Components other than the file portion are ignored.
-    fn has_name_case(&self, path: &SystemPath) -> Result<bool> {
-        let Some(parent) = path.parent() else {
-            // The root path is always considered to exist.
-            return Ok(true);
-        };
-
-        let Some(file_name) = path.file_name() else {
-            // We can only get here for paths ending in `..` or the root path. Root paths are handled above.
-            // Return `true` for paths ending in `..` because `..` is the same regardless of casing.
-            return Ok(true);
-        };
-
-        let lower_case_path = SystemPathBuf::from(parent.as_str().to_lowercase());
-        let last_modification_time =
-            FileTime::from_last_modification_time(&parent.as_std_path().metadata()?);
-
-        let entry = self.by_lower_case.entry(lower_case_path);
-
-        if let dashmap::Entry::Occupied(entry) = &entry {
-            // Only do a cached lookup if the directory hasn't changed.
-            if entry.get().last_modification_time == last_modification_time {
-                tracing::trace!("Use cached case-sensitive entry for directory `{}`", parent);
-                return Ok(entry.get().names.contains(file_name));
-            }
-        }
-
-        tracing::trace!(
-            "Reading directory `{}` for its case-sensitive filenames",
-            parent
-        );
-        let start = std::time::Instant::now();
-        let mut names = FxHashSet::default();
-
-        for entry in parent.as_std_path().read_dir()? {
-            let Ok(entry) = entry else {
-                continue;
-            };
-
-            let Ok(name) = entry.file_name().into_string() else {
-                continue;
-            };
-
-            names.insert(name.into_boxed_str());
-        }
-
-        let directory = entry.insert(ListedDirectory {
-            last_modification_time,
-            names,
-        });
-
-        tracing::debug!(
-            "Caching the case-sensitive paths for directory `{parent}` took {:?}",
-            start.elapsed()
-        );
-
-        Ok(directory.names.contains(file_name))
-    }
-}
-
-impl RefUnwindSafe for CaseSensitivePathsCache {}
-
-#[derive(Debug, Eq, PartialEq)]
-struct ListedDirectory {
-    last_modification_time: FileTime,
-    names: FxHashSet<Box<str>>,
 }
 
 #[derive(Debug)]

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -163,10 +163,6 @@ impl System for TestSystem {
         self
     }
 
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
-        self.system().path_exists_case_sensitive(path, prefix)
-    }
-
     fn case_sensitivity(&self) -> CaseSensitivity {
         self.system().case_sensitivity()
     }
@@ -428,12 +424,6 @@ impl System for InMemorySystem {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
-    }
-
-    #[inline]
-    fn path_exists_case_sensitive(&self, path: &SystemPath, _prefix: &SystemPath) -> bool {
-        // The memory file system is case-sensitive.
-        self.path_exists(path)
     }
 
     fn case_sensitivity(&self) -> CaseSensitivity {

--- a/crates/ty_module_resolver/src/list.rs
+++ b/crates/ty_module_resolver/src/list.rs
@@ -1,5 +1,6 @@
 use std::collections::btree_map::{BTreeMap, Entry};
 
+use ruff_db::files::directory_listing;
 use ruff_python_ast::PythonVersion;
 
 use crate::db::Db;
@@ -77,19 +78,13 @@ fn list_modules_in<'db>(
     let mut lister = Lister::new(db, search_path.path(db));
     match search_path.path(db).as_path() {
         SystemOrVendoredPathRef::System(system_search_path) => {
-            // Read the revision on the corresponding file root to
-            // register an explicit dependency on this directory. When
-            // the revision gets bumped, the cache that Salsa creates
-            // for this routine will be invalidated.
-            let root = db.files().expect_root(db, system_search_path);
-            let _ = root.revision(db);
-
-            let Ok(it) = db.system().read_directory(system_search_path) else {
+            let directory = db.files().directory(db, system_search_path);
+            let Ok(listing) = directory_listing(db, directory) else {
                 return vec![];
             };
-            for result in it {
-                let Ok(entry) = result else { continue };
-                lister.add_path(&entry.path().into(), entry.file_type().into());
+            for (name, file_type) in listing.iter() {
+                let path = system_search_path.join(name);
+                lister.add_path(&path.as_path().into(), file_type.into());
             }
         }
         SystemOrVendoredPathRef::Vendored(vendored_search_path) => {
@@ -402,6 +397,8 @@ mod tests {
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem, SystemPath, SystemPathBuf};
     use ruff_db::testing::assert_function_query_was_not_run;
     use ruff_python_ast::PythonVersion;
+    use salsa::Database as _;
+    use salsa::plumbing::AsId as _;
 
     use crate::db::{Db, tests::TestDb};
     use crate::module::Module;
@@ -413,6 +410,24 @@ mod tests {
     use crate::testing::{FileSpec, MockedTypeshed, TestCase, TestCaseBuilder};
 
     use super::list_modules;
+
+    fn assert_query_was_not_run(
+        db: &TestDb,
+        query_name: &str,
+        input: Option<salsa::Id>,
+        events: &[salsa::Event],
+    ) {
+        assert!(
+            !events.iter().any(|event| {
+                let salsa::EventKind::WillExecute { database_key } = event.kind else {
+                    return false;
+                };
+                db.ingredient_debug_name(database_key.ingredient_index()) == query_name
+                    && input.is_none_or(|input| database_key.key_index() == input)
+            }),
+            "Expected {query_name} not to run:\n{events:#?}"
+        );
+    }
 
     struct ModuleDebugSnapshot<'db> {
         db: &'db dyn Db,
@@ -1050,6 +1065,60 @@ mod tests {
     }
 
     #[test]
+    fn nested_file_does_not_invalidate_top_level_listing() -> anyhow::Result<()> {
+        let TestCase { mut db, src, .. } = TestCaseBuilder::new()
+            .with_src_files(&[("package/__init__.py", "")])
+            .build();
+
+        list_modules(&db);
+        db.clear_salsa_events();
+
+        db.write_file(src.join("package/nested.py"), "")?;
+        list_modules(&db);
+
+        let events = db.take_salsa_events();
+        assert_query_was_not_run(&db, "list_modules_in", None, &events);
+
+        Ok(())
+    }
+
+    #[test]
+    fn sibling_file_does_not_invalidate_package_submodules() -> anyhow::Result<()> {
+        let TestCase { mut db, src, .. } = TestCaseBuilder::new()
+            .with_src_files(&[("package/__init__.py", "")])
+            .build();
+
+        let package_id = {
+            let package = list_modules(&db)
+                .iter()
+                .find(|module| module.name(&db).as_str() == "package")
+                .copied()
+                .expect("package to exist");
+            package.all_submodules(&db);
+            package.as_id()
+        };
+        db.clear_salsa_events();
+
+        db.write_file(src.join("sibling.py"), "")?;
+        let package = list_modules(&db)
+            .iter()
+            .find(|module| module.name(&db).as_str() == "package")
+            .copied()
+            .expect("package to exist");
+        package.all_submodules(&db);
+
+        let events = db.take_salsa_events();
+        assert_query_was_not_run(
+            &db,
+            "all_submodule_names_for_package",
+            Some(package_id),
+            &events,
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn removing_file_on_which_module_resolution_depends_invalidates_previously_successful_query_that_now_fails()
     -> anyhow::Result<()> {
         const SRC: &[FileSpec] = &[("foo.py", "x = 1"), ("foo/__init__.py", "x = 2")];
@@ -1617,9 +1686,8 @@ not_a_directory
         db.write_file(src.join("main.py"), "print('Hy')")
             .context("Failed to write `main.py`")?;
 
-        // The symlink triggers the slow-path in the `OsSystem`'s
-        // `exists_path_case_sensitive` code because canonicalizing the path
-        // for `a/__init__.py` results in `a-package/__init__.py`
+        // Directory listings preserve the source entry's casing even though resolving the symlink
+        // for `a/__init__.py` results in `a-package/__init__.py`.
         std::os::unix::fs::symlink(a_package_target.as_std_path(), a_src.as_std_path())
             .context("Failed to symlink `src/a` to `a-package`")?;
 

--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -1,7 +1,7 @@
 use std::fmt::Formatter;
 use std::str::FromStr;
 
-use ruff_db::files::{File, system_path_to_file, vendored_path_to_file};
+use ruff_db::files::{File, directory_listing, system_path_to_file, vendored_path_to_file};
 use ruff_db::system::SystemPath;
 use ruff_db::vendored::VendoredPath;
 use salsa::Database;
@@ -166,27 +166,18 @@ fn all_submodule_names_for_package<'db>(
 
     Some(match path.parent()? {
         SystemOrVendoredPathRef::System(parent_directory) => {
-            // Read the revision on the corresponding file root to
-            // register an explicit dependency on this directory
-            // tree. When the revision gets bumped, the cache
-            // that Salsa creates does for this routine will be
-            // invalidated.
-            let root = db.files().expect_root(db, parent_directory);
-            let _ = root.revision(db);
-
-            db.system()
-                .read_directory(parent_directory)
-                .inspect_err(|err| {
+            let directory = db.files().directory(db, parent_directory);
+            directory_listing(db, directory)
+                .inspect_err(|error| {
                     tracing::debug!(
                         "Failed to read {parent_directory:?} when looking for \
-                         its possible submodules: {err}"
+                         its possible submodules: {error}"
                     );
                 })
                 .ok()?
-                .flatten()
-                .filter(|entry| {
-                    let ty = entry.file_type();
-                    let path = entry.path();
+                .iter()
+                .filter(|(name, ty)| {
+                    let path = SystemPath::new(name);
                     is_submodule(
                         ty.is_directory(),
                         ty.is_file(),
@@ -194,18 +185,17 @@ fn all_submodule_names_for_package<'db>(
                         path.extension(),
                     )
                 })
-                .filter_map(|entry| {
-                    let stem = entry.path().file_stem()?;
+                .filter_map(|(entry_name, file_type)| {
+                    let relative = SystemPath::new(entry_name);
+                    let stem = relative.file_stem()?;
+                    let path = parent_directory.join(relative);
                     let mut name = module.name(db).clone();
                     name.extend(&ModuleName::new(stem)?);
 
-                    let (kind, file) = if entry.file_type().is_directory() {
-                        (
-                            ModuleKind::Package,
-                            find_package_init_system(db, entry.path())?,
-                        )
+                    let (kind, file) = if file_type.is_directory() {
+                        (ModuleKind::Package, find_package_init_system(db, &path)?)
                     } else {
-                        let file = system_path_to_file(db, entry.path()).ok()?;
+                        let file = system_path_to_file(db, &path).ok()?;
                         (ModuleKind::Module, file)
                     };
                     Some(Module::file_module(

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -37,8 +37,9 @@ use std::iter::FusedIterator;
 
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
-use ruff_db::files::{File, FilePath, FileRootKind};
-use ruff_db::system::{DirectoryEntry, System, SystemPath, SystemPathBuf};
+use ruff_db::files::{File, FilePath, FileRootKind, directory_listing, system_path_to_file};
+use ruff_db::source::{SourceText, source_text};
+use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_python_ast::{
     self as ast, PySourceType, PythonVersion,
@@ -386,36 +387,27 @@ fn absolute_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<
             ))
         })?;
 
-    // Read the revision on the corresponding file root to
-    // register an explicit dependency on this directory. When
-    // the revision gets bumped, the cache that Salsa creates
-    // for this routine will be invalidated.
-    //
-    // (This is conditional because ruff uses this code too and doesn't set roots)
-    if let Some(root) = db.files().root(db, base_path) {
-        let _ = root.revision(db);
-    }
-
     // Only allow searching up to the first-party path's root
     let mut search_paths = Vec::new();
     for rel_dir in rel_path.ancestors() {
         let candidate_path = base_path.join(rel_dir);
-        if !system.is_directory(&candidate_path) {
+        let directory = db.files().directory(db, &candidate_path);
+        let Ok(listing) = directory_listing(db, directory) else {
             continue;
-        }
+        };
         // Any dir that isn't a proper package is plausibly some test/script dir that could be
         // added as a search-path at runtime. Notably this reflects pytest's default mode where
         // it adds every dir with a .py to the search-paths (making all test files root modules),
         // unless they see an `__init__.py`, in which case they assume you don't want that.
-        let isnt_regular_package = !system.is_file(&candidate_path.join("__init__.py"))
-            && !system.is_file(&candidate_path.join("__init__.pyi"));
+        let isnt_regular_package = !listing.entry_is_file(db, directory, "__init__.py")
+            && !listing.entry_is_file(db, directory, "__init__.pyi");
         // Any dir with a pyproject.toml or ty.toml is a valid relative desperate search-path and
         // we want all of those to also be valid absolute desperate search-paths. It doesn't
         // make any sense for a folder to have `pyproject.toml` and `__init__.py` but let's
         // not let something cursed and spooky happen, ok? d
         if isnt_regular_package
-            || system.is_file(&candidate_path.join("pyproject.toml"))
-            || system.is_file(&candidate_path.join("ty.toml"))
+            || listing.entry_is_file(db, directory, "pyproject.toml")
+            || listing.entry_is_file(db, directory, "ty.toml")
         {
             let search_path = SearchPath::first_party(system, candidate_path).ok()?;
             search_paths.push(search_path);
@@ -460,22 +452,16 @@ fn relative_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<
             ))
         })?;
 
-    // Read the revision on the corresponding file root to
-    // register an explicit dependency on this directory. When
-    // the revision gets bumped, the cache that Salsa creates
-    // for this routine will be invalidated.
-    //
-    // (This is conditional because ruff uses this code too and doesn't set roots)
-    if let Some(root) = db.files().root(db, base_path) {
-        let _ = root.revision(db);
-    }
-
     // Only allow searching up to the first-party path's root
     for rel_dir in rel_path.ancestors() {
         let candidate_path = base_path.join(rel_dir);
+        let directory = db.files().directory(db, &candidate_path);
+        let Ok(listing) = directory_listing(db, directory) else {
+            continue;
+        };
         // Any dir with a pyproject.toml or ty.toml might be a project root
-        if system.is_file(&candidate_path.join("pyproject.toml"))
-            || system.is_file(&candidate_path.join("ty.toml"))
+        if listing.entry_is_file(db, directory, "pyproject.toml")
+            || listing.entry_is_file(db, directory, "ty.toml")
         {
             let search_path = SearchPath::first_party(system, candidate_path).ok()?;
             return Some(search_path);
@@ -838,15 +824,6 @@ pub(crate) fn dynamic_resolution_paths<'db>(
             continue;
         }
 
-        let site_packages_root = files.expect_root(db, site_packages_dir);
-
-        // This query needs to be re-executed each time a `.pth` file
-        // is added, modified or removed from the `site-packages` directory.
-        // However, we don't use Salsa queries to read the source text of `.pth` files;
-        // we use the APIs on the `System` trait directly. As such, add a dependency on the
-        // site-package directory's revision.
-        site_packages_root.revision(db);
-
         dynamic_paths.push(site_packages_search_path.clone());
 
         // As well as modules installed directly into `site-packages`,
@@ -855,8 +832,9 @@ pub(crate) fn dynamic_resolution_paths<'db>(
         // containing a (relative or absolute) path.
         // Each of these paths may point to an editable install of a package,
         // so should be considered an additional search path.
-        let pth_file_iterator = match PthFileIterator::new(db, site_packages_dir) {
-            Ok(iterator) => iterator,
+        let directory = files.directory(db, site_packages_dir);
+        let listing = match directory_listing(db, directory) {
+            Ok(listing) => listing,
             Err(error) => {
                 tracing::warn!(
                     "Failed to search for editable installation in {site_packages_dir}: {error}"
@@ -866,10 +844,33 @@ pub(crate) fn dynamic_resolution_paths<'db>(
         };
 
         // The Python documentation specifies that `.pth` files in `site-packages`
-        // are processed in alphabetical order, so collecting and then sorting is necessary.
+        // are processed in alphabetical order. `DirectoryListing` is already sorted.
         // https://docs.python.org/3/library/site.html#module-site
-        let mut all_pth_files: Vec<PthFile> = pth_file_iterator.collect();
-        all_pth_files.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+        let all_pth_files = listing
+            .iter()
+            .filter(|(name, file_type)| {
+                !file_type.is_directory() && SystemPath::new(name).extension() == Some("pth")
+            })
+            .filter_map(|(name, _)| {
+                let path = site_packages_dir.join(name);
+                // Track each `.pth` file independently so content changes invalidate this query.
+                let file = system_path_to_file(db, &path)
+                    .inspect_err(|error| {
+                        tracing::warn!("Failed to open .pth file `{path}`: {error}");
+                    })
+                    .ok()?;
+                let contents = source_text(db, file);
+                if let Some(error) = contents.read_error() {
+                    tracing::warn!("Failed to read .pth file `{path}`: {error}");
+                    return None;
+                }
+
+                Some(PthFile {
+                    contents,
+                    site_packages: site_packages_dir,
+                })
+            })
+            .collect::<Vec<_>>();
 
         let installations = all_pth_files.iter().flat_map(PthFile::items);
 
@@ -956,8 +957,7 @@ impl FusedIterator for SearchPathIterator<'_> {}
 /// One or more lines in a `.pth` file may be a (relative or absolute)
 /// path that represents an editable installation of a package.
 struct PthFile<'db> {
-    path: SystemPathBuf,
-    contents: String,
+    contents: SourceText,
     site_packages: &'db SystemPath,
 }
 
@@ -966,7 +966,6 @@ impl<'db> PthFile<'db> {
     /// and should therefore be added as module-resolution search paths.
     fn items(&'db self) -> impl Iterator<Item = SystemPathBuf> + 'db {
         let PthFile {
-            path: _,
             contents,
             site_packages,
         } = self;
@@ -987,67 +986,6 @@ impl<'db> PthFile<'db> {
 
             Some(SystemPath::absolute(line, site_packages))
         })
-    }
-}
-
-/// Iterator that yields a [`PthFile`] instance for every `.pth` file
-/// found in a given `site-packages` directory.
-struct PthFileIterator<'db> {
-    db: &'db dyn Db,
-    directory_iterator: Box<dyn Iterator<Item = std::io::Result<DirectoryEntry>> + 'db>,
-    site_packages: &'db SystemPath,
-}
-
-impl<'db> PthFileIterator<'db> {
-    fn new(db: &'db dyn Db, site_packages: &'db SystemPath) -> std::io::Result<Self> {
-        Ok(Self {
-            db,
-            directory_iterator: db.system().read_directory(site_packages)?,
-            site_packages,
-        })
-    }
-}
-
-impl<'db> Iterator for PthFileIterator<'db> {
-    type Item = PthFile<'db>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let PthFileIterator {
-            db,
-            directory_iterator,
-            site_packages,
-        } = self;
-
-        let system = db.system();
-
-        loop {
-            let entry_result = directory_iterator.next()?;
-            let Ok(entry) = entry_result else {
-                continue;
-            };
-            let file_type = entry.file_type();
-            if file_type.is_directory() {
-                continue;
-            }
-            let path = entry.into_path();
-            if path.extension() != Some("pth") {
-                continue;
-            }
-
-            let contents = match system.read_to_string(&path) {
-                Ok(contents) => contents,
-                Err(error) => {
-                    tracing::warn!("Failed to read .pth file `{path}`: {error}");
-                    continue;
-                }
-            };
-
-            return Some(PthFile {
-                path,
-                contents,
-                site_packages,
-            });
-        }
     }
 }
 
@@ -1371,6 +1309,11 @@ fn resolve_name_in_search_path(
         );
         return Err(());
     }
+
+    if !candidate_may_exist(context, candidate, module_name) {
+        return Err(());
+    }
+
     let package_path = &mut candidate.path;
     package_path.push(module_name);
 
@@ -1416,24 +1359,51 @@ fn resolve_name_in_search_path(
     // ever uses namespace packages, ensure that this check also takes the
     // `VERSIONS` file into consideration.
     if !package_path.search_path().is_standard_library() && package_path.is_directory(context) {
-        if let Some(path) = package_path.to_system_path() {
-            let system = context.db.system();
-            if system.case_sensitivity().is_case_sensitive()
-                || system.path_exists_case_sensitive(
-                    &path,
-                    package_path.search_path().as_system_path().unwrap(),
-                )
-            {
-                candidate.py_typed = package_path
-                    .py_typed(context)
-                    .inherit_parent(candidate.py_typed);
-                candidate.module = ResolvedModule::NamespacePackage;
-                return Ok(());
-            }
-        }
+        candidate.py_typed = package_path
+            .py_typed(context)
+            .inherit_parent(candidate.py_typed);
+        candidate.module = ResolvedModule::NamespacePackage;
+        return Ok(());
     }
 
     Err(())
+}
+
+/// Uses the parent directory's entries to reject candidates that cannot exist without
+/// performing an individual file-system probe for every supported module layout.
+fn candidate_may_exist(
+    context: &ResolverContext,
+    candidate: &ModuleResolutionCandidate,
+    module_name: &str,
+) -> bool {
+    let Some(parent) = candidate.path.to_system_path() else {
+        return true;
+    };
+
+    let directory = context.db.files().directory(context.db, &parent);
+    let Ok(listing) = directory_listing(context.db, directory) else {
+        return false;
+    };
+
+    if listing
+        .file_type(module_name)
+        .is_some_and(|file_type| !file_type.is_file())
+    {
+        return true;
+    }
+
+    if context.mode.stubs_allowed()
+        && listing
+            .file_type(&format!("{module_name}.pyi"))
+            .is_some_and(|file_type| !file_type.is_directory())
+    {
+        return true;
+    }
+
+    !candidate.path.is_standard_library()
+        && listing
+            .file_type(&format!("{module_name}.py"))
+            .is_some_and(|file_type| !file_type.is_directory())
 }
 
 type ResolvedNames = Vec<ModuleResolutionCandidate>;
@@ -1459,16 +1429,20 @@ pub(super) fn resolve_file_module(
             .and_then(|path| path.to_file(resolver_state))
     })?;
 
-    // For system files, test if the path has the correct casing.
-    // We can skip this step for vendored files or virtual files because
-    // those file systems are case sensitive (we wouldn't get to this point).
+    // System files on case-insensitive file systems must still match the casing on disk.
     if let Some(path) = file.path(resolver_state.db).as_system_path() {
         let system = resolver_state.db.system();
-        if !system.case_sensitivity().is_case_sensitive()
-            && !system
-                .path_exists_case_sensitive(path, module.search_path().as_system_path().unwrap())
-        {
-            return None;
+        if !system.case_sensitivity().is_case_sensitive() {
+            let parent = path.parent()?;
+            let name = path.file_name()?;
+            let directory = resolver_state
+                .db
+                .files()
+                .directory(resolver_state.db, parent);
+            let Ok(listing) = directory_listing(resolver_state.db, directory) else {
+                return None;
+            };
+            listing.file_type(name)?;
         }
     }
 
@@ -1843,6 +1817,30 @@ mod tests {
             Some(foo_module),
             path_to_module(&db, &FilePath::from(expected_foo_path))
         );
+    }
+
+    #[test]
+    fn missing_module_uses_directory_listing_as_prefilter() {
+        let TestCase { db, src, .. } = TestCaseBuilder::new().build();
+
+        assert!(
+            resolve_module_confident(&db, &ModuleName::new_static("missing").unwrap()).is_none()
+        );
+
+        for relative_path in [
+            "missing-stubs/__init__.pyi",
+            "missing-stubs/__init__.py",
+            "missing/__init__.pyi",
+            "missing/__init__.py",
+            "missing.pyi",
+            "missing.py",
+        ] {
+            assert_eq!(
+                db.files().try_system(&db, &src.join(relative_path)),
+                None,
+                "unexpected point probe for {relative_path}"
+            );
+        }
     }
 
     /// Tests precedence when there is a package and a sibling stub file.
@@ -2356,9 +2354,9 @@ mod tests {
     }
 
     #[test]
-    fn deleting_an_unrelated_file_doesnt_change_module_resolution() {
+    fn deleting_file_from_different_directory_doesnt_change_module_resolution() {
         let TestCase { mut db, src, .. } = TestCaseBuilder::new()
-            .with_src_files(&[("foo.py", "x = 1"), ("bar.py", "x = 2")])
+            .with_src_files(&[("foo.py", "x = 1"), ("other/bar.py", "x = 2")])
             .with_python_version(PythonVersion::PY38)
             .build();
 
@@ -2372,7 +2370,7 @@ mod tests {
             foo_module.kind(&db),
         );
 
-        let bar_path = src.join("bar.py");
+        let bar_path = src.join("other/bar.py");
         let bar = system_path_to_file(&db, &bar_path).expect("bar.py to exist");
 
         db.clear_salsa_events();
@@ -2381,8 +2379,8 @@ mod tests {
         db.memory_file_system().remove_file(&bar_path).unwrap();
         bar.sync(&mut db);
 
-        // Re-query the foo module. The foo module should still be cached
-        // because `bar.py` isn't relevant for resolving `foo`.
+        // Re-query the foo module. The foo module should still be cached because the changed
+        // directory isn't relevant for resolving `foo`.
 
         let foo_module2 = resolve_module_confident(&db, &foo_module_name);
         let foo_pieces2 = foo_module2.map(|foo_module2| {
@@ -2395,10 +2393,12 @@ mod tests {
             )
         });
 
-        assert!(
-            !db.take_salsa_events()
-                .iter()
-                .any(|event| { matches!(event.kind, salsa::EventKind::WillExecute { .. }) })
+        let events = db.take_salsa_events();
+        assert_function_query_was_not_run(
+            &db,
+            resolve_module_query,
+            ModuleNameIngredient::new(&db, foo_module_name, ModuleResolveMode::StubsAllowed),
+            &events,
         );
 
         assert_eq!(Some(foo_pieces), foo_pieces2);
@@ -2757,6 +2757,66 @@ not_a_directory
     }
 
     #[test]
+    fn nested_site_packages_change_does_not_invalidate_dynamic_resolution_paths() {
+        const SITE_PACKAGES: &[FileSpec] = &[("_foo.pth", "/x/src"), ("package/__init__.py", "")];
+
+        let TestCase {
+            mut db,
+            site_packages,
+            ..
+        } = TestCaseBuilder::new()
+            .with_site_packages_files(SITE_PACKAGES)
+            .build();
+
+        dynamic_resolution_paths(
+            &db,
+            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::StubsAllowed),
+        );
+        db.clear_salsa_events();
+
+        db.write_file(site_packages.join("package/nested.py"), "")
+            .unwrap();
+        dynamic_resolution_paths(
+            &db,
+            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::StubsAllowed),
+        );
+
+        let events = db.take_salsa_events();
+        assert_function_query_was_not_run(
+            &db,
+            dynamic_resolution_paths,
+            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::StubsAllowed),
+            &events,
+        );
+    }
+
+    #[test]
+    fn modifying_pth_file_invalidates_dynamic_resolution_paths() {
+        const SITE_PACKAGES: &[FileSpec] = &[("_editable.pth", "/x/src")];
+
+        let TestCase {
+            mut db,
+            site_packages,
+            ..
+        } = TestCaseBuilder::new()
+            .with_site_packages_files(SITE_PACKAGES)
+            .build();
+        db.write_files([("/x/src/foo.py", ""), ("/y/src/bar.py", "")])
+            .unwrap();
+
+        assert!(resolve_module_confident(&db, &ModuleName::new_static("foo").unwrap()).is_some());
+
+        let pth_path = site_packages.join("_editable.pth");
+        db.memory_file_system()
+            .write_file(&pth_path, "/y/src")
+            .unwrap();
+        File::sync_path_only(&mut db, &pth_path);
+
+        assert!(resolve_module_confident(&db, &ModuleName::new_static("foo").unwrap()).is_none());
+        assert!(resolve_module_confident(&db, &ModuleName::new_static("bar").unwrap()).is_some());
+    }
+
+    #[test]
     fn deleting_pth_file_on_which_module_resolution_depends_invalidates_cache() {
         const SITE_PACKAGES: &[FileSpec] = &[("_foo.pth", "/x/src")];
         let x_directory = [("/x/src/foo.py", "")];
@@ -2920,9 +2980,8 @@ not_a_directory
         db.write_file(src.join("main.py"), "print('Hy')")
             .context("Failed to write `main.py`")?;
 
-        // The symlink triggers the slow-path in the `OsSystem`'s
-        // `exists_path_case_sensitive` code because canonicalizing the path
-        // for `a/__init__.py` results in `a-package/__init__.py`
+        // Directory listings preserve the source entry's casing even though resolving the symlink
+        // for `a/__init__.py` results in `a-package/__init__.py`.
         std::os::unix::fs::symlink(a_package_target.as_std_path(), a_src.as_std_path())
             .context("Failed to symlink `src/a` to `a-package`")?;
 

--- a/crates/ty_module_resolver/src/testing.rs
+++ b/crates/ty_module_resolver/src/testing.rs
@@ -109,11 +109,6 @@ pub(crate) struct TestCaseBuilder<T> {
     site_packages_files: Vec<FileSpec>,
     // Additional file roots (beyond site_packages, src and stdlib)
     // that should be registered with the `Db` abstraction.
-    //
-    // This is necessary to make testing "list modules" work. Namely,
-    // "list modules" relies on caching via a file root's revision,
-    // and if file roots aren't registered, then the implementation
-    // can't access the root's revision.
     roots: Vec<SystemPathBuf>,
 }
 
@@ -259,13 +254,6 @@ impl TestCaseBuilder<MockedTypeshed> {
 
         db = db.with_search_paths(search_paths);
 
-        // This root is needed for correct Salsa tracking.
-        // Namely, a `SearchPath` is treated as an input, and
-        // thus the revision number must be bumped accordingly
-        // when the directory tree changes. We rely on detecting
-        // this revision from the file root. If we don't add them
-        // here, they won't get added.
-        //
         // Roots for other search paths are added as part of
         // search path initialization in `SearchPaths::from_settings`,
         // and any remaining are added below.

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -7,11 +7,9 @@ use std::collections::BTreeSet;
 use super::ignore::IgnoreFiles;
 use crate::walk::ProjectFilesWalker;
 use ruff_db::Db as _;
-use ruff_db::file_revision::FileRevision;
-use ruff_db::files::{File, FileRootKind, Files, system_path_to_file};
+use ruff_db::files::{File, Files, system_path_to_file};
 use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
 use rustc_hash::FxHashSet;
-use salsa::Setter;
 use ty_python_core::program::{FallibleStrategy, Program};
 
 /// Represents the result of applying changes to the project database.
@@ -58,6 +56,7 @@ impl ProjectDatabase {
 
         // Deduplicate the `sync` calls. Many file watchers emit multiple events for the same path.
         let mut synced_files = FxHashSet::default();
+        let mut changed_directories = BTreeSet::default();
         let mut sync_recursively = BTreeSet::default();
         // A non-file delete may be a deleted directory or an ambiguous LSP delete for a path
         // that no longer exists. Handle it recursively to keep Salsa's file state in sync.
@@ -74,6 +73,12 @@ impl ProjectDatabase {
         for change in changes {
             tracing::debug!("Handling file watcher change event: {:?}", change);
 
+            if let ChangeEvent::Created { path, .. } | ChangeEvent::Deleted { path, .. } = change
+                && let Some(parent) = path.parent()
+            {
+                changed_directories.insert(parent.to_path_buf());
+            }
+
             if let Some(path) = change.system_path() {
                 if is_project_configuration_path(
                     path,
@@ -81,14 +86,14 @@ impl ProjectDatabase {
                     config_file_override.as_ref(),
                     &extra_configuration_paths,
                 ) {
-                    File::sync_path(self, path);
+                    File::sync_path_only(self, path);
                     reload_project = true;
 
                     continue;
                 }
 
                 if is_ignore_file(path) && project.settings(self).src().respect_ignore_files {
-                    File::sync_path(self, path);
+                    File::sync_path_only(self, path);
                     if let Some(directory) = path.parent() {
                         if project
                             .included_paths_or_root(self)
@@ -138,35 +143,6 @@ impl ProjectDatabase {
                 ChangeEvent::Changed { path, kind: _ } | ChangeEvent::Opened(path) => {
                     if synced_files.insert(path.to_path_buf()) {
                         File::sync_path_only(self, path);
-                        if let Some(root) = self.files().root(self, path) {
-                            match root.kind_at_time_of_creation(self) {
-                                // When a file inside the root of
-                                // the project is changed, we don't
-                                // want to mark the entire root as
-                                // having changed too. In theory it
-                                // might make sense to, but at time
-                                // of writing, the file root revision
-                                // on a project is used to invalidate
-                                // the submodule files found within a
-                                // directory. If we bumped the revision
-                                // on every change within a project,
-                                // then this caching technique would be
-                                // effectively useless.
-                                //
-                                // It's plausible we should explore
-                                // a more robust cache invalidation
-                                // strategy that models more directly
-                                // what we care about. For example, by
-                                // keeping track of directories and
-                                // their direct children explicitly,
-                                // and then keying the submodule cache
-                                // off of that instead. ---AG
-                                FileRootKind::Project => {}
-                                FileRootKind::SearchPath => {
-                                    root.set_revision(self).to(FileRevision::now());
-                                }
-                            }
-                        }
                     }
                 }
 
@@ -174,7 +150,7 @@ impl ProjectDatabase {
                     match kind {
                         CreatedKind::File => {
                             if synced_files.insert(path.to_path_buf()) {
-                                File::sync_path(self, path);
+                                File::sync_path_only(self, path);
                             }
                         }
                         CreatedKind::Directory | CreatedKind::Any => {
@@ -225,7 +201,7 @@ impl ProjectDatabase {
 
                     if is_file {
                         if synced_files.insert(path.to_path_buf()) {
-                            File::sync_path(self, path);
+                            File::sync_path_only(self, path);
                         }
 
                         if let Some(file) = self.files().try_system(self, path) {
@@ -271,12 +247,16 @@ impl ProjectDatabase {
                     reload_project_files = true;
                     Files::sync_all(self);
                     sync_recursively.clear();
+                    changed_directories.clear();
                     removed_paths.clear();
                     break;
                 }
             }
         }
 
+        for directory in changed_directories {
+            Files::touch_directory(self, &directory);
+        }
         Files::sync_all_recursive(self, deduplicate_nested_paths(sync_recursively));
 
         if reload_project {

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -181,10 +181,6 @@ impl System for LSPSystem {
         self.native_system.is_same_file(first, second)
     }
 
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
-        self.native_system.path_exists_case_sensitive(path, prefix)
-    }
-
     fn source_type(&self, path: &SystemPath) -> Option<PySourceType> {
         let document = self.system_path_to_document(path)?;
         Self::source_type_from_document(document, path.extension())

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -404,11 +404,6 @@ impl System for MdtestSystem {
         self.as_system().read_virtual_path_to_notebook(path)
     }
 
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
-        self.as_system()
-            .path_exists_case_sensitive(&self.normalize_path(path), &self.normalize_path(prefix))
-    }
-
     fn case_sensitivity(&self) -> CaseSensitivity {
         self.as_system().case_sensitivity()
     }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -1612,10 +1612,6 @@ impl System for WasmSystem {
         Err(ruff_notebook::NotebookError::Io(not_found()))
     }
 
-    fn path_exists_case_sensitive(&self, path: &SystemPath, _prefix: &SystemPath) -> bool {
-        self.path_exists(path)
-    }
-
     fn case_sensitivity(&self) -> CaseSensitivity {
         CaseSensitivity::CaseSensitive
     }


### PR DESCRIPTION
## Summary

Cache directory listings as Salsa inputs and use them to prefilter module resolution. This avoids repeated negative file probes while keeping invalidation scoped to the affected directory and candidate name. Specifically, we call multiple `File` methods only to test whether `module.py`, `module.pyi`, `module/__init__.py`, `module/__init__.pyi` exist in a folder (and repeat the same for stubs), even if the folder contains no file or directory named `module`. For a negative probe, each of those call create a `File` (with status deleted), always requiring at least one system call. It also results in ty retaining a lot of `File`'s with status `Deleted` (nor not exists).


This PR changes the module resolver to prefilter by first checking the directory listing on whether visting a search path is worthwhile. This can improve performance 5-10x when using many search paths (25+)



Based on the idea in https://github.com/lpetre/ruff/pull/2

Testing: Targeted resolver and file-watching tests, workspace Clippy, repository hooks, and module-resolution benchmarks pass.