### PR TITLE
[ty] Run benchmarks for cached Salsa intern hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,15 +1402,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -1422,11 +1413,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3715,8 +3706,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfc1e32b8d1a486e3a45a5480fb5dca7912f49262a8916a67378064da4fe1ab"
+source = "git+https://github.com/charliermarsh/salsa.git?rev=8dc16c93c2e941cc7bd3652a4e2aab6cf6e7990f#8dc16c93c2e941cc7bd3652a4e2aab6cf6e7990f"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3742,14 +3732,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dad477a3e3a484a7c2311c1d25160fb270214981be24022de7de8a206a3300"
+source = "git+https://github.com/charliermarsh/salsa.git?rev=8dc16c93c2e941cc7bd3652a4e2aab6cf6e7990f#8dc16c93c2e941cc7bd3652a4e2aab6cf6e7990f"
 
 [[package]]
 name = "salsa-macros"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943f70e101fb3bd599960e79e719e70d85142730e5b45f3269246086ed218562"
+source = "git+https://github.com/charliermarsh/salsa.git?rev=8dc16c93c2e941cc7bd3652a4e2aab6cf6e7990f#8dc16c93c2e941cc7bd3652a4e2aab6cf6e7990f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,8 +156,8 @@ regex-automata = { version = "0.4.9" }
 regex-syntax = { version = "0.8.8" }
 rustc-hash = { version = "2.0.0" }
 rustc-stable-hash = { version = "0.1.2" }
-# When updating salsa, make sure to also update the version in `fuzz/Cargo.toml`
-salsa = { version = "0.27.0", default-features = false, features = [
+# When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
+salsa = { git = "https://github.com/charliermarsh/salsa.git", rev = "8dc16c93c2e941cc7bd3652a4e2aab6cf6e7990f", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,7 +33,7 @@ ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { version = "0.27.0", default-features = false, features = [
+salsa = { git = "https://github.com/charliermarsh/salsa.git", rev = "8dc16c93c2e941cc7bd3652a4e2aab6cf6e7990f", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",


### PR DESCRIPTION
This draft pins Salsa to [8dc16c9](https://github.com/charliermarsh/salsa/commit/8dc16c93c2e941cc7bd3652a4e2aab6cf6e7990f). Salsa currently stores only each interned ID in its sharded lookup table, so table growth and rehashing must recover every value and hash its fields again. This stores a compact 32-bit cached hash beside the ID, keeping the table entry at 12 bytes and avoiding those field dereferences during rehashing.

Relative to unmodified Salsa master, the patch was 1.57% faster by CPU time on the Home Assistant benchmark across 10 paired runs. On top of the refined LRU and SyncTable sharding changes, it was 2.08% faster with 10/10 wins. Peak RSS increased by 26.3 MB, or 0.62%, and diagnostic output was byte-for-byte identical.

The control draft #25951 pins unmodified Salsa master so CI can separate changes already present on master from this patch.