### PR TITLE
[ty] Compare function signatures directly in callable relations

### DIFF
--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -712,10 +712,25 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: CallableType<'db>,
         target: CallableType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        if target.is_function_like(db) && !source.is_function_like(db) {
+        self.check_callable_signature_source_pair(
+            db,
+            source.signatures(db),
+            source.kind(db),
+            target,
+        )
+    }
+
+    pub(super) fn check_callable_signature_source_pair(
+        &self,
+        db: &'db dyn Db,
+        source: &CallableSignature<'db>,
+        source_kind: CallableTypeKind,
+        target: CallableType<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        if target.is_function_like(db) && source_kind != CallableTypeKind::FunctionLike {
             return self.never();
         }
-        self.check_callable_signature_pair(db, source.signatures(db), target.signatures(db))
+        self.check_callable_signature_pair(db, source, target.signatures(db))
     }
 
     pub(super) fn check_callables_vs_callable(

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1786,6 +1786,26 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 | Type::ModuleLiteral(_),
             ) => self.never(),
 
+            (Type::FunctionLiteral(source_function), Type::Callable(target_callable)) => self
+                .with_recursion_guard(source, target, || {
+                    self.check_callable_signature_source_pair(
+                        db,
+                        source_function.signature(db),
+                        source_function.callable_type_kind(db),
+                        target_callable,
+                    )
+                }),
+
+            (Type::BoundMethod(source_method), Type::Callable(target_callable)) => self
+                .with_recursion_guard(source, target, || {
+                    self.check_callable_signature_source_pair(
+                        db,
+                        &source_method.bound_signatures(db),
+                        CallableTypeKind::FunctionLike,
+                        target_callable,
+                    )
+                }),
+
             (Type::Callable(source_callable), Type::Callable(target_callable)) => self
                 .with_recursion_guard(source, target, || {
                     self.check_callable_pair(db, source_callable, target_callable)


### PR DESCRIPTION
## Summary

When checking whether a function literal or bound method satisfies a `Callable` target, the general relation path first upcasts the source into an interned `CallableType`, then immediately extracts its signatures for comparison.

This compares the source signatures directly instead. The shared helper retains the existing function-like callable check, recursion guard, signature relation, and constraint behavior. Other source types that require a real callable upcast continue through the general path.

On the Home Assistant benchmark, this reduced CPU time by about 0.5% and wall time by about 3.5% across 20 paired runs, with byte-identical diagnostics.
